### PR TITLE
Read body in Vercel adapter

### DIFF
--- a/packages/adapter-begin/src/index.js
+++ b/packages/adapter-begin/src/index.js
@@ -27,6 +27,7 @@ exports.handler = async function http(req) {
 			method,
 			headers,
 			path,
+			// body, TODO: convert this file to typescript and utilize the body once we know what type it is and whether it first needs some conversion
 			query
 		},
 		{

--- a/packages/adapter-vercel/src/server.ts
+++ b/packages/adapter-vercel/src/server.ts
@@ -16,8 +16,8 @@ export const handler: APIGatewayProxyHandler = async (event) => {
 		path,
 		httpMethod,
 		headers,
-		queryStringParameters
-		// body, // TODO pass this to renderer
+		queryStringParameters,
+		body
 		// isBase64Encoded // TODO is this useful?
 	} = event;
 
@@ -35,6 +35,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
 			method: httpMethod as Method,
 			headers,
 			path,
+			body,
 			query
 		},
 		{


### PR DESCRIPTION
As requested in https://github.com/sveltejs/kit/issues/71

The incoming request body is a `string` in the Vercel adapter, so it looks like we can just use it directly. `render` takes the body as type `any`, which seems unspecified, but I'm assuming that a `string` would be one of the accepted types

I have no idea what the Begin types are but added a TODO that @antony can hopefully implement at some point. I'm already disliking how many adapters we have :smile: 