### PR TITLE
chore: cache pnpm store file in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,19 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Get windows pnpm cache path
+      if: runner.os == 'windows'
+      run: echo "cache_path=D:\.pnpm-store\v3" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    - name: Get non-windows pnpm cache path
+      if: runner.os != 'windows'
+      run: echo "cache_path=~/.pnpm-store/v3" >> $GITHUB_ENV
+    - name: Cache ~/.pnpm-store
+      uses: actions/cache@main
+      with:
+        path: ${{ env.cache_path }}
+        key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.node-version }}
     - run: npm install -g pnpm
     - run: pnpm install --frozen-lockfile
     - run: pnpm build --filter ./packages
@@ -49,6 +62,19 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Get windows pnpm cache path
+      if: runner.os == 'windows'
+      run: echo "cache_path=D:\.pnpm-store\v3" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    - name: Get non-windows pnpm cache path
+      if: runner.os != 'windows'
+      run: echo "cache_path=~/.pnpm-store/v3" >> $GITHUB_ENV
+    - name: Cache ~/.pnpm-store
+      uses: actions/cache@main
+      with:
+        path: ${{ env.cache_path }}
+        key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.node-version }}
     - run: npm install -g pnpm
     - run: pnpm install --frozen-lockfile
     - run: pnpm -r build
@@ -59,6 +85,13 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'
+    - name: Cache ~/.pnpm-store
+      uses: actions/cache@main
+      with:
+        path: ~/.pnpm-store
+        key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.node-version }}
     - run: npm install -g pnpm
     - run: pnpm install --frozen-lockfile
     - run: pnpm build --filter ./packages


### PR DESCRIPTION
Cache deps in CI.

- caches deps
- keys based on a hash of the lockfile
- has a fallback key for when deps have changed, that should keep install times reasonable even when some dependencies need installing
- Gets the correct store directory location for windows/ *nix 