### PR TITLE
skip vite prebundling step

### DIFF
--- a/.changeset/brave-avocados-relax.md
+++ b/.changeset/brave-avocados-relax.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Skip pre-bundling

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -381,6 +381,9 @@ async function build_server(
 		],
 		ssr: {
 			noExternal: ['svelte']
+		},
+		optimizeDeps: {
+			entries: []
 		}
 	});
 }
@@ -456,6 +459,9 @@ async function build_service_worker(
 			alias: {
 				'$service-worker': path.resolve(`${build_dir}/runtime/service-worker`)
 			}
+		},
+		optimizeDeps: {
+			entries: []
 		}
 	});
 }


### PR DESCRIPTION
So this was a fun debugging experience: 

Vite scans your app, starting at your HTML files, looking for dependencies to prebundle before it bundles your actual app. Not totally sure I understand why this is necessary in SSR mode, or if `build.lib` is specified, but it happens.

Unfortunately, it does that by globbing for HTML files in the project directory. In a standard Vite project that's fine, because it excludes the build directory from the globbing, but it obviously doesn't know not to look at a SvelteKit adapter's output directory.

Suppose you're building an app that uses `adapter-static` to bake out some HTML for every page in your site. Let's further postulate that the site in question has a page for every county in the US, plus a few other pages, and needs to be built twice (the second time for AMP). Finally, imagine that the `src/app.html` template and its AMP counterpart contain hundreds of elements before you add your content. 

Vite will try to parse and walk all ~7,000 large pages at once. There is no `--max-old-space-size` that would make this possible.

Luckily, disabling it is very easy, hence this PR.