### PR TITLE
SetupModule with generics for Context and Session

### DIFF
--- a/packages/app-utils/src/types.d.ts
+++ b/packages/app-utils/src/types.d.ts
@@ -23,6 +23,12 @@ export interface PageResponse extends EndpointResponse {
 	dependencies: Record<string, EndpointResponse>;
 }
 
+export interface SetupModule<Context = any, Session = any> {
+	prepare?: (headers: Headers) => Promise<{ context: Context, headers: Headers }>;
+	getSession?: (context: Context) => Promise<Session> | Session;
+	setSession?: (context: Context, session: Session) => Promise<Session> | Session;
+}
+
 export interface SSRComponentModule {
 	default: SSRComponent;
 }
@@ -33,12 +39,6 @@ export interface SSRComponent {
 		head: string
 		css: { code: string, map: unknown };
 	}
-}
-
-export interface SetupModule<Context = any, Session = any> {
-	prepare?: (headers: Headers) => Promise<{ context: Context, headers: Headers }>;
-	getSession?: (context: Context) => Promise<Session> | Session;
-	setSession?: (context: Context, session: Session) => Promise<Session> | Session;
 }
 
 export interface RenderOptions {


### PR DESCRIPTION
I'd suggest making the `SetupModule` interface generic, using the context and session type as parameters.

If we allow a default export of a `SetupModule` (there's no way to type an entire module), then it's possible to make the project setup code type safe using

```
interface MyContext {
  secretToken: string
}

interface MySession {
  userId: number
}

const setup: SetupModule<MyContext, MySession> = { 
  getSession(context) {
      // compiler knows context is MyContext, result type is MySession
  }
 };

export default setup;
```

<img width="752" alt="Screen Shot 2020-10-23 at 11 49 56 AM" src="https://user-images.githubusercontent.com/1862212/96977889-144b7f80-14f4-11eb-9a5d-fb6fa2d5ce36.png">

