### PR TITLE
fix: builder.copy is not a function while building with adapter-vercel

### DIFF
--- a/.changeset/famous-turtles-appear.md
+++ b/.changeset/famous-turtles-appear.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add copy function to Builder.js

--- a/packages/kit/src/core/adapt/Builder.js
+++ b/packages/kit/src/core/adapt/Builder.js
@@ -37,6 +37,15 @@ export default class Builder {
 		rimraf(path);
 	}
 
+	/**
+	 * @param {string} from
+	 * @param {string} to
+	 * @param {(basename: string) => boolean} filter
+	 */
+	copy(from, to, filter = () => true) {
+		copy(from, to, filter);
+	}
+
 	/** @param {string} dir */
 	mkdirp(dir) {
 		mkdirp(dir);


### PR DESCRIPTION
Hi, I noticed that the `builder.copy` line was replacing a line that calls the copy function in @sveltejs/app-utils/files. I found that the same function is now exported by `@sveltejs/kit/filesystem`. So I tried replacing builder.copy with the copy function from `@sveltejs/kit/filesystem`.

I've tested this on the realworld.svelte.dev example project by temporarily replacing its adapter-node with adapter-vercel and it seems to be working.

Fixes  #617. 