### PR TITLE
Fix adapter-vercel using the wrong directory

### DIFF
--- a/.changeset/light-roses-teach.md
+++ b/.changeset/light-roses-teach.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+Fix adapter-vercel using the wrong directory

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -19,7 +19,7 @@ export default async function adapter(builder) {
 	builder.log.minor('Building lambda...');
 	builder.copy_server_files(server_directory);
 
-	copy(join(__dirname, '../files'), lambda_directory);
+	copy(join(__dirname, 'files'), lambda_directory);
 
 	builder.log.minor('Prerendering static pages...');
 	await builder.prerender({


### PR DESCRIPTION
`adapter-vercel` was erroneously going up a directory for some reason.

Lint probably will fail until #449 is merged.