### PR TITLE
Draft: Show error page on client exception while loading

### DIFF
--- a/packages/app-utils/src/renderer/render/index.ts
+++ b/packages/app-utils/src/renderer/render/index.ts
@@ -11,9 +11,9 @@ export async function render(
 	request: IncomingRequest,
 	options: RenderOptions
 ): Promise<EndpointResponse | PageResponse | undefined> {
-	const { context, headers = {} } = (await options.setup.prepare?.(request.headers)) || {};
-
 	try {
+		const { context, headers = {} } = (await options.setup.prepare?.(request.headers)) || {};
+
 		const response = await (
 			render_endpoint(request, context, options) ||
 			render_page(request, context, options)

--- a/packages/kit/src/runtime/navigation/internal.ts
+++ b/packages/kit/src/runtime/navigation/internal.ts
@@ -1,6 +1,7 @@
 import { ScrollPosition, Target } from './types';
 import { find_anchor } from './utils';
 import { routes } from 'MANIFEST';
+import { render_error_page } from './start';
 
 // TODO
 // import { Page, Query } from '@sapper/common';
@@ -34,6 +35,9 @@ export function load_current_page(): Promise<void> {
 
 		const target = select_target(new URL(location.href));
 		if (target) return navigate(target, uid, true, hash);
+	})
+	.catch (error => {
+		render_error_page({ status: 500, error });
 	});
 }
 


### PR DESCRIPTION
Currently, if an error is thrown when a component is initializing on the client side, you wind up with an empty page and a stack trace in the console when running the built code (in dev mode you get the Snowpack overlay). If the same error occurs on the server side, you get to the project error page.

IMO it would be sensible to show the error page in both situations.

Speaking against it is that this will prevent the Snowpack error overlay from displaying in this situation in dev mode. The overlay is probably a nicer DX than the error page. We could consider using this behavior only in prod mode.

If we do want the error page, we should also consider whether we also want it on a client-side navigation action where a component blows up.

(Btw, this PR introduces a circular dependency that should be broken. Consider it a draft for discussion; I don't have a draft PR option for whatever reason)