### PR TITLE
delete redundant global.css stylesheet link from hn.svelte.dev example

### DIFF
--- a/examples/hn.svelte.dev/src/app.html
+++ b/examples/hn.svelte.dev/src/app.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html lang="en">
+
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
@@ -19,13 +20,14 @@
 		}
 	</script>
 
-	<link rel="stylesheet" href="/global.css">
 	<link rel="manifest" href="/manifest.json">
 	<link rel="icon" type="image/png" href="/favicon.png">
 
 	%svelte.head%
 </head>
+
 <body>
 	<div id="svelte">%svelte.body%</div>
 </body>
+
 </html>


### PR DESCRIPTION
Delete redundant `global.css` stylesheet link from the `app.html` of the hn.svelte.dev example as it displays the bellow error in browser's console. The file `static/global.css` is not part of the example anymore, the contents of the file have been previously moved to `src/app.css`.

```
The resource from “http://localhost:3000/global.css” was blocked due to MIME type (“text/html”) mismatch (X-Content-Type-Options: nosniff).
```