### PR TITLE
Fix fatal error when parsing URLs in Node adapter

### DIFF
--- a/.changeset/silver-elephants-tap.md
+++ b/.changeset/silver-elephants-tap.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Fix fatal error when trying to parse URLs of incoming requests

--- a/.changeset/witty-eyes-relax.md
+++ b/.changeset/witty-eyes-relax.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+Simplify parsing of URLS of incoming requests

--- a/packages/adapter-node/src/server.js
+++ b/packages/adapter-node/src/server.js
@@ -31,7 +31,7 @@ const assets_handler = sirv(join(__dirname, '/assets'), {
 
 polka()
 	.use(compression({ threshold: 0 }), assets_handler, prerendered_handler, async (req, res) => {
-		const parsed = new URL(req.url || '');
+		const parsed = new URL(req.url || '', 'http://localhost');
 		const rendered = await app.render({
 			method: req.method,
 			headers: req.headers, // TODO: what about repeated headers, i.e. string[]

--- a/packages/adapter-vercel/src/entry.js
+++ b/packages/adapter-vercel/src/entry.js
@@ -3,8 +3,7 @@ import { URL } from 'url';
 import { get_body } from '@sveltejs/kit/http';
 
 export default async (req, res) => {
-	const host = `${req.headers['x-forwarded-proto']}://${req.headers.host}`;
-	const { pathname, searchParams } = new URL(req.url || '', host);
+	const { pathname, searchParams } = new URL(req.url || '', 'http://localhost');
 
 	const { render } = await import('./server/app.mjs');
 


### PR DESCRIPTION
Fixes the bug with the Node adapter in #801, and also performs the tidying I mentioned in that issue for the Vercel adapter.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
