### PR TITLE
Fix adapter-vercel imports

### DIFF
--- a/.changeset/new-birds-march.md
+++ b/.changeset/new-birds-march.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+Fix adapter-vercel imports

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -1,6 +1,6 @@
-import { writeFileSync, mkdirSync, renameSync } from 'fs';
-import { resolve, join } from 'path';
-import { copy } from '@sveltejs/app-utils/files';
+const { writeFileSync, mkdirSync, renameSync } = require('fs');
+const { resolve, join } = require('path');
+const { copy } = require('@sveltejs/app-utils/files');
 
 module.exports = function () {
 	/** @type {import('@sveltejs/kit').Adapter} */

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -2,7 +2,6 @@
 	"name": "@sveltejs/adapter-vercel",
 	"version": "1.0.0-next.6",
 	"main": "index.js",
-	"type": "module",
 	"files": [
 		"files"
 	],


### PR DESCRIPTION
I've seen lots of reports of `adapter-vercel` having recently been broken. I don't have a Vercel account to test this, so I have no idea if it works, but I would assume the issue is related to ES6 import and CJS export in the same file