### PR TITLE
--verbose

### DIFF
--- a/packages/kit/src/api/adapt/index.js
+++ b/packages/kit/src/api/adapt/index.js
@@ -3,14 +3,14 @@ import relative from 'require-relative';
 import { logger } from '../utils';
 import Builder from './Builder';
 
-export async function adapt(config) {
+export async function adapt(config, { verbose }) {
 	const [adapter, options] = config.adapter;
 
 	if (!adapter) {
 		throw new Error('No adapter specified');
 	}
 
-	const log = logger();
+	const log = logger({ verbose });
 
 	console.log(colors.bold().cyan(`\n> Using ${adapter}`));
 

--- a/packages/kit/src/api/utils.js
+++ b/packages/kit/src/api/utils.js
@@ -6,13 +6,17 @@ export function copy_assets() {
 	copy(resolve(__dirname, '../assets'), '.svelte/assets');
 }
 
-export function logger() {
+function noop() {}
+
+export function logger({ verbose }) {
 	const log = (msg) => console.log(msg.replace(/^/gm, '  '));
+
 	log.success = (msg) => log(colors.green(`✔ ${msg}`));
 	log.error = (msg) => log(colors.bold().red(msg));
 	log.warn = (msg) => log(colors.bold().yellow(msg));
-	log.minor = (msg) => log(colors.grey(msg));
-	log.info = log;
+
+	log.minor = verbose ? (msg) => log(colors.grey(msg)) : noop;
+	log.info = verbose ? log : noop;
 
 	return log;
 }

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -103,14 +103,15 @@ prog
 prog
 	.command('adapt')
 	.describe('Customise your production build for different platforms')
-	.action(async () => {
+	.option('--verbose', 'Log more stuff', false)
+	.action(async ({ verbose }) => {
 		process.env.NODE_ENV = 'production';
 		const config = get_config();
 
 		const { adapt } = await import('./api/adapt');
 
 		try {
-			await adapt(config);
+			await adapt(config, { verbose });
 		} catch (error) {
 			handle_error(error);
 		}


### PR DESCRIPTION
Ref #335. Turns `log.info` and `log.minor` into noops without `--verbose`. Currently only applies to `adapt`, since nothing else uses `log.info` or `log.minor`