### PR TITLE
Revert "Moving Route and RouteParams types to app-utils"

### DIFF
--- a/packages/app-utils/index.d.ts
+++ b/packages/app-utils/index.d.ts
@@ -8,7 +8,5 @@ export {
 	Page,
 	PageContext,
 	Query,
-	Method,
-	Route,
-	RouteParams
+	Method
 } from './src/types';

--- a/packages/app-utils/src/types/index.d.ts
+++ b/packages/app-utils/src/types/index.d.ts
@@ -56,14 +56,6 @@ export interface RenderOptions {
 	dev: boolean; // TODO this is awkward
 }
 
-export interface Route {
-  pattern: RegExp;
-  parts: Array<{
-    params: (match: RegExpExecArray) => RouteParams,
-		i: number
-  }>;
-}
-
 export type RouteParams = Record<string, string | string[]>;
 
 export interface PageComponentManifest {

--- a/packages/kit/src/ambient.d.ts
+++ b/packages/kit/src/ambient.d.ts
@@ -1,20 +1,27 @@
-declare module 'MANIFEST' {
-	import { SvelteComponent } from 'svelte';
-	import { Route } from '@sveltejs/app-utils';
+declare module "MANIFEST" {
+  import { SvelteComponent } from "svelte";
 
-	export const components: Array<() => SvelteComponent>;
-	export const routes: Route[];
-	export const layout: SvelteComponent;
-	export const ErrorComponent: SvelteComponent;
+  export type Route = {
+    pattern: RegExp;
+    parts: {
+      params: (match: RegExpExecArray) => Record<string, string>,
+      i: number
+    }[];
+  };  
+
+  export const components: (() => SvelteComponent)[];
+  export const routes: Route[];
+  export const layout: SvelteComponent;
+  export const ErrorComponent: SvelteComponent;
 }
 
-declare module 'ROOT' {
-	import { SvelteComponent } from 'svelte';
+declare module "ROOT" {
+  import { SvelteComponent } from "svelte";
 
-	type Constructor<T> = {
-		new (...args: any[]): T;
-	};
+  type Constructor<T> = {
+    new (...args: any[]): T;
+  }
 
-	const root: Constructor<SvelteComponent>;
-	export default root;
+  const root: Constructor<SvelteComponent>;
+  export default root;
 }

--- a/packages/kit/src/interfaces.ts
+++ b/packages/kit/src/interfaces.ts
@@ -4,6 +4,19 @@ export interface SvelteAppConfig {
 	adapter: string;
 }
 
+export interface Route {
+	id: string;
+	handlers: Array<{
+		type: 'page' | 'route';
+		file: string;
+	}>;
+	pattern: RegExp;
+	test: (url: string) => boolean;
+	exec: (url: string) => Record<string, string>;
+	parts: string[];
+	params: string[];
+};
+
 export interface Template {
 	render: (data: Record<string, string>) => string;
 	stream: (req, res, data: Record<string, string | Promise<string>>) => void;

--- a/packages/kit/src/runtime/navigation/types.ts
+++ b/packages/kit/src/runtime/navigation/types.ts
@@ -1,5 +1,5 @@
 import { Page } from '@sveltejs/app-utils';
-export { Page, Query, PageContext, Route, RouteParams } from '@sveltejs/app-utils';
+export { Page, Query, PageContext } from '@sveltejs/app-utils';
 
 export interface HydratedTarget {
 	redirect?: Redirect;
@@ -26,6 +26,16 @@ export interface InitialData {
 export interface ScrollPosition {
 	x: number;
 	y: number;
+}
+
+export type RouteParams = Record<string, string | string[]>;
+
+export interface Route {
+  pattern: RegExp;
+  parts: Array<{
+    params: (match: RegExpExecArray) => RouteParams,
+		i: number
+  }>;
 }
 
 export interface Target {


### PR DESCRIPTION
Can't currently build `kit`. Trying this...

Reverts sveltejs/kit#146