### PR TITLE
chore: wildcard workspace versions

### DIFF
--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -2,7 +2,7 @@
 	"name": "@sveltejs/adapter-netlify",
 	"version": "0.0.9",
 	"devDependencies": {
-		"@sveltejs/app-utils": "workspace:0.0.12",
+		"@sveltejs/app-utils": "workspace:*",
 		"devalue": "^2.0.1",
 		"rollup": "^2.32.0"
 	},

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -16,6 +16,6 @@
 		"prepublishOnly": "npm run build"
 	},
 	"dependencies": {
-		"@sveltejs/app-utils": "workspace:0.0.12"
+		"@sveltejs/app-utils": "workspace:*"
 	}
 }

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -2,6 +2,6 @@
 	"name": "@sveltejs/adapter-static",
 	"version": "0.0.9",
 	"dependencies": {
-		"@sveltejs/app-utils": "workspace:0.0.12"
+		"@sveltejs/app-utils": "workspace:*"
 	}
 }

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -3,7 +3,7 @@
 	"version": "2.0.0-alpha.15",
 	"bin": "./bin",
 	"devDependencies": {
-		"@sveltejs/app-utils": "workspace:^0.0.12",
+		"@sveltejs/app-utils": "workspace:*",
 		"gitignore-parser": "^0.0.2",
 		"kleur": "^4.1.3",
 		"prompts": "^2.3.2",

--- a/packages/create-svelte/template/package.json
+++ b/packages/create-svelte/template/package.json
@@ -6,9 +6,9 @@
 		"build": "svelte build"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-node": "workspace:0.0.7",
-		"@sveltejs/kit": "workspace:0.0.17",
-		"@sveltejs/snowpack-config": "workspace:^0.0.3",
+		"@sveltejs/adapter-node": "workspace:*",
+		"@sveltejs/kit": "workspace:*",
+		"@sveltejs/snowpack-config": "workspace:*",
 		"svelte": "^3.29.0"
 	}
 }

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -2,7 +2,7 @@
 	"name": "@sveltejs/kit",
 	"version": "0.0.19",
 	"dependencies": {
-		"@sveltejs/app-utils": "workspace:0.0.12",
+		"@sveltejs/app-utils": "workspace:*",
 		"cheap-watch": "^1.0.2",
 		"find-cache-dir": "^3.3.1",
 		"http-proxy": "^1.18.1",


### PR DESCRIPTION
Using `workspace:0.0.12` (for example) publishes a package as `"thing": "0.0.12"` because you're telling pnpm you want this _specific_ version, and it happens to come from the workspace.

Using a version range will also be a simple rewrite on `pnpm -r publish` (eg, `"thing": "workspace:^0.0.10"` => `"thing": "^0.0.10"` -- or it may be "^0.0.12" if that's known to exist, not sure but doesnt matter)

Using a "*" will update to the latest (pinned) version when publishing. I figure that's more useful right now during active development of multiple things. But if publishing changes to everything, everything will be pointing to each other's latest versions.

> More info: https://pnpm.js.org/en/workspaces#publishing-workspace-packages