### PR TITLE
Do not globally generate typings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,9 +10,6 @@
 		// the only missing feature is Array.prototype.values
 		"target": "es2020",
 
-		"declaration": true,
-		"declarationDir": "types",
-
 		"noEmitOnError": true,
 		"noErrorTruncation": true,
 


### PR DESCRIPTION
Having a common `tsconfig` is great, but I don't believe it should turn on typings generation by default. For the adapters the outcome is generally not what we want. For example, the Netlify adapter puts the typings of `render.ts` into an `index.d.ts` that is next to an unrelated `index.js`. (I notice this is fixed by #138, but anyway, I don't think it's a reasonable default) 

So I think we'd better turn it off on a global level and activate it in the subprojects where we actually support it.

As for `declarationDir` it seems to be ignored by the rollup typescript plugin.