### PR TITLE
disable transform cache

### DIFF
--- a/.changeset/wet-worms-cross.md
+++ b/.changeset/wet-worms-cross.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Disable vite-plugin-svelte transform cache

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -94,6 +94,8 @@ class Watcher extends EventEmitter {
 			plugins: [
 				...(user_config.plugins || []),
 				svelte({
+					// TODO remove this once vite-plugin-svelte caching bugs are fixed
+					disableTransformCache: true,
 					extensions: this.config.extensions
 				})
 			],


### PR DESCRIPTION
I think we should just disable the transform cache altogether for now. Fixes #572