### PR TITLE
.d.ts fixes

### DIFF
--- a/.changeset/brave-berries-join.md
+++ b/.changeset/brave-berries-join.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+kit: include missing types.d.ts

--- a/.changeset/three-chicken-ring.md
+++ b/.changeset/three-chicken-ring.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+create-svelte: Remove duplicate types

--- a/packages/create-svelte/template/globals.d.ts
+++ b/packages/create-svelte/template/globals.d.ts
@@ -1,30 +1,3 @@
 /// <reference types="@sveltejs/kit" />
+/// <reference types="svelte" />
 /// <reference types="vite/client" />
-
-//#region Ensure Svelte file endings have a type for TypeScript
-/**
- * These declarations tell TypeScript that we allow import of Svelte files in TS files, e.g.
- * ```js
- * import Component from './Component.svelte';
- * ```
- */
-declare module '*.svelte' {
-	export { SvelteComponent as default } from 'svelte';
-}
-//#endregion
-
-//#region Ensure image file endings have a type for TypeScript
-/**
- * Tell TypeScript that we allow import of images, e.g.
- * ```html
- * <script lang='ts'>
- * 	import successkid from 'images/successkid.jpg';
- * </script>
- * <img src="{successkid}">
- * ```
- */
-declare module '*.(gif|jpg|jpeg|png|svg|webp)' {
-	const value: string;
-	export = value;
-}
-//#endregion

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -40,7 +40,8 @@
 	"files": [
 		"assets",
 		"dist",
-		"client"
+		"client",
+		"types.d.ts"
 	],
 	"scripts": {
 		"dev": "rm -rf assets/runtime && rollup -cw",
@@ -59,7 +60,8 @@
 		"./package.json": "./package.json",
 		"./ssr": {
 			"import": "./dist/ssr.js"
-		}
+		},
+		"./types.d.ts": "./types.d.ts"
 	},
 	"types": "types.d.ts"
 }


### PR DESCRIPTION
`create-svelte`
- Removed `*.svelte` type, [already defined by `svelte`](https://github.com/sveltejs/svelte/blob/ce3a5791258ec6ecf8c1ea022cb871afe805a45c/src/runtime/ambient.ts)
- Removed media types, [already defined by `vite/client`](https://github.com/vitejs/vite/blob/0006e89af419472a3c4c3f0f5328242aade2939a/packages/vite/client.d.ts#L108-L109)

`kit`
- Include missing `types.d.ts`