### PR TITLE
hydrate initial page before starting router

### DIFF
--- a/.changeset/sharp-pigs-study.md
+++ b/.changeset/sharp-pigs-study.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Hydrate initial page before starting router

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -134,7 +134,10 @@ export class Renderer {
 			const hydrated = await this._hydrate(selected);
 
 			if (hydrated.redirect) {
-				throw new Error('TODO client-side redirects');
+				// this is a real edge case — `load` would need to return
+				// a redirect but only in the browser
+				location.href = new URL(hydrated.redirect, location.href).href;
+				return;
 			}
 
 			Object.assign(props, hydrated.props);

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -36,8 +36,8 @@ export async function start({ paths, target, session, error, status, nodes, page
 	init({ router, renderer });
 	set_paths(paths);
 
-	router.init(renderer);
 	await renderer.start({ nodes, page }, status, error);
+	router.init(renderer);
 
 	dispatchEvent(new CustomEvent('sveltekit:start'));
 }


### PR DESCRIPTION
fixes #652, by only initing the router _after_ the initial page has been hydrated. This is a bit finicky to write a test for, so I haven't. If anyone is feeling particularly motivated, go nuts.

Also, removes a TODO by handling the edge case in which a `load` function causes a redirect for the initial page, but only in the browser.

