### PR TITLE
Add node engine requirements

### DIFF
--- a/packages/create-svelte/template/package.json
+++ b/packages/create-svelte/template/package.json
@@ -12,5 +12,8 @@
 		"@sveltejs/snowpack-config": "workspace:*",
 		"svelte": "^3.29.0"
 	},
-	"type": "module"
+	"type": "module",
+	"engines": {
+		"node": ">= 12.17.0"
+	}
 }


### PR DESCRIPTION
Currently, if using `node < 12.17.0` will get an error saying:

```
internal/modules/cjs/loader.js:1172
      throw new ERR_REQUIRE_ESM(filename, parentPath, packageJsonPath);
      ^

Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /xxx/node_modules/@sveltejs/kit/svelte-kit.js
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1172:13)
    at Module.load (internal/modules/cjs/loader.js:1000:32)
    at Function.Module._load (internal/modules/cjs/loader.js:899:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:74:12)
    at internal/main/run_main_module.js:18:47 {
  code: 'ERR_REQUIRE_ESM'
}
```

Because it needs the `--experimental-modules` flag:

```sh
node --experimental-modules node_modules/.bin/svelte-kit dev
```

which was [removed after v12.17.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#2020-05-26-version-12170-erbium-lts-targos)

Adding the engine requirements makes it clearer that it needs node v12.17 and above for it to work, with the following error message:

```sh
The engine "node" is incompatible with this module. Expected version ">= 12.17.0". Got "12.16.2"
```

### Before submitting the PR, please make sure you do the following
- [x] This message body should clearly illustrate what problems it solves.

### Tests
-  [x] Run the tests with `npm test` and lint the project with `npm run lint`
