### PR TITLE
(fix) add node to exec

### DIFF
--- a/packages/kit/src/api/build/index.ts
+++ b/packages/kit/src/api/build/index.ts
@@ -68,9 +68,9 @@ export async function build(config: SvelteAppConfig) {
 			fs.writeFileSync(setup_file, '');
 		}
 
-		await exec(`${snowpack_bin} build --out=${unoptimized}/server --ssr`);
+		await exec(`node ${snowpack_bin} build --out=${unoptimized}/server --ssr`);
 		log.success('server');
-		await exec(`${snowpack_bin} build --out=${unoptimized}/client`);
+		await exec(`node ${snowpack_bin} build --out=${unoptimized}/client`);
 		log.success('client');
 	}
 


### PR DESCRIPTION
Else build fails on windows.
If the build worked for someone before on windows I'd like to know how.. I'm also wondering why Mac/Linux would be ok with a command line execution pointing to a JS file but without the explicit command to tell it how to run it.