### PR TITLE
Fix adapter-cloudflare-workers dependencies

### DIFF
--- a/.changeset/quiet-mugs-matter.md
+++ b/.changeset/quiet-mugs-matter.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+---
+
+Fix dev/prod deps (oops)

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -11,7 +11,9 @@
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore"
 	},
 	"dependencies": {
-		"toml": "^3.0.0",
+		"toml": "^3.0.0"
+	},
+	"devDependencies": {
 		"@sveltejs/kit": "workspace:*"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,9 @@ importers:
       typescript: ^4.2.3
   packages/adapter-cloudflare-workers:
     dependencies:
-      '@sveltejs/kit': link:../kit
       toml: 3.0.0
+    devDependencies:
+      '@sveltejs/kit': link:../kit
     specifiers:
       '@sveltejs/kit': workspace:*
       toml: ^3.0.0


### PR DESCRIPTION
I think this was why it was leaking to the published npm module.