### PR TITLE
Wrong version of app-util in adapter-vercel

### DIFF
--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -13,6 +13,6 @@
 		"tiny-glob": "^0.2.6"
 	},
 	"devDependencies": {
-		"@sveltejs/app-utils": "*"
+		"@sveltejs/app-utils": "workspace:*"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,7 +125,7 @@ importers:
     devDependencies:
       '@sveltejs/app-utils': 'link:../app-utils'
     specifiers:
-      '@sveltejs/app-utils': '*'
+      '@sveltejs/app-utils': 'workspace:*'
       tiny-glob: ^0.2.6
   packages/app-utils:
     dependencies:


### PR DESCRIPTION
(it's `workspace:*` in all the other adapters)