### PR TITLE
Update polka to handle url decoding

### DIFF
--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -17,7 +17,7 @@
 		"@rollup/plugin-json": "^4.1.0",
 		"@sveltejs/kit": "workspace:*",
 		"compression": "^1.7.4",
-		"polka": "^0.5.2",
+		"polka": "^1.0.0-next.13",
 		"rollup": "^2.41.1",
 		"sirv": "^1.0.11",
 		"typescript": "^4.2.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,7 +106,7 @@ importers:
       '@rollup/plugin-json': 4.1.0_rollup@2.41.1
       '@sveltejs/kit': link:../kit
       compression: 1.7.4
-      polka: 0.5.2
+      polka: 1.0.0-next.13
       rollup: 2.41.1
       sirv: 1.0.11
       typescript: 4.2.3
@@ -114,7 +114,7 @@ importers:
       '@rollup/plugin-json': ^4.1.0
       '@sveltejs/kit': workspace:*
       compression: ^1.7.4
-      polka: ^0.5.2
+      polka: ^1.0.0-next.13
       rollup: ^2.41.1
       sirv: ^1.0.11
       typescript: ^4.2.3
@@ -213,12 +213,6 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-mXn5Ha5a3tEOV5vkGHLdrDinSRfO8g9s72gKuOWA13HJtGcfI+jkYrEdQbLqe63gz0RPQN27h0e1IKc2kSzqHw==
-  /@arr/every/1.0.1:
-    dev: true
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-UQFQ6SgyJ6LX42W8rHCs8KVc0JS0tzVL9ct4XYedJukskYVWTo49tNiMEK9C2HTyarbNiT/RVIRSY82vH+6sTg==
   /@babel/code-frame/7.12.11:
     dependencies:
       '@babel/highlight': 7.13.10
@@ -478,14 +472,10 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==
-  /@polka/url/0.5.0:
+  /@polka/url/1.0.0-next.12:
     dev: true
     resolution:
-      integrity: sha512-oZLYFEAzUKyi3SKnXvj32ZCEGH6RDnao7COuCVhDydMS9NrCSVXhM79VaKyP5+Zc33m0QXEd2DN3UkU7OsHcfw==
-  /@polka/url/1.0.0-next.11:
-    dev: true
-    resolution:
-      integrity: sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==
+      integrity: sha512-6RglhutqrGFMO1MNUXp95RBuYIuc8wTnMAV5MUhLmjTOy78ncwOw7RgeQ/HeymkKXRhZd0s2DNrM1rL7unk3MQ==
   /@rollup/plugin-commonjs/17.1.0_rollup@2.42.3:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.42.3
@@ -2376,14 +2366,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==
-  /matchit/1.1.0:
-    dependencies:
-      '@arr/every': 1.0.1
-    dev: true
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-+nGYoOlfHmxe5BW5tE0EMJppXEwdSf8uBA1GTZC7Q77kbT35+VKLYJMzVNWCHSsga1ps1tPYFtFyvxvKzWVmMA==
   /meow/6.1.1:
     dependencies:
       '@types/minimist': 1.2.1
@@ -2818,13 +2800,15 @@ packages:
       node: '>=10.13.0'
     resolution:
       integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==
-  /polka/0.5.2:
+  /polka/1.0.0-next.13:
     dependencies:
-      '@polka/url': 0.5.0
-      trouter: 2.0.1
+      '@polka/url': 1.0.0-next.12
+      trouter: 3.2.0
     dev: true
+    engines:
+      node: '>=6'
     resolution:
-      integrity: sha512-FVg3vDmCqP80tOrs+OeNlgXYmFppTXdjD5E7I4ET1NjvtNmQrb1/mJibybKkb/d4NA7YWAr1ojxuhpL3FHqdlw==
+      integrity: sha512-ISFBSJ3hHeSDOhbEUwBn0Jp8Rd9iOdXJa5LUaYyECw6lQOSkr0wJ7Shl5pRRS/u0t+uQpw9jJPypHRyX8mPpPQ==
   /port-authority/1.1.2:
     dev: true
     resolution:
@@ -2994,6 +2978,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
+  /regexparam/1.3.0:
+    dev: true
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-6IQpFBv6e5vz1QAqI+V4k8P2e/3gRrqfCJ9FI+O1FLQTO+Uz6RXZEZOPmTJ6hlGj7gkERzY5BRCv09whKP96/g==
   /regexpp/3.1.0:
     dev: true
     engines:
@@ -3159,7 +3149,7 @@ packages:
       integrity: sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
   /sirv/1.0.11:
     dependencies:
-      '@polka/url': 1.0.0-next.11
+      '@polka/url': 1.0.0-next.12
       mime: 2.5.2
       totalist: 1.1.0
     dev: true
@@ -3439,14 +3429,14 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
-  /trouter/2.0.1:
+  /trouter/3.2.0:
     dependencies:
-      matchit: 1.1.0
+      regexparam: 1.3.0
     dev: true
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-kr8SKKw94OI+xTGOkfsvwZQ8mWoikZDd2n8XZHjJVZUARZT+4/VV6cacRS6CLsH9bNm+HFIPU1Zx4CnNnb4qlQ==
+      integrity: sha512-rLLXbhTObLy2MBVjLC+jTnoIKw99n0GuJs9ov10J870vDw5qhTurPzsDrudNtBf5w/CZ9ctZy2p2IMmhGcel2w==
   /tsconfig-paths/3.9.0:
     dependencies:
       '@types/json5': 0.0.29


### PR DESCRIPTION
sirv assumes that if req.path is present that the URL has already been
decoded. This is not true for the stable version of polka. As such upgrade to the @next version of polka which fixes the problem

Fixes #740 
