### PR TITLE
Type vite config

### DIFF
--- a/.changeset/seven-jars-argue.md
+++ b/.changeset/seven-jars-argue.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add type to config.kit.vite

--- a/packages/kit/types.d.ts
+++ b/packages/kit/types.d.ts
@@ -1,4 +1,5 @@
 import { Headers, LoadInput, LoadOutput, Logger } from './types.internal';
+import { UserConfig as ViteConfig } from 'vite';
 
 export type Config = {
 	compilerOptions?: any;
@@ -31,7 +32,7 @@ export type Config = {
 		router?: boolean;
 		ssr?: boolean;
 		target?: string;
-		vite?: {} | (() => {});
+		vite?: ViteConfig | (() => ViteConfig);
 	};
 	preprocess?: any;
 };

--- a/packages/kit/types.internal.d.ts
+++ b/packages/kit/types.internal.d.ts
@@ -1,4 +1,5 @@
 import { Adapter, GetContext, GetSession, Handle, Incoming, Load, Response } from './types';
+import { UserConfig as ViteConfig } from 'vite';
 
 declare global {
 	interface ImportMeta {
@@ -47,7 +48,7 @@ export type ValidatedConfig = {
 		router: boolean;
 		ssr: boolean;
 		target: string;
-		vite: () => {};
+		vite: () => ViteConfig;
 	};
 	preprocess: any;
 };


### PR DESCRIPTION
Adds missing type to `config.kit.vite`, which previously was `any`.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
