### PR TITLE
adapter-vercel: Use CJS entrypoint to load ESM files

### DIFF
--- a/.changeset/selfish-owls-own.md
+++ b/.changeset/selfish-owls-own.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+Fix mixed usage of CJS and ESM

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -1,4 +1,4 @@
-import { writeFileSync, mkdirSync } from 'fs';
+import { writeFileSync, mkdirSync, renameSync } from 'fs';
 import { dirname, resolve, join } from 'path';
 import { fileURLToPath } from 'url';
 import { copy } from '@sveltejs/app-utils/files';
@@ -18,6 +18,7 @@ export default async function adapter(builder) {
 
 	builder.log.minor('Building lambda...');
 	builder.copy_server_files(server_directory);
+	renameSync(join(server_directory, 'app.js'), join(server_directory, 'app.mjs'));
 
 	copy(join(__dirname, 'files'), lambda_directory);
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -28,7 +28,11 @@ export default async function adapter(builder) {
 	});
 
 	builder.log.minor('Writing routes...');
-	mkdirSync(config_directory);
+	try {
+		mkdirSync(config_directory);
+	} catch {
+		// directory already exists
+	}
 	writeFileSync(
 		join(config_directory, 'routes.json'),
 		JSON.stringify([

--- a/packages/adapter-vercel/rollup.config.js
+++ b/packages/adapter-vercel/rollup.config.js
@@ -10,5 +10,5 @@ export default {
 		exports: 'default'
 	},
 	plugins: [nodeResolve(), commonjs()],
-	external: require('module').builtinModules
+	external: [...require('module').builtinModules, './server/app.js']
 };

--- a/packages/adapter-vercel/rollup.config.js
+++ b/packages/adapter-vercel/rollup.config.js
@@ -1,14 +1,23 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
-export default {
-	input: 'src/index.js',
-	output: {
-		file: 'files/index.js',
-		format: 'esm',
-		sourcemap: true,
-		exports: 'default'
+export default [
+	{
+		input: 'src/entry.js',
+		output: {
+			file: 'files/entry.mjs',
+			format: 'es',
+			sourcemap: true,
+			exports: 'default'
+		},
+		plugins: [nodeResolve(), commonjs()],
+		external: [...require('module').builtinModules, './server/app.mjs']
 	},
-	plugins: [nodeResolve(), commonjs()],
-	external: [...require('module').builtinModules, './server/app.js']
-};
+	{
+		input: 'src/index.cjs',
+		output: {
+			file: 'files/index.js'
+		},
+		external: './entry.mjs'
+	}
+];

--- a/packages/adapter-vercel/src/entry.js
+++ b/packages/adapter-vercel/src/entry.js
@@ -5,7 +5,7 @@ export default async (req, res) => {
 	const host = `${req.headers['x-forwarded-proto']}://${req.headers.host}`;
 	const { pathname, query = '' } = new URL(req.url || '', host);
 
-	const { default: app } = await import('./server/app.js');
+	const { default: app } = await import('./server/app.mjs');
 
 	const rendered = await app.render({
 		method: req.method,

--- a/packages/adapter-vercel/src/entry.js
+++ b/packages/adapter-vercel/src/entry.js
@@ -5,9 +5,9 @@ export default async (req, res) => {
 	const host = `${req.headers['x-forwarded-proto']}://${req.headers.host}`;
 	const { pathname, query = '' } = new URL(req.url || '', host);
 
-	const { default: app } = await import('./server/app.mjs');
+	const { render } = await import('./server/app.mjs');
 
-	const rendered = await app.render({
+	const rendered = await render({
 		method: req.method,
 		headers: req.headers,
 		path: pathname,

--- a/packages/adapter-vercel/src/index.cjs
+++ b/packages/adapter-vercel/src/index.cjs
@@ -1,0 +1,4 @@
+module.exports = async (res, req) => {
+	const { default: app } = await import('./entry.mjs');
+	await app(res, req);
+};

--- a/packages/adapter-vercel/src/index.js
+++ b/packages/adapter-vercel/src/index.js
@@ -2,7 +2,8 @@ import { URL, URLSearchParams } from 'url';
 import { get_body } from '@sveltejs/app-utils/http';
 
 export default async (req, res) => {
-	const { pathname, query = '' } = new URL(req.url || '', req.host);
+	const host = `${req.headers['x-forwarded-proto']}://${req.headers.host}`;
+	const { pathname, query = '' } = new URL(req.url || '', host);
 
 	const { default: app } = await import('./server/app.js');
 

--- a/packages/adapter-vercel/src/index.js
+++ b/packages/adapter-vercel/src/index.js
@@ -1,10 +1,10 @@
-import { parse, URLSearchParams } from 'url';
+import { URL, URLSearchParams } from 'url';
 import { get_body } from '@sveltejs/app-utils/http';
 
-const app = require('./server/app.js');
-
 export default async (req, res) => {
-	const { pathname, query = '' } = parse(req.url || '');
+	const { pathname, query = '' } = new URL(req.url || '', req.host);
+
+	const { default: app } = await import('./server/app.js');
 
 	const rendered = await app.render({
 		method: req.method,


### PR DESCRIPTION
- Replace `require()` with `await import()`
- Replace `url.parse` with new `URL()`
- Use `.mjs` files for ESM with a single CJS `index.js` entrypoint