### PR TITLE
Made error page work

### DIFF
--- a/packages/app-utils/src/renderer/render/page.ts
+++ b/packages/app-utils/src/renderer/render/page.ts
@@ -292,8 +292,7 @@ export default async function render_page(
 		if (!error) {	
 			const status = thrown.status || 500;
 			return render_page(request, context, options, status, thrown);
-		}
-		else {
+		} else {
 			// oh lawd now you've done it
 			return {
 				status: 500,


### PR DESCRIPTION
The error page wasn't loading because a bunch of properties and stores weren't provided.
I solved this the same way we do in Sapper, with a recursive call to `render_page` passing `error` and `status` as parameters. It seems to work now (except that we reference `process` in the Hacker News error page and it's not implemented).

I also added `error` to the page store as per sveltejs/sapper#1498 and [Ben's comment](https://github.com/sveltejs/kit/issues/6#issuecomment-718903361) in #6