### PR TITLE
Prefer interfaces over types

### DIFF
--- a/packages/kit/src/api/dev/types.ts
+++ b/packages/kit/src/api/dev/types.ts
@@ -4,28 +4,28 @@ export type Query = Record<string, string | true>;
 
 export type Params = Record<string, any>;
 
-export type Request = {
+export interface Request {
 	host: string;
 	path: string;
 	query: Query;
 	params: Params;
-};
+}
 
-export type Response = {
+export interface Response {
 	status?: number;
 	text?: string;
 	headers?: Record<string, string>;
 	body: any
-};
+}
 
-export type ServerRoute = {
+export interface ServerRoute {
 	get?: (request?: Request, session?: any) => Response | Promise<Response>;
 	post?: (request?: Request, session?: any) => Response | Promise<Response>;
 	put?: (request?: Request, session?: any) => Response | Promise<Response>;
 	del?: (request?: Request, session?: any) => Response | Promise<Response>;
-};
+}
 
-export type PageComponent = {
+export interface PageComponent {
 	default: {
 		render: (props: Record<string, any>) => {
 			html: string;
@@ -37,8 +37,8 @@ export type PageComponent = {
 		}
 	};
 	preload?: (page?: Request, session?: any) => Record<string, any>;
-};
+}
 
-export type DevConfig = {
+export interface DevConfig {
 	port: number;
-};
+}

--- a/packages/kit/src/interfaces.ts
+++ b/packages/kit/src/interfaces.ts
@@ -1,10 +1,10 @@
 import { PageComponentManifest, PageManifest, EndpointManifest } from '@sveltejs/app-utils';
 
-export type SvelteAppConfig = {
+export interface SvelteAppConfig {
 	adapter: string;
 }
 
-export type Route = {
+export interface Route {
 	id: string;
 	handlers: Array<{
 		type: 'page' | 'route';
@@ -17,36 +17,36 @@ export type Route = {
 	params: string[];
 };
 
-export type Template = {
+export interface Template {
 	render: (data: Record<string, string>) => string;
 	stream: (req, res, data: Record<string, string | Promise<string>>) => void;
-};
+}
 
-export type WritableStore<T> = {
+export interface WritableStore<T> {
 	set: (value: T) => void;
 	update: (fn: (value: T) => T) => void;
 	subscribe: (fn: (T: any) => void) => () => void;
-};
+}
 
-export type Dirs = {
+export interface Dirs {
 	dest: string;
 	src: string;
 	routes: string;
-};
+}
 
-export type ManifestData = {
+export interface ManifestData {
 	error: PageComponentManifest;
 	layout: PageComponentManifest;
 	components: PageComponentManifest[];
 	pages: PageManifest[];
 	endpoints: EndpointManifest[];
-};
+}
 
-export type ReadyEvent = {
+export interface ReadyEvent {
 	port: number;
-};
+}
 
-export type ErrorEvent = {
+export interface ErrorEvent {
 	type: string;
 	error: Error & {
 		frame?: unknown;
@@ -56,26 +56,26 @@ export type ErrorEvent = {
 			column: number;
 		};
 	};
-};
+}
 
-export type FatalEvent = {
+export interface FatalEvent {
 	message: string;
 	log?: unknown;
-};
+}
 
-export type InvalidEvent = {
+export interface InvalidEvent {
 	changed: string[];
 	invalid: {
 		client: boolean;
 		server: boolean;
 		serviceworker: boolean;
 	};
-};
+}
 
-// export type BuildEvent = {
+// export interface BuildEvent {
 // 	type: string;
 // 	errors: Array<{ file: string; message: string; duplicate: boolean }>;
 // 	warnings: Array<{ file: string; message: string; duplicate: boolean }>;
 // 	duration: number;
 // 	result: CompileResult;
-// };
+// }

--- a/packages/kit/src/runtime/navigation/types.ts
+++ b/packages/kit/src/runtime/navigation/types.ts
@@ -12,7 +12,7 @@ export type Branch = Array<{
 	part?: number;
 }>;
 
-export type InitialData = {
+export interface InitialData {
 	session: any;
 	preloaded?: object[];
 	status: number;
@@ -46,4 +46,4 @@ export interface Page {
 
 export interface PageContext extends Page {
 	error?: Error
-};
+}


### PR DESCRIPTION
This is a change we made in Sapper. Discussion here: https://github.com/sveltejs/sapper/pull/1386#discussion_r469725593

`packages/app-utils/src/types.d.ts` was changed in https://github.com/sveltejs/kit/pull/116. This handles the rest