### PR TITLE
create-svelte: allow importing JSON modules

### DIFF
--- a/.changeset/poor-bobcats-unite.md
+++ b/.changeset/poor-bobcats-unite.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+allow importing JSON modules

--- a/packages/create-svelte/template-additions/tsconfig.json
+++ b/packages/create-svelte/template-additions/tsconfig.json
@@ -8,6 +8,7 @@
 			*/
 		"importsNotUsedAsValues": "error",
 		"isolatedModules": true,
+		"resolveJsonModule": true,
 		/**
 			To have warnings/errors of the Svelte compiler at the correct position,
 			enable source maps by default.


### PR DESCRIPTION
Since Vite supports [directly importing JSON modules](https://vitejs.dev/guide/features.html#json) this should be enabled in `tsconfig.json` so that TypeScript or VS Code doesn't complain about it.

This doesn't need to be added to `jsconfig.json`.