### PR TITLE
Standardize npm lifecycle usage

### DIFF
--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -17,7 +17,6 @@
 		"lint": "eslint --ignore-pattern node_modules/ --ignore-pattern render.js \"**/*.{ts,js,svelte}\" && npm run check-format",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
-		"prepare": "npm run build",
 		"prepublishOnly": "npm run build"
 	},
 	"dependencies": {

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -11,7 +11,6 @@
 		"lint": "eslint --ignore-pattern node_modules/ \"**/*.{ts,js,svelte}\" && npm run check-format",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
-		"prepare": "npm run build",
 		"prepublishOnly": "npm run build"
 	},
 	"dependencies": {

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -5,7 +5,8 @@
 		"build": "rollup -c",
 		"lint": "eslint --ignore-pattern node_modules/ \"**/*.{ts,js,svelte}\" && npm run check-format",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
-		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore"
+		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
+		"prepublishOnly": "npm run build"
 	},
 	"dependencies": {
 		"@sveltejs/app-utils": "workspace:*"

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -5,7 +5,8 @@
 		"build": "rollup -c",
 		"lint": "eslint --ignore-pattern node_modules/ \"**/*.{ts,js,svelte}\" && npm run check-format",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
-		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore"
+		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
+		"prepublishOnly": "npm run build"
 	},
 	"main": "index.js",
 	"files": [

--- a/packages/app-utils/package.json
+++ b/packages/app-utils/package.json
@@ -8,7 +8,6 @@
 		"lint": "eslint --ignore-pattern node_modules/ --ignore-pattern dist/ --ignore-pattern files/ --ignore-pattern http/ --ignore-pattern renderer/ \"**/*.{ts,js,svelte}\" && npm run check-format",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
-		"prepare": "npm run build",
 		"prepublishOnly": "npm run build",
 		"test": "uvu -r ts-node/register"
 	},

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -16,7 +16,6 @@
 		"lint": "eslint --ignore-pattern node_modules/ --ignore-pattern bin/ \"**/*.{ts,js,svelte}\" && npm run check-format",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
-		"prepare": "npm run build",
 		"prepublishOnly": "npm run build"
 	},
 	"files": [

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -43,7 +43,6 @@
 		"lint": "eslint --ignore-pattern node_modules/ --ignore-pattern dist/ \"**/*.{ts,mjs,js,svelte}\" && npm run check-format",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
-		"prepare": "npm run build",
 		"prepublishOnly": "npm run build"
 	}
 }


### PR DESCRIPTION
Per discussion on Discord. This:
* Makes sure all packages are built
* Avoids unnecessary work when installing and publishing
