### PR TITLE
prevent svelte-announcer causing css glitch

### DIFF
--- a/packages/kit/src/core/create_app.js
+++ b/packages/kit/src/core/create_app.js
@@ -189,13 +189,15 @@ function generate_app(manifest_data) {
 
 		<style>
 			#svelte-announcer {
+				position: absolute;
+				left: 0;
+				top: 0;
 				clip: rect(0 0 0 0);
 				clip-path: inset(50%);
-				height: 1px;
 				overflow: hidden;
-				position: absolute;
 				white-space: nowrap;
 				width: 1px;
+				height: 1px;
 			}
 		</style>
 	`);


### PR DESCRIPTION
Without the `top: 0; left: 0`, it will sit wherever it would without `position: absolute` which in some circumstances can cause a scrollbar to appear when it isn't wanted