### PR TITLE
Set target to es2019 in default tsconfig.json

### DIFF
--- a/.changeset/shaggy-elephants-sell.md
+++ b/.changeset/shaggy-elephants-sell.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Set target to es2019 in default tsconfig.json

--- a/packages/create-svelte/template-additions/.eslintrc.cjs
+++ b/packages/create-svelte/template-additions/.eslintrc.cjs
@@ -5,7 +5,7 @@ module.exports = {
 	overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],
 	parserOptions: {
 		sourceType: 'module',
-		ecmaVersion: 2018
+		ecmaVersion: 2019
 	},
 	env: {
 		browser: true,

--- a/packages/create-svelte/template-additions/.eslintrc.ts.cjs
+++ b/packages/create-svelte/template-additions/.eslintrc.ts.cjs
@@ -10,7 +10,7 @@ module.exports = {
 	},
 	parserOptions: {
 		sourceType: 'module',
-		ecmaVersion: 2018
+		ecmaVersion: 2019
 	},
 	env: {
 		browser: true,

--- a/packages/create-svelte/template-additions/tsconfig.json
+++ b/packages/create-svelte/template-additions/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"moduleResolution": "node",
-		"target": "es2018",
+		"target": "es2019",
 		/**
 			svelte-preprocess cannot figure out whether you have a value or a type, so tell TypeScript
 			to enforce using \`import type\` instead of \`import\` for Types.


### PR DESCRIPTION
Should at least make it 2020. Someone on Discord ran into an issue with it being an older version

I hadn't set it in `jsconfig.json` because that file is pretty minimal and doesn't have any of the other `tsconfig.json` contents. I'm not sure which settings go in both vs just one or the other