### PR TITLE
Set .eslintrc.ts.cjs to ignore all .cjs files.

### DIFF
--- a/.changeset/metal-tigers-kiss.md
+++ b/.changeset/metal-tigers-kiss.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Set `.eslintrc.cjs` to ignore all `.cjs` files.

--- a/packages/create-svelte/template-additions/.eslintrc.ts.cjs
+++ b/packages/create-svelte/template-additions/.eslintrc.ts.cjs
@@ -3,7 +3,7 @@ module.exports = {
 	parser: '@typescript-eslint/parser',
 	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
 	plugins: ['svelte3', '@typescript-eslint'],
-	ignorePatterns: ['.eslintrc.cjs'],
+	ignorePatterns: ['*.cjs'],
 	overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],
 	settings: {
 		'svelte3/typescript': require('typescript')


### PR DESCRIPTION
Just a quick fix for #706 (using the first option I suggested). It gets the ESLint config to ignore all `.cjs` files, which gets rid of the complaints in those `.cjs` files that it isn't really configured to lint.
Feel free to use it if it does the job 🙂

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
