### PR TITLE
set optimizeDeps.entries: []

### DIFF
--- a/.changeset/neat-olives-hope.md
+++ b/.changeset/neat-olives-hope.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Prevent Vite prebundling from crashing on startup

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -103,6 +103,10 @@ class Watcher extends EventEmitter {
 			server: {
 				...user_config.server,
 				middlewareMode: true
+			},
+			optimizeDeps: {
+				...user_config.optimizeDeps,
+				entries: []
 			}
 		});
 


### PR DESCRIPTION
Without this, Vite will attempt to scan entry files for imports that should be prebundled, which isn't helpful in the context of SvelteKit but _can_ cause the entire thing to go up in flames when you run `svelte-kit dev` if you have enough stuff in your project