### PR TITLE
Set "type":"module" for all examples

### DIFF
--- a/examples/hn.svelte.dev/package.json
+++ b/examples/hn.svelte.dev/package.json
@@ -2,6 +2,7 @@
 	"name": "hn.svelte.dev",
 	"version": "1.0.0",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",

--- a/examples/realworld.svelte.dev/package.json
+++ b/examples/realworld.svelte.dev/package.json
@@ -2,6 +2,7 @@
 	"name": "realworld.svelte.dev",
 	"version": "1.0.0",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",

--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -2,6 +2,7 @@
 	"name": "sandbox",
 	"version": "1.0.0",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",

--- a/examples/svelte-kit-demo/package.json
+++ b/examples/svelte-kit-demo/package.json
@@ -2,6 +2,7 @@
 	"name": "svelte-kit-demo",
 	"version": "1.0.0",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",


### PR DESCRIPTION
`"type":"module"` is set when you create a new app, so it'd make sense to use it for the examples as well