### PR TITLE
make router responsible for prefetching

### DIFF
--- a/documentation/docs/07-a-options.md
+++ b/documentation/docs/07-a-options.md
@@ -16,6 +16,8 @@ We can mitigate that by _prefetching_ the data. Adding a `sveltekit:prefetch` at
 
 ...will cause SvelteKit to run the page's `load` function as soon as the user hovers over the link (on a desktop) or touches it (on mobile), rather than waiting for the `click` event to trigger navigation. Typically, this buys us an extra couple of hundred milliseconds, which is the difference between a user interface that feels laggy, and one that feels snappy.
 
+Note that prefetching will not work if the [`router`](#ssr-and-javascript-router) setting is `false`.
+
 You can also programmatically invoke `prefetch` from `$app/navigation`.
 
 ### sveltekit:noscroll

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -27,7 +27,7 @@ async function goto_(href, opts) {
 
 /** @param {string} href */
 function prefetch_(href) {
-	return renderer.prefetch(new URL(href, get_base_uri(document)));
+	return router.prefetch(new URL(href, get_base_uri(document)));
 }
 
 /** @param {string[]} [pathnames] */

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -1,12 +1,3 @@
-/**
- * @param {Node} node
- * @returns {HTMLAnchorElement | SVGAElement}
- */
-export function find_anchor(node) {
-	while (node && node.nodeName.toUpperCase() !== 'A') node = node.parentNode; // SVG <a> elements have a lowercase name
-	return /** @type {HTMLAnchorElement | SVGAElement} */ (node);
-}
-
 /** @param {HTMLDocument} doc */
 export function get_base_uri(doc) {
 	let baseURI = doc.baseURI;


### PR DESCRIPTION
#755 prompted me to fix this slightly oddity in the codebase: the router should be responsible for prefetching, rather than the renderer. `sveltekit:prefetch` now only works for pages that don't have `router=false`, which makes sense.