### PR TITLE
Generate TypeScript declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"eslint-plugin-import": "^2.22.1",
 		"eslint-plugin-svelte3": "^2.7.3",
 		"rollup": "^2.32.0",
+		"rollup-plugin-typescript2": "^0.29.0",
 		"tslib": "^2.0.3",
 		"typescript": "^4.0.3"
 	}

--- a/packages/adapter-netlify/rollup.config.js
+++ b/packages/adapter-netlify/rollup.config.js
@@ -1,5 +1,6 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
+// TODO: see if we can get rollup-plugin-typescript2 working to standardize on Rollup TypeScript plugin used
 import typescript from '@rollup/plugin-typescript';
 
 export default {

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -1,5 +1,6 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
+// TODO: see if we can get rollup-plugin-typescript2 working to standardize on Rollup TypeScript plugin used
 import typescript from '@rollup/plugin-typescript';
 
 export default {

--- a/packages/app-utils/.gitignore
+++ b/packages/app-utils/.gitignore
@@ -5,3 +5,4 @@ node_modules
 /files
 /http
 /renderer
+/types

--- a/packages/app-utils/rollup.config.js
+++ b/packages/app-utils/rollup.config.js
@@ -1,5 +1,5 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import typescript from '@rollup/plugin-typescript';
+import typescript from 'rollup-plugin-typescript2';
 import pkg from './package.json';
 
 const input = {};
@@ -27,7 +27,7 @@ export default {
 	],
 	plugins: [
 		nodeResolve(),
-		typescript()
+		typescript({ useTsconfigDeclarationDir: true })
 	],
 	external: [
 		...require('module').builtinModules,

--- a/packages/app-utils/tsconfig.json
+++ b/packages/app-utils/tsconfig.json
@@ -10,8 +10,8 @@
 		"lib": ["es2020"],
 		"target": "es2019",
 
-		// "declaration": true,
-		// "declarationDir": "types",
+		"declaration": true,
+		"declarationDir": "types",
 
 		// "noEmitOnError": true,
 		"noErrorTruncation": true,

--- a/packages/create-svelte/rollup.config.js
+++ b/packages/create-svelte/rollup.config.js
@@ -1,6 +1,6 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import typescript from '@rollup/plugin-typescript';
+import typescript from 'rollup-plugin-typescript2';
 
 export default {
 	input: 'cli/index.ts',

--- a/packages/kit/client/tsconfig.json
+++ b/packages/kit/client/tsconfig.json
@@ -6,7 +6,6 @@
 		"moduleResolution": "node",
 		"target": "ES6",
 		"esModuleInterop": true,
-		"emitDeclarationOnly": true,
 		"declaration": true,
 		"outDir": "."
 	},

--- a/packages/kit/rollup.config.js
+++ b/packages/kit/rollup.config.js
@@ -1,7 +1,7 @@
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
-import typescript from '@rollup/plugin-typescript';
+import typescript from 'rollup-plugin-typescript2';
 import pkg from './package.json';
 
 const external = [].concat(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ importers:
       '@rollup/plugin-commonjs': 15.1.0_rollup@2.32.0
       '@rollup/plugin-json': 4.1.0_rollup@2.32.0
       '@rollup/plugin-node-resolve': 9.0.0_rollup@2.32.0
-      '@rollup/plugin-typescript': 6.0.0_fdbcfa007260ce7ec26f11dd44471702
+      '@rollup/plugin-typescript': 6.1.0_fdbcfa007260ce7ec26f11dd44471702
       '@sveltejs/eslint-config': github.com/sveltejs/eslint-config/7224f2bba6ac40407c332b41fa2bede946f4868f_aa0d6b64385e65baa59ec3d0ba654ef0
       '@typescript-eslint/eslint-plugin': 4.6.0_f414f6c88b79e375ea6c4ff6443d1d22
       '@typescript-eslint/parser': 4.6.0_eslint@7.11.0+typescript@4.0.3
@@ -13,6 +13,7 @@ importers:
       eslint-plugin-import: 2.22.1_eslint@7.11.0
       eslint-plugin-svelte3: 2.7.3_eslint@7.11.0
       rollup: 2.32.0
+      rollup-plugin-typescript2: 0.29.0_rollup@2.32.0+typescript@4.0.3
       tslib: 2.0.3
       typescript: 4.0.3
     specifiers:
@@ -28,6 +29,7 @@ importers:
       eslint-plugin-import: ^2.22.1
       eslint-plugin-svelte3: ^2.7.3
       rollup: ^2.32.0
+      rollup-plugin-typescript2: ^0.29.0
       tslib: ^2.0.3
       typescript: ^4.0.3
   examples/hn.svelte.dev:
@@ -609,7 +611,7 @@ packages:
       rollup: ^1.20.0 || ^2.0.0
     resolution:
       integrity: sha512-XPmVXZ7IlaoWaJLkSCDaa0Y6uVo5XQYHhiMFzOd5qSv5rE+t/UJToPIOE56flKIxBFQI27ONsxb7dqHnwSsjKQ==
-  /@rollup/plugin-typescript/6.0.0_fdbcfa007260ce7ec26f11dd44471702:
+  /@rollup/plugin-typescript/6.1.0_fdbcfa007260ce7ec26f11dd44471702:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.32.0
       resolve: 1.18.1
@@ -624,7 +626,7 @@ packages:
       tslib: '*'
       typescript: '>=3.4.0'
     resolution:
-      integrity: sha512-Y5U2L4eaF3wUSgCZRMdvNmuzWkKMyN3OwvhAdbzAi5sUqedaBk/XbzO4T7RlViDJ78MOPhwAIv2FtId/jhMtbg==
+      integrity: sha512-hJxaiE6WyNOsK+fZpbFh9CUijZYqPQuAOWO5khaGTUkM8DYNNyA2TDlgamecE+qLOG1G1+CwbWMAx3rbqpp6xQ==
   /@rollup/pluginutils/3.1.0_rollup@2.32.0:
     dependencies:
       '@types/estree': 0.0.39
@@ -1877,7 +1879,6 @@ packages:
       commondir: 1.0.1
       make-dir: 3.1.0
       pkg-dir: 4.2.0
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -2517,7 +2518,6 @@ packages:
   /make-dir/3.1.0:
     dependencies:
       semver: 6.3.0
-    dev: false
     engines:
       node: '>=8'
     resolution:
@@ -3257,6 +3257,12 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+  /resolve/1.17.0:
+    dependencies:
+      path-parse: 1.0.6
+    dev: true
+    resolution:
+      integrity: sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   /resolve/1.18.1:
     dependencies:
       is-core-module: 2.0.0
@@ -3336,6 +3342,21 @@ packages:
       rollup: ^2.0.0
     resolution:
       integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==
+  /rollup-plugin-typescript2/0.29.0_rollup@2.32.0+typescript@4.0.3:
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.32.0
+      find-cache-dir: 3.3.1
+      fs-extra: 8.1.0
+      resolve: 1.17.0
+      rollup: 2.32.0
+      tslib: 2.0.1
+      typescript: 4.0.3
+    dev: true
+    peerDependencies:
+      rollup: '>=1.26.3'
+      typescript: '>=2.4.0'
+    resolution:
+      integrity: sha512-YytahBSZCIjn/elFugEGQR5qTsVhxhUwGZIsA9TmrSsC88qroGo65O5HZP/TTArH2dm0vUmYWhKchhwi2wL9bw==
   /rollup-pluginutils/2.8.2:
     dependencies:
       estree-walker: 0.6.1
@@ -3392,7 +3413,6 @@ packages:
     resolution:
       integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
   /semver/6.3.0:
-    dev: false
     hasBin: true
     resolution:
       integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -3877,6 +3897,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+  /tslib/2.0.1:
+    dev: true
+    resolution:
+      integrity: sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
   /tslib/2.0.3:
     dev: true
     resolution:


### PR DESCRIPTION
@ehrencrona I'm sending this PR against your branch in https://github.com/sveltejs/kit/pull/121

This builds the type declarations when you build the project

This uses `rollup-plugin-typescript2` in some subprojects and `@rollup/plugin-typescript` in others, which probably isn't ideal, but works well enough for now.

I couldn't get `@rollup/plugin-typescript` to generate the types. I'm not exactly sure why, but https://github.com/rollup/plugins/issues/247 might be related. I find `@rollup/plugin-typescript` to be so full of issues I try to avoid it as much as I can

`rollup-plugin-typescript2` generated the type declarations without problem once I realized we had `"emitDeclarationOnly": true` and removed that so that it generated the `.js` files. It didn't work on a couple of the adapters, so they haven't been switched. The error message was unclear. We should file a bug to request a better error message. I was wondering if it was because of the `require` statements in `adapter-netlify` and perhaps TypeScript was expecting `import` statements instead

You should check that this works end-to-end and gets picked up by the other sub-projects. I wasn't quite sure how to test that all the pieces fit together