### PR TITLE
Fix ESLint errors after generating app with create-svelte

### DIFF
--- a/packages/create-svelte/cli/modifications/add_eslint.js
+++ b/packages/create-svelte/cli/modifications/add_eslint.js
@@ -18,7 +18,7 @@ export default async function add_eslint(cwd, yes, use_typescript) {
 	}
 
 	upsert_package_json_scripts(cwd, {
-		lint: 'eslint .'
+		lint: 'eslint --ignore-path .gitignore .'
 	});
 
 	if (use_typescript) {

--- a/packages/create-svelte/cli/modifications/add_prettier.js
+++ b/packages/create-svelte/cli/modifications/add_prettier.js
@@ -32,7 +32,7 @@ export default async function add_prettier(cwd, yes, usesEslint) {
 		});
 		add_prettier_to_eslint_extends(cwd);
 		upsert_package_json_scripts(cwd, {
-			lint: 'prettier --check . && eslint .',
+			lint: 'prettier --check . && eslint --ignore-path .gitignore .',
 			format: 'prettier --write .'
 		});
 	} else {

--- a/packages/create-svelte/cli/modifications/add_typescript.js
+++ b/packages/create-svelte/cli/modifications/add_typescript.js
@@ -21,7 +21,10 @@ export default async function add_typescript(cwd, yes) {
 			tslib: '^2.0.0',
 			'svelte-preprocess': '^4.0.0'
 		});
-		update_component(cwd, 'src/lib/Counter.svelte', [['<script>', '<script lang="ts">']]);
+		update_component(cwd, 'src/lib/Counter.svelte', [
+			['<script>', '<script lang="ts">'],
+			['const increment = () => {', 'const increment = (): void => {']
+		]);
 		update_component(cwd, 'src/routes/index.svelte', [['<script>', '<script lang="ts">']]);
 		add_svelte_preprocess_to_config(cwd);
 		add_tsconfig(cwd);

--- a/packages/create-svelte/cli/modifications/add_typescript.js
+++ b/packages/create-svelte/cli/modifications/add_typescript.js
@@ -21,10 +21,7 @@ export default async function add_typescript(cwd, yes) {
 			tslib: '^2.0.0',
 			'svelte-preprocess': '^4.0.0'
 		});
-		update_component(cwd, 'src/lib/Counter.svelte', [
-			['<script>', '<script lang="ts">'],
-			['let count = 0', 'let count: number = 0']
-		]);
+		update_component(cwd, 'src/lib/Counter.svelte', [['<script>', '<script lang="ts">']]);
 		update_component(cwd, 'src/routes/index.svelte', [['<script>', '<script lang="ts">']]);
 		add_svelte_preprocess_to_config(cwd);
 		add_tsconfig(cwd);


### PR DESCRIPTION
This PR fixes 2 problems that appear when generating an app with `create-svelte`:

