### PR TITLE
add routes command

### DIFF
--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -1,6 +1,7 @@
 import { existsSync } from 'fs';
 import sade from 'sade';
 import colors from 'kleur';
+import create_manifest_data from './core/create_manifest_data/index.js';
 import { load_config } from './core/load_config/index.js';
 
 async function get_config() {
@@ -150,6 +151,16 @@ prog
 	.option('--verbose', 'Log more stuff', false)
 	.action(async () => {
 		console.log('"svelte-kit build" will now run the adapter');
+	});
+
+prog
+	.command('routes')
+	.describe('View routes and endpoints for your app')
+	.action(async () => {
+		const config = await get_config();
+
+		const { routes } = create_manifest_data({ config });
+		console.log(routes);
 	});
 
 prog.parse(process.argv, { unknown: (arg) => `Unknown option: ${arg}` });


### PR DESCRIPTION
## Add `svelte-kit routes` command

While reading https://github.com/sveltejs/kit/issues/738, I thought adding a `svelte-kit routes` command would be a helpful command to help mitigate the difficulty of knowing what routes are available as the file structure grows. The current version of the PR is very crude (i.e. just prints the route objects), but if the team finds this useful, we could prettify the output. Additionally, I can see this command helping users understand trickier route behavior (e.g. "fallthrough" routes).

### Example

```bash
> svelte-kit routes

[
  {
    type: 'page',
    pattern: /^\/$/,
    params: [],
    parts: [ 'src/routes/index.svelte' ]
  },
  {
    type: 'endpoint',
    pattern: /^\/about\/?$/,
    file: 'src/routes/about.js',
    params: []
  },
  {
    type: 'page',
    pattern: /^\/about\/?$/,
    params: [],
    parts: [ 'src/routes/about.svelte' ]
  }
]
```

Inspiration for this comes from [`rails routes`](https://guides.rubyonrails.org/routing.html#listing-existing-routes).
