### PR TITLE
Add static adapter's build directory to .prettierignore

### DIFF
--- a/packages/create-svelte/template-additions/.prettierignore
+++ b/packages/create-svelte/template-additions/.prettierignore
@@ -1,3 +1,4 @@
 .svelte/**
 static/**
+build/**
 node_modules/**


### PR DESCRIPTION
The build directory for adapter-static is 'build'. It was not mentioned
in the .prettierignore file, which caused errors during linting after
building.

I've noticed the `static` directory may be in use
https://github.com/sveltejs/kit/blob/master/packages/adapter-vercel/index.js#L12
so I left both intact. ~~However, `.gitignore` does not contain the `static` directory, so I'd suggest having consistency between the 2 ignore files, as it may be surprising otherwise~~

## Reproduction steps

```sh
npm init svelte@next
npm install
npm install @sveltekit/adapter-static@next
# Change the adapter in svelte.config.cjs
npm run build
npm run lint
```

Here are the logs:

```
19:01 $ npm run lint

> supreme-trobot@0.0.1 lint /home/voreny/projects/personal/supreme-trobot
> prettier --check . && eslint .

Checking formatting...
[warn] build/_app/assets/pages/index.svelte-0be37bb8.css
[warn] build/_app/assets/start-a8cd1609.css
[warn] build/_app/chunks/index-21894282.js
[warn] build/_app/pages/index.svelte-4d297661.js
[warn] build/_app/start-465c6d25.js
[warn] build/app.js
[warn] build/assets/_app/assets/pages/index.svelte-0be37bb8.css
[warn] build/assets/_app/assets/start-a8cd1609.css
[warn] build/assets/_app/chunks/index-21894282.js
[warn] build/assets/_app/pages/index.svelte-4d297661.js
[warn] build/assets/_app/start-465c6d25.js
[warn] build/index.html
[warn] build/index.js
[warn] build/style.css
[warn] src/lib/Counter.svelte
[warn] Code style issues found in the above file(s). Forgot to run Prettier?
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! supreme-trobot@0.0.1 lint: `prettier --check . && eslint .`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the supreme-trobot@0.0.1 lint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/voreny/.npm/_logs/2021-03-27T18_02_09_952Z-debug.log
```