### PR TITLE
docs: fix typo and add additional info

### DIFF
--- a/documentation/docs/11-ssr-and-javascript.md
+++ b/documentation/docs/11-ssr-and-javascript.md
@@ -34,7 +34,7 @@ In certain circumstances you might need to disable this behaviour with the app-w
 </script>
 ```
 
-Note that this will disabling client-side routing for any navigation from this page, regardless of whether the router is already active.
+Note that this will disable client-side routing for any navigation from this page, regardless of whether the router is already active.
 
 ### hydrate
 

--- a/documentation/docs/11-ssr-and-javascript.md
+++ b/documentation/docs/11-ssr-and-javascript.md
@@ -46,7 +46,7 @@ Ordinarily, SvelteKit 'hydrates' your server-rendered HTML into an interactive p
 </script>
 ```
 
-> If `hydrate` and `router` are both `false`, SvelteKit will not add any JavaScript to the page at all. As a result, anchor elements with [`sveltekit:` prefix](#anchor-options) won't work either.
+> If `hydrate` and `router` are both `false`, SvelteKit will not add any JavaScript to the page at all.
 
 ### prerender
 

--- a/documentation/docs/11-ssr-and-javascript.md
+++ b/documentation/docs/11-ssr-and-javascript.md
@@ -46,7 +46,7 @@ Ordinarily, SvelteKit 'hydrates' your server-rendered HTML into an interactive p
 </script>
 ```
 
-> If `hydrate` and `router` are both `false`, SvelteKit will not add any JavaScript to the page at all.
+> If `hydrate` and `router` are both `false`, SvelteKit will not add any JavaScript to the page at all. As a result, anchor elements with [`sveltekit:` prefix](#anchor-options) won't work either.
 
 ### prerender
 


### PR DESCRIPTION
Fix typo made in #713. Also add a noteworthy info for pages with no JS at all