### PR TITLE
prevent erroneous <style>undefined</style> 

### DIFF
--- a/.changeset/old-files-jump.md
+++ b/.changeset/old-files-jump.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Prevent erronous <style>undefined</style>

--- a/packages/kit/src/runtime/server/page.js
+++ b/packages/kit/src/runtime/server/page.js
@@ -340,7 +340,7 @@ async function get_response({ request, options, $session, route, status = 200, e
 
 	const head = [
 		rendered.head,
-		options.amp ? '' : `<style data-svelte>${style}</style>`,
+		style && !options.amp ? `<style data-svelte>${style}</style>` : '',
 		links,
 		init
 	].join('\n\n');


### PR DESCRIPTION
fixes #516. I suspect there's more work to be done around injected styles — specifically around sourcemaps, deduplication and always using .css files instead of `<style>` — but this is the quick win