1. ESLint linted the `build` directory (generated by `adapter-static`), which results in over 500 problems being reported by ESLint

    <details>
      <summary>Logs from running ESLint after building with `adapter-static`</summary>

    ```
    10:42 $ npm run lint

    > supreme-trobot@0.0.1 lint /home/voreny/projects/personal/supreme-trobot
    > prettier --check . && eslint .

    Checking formatting...
    All matched files use Prettier code style!

    /home/voreny/projects/personal/supreme-trobot/build/_app/chunks/index-21894282.js
    1:1     warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:13    error    Unexpected empty function 't'    @typescript-eslint/no-empty-function
    1:15    warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:26    warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:28    warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:200   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:211   warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:213   warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:284   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:295   warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:297   warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:299   warning  Argument 'e' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:301   warning  Argument 'o' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:414   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:425   warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:427   warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:429   warning  Argument 'e' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:431   warning  Argument 'o' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:433   warning  Argument 'r' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:435   warning  Argument 'c' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:437   warning  Argument 'u' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:724   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:735   warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:737   warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:757   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:768   warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:770   warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:772   warning  Argument 'e' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:801   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:812   warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:843   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:854   warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:864   error    'document' is not defined        no-undef
    1:890   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:901   warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:911   error    'document' is not defined        no-undef
    1:938   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:965   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:991   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1002  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1004  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1006  warning  Argument 'e' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1008  warning  Argument 'o' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1077  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1088  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1090  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1092  warning  Argument 'e' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1167  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1178  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1213  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1224  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1226  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1228  warning  Argument 'e' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1230  warning  Argument 'o' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1498  error    'document' is not defined        no-undef
    1:1564  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1575  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1577  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1688  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1699  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1718  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1729  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1731  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1889  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1900  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1927  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1938  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1969  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1980  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1982  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:2557  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:2587  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:2618  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:2629  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:2631  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:2663  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:2674  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:2676  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:2678  warning  Argument 'e' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:2680  warning  Argument 'o' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:2779  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:2790  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:2792  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3037  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:3048  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3091  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:3102  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3114  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:3125  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3127  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3140  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:3151  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3153  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3155  warning  Argument 'o' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3157  warning  Argument 'u' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3325  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:3336  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3338  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3572  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:3584  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3586  warning  Argument 'e' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3588  warning  Argument 'c' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3590  warning  Argument 'u' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3592  warning  Argument 'i' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3594  warning  Argument 's' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:4276  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:4313  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:4317  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:4319  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:4444  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:4449  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types

    /home/voreny/projects/personal/supreme-trobot/build/_app/pages/index.svelte-4d297661.js
    1:649   warning  's' is defined but never used  @typescript-eslint/no-unused-vars
    1:1608  warning  Argument 's' should be typed   @typescript-eslint/explicit-module-boundary-types

    /home/voreny/projects/personal/supreme-trobot/build/_app/start-465c6d25.js
    1:289    error    'a' is already defined                   no-redeclare
    1:1635   warning  't' is defined but never used            @typescript-eslint/no-unused-vars
    1:2493   warning  'e' is defined but never used            @typescript-eslint/no-unused-vars
    1:2763   warning  't' is defined but never used            @typescript-eslint/no-unused-vars
    1:2784   warning  't' is defined but never used            @typescript-eslint/no-unused-vars
    1:4278   error    'document' is not defined                no-undef
    1:5319   error    'document' is not defined                no-undef
    1:5542   error    'document' is not defined                no-undef
    1:5605   error    'document' is not defined                no-undef
    1:5711   error    'document' is not defined                no-undef
    1:6570   error    'pageXOffset' is not defined             no-undef
    1:6584   error    'pageYOffset' is not defined             no-undef
    1:6729   error    'history' is not defined                 no-undef
    1:6739   error    'history' is not defined                 no-undef
    1:6775   error    'addEventListener' is not defined        no-undef
    1:6813   error    'history' is not defined                 no-undef
    1:6849   error    'addEventListener' is not defined        no-undef
    1:6879   error    'history' is not defined                 no-undef
    1:6917   error    'addEventListener' is not defined        no-undef
    1:6949   error    'clearTimeout' is not defined            no-undef
    1:6967   error    'setTimeout' is not defined              no-undef
    1:6999   error    'history' is not defined                 no-undef
    1:7045   error    'history' is not defined                 no-undef
    1:7068   error    'document' is not defined                no-undef
    1:7083   error    'window' is not defined                  no-undef
    1:7114   error    'addEventListener' is not defined        no-undef
    1:7430   error    'location' is not defined                no-undef
    1:7456   error    'location' is not defined                no-undef
    1:7614   error    'URL' is not defined                     no-undef
    1:7637   error    'location' is not defined                no-undef
    1:7667   error    'location' is not defined                no-undef
    1:7763   error    'history' is not defined                 no-undef
    1:7858   error    'addEventListener' is not defined        no-undef
    1:7915   error    'URL' is not defined                     no-undef
    1:7919   error    'location' is not defined                no-undef
    1:8001   error    'location' is not defined                no-undef
    1:8015   error    'location.href' is assigned to itself    no-self-assign
    1:8015   error    'location' is not defined                no-undef
    1:8033   error    'document' is not defined                no-undef
    1:8077   error    'history' is not defined                 no-undef
    1:8098   error    'history' is not defined                 no-undef
    1:8119   error    'location' is not defined                no-undef
    1:8157   error    'location' is not defined                no-undef
    1:8350   error    'URLSearchParams' is not defined         no-undef
    1:8489   error    'URL' is not defined                     no-undef
    1:8606   error    'document' is not defined                no-undef
    1:8643   error    'history' is not defined                 no-undef
    1:8731   error    'location' is not defined                no-undef
    1:8764   error    Unexpected empty arrow function          @typescript-eslint/no-empty-function
    1:8845   error    'location' is not defined                no-undef
    1:8884   error    'location' is not defined                no-undef
    1:8903   error    'history' is not defined                 no-undef
    1:8933   error    'location' is not defined                no-undef
    1:8965   error    'location' is not defined                no-undef
    1:9016   error    'document' is not defined                no-undef
    1:9049   error    'document' is not defined                no-undef
    1:9087   error    'scrollTo' is not defined                no-undef
    1:9107   error    'scrollTo' is not defined                no-undef
    1:9148   error    'scrollY' is not defined                 no-undef
    1:9157   error    'scrollTo' is not defined                no-undef
    1:9314   error    'console' is not defined                 no-undef
    1:10577  error    'URL' is not defined                     no-undef
    1:10597  error    'addEventListener' is not defined        no-undef
    1:10630  error    'addEventListener' is not defined        no-undef
    1:10664  error    'clearTimeout' is not defined            no-undef
    1:10682  error    'setTimeout' is not defined              no-undef
    1:10854  error    'URL' is not defined                     no-undef
    1:10858  error    'location' is not defined                no-undef
    1:11079  error    'location' is not defined                no-undef
    1:11097  error    'URL' is not defined                     no-undef
    1:11112  error    'location' is not defined                no-undef
    1:11285  error    'dispatchEvent' is not defined           no-undef
    1:11303  error    'CustomEvent' is not defined             no-undef
    1:11571  error    'location' is not defined                no-undef
    1:11905  error    'dispatchEvent' is not defined           no-undef
    1:11923  error    'CustomEvent' is not defined             no-undef
    1:13006  error    'document' is not defined                no-undef
    1:13220  error    'a' is already defined                   no-redeclare
    1:13321  error    'Response' is not defined                no-undef
    1:13344  error    'fetch' is not defined                   no-undef
    1:14979  error    'setTimeout' is not defined              no-undef
    1:15053  error    'clearTimeout' is not defined            no-undef
    1:15419  warning  Missing return type on function          @typescript-eslint/explicit-module-boundary-types
    1:15437  warning  Object pattern argument should be typed  @typescript-eslint/explicit-module-boundary-types
    1:15645  error    'dispatchEvent' is not defined           no-undef
    1:15663  error    'CustomEvent' is not defined             no-undef

    /home/voreny/projects/personal/supreme-trobot/build/app.js
    260:18  error    'Buffer' is not defined                              no-undef
    283:30  error    'Buffer' is not defined                              no-undef
    286:18  error    'Buffer' is not defined                              no-undef
    288:18  error    'Buffer' is not defined                              no-undef
    292:18  error    'Buffer' is not defined                              no-undef
    311:12  error    'Buffer' is not defined                              no-undef
    402:24  error    'Buffer' is not defined                              no-undef
    430:15  error    'Buffer' is not defined                              no-undef
    434:17  error    'Buffer' is not defined                              no-undef
    438:13  error    'Buffer' is not defined                              no-undef
    450:14  error    'Buffer' is not defined                              no-undef
    453:14  error    'Buffer' is not defined                              no-undef
    456:14  error    'Buffer' is not defined                              no-undef
    458:14  error    'Buffer' is not defined                              no-undef
    465:14  error    'Buffer' is not defined                              no-undef
    528:12  error    'Buffer' is not defined                              no-undef
    533:7   error    'Buffer' is not defined                              no-undef
    537:12  error    'Buffer' is not defined                              no-undef
    561:16  error    'Buffer' is not defined                              no-undef
    563:14  error    'Buffer' is not defined                              no-undef
    601:7   error    'Buffer' is not defined                              no-undef
    623:7   error    'Buffer' is not defined                              no-undef
    639:14  error    'Buffer' is not defined                              no-undef
    660:23  error    'URLSearchParams' is not defined                     no-undef
    699:16  error    'Proxy' is not defined                               no-undef
    707:22  error    'URLSearchParams' is not defined                     no-undef
    714:22  error    'URLSearchParams' is not defined                     no-undef
    719:30  error    'URLSearchParams' is not defined                     no-undef
    863:23  error    'URL' is not defined                                 no-undef
    897:23  error    'URL' is not defined                                 no-undef
    899:23  error    'URL' is not defined                                 no-undef
    1079:60  error    'URL' is not defined                                 no-undef
    1138:11  error    'process' is not defined                             no-undef
    1201:17  error    Unexpected empty function 'noop'                     @typescript-eslint/no-empty-function
    1263:7   error    'console' is not defined                             no-undef
    1382:25  error    'Proxy' is not defined                               no-undef
    1707:5   error    'console' is not defined                             no-undef
    1798:70  warning  'slots' is defined but never used                    @typescript-eslint/no-unused-vars
    1817:5   warning  'root_svelte' is assigned a value but never used     @typescript-eslint/no-unused-vars
    1822:67  warning  'slots' is defined but never used                    @typescript-eslint/no-unused-vars
    1840:17  error    'document' is not defined                            no-undef
    1878:1   warning  Missing return type on function                      @typescript-eslint/explicit-module-boundary-types
    1878:15  warning  Object pattern argument should be typed              @typescript-eslint/explicit-module-boundary-types
    1878:16  warning  'paths' is defined but never used                    @typescript-eslint/no-unused-vars
    1878:24  error    Unexpected empty function 'init'                     @typescript-eslint/no-empty-function
    1912:1   warning  Missing return type on function                      @typescript-eslint/explicit-module-boundary-types
    1912:17  warning  Argument 'request' should be typed                   @typescript-eslint/explicit-module-boundary-types
    1937:27  error    'amp_css_lookup' is not defined                      no-undef
    1940:5   warning  'Counter_svelte' is assigned a value but never used  @typescript-eslint/no-unused-vars
    1945:49  warning  '$$props' is defined but never used                  @typescript-eslint/no-unused-vars
    1945:58  warning  '$$bindings' is defined but never used               @typescript-eslint/no-unused-vars
    1945:70  warning  'slots' is defined but never used                    @typescript-eslint/no-unused-vars
    1951:5   warning  'index_svelte' is assigned a value but never used    @typescript-eslint/no-unused-vars
    1956:48  warning  '$$props' is defined but never used                  @typescript-eslint/no-unused-vars
    1956:57  warning  '$$bindings' is defined but never used               @typescript-eslint/no-unused-vars
    1956:69  warning  'slots' is defined but never used                    @typescript-eslint/no-unused-vars

    /home/voreny/projects/personal/supreme-trobot/build/assets/_app/chunks/index-21894282.js
    1:1     warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:13    error    Unexpected empty function 't'    @typescript-eslint/no-empty-function
    1:15    warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:26    warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:28    warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:200   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:211   warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:213   warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:284   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:295   warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:297   warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:299   warning  Argument 'e' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:301   warning  Argument 'o' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:414   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:425   warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:427   warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:429   warning  Argument 'e' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:431   warning  Argument 'o' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:433   warning  Argument 'r' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:435   warning  Argument 'c' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:437   warning  Argument 'u' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:724   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:735   warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:737   warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:757   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:768   warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:770   warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:772   warning  Argument 'e' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:801   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:812   warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:843   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:854   warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:864   error    'document' is not defined        no-undef
    1:890   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:901   warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:911   error    'document' is not defined        no-undef
    1:938   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:965   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:991   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1002  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1004  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1006  warning  Argument 'e' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1008  warning  Argument 'o' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1077  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1088  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1090  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1092  warning  Argument 'e' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1167  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1178  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1213  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1224  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1226  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1228  warning  Argument 'e' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1230  warning  Argument 'o' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1498  error    'document' is not defined        no-undef
    1:1564  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1575  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1577  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1688  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1699  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1718  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1729  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1731  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1889  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1900  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1927  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1938  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1969  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:1980  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:1982  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:2557  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:2587  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:2618  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:2629  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:2631  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:2663  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:2674  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:2676  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:2678  warning  Argument 'e' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:2680  warning  Argument 'o' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:2779  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:2790  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:2792  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3037  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:3048  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3091  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:3102  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3114  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:3125  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3127  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3140  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:3151  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3153  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3155  warning  Argument 'o' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3157  warning  Argument 'u' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3325  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:3336  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3338  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3572  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:3584  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3586  warning  Argument 'e' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3588  warning  Argument 'c' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3590  warning  Argument 'u' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3592  warning  Argument 'i' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:3594  warning  Argument 's' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:4276  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:4313  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:4317  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:4319  warning  Argument 'n' should be typed     @typescript-eslint/explicit-module-boundary-types
    1:4444  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
    1:4449  warning  Argument 't' should be typed     @typescript-eslint/explicit-module-boundary-types

    /home/voreny/projects/personal/supreme-trobot/build/assets/_app/pages/index.svelte-4d297661.js
    1:649   warning  's' is defined but never used  @typescript-eslint/no-unused-vars
    1:1608  warning  Argument 's' should be typed   @typescript-eslint/explicit-module-boundary-types

    /home/voreny/projects/personal/supreme-trobot/build/assets/_app/start-465c6d25.js
    1:289    error    'a' is already defined                   no-redeclare
    1:1635   warning  't' is defined but never used            @typescript-eslint/no-unused-vars
    1:2493   warning  'e' is defined but never used            @typescript-eslint/no-unused-vars
    1:2763   warning  't' is defined but never used            @typescript-eslint/no-unused-vars
    1:2784   warning  't' is defined but never used            @typescript-eslint/no-unused-vars
    1:4278   error    'document' is not defined                no-undef
    1:5319   error    'document' is not defined                no-undef
    1:5542   error    'document' is not defined                no-undef
    1:5605   error    'document' is not defined                no-undef
    1:5711   error    'document' is not defined                no-undef
    1:6570   error    'pageXOffset' is not defined             no-undef
    1:6584   error    'pageYOffset' is not defined             no-undef
    1:6729   error    'history' is not defined                 no-undef
    1:6739   error    'history' is not defined                 no-undef
    1:6775   error    'addEventListener' is not defined        no-undef
    1:6813   error    'history' is not defined                 no-undef
    1:6849   error    'addEventListener' is not defined        no-undef
    1:6879   error    'history' is not defined                 no-undef
    1:6917   error    'addEventListener' is not defined        no-undef
    1:6949   error    'clearTimeout' is not defined            no-undef
    1:6967   error    'setTimeout' is not defined              no-undef
    1:6999   error    'history' is not defined                 no-undef
    1:7045   error    'history' is not defined                 no-undef
    1:7068   error    'document' is not defined                no-undef
    1:7083   error    'window' is not defined                  no-undef
    1:7114   error    'addEventListener' is not defined        no-undef
    1:7430   error    'location' is not defined                no-undef
    1:7456   error    'location' is not defined                no-undef
    1:7614   error    'URL' is not defined                     no-undef
    1:7637   error    'location' is not defined                no-undef
    1:7667   error    'location' is not defined                no-undef
    1:7763   error    'history' is not defined                 no-undef
    1:7858   error    'addEventListener' is not defined        no-undef
    1:7915   error    'URL' is not defined                     no-undef
    1:7919   error    'location' is not defined                no-undef
    1:8001   error    'location' is not defined                no-undef
    1:8015   error    'location.href' is assigned to itself    no-self-assign
    1:8015   error    'location' is not defined                no-undef
    1:8033   error    'document' is not defined                no-undef
    1:8077   error    'history' is not defined                 no-undef
    1:8098   error    'history' is not defined                 no-undef
    1:8119   error    'location' is not defined                no-undef
    1:8157   error    'location' is not defined                no-undef
    1:8350   error    'URLSearchParams' is not defined         no-undef
    1:8489   error    'URL' is not defined                     no-undef
    1:8606   error    'document' is not defined                no-undef
    1:8643   error    'history' is not defined                 no-undef
    1:8731   error    'location' is not defined                no-undef
    1:8764   error    Unexpected empty arrow function          @typescript-eslint/no-empty-function
    1:8845   error    'location' is not defined                no-undef
    1:8884   error    'location' is not defined                no-undef
    1:8903   error    'history' is not defined                 no-undef
    1:8933   error    'location' is not defined                no-undef
    1:8965   error    'location' is not defined                no-undef
    1:9016   error    'document' is not defined                no-undef
    1:9049   error    'document' is not defined                no-undef
    1:9087   error    'scrollTo' is not defined                no-undef
    1:9107   error    'scrollTo' is not defined                no-undef
    1:9148   error    'scrollY' is not defined                 no-undef
    1:9157   error    'scrollTo' is not defined                no-undef
    1:9314   error    'console' is not defined                 no-undef
    1:10577  error    'URL' is not defined                     no-undef
    1:10597  error    'addEventListener' is not defined        no-undef
    1:10630  error    'addEventListener' is not defined        no-undef
    1:10664  error    'clearTimeout' is not defined            no-undef
    1:10682  error    'setTimeout' is not defined              no-undef
    1:10854  error    'URL' is not defined                     no-undef
    1:10858  error    'location' is not defined                no-undef
    1:11079  error    'location' is not defined                no-undef
    1:11097  error    'URL' is not defined                     no-undef
    1:11112  error    'location' is not defined                no-undef
    1:11285  error    'dispatchEvent' is not defined           no-undef
    1:11303  error    'CustomEvent' is not defined             no-undef
    1:11571  error    'location' is not defined                no-undef
    1:11905  error    'dispatchEvent' is not defined           no-undef
    1:11923  error    'CustomEvent' is not defined             no-undef
    1:13006  error    'document' is not defined                no-undef
    1:13220  error    'a' is already defined                   no-redeclare
    1:13321  error    'Response' is not defined                no-undef
    1:13344  error    'fetch' is not defined                   no-undef
    1:14979  error    'setTimeout' is not defined              no-undef
    1:15053  error    'clearTimeout' is not defined            no-undef
    1:15419  warning  Missing return type on function          @typescript-eslint/explicit-module-boundary-types
    1:15437  warning  Object pattern argument should be typed  @typescript-eslint/explicit-module-boundary-types
    1:15645  error    'dispatchEvent' is not defined           no-undef
    1:15663  error    'CustomEvent' is not defined             no-undef

    /home/voreny/projects/personal/supreme-trobot/build/index.js
    564:39   error    Unnecessary escape character: \/                                 no-useless-escape
    829:12   error    'i' is already defined                                           no-redeclare
    11885:1    error    Definition for rule 'node/no-deprecated-api' was not found       node/no-deprecated-api
    12431:45   error    'console' is not defined                                         no-undef
    12431:62   error    'console' is not defined                                         no-undef
    12537:41   error    'chrome' is not defined                                          no-undef
    12538:21   error    'chrome' is not defined                                          no-undef
    12566:40   error    'window' is not defined                                          no-undef
    12566:58   error    'window' is not defined                                          no-undef
    12572:46   error    'document' is not defined                                        no-undef
    12572:74   error    'document' is not defined                                        no-undef
    12572:108  error    'document' is not defined                                        no-undef
    12574:39   error    'window' is not defined                                          no-undef
    12574:58   error    'window' is not defined                                          no-undef
    12574:85   error    'window' is not defined                                          no-undef
    12574:113  error    'window' is not defined                                          no-undef
    12577:42   error    'navigator' is not defined                                       no-undef
    12577:65   error    'navigator' is not defined                                       no-undef
    12579:42   error    'navigator' is not defined                                       no-undef
    12579:65   error    'navigator' is not defined                                       no-undef
    12645:8    error    'console' is not defined                                         no-undef
    12646:38   error    'console' is not defined                                         no-undef
    12646:51   error    'console' is not defined                                         no-undef
    12663:14   error    Empty block statement                                            no-empty
    12677:14   error    Empty block statement                                            no-empty
    12680:56   error    'process' is not defined                                         no-undef
    12681:9    error    'process' is not defined                                         no-undef
    12706:12   error    'window' is not defined                                          no-undef
    12707:15   error    Empty block statement                                            no-empty
    12742:35   error    'process' is not defined                                         no-undef
    12752:13   error    'process' is not defined                                         no-undef
    12769:19   error    'process' is not defined                                         no-undef
    12772:28   error    Unexpected empty function                                        @typescript-eslint/no-empty-function
    12775:25   error    'process' is not defined                                         no-undef
    12776:25   error    'process' is not defined                                         no-undef
    12851:12   error    'process' is not defined                                         no-undef
    12853:5    error    'process' is not defined                                         no-undef
    12865:10   error    'process' is not defined                                         no-undef
    12877:18   error    'process' is not defined                                         no-undef
    12965:39   error    'process' is not defined                                         no-undef
    12997:30   warning  'statusCode' is defined but never used                           @typescript-eslint/no-unused-vars
    13759:33   warning  'next' is defined but never used                                 @typescript-eslint/no-unused-vars
    13834:14   warning  '_' is defined but never used                                    @typescript-eslint/no-unused-vars
    13862:7    error    Redundant double negation                                        no-extra-boolean-cast
    14007:20   error    Unexpected empty arrow function                                  @typescript-eslint/no-empty-function
    14034:7    error    Expected a conditional expression and instead saw an assignment  no-cond-assign
    14066:6    error    Expected a conditional expression and instead saw an assignment  no-cond-assign
    14125:15   error    Redundant double negation                                        no-extra-boolean-cast
    14144:25   error    Unnecessary escape character: \/                                 no-useless-escape
    14145:42   error    Unnecessary escape character: \/                                 no-useless-escape
    14428:25   error    'process' is not defined                                         no-undef
    14466:4    error    'console' is not defined                                         no-undef
    14468:4    error    'console' is not defined                                         no-undef

    /home/voreny/projects/personal/supreme-trobot/src/lib/Counter.svelte
    2:6  error  Type number trivially inferred from a number literal, remove type annotation  @typescript-eslint/no-inferrable-types

    ✖ 508 problems (259 errors, 249 warnings)
      3 errors and 0 warnings potentially fixable with the `--fix` option.

      npm ERR! code ELIFECYCLE
      npm ERR! errno 1
      npm ERR! supreme-trobot@0.0.1 lint: `prettier --check . && eslint .`
      npm ERR! Exit status 1
      npm ERR!
      npm ERR! Failed at the supreme-trobot@0.0.1 lint script.
      npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

      npm ERR! A complete log of this run can be found in:
      npm ERR!     /home/voreny/.npm/_logs/2021-03-28T08_45_44_333Z-debug.log
      ```

    </details>

