### PR TITLE
Closes #648: Update adapter-static documentation

### DIFF
--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -1,7 +1,5 @@
 # adapter-static
 
-Adapter for Svelte apps that prerenders your entire site as a collection of
-static files.
+Adapter for Svelte apps that prerenders your entire site as a collection of static files, which is equivalent to `sapper export`.
 
-This is very experimental. The adapter API is still in flux and will likely
-change before 1.0.
+This is very experimental. The adapter API is still in flux and will likely change before 1.0.

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -1,5 +1,7 @@
 # adapter-static
 
-Adapter for Svelte apps that builds a Node server — the equivalent of `sapper export`.
+Adapter for Svelte apps that prerenders your entire site as a collection of
+static files.
 
-This is very experimental; the adapter API isn't at all fleshed out, and things will definitely change.
+This is very experimental. The adapter API is still in flux and will likely
+change before 1.0.


### PR DESCRIPTION
Updated the README.md to state that the static adapter prerenders your site as a collection of static files instead of stating that it builds a Node server.