### PR TITLE
fix(create-svelte): Add `$service-worker` to `paths` in `tsconfig.json`

### DIFF
--- a/.changeset/heavy-humans-check.md
+++ b/.changeset/heavy-humans-check.md
@@ -1,5 +1,5 @@
 ---
-'create-svelte': minor
+'create-svelte': patch
 ---
 
 Add '\$service-worker' to paths in tsconfig.json

--- a/.changeset/heavy-humans-check.md
+++ b/.changeset/heavy-humans-check.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': minor
+---
+
+Add '\$service-worker' to paths in tsconfig.json

--- a/packages/create-svelte/template-additions/tsconfig.json
+++ b/packages/create-svelte/template-additions/tsconfig.json
@@ -19,8 +19,10 @@
 		"baseUrl": ".",
 		"allowJs": true,
 		"checkJs": true,
+		"noEmit": true,
 		"paths": {
 			"$app/*": [".svelte/dev/runtime/app/*", ".svelte/build/runtime/app/*"],
+			"$service-worker": [".svelte/build/runtime/service-worker"],
 			"$lib/*": ["src/lib/*"]
 		}
 	},

--- a/packages/create-svelte/template-additions/tsconfig.json
+++ b/packages/create-svelte/template-additions/tsconfig.json
@@ -19,7 +19,6 @@
 		"baseUrl": ".",
 		"allowJs": true,
 		"checkJs": true,
-		"noEmit": true,
 		"paths": {
 			"$app/*": [".svelte/dev/runtime/app/*", ".svelte/build/runtime/app/*"],
 			"$service-worker": [".svelte/build/runtime/service-worker"],


### PR DESCRIPTION
Adds `$service-worker` to `paths` in the template's `tsconfig.json` so service workers can be properly type-checked. I also had to add `noEmit` because TypeScript was complaining about overwriting .svelte/build/runtime/service-worker.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
