### PR TITLE
fix "Visit the svelte.dev"

### DIFF
--- a/examples/sandbox/src/routes/index.svelte
+++ b/examples/sandbox/src/routes/index.svelte
@@ -31,11 +31,11 @@
 
 	<p>the answer is {answer}</p>
 
-	<Counter/>
-	<p>Visit the <a href="https://svelte.dev">svelte.dev</a> to learn how to build Svelte apps.</p>
+	<Counter />
+	<p>Visit <a href="https://svelte.dev">svelte.dev</a> to learn how to build Svelte apps.</p>
 
 	<form on:submit={handle_submit} action="/doubler" method="post">
-		<input type="number" name="num" value="1">
+		<input type="number" name="num" value="1" />
 		<button>double it</button>
 	</form>
 
@@ -46,7 +46,8 @@
 
 <style>
 	:root {
-		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+			'Open Sans', 'Helvetica Neue', sans-serif;
 	}
 
 	main {

--- a/packages/create-svelte/template/src/routes/index.svelte
+++ b/packages/create-svelte/template/src/routes/index.svelte
@@ -5,13 +5,14 @@
 <main>
 	<h1>Hello world!</h1>
 
-	<Counter/>
-	<p>Visit the <a href="https://svelte.dev">svelte.dev</a> to learn how to build Svelte apps.</p>
+	<Counter />
+	<p>Visit <a href="https://svelte.dev">svelte.dev</a> to learn how to build Svelte apps.</p>
 </main>
 
 <style>
 	:root {
-		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+			'Open Sans', 'Helvetica Neue', sans-serif;
 	}
 
 	main {


### PR DESCRIPTION
This is a typo that's survived for a surprisingly long time. Plus also some other fixes because `editor.formatOnSave`.