### PR TITLE
Fix check for no adapter specified

### DIFF
--- a/packages/kit/src/api/adapt/index.js
+++ b/packages/kit/src/api/adapt/index.js
@@ -4,11 +4,11 @@ import { logger } from '../utils';
 import Builder from './Builder';
 
 export async function adapt(config, { verbose }) {
-	const [adapter, options] = config.adapter;
-
-	if (!adapter) {
+	if (!config.adapter) {
 		throw new Error('No adapter specified');
 	}
+
+	const [adapter, options] = config.adapter;
 
 	const log = logger({ verbose });
 


### PR DESCRIPTION
Right now I'm getting `undefined is not iterable (cannot read property Symbol(Symbol.iterator))`. This fixes it so that I get `No adapter specified`