### PR TITLE
call correct set_paths function

### DIFF
--- a/.changeset/healthy-pumpkins-bathe.md
+++ b/.changeset/healthy-pumpkins-bathe.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Call correct set_paths function

--- a/packages/kit/rollup.config.js
+++ b/packages/kit/rollup.config.js
@@ -17,7 +17,8 @@ export default [
 			'app/navigation': 'src/runtime/app/navigation.js',
 			'app/stores': 'src/runtime/app/stores.js',
 			'app/paths': 'src/runtime/app/paths.js',
-			'app/env': 'src/runtime/app/env.js'
+			'app/env': 'src/runtime/app/env.js',
+			paths: 'src/runtime/paths.js'
 		},
 		output: {
 			dir: 'assets/runtime',

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -262,7 +262,7 @@ async function build_server(
 		`
 			import { ssr } from '${runtime}';
 			import root from './generated/root.svelte';
-			import { set_paths } from './runtime/internal/singletons.js';
+			import { set_paths } from './runtime/paths.js';
 			import * as setup from ${s(app_relative(setup_file))};
 
 			const template = ({ head, body }) => ${s(fs.readFileSync(config.kit.files.template, 'utf-8'))
@@ -275,8 +275,6 @@ async function build_server(
 			export function init({ paths }) {
 				set_paths(paths);
 			}
-
-			init({ paths: ${s(config.kit.paths)} });
 
 			const d = decodeURIComponent;
 			const empty = () => ({});


### PR DESCRIPTION
going to expedite a release so that i can deploy a new version of the NYT's coronavirus tracker before anyone realises i broke all our AMP pages