### PR TITLE
create-svelte: vite.optimizeDeps all production deps

### DIFF
--- a/.changeset/breezy-taxis-mix.md
+++ b/.changeset/breezy-taxis-mix.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Include all production dependencies in vite.optimizeDeps

--- a/packages/create-svelte/template/svelte.config.cjs
+++ b/packages/create-svelte/template/svelte.config.cjs
@@ -12,7 +12,11 @@ module.exports = {
 		// hydrate the <div id="svelte"> element in src/app.html
 		target: '#svelte',
 
+		// visit https://vitejs.dev/config/ for more details
 		vite: {
+			optimizeDeps: {
+				include: Object.keys(pkg.dependencies || {})
+			},
 			ssr: {
 				noExternal: Object.keys(pkg.dependencies || {})
 			}


### PR DESCRIPTION
This should solve the *majority* of CJS imports. There might be side effects but we can deal with those as they come up.

Also added a comment to point to Vite config page.