### PR TITLE
let hash changes be handled by the router

### DIFF
--- a/.changeset/five-shirts-allow.md
+++ b/.changeset/five-shirts-allow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+let hash only changes be handled by router

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -132,9 +132,6 @@ export class Router {
 
 			const url = new URL(href);
 
-			// Don't handle hash changes
-			if (url.pathname === location.pathname && url.search === location.search) return;
-
 			if (!this.owns(url)) return;
 
 			const noscroll = a.hasAttribute('sveltekit:noscroll');

--- a/packages/kit/test/apps/basics/src/routes/routing/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/_tests.js
@@ -190,6 +190,18 @@ export default function (test) {
 		assert.equal(await page.textContent('h1'), 'Great success!');
 	});
 
+	test(
+		'back button returns to previous route when previous route has been navigated to via hash anchor',
+		'/routing/hashes/a',
+		async ({ page, clicknav }) => {
+			await clicknav('[href="#hash-target"]');
+			await clicknav('[href="/routing/hashes/b"]');
+
+			await page.goBack();
+			assert.equal(await page.textContent('h1'), 'a');
+		}
+	);
+
 	test('falls through', '/routing/fallthrough/borax', async ({ page, clicknav }) => {
 		assert.equal(await page.textContent('h1'), 'borax is a mineral');
 

--- a/packages/kit/test/apps/basics/src/routes/routing/hashes/a.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/hashes/a.svelte
@@ -1,0 +1,3 @@
+<h1 id="hash-target">a</h1>
+<a href="#hash-target">hash link</a>
+<a href="/routing/hashes/b">b</a>

--- a/packages/kit/test/apps/basics/src/routes/routing/hashes/b.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/hashes/b.svelte
@@ -1,0 +1,2 @@
+<h1>b</h1>
+<button on:click={() => history.back()}>go back</button>


### PR DESCRIPTION
Allow router to handle hash only changes in order to make browser (back) navigation to hash routes work.
Fixes https://github.com/sveltejs/kit/issues/821


