### PR TITLE
Replace spaces with tabs

### DIFF
--- a/packages/create-svelte/cli/modifications/utils.js
+++ b/packages/create-svelte/cli/modifications/utils.js
@@ -44,9 +44,9 @@ export function add_svelte_prepocess_to_config(cwd) {
 	config = config.replace(
 		'module.exports = {',
 		`module.exports = {
-    // Consult https://github.com/sveltejs/svelte-preprocess
-    // for more information about preprocessors
-    preprocess: sveltePreprocess(),`
+	// Consult https://github.com/sveltejs/svelte-preprocess
+	// for more information about preprocessors
+	preprocess: sveltePreprocess(),`
 	);
 
 	fs.writeFileSync(file, config);


### PR DESCRIPTION
`svelte.config.js` is being created with mixed spaces and tabs. This should fix it