### PR TITLE
Upgrade to latest version of source-map library

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -29,6 +29,7 @@
 		"require-relative": "^0.8.7",
 		"rimraf": "^3.0.2",
 		"sirv": "^1.0.7",
+		"source-map": "^0.7.3",
 		"source-map-support": "^0.5.19",
 		"svelte": "^3.29.0",
 		"tiny-glob": "^0.2.8"

--- a/packages/kit/src/renderer/page.js
+++ b/packages/kit/src/renderer/page.js
@@ -5,6 +5,7 @@ import fetch, { Response } from 'node-fetch';
 import { writable } from 'svelte/store';
 import { parse, resolve, URLSearchParams } from 'url';
 import { render } from './index';
+import { sourcemap_stacktrace } from '../api/dev/sourcemap_stacktrace'
 
 async function get_response({
 	request,
@@ -284,7 +285,7 @@ export default async function render_page(
 			return {
 				status: 500,
 				headers: {},
-				body: error.stack, // TODO probably not in prod?
+				body: await sourcemap_stacktrace(error.stack), // TODO probably not in prod?
 				dependencies: {}
 			};
 		}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,7 @@ importers:
       require-relative: 0.8.7
       rimraf: 3.0.2
       sirv: 1.0.7
+      source-map: 0.7.3
       source-map-support: 0.5.19
       svelte: 3.29.0
       tiny-glob: 0.2.8
@@ -218,6 +219,7 @@ importers:
       scorta: ^1.0.0
       sirv: ^1.0.7
       snowpack: ^2.17.0
+      source-map: ^0.7.3
       source-map-support: ^0.5.19
       svelte: ^3.29.0
       tiny-glob: ^0.2.8
@@ -3787,7 +3789,6 @@ packages:
     resolution:
       integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
   /source-map/0.7.3:
-    dev: false
     engines:
       node: '>= 8'
     resolution:


### PR DESCRIPTION
https://github.com/sveltejs/kit/issues/76

Sapper uses version 0.6.1 of `source-map` instead of the latest 0.7.3 because 0.7.3 is `async`. However, we're calling `sourcemap_stacktrace` it in an `async` context in Kit, so now we can use the latest

