### PR TITLE
Add env to eslint config

### DIFF
--- a/.changeset/nasty-waves-kneel.md
+++ b/.changeset/nasty-waves-kneel.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Add env options to eslint config

--- a/packages/create-svelte/template-additions/.eslintrc.cjs
+++ b/packages/create-svelte/template-additions/.eslintrc.cjs
@@ -6,5 +6,10 @@ module.exports = {
 	parserOptions: {
 		sourceType: 'module',
 		ecmaVersion: 2018
+	},
+	env: {
+		browser: true,
+		es2017: true,
+		node: true
 	}
 };

--- a/packages/create-svelte/template-additions/.eslintrc.ts.cjs
+++ b/packages/create-svelte/template-additions/.eslintrc.ts.cjs
@@ -11,5 +11,10 @@ module.exports = {
 	parserOptions: {
 		sourceType: 'module',
 		ecmaVersion: 2018
+	},
+	env: {
+		browser: true,
+		es2017: true,
+		node: true
 	}
 };


### PR DESCRIPTION
Else it will complain about uses of console.log etc. Added node/browser/es2017 for the 90% use case. Fixes sveltejs/language-tools#918
