### PR TITLE
Convert the tests from TypeScript to ES

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"eslint": "^7.11.0",
 		"eslint-plugin-import": "^2.22.1",
 		"eslint-plugin-svelte3": "^2.7.3",
+		"esm": "^3.2.25",
 		"prettier": "2.1.2",
 		"rollup": "^2.32.0",
 		"rollup-plugin-typescript2": "^0.29.0",

--- a/packages/app-utils/package.json
+++ b/packages/app-utils/package.json
@@ -9,7 +9,7 @@
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"prepublishOnly": "npm run build",
-		"test": "uvu -r ts-node/register"
+		"test": "pnpm build && uvu -r esm"
 	},
 	"dependencies": {
 		"mime": "^2.4.6"
@@ -22,7 +22,6 @@
 		"node-fetch": "^2.6.1",
 		"rollup": "^2.32.0",
 		"svelte": "^3.29.0",
-		"ts-node": "^9.0.0",
 		"uvu": "^0.3.4"
 	},
 	"exports": {

--- a/packages/app-utils/src/files/index.spec.js
+++ b/packages/app-utils/src/files/index.spec.js
@@ -3,12 +3,12 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
-import { copy } from '.';
+import { copy } from '../../files';
 
 const suite_copy = suite('#copy()');
 
-let source_dir: string;
-let dest_dir: string;
+let source_dir;
+let dest_dir;
 
 suite_copy.before.each(() => {
 	const temp_dir = mkdtempSync(join(tmpdir(), 'app-utils-'));

--- a/packages/app-utils/src/renderer/manifest/index.spec.data.js
+++ b/packages/app-utils/src/renderer/manifest/index.spec.data.js
@@ -1,6 +1,4 @@
-import { PageComponentManifest, RouteManifest, PageManifest, EndpointManifest } from '../../types';
-
-const examplePageComponentManifest: PageComponentManifest = {
+const examplePageComponentManifest = {
 	default: true,
 	type: 'foo',
 	name: 'bar',
@@ -8,7 +6,7 @@ const examplePageComponentManifest: PageComponentManifest = {
 	url: 'boo'
 };
 
-const examplePageManifest: PageManifest = {
+const examplePageManifest = {
 	pattern: /a/,
 	path: 'qux',
 	parts: [
@@ -19,7 +17,7 @@ const examplePageManifest: PageManifest = {
 	]
 };
 
-const exampleEndpointManifest: EndpointManifest = {
+const exampleEndpointManifest = {
 	name: 'grault',
 	pattern: /b/,
 	file: 'garply',
@@ -27,7 +25,7 @@ const exampleEndpointManifest: EndpointManifest = {
 	params: ['waldo', 'fred']
 };
 
-export const exampleRouteManifest: RouteManifest = {
+export const exampleRouteManifest = {
 	layout: examplePageComponentManifest,
 	error: examplePageComponentManifest,
 	components: [examplePageComponentManifest, examplePageComponentManifest],

--- a/packages/app-utils/src/renderer/manifest/index.spec.js
+++ b/packages/app-utils/src/renderer/manifest/index.spec.js
@@ -1,7 +1,7 @@
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { exampleRouteManifest } from './index.spec.data';
-import { generate_manifest_module } from '.';
+import { generate_manifest_module } from '../../../renderer';
 
 const generate_manifest_module_suite = suite('#generate_manifest_module()');
 

--- a/packages/app-utils/tsconfig.json
+++ b/packages/app-utils/tsconfig.json
@@ -1,8 +1,3 @@
 {
-	"extends": "../../tsconfig.json",
-	"ts-node": {
-		"compilerOptions": {
-			"module": "commonjs"
-		}
-	}
+	"extends": "../../tsconfig.json"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ importers:
       eslint: 7.11.0
       eslint-plugin-import: 2.22.1_eslint@7.11.0
       eslint-plugin-svelte3: 2.7.3_eslint@7.11.0
+      esm: 3.2.25
       prettier: 2.1.2
       rollup: 2.32.0
       rollup-plugin-typescript2: 0.29.0_rollup@2.32.0+typescript@4.0.3
@@ -27,6 +28,7 @@ importers:
       eslint: ^7.11.0
       eslint-plugin-import: ^2.22.1
       eslint-plugin-svelte3: ^2.7.3
+      esm: ^3.2.25
       prettier: 2.1.2
       rollup: ^2.32.0
       rollup-plugin-typescript2: ^0.29.0
@@ -125,7 +127,6 @@ importers:
       node-fetch: 2.6.1
       rollup: 2.32.0
       svelte: 3.29.0
-      ts-node: 9.0.0
       uvu: 0.3.4
     specifiers:
       '@types/mime': ^2.0.3
@@ -136,7 +137,6 @@ importers:
       node-fetch: ^2.6.1
       rollup: ^2.32.0
       svelte: ^3.29.0
-      ts-node: ^9.0.0
       uvu: ^0.3.4
   packages/create-svelte:
     devDependencies:
@@ -928,10 +928,6 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
-  /arg/4.1.3:
-    dev: true
-    resolution:
-      integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
   /argparse/1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -1682,6 +1678,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==
+  /esm/3.2.25:
+    dev: true
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
   /espree/7.3.0:
     dependencies:
       acorn: 7.4.1
@@ -2495,10 +2497,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
-  /make-error/1.3.6:
-    dev: true
-    resolution:
-      integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
   /map-obj/1.0.1:
     dev: true
     engines:
@@ -3843,21 +3841,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
-  /ts-node/9.0.0:
-    dependencies:
-      arg: 4.1.3
-      diff: 4.0.2
-      make-error: 1.3.6
-      source-map-support: 0.5.19
-      yn: 3.1.1
-    dev: true
-    engines:
-      node: '>=10.0.0'
-    hasBin: true
-    peerDependencies:
-      typescript: '>=2.7'
-    resolution:
-      integrity: sha512-/TqB4SnererCDR/vb4S/QvSZvzQMJN8daAslg7MeaiHvD8rDZsSfXmNeNumyZZzMned72Xoq/isQljYSt8Ynfg==
   /tsconfig-paths/3.9.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -4132,12 +4115,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
-  /yn/3.1.1:
-    dev: true
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
   github.com/sveltejs/eslint-config/7224f2bba6ac40407c332b41fa2bede946f4868f_aa0d6b64385e65baa59ec3d0ba654ef0:
     dependencies:
       '@typescript-eslint/eslint-plugin': 4.6.0_f414f6c88b79e375ea6c4ff6443d1d22

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 		"lib": ["es2020"],
 		// target node v8+ (https://node.green/)
 		// the only missing feature is Array.prototype.values
-		"target": "es2020",
+		"target": "es2019",
 
 		"declaration": true,
 		"declarationDir": "types",


### PR DESCRIPTION
As a potential alternative to https://github.com/sveltejs/kit/pull/178 or possible first step if still deemed to not be sufficient