### PR TITLE
Bump snowpack-config version

### DIFF
--- a/.changeset/tidy-boats-listen.md
+++ b/.changeset/tidy-boats-listen.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/snowpack-config': patch
+---
+
+Make `@snowpack/plugin-svelte` use `svelte.config.cjs`

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ pnpm build
 
 You should now be able to run the [examples](examples) by navigating to one of the directories and doing `pnpm dev`.
 
+### Version bumps
+
+You can bump the package versions by running `pnpx changeset`.
+
 ## Testing
 
 Run `pnpm test` to run the tests from all subpackages. Browser tests live in subpackages of `test/` such as `test/apps/basics/`. To run a single test, open up the file and change `test` to `test.only` for the relevant test.


### PR DESCRIPTION
Kit apps are currently broken. I'd really like to get https://github.com/sveltejs/kit/pull/364 released

This is my first time trying this, so please take a look and let me know if I missed anything.

Will this automatically get published to `npm` after this or do we need to take some manual step?