### PR TITLE
Add ts-ignore to lines that should be ignored

### DIFF
--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -389,6 +389,7 @@ async function build_server(
 		// this API is marked as @alpha https://github.com/vitejs/vite/blob/27785f7fcc5b45987b5f0bf308137ddbdd9f79ea/packages/vite/src/node/config.ts#L129
 		// it's not exposed in the typescript definitions as a result
 		// so we need to ignore the fact that it's missing
+		// @ts-ignore
 		ssr: {
 			noExternal: ['svelte', '@sveltejs/kit']
 		},

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -1,4 +1,6 @@
+// @ts-ignore
 import Root from 'ROOT'; // eslint-disable-line import/no-unresolved
+// @ts-ignore
 import { pages, ignore, layout } from 'MANIFEST'; // eslint-disable-line import/no-unresolved
 import { Router } from './router.js';
 import { Renderer } from './renderer.js';


### PR DESCRIPTION
Only half a dozen errors left after this, which are mostly caused by inconsistent typing of headers and error field