### PR TITLE
Show good error message if project code has broken import

### DIFF
--- a/packages/kit/src/api/dev/index.ts
+++ b/packages/kit/src/api/dev/index.ts
@@ -137,6 +137,23 @@ class Watcher extends EventEmitter {
 					setup = {};
 				}
 
+				let root;
+				
+				try {
+					root = await load(`/_app/main/root.js`);
+
+					if (!root.default) {
+						res.statusCode = 500;
+						res.end('Failed to load root component');
+						return
+					}
+				}
+				catch (e) {
+					res.statusCode = 500;
+					res.end(e.toString());
+					return
+				}
+
 				const rendered = await render({
 					host: null, // TODO what should this be? is it necessary?
 					headers: req.headers,
@@ -153,7 +170,7 @@ class Watcher extends EventEmitter {
 					},
 					files: 'build',
 					dev: true,
-					root: await load(`/_app/main/root.js`),
+					root,
 					setup,
 					load: route => load(route.url.replace(/\.\w+$/, '.js')) // TODO is the replace still necessary?
 				});


### PR DESCRIPTION
Fixes #63.

I'm honestly not sure of the details of what snowpack does here but for whatever reason, the first attempt to load a root module with a broken import will throw an error during load (that's what the `catch` handles); the second will return an empty module (maybe because it cached the broken module?) and that's why it checks if it has a `default` export.