### PR TITLE
Fix svelte-kit start for Windows

### DIFF
--- a/.changeset/smart-bears-leave.md
+++ b/.changeset/smart-bears-leave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix svelte-kit start for Windows

--- a/packages/kit/src/api/start/index.js
+++ b/packages/kit/src/api/start/index.js
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as http from 'http';
-import { parse, URLSearchParams } from 'url';
+import { parse, pathToFileURL, URLSearchParams } from 'url';
 import sirv from 'sirv';
 import { get_body } from '@sveltejs/app-utils/http';
 import { join, resolve } from 'path';
@@ -13,7 +13,7 @@ const mutable = (dir) =>
 
 export async function start({ port, config }) {
 	const app_file = resolve('.svelte/output/server/app.js');
-	const app = await import(app_file);
+	const app = await import(pathToFileURL(app_file));
 
 	const static_handler = fs.existsSync(config.files.assets)
 		? mutable(config.files.assets)


### PR DESCRIPTION
Apparently I missed `svelte-kit start` when I was updating the imports to use `pathToFileURL`. Whoops.
