### PR TITLE
Don't export getStores

### DIFF
--- a/packages/kit/src/runtime/app/stores/index.js
+++ b/packages/kit/src/runtime/app/stores/index.js
@@ -7,13 +7,13 @@ const ssr = typeof window === 'undefined'; // TODO why doesn't previous line wor
 let warned = false;
 export function stores() {
 	if (!warned) {
-		console.error('stores() is deprecated; use getStores() instead');
+		console.error('stores() is deprecated; import the desired store instead');
 		warned = true;
 	}
 	return getStores();
 }
 
-export const getStores = () => {
+const getStores = () => {
 	const stores = getContext('__svelte__');
 
 	return {


### PR DESCRIPTION
The examples all do:
```
import { navigating, page, session } from "$app/stores";
import { goto, prefetch, prefetchRoutes } from "$app/navigation";
```

I think that's nicer. We probably shouldn't have multiple ways of doing the same things as it might be confusing to users