### PR TITLE
Avoid parens for single parameter arrow functions

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,7 @@
 {
-	"useTabs": true,
+	"arrowParens": "avoid",
+	"printWidth": 100,
 	"singleQuote": true,
 	"trailingComma": "none",
-	"printWidth": 100
+	"useTabs": true
 }


### PR DESCRIPTION
This is a lot more in line with current code base. If you try to reformat the whole codebase today then about half the changes are adding unnecessary parentheses. This change will allow us to reformat with fewer changes necessary. It also just looks nicer and requires reading fewer characters

`x => {}` vs `(x) => {}`