### PR TITLE
Fix CLI for Windows

### DIFF
--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -1,6 +1,7 @@
 import { existsSync } from 'fs';
 import sade from 'sade';
 import colors from 'kleur';
+import { fileURLToPath } from 'url';
 import { load_config } from './core/load_config/index.js';
 
 async function get_config() {
@@ -72,7 +73,7 @@ prog
 		process.env.NODE_ENV = 'development';
 		const config = await get_config();
 
-		const { dev } = await import('./core/dev/index.js');
+		const { dev } = await import(fileURLToPath('./core/dev/index.js'));
 
 		try {
 			const watcher = await dev({ port, config });
@@ -131,7 +132,7 @@ prog
 		process.env.NODE_ENV = 'production';
 		const config = await get_config();
 
-		const { start } = await import('./core/start/index.js');
+		const { start } = await import(fileURLToPath('./core/start/index.js'));
 
 		try {
 			await start({ port, config });


### PR DESCRIPTION
Ye olde problem of fixing paths on Windows. I think #454 probably forgot to include these.

For reasons beyond my understanding, the bare import works for `svelte-kit build`, so I've deliberately not modified that - wrapping it in `pathToFileURL` actually breaks it with `TypeError [ERR_INVALID_URL]: Invalid URL: ./core/build/index.js`, for some reason.

No changeset required since we haven't pushed out a new version yet.