### PR TITLE
Fix query params being empty

### DIFF
--- a/.changeset/flat-pillows-think.md
+++ b/.changeset/flat-pillows-think.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-vercel': patch
+---
+
+Fix adapter-vercel query parsing and update adapter-node's

--- a/.changeset/fluffy-carpets-confess.md
+++ b/.changeset/fluffy-carpets-confess.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+Fix query params not being set

--- a/.changeset/fluffy-carpets-confess.md
+++ b/.changeset/fluffy-carpets-confess.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/adapter-vercel': patch
----
-
-Fix query params not being set

--- a/packages/adapter-node/src/server.js
+++ b/packages/adapter-node/src/server.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import polka from 'polka';
 import { dirname, join } from 'path';
 import sirv from 'sirv';
-import { parse, URLSearchParams, fileURLToPath } from 'url';
+import { URL, fileURLToPath } from 'url';
 // eslint-disable-next-line import/no-unresolved
 import { get_body } from '@sveltejs/kit/http';
 // App is a dynamic file built from the application layer.
@@ -31,13 +31,13 @@ const assets_handler = sirv(join(__dirname, '/assets'), {
 
 polka()
 	.use(compression({ threshold: 0 }), assets_handler, prerendered_handler, async (req, res) => {
-		const parsed = parse(req.url || '');
+		const parsed = new URL(req.url || '');
 		const rendered = await app.render({
 			method: req.method,
 			headers: req.headers, // TODO: what about repeated headers, i.e. string[]
 			path: parsed.pathname,
 			body: await get_body(req),
-			query: new URLSearchParams(parsed.query || '')
+			query: parsed.searchParams
 		});
 
 		if (rendered) {

--- a/packages/adapter-vercel/src/entry.js
+++ b/packages/adapter-vercel/src/entry.js
@@ -1,10 +1,10 @@
-import { URL, URLSearchParams } from 'url';
+import { URL } from 'url';
 // eslint-disable-next-line import/no-unresolved
 import { get_body } from '@sveltejs/kit/http';
 
 export default async (req, res) => {
 	const host = `${req.headers['x-forwarded-proto']}://${req.headers.host}`;
-	const { pathname, query = '' } = new URL(req.url || '', host);
+	const { pathname, searchParams } = new URL(req.url || '', host);
 
 	const { render } = await import('./server/app.mjs');
 
@@ -12,7 +12,7 @@ export default async (req, res) => {
 		method: req.method,
 		headers: req.headers,
 		path: pathname,
-		query: new URLSearchParams(query),
+		query: searchParams,
 		body: await get_body(req)
 	});
 


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/issues/631

The query params are not parsed correctly, because `URL` does not return `query` - instead it returns the desired searchParams!

Tested here - https://sveltekit-vercel.vercel.app/queryparams?q=pizza
