### PR TITLE
Use `Response` type from `node-fetch` to type our own fetch responses

### DIFF
--- a/.changeset/warm-cameras-fix.md
+++ b/.changeset/warm-cameras-fix.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Correct response type for fetch

--- a/packages/kit/types.d.ts
+++ b/packages/kit/types.d.ts
@@ -1,5 +1,6 @@
 import { Headers, LoadInput, LoadOutput, Logger } from './types.internal';
 import { UserConfig as ViteConfig } from 'vite';
+import { Response as NodeFetchResponse } from 'node-fetch';
 
 export type Config = {
 	compilerOptions?: any;
@@ -82,11 +83,7 @@ export type Request<Context = any, Body = unknown> = {
 	context: Context;
 };
 
-export type Response = {
-	status?: number;
-	headers?: Headers;
-	body?: any;
-};
+export type Response = NodeFetchResponse;
 
 export type RequestHandler<Context = any, Body = unknown> = (
 	request?: Request<Context, Body>

--- a/packages/kit/types.d.ts
+++ b/packages/kit/types.d.ts
@@ -1,6 +1,5 @@
 import { Headers, LoadInput, LoadOutput, Logger } from './types.internal';
 import { UserConfig as ViteConfig } from 'vite';
-import { Response as NodeFetchResponse } from 'node-fetch';
 
 export type Config = {
 	compilerOptions?: any;
@@ -83,7 +82,11 @@ export type Request<Context = any, Body = unknown> = {
 	context: Context;
 };
 
-export type Response = NodeFetchResponse;
+export type Response = {
+	status?: number;
+	headers?: Headers;
+	body?: any;
+};
 
 export type RequestHandler<Context = any, Body = unknown> = (
 	request?: Request<Context, Body>

--- a/packages/kit/types.internal.d.ts
+++ b/packages/kit/types.internal.d.ts
@@ -1,5 +1,6 @@
 import { Adapter, GetContext, GetSession, Handle, Incoming, Load, Response } from './types';
 import { UserConfig as ViteConfig } from 'vite';
+import { Response as NodeFetchResponse } from 'node-fetch';
 
 declare global {
 	interface ImportMeta {
@@ -84,7 +85,7 @@ export type Page = {
 
 export type LoadInput = {
 	page: Page;
-	fetch: (info: RequestInfo, init?: RequestInit) => Promise<Response>;
+	fetch: (info: RequestInfo, init?: RequestInit) => Promise<NodeFetchResponse>;
 	session: any;
 	context: Record<string, any>;
 };


### PR DESCRIPTION
Fixes #691