### PR TITLE
Fix missing history call when calling goto.

### DIFF
--- a/packages/kit/src/runtime/internal/router/index.js
+++ b/packages/kit/src/runtime/internal/router/index.js
@@ -159,6 +159,7 @@ export class Router {
 
 		if (selected) {
 			// TODO shouldn't need to pass the hash here
+			this.history[replaceState ? 'replaceState' : 'pushState']({}, '', href);
 			return this.navigate(selected, noscroll ? scroll_state() : false, url.hash);
 		}
 


### PR DESCRIPTION
Previously goto would render the new page but would not update the URL.
FIXES=#296
