### PR TITLE
Fix adapters

### DIFF
--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -1,8 +1,11 @@
 'use strict';
 
 import { existsSync, readFileSync, copyFileSync, writeFileSync } from 'fs';
-import { resolve } from 'path';
+import { dirname, resolve } from 'path';
 import toml from 'toml';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default async function adapter(builder) {
 	let netlify_config;

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -1,6 +1,9 @@
 import { writeFileSync, mkdirSync } from 'fs';
-import { resolve, join } from 'path';
+import { dirname, resolve, join } from 'path';
+import { fileURLToPath } from 'url';
 import { copy } from '@sveltejs/app-utils/files';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default async function adapter(builder) {
 	const vercel_output_directory = resolve('.vercel_build_output');

--- a/packages/kit/src/api/adapt/index.js
+++ b/packages/kit/src/api/adapt/index.js
@@ -2,6 +2,7 @@ import colors from 'kleur';
 import { pathToFileURL } from 'url';
 import { logger } from '../utils';
 import Builder from './Builder';
+import { createRequire } from 'module';
 
 export async function adapt(config, { verbose }) {
 	const [adapter, options] = config.adapter;
@@ -20,8 +21,9 @@ export async function adapt(config, { verbose }) {
 		log
 	});
 
-	const resolved = await import.meta.resolve(adapter, pathToFileURL(process.cwd()));
-	const fn = await import(resolved);
+	const require = createRequire(import.meta.url);
+	const resolved = require.resolve(adapter, pathToFileURL(process.cwd()));
+	const fn = (await import(resolved)).default;
 	await fn(builder, options);
 
 	log.success('done');

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -4,9 +4,9 @@ import colors from 'kleur';
 import { load_config } from './api/load_config';
 import * as pkg from '../package.json';
 
-function get_config() {
+async function get_config() {
 	try {
-		return load_config();
+		return await load_config();
 	} catch (error) {
 		let message = error.message;
 
@@ -113,7 +113,7 @@ prog
 	.option('--verbose', 'Log more stuff', false)
 	.action(async ({ verbose }) => {
 		process.env.NODE_ENV = 'production';
-		const config = get_config();
+		const config = await get_config();
 
 		const { adapt } = await import('./api/adapt');
 


### PR DESCRIPTION
Right now I'm getting:

```
hn.svelte.dev $ npx svelte-kit adapt
> undefined is not iterable (cannot read property Symbol(Symbol.iterator))
TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at adapt (packages/kit/src/api/adapt/index.js:7:29)
    at packages/kit/src/cli.js:121:10
```

That's a bad error message, which is being fixed in https://github.com/sveltejs/kit/pull/384. This PR fixes the underlying issue

We should run the adapters on the CI to avoid this in the future https://github.com/sveltejs/kit/issues/382