### PR TITLE
Fix typo in ignorePatterns for the generated TypeScript .eslintrc.cjs

### DIFF
--- a/.changeset/famous-rules-sort.md
+++ b/.changeset/famous-rules-sort.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Fix typo in `ignorePatterns` for the `.eslintrc.cjs` generated for TypeScript projects so that `.eslintrc.cjs` correctly ignores itself.

--- a/packages/create-svelte/template-additions/.eslintrc.ts.cjs
+++ b/packages/create-svelte/template-additions/.eslintrc.ts.cjs
@@ -3,7 +3,7 @@ module.exports = {
 	parser: '@typescript-eslint/parser',
 	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
 	plugins: ['svelte3', '@typescript-eslint'],
-	ignorePatterns: ['.eslintrc.js'],
+	ignorePatterns: ['.eslintrc.cjs'],
 	overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],
 	settings: {
 		'svelte3/typescript': require('typescript')


### PR DESCRIPTION
Just a small one - the `.eslintrc.cjs` config file optionally generated by `create-svelte` for TypeScript projects looks like it's trying to ignore itself via `ignorePatterns` (probably because it's using the TS ESLint parser but the config is in JS).
But it says `.eslintrc.js` in `ignorePatterns`, when the generated file actually has a `.cjs` extension!

Thanks so much for your work on the framework 😄

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
