### PR TITLE
Force LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
By default, Git on Windows checks out files using CRLF endings locally, and then converts them when you commit files. This means that when you run `pnpm lint`, it sees the CRLF endings and `prettier` throws an error.

<details><summary>pnpm lint output</summary>

```
$ pnpm lint

> kit@0.0.1 lint C:\Users\GrygrFlzr\Documents\projects\kit-backup
> pnpm -r lint

Scope: all 19 workspace projects
packages/adapter-static lint$ eslint --ignore-path .gitignore "**/*.{ts,js,svelte}" && npm run check-format
│ > @sveltejs/adapter-static@1.0.0-next.2 check-format
│ > prettier --check . --config ../../.prettierrc --ignore-path .gitignore
│ Checking formatting...
│ [warn] CHANGELOG.md
│ [warn] index.js
│ [warn] package.json
│ [warn] README.md
│ [warn] Code style issues found in the above file(s). Forgot to run Prettier?
│ npm ERR! code 1
│ npm ERR! path C:\Users\GrygrFlzr\Documents\projects\kit-backup\packages\adapter-static
│ npm ERR! command failed
│ npm ERR! command C:\Windows\system32\cmd.exe /d /s /c prettier --check . --config ../../.prettierrc --ignore-path .g
│ npm ERR! A complete log of this run can be found in:
│ npm ERR!     C:\Users\GrygrFlzr\AppData\Local\npm-cache\_logs\2021-03-03T15_14_18_179Z-debug.log
└─ Failed in 2.1s
packages/app-utils lint$ eslint --ignore-path .gitignore "**/*.{ts,js,svelte}" && npm run check-format
│ > @sveltejs/app-utils@1.0.0-next.1 check-format
│ > prettier --check . --config ../../.prettierrc --ignore-path .gitignore
│ Checking formatting...
└─ Running...
packages/adapter-netlify lint$ eslint --ignore-path .gitignore "**/*.{ts,js,svelte}" && npm run check-format
│ > @sveltejs/adapter-netlify@1.0.0-next.1 check-format
│ > prettier --check . --config ../../.prettierrc --ignore-path .gitignore
│ Checking formatting...
│ [warn] CHANGELOG.md
└─ Running...
packages/vite-plugin-svelte lint$ eslint --ignore-path .gitignore "src/**/*.{ts,mjs,js,svelte}" && npm run check-forma
│ > @sveltejs/vite-plugin-svelte@1.0.0-next.2 check-format
│ > prettier --check . --config ../../.prettierrc --ignore-path .gitignore
└─ Running...
C:\Users\GrygrFlzr\Documents\projects\kit-backup\packages\adapter-static:
 ERROR  @sveltejs/adapter-static@1.0.0-next.2 lint: `eslint --ignore-path .gitignore "**/*.{ts,js,svelte}" && npm run check-format`
Exit status 1
 ERROR  Command failed with exit code 1.
```
</details>

Running `prettier . --write` over the files will touch nearly everything, and have git see them as changed files as it has changed the line endings from CRLF to LF locally, even though on commit it would have converted them into LF endings anyway.

This `.gitattributes` file forces the check out process to use LF even on Windows, although existing Windows copies will still need to either re-clone the repo or renormalize the files:
```bash
git rm --cached -r .
git reset --hard
```