### PR TITLE
make the button look more like a button

### DIFF
--- a/packages/create-svelte/template/src/lib/Counter.svelte
+++ b/packages/create-svelte/template/src/lib/Counter.svelte
@@ -21,7 +21,12 @@
 		border: 2px solid #ff3e00;
 		outline: none;
 		width: 200px;
+		height: 60px;
 		font-variant-numeric: tabular-nums;
+	}
+	
+	button:hover {
+		border: 3px solid #ff3e00;
 	}
 
 	button:active {

--- a/packages/create-svelte/template/src/lib/Counter.svelte
+++ b/packages/create-svelte/template/src/lib/Counter.svelte
@@ -24,6 +24,7 @@
 		height: 60px;
 		font-variant-numeric: tabular-nums;
 	}
+
 	button:hover {
 		border: 3px solid #ff3e00;
 	}

--- a/packages/create-svelte/template/src/lib/Counter.svelte
+++ b/packages/create-svelte/template/src/lib/Counter.svelte
@@ -24,7 +24,6 @@
 		height: 60px;
 		font-variant-numeric: tabular-nums;
 	}
-	
 	button:hover {
 		border: 3px solid #ff3e00;
 	}

--- a/packages/create-svelte/template/src/lib/Counter.svelte
+++ b/packages/create-svelte/template/src/lib/Counter.svelte
@@ -22,6 +22,7 @@
 		outline: none;
 		width: 200px;
 		font-variant-numeric: tabular-nums;
+		cursor: pointer;
 	}
 
 	button:focus {

--- a/packages/create-svelte/template/src/lib/Counter.svelte
+++ b/packages/create-svelte/template/src/lib/Counter.svelte
@@ -18,15 +18,10 @@
 		color: #ff3e00;
 		background-color: rgba(255, 62, 0, 0.1);
 		border-radius: 2em;
-		border: 2px solid rgba(255, 62, 0, 0);
+		border: 2px solid #ff3e00;
 		outline: none;
 		width: 200px;
 		font-variant-numeric: tabular-nums;
-		cursor: pointer;
-	}
-
-	button:focus {
-		border: 2px solid #ff3e00;
 	}
 
 	button:active {


### PR DESCRIPTION
The button to increase the counter doesn't really look like a button. There are no visual hints that you can click on the orange area. This PR adds a visual clue in form of the changing mouse-cursor representation.