### PR TITLE
try to fix test flakiness

### DIFF
--- a/packages/kit/test/apps/basics/src/routes/routing/disabled/__tests__.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/disabled/__tests__.js
@@ -7,7 +7,7 @@ export default function (test, is_dev) {
 			await page.click('button');
 			assert.equal(await page.textContent('button'), 'clicks: 1');
 
-			await clicknav('[href="/routing/disabled/b"]');
+			await Promise.all([page.click('[href="/routing/disabled/b"]'), page.waitForNavigation()]);
 			assert.equal(await page.textContent('button'), 'clicks: 0');
 
 			await page.click('button');
@@ -16,7 +16,7 @@ export default function (test, is_dev) {
 			await clicknav('[href="/routing/disabled/a"]');
 			assert.equal(await page.textContent('button'), 'clicks: 1');
 
-			await clicknav('[href="/routing/disabled/b"]');
+			await Promise.all([page.click('[href="/routing/disabled/b"]'), page.waitForNavigation()]);
 			assert.equal(await page.textContent('button'), 'clicks: 0');
 		}
 	});

--- a/packages/kit/test/test.js
+++ b/packages/kit/test/test.js
@@ -24,7 +24,7 @@ async function setup({ port }) {
 
 	pages.js.addInitScript({
 		content: `
-			window.started = new Promise(fulfil => {
+			window.started = new Promise((fulfil, reject) => {
 				setTimeout(() => {
 					reject(new Error('Timed out'));
 				}, 5000);
@@ -145,7 +145,6 @@ function duplicate(test_fn, config) {
 
 						await context.pages.js.click(selector);
 						await context.pages.js.evaluate(() => window.navigated);
-						await context.pages.js.evaluate(() => window.started); // in case router=false
 					},
 					js: true,
 					response

--- a/packages/kit/test/test.js
+++ b/packages/kit/test/test.js
@@ -144,8 +144,8 @@ function duplicate(test_fn, config) {
 						});
 
 						await context.pages.js.click(selector);
-
 						await context.pages.js.evaluate(() => window.navigated);
+						await context.pages.js.evaluate(() => window.started); // in case router=false
 					},
 					js: true,
 					response


### PR DESCRIPTION
#777. not sure if this will work, because I can't reproduce the failure locally. it seems to mostly (always?) happen on windows. ~~to be honest i'm not sure how the `clicknav` helper even works when `router=false`, as i'd expect the execution context to be destroyed, but somehow it does work usually~~ never mind, i get it now