### PR TITLE
Service Worker Crash

### DIFF
--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -46,9 +46,7 @@ export async function start({ paths, target, session, host, route, hydrate }) {
 }
 
 if (import.meta.env.VITE_SVELTEKIT_SERVICE_WORKER) {
-	try {
+	if ('serviceWorker' in navigator) {
 		navigator.serviceWorker.register(import.meta.env.VITE_SVELTEKIT_SERVICE_WORKER);
-	} catch (e){
-		console.log(e);
 	}
 }

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -46,5 +46,9 @@ export async function start({ paths, target, session, host, route, hydrate }) {
 }
 
 if (import.meta.env.VITE_SVELTEKIT_SERVICE_WORKER) {
-	navigator.serviceWorker.register(import.meta.env.VITE_SVELTEKIT_SERVICE_WORKER);
+	try{
+		navigator.serviceWorker.register(import.meta.env.VITE_SVELTEKIT_SERVICE_WORKER);
+	}catch(e){
+		console.log(e)
+	}
 }

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -46,9 +46,9 @@ export async function start({ paths, target, session, host, route, hydrate }) {
 }
 
 if (import.meta.env.VITE_SVELTEKIT_SERVICE_WORKER) {
-	try{
+	try {
 		navigator.serviceWorker.register(import.meta.env.VITE_SVELTEKIT_SERVICE_WORKER);
-	}catch(e){
-		console.log(e)
+	} catch (e){
+		console.log(e);
 	}
 }


### PR DESCRIPTION
Avoid Service Worker crashing client side if it's not supported,
when the service worker is not supported, it throws an error : 
` Cannot read property 'register' of undefined`
so to fix it, just warp it in try & catch block
