### PR TITLE
Closes #662: svelte-kit dev --open doesn't work on Linux

### DIFF
--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -49,7 +49,13 @@ function handle_error(error) {
 /** @param {number} port */
 async function launch(port) {
 	const { exec } = await import('child_process');
-	exec(`${process.platform == 'win32' ? 'start' : 'open'} http://localhost:${port}`);
+	let cmd = 'open';
+	if (process.platform == 'win32') {
+		cmd = 'start';
+	} else if (process.platform == 'linux') {
+		cmd = 'xdg-open';
+	}
+	exec(`${cmd} http://localhost:${port}`);
 }
 
 const prog = sade('svelte-kit').version('__VERSION__');


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

Fixes `svelte-kit dev --open` not working on Linux.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

Some existing tests fail (e.g. dev:amp), but they also fail on the previous hash (957613747ba48cb9ccb9d339d4c6e61e539ca709). Linter passes.

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts

Unsure about this, I opted not to do these.