### PR TITLE
correctly handle a=b%26c=d

### DIFF
--- a/packages/kit/src/api/dev/index.js
+++ b/packages/kit/src/api/dev/index.js
@@ -100,6 +100,8 @@ class Watcher extends EventEmitter {
 				return this.snowpack.handleRequest(req, res);
 			}
 
+			const parsed = parse(req.url);
+
 			static_handler(req, res, async () => {
 				try {
 					await this.snowpack.handleRequest(req, res, { handleError: false });
@@ -111,6 +113,8 @@ class Watcher extends EventEmitter {
 					}
 				}
 
+				if (req.url === '/favicon.ico') return;
+
 				const template = readFileSync(this.config.paths.template, 'utf-8').replace(
 					'</head>',
 					`
@@ -120,7 +124,6 @@ class Watcher extends EventEmitter {
 					</head>`.replace(/^\t{6}/gm, '')
 				);
 
-				const parsed = parse(req.url);
 				let setup;
 
 				try {

--- a/test/apps/basics/src/routes/query/__tests__.js
+++ b/test/apps/basics/src/routes/query/__tests__.js
@@ -1,11 +1,13 @@
 import * as assert from 'uvu/assert';
 
 export default function (test) {
-	const assert_query_echoed = (query, parsed) => async ({ visit, html }) => {
+	const assert_query_echoed = (query, parsed) => async ({ visit, text }) => {
 		await visit(`/query/echo${query}`);
 
-		assert.equal(await html('#one'), JSON.stringify(parsed));
-		assert.equal(await html('#two'), JSON.stringify(parsed));
+		const json = JSON.stringify(parsed);
+
+		assert.equal(await text('#one'), json);
+		assert.equal(await text('#two'), json);
 	};
 
 	test('exposes query string parameters', assert_query_echoed('?foo=1', { foo: '1' }));
@@ -17,6 +19,5 @@ export default function (test) {
 		assert_query_echoed('?key=one&key=two', { key: ['one', 'two'] })
 	);
 
-	/** @todo this is currently not working and should be fixed. */
-	test.skip('encoded query parameter', assert_query_echoed('?key=%26a=b', { key: '&' }));
+	test('encoded query parameter', assert_query_echoed('?key=%26a=b', { key: '&a=b' }));
 }


### PR DESCRIPTION
This is one of the bugs exposed by porting the Sapper tests over. It turns out the problem lies with sirv, which is mutating `req.url` (cc @lukeed) — it goes from `/query/echo?key=%26a=b` to `/query/echo?key=&a=b`, which obviously breaks parsing