### PR TITLE
Update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
 # READ THIS FIRST!
 
-We're getting ready to open up the SvelteKit public beta, which means that things will be in a stable enough state to start experimenting, and documentation will be available. Right now, even though [this repo is open](https://www.reddit.com/r/sveltejs/comments/m337r7/sveltekit_repository_is_now_public_on_github/gqmvj9k), there are still some known issues to resolve and there are aspects of the design that _will_ change over the next few days. We're close. Please bear with us!
+We're getting ready to open up the SvelteKit public beta, which means that things will be in a stable enough state to start experimenting. Right now, even though [this repo is open](https://www.reddit.com/r/sveltejs/comments/m337r7/sveltekit_repository_is_now_public_on_github/gqmvj9k), there are still some known issues to resolve and there are aspects of the design that _will_ change over the next few days. We're close. Please bear with us!
 
----
+## Documentation
 
-# @sveltejs/kit
-
-Everything you need to build a Svelte app.
-
-To get started, run `npm init svelte@next` — this will fetch and run the [`create-svelte`](packages/create-svelte) package.
+Please see [the documentation](https://kit.svelte.dev/docs) for information about getting started and developing with SvelteKit.
 
 ## Developing
 
@@ -50,6 +46,6 @@ New packages will need to be published manually the first time if they are scope
 npm publish --access=public
 ```
 
-## Testing
+### Testing
 
 Run `pnpm test` to run the tests from all subpackages. Browser tests live in subdirectories of `packages/kit/test` such as `packages/kit/test/apps/basics`. To run a single test, open up the file and change `test` to `test.only` for the relevant test.

--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -1,15 +1,3 @@
 # @sveltejs/kit
 
-Here be dragons, etc etc.
-
-This project aims to replicate Sapper's functionality in its entirety, minus building for deployment (which can be handled by 'adapters' that do various opinionated things with the output of `snowpack build`).
-
-It's currently missing a ton of stuff but I figured I'd throw it up on GitHub anyway partly for the sake of 'working in the open' but mostly because I need an issue tracker to organise my thoughts.
-
-There are no tests yet or anything like that. Some of the code has just been straight copied over from the existing Sapper repo, but a pleasing amount of it can safely be left behind.
-
-## Trying it out
-
-Clone this repo, `npm install`, and `npm link`. That will create a global link to the `svelte` bin. You can then either `npm run build` or `npm run dev`, if you intend to make changes and see them immediately reflected.
-
-Then, clone the corresponding [svelte-app-demo](https://github.com/sveltejs/svelte-app-demo) repo and follow the instructions therein.
+This is the core SvelteKit library. It's responsible for SSR rendering and Vite integration. It also provides the client-side library that end users call from their projects

--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -4,4 +4,4 @@ This package provides the `svelte-kit` CLI. It's responsible for SSR rendering a
 
 ## Documentation
 
-Documentation coming soon. For now it lives in GitHub: https://github.com/sveltejs/kit/tree/master/documentation
+Please see [the documentation](https://kit.svelte.dev/docs) for information about getting started and developing with SvelteKit.

--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -1,7 +1,15 @@
-# @sveltejs/kit
+# The fastest way to build Svelte apps
 
-This package provides the `svelte-kit` CLI. It's responsible for SSR rendering and Vite integration. It also provides the client-side library that end users call from their projects via `$app` and `$navigation`.
+This is the [SvelteKit](https://kit.svelte.dev) framework and CLI. 
 
-## Documentation
+The quickest way to get started is via the [create-svelte](https://github.com/sveltejs/kit/tree/master/packages/create-svelte) package:
 
-Please see [the documentation](https://kit.svelte.dev/docs) for information about getting started and developing with SvelteKit.
+```bash
+mkdir my-app
+cd my-app
+npm init svelte@next
+npm install
+npm run dev
+```
+
+See the [documentation](https://kit.svelte.dev/docs) to learn more.

--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -1,3 +1,7 @@
 # @sveltejs/kit
 
-This is the core SvelteKit library. It's responsible for SSR rendering and Vite integration. It also provides the client-side library that end users call from their projects
+This package provides the `svelte-kit` CLI. It's responsible for SSR rendering and Vite integration. It also provides the client-side library that end users call from their projects via `$app` and `$navigation`.
+
+## Documentation
+
+Documentation coming soon. For now it lives in GitHub: https://github.com/sveltejs/kit/tree/master/documentation


### PR DESCRIPTION
At first I was just going to remove this thinking that there was no need for it given the README in the main repo, but then I decided it'd be useful to have some minimal content here to help users who might want to contribute and are navigating the directory structure and also realized that it probably shows up on npm