### PR TITLE
Cleanup eslint ignores

### DIFF
--- a/packages/adapter-begin/package.json
+++ b/packages/adapter-begin/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0-next.0",
 	"main": "index.js",
 	"scripts": {
-		"lint": "eslint --ignore-pattern node_modules/ \"**/*.{ts,js,svelte}\" && npm run check-format",
+		"lint": "eslint --ignore-path .gitignore \"**/*.{ts,js,svelte}\" && npm run check-format",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore"
 	},

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -6,7 +6,7 @@
 		"files"
 	],
 	"scripts": {
-		"lint": "eslint --ignore-pattern node_modules/ --ignore-pattern render.js \"**/*.{ts,js,svelte}\" && npm run check-format",
+		"lint": "eslint --ignore-path .gitignore \"**/*.{ts,js,svelte}\" && npm run check-format",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore"
 	},

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -8,7 +8,7 @@
 	"scripts": {
 		"dev": "rollup -cw",
 		"build": "rollup -c",
-		"lint": "eslint --ignore-pattern node_modules/ \"**/*.{ts,js,svelte}\" && npm run check-format",
+		"lint": "eslint --ignore-path .gitignore \"**/*.{ts,js,svelte}\" && npm run check-format",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"prepublishOnly": "npm run build"

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -2,7 +2,7 @@
 	"name": "@sveltejs/adapter-static",
 	"version": "1.0.0-next.0",
 	"scripts": {
-		"lint": "eslint --ignore-pattern node_modules/ \"**/*.{ts,js,svelte}\" && npm run check-format",
+		"lint": "eslint --ignore-path .gitignore \"**/*.{ts,js,svelte}\" && npm run check-format",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore"
 	}

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -8,7 +8,7 @@
 	"scripts": {
 		"dev": "rollup -cw",
 		"build": "rollup -c",
-		"lint": "eslint --ignore-pattern node_modules/ \"**/*.{ts,js,svelte}\" && npm run check-format",
+		"lint": "eslint --ignore-path .gitignore \"**/*.{ts,js,svelte}\" && npm run check-format",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"prepublishOnly": "npm run build"

--- a/packages/app-utils/package.json
+++ b/packages/app-utils/package.json
@@ -5,7 +5,7 @@
 		"clean": "node rimraf.js files http renderer",
 		"dev": "npm run clean && rollup -cw",
 		"build": "npm run clean && rollup -c",
-		"lint": "eslint --ignore-pattern node_modules/ --ignore-pattern dist/ --ignore-pattern files/ --ignore-pattern http/ --ignore-pattern renderer/ \"**/*.{ts,js,svelte}\" && npm run check-format",
+		"lint": "eslint --ignore-path .gitignore \"**/*.{ts,js,svelte}\" && npm run check-format",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"prepublishOnly": "npm run build",

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -17,7 +17,7 @@
 	"scripts": {
 		"dev": "rollup -cw",
 		"build": "node scripts/update-versions && rollup -c",
-		"lint": "eslint --ignore-pattern node_modules/ --ignore-pattern bin/ \"**/*.{ts,js,svelte}\" && npm run check-format",
+		"lint": "eslint --ignore-path .gitignore \"**/*.{ts,js,svelte}\" && npm run check-format",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"prepublishOnly": "npm run build"

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -46,7 +46,7 @@
 	"scripts": {
 		"dev": "rollup -cw",
 		"build": "rollup -c",
-		"lint": "eslint --ignore-pattern node_modules/ --ignore-pattern dist/ --ignore-pattern assets/ \"**/*.{ts,mjs,js,svelte}\" && npm run check-format",
+		"lint": "eslint --ignore-path .gitignore \"**/*.{ts,mjs,js,svelte}\" && npm run check-format",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"prepublishOnly": "npm run build",


### PR DESCRIPTION
This is much simpler and also works better - one of the adapters was creating tons of lint errors because it was trying to lint one of the bundled files