### PR TITLE
Fix Windows tests

### DIFF
--- a/packages/kit/test/test.js
+++ b/packages/kit/test/test.js
@@ -7,7 +7,7 @@ import { dev } from '../src/core/dev/index.js';
 import { build } from '../src/core/build/index.js';
 import { start } from '../src/core/start/index.js';
 import { load_config } from '../src/core/load_config/index.js';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 async function setup({ port }) {
 	const browser = await chromium.launch();
@@ -191,7 +191,7 @@ async function main() {
 	for (const app of apps) {
 		const cwd = fileURLToPath(new URL(`apps/${app}`, import.meta.url));
 		const tests = await Promise.all(
-			glob('**/__tests__.js', { cwd }).map((file) => import(`${cwd}/${file}`))
+			glob('**/__tests__.js', { cwd }).map((file) => import(pathToFileURL(`${cwd}/${file}`)))
 		);
 
 		const config = await load_config({ cwd });


### PR DESCRIPTION
It's your old friend - importing without `pathToFileURL`!

Strangely, TypeScript in VS Code is complaining that `import` doesn't take in a `URL` (despite the fact that it does).

Note that Windows tests will (correctly) fail because #451 needs to be fixed via a change in either `vite-plugin-svelte` or `svelte-hmr`

If you check the CI run on the main branch, it actually only "passes" because it fails to load the tests in the first place.

https://github.com/sveltejs/kit/runs/2044743802