### PR TITLE
Enable lint on CI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,5 +3,9 @@
 	"extends": "@sveltejs",
 	"parserOptions": {
 		"sourceType": "module"
+	},
+	"settings": {
+		"import/ignore": "/template/"
+
 	}
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,14 @@ jobs:
     - run: npm install -g pnpm
     - run: pnpm install --frozen-lockfile
     - run: pnpm -r build
-#  Lint:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - uses: actions/checkout@v2
-#    - uses: actions/setup-node@v1
-#    - run: npm install -g pnpm
-#    - run: pnpm install --frozen-lockfile
-#    - run: pnpm lint
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - run: npm install -g pnpm
+    - run: pnpm install --frozen-lockfile
+    - run: pnpm build --filter ./packages
+    - run: pnpm lint

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -17,7 +17,7 @@
 	"scripts": {
 		"dev": "rollup -cw",
 		"build": "node scripts/update-versions && rollup -c",
-		"lint": "eslint --ignore-path .gitignore \"**/*.{ts,js,svelte}\" && npm run check-format",
+		"lint": "eslint --ignore-path .gitignore --ignore-pattern template/ \"**/*.{ts,js,svelte}\" && npm run check-format",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"prepublishOnly": "npm run build"

--- a/packages/kit/src/api/build/index.js
+++ b/packages/kit/src/api/build/index.js
@@ -82,21 +82,27 @@ export async function build(config) {
 	];
 
 	const promises = {
-		transform_client: execFile(process.argv[0], [snowpack_bin, 'build', ...mount, `--out=${UNOPTIMIZED}/client`], {
-			env: {
-				SVELTE_KIT_APP_DIR: config.appDir
+		transform_client: execFile(
+			process.argv[0],
+			[snowpack_bin, 'build', ...mount, `--out=${UNOPTIMIZED}/client`],
+			{
+				env: {
+					SVELTE_KIT_APP_DIR: config.appDir
+				}
 			}
-		}).then(
-			() => {
-				progress.transformed_client = true;
-				render();
+		).then(() => {
+			progress.transformed_client = true;
+			render();
+		}),
+		transform_server: execFile(
+			process.argv[0],
+			[snowpack_bin, 'build', ...mount, `--out=${UNOPTIMIZED}/server`, '--ssr'],
+			{
+				env: {
+					SVELTE_KIT_APP_DIR: config.appDir
+				}
 			}
-		),
-		transform_server: execFile(process.argv[0], [snowpack_bin, 'build', ...mount, `--out=${UNOPTIMIZED}/server`, '--ssr'], {
-			env: {
-				SVELTE_KIT_APP_DIR: config.appDir
-			}
-		}).then(() => {
+		).then(() => {
 			progress.transformed_server = true;
 			render();
 		})
@@ -111,7 +117,9 @@ export async function build(config) {
 		deps: {}
 	};
 
-	const entry = path.resolve(`${UNOPTIMIZED}/client/${config.appDir}/assets/runtime/internal/start.js`);
+	const entry = path.resolve(
+		`${UNOPTIMIZED}/client/${config.appDir}/assets/runtime/internal/start.js`
+	);
 
 	const client_chunks = await rollup({
 		input: {

--- a/packages/kit/src/api/dev/index.js
+++ b/packages/kit/src/api/dev/index.js
@@ -108,7 +108,9 @@ class Watcher extends EventEmitter {
 	async init_server() {
 		const load = loader(this.snowpack, this.snowpack_config);
 
-		const { set_paths } = await load(`/${this.config.appDir}/assets/runtime/internal/singletons.js`);
+		const { set_paths } = await load(
+			`/${this.config.appDir}/assets/runtime/internal/singletons.js`
+		);
 		set_paths(this.config.paths);
 
 		const static_handler = sirv(this.config.files.static, {

--- a/packages/kit/src/api/dev/loader.js
+++ b/packages/kit/src/api/dev/loader.js
@@ -84,7 +84,9 @@ export default function loader(snowpack, config) {
 				name: 'require',
 				value: (id) => {
 					// TODO can/should this restriction be relaxed?
-					throw new Error(`Use import instead of require (attempted to load '${id}' from '${url}')`);
+					throw new Error(
+						`Use import instead of require (attempted to load '${id}' from '${url}')`
+					);
 				}
 			},
 			{
@@ -116,18 +118,17 @@ export default function loader(snowpack, config) {
 				value: { url }
 			},
 
-			...await Promise.all(deps.map(async (dep) => {
-				return {
-					name: dep.name,
-					value: await get_module(url, dep.source, url_stack)
-				};
-			}))
+			...(await Promise.all(
+				deps.map(async (dep) => {
+					return {
+						name: dep.name,
+						value: await get_module(url, dep.source, url_stack)
+					};
+				})
+			))
 		];
 
-		const fn = new Function(
-			...args.map((d) => d.name),
-			`${code}\n//# sourceURL=${url}`
-		);
+		const fn = new Function(...args.map((d) => d.name), `${code}\n//# sourceURL=${url}`);
 
 		fn(...args.map((d) => d.value));
 

--- a/packages/kit/src/api/dev/sourcemap_stacktrace.js
+++ b/packages/kit/src/api/dev/sourcemap_stacktrace.js
@@ -28,13 +28,13 @@ function get_file_contents(file_path) {
 }
 
 async function replace_async(str, regex, asyncFn) {
-    const promises = [];
-    str.replace(regex, (match, ...args) => {
-        const promise = asyncFn(match, ...args);
-        promises.push(promise);
-    });
-    const data = await Promise.all(promises);
-    return str.replace(regex, () => data.shift());
+	const promises = [];
+	str.replace(regex, (match, ...args) => {
+		const promise = asyncFn(match, ...args);
+		promises.push(promise);
+	});
+	const data = await Promise.all(promises);
+	return str.replace(regex, () => data.shift());
 }
 
 export async function sourcemap_stacktrace(stack) {

--- a/packages/kit/src/api/dev/transform.js
+++ b/packages/kit/src/api/dev/transform.js
@@ -44,14 +44,15 @@ export function transform(data) {
 
 	ast.body.forEach((node) => {
 		if (node.type === 'ImportDeclaration') {
-			const is_namespace = node.specifiers[0] && node.specifiers[0].type === 'ImportNamespaceSpecifier';
-			const default_specifier = node.specifiers.find(specifier => !specifier.imported);
+			const is_namespace =
+				node.specifiers[0] && node.specifiers[0].type === 'ImportNamespaceSpecifier';
+			const default_specifier = node.specifiers.find((specifier) => !specifier.imported);
 
 			const name = is_namespace
 				? node.specifiers[0].local.name
 				: default_specifier
-					? default_specifier.local.name
-					: get_import_name();
+				? default_specifier.local.name
+				: get_import_name();
 
 			const source = node.source.value;
 
@@ -73,11 +74,7 @@ export function transform(data) {
 
 			deps.push({ name, source });
 
-			code.overwrite(
-				node.start,
-				node.end,
-				`${__export_all}(${name})`
-			);
+			code.overwrite(node.start, node.end, `${__export_all}(${name})`);
 		}
 
 		if (node.type === 'ExportDefaultDeclaration') {
@@ -91,9 +88,11 @@ export function transform(data) {
 
 				deps.push({ name, source });
 
-				const export_block = node.specifiers.map(specifier => {
-					return `${__export}('${specifier.exported.name}', () => ${name}.${specifier.local.name})`;
-				}).join('; ');
+				const export_block = node.specifiers
+					.map((specifier) => {
+						return `${__export}('${specifier.exported.name}', () => ${name}.${specifier.local.name})`;
+					})
+					.join('; ');
 
 				code.overwrite(node.start, node.end, export_block);
 			} else if (node.declaration) {
@@ -123,7 +122,8 @@ export function transform(data) {
 						code.overwrite(
 							specifier.start,
 							specifier.end,
-							`${__export}('${specifier.exported.name}', () => ${specifier.local.name})`);
+							`${__export}('${specifier.exported.name}', () => ${specifier.local.name})`
+						);
 					});
 
 					code.remove(node.specifiers[node.specifiers.length - 1].end, node.end);

--- a/packages/kit/src/api/dev/transform.spec.js
+++ b/packages/kit/src/api/dev/transform.spec.js
@@ -90,9 +90,7 @@ test('creates live bindings', () => {
 	`
 	);
 
-	assert.equal(deps, [
-		{ name: '__import0', source: './a.js' }
-	]);
+	assert.equal(deps, [{ name: '__import0', source: './a.js' }]);
 });
 
 test('handles shorthand object properties', () => {
@@ -130,9 +128,7 @@ test('deconflicts with __importn and __export', () => {
 	`
 	);
 
-	assert.equal(deps, [
-		{ name: '__import0_', source: './a.js' }
-	]);
+	assert.equal(deps, [{ name: '__import0_', source: './a.js' }]);
 });
 
 test.run();

--- a/packages/kit/src/api/load_config/index.js
+++ b/packages/kit/src/api/load_config/index.js
@@ -21,7 +21,8 @@ function validate(definition, option, keypath) {
 		const actual = option[key];
 
 		const child_keypath = `${keypath}.${key}`;
-		const has_children = expected.default && typeof expected.default === 'object' && !Array.isArray(expected.default);
+		const has_children =
+			expected.default && typeof expected.default === 'object' && !Array.isArray(expected.default);
 
 		if (key in option) {
 			if (has_children) {
@@ -34,9 +35,7 @@ function validate(definition, option, keypath) {
 				merged[key] = expected.validate(actual, child_keypath);
 			}
 		} else {
-			merged[key] = has_children
-				? validate(expected.default, {}, child_keypath)
-				: expected.default;
+			merged[key] = has_children ? validate(expected.default, {}, child_keypath) : expected.default;
 		}
 	}
 
@@ -46,9 +45,7 @@ function validate(definition, option, keypath) {
 function resolve(from, to) {
 	// the `/.` is weird, but allows `${assets}/images/blah.jpg` to work
 	// when `assets` is empty
-	return remove_trailing_slash(
-		url.resolve(add_trailing_slash(from), to)
-	) || '/.';
+	return remove_trailing_slash(url.resolve(add_trailing_slash(from), to)) || '/.';
 }
 
 function add_trailing_slash(str) {

--- a/packages/kit/src/api/load_config/index.spec.js
+++ b/packages/kit/src/api/load_config/index.spec.js
@@ -107,56 +107,84 @@ function validate_paths(name, input, output) {
 	});
 }
 
-validate_paths('assets relative to empty string', {
-	assets: 'path/to/assets'
-}, {
-	base: '',
-	assets: '/path/to/assets'
-});
+validate_paths(
+	'assets relative to empty string',
+	{
+		assets: 'path/to/assets'
+	},
+	{
+		base: '',
+		assets: '/path/to/assets'
+	}
+);
 
-validate_paths('assets relative to base path', {
-	base: '/path/to/base',
-	assets: 'path/to/assets'
-}, {
-	base: '/path/to/base',
-	assets: '/path/to/base/path/to/assets'
-});
+validate_paths(
+	'assets relative to base path',
+	{
+		base: '/path/to/base',
+		assets: 'path/to/assets'
+	},
+	{
+		base: '/path/to/base',
+		assets: '/path/to/base/path/to/assets'
+	}
+);
 
-validate_paths('empty assets relative to base path', {
-	base: '/path/to/base'
-}, {
-	base: '/path/to/base',
-	assets: '/path/to/base'
-});
+validate_paths(
+	'empty assets relative to base path',
+	{
+		base: '/path/to/base'
+	},
+	{
+		base: '/path/to/base',
+		assets: '/path/to/base'
+	}
+);
 
-validate_paths('root-relative assets', {
-	assets: '/path/to/assets'
-}, {
-	base: '',
-	assets: '/path/to/assets'
-});
+validate_paths(
+	'root-relative assets',
+	{
+		assets: '/path/to/assets'
+	},
+	{
+		base: '',
+		assets: '/path/to/assets'
+	}
+);
 
-validate_paths('root-relative assets with base path', {
-	base: '/path/to/base',
-	assets: '/path/to/assets'
-}, {
-	base: '/path/to/base',
-	assets: '/path/to/assets'
-});
+validate_paths(
+	'root-relative assets with base path',
+	{
+		base: '/path/to/base',
+		assets: '/path/to/assets'
+	},
+	{
+		base: '/path/to/base',
+		assets: '/path/to/assets'
+	}
+);
 
-validate_paths('external assets', {
-	assets: 'https://cdn.example.com'
-}, {
-	base: '',
-	assets: 'https://cdn.example.com'
-});
+validate_paths(
+	'external assets',
+	{
+		assets: 'https://cdn.example.com'
+	},
+	{
+		base: '',
+		assets: 'https://cdn.example.com'
+	}
+);
 
-validate_paths('external assets with base', {
-	base: '/path/to/base',
-	assets: 'https://cdn.example.com'
-}, {
-	base: '/path/to/base',
-	assets: 'https://cdn.example.com'
-});
+validate_paths(
+	'external assets with base',
+	{
+		base: '/path/to/base',
+		assets: 'https://cdn.example.com'
+	},
+	{
+		base: '/path/to/base',
+		assets: 'https://cdn.example.com'
+	}
+);
 
 test.run();

--- a/packages/kit/src/api/start/index.js
+++ b/packages/kit/src/api/start/index.js
@@ -29,19 +29,22 @@ export function start({ port, config }) {
 
 			assets_handler(req, res, () => {
 				static_handler(req, res, async () => {
-					const rendered = await app.render({
-						host: null, // TODO
-						method: req.method,
-						headers: req.headers, // TODO: what about repeated headers, i.e. string[]
-						path: parsed.pathname,
-						body: await get_body(req),
-						query: new URLSearchParams(parsed.query || '')
-					}, {
-						paths: {
-							base: '',
-							assets: '/.'
+					const rendered = await app.render(
+						{
+							host: null, // TODO
+							method: req.method,
+							headers: req.headers, // TODO: what about repeated headers, i.e. string[]
+							path: parsed.pathname,
+							body: await get_body(req),
+							query: new URLSearchParams(parsed.query || '')
+						},
+						{
+							paths: {
+								base: '',
+								assets: '/.'
+							}
 						}
-					});
+					);
 
 					if (rendered) {
 						res.writeHead(rendered.status, rendered.headers);

--- a/packages/kit/src/core/create_app.js
+++ b/packages/kit/src/core/create_app.js
@@ -2,15 +2,9 @@ import * as fs from 'fs';
 import { stringify, walk, write_if_changed } from '../utils';
 
 export function create_app({ manifest_data, output }) {
-	write_if_changed(
-		`${output}/generated/manifest.js`,
-		generate_client_manifest(manifest_data)
-	);
+	write_if_changed(`${output}/generated/manifest.js`, generate_client_manifest(manifest_data));
 
-	write_if_changed(
-		`${output}/generated/root.svelte`,
-		generate_app(manifest_data)
-	);
+	write_if_changed(`${output}/generated/root.svelte`, generate_app(manifest_data));
 }
 
 function trim(str) {

--- a/packages/kit/src/core/create_manifest_data.js
+++ b/packages/kit/src/core/create_manifest_data.js
@@ -2,7 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { posixify, reserved_words } from '../utils';
 
-export default function create_manifest_data(config, extensions = '.svelte') { // TODO support .svelte.md etc?
+export default function create_manifest_data(config, extensions = '.svelte') {
+	// TODO support .svelte.md etc?
 	const cwd = config.files.routes;
 	const component_extensions = extensions.split(' ');
 

--- a/packages/kit/src/core/test/create_manifest_data.spec.js
+++ b/packages/kit/src/core/test/create_manifest_data.spec.js
@@ -168,9 +168,7 @@ test('allows multiple slugs', () => {
 });
 
 test('allows multiple slugs with nested square brackets', () => {
-	const { endpoints } = create_manifest_data(
-		get_config('samples/nested-square-brackets')
-	);
+	const { endpoints } = create_manifest_data(get_config('samples/nested-square-brackets'));
 
 	assert.equal(endpoints, [
 		{

--- a/packages/kit/src/renderer/page.js
+++ b/packages/kit/src/renderer/page.js
@@ -199,7 +199,8 @@ async function get_response({ request, options, session, page, status = 200, err
 		});
 	}
 
-	const path_to = (asset) => `${options.paths.assets}/${options.app_dir}/${asset}`.replace(/^\/\./, '');
+	const path_to = (asset) =>
+		`${options.paths.assets}/${options.app_dir}/${asset}`.replace(/^\/\./, '');
 
 	const entry = path_to(options.client.entry);
 

--- a/packages/kit/src/runtime/internal/start.js
+++ b/packages/kit/src/runtime/internal/start.js
@@ -1,5 +1,5 @@
-import Root from 'ROOT';
-import { pages, ignore, layout } from 'MANIFEST';
+import Root from 'ROOT'; // eslint-disable-line import/no-unresolved
+import { pages, ignore, layout } from 'MANIFEST'; // eslint-disable-line import/no-unresolved
 import { Router } from './router';
 import { Renderer } from './renderer';
 import { init, set_paths } from './singletons';


### PR DESCRIPTION
Three things I had to do to enable:
* I ignored the `template` directory in `create-svelte` because it couldn't resolve the `$components` import
* I ignored the imports of `ROOT` and `MANIFEST` in `packages/kit/src/runtime/internal/start.js` because I don't know what those are. I'm guessing that they're replaced at build time
* I ran `pnpm format` on the `kit` sub-package

Hopefully adding another action won't use up too many minutes, but GitHub is reporting that each one finishes in under a minute, so it seems like it should be reasonable to add