### PR TITLE
handle initialization errors in CLI

### DIFF
--- a/packages/kit/src/api/dev/index.ts
+++ b/packages/kit/src/api/dev/index.ts
@@ -19,8 +19,8 @@ import { DevConfig, Loader } from './types';
 import { copy_assets } from '../utils';
 import { readFileSync } from 'fs';
 
-export function dev(opts: DevConfig) {
-	return new Watcher(opts);
+export function dev(opts: DevConfig): Promise<Watcher> {
+	return new Watcher(opts).init();
 }
 
 class Watcher extends EventEmitter {
@@ -47,8 +47,6 @@ class Watcher extends EventEmitter {
 		process.on('exit', () => {
 			this.close();
 		});
-
-		this.init();
 	}
 
 	async init() {
@@ -61,6 +59,8 @@ class Watcher extends EventEmitter {
 		this.emit('ready', {
 			port: this.opts.port
 		} as ReadyEvent);
+
+		return this;
 	}
 
 	async init_filewatcher() {

--- a/packages/kit/src/cli.ts
+++ b/packages/kit/src/cli.ts
@@ -31,7 +31,7 @@ prog.command('dev')
 		const { dev } = await import('./api/dev');
 
 		try {
-			const watcher = dev({
+			const watcher = await dev({
 				port: opts.port
 			});
 


### PR DESCRIPTION
If an error occurs when initializing Snowpack (e.g. that the `snowpack.config.js` does not exist), there is an unhandled promise rejection. Don't drop the promise chain when initializing.