### PR TITLE
Added template transform api and changed documentation

### DIFF
--- a/.changeset/sweet-masks-leave.md
+++ b/.changeset/sweet-masks-leave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+Added template transform api, requested in the sapper repo #1695 #1642

--- a/.changeset/sweet-masks-leave.md
+++ b/.changeset/sweet-masks-leave.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/kit': minor
+'@sveltejs/kit': patch
 ---
 
 Added template transform api, requested in the sapper repo #1695 #1642

--- a/documentation/docs/04-setup.md
+++ b/documentation/docs/04-setup.md
@@ -117,7 +117,7 @@ This function takes the `src/app.html template` and the `context` returned from 
  * }} options
  * @returns {string}
  */
-export function getSession({ context, template }) {
+export function transformTemplate({ context, template }) {
 	if (!context.darkMode) {
 		return template;
 	}

--- a/examples/sandbox/src/app.html
+++ b/examples/sandbox/src/app.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
-	<meta charset="utf-8">
-	<link rel="icon" href="/favicon.ico">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	%svelte.head%
-</head>
-<body>
-	<div id="svelte">%svelte.body%</div>
-</body>
+<html class="%svelte.htmlClass%" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" href="/favicon.ico" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%svelte.head%
+	</head>
+	<body>
+		<div id="svelte">%svelte.body%</div>
+	</body>
 </html>

--- a/examples/sandbox/src/setup/index.js
+++ b/examples/sandbox/src/setup/index.js
@@ -1,7 +1,8 @@
 export function prepare({ headers }) {
 	return {
 		context: {
-			answer: 42
+			answer: 42,
+			darkMode: true
 		},
 		headers: {
 			'x-foo': 'banana'
@@ -11,4 +12,11 @@ export function prepare({ headers }) {
 
 export function getSession({ context }) {
 	return context;
+}
+
+export function transformTemplate({ context, template }) {
+	if (context.darkMode) {
+		return template.replace('%svelte.htmlClass%', 'dark');
+	}
+	return template;
 }

--- a/packages/kit/src/runtime/server/page.js
+++ b/packages/kit/src/runtime/server/page.js
@@ -397,9 +397,10 @@ async function get_response({ request, options, context, $session, route, status
 	}
 
 	let template = options.template({ head, body });
-	template =
-		(await (options.setup.transformTemplate &&
-			options.setup.transformTemplate({ template, context }))) || template;
+
+	if (options.setup.transformTemplate) {
+		template = (await options.setup.transformTemplate({ template, context })) || template;
+	}
 
 	return {
 		status,

--- a/packages/kit/test/apps/template-transform/src/app.html
+++ b/packages/kit/test/apps/template-transform/src/app.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html class="%svelte.htmlClass%" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%svelte.head%
+	</head>
+	<body>
+		%svelte.body%
+	</body>
+</html>

--- a/packages/kit/test/apps/template-transform/src/routes/__tests__.js
+++ b/packages/kit/test/apps/template-transform/src/routes/__tests__.js
@@ -1,0 +1,8 @@
+import * as assert from 'uvu/assert';
+
+/** @type {import('../../../../types').TestMaker} */
+export default function (test) {
+	test('Should apply dark class to html element', '/', async ({ page }) => {
+		assert.equal(await page.evaluate(() => document.documentElement.className), 'dark');
+	});
+}

--- a/packages/kit/test/apps/template-transform/src/routes/index.svelte
+++ b/packages/kit/test/apps/template-transform/src/routes/index.svelte
@@ -1,0 +1,1 @@
+Template Transform Test

--- a/packages/kit/test/apps/template-transform/src/setup.js
+++ b/packages/kit/test/apps/template-transform/src/setup.js
@@ -1,0 +1,28 @@
+export function prepare() {
+	return {
+		context: {
+			darkMode: true,
+			answer: 42
+		}
+	};
+}
+
+/** @param {any} context */
+export function getSession({ context }) {
+	return context;
+}
+
+/**
+ * @param {{
+ *   template: string
+ *   context: any
+ * }} options
+ * @returns {string}
+ */
+export function transformTemplate({ context, template }) {
+	if (!context.darkMode) {
+		return template;
+	}
+
+	return template.replace('%svelte.htmlClass%', 'dark');
+}

--- a/packages/kit/test/apps/template-transform/svelte.config.cjs
+++ b/packages/kit/test/apps/template-transform/svelte.config.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+	kit: {
+		hostHeader: 'x-forwarded-host',
+		vite: {
+			build: {
+				minify: false
+			},
+			clearScreen: false
+		}
+	}
+};

--- a/packages/kit/types.internal.d.ts
+++ b/packages/kit/types.internal.d.ts
@@ -185,6 +185,7 @@ export type SSRRenderOptions = {
 			headers?: Headers;
 		};
 		getSession?: ({ context }: { context: any }) => any;
+		transformTemplate?: ({ context, template }: { context: any; template: string }) => string;
 	};
 	dev?: boolean;
 	amp?: boolean;


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

I couldn't find any issue or milestone about transforming the app.html template as requested in [#1642](https://github.com/sveltejs/sapper/pull/1642) and [1695](https://github.com/sveltejs/sapper/pull/1695).

This opens up for stuff like adding classes to the html element or changing the language attribute. 
It would be really useful for tailwind darkmode or theming in general, adding csrf token on a meta tag etc.

Im open for any changes to this, its also okay if you don't consider this right now it would just help me adding proper darkmode to my project without setting it on the client with javascript.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

I don't really know how to write tests for this atm.

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
