### PR TITLE
fix: lib build-mode causes assets to be inlined (#461)

### DIFF
--- a/.changeset/nice-bags-bathe.md
+++ b/.changeset/nice-bags-bathe.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Assets imported from css and js/ts files are emitted as files instead of being inlined

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -119,15 +119,8 @@ async function build_client({
 			...user_config.build,
 			cssCodeSplit: true,
 			manifest: true,
-			lib: {
-				// TODO i'm not convinced this block is necessary if we're
-				// providing inputs explicitly via rollupOptions, but without
-				// it Vite complains about the dynamic import polyfill
-				entry: client_entry_file,
-				name: 'app',
-				formats: ['es']
-			},
 			outDir: client_out_dir,
+			polyfillDynamicImport: false,
 			rollupOptions: {
 				...(user_config.build && user_config.build.rollupOptions),
 				input,


### PR DESCRIPTION
When running vite in lib mode, all assets referenced in css and js files are base64-inlined instead of being emitted as asset files.
Lib mode was apparently only enabled to avoid the warning wrt to the missing dynamic import module. However, in lib mode, the polyfill is not applied in the first place (https://vitejs.dev/config/#build-polyfilldynamicimport). So, dropping the lib mode and disabling the polyfill explicitly (polyfillDynamicImport: false) should work fine, too. Plus now assets get emitted properly (adhering to the assetsInlineLimit).

I did not find a way to test this automatically. Ideally a test would include a page that references e.g. an image by importing it and the test would check that a file is emitted. However, I could not find a way to test a post-vite build, so help is appreciated.

Tests and linting passed successfully. The example apps worked as they did before. The output of the non-lib-mode build is actually very similar to the lib-mode builds - as is expected.

I've created a changeset for this change.