### PR TITLE
Fix client-side load error handling

### DIFF
--- a/.changeset/beige-grapes-love.md
+++ b/.changeset/beige-grapes-love.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Always apply layout props when hydrating

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -267,19 +267,17 @@ export class Renderer {
 			if (result) return result;
 		}
 
-		return {
-			state: {
-				page: null,
-				query: null,
-				session_changed: false,
-				contexts: [],
-				nodes: []
-			},
-			props: {
-				status: 404,
-				error: new Error(`Not found: ${info.path}`)
+		return await this._load({
+			status: 404,
+			error: new Error(`Not found: ${info.path}`),
+			nodes: [],
+			page: {
+				host: this.host,
+				path: info.path,
+				query: info.query,
+				params: {}
 			}
-		};
+		});
 	}
 
 	/** @param {import('./types').NavigationResult} result */
@@ -316,7 +314,6 @@ export class Renderer {
 
 		/** @type {import('./types').NavigationResult} */
 		const result = {
-			page, // TODO is this duplicative?
 			state: {
 				page,
 				query,

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -268,8 +268,6 @@ export class Renderer {
 		}
 
 		return {
-			nodes: [],
-			page: null,
 			state: {
 				page: null,
 				query: null,
@@ -300,9 +298,7 @@ export class Renderer {
 		this.root = new this.Root({
 			target: this.target,
 			props: {
-				// TODO should these be part of `result`?
 				stores: this.stores,
-				page: result.page,
 				...result.props
 			},
 			hydrate: true
@@ -320,8 +316,7 @@ export class Renderer {
 
 		/** @type {import('./types').NavigationResult} */
 		const result = {
-			nodes, // TODO are these and page duplicative?
-			page,
+			page, // TODO is this duplicative?
 			state: {
 				page,
 				query,

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -18,12 +18,9 @@ import { set_paths } from '../paths.js';
  *   status: number;
  *   host: string;
  *   route: boolean;
- *   hydrate: {
- *     nodes: import('./types').NavigationCandidate["nodes"];
- *     page: import('./types').NavigationCandidate["page"];
- *   }
+ *   hydrate: import('./types').NavigationCandidate;
  * }} opts */
-export async function start({ paths, target, session, error, status, host, route, hydrate }) {
+export async function start({ paths, target, session, host, route, hydrate }) {
 	const router =
 		route &&
 		new Router({
@@ -42,7 +39,7 @@ export async function start({ paths, target, session, error, status, host, route
 	init({ router, renderer });
 	set_paths(paths);
 
-	if (hydrate) await renderer.start(hydrate, status, error);
+	if (hydrate) await renderer.start(hydrate);
 	if (route) router.init(renderer);
 
 	dispatchEvent(new CustomEvent('sveltekit:start'));

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -8,6 +8,8 @@ export type NavigationInfo = {
 };
 
 export type NavigationCandidate = {
+	status: number;
+	error: Error;
 	nodes: Array<Promise<CSRComponent>>;
 	page: Page;
 };

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -17,9 +17,6 @@ export type NavigationCandidate = {
 export type NavigationResult = {
 	reload?: boolean;
 	redirect?: string;
-
-	nodes?: Array<Promise<CSRComponent>>;
-	page?: Page;
 	state?: NavigationState;
 	props?: Record<string, any>;
 };

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -15,10 +15,11 @@ export type NavigationCandidate = {
 };
 
 export type NavigationResult = {
-	nodes?: Array<Promise<CSRComponent>>;
-	page?: Page;
 	reload?: boolean;
 	redirect?: string;
+
+	nodes?: Array<Promise<CSRComponent>>;
+	page?: Page;
 	state?: NavigationState;
 	props?: Record<string, any>;
 };

--- a/packages/kit/src/runtime/server/page.js
+++ b/packages/kit/src/runtime/server/page.js
@@ -37,8 +37,8 @@ async function get_response({ request, options, $session, route, status = 200, e
 	 * }>} */
 	const serialized_data = [];
 
-	const match = route && route.pattern.exec(request.path);
-	const params = route && route.params(match);
+	const match = error ? null : route.pattern.exec(request.path);
+	const params = error ? {} : route.params(match);
 
 	const page = {
 		host: request.host,
@@ -277,7 +277,7 @@ async function get_response({ request, options, $session, route, status = 200, e
 						context: { ...context }
 					});
 
-					if (!loaded) return;
+					if (!loaded && mod === page_component) return;
 				}
 			} catch (e) {
 				// if load fails when we're already rendering the
@@ -420,12 +420,12 @@ async function get_response({ request, options, $session, route, status = 200, e
 			start({
 				target: ${options.target ? `document.querySelector(${s(options.target)})` : 'document.body'},
 				paths: ${s(options.paths)},
-				status: ${status},
-				error: ${serialize_error(error)},
 				session: ${serialized_session},
 				host: ${request.host ? s(request.host) : 'location.host'},
 				route: ${!!page_config.router},
 				hydrate: ${page_config.hydrate? `{
+					status: ${status},
+					error: ${serialize_error(error)},
 					nodes: ${route ? `[
 						${(route ? route.parts : [])
 						.map((part) => `import(${s(options.get_component_path(part.id))})`)

--- a/packages/kit/test/apps/basics/src/routes/$layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/$layout.svelte
@@ -1,14 +1,28 @@
+<script context="module">
+	export async function load() {
+		return {
+			props: {
+				foo: {
+					bar: 'Custom layout'
+				}
+			}
+		};
+	}
+</script>
+
 <script>
 	import { goto, prefetch, prefetchRoutes } from '$app/navigation';
 
 	if (typeof window !== 'undefined') {
 		Object.assign(window, { goto, prefetch, prefetchRoutes });
 	}
+
+	export let foo;
 </script>
 
 <slot></slot>
 
-<footer>Custom layout</footer>
+<footer>{foo.bar}</footer>
 
 <style>
 	footer {

--- a/packages/kit/test/apps/basics/src/routes/preload/__tests__.js
+++ b/packages/kit/test/apps/basics/src/routes/preload/__tests__.js
@@ -9,7 +9,7 @@ export default function test(test) {
 		assert.equal(await page.textContent('footer'), 'Custom layout');
 		assert.equal(
 			await page.textContent('#message'),
-			'This is your custom error page saying: "preload has been deprecated in favour of load. Please consult the documentation: https://kit.svelte.dev/docs#load"'
+			'This is your custom error page saying: "preload has been deprecated in favour of load. Please consult the documentation: https://kit.svelte.dev/docs#loading"'
 		);
 	});
 }


### PR DESCRIPTION
I don't think there's an issue for this, but it's an annoying bug that has been wrecking productivity. Basically, if an error was encountered in a `load` function, any props returned from the root layout's `load` would be unaccounted for when the page hydrates, which triggers the `svelte-hmr` error overlay (which on a separate note, I think we should get rid of, since it should be covered by Vite's own error handling. cc @rixo, though I'll probably add a separate issue for this in due course).

This PR mostly amends the client-side logic to mirror the server-side logic, with a couple of other bonus fixes for good measure.