### PR TITLE
remove workspace: prefix

### DIFF
--- a/packages/create-svelte/cli/index.js
+++ b/packages/create-svelte/cli/index.js
@@ -53,6 +53,9 @@ async function main() {
 
 	fs.writeFileSync(path.join(target, '.gitignore'), gitignore_contents);
 
+	const pkg_file = path.join(target, 'package.json');
+	fs.writeFileSync(pkg_file, fs.readFileSync(pkg_file, 'utf-8').replace(/workspace:/g, ''));
+
 	console.log(bold(green(`✔ Copied project files`)));
 	console.log(`\nNext steps:`);
 	let i = 1;

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-svelte",
-  "version": "2.0.0-alpha.6",
+  "version": "2.0.0-alpha.7",
   "bin": "./bin",
   "devDependencies": {
     "gitignore-parser": "^0.0.2",


### PR DESCRIPTION
Without this, every time anyone runs `pnpm i` the dependencies in `create-svelte/template` will get converted to `workspace:` dependencies, which will show up for anyone who creates a new project