### PR TITLE
create-svelte: update tsconfig to allow es2020 module and lib

### DIFF
--- a/.changeset/heavy-lamps-explode.md
+++ b/.changeset/heavy-lamps-explode.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Update tsconfig to use module and lib es2020

--- a/packages/create-svelte/template-additions/tsconfig.json
+++ b/packages/create-svelte/template-additions/tsconfig.json
@@ -1,6 +1,8 @@
 {
 	"compilerOptions": {
 		"moduleResolution": "node",
+		"module": "es2020",
+		"lib": ["es2020"],
 		"target": "es2019",
 		/**
 			svelte-preprocess cannot figure out whether you have a value or a type, so tell TypeScript


### PR DESCRIPTION
**Why `module es2020`?**
Currently, using dynamic imports with TypeScript results in:
```
Dynamic imports are only supported when the '--module' flag is set to 'es2020', 'esnext', 'commonjs', 'amd', 'system', or 'umd'.ts(1323)
```
Dynamic imports have been available unflagged [since Node v12.17](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#2020-05-26-version-12170-erbium-lts-targos).

**Why `lib es2020`?**
Node v12.10+ has [support for `String.prototype.matchAll`, `BigInt`, `Promise.allSettled`, and `globalThis`](https://node.green/#ES2020).

---

Since we target Node v12.17+ for ESM support, this allows TS users to use the new builtins and dynamic imports without forcing `target es2020` which lets the nullish coalescing operator `??` and optional chaining operator `?.` pass through and are undesirable.

`jsconfig` does not need these changes.