### PR TITLE
Some useful hints in migration docs

### DIFF
--- a/documentation/migrating/02-pkg.md
+++ b/documentation/migrating/02-pkg.md
@@ -2,6 +2,10 @@
 title: package.json
 ---
 
+### type : "module"
+
+Add `"type": "module"` to your `package.json`
+
 ### dependencies
 
 Remove `polka` or `express`, if you're using one of those, and any middleware such as `sirv` or `compression`.

--- a/documentation/migrating/04-pages.md
+++ b/documentation/migrating/04-pages.md
@@ -22,6 +22,8 @@ This function has been renamed from `preload` to [`load`](/docs#loading), and it
 
 There is no more `this` object, and consequently no `this.fetch`, `this.error` or `this.redirect`. Instead of returning props directly, `load` now returns an object that _contains_ `props`, alongside various other things.
 
+Lastly if your page has `load`, make sure to return something otherwise you will get `Not found`.
+
 ### Stores
 
 In Sapper, you would get references to provided stores like so:

--- a/documentation/migrating/04-pages.md
+++ b/documentation/migrating/04-pages.md
@@ -22,7 +22,7 @@ This function has been renamed from `preload` to [`load`](/docs#loading), and it
 
 There is no more `this` object, and consequently no `this.fetch`, `this.error` or `this.redirect`. Instead of returning props directly, `load` now returns an object that _contains_ `props`, alongside various other things.
 
-Lastly if your page has `load`, make sure to return something otherwise you will get `Not found`.
+Lastly, if your page has a `load` method, make sure to return something otherwise you will get `Not found`.
 
 ### Stores
 


### PR DESCRIPTION
- Hint to add `type: module` in package.json
- Hint to return something from `load` function or we get 'Not found' which is really difficult to debug.