### PR TITLE
Pass adapters directly to config

### DIFF
--- a/.changeset/tough-lamps-brake.md
+++ b/.changeset/tough-lamps-brake.md
@@ -1,0 +1,11 @@
+---
+'@sveltejs/adapter-begin': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-static': patch
+'@sveltejs/adapter-vercel': patch
+'create-svelte': patch
+'@sveltejs/kit': patch
+---
+
+Pass adapters directly to svelte.config.cjs

--- a/documentation/docs/10-adapters.md
+++ b/documentation/docs/10-adapters.md
@@ -8,9 +8,11 @@ For example, if you want to run your app as a simple Node server, you would use 
 
 ```js
 // svelte.config.cjs
+const node = require('@sveltejs/adapter-node');
+
 module.exports = {
 	kit: {
-		adapter: '@sveltejs/adapter-node'
+		adapter: node()
 	}
 };
 ```
@@ -19,26 +21,25 @@ With this, [svelte-kit build](#command-line-interface-svelte-kit-build) will gen
 
 ```diff
 // svelte.config.cjs
+const node = require('@sveltejs/adapter-node');
+
 module.exports = {
 	kit: {
--		adapter: '@sveltejs/adapter-node'
-+		adapter: ['@sveltejs/adapter-node', {
-+			out: 'my-output-directory'
-+		}]
+-		adapter: node()
++		adapter: node({ out: 'my-output-directory' })
 	}
 };
 ```
 
 A variety of official adapters exist for serverless platforms...
 
-* [`adapter-begin`](https://github.com/sveltejs/kit/tree/master/packages/adapter-begin) — for [begin.com](https://begin.com)
-* [`adapter-netlify`](https://github.com/sveltejs/kit/tree/master/packages/adapter-netlify) — for [netlify.com](https://netlify.com)
-* [`adapter-vercel`](https://github.com/sveltejs/kit/tree/master/packages/adapter-vercel) — for [vercel.com](https://vercel.com)
+- [`adapter-begin`](https://github.com/sveltejs/kit/tree/master/packages/adapter-begin) — for [begin.com](https://begin.com)
+- [`adapter-netlify`](https://github.com/sveltejs/kit/tree/master/packages/adapter-netlify) — for [netlify.com](https://netlify.com)
+- [`adapter-vercel`](https://github.com/sveltejs/kit/tree/master/packages/adapter-vercel) — for [vercel.com](https://vercel.com)
 
 ...and others:
 
-* [`adapter-node`](https://github.com/sveltejs/kit/tree/master/packages/adapter-node) — for creating self-contained Node apps
-* [`adapter-static`](https://github.com/sveltejs/kit/tree/master/packages/adapter-static) — for prerendering your entire site as a collection of static files
-
+- [`adapter-node`](https://github.com/sveltejs/kit/tree/master/packages/adapter-node) — for creating self-contained Node apps
+- [`adapter-static`](https://github.com/sveltejs/kit/tree/master/packages/adapter-static) — for prerendering your entire site as a collection of static files
 
 > The adapter API is still in flux and will likely change before 1.0.

--- a/documentation/docs/13-configuration.md
+++ b/documentation/docs/13-configuration.md
@@ -48,7 +48,7 @@ module.exports = {
 
 #### adapter
 
-Determines how the output of `svelte-kit build` is converted for different platforms. Can be specified as a `string` or a `[string, object]` tuple if you need to pass options.
+Determines how the output of `svelte-kit build` is converted for different platforms. See [Adapters](#adapters).
 
 #### amp
 

--- a/examples/hn.svelte.dev/svelte.config.cjs
+++ b/examples/hn.svelte.dev/svelte.config.cjs
@@ -1,6 +1,8 @@
+const netlify = require('@sveltejs/adapter-netlify');
+
 module.exports = {
 	kit: {
-		adapter: '@sveltejs/adapter-netlify',
+		adapter: netlify(),
 		target: '#svelte'
 	}
 };

--- a/examples/realworld.svelte.dev/svelte.config.cjs
+++ b/examples/realworld.svelte.dev/svelte.config.cjs
@@ -1,9 +1,11 @@
+const node = require('@sveltejs/adapter-node');
+
 module.exports = {
 	kit: {
 		// By default, `npm run build` will create a standard Node app.
 		// You can create optimized builds for different platforms by
 		// specifying a different adapter
-		adapter: '@sveltejs/adapter-node',
+		adapter: node(),
 
 		// hydrate the <div id="svelte"> element in src/app.html
 		target: '#svelte',

--- a/examples/sandbox/svelte.config.cjs
+++ b/examples/sandbox/svelte.config.cjs
@@ -1,8 +1,9 @@
+const node = require('@sveltejs/adapter-node');
 const pkg = require('./package.json');
 
 module.exports = {
 	kit: {
-		adapter: '@sveltejs/adapter-node',
+		adapter: node(),
 		target: '#svelte',
 		vite: {
 			build: {

--- a/examples/svelte-kit-demo/svelte.config.cjs
+++ b/examples/svelte-kit-demo/svelte.config.cjs
@@ -1,6 +1,8 @@
+const node = require('@sveltejs/adapter-node');
+
 module.exports = {
 	kit: {
-		adapter: '@sveltejs/adapter-node',
+		adapter: node(),
 		target: '#svelte'
 	}
 };

--- a/packages/adapter-begin/.gitignore
+++ b/packages/adapter-begin/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 node_modules
 /files
+/index.cjs
+/index.cjs.map

--- a/packages/adapter-begin/index.js
+++ b/packages/adapter-begin/index.js
@@ -3,27 +3,29 @@ import { copy } from '@sveltejs/app-utils/files';
 import { resolve, join } from 'path';
 import parse from '@architect/parser';
 
-function parse_arc(arcPath) {
-	if (!existsSync(arcPath)) {
-		throw new Error(`No ${arcPath} found. See the documentation.`);
+/** @param {string} file */
+function parse_arc(file) {
+	if (!existsSync(file)) {
+		throw new Error(`No ${file} found. See the documentation.`);
 	}
 
 	try {
-		const text = readFileSync(arcPath).toString();
+		const text = readFileSync(file).toString();
 		const arc = parse(text);
 
 		return {
 			static: arc.static[0][1]
 		};
 	} catch (e) {
-		throw new Error(
-			`Error parsing ${arcPath}. Please consult the documentation for correct syntax.`
-		);
+		throw new Error(`Error parsing ${file}. Please consult the documentation for correct syntax.`);
 	}
 }
 
 export default function () {
-	return {
+	/** @type {import('@sveltejs/kit').Adapter} */
+	const adapter = {
+		name: '@sveltejs/adapter-begin',
+
 		async adapt(builder) {
 			builder.log.minor('Parsing app.arc file');
 			const { static: static_mount_point } = parse_arc('app.arc');
@@ -49,4 +51,6 @@ export default function () {
 			});
 		}
 	};
+
+	return adapter;
 }

--- a/packages/adapter-begin/package.json
+++ b/packages/adapter-begin/package.json
@@ -1,13 +1,14 @@
 {
 	"name": "@sveltejs/adapter-begin",
 	"version": "1.0.0-next.3",
-	"main": "index.js",
+	"main": "index.cjs",
 	"scripts": {
 		"lint": "eslint --ignore-path .gitignore \"**/*.{ts,js,svelte}\" && npm run check-format",
 		"dev": "rollup -cw",
 		"build": "rollup -c",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
-		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore"
+		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
+		"prepublishOnly": "npm run build"
 	},
 	"files": [
 		"files"
@@ -17,7 +18,13 @@
 		"@sveltejs/app-utils": "workspace:*"
 	},
 	"devDependencies": {
+		"@sveltejs/kit": "workspace:*",
 		"rollup": "^2.41.1",
-		"sirv": "^1.0.11"
+		"sirv": "^1.0.11",
+		"typescript": "^4.2.3"
+	},
+	"exports": {
+		"import": "./index.js",
+		"require": "./index.cjs"
 	}
 }

--- a/packages/adapter-begin/rollup.config.js
+++ b/packages/adapter-begin/rollup.config.js
@@ -1,14 +1,28 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
-export default {
-	input: 'src/index.js',
-	output: {
-		file: 'files/index.js',
-		format: 'cjs',
-		sourcemap: true,
-		exports: 'named'
+export default [
+	{
+		input: 'src/index.js',
+		output: {
+			file: 'files/index.js',
+			format: 'cjs',
+			sourcemap: true,
+			exports: 'named'
+		},
+		plugins: [nodeResolve(), commonjs()],
+		external: [...require('module').builtinModules, '@architect/shared/app.js']
 	},
-	plugins: [nodeResolve(), commonjs()],
-	external: [...require('module').builtinModules, '@architect/shared/app.js']
-};
+
+	{
+		input: 'index.js',
+		output: {
+			file: 'index.cjs',
+			format: 'cjs',
+			sourcemap: true,
+			exports: 'named'
+		},
+		plugins: [nodeResolve(), commonjs()],
+		external: [...require('module').builtinModules, '@architect/parser']
+	}
+];

--- a/packages/adapter-begin/tsconfig.json
+++ b/packages/adapter-begin/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"noEmit": true,
+		"noImplicitAny": true,
+		"target": "es2020",
+		"module": "es2020",
+		"moduleResolution": "node",
+		"allowSyntheticDefaultImports": true
+	},
+	"include": ["./index.js", "src"]
+}

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -1,12 +1,12 @@
-import { existsSync, readFileSync, copyFileSync, writeFileSync, renameSync } from 'fs';
-import { dirname, resolve } from 'path';
-import toml from 'toml';
-import { fileURLToPath } from 'url';
+const { existsSync, readFileSync, copyFileSync, writeFileSync, renameSync } = require('fs');
+const { resolve } = require('path');
+const toml = require('toml');
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+module.exports = function () {
+	/** @type {import('@sveltejs/kit').Adapter} */
+	const adapter = {
+		name: '@sveltejs/adapter-netlify',
 
-export default function () {
-	return {
 		async adapt(builder) {
 			let netlify_config;
 
@@ -60,4 +60,6 @@ export default function () {
 			});
 		}
 	};
-}
+
+	return adapter;
+};

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -2,7 +2,6 @@
 	"name": "@sveltejs/adapter-netlify",
 	"version": "1.0.0-next.3",
 	"main": "index.js",
-	"type": "module",
 	"files": [
 		"files"
 	],
@@ -13,5 +12,9 @@
 	},
 	"dependencies": {
 		"toml": "^3.0.0"
+	},
+	"devDependencies": {
+		"@sveltejs/kit": "workspace:*",
+		"typescript": "^4.2.3"
 	}
 }

--- a/packages/adapter-netlify/tsconfig.json
+++ b/packages/adapter-netlify/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"noEmit": true,
+		"noImplicitAny": true,
+		"target": "es2020",
+		"module": "es2020",
+		"moduleResolution": "node",
+		"allowSyntheticDefaultImports": true
+	},
+	"include": ["./index.js", "src"]
+}

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -1,18 +1,17 @@
-import { copyFileSync } from 'fs';
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
+const { copyFileSync } = require('fs');
+const { join } = require('path');
 
 /**
  * @param {{
  *   out?: string;
  * }} options
  */
-export default function ({ out = 'build' } = {}) {
+module.exports = function ({ out = 'build' } = {}) {
 	/** @type {import('@sveltejs/kit').Adapter} */
 	const adapter = {
-		async adapt(builder) {
-			const dir = dirname(fileURLToPath(import.meta.url));
+		name: '@sveltejs/adapter-node',
 
+		async adapt(builder) {
 			builder.log.minor('Copying assets');
 			const static_directory = join(out, 'assets');
 			builder.copy_client_files(static_directory);
@@ -21,7 +20,7 @@ export default function ({ out = 'build' } = {}) {
 			builder.log.minor('Copying server');
 			builder.copy_server_files(out);
 
-			copyFileSync(`${dir}/files/server.js`, `${out}/index.js`);
+			copyFileSync(`${__dirname}/files/server.js`, `${out}/index.js`);
 
 			builder.log.minor('Prerendering static pages');
 			await builder.prerender({
@@ -31,4 +30,4 @@ export default function ({ out = 'build' } = {}) {
 	};
 
 	return adapter;
-}
+};

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -2,7 +2,6 @@
 	"name": "@sveltejs/adapter-node",
 	"version": "1.0.0-next.8",
 	"main": "index.js",
-	"type": "module",
 	"files": [
 		"files"
 	],

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -1,5 +1,8 @@
-export default function ({ pages = 'build', assets = 'build' } = {}) {
-	return {
+module.exports = function ({ pages = 'build', assets = 'build' } = {}) {
+	/** @type {import('@sveltejs/kit').Adapter} */
+	const adapter = {
+		name: '@sveltejs/adapter-static',
+
 		async adapt(builder) {
 			builder.copy_static_files(assets);
 			builder.copy_client_files(assets);
@@ -10,4 +13,6 @@ export default function ({ pages = 'build', assets = 'build' } = {}) {
 			});
 		}
 	};
-}
+
+	return adapter;
+};

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -1,10 +1,13 @@
 {
 	"name": "@sveltejs/adapter-static",
 	"version": "1.0.0-next.3",
-	"type": "module",
 	"scripts": {
 		"lint": "eslint --ignore-path .gitignore \"**/*.{ts,js,svelte}\" && npm run check-format",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore"
+	},
+	"devDependencies": {
+		"@sveltejs/kit": "workspace:*",
+		"typescript": "^4.2.3"
 	}
 }

--- a/packages/adapter-static/tsconfig.json
+++ b/packages/adapter-static/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"noEmit": true,
+		"noImplicitAny": true,
+		"target": "es2020",
+		"module": "es2020",
+		"moduleResolution": "node",
+		"allowSyntheticDefaultImports": true
+	},
+	"include": ["./index.js", "src"]
+}

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -1,12 +1,12 @@
 import { writeFileSync, mkdirSync, renameSync } from 'fs';
-import { dirname, resolve, join } from 'path';
-import { fileURLToPath } from 'url';
+import { resolve, join } from 'path';
 import { copy } from '@sveltejs/app-utils/files';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+module.exports = function () {
+	/** @type {import('@sveltejs/kit').Adapter} */
+	const adapter = {
+		name: '@sveltejs/adapter-vercel',
 
-export default function () {
-	return {
 		async adapt(builder) {
 			const vercel_output_directory = resolve('.vercel_build_output');
 			const config_directory = join(vercel_output_directory, 'config');
@@ -49,4 +49,6 @@ export default function () {
 			);
 		}
 	};
-}
+
+	return adapter;
+};

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -18,7 +18,9 @@
 		"@sveltejs/app-utils": "workspace:*"
 	},
 	"devDependencies": {
+		"@sveltejs/kit": "workspace:*",
 		"rollup": "^2.41.1",
-		"sirv": "^1.0.11"
+		"sirv": "^1.0.11",
+		"typescript": "^4.2.3"
 	}
 }

--- a/packages/adapter-vercel/tsconfig.json
+++ b/packages/adapter-vercel/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"noEmit": true,
+		"noImplicitAny": true,
+		"target": "es2020",
+		"module": "es2020",
+		"moduleResolution": "node",
+		"allowSyntheticDefaultImports": true
+	},
+	"include": ["./index.js", "src"]
+}

--- a/packages/create-svelte/template/svelte.config.cjs
+++ b/packages/create-svelte/template/svelte.config.cjs
@@ -1,3 +1,4 @@
+const node = require('@sveltejs/adapter-node');
 const pkg = require('./package.json');
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -6,7 +7,7 @@ module.exports = {
 		// By default, `npm run build` will create a standard Node app.
 		// You can create optimized builds for different platforms by
 		// specifying a different adapter
-		adapter: '@sveltejs/adapter-node',
+		adapter: node(),
 
 		// hydrate the <div id="svelte"> element in src/app.html
 		target: '#svelte',

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -97,7 +97,7 @@ prog
 
 			console.log(`\nRun ${colors.bold().cyan('npm start')} to try your app locally.`);
 
-			if (config.kit.adapter[0]) {
+			if (config.kit.adapter) {
 				const { adapt } = await import('./core/adapt/index.js');
 				await adapt(config, { verbose });
 			} else {

--- a/packages/kit/src/core/adapt/index.js
+++ b/packages/kit/src/core/adapt/index.js
@@ -1,32 +1,19 @@
 import colors from 'kleur';
-import { pathToFileURL } from 'url';
 import { logger } from '../utils.js';
 import Builder from './Builder.js';
-import { createRequire } from 'module';
 
 /**
  * @param {import('../../../types.internal').ValidatedConfig} config
  * @param {{ cwd?: string, verbose: boolean }} opts
  */
 export async function adapt(config, { cwd = process.cwd(), verbose }) {
-	if (!config.kit.adapter) {
-		throw new Error('No adapter specified');
-	}
-
-	const [name, options] = config.kit.adapter;
-
-	const log = logger({ verbose });
+	const { name, adapt } = config.kit.adapter;
 
 	console.log(colors.bold().cyan(`\n> Using ${name}`));
 
+	const log = logger({ verbose });
 	const builder = new Builder({ cwd, config, log });
-
-	const require = createRequire(import.meta.url);
-	const resolved = require.resolve(name, { paths: [pathToFileURL(process.cwd()).href] });
-	const mod = await import(pathToFileURL(resolved).href);
-	const adapter = mod.default(options);
-
-	await adapter.adapt(builder);
+	await adapt(builder);
 
 	log.success('done');
 }

--- a/packages/kit/src/core/load_config/options.js
+++ b/packages/kit/src/core/load_config/options.js
@@ -39,13 +39,16 @@ const options = {
 				type: 'leaf',
 				default: [null],
 				validate: (option, keypath) => {
-					// support both `adapter: 'foo'` and `adapter: ['foo', opts]`
-					if (!Array.isArray(option)) {
-						option = [option];
-					}
+					if (typeof option !== 'object' || !option.adapt) {
+						let message = `${keypath} should be an object with an "adapt" method`;
 
-					// TODO allow inline functions
-					assert_is_string(option[0], keypath);
+						if (Array.isArray(option) || typeof option === 'string') {
+							// for the early adapter adopters
+							message += ', rather than the name of an adapter';
+						}
+
+						throw new Error(`${message}. See https://kit.svelte.dev/docs#adapters`);
+					}
 
 					return option;
 				}

--- a/packages/kit/test/apps/basics/svelte.config.cjs
+++ b/packages/kit/test/apps/basics/svelte.config.cjs
@@ -1,6 +1,5 @@
 module.exports = {
 	kit: {
-		adapter: '@sveltejs/adapter-node',
 		hostHeader: 'x-forwarded-host',
 		vite: {
 			build: {

--- a/packages/kit/test/apps/custom-extension/svelte.config.cjs
+++ b/packages/kit/test/apps/custom-extension/svelte.config.cjs
@@ -1,7 +1,3 @@
 module.exports = {
-	extensions: ['.jesuslivesineveryone', '.whokilledthemuffinman', '.svelte.md', '.svelte'],
-
-	kit: {
-		adapter: '@sveltejs/adapter-node'
-	}
+	extensions: ['.jesuslivesineveryone', '.whokilledthemuffinman', '.svelte.md', '.svelte']
 };

--- a/packages/kit/test/apps/options/svelte.config.cjs
+++ b/packages/kit/test/apps/options/svelte.config.cjs
@@ -1,6 +1,5 @@
 module.exports = {
 	kit: {
-		adapter: '@sveltejs/adapter-node',
 		files: {
 			assets: 'public',
 			lib: 'source/components',

--- a/packages/kit/types.d.ts
+++ b/packages/kit/types.d.ts
@@ -4,7 +4,7 @@ export type Config = {
 	compilerOptions?: any;
 	extensions?: string[];
 	kit?: {
-		adapter?: string | [string, any];
+		adapter?: Adapter;
 		amp?: boolean;
 		appDir?: string;
 		files?: {
@@ -42,6 +42,7 @@ type Builder = {
 };
 
 export type Adapter = {
+	name: string;
 	adapt: (builder: Builder) => Promise<void>;
 };
 

--- a/packages/kit/types.internal.d.ts
+++ b/packages/kit/types.internal.d.ts
@@ -1,4 +1,4 @@
-import { Load } from './types';
+import { Adapter, Load } from './types';
 
 declare global {
 	interface ImportMeta {
@@ -19,7 +19,7 @@ export type ValidatedConfig = {
 	compilerOptions: any;
 	extensions: string[];
 	kit: {
-		adapter: [string, any];
+		adapter: Adapter;
 		amp: boolean;
 		appDir: string;
 		files: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,18 +78,27 @@ importers:
       '@architect/parser': 3.0.1
       '@sveltejs/app-utils': link:../app-utils
     devDependencies:
+      '@sveltejs/kit': link:../kit
       rollup: 2.41.1
       sirv: 1.0.11
+      typescript: 4.2.3
     specifiers:
       '@architect/parser': ^3.0.1
       '@sveltejs/app-utils': workspace:*
+      '@sveltejs/kit': workspace:*
       rollup: ^2.41.1
       sirv: ^1.0.11
+      typescript: ^4.2.3
   packages/adapter-netlify:
     dependencies:
       toml: 3.0.0
+    devDependencies:
+      '@sveltejs/kit': link:../kit
+      typescript: 4.2.3
     specifiers:
+      '@sveltejs/kit': workspace:*
       toml: ^3.0.0
+      typescript: ^4.2.3
   packages/adapter-node:
     devDependencies:
       '@rollup/plugin-json': 4.1.0_rollup@2.41.1
@@ -110,17 +119,26 @@ importers:
       sirv: ^1.0.11
       typescript: ^4.2.3
   packages/adapter-static:
-    specifiers: {}
+    devDependencies:
+      '@sveltejs/kit': link:../kit
+      typescript: 4.2.3
+    specifiers:
+      '@sveltejs/kit': workspace:*
+      typescript: ^4.2.3
   packages/adapter-vercel:
     dependencies:
       '@sveltejs/app-utils': link:../app-utils
     devDependencies:
+      '@sveltejs/kit': link:../kit
       rollup: 2.41.1
       sirv: 1.0.11
+      typescript: 4.2.3
     specifiers:
       '@sveltejs/app-utils': workspace:*
+      '@sveltejs/kit': workspace:*
       rollup: ^2.41.1
       sirv: ^1.0.11
+      typescript: ^4.2.3
   packages/app-utils:
     devDependencies:
       '@types/node': 14.14.33
@@ -635,17 +653,17 @@ packages:
     dev: true
     resolution:
       integrity: sha512-oJqcTrgPUF29oUP8AsUqbXGJNuPutsetaa9kTQAQce5Lx5dTYWV02ScBiT/k1BX/Z7pKeqedmvp39Wu4zR7N7g==
-  /@types/node/14.14.34:
+  /@types/node/14.14.35:
     dev: true
     resolution:
-      integrity: sha512-dBPaxocOK6UVyvhbnpFIj2W+S+1cBTkHQbFQfeeJhoKFbzYcVUGHvddeWPSucKATb3F0+pgDq0i6ghEaZjsugA==
+      integrity: sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
   /@types/normalize-package-data/2.4.0:
     dev: true
     resolution:
       integrity: sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
   /@types/resolve/1.17.1:
     dependencies:
-      '@types/node': 14.14.34
+      '@types/node': 14.14.35
     dev: true
     resolution:
       integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
@@ -2385,13 +2403,13 @@ packages:
   /ms/2.1.2:
     resolution:
       integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-  /nanoid/3.1.21:
+  /nanoid/3.1.22:
     dev: true
     engines:
       node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1
     hasBin: true
     resolution:
-      integrity: sha512-A6oZraK4DJkAOICstsGH98dvycPr/4GGDH7ZWKmMdd3vGcOurZ6JmWFUt0DA5bzrrn2FrUjmv6mFNWvv8jpppA==
+      integrity: sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==
   /natural-compare/1.4.0:
     dev: true
     resolution:
@@ -2735,7 +2753,7 @@ packages:
   /postcss/8.2.8:
     dependencies:
       colorette: 1.2.2
-      nanoid: 3.1.21
+      nanoid: 3.1.22
       source-map: 0.6.1
     dev: true
     engines:


### PR DESCRIPTION
Closes #439. Slightly unfortunate that this requires turning the adapters back into CommonJS packages, but I think this is a fundamentally better design.