### PR TITLE
Fix paths in tsconfig.json

### DIFF
--- a/packages/create-svelte/template/tsconfig.json
+++ b/packages/create-svelte/template/tsconfig.json
@@ -2,8 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"paths": {
-			"$app/*": [".svelte/dev/runtime/app/*", ".svelte/build/runtime/app/*"],
-			"$components/*": ["src/components/*"]
+			"$app/*": ["./.svelte/dev/runtime/app/*", "./.svelte/build/runtime/app/*"],
+			"$components/*": ["./src/components/*"]
 		}
 	},
 	"include": ["src/**/*.js", "src/**/*.ts", "src/**/*.svelte"]


### PR DESCRIPTION
VS Code is reporting errors in this file (at least when used in a vanilla JS project - I didn't test with a TS project)

![Screen_Shot_2021-03-12_at_12 57 40_PM](https://user-images.githubusercontent.com/322311/110998542-cd8be400-8333-11eb-9230-13fedf7bc1b2.png)

I left renaming the file to `jsonconfig.json` for a follow-up