### PR TITLE
Fix svelte-kit adapt for Windows

### DIFF
--- a/.changeset/chilly-files-greet.md
+++ b/.changeset/chilly-files-greet.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix svelte-kit adapt for Windows

--- a/packages/kit/src/api/adapt/index.js
+++ b/packages/kit/src/api/adapt/index.js
@@ -19,7 +19,7 @@ export async function adapt(config, { cwd, verbose }) {
 
 	const require = createRequire(import.meta.url);
 	const resolved = require.resolve(adapter, pathToFileURL(process.cwd()));
-	const fn = (await import(resolved)).default;
+	const fn = (await import(pathToFileURL(resolved))).default;
 	await fn(builder, options);
 
 	log.success('done');


### PR DESCRIPTION
I think this is the last missing `fileURLToPath`. I did ctrl+f for `import(` this time, so hopefully that covers all the cases.