### PR TITLE
create-svelte: Actually fix component => lib transition

### DIFF
--- a/.changeset/rotten-singers-taste.md
+++ b/.changeset/rotten-singers-taste.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Actually fix $component => $lib transition

--- a/packages/create-svelte/cli/modifications/add_css.js
+++ b/packages/create-svelte/cli/modifications/add_css.js
@@ -9,7 +9,7 @@ export default async function add_css(cwd, which) {
 			less: '^3.0.0',
 			'svelte-preprocess': '^4.0.0'
 		});
-		update_component(cwd, 'src/components/Counter.svelte', [['<style>', '<style lang="less">']]);
+		update_component(cwd, 'src/lib/Counter.svelte', [['<style>', '<style lang="less">']]);
 		update_component(cwd, 'src/routes/index.svelte', [['<style>', '<style lang="less">']]);
 		add_svelte_preprocess_to_config(cwd);
 		console.log(
@@ -25,7 +25,7 @@ export default async function add_css(cwd, which) {
 			sass: '^1.0.0',
 			'svelte-preprocess': '^4.0.0'
 		});
-		update_component(cwd, 'src/components/Counter.svelte', [['<style>', '<style lang="scss">']]);
+		update_component(cwd, 'src/lib/Counter.svelte', [['<style>', '<style lang="scss">']]);
 		update_component(cwd, 'src/routes/index.svelte', [['<style>', '<style lang="scss">']]);
 		add_svelte_preprocess_to_config(cwd);
 		console.log(

--- a/packages/create-svelte/cli/modifications/add_typescript.js
+++ b/packages/create-svelte/cli/modifications/add_typescript.js
@@ -10,7 +10,7 @@ export default async function add_typescript(cwd, yes) {
 			tslib: '^2.0.0',
 			'svelte-preprocess': '^4.0.0'
 		});
-		update_component(cwd, 'src/components/Counter.svelte', [
+		update_component(cwd, 'src/lib/Counter.svelte', [
 			['<script>', '<script lang="ts">'],
 			['let count = 0', 'let count: number = 0']
 		]);

--- a/packages/create-svelte/ts-template/tsconfig.json
+++ b/packages/create-svelte/ts-template/tsconfig.json
@@ -21,7 +21,7 @@
 		"checkJs": true,
 		"paths": {
 			"$app/*": [".svelte/dev/runtime/app/*", ".svelte/build/runtime/app/*"],
-			"$components/*": ["src/components/*"]
+			"$lib/*": ["src/lib/*"]
 		}
 	},
 	"include": ["src/**/*.js", "src/**/*.ts", "src/**/*.svelte"]


### PR DESCRIPTION
We should really have integration tests that check if you can run the CLI and that the options at least build without errors.