### PR TITLE
Update outdated kit README.md

### DIFF
--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -9,15 +9,6 @@ It's currently missing a ton of stuff but I figured I'd throw it up on GitHub an
 There are no tests yet or anything like that. Some of the code has just been straight copied over from the existing Sapper repo, but a pleasing amount of it can safely be left behind.
 
 
-## Snowpack impressions
-
-This thing is really neat. It has some bugs and missing features, but identifying those is the whole purpose of this experiment, and so far I've been able to MacGyver my way around them:
-
-* ~~the server app and the client app trip over each other [because Snowpack has a global caching mechanism](https://github.com/pikapkg/snowpack/discussions/1060). I'm currently working around it by symlinking various folders for one of the instances~~
-* it rewrites imports but seems to do so incorrectly at times? e.g. if you import `foo.svelte` it will rewrite it to `foo.svelte.js`, but that import will fail unless you modify the request to `foo.js`
-* ~~it'd be really nice if it exposed a JavaScript API so that it wasn't necessary to invoke the CLI in a child process and communicate with it over HTTP — ideally there'd be a way to 'import' a file from a Snowpack instance, and a way to run Snowpack as middleware that you can use with a regular HTTP server~~
-
-
 ## Trying it out
 
 Clone this repo, `npm install`, and `npm link`. That will create a global link to the `svelte` bin. You can then either `npm run build` or `npm run dev`, if you intend to make changes and see them immediately reflected.


### PR DESCRIPTION
People are finding/sharing https://www.npmjs.com/package/@sveltejs/kit, which is using this outdated README. The Snowpack section is no longer relevant (mainly used to track early bugs, all of which have been addressed) so I'd love to remove this so that people don't read too deep into this.