### PR TITLE
adapter-netlify: Use CJS entrypoint to load ESM files

### DIFF
--- a/.changeset/silver-scissors-peel.md
+++ b/.changeset/silver-scissors-peel.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+adapter-netlify: Use CJS entrypoint

--- a/packages/adapter-netlify/files/index.cjs
+++ b/packages/adapter-netlify/files/index.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+	async handler(event) {
+		const { handler } = await import('./handler.mjs');
+		return await handler(event);
+	}
+};

--- a/packages/adapter-netlify/files/render.js
+++ b/packages/adapter-netlify/files/render.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { URLSearchParams } from 'url';
-import { render } from './app.js'; // eslint-disable-line import/no-unresolved
+import { render } from './app.mjs'; // eslint-disable-line import/no-unresolved
 
 export async function handler(event) {
 	const {

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { existsSync, readFileSync, copyFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, copyFileSync, writeFileSync, renameSync } from 'fs';
 import { dirname, resolve } from 'path';
 import toml from 'toml';
 import { fileURLToPath } from 'url';
@@ -37,8 +37,14 @@ export default async function adapter(builder) {
 	builder.copy_client_files(publish);
 	builder.copy_server_files(`${functions}/render`);
 
+	// rename app to .mjs
+	renameSync(`${functions}/render/app.js`, `${functions}/render/app.mjs`);
+
 	// copy the renderer
-	copyFileSync(resolve(__dirname, 'files/render.js'), `${functions}/render/index.js`);
+	copyFileSync(resolve(__dirname, 'files/render.js'), `${functions}/render/handler.mjs`);
+
+	// copy the entry point
+	copyFileSync(resolve(__dirname, 'files/index.cjs'), `${functions}/render/index.js`);
 
 	// create _redirects
 	writeFileSync(`${publish}/_redirects`, '/* /.netlify/functions/render 200');


### PR DESCRIPTION
- Rename ESM files to `.mjs`
- Add CJS `index.js` entry point for lambda