### PR TITLE
chore: `find-cache-dir` => `scorta/sync`

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -4,13 +4,13 @@
 	"dependencies": {
 		"@sveltejs/app-utils": "workspace:0.0.12",
 		"cheap-watch": "^1.0.2",
-		"find-cache-dir": "^3.3.1",
 		"http-proxy": "^1.18.1",
 		"rollup": "^2.32.0",
 		"rollup-dependency-tree": "0.0.14",
 		"rollup-plugin-css-chunks": "^1.2.8",
 		"rollup-plugin-terser": "^7.0.2",
 		"sade": "^1.7.4",
+		"scorta": "^1.0.0",
 		"snowpack": "^2.15.0"
 	},
 	"devDependencies": {

--- a/packages/kit/src/api/dev/index.ts
+++ b/packages/kit/src/api/dev/index.ts
@@ -1,7 +1,7 @@
 import { parse, URLSearchParams } from 'url';
 import { EventEmitter } from 'events';
 import CheapWatch from 'cheap-watch';
-import find_cache_dir from 'find-cache-dir';
+import { scorta } from 'scorta/sync';
 import * as ports from 'port-authority';
 import sirv from 'sirv';
 import { mkdirp } from '@sveltejs/app-utils';
@@ -35,7 +35,7 @@ class Watcher extends EventEmitter {
 	constructor(opts: DevConfig) {
 		super();
 
-		this.cachedir = find_cache_dir({ name: 'svelte' });
+		this.cachedir = scorta('svelte');
 		this.opts = opts;
 		this.update();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,13 +126,13 @@ importers:
     dependencies:
       '@sveltejs/app-utils': 'link:../app-utils'
       cheap-watch: 1.0.2
-      find-cache-dir: 3.3.1
       http-proxy: 1.18.1
       rollup: 2.32.0
       rollup-dependency-tree: 0.0.14
       rollup-plugin-css-chunks: 1.2.8_rollup@2.32.0
       rollup-plugin-terser: 7.0.2_rollup@2.32.0
       sade: 1.7.4
+      scorta: 1.0.0
       snowpack: 2.15.0
     devDependencies:
       '@types/node': 14.11.10
@@ -154,7 +154,6 @@ importers:
       '@types/sade': ^1.7.2
       cheap-watch: ^1.0.2
       estree-walker: ^2.0.1
-      find-cache-dir: ^3.3.1
       http-proxy: ^1.18.1
       kleur: ^4.1.3
       magic-string: ^0.25.7
@@ -168,6 +167,7 @@ importers:
       rollup-plugin-css-chunks: ^1.2.8
       rollup-plugin-terser: ^7.0.2
       sade: ^1.7.4
+      scorta: ^1.0.0
       sirv: ^1.0.7
       snowpack: ^2.15.0
       source-map-support: ^0.5.19
@@ -1394,6 +1394,12 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-5lO1NBOekZYU8h55SJJUc2dMe8duAwIqOQrIIvawRwbBRoWCmLSsMJmEvdFDITt24pkhu8AN4IKfyflLgaKxbg==
+  /escalade/3.1.1:
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
   /escape-string-regexp/1.0.5:
     engines:
       node: '>=0.8.0'
@@ -3206,6 +3212,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+  /scorta/1.0.0:
+    dependencies:
+      escalade: 3.1.1
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-q6qyZNQEeJopoG5eWMVb92qeeKVRaThhaDwlyhu7V2MAROZjD0BJyGaNnf4d+QJcaJu+Mv72RqEB+BZVo+ONCA==
   /semver/5.7.1:
     dev: true
     hasBin: true


### PR DESCRIPTION
Same behavior, nearly the same (but more sensible 😉) API.

This is mostly because [`find-cache-dir`](https://npm.anvaka.com/#/view/2d/find-cache-dir) is a bloated mess. Compare with [`scorta`](https://npm.anvaka.com/#/view/2d/scorta).

And not that it matters, but `scorta` is at least 3x faster due to [`escalade` vs `find-up` boost](https://github.com/lukeed/escalade#benchmarks)