### PR TITLE
bump vite-plugin-svelte to 0.11.0

### DIFF
--- a/.changeset/tough-chefs-remember.md
+++ b/.changeset/tough-chefs-remember.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+bump vite-plugin-svelte to 0.11.0

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -3,8 +3,7 @@
 	"version": "1.0.0-next.46",
 	"type": "module",
 	"dependencies": {
-		"@sveltejs/vite-plugin-svelte": "workspace:*",
-		"@svitejs/vite-plugin-svelte": "^0.10.0",
+		"@svitejs/vite-plugin-svelte": "^0.11.0",
 		"cheap-watch": "^1.0.3",
 		"sade": "^1.7.4"
 	},

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -142,12 +142,6 @@ async function build_client({
 		},
 		plugins: [
 			svelte({
-				emitCss: true,
-				compilerOptions: {
-					dev: true,
-					hydratable: true
-				},
-				hot: true,
 				extensions: config.extensions
 			})
 		]
@@ -389,12 +383,6 @@ async function build_server(
 		},
 		plugins: [
 			svelte({
-				emitCss: true,
-				compilerOptions: {
-					dev: true,
-					hydratable: true
-				},
-				hot: true,
 				extensions: config.extensions
 			})
 		],

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -84,12 +84,6 @@ class Watcher extends EventEmitter {
 			},
 			plugins: [
 				svelte({
-					emitCss: true,
-					compilerOptions: {
-						dev: true,
-						hydratable: true
-					},
-					hot: true, // TODO: fix type https://github.com/svitejs/svite/issues/6
 					extensions: this.config.extensions
 				})
 			],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,8 +149,7 @@ importers:
       tiny-glob: ^0.2.8
   packages/kit:
     dependencies:
-      '@sveltejs/vite-plugin-svelte': link:../vite-plugin-svelte
-      '@svitejs/vite-plugin-svelte': 0.10.0_a4965e5a794d987a97e8b2913f7a1c40
+      '@svitejs/vite-plugin-svelte': 0.11.0_a4965e5a794d987a97e8b2913f7a1c40
       cheap-watch: 1.0.3
       sade: 1.7.4
     devDependencies:
@@ -178,8 +177,7 @@ importers:
     specifiers:
       '@rollup/plugin-replace': ^2.4.1
       '@sveltejs/app-utils': workspace:*
-      '@sveltejs/vite-plugin-svelte': workspace:*
-      '@svitejs/vite-plugin-svelte': ^0.10.0
+      '@svitejs/vite-plugin-svelte': ^0.11.0
       '@types/amphtml-validator': ^1.0.1
       '@types/mime': ^2.0.3
       '@types/node': ^14.14.33
@@ -597,7 +595,7 @@ packages:
       rollup: ^1.20.0||^2.0.0
     resolution:
       integrity: sha512-TrBhfJkFxA+ER+ew2U2/fHbebhLT/l/2pRk0hfj9KusXUuRXd2v0R58AfaZK9VXDQ4TogOSEmICVrQAA3zFnHQ==
-  /@svitejs/vite-plugin-svelte/0.10.0_a4965e5a794d987a97e8b2913f7a1c40:
+  /@svitejs/vite-plugin-svelte/0.11.0_a4965e5a794d987a97e8b2913f7a1c40:
     dependencies:
       '@rollup/pluginutils': 4.1.0_rollup@2.41.1
       chalk: 4.1.0
@@ -617,7 +615,7 @@ packages:
       svelte: ^3.35.0
       vite: ^2.0.5
     resolution:
-      integrity: sha512-gttcMIZvLwanYbkfkl77o8mkPKxnYGoqz0xOfz4ZPrzJdan+DzH9b2PEQbpWb53klFKANB7FPBDr7bCaixIT5Q==
+      integrity: sha512-Zeha2eeFHUyHvyd1pqK+e5NfTeZ9zwgYSGd4fOMK/GN9iTKNhGighxWAibafE/Bh2V1JC3JEvqc+nxK+PyQE2Q==
   /@types/amphtml-validator/1.0.1:
     dependencies:
       '@types/node': 14.14.33


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts


Changelog for 0.11.0 is here: https://github.com/svitejs/svite/blob/main/packages/vite-plugin-svelte/CHANGELOG.md#0110-2021-03-13

Due to automatic configuration based on vite mode, passing options for hot and dev is no longer needed. 
