### PR TITLE
Bump marked to fix dependency version security warning

### DIFF
--- a/examples/realworld.svelte.dev/package.json
+++ b/examples/realworld.svelte.dev/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-node": "workspace:*",
 		"@sveltejs/kit": "workspace:*",
-		"marked": "^1.2.8",
+		"marked": "^2.0.0",
 		"svelte": "^3.32.1"
 	},
 	"dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,12 +45,12 @@ importers:
     devDependencies:
       '@sveltejs/adapter-node': link:../../packages/adapter-node
       '@sveltejs/kit': link:../../packages/kit
-      marked: 1.2.9
+      marked: 2.0.1
       svelte: 3.34.0
     specifiers:
       '@sveltejs/adapter-node': workspace:*
       '@sveltejs/kit': workspace:*
-      marked: ^1.2.8
+      marked: ^2.0.0
       node-fetch: ^2.6.1
       svelte: ^3.32.1
   examples/sandbox:
@@ -2310,13 +2310,13 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==
-  /marked/1.2.9:
+  /marked/2.0.1:
     dev: true
     engines:
       node: '>= 8.16.2'
     hasBin: true
     resolution:
-      integrity: sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==
+      integrity: sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==
   /meow/6.1.1:
     dependencies:
       '@types/minimist': 1.2.1


### PR DESCRIPTION
Unrelated - while testing this, I was noticing some server-side rendering issues running the realworld app:
```
(node:11879) UnhandledPromiseRejectionWarning: TypeError: res.setHeader is not a function
    at eval (src/routes/auth/register.js:14:7)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:11879) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:11879) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
TypeError: Cannot read property 'body' of undefined
    at packages/kit/dist/renderer.js:2328:16
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```