### PR TITLE
Update docs to show how `load` differs from Next.js's getStaticProps

### DIFF
--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -54,7 +54,7 @@ type LoadOutput = {
 </script>
 ```
 
-`load` is the SvelteKit equivalent of `getStaticProps` or `getServerSideProps` in Next.js or `asyncData` in Nuxt.js.
+`load` is the SvelteKit similar of `getStaticProps` or `getServerSideProps` in Next.js or `asyncData` in Nuxt.js, except that it runs on both the server and the client.
 
 If `load` returns nothing, SvelteKit will [fall through](#routing-advanced-fallthrough-routes) to other routes until something responds, or will respond with a generic 404.
 

--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -54,7 +54,7 @@ type LoadOutput = {
 </script>
 ```
 
-`load` is similar to Next.js's `getStaticProps` or `getServerSideProps` or Nuxt.js's `asyncData`, except that it runs on both the server and the client.
+`load` is similar to `getStaticProps` or `getServerSideProps` in Next.js, except that it runs on both the server and the client.
 
 If `load` returns nothing, SvelteKit will [fall through](#routing-advanced-fallthrough-routes) to other routes until something responds, or will respond with a generic 404.
 

--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -54,7 +54,7 @@ type LoadOutput = {
 </script>
 ```
 
-`load` is the SvelteKit similar of `getStaticProps` or `getServerSideProps` in Next.js or `asyncData` in Nuxt.js, except that it runs on both the server and the client.
+`load` is similar to Next.js's `getStaticProps` or `getServerSideProps` or Nuxt.js's `asyncData`, except that it runs on both the server and the client.
 
 If `load` returns nothing, SvelteKit will [fall through](#routing-advanced-fallthrough-routes) to other routes until something responds, or will respond with a generic 404.
 


### PR DESCRIPTION
Currently the docs say that the `load` function is the Sveltekit equivalent to Next.js's `getStaticProps` or `getServerSideProps`.

> load is the SvelteKit equivalent of getStaticProps or getServerSideProps in Next.js or asyncData in Nuxt.js.

This PR reflects the fact that Sveltekit's `load` function also runs on the client. Here's the new sentence:

> `load` is similar to Next.js's `getStaticProps` or `getServerSideProps` or Nuxt.js's `asyncData`, except that it runs on both the server and the client.

In Next.js, `getStaticProps` and `getServerSideProps` both only run on the server. This means it's safe to run privileged code in these functions. However, according the current Sveltekit docs, `load` runs on both the client and server, meaning that you should not run privileged code in it.

This PR should help prevent Sveltekit users from accidentally creating security vulnerabilities in their apps due to this difference.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
