### PR TITLE
added eslint to kit package

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -16,6 +16,7 @@
 	"devDependencies": {
 		"@types/node": "^14.11.10",
 		"@types/sade": "^1.7.2",
+		"eslint": "^7.11.0",
 		"estree-walker": "^2.0.1",
 		"kleur": "^4.1.3",
 		"magic-string": "^0.25.7",


### PR DESCRIPTION
`run lint` wouldn't work for me without `eslint` in the local `package.json`. I suspect it works for others because it's installed globally.