### PR TITLE
check port before dev/start and expose network address

### DIFF
--- a/.changeset/tiny-gorillas-whisper.md
+++ b/.changeset/tiny-gorillas-whisper.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Check port, expose network address

--- a/.changeset/tiny-gorillas-whisper.md
+++ b/.changeset/tiny-gorillas-whisper.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Check port, expose network address
+Check port, only expose to network with --host flag

--- a/packages/kit/rollup.config.js
+++ b/packages/kit/rollup.config.js
@@ -79,6 +79,7 @@ export default [
 		plugins: [
 			replace({
 				preventAssignment: true,
+				delimiters: ['', ''],
 				values: {
 					__VERSION__: pkg.version
 				}

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -179,6 +179,7 @@ async function check_port(port) {
 /**
  * @param {{
  *   open: boolean;
+ *   host: string;
  *   port: number;
  * }} param0
  */

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -197,10 +197,14 @@ function welcome({ port, host, open }) {
 			// prettier-ignore
 			if (details.internal) {
 				console.log(`  ${colors.gray('local:  ')} http://${colors.bold(`localhost:${port}`)}`);
-			} else if (exposed) {
-				console.log(`  ${colors.gray('network:')} http://${colors.bold(`${details.address}:${port}`)}`);
 			} else {
-				console.log(`  ${colors.gray('network: not exposed')}`);
+				if (details.mac === '00:00:00:00:00:00') return;
+
+				if (exposed) {
+					console.log(`  ${colors.gray('network:')} http://${colors.bold(`${details.address}:${port}`)}`);
+				} else {
+					console.log(`  ${colors.gray('network: not exposed')}`);
+				}
 			}
 		});
 	});

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -14,7 +14,7 @@ import { get_body } from '../http/index.js';
 import { copy_assets } from '../utils.js';
 import svelte from '@sveltejs/vite-plugin-svelte';
 
-/** @typedef {{ cwd?: string, port: number, config: import('../../../types.internal').ValidatedConfig }} Options */
+/** @typedef {{ cwd?: string, port: number, host: string, config: import('../../../types.internal').ValidatedConfig }} Options */
 /** @typedef {import('../../../types.internal').SSRComponent} SSRComponent */
 
 /** @param {Options} opts */
@@ -24,13 +24,14 @@ export function dev(opts) {
 
 class Watcher extends EventEmitter {
 	/** @param {Options} opts */
-	constructor({ cwd = process.cwd(), port, config }) {
+	constructor({ cwd = process.cwd(), port, host, config }) {
 		super();
 
 		this.cwd = cwd;
 		this.dir = path.resolve(cwd, '.svelte/dev');
 
 		this.port = port;
+		this.host = host;
 		this.config = config;
 
 		process.env.NODE_ENV = 'development';
@@ -244,7 +245,7 @@ class Watcher extends EventEmitter {
 			});
 		});
 
-		this.server.listen(this.port);
+		this.server.listen(this.port, this.host || '0.0.0.0');
 	}
 
 	update() {

--- a/packages/kit/src/core/start/index.js
+++ b/packages/kit/src/core/start/index.js
@@ -15,12 +15,13 @@ const mutable = (dir) =>
 /**
  * @param {{
  *   port: number;
+ *   host: string;
  *   config: import('../../../types.internal').ValidatedConfig;
  *   cwd?: string;
  * }} opts
  * @returns {Promise<import('http').Server>}
  */
-export async function start({ port, config, cwd = process.cwd() }) {
+export async function start({ port, host, config, cwd = process.cwd() }) {
 	const app_file = resolve(cwd, '.svelte/output/server/app.js');
 
 	/** @type {import('../../../types.internal').App} */
@@ -73,7 +74,7 @@ export async function start({ port, config, cwd = process.cwd() }) {
 			});
 		});
 
-		server.listen(port, () => {
+		server.listen(port, host || '0.0.0.0', () => {
 			fulfil(server);
 		});
 


### PR DESCRIPTION
closes #688. This adds two things — firstly, it checks the port is available when you run `dev` or `start`, and prints a helpful message if not...

![image](https://user-images.githubusercontent.com/1162160/113301047-92def100-92cc-11eb-976c-cbc2bde18a93.png)

...and prints the network address on startup:

![image](https://user-images.githubusercontent.com/1162160/113301162-b609a080-92cc-11eb-9901-a204d4540a98.png)

This is in line with similar dev tools (e.g. Vite) — I don't think we need to add an explicit `--host` option for dev tooling, but others may disagree.

I'm not sure how the `check_port` function will behave on Windows machines — I think it'll just fail silently, but if someone with access to one can check the behaviour (both when the port is occupied and when it isn't) that would be very helpful.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