2. ESLint reported an unnecessary type annotation in `Counter.svelte`. It was added by the modification script for TypeScript.

    <details>
    <summary>Logs</summary>

    ```
    10:45 $ npm run lint

    > supreme-trobot@0.0.1 lint /home/voreny/projects/personal/supreme-trobot
    > prettier --check . && eslint --ignore-path .gitignore .

    Checking formatting...
    All matched files use Prettier code style!

    /home/voreny/projects/personal/supreme-trobot/src/lib/Counter.svelte
      2:6  error  Type number trivially inferred from a number literal, remove type annotation  @typescript-eslint/no-inferrable-types


    ✖ 1 problem (1 error, 0 warnings)
      1 error and 0 warnings potentially fixable with the `--fix` option.

    npm ERR! code ELIFECYCLE
    npm ERR! errno 1
    npm ERR! supreme-trobot@0.0.1 lint: `prettier --check . && eslint --ignore-path .gitignore .`
    npm ERR! Exit status 1
    npm ERR!
    npm ERR! Failed at the supreme-trobot@0.0.1 lint script.
    npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

    npm ERR! A complete log of this run can be found in:
    npm ERR!     /home/voreny/.npm/_logs/2021-03-28T08_57_56_807Z-debug.log
    ```

    </details>

The idea for using `.gitignore` as the ignore file for ESLint was inspired by @benmccann  https://github.com/sveltejs/kit/pull/723#issuecomment-808786704