### PR TITLE
document --host and --https, simplify https stuff

### DIFF
--- a/documentation/docs/12-cli.md
+++ b/documentation/docs/12-cli.md
@@ -17,7 +17,7 @@ Starts a development server. It accepts the following options:
 - `-p`/`--port` — which port to start the server on
 - `-o`/`--open` — open a browser tab once the server starts
 - `-h`/`--host` — expose the server to the network. This will allow people using the same coffee shop WiFi as you to see files on your computer; use it with care
-- `-H`,`--https` — launch an HTTPS server using a self-signed certificate. Useful for testing HTTPS-only features on an external device
+- `-H`/`--https` — launch an HTTPS server using a self-signed certificate. Useful for testing HTTPS-only features on an external device
 
 ### svelte-kit build
 

--- a/documentation/docs/12-cli.md
+++ b/documentation/docs/12-cli.md
@@ -34,4 +34,4 @@ Like `svelte-kit dev`, it accepts the following options:
 - `-p`/`--port`
 - `-o`/`--open`
 - `-h`/`--host` (note the security caveat [above](#command-line-interface-svelte-kit-dev))
-- `-H`,`-https`
+- `-H`/`--https`

--- a/documentation/docs/12-cli.md
+++ b/documentation/docs/12-cli.md
@@ -17,7 +17,7 @@ Starts a development server. It accepts the following options:
 - `-p`/`--port` — which port to start the server on
 - `-o`/`--open` — open a browser tab once the server starts
 - `-h`/`--host` — expose the server to the network. This will allow people using the same coffee shop WiFi as you to see files on your computer; use it with care
-- `--https` — launch an HTTPS server using a self-signed certificate. Useful for testing HTTPS-only features on an external device
+- `-H`,`--https` — launch an HTTPS server using a self-signed certificate. Useful for testing HTTPS-only features on an external device
 
 ### svelte-kit build
 
@@ -34,4 +34,4 @@ Like `svelte-kit dev`, it accepts the following options:
 - `-p`/`--port`
 - `-o`/`--open`
 - `-h`/`--host` (note the security caveat [above](#command-line-interface-svelte-kit-dev))
-- `-https`
+- `-H`,`-https`

--- a/documentation/docs/12-cli.md
+++ b/documentation/docs/12-cli.md
@@ -14,14 +14,16 @@ npx svelte-kit dev
 
 Starts a development server. It accepts the following options:
 
-* `-p`/`--port` — which port to start the server on
-* `-o`/`--open` — open a browser tab once the server starts
+- `-p`/`--port` — which port to start the server on
+- `-o`/`--open` — open a browser tab once the server starts
+- `-h`/`--host` — expose the server to the network. This will allow people using the same coffee shop WiFi as you to see files on your computer; use it with care
+- `--https` — launch an HTTPS server using a self-signed certificate. Useful for testing HTTPS-only features on an external device
 
 ### svelte-kit build
 
 Builds a production version of your app, and runs your adapter if you have one specified in your [config](#configuration). It accepts the following option:
 
-* `--verbose` — log more detail
+- `--verbose` — log more detail
 
 ### svelte-kit start
 
@@ -29,5 +31,7 @@ After you've built your app with `svelte-kit build`, you can start the productio
 
 Like `svelte-kit dev`, it accepts the following options:
 
-* `-p`/`--port` — which port to start the server on
-* `-o`/`--open` — open a browser tab once the server starts
+- `-p`/`--port`
+- `-o`/`--open`
+- `-h`/`--host` (note the security caveat [above](#command-line-interface-svelte-kit-dev))
+- `-https`

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -70,7 +70,7 @@ prog
 	.describe('Start a development server')
 	.option('-p, --port', 'Port', 3000)
 	.option('-h, --host', 'Host (only use this on trusted networks)', 'localhost')
-	.option('--https', 'use self-signed HTTPS certificate', false)
+	.option('-H, --https', 'Use self-signed HTTPS certificate', false)
 	.option('-o, --open', 'Open a browser tab', false)
 	.action(async ({ port, host, https, open }) => {
 		await check_port(port);
@@ -132,7 +132,7 @@ prog
 	.describe('Serve an already-built app')
 	.option('-p, --port', 'Port', 3000)
 	.option('-h, --host', 'Host (only use this on trusted networks)', 'localhost')
-	.option('--https', 'use self-signed HTTPS certificate', false)
+	.option('-H, --https', 'Use self-signed HTTPS certificate', false)
 	.option('-o, --open', 'Open a browser tab', false)
 	.action(async ({ port, host, https, open }) => {
 		await check_port(port);

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -14,7 +14,7 @@ import { copy_assets } from '../utils.js';
 import svelte from '@sveltejs/vite-plugin-svelte';
 import { get_server } from '../server/index.js';
 
-/** @typedef {{ cwd?: string, port: number, host: string, https: boolean | import('https').ServerOptions, config: import('../../../types.internal').ValidatedConfig }} Options */
+/** @typedef {{ cwd?: string, port: number, host: string, https: boolean, config: import('../../../types.internal').ValidatedConfig }} Options */
 /** @typedef {import('../../../types.internal').SSRComponent} SSRComponent */
 
 /** @param {Options} opts */

--- a/packages/kit/src/core/server/index.js
+++ b/packages/kit/src/core/server/index.js
@@ -11,7 +11,7 @@ import https from 'https';
  */
 export async function get_server(port, host, use_https, handler) {
 	/** @type {https.ServerOptions} */
-	let https_options = {};
+	const https_options = {};
 
 	if (use_https) {
 		https_options.key = https_options.cert = (await import('./cert')).createCertificate();

--- a/packages/kit/src/core/server/index.js
+++ b/packages/kit/src/core/server/index.js
@@ -5,22 +5,20 @@ import https from 'https';
  *
  * @param {number} port
  * @param {string} host
- * @param {boolean | https.ServerOptions} https_options
+ * @param {boolean} use_https
  * @param {(req: http.IncomingMessage, res: http.ServerResponse) => void} handler
  * @returns {Promise<http.Server | https.Server>}
  */
-export async function get_server(port, host, https_options, handler) {
-	if (https_options) {
-		https_options =
-			typeof https_options === 'boolean' ? /** @type {https.ServerOptions} */ ({}) : https_options;
+export async function get_server(port, host, use_https, handler) {
+	/** @type {https.ServerOptions} */
+	let https_options = {};
 
-		if (!https_options.key || !https_options.cert) {
-			https_options.key = https_options.cert = (await import('./cert')).createCertificate();
-		}
+	if (use_https) {
+		https_options.key = https_options.cert = (await import('./cert')).createCertificate();
 	}
 
 	return new Promise((fulfil) => {
-		const server = https_options
+		const server = use_https
 			? https.createServer(/** @type {https.ServerOptions} */ (https_options), handler)
 			: http.createServer(handler);
 

--- a/packages/kit/src/core/start/index.js
+++ b/packages/kit/src/core/start/index.js
@@ -17,17 +17,11 @@ const mutable = (dir) =>
  *   port: number;
  *   host: string;
  *   config: import('types.internal').ValidatedConfig;
- *   https?: boolean | import('https').ServerOptions;
+ *   https?: boolean;
  *   cwd?: string;
  * }} opts
  */
-export async function start({
-	port,
-	host,
-	config,
-	https: https_options = false,
-	cwd = process.cwd()
-}) {
+export async function start({ port, host, config, https: use_https = false, cwd = process.cwd() }) {
 	const app_file = resolve(cwd, '.svelte/output/server/app.js');
 
 	/** @type {import('types.internal').App} */
@@ -43,7 +37,7 @@ export async function start({
 		immutable: true
 	});
 
-	return get_server(port, host, https_options, (req, res) => {
+	return get_server(port, host, use_https, (req, res) => {
 		const parsed = parse(req.url || '');
 
 		assets_handler(req, res, () => {


### PR DESCRIPTION
Realised that the CLI doesn't give us a way to specify an options object, so for now at least there's no way to bring your own key/certificate