### PR TITLE
Specify minimum node version number

### DIFF
--- a/.changeset/purple-windows-wink.md
+++ b/.changeset/purple-windows-wink.md
@@ -1,0 +1,6 @@
+---
+'create-svelte': patch
+'@sveltejs/kit': patch
+---
+
+Specify minimum Node version number in @sveltejs/kit and add .npmrc to enforce it

--- a/packages/create-svelte/template/.npmrc
+++ b/packages/create-svelte/template/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/create-svelte/template/package.json
+++ b/packages/create-svelte/template/package.json
@@ -12,8 +12,5 @@
 		"svelte": "^3.29.0",
 		"vite": "^2.1.0"
 	},
-	"type": "module",
-	"engines": {
-		"node": ">= 12.17.0"
-	}
+	"type": "module"
 }

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -70,5 +70,8 @@
 		},
 		"./types.d.ts": "./types.d.ts"
 	},
-	"types": "types.d.ts"
+	"types": "types.d.ts",
+	"engines": {
+		"node": ">= 12.17.0"
+	}
 }


### PR DESCRIPTION
It's currently specified in https://github.com/sveltejs/kit/blob/96cbda341e4139bd944ac01f9fe8753e8a25a171/packages/create-svelte/template/package.json#L17 but I think that's the wrong place because it still seems like people are hitting this (https://github.com/sveltejs/kit/issues/724 https://github.com/sveltejs/kit/issues/732). I think we may need to specify it in Kit since that's where the CLI comes from