### PR TITLE
let snowpack handle "static/" directory

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -23,7 +23,6 @@
 		"periscopic": "^2.0.2",
 		"port-authority": "^1.1.1",
 		"require-relative": "^0.8.7",
-		"sirv": "^1.0.7",
 		"source-map-support": "^0.5.19",
 		"svelte": "^3.29.0"
 	},

--- a/packages/snowpack-config/snowpack.config.js
+++ b/packages/snowpack-config/snowpack.config.js
@@ -19,6 +19,7 @@ module.exports = {
 		sourceMaps: true
 	},
 	mount: {
+		'static': '/',
 		'.svelte/main': '/_app/main',
 		'src/routes': '/_app/routes',
 		'src/components': '/_app/components/'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,7 +134,6 @@ importers:
       periscopic: 2.0.2
       port-authority: 1.1.1
       require-relative: 0.8.7
-      sirv: 1.0.7
       source-map-support: 0.5.19
       svelte: 3.29.0
     specifiers:
@@ -156,7 +155,6 @@ importers:
       rollup-plugin-css-chunks: ^1.2.8
       rollup-plugin-terser: ^7.0.2
       sade: ^1.7.4
-      sirv: ^1.0.7
       snowpack: 2.14.3
       source-map-support: ^0.5.19
       svelte: ^3.29.0


### PR DESCRIPTION
Snowpack is already being used to mount different directories in your project. This PR mounts the `static/` directory as well to remove the need for a secondary static file server.

Removing a callback = noisy indentation diff. No code was changed after line 107.