### PR TITLE
Future proof adapters

### DIFF
--- a/.changeset/sharp-mangos-tickle.md
+++ b/.changeset/sharp-mangos-tickle.md
@@ -1,0 +1,10 @@
+---
+'@sveltejs/adapter-begin': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-static': patch
+'@sveltejs/adapter-vercel': patch
+'@sveltejs/kit': patch
+---
+
+Change adapter signature

--- a/packages/adapter-begin/index.js
+++ b/packages/adapter-begin/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import { readFileSync, existsSync } from 'fs';
 import { copy } from '@sveltejs/app-utils/files';
 import { resolve, join } from 'path';
@@ -24,27 +22,31 @@ function parse_arc(arcPath) {
 	}
 }
 
-export default async function adapter(builder) {
-	builder.log.minor('Parsing app.arc file');
-	const { static: static_mount_point } = parse_arc('app.arc');
+export default function adapter() {
+	return {
+		async adapt(builder) {
+			builder.log.minor('Parsing app.arc file');
+			const { static: static_mount_point } = parse_arc('app.arc');
 
-	const lambda_directory = resolve(join('src', 'http', 'get-index'));
-	const static_directory = resolve(static_mount_point);
-	const server_directory = resolve(join('src', 'shared'));
+			const lambda_directory = resolve(join('src', 'http', 'get-index'));
+			const static_directory = resolve(static_mount_point);
+			const server_directory = resolve(join('src', 'shared'));
 
-	builder.log.minor('Writing client application...');
-	builder.copy_static_files(static_directory);
-	builder.copy_client_files(static_directory);
+			builder.log.minor('Writing client application...');
+			builder.copy_static_files(static_directory);
+			builder.copy_client_files(static_directory);
 
-	builder.log.minor('Building lambda...');
-	const local_lambda_dir = join(__dirname, 'files');
-	copy(local_lambda_dir, lambda_directory);
+			builder.log.minor('Building lambda...');
+			const local_lambda_dir = join(__dirname, 'files');
+			copy(local_lambda_dir, lambda_directory);
 
-	builder.log.minor('Writing server application...');
-	builder.copy_server_files(server_directory);
+			builder.log.minor('Writing server application...');
+			builder.copy_server_files(server_directory);
 
-	builder.log.minor('Prerendering static pages...');
-	await builder.prerender({
-		dest: static_directory
-	});
+			builder.log.minor('Prerendering static pages...');
+			await builder.prerender({
+				dest: static_directory
+			});
+		}
+	};
 }

--- a/packages/adapter-begin/index.js
+++ b/packages/adapter-begin/index.js
@@ -22,7 +22,7 @@ function parse_arc(arcPath) {
 	}
 }
 
-export default function adapter() {
+export default function () {
 	return {
 		async adapt(builder) {
 			builder.log.minor('Parsing app.arc file');

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import { existsSync, readFileSync, copyFileSync, writeFileSync, renameSync } from 'fs';
 import { dirname, resolve } from 'path';
 import toml from 'toml';
@@ -7,51 +5,59 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-export default async function adapter(builder) {
-	let netlify_config;
+export default function () {
+	return {
+		async adapt(builder) {
+			let netlify_config;
 
-	if (existsSync('netlify.toml')) {
-		try {
-			netlify_config = toml.parse(readFileSync('netlify.toml', 'utf-8'));
-		} catch (err) {
-			err.message = `Error parsing netlify.toml: ${err.message}`;
-			throw err;
+			if (existsSync('netlify.toml')) {
+				try {
+					netlify_config = toml.parse(readFileSync('netlify.toml', 'utf-8'));
+				} catch (err) {
+					err.message = `Error parsing netlify.toml: ${err.message}`;
+					throw err;
+				}
+			} else {
+				// TODO offer to create one?
+				throw new Error(
+					'Missing a netlify.toml file. Consult https://github.com/sveltejs/kit/tree/master/packages/adapter-netlify#configuration'
+				);
+			}
+
+			if (
+				!netlify_config.build ||
+				!netlify_config.build.publish ||
+				!netlify_config.build.functions
+			) {
+				throw new Error(
+					'You must specify build.publish and build.functions in netlify.toml. Consult https://github.com/sveltejs/kit/tree/master/packages/adapter-netlify#configuration'
+				);
+			}
+
+			const publish = resolve(netlify_config.build.publish);
+			const functions = resolve(netlify_config.build.functions);
+
+			builder.copy_static_files(publish);
+			builder.copy_client_files(publish);
+			builder.copy_server_files(`${functions}/render`);
+
+			// rename app to .mjs
+			renameSync(`${functions}/render/app.js`, `${functions}/render/app.mjs`);
+
+			// copy the renderer
+			copyFileSync(resolve(__dirname, 'files/render.js'), `${functions}/render/handler.mjs`);
+
+			// copy the entry point
+			copyFileSync(resolve(__dirname, 'files/index.cjs'), `${functions}/render/index.js`);
+
+			// create _redirects
+			writeFileSync(`${publish}/_redirects`, '/* /.netlify/functions/render 200');
+
+			// prerender
+			builder.log.info('Prerendering static pages...');
+			await builder.prerender({
+				dest: publish
+			});
 		}
-	} else {
-		// TODO offer to create one?
-		throw new Error(
-			'Missing a netlify.toml file. Consult https://github.com/sveltejs/kit/tree/master/packages/adapter-netlify#configuration'
-		);
-	}
-
-	if (!netlify_config.build || !netlify_config.build.publish || !netlify_config.build.functions) {
-		throw new Error(
-			'You must specify build.publish and build.functions in netlify.toml. Consult https://github.com/sveltejs/kit/tree/master/packages/adapter-netlify#configuration'
-		);
-	}
-
-	const publish = resolve(netlify_config.build.publish);
-	const functions = resolve(netlify_config.build.functions);
-
-	builder.copy_static_files(publish);
-	builder.copy_client_files(publish);
-	builder.copy_server_files(`${functions}/render`);
-
-	// rename app to .mjs
-	renameSync(`${functions}/render/app.js`, `${functions}/render/app.mjs`);
-
-	// copy the renderer
-	copyFileSync(resolve(__dirname, 'files/render.js'), `${functions}/render/handler.mjs`);
-
-	// copy the entry point
-	copyFileSync(resolve(__dirname, 'files/index.cjs'), `${functions}/render/index.js`);
-
-	// create _redirects
-	writeFileSync(`${publish}/_redirects`, '/* /.netlify/functions/render 200');
-
-	// prerender
-	builder.log.info('Prerendering static pages...');
-	await builder.prerender({
-		dest: publish
-	});
+	};
 }

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -2,22 +2,26 @@ import { copyFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-export default async function adapter(builder) {
-	const dir = dirname(fileURLToPath(import.meta.url));
-	const out = 'build'; // TODO implement adapter options
+export default function () {
+	return {
+		async adapt(builder) {
+			const dir = dirname(fileURLToPath(import.meta.url));
+			const out = 'build'; // TODO implement adapter options
 
-	builder.log.minor('Writing client application...');
-	const static_directory = join(out, 'assets');
-	builder.copy_client_files(static_directory);
-	builder.copy_static_files(static_directory);
+			builder.log.minor('Writing client application...');
+			const static_directory = join(out, 'assets');
+			builder.copy_client_files(static_directory);
+			builder.copy_static_files(static_directory);
 
-	builder.log.minor('Building server');
-	builder.copy_server_files(out);
+			builder.log.minor('Building server');
+			builder.copy_server_files(out);
 
-	copyFileSync(`${dir}/files/server.js`, `${out}/index.js`);
+			copyFileSync(`${dir}/files/server.js`, `${out}/index.js`);
 
-	builder.log.minor('Prerendering static pages...');
-	await builder.prerender({
-		dest: `${out}/prerendered`
-	});
+			builder.log.minor('Prerendering static pages...');
+			await builder.prerender({
+				dest: `${out}/prerendered`
+			});
+		}
+	};
 }

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -1,11 +1,13 @@
-'use strict';
+export default function ({ pages = 'build', assets = 'build' } = {}) {
+	return {
+		async adapt(builder) {
+			builder.copy_static_files(assets);
+			builder.copy_client_files(assets);
 
-export default async function adapter(builder, { pages = 'build', assets = 'build' } = {}) {
-	builder.copy_static_files(assets);
-	builder.copy_client_files(assets);
-
-	await builder.prerender({
-		force: true,
-		dest: pages
-	});
+			await builder.prerender({
+				force: true,
+				dest: pages
+			});
+		}
+	};
 }

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -5,44 +5,48 @@ import { copy } from '@sveltejs/app-utils/files';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-export default async function adapter(builder) {
-	const vercel_output_directory = resolve('.vercel_build_output');
-	const config_directory = join(vercel_output_directory, 'config');
-	const static_directory = join(vercel_output_directory, 'static');
-	const lambda_directory = join(vercel_output_directory, 'functions', 'node', 'render');
-	const server_directory = join(lambda_directory, 'server');
+export default function () {
+	return {
+		async adapt(builder) {
+			const vercel_output_directory = resolve('.vercel_build_output');
+			const config_directory = join(vercel_output_directory, 'config');
+			const static_directory = join(vercel_output_directory, 'static');
+			const lambda_directory = join(vercel_output_directory, 'functions', 'node', 'render');
+			const server_directory = join(lambda_directory, 'server');
 
-	builder.log.minor('Writing client application...');
-	builder.copy_static_files(static_directory);
-	builder.copy_client_files(static_directory);
+			builder.log.minor('Writing client application...');
+			builder.copy_static_files(static_directory);
+			builder.copy_client_files(static_directory);
 
-	builder.log.minor('Building lambda...');
-	builder.copy_server_files(server_directory);
-	renameSync(join(server_directory, 'app.js'), join(server_directory, 'app.mjs'));
+			builder.log.minor('Building lambda...');
+			builder.copy_server_files(server_directory);
+			renameSync(join(server_directory, 'app.js'), join(server_directory, 'app.mjs'));
 
-	copy(join(__dirname, 'files'), lambda_directory);
+			copy(join(__dirname, 'files'), lambda_directory);
 
-	builder.log.minor('Prerendering static pages...');
-	await builder.prerender({
-		dest: static_directory
-	});
+			builder.log.minor('Prerendering static pages...');
+			await builder.prerender({
+				dest: static_directory
+			});
 
-	builder.log.minor('Writing routes...');
-	try {
-		mkdirSync(config_directory);
-	} catch {
-		// directory already exists
-	}
-	writeFileSync(
-		join(config_directory, 'routes.json'),
-		JSON.stringify([
-			{
-				handle: 'filesystem'
-			},
-			{
-				src: '/.*',
-				dest: '.vercel/functions/render'
+			builder.log.minor('Writing routes...');
+			try {
+				mkdirSync(config_directory);
+			} catch {
+				// directory already exists
 			}
-		])
-	);
+			writeFileSync(
+				join(config_directory, 'routes.json'),
+				JSON.stringify([
+					{
+						handle: 'filesystem'
+					},
+					{
+						src: '/.*',
+						dest: '.vercel/functions/render'
+					}
+				])
+			);
+		}
+	};
 }

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -56,6 +56,7 @@
 		"test:integration": "uvu test test.js"
 	},
 	"exports": {
+		"./package.json": "./package.json",
 		"./ssr": {
 			"import": "./dist/ssr.js"
 		}

--- a/packages/kit/src/core/adapt/index.js
+++ b/packages/kit/src/core/adapt/index.js
@@ -13,18 +13,20 @@ export async function adapt(config, { cwd = process.cwd(), verbose }) {
 		throw new Error('No adapter specified');
 	}
 
-	const [adapter, options] = config.kit.adapter;
+	const [name, options] = config.kit.adapter;
 
 	const log = logger({ verbose });
 
-	console.log(colors.bold().cyan(`\n> Using ${adapter}`));
+	console.log(colors.bold().cyan(`\n> Using ${name}`));
 
 	const builder = new Builder({ cwd, config, log });
 
 	const require = createRequire(import.meta.url);
-	const resolved = require.resolve(adapter, { paths: [pathToFileURL(process.cwd()).href] });
-	const fn = (await import(pathToFileURL(resolved).href)).default;
-	await fn(builder, options);
+	const resolved = require.resolve(name, { paths: [pathToFileURL(process.cwd()).href] });
+	const mod = await import(pathToFileURL(resolved).href);
+	const adapter = mod.default(options);
+
+	await adapter.adapt(builder);
 
 	log.success('done');
 }


### PR DESCRIPTION
This future-proofs the adapter API in such a way that we can add new stuff (like platform-specific deployment logic, or metadata that instructs Vite to output CJS per #503) in a non-breaking way. It also makes #439 possible, if we can figure out what we want to do about the ESM headaches