### PR TITLE
Changes to get build and dev behaving on windows

### DIFF
--- a/packages/kit/src/api/build/index.js
+++ b/packages/kit/src/api/build/index.js
@@ -189,7 +189,7 @@ export async function build(config) {
 						client.deps.__entry__ = get_deps(client.entry);
 
 						manifest.components.forEach((component) => {
-							const file = component.file.replace(/\.svelte$/, '.js');
+							const file = path.normalize(component.file.replace(/\.svelte$/, '.js'));
 							const key = reverse_lookup.get(file);
 
 							client.deps[component.name] = get_deps(key);

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -23,7 +23,7 @@ function handle_error(error) {
 
 async function launch(port) {
 	const { exec } = await import('child_process');
-	exec(`open http://localhost:${port}`);
+	exec(`${process.platform == 'win32' ? 'start' : 'open'} http://localhost:${port}`);
 }
 
 const prog = sade('svelte').version(pkg.version);


### PR DESCRIPTION
The examples wouldn't build on windows. This was due to the reverse lookup failing because of windows path separators.

The webpage wouldn't open on dev launch, used "start" on windows instead of "open" to fix

