### PR TITLE
Credentialed fetch from `load`

### DIFF
--- a/.changeset/six-rules-collect.md
+++ b/.changeset/six-rules-collect.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Pass through credentials when fetching in load

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -15,6 +15,7 @@
 		"@types/rimraf": "^3.0.0",
 		"@types/sade": "^1.7.2",
 		"amphtml-validator": "^1.0.34",
+		"cookie": "^0.4.1",
 		"devalue": "^2.0.1",
 		"eslint": "^7.21.0",
 		"kleur": "^4.1.4",

--- a/packages/kit/test/apps/basics/src/hooks.js
+++ b/packages/kit/test/apps/basics/src/hooks.js
@@ -24,7 +24,7 @@ export async function handle(request, render) {
 			...response,
 			headers: {
 				...response.headers,
-				'set-cookie': 'name=SvelteKit; path=/; HttpOnly'
+				'Set-Cookie': 'name=SvelteKit; path=/; HttpOnly'
 			}
 		};
 	}

--- a/packages/kit/test/apps/basics/src/hooks.js
+++ b/packages/kit/test/apps/basics/src/hooks.js
@@ -1,10 +1,31 @@
-export function getContext() {
+import cookie from 'cookie';
+
+/** @type {import('../../../../types').GetContext} */
+export function getContext(request) {
+	const cookies = cookie.parse(request.headers.cookie || '');
+
 	return {
-		answer: 42
+		answer: 42,
+		name: cookies.name
 	};
 }
 
-/** @param {any} context */
+/** @type {import('../../../../types').GetSession} */
 export function getSession({ context }) {
 	return context;
+}
+
+/** @type {import('../../../../types').Handle} */
+export async function handle(request, render) {
+	const response = await render(request);
+
+	if (response) {
+		return {
+			...response,
+			headers: {
+				...response.headers,
+				'set-cookie': 'name=SvelteKit; path=/; HttpOnly'
+			}
+		};
+	}
 }

--- a/packages/kit/test/apps/basics/src/routes/load/__tests__.js
+++ b/packages/kit/test/apps/basics/src/routes/load/__tests__.js
@@ -134,7 +134,7 @@ export default function (test, is_dev) {
 		server.close();
 	});
 
-	test.only(
+	test(
 		'makes credentialed fetches to endpoints by default',
 		'/load',
 		async ({ page, clicknav }) => {

--- a/packages/kit/test/apps/basics/src/routes/load/__tests__.js
+++ b/packages/kit/test/apps/basics/src/routes/load/__tests__.js
@@ -133,4 +133,13 @@ export default function (test, is_dev) {
 
 		server.close();
 	});
+
+	test.only(
+		'makes credentialed fetches to endpoints by default',
+		'/load',
+		async ({ page, clicknav }) => {
+			await clicknav('[href="/load/fetch-credentialed"]');
+			assert.equal(await page.textContent('h1'), 'Hello SvelteKit!');
+		}
+	);
 }

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-credentialed.json.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-credentialed.json.js
@@ -1,0 +1,7 @@
+export function get(request) {
+	return {
+		body: {
+			name: request.context.name
+		}
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-credentialed.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-credentialed.svelte
@@ -1,0 +1,22 @@
+<script context="module">
+	/** @type {import('../../../../../../types').Load} */
+	export async function load({ fetch }) {
+		const res = await fetch('/load/fetch-credentialed.json');
+
+		/** @type {any} */
+		const { name } = await res.json();
+
+		return {
+			props: {
+				name
+			}
+		};
+	}
+</script>
+
+<script>
+	/** @type {string} */
+	export let name;
+</script>
+
+<h1>Hello {name}!</h1>

--- a/packages/kit/test/apps/basics/src/routes/load/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/index.svelte
@@ -19,4 +19,5 @@
 <h1>bar == {foo}?</h1>
 
 <a href="/load/fetch-request">fetch request</a>
+<a href="/load/fetch-credentialed">fetch credentialed</a>
 <a href="/load/large-response">large response</a>

--- a/packages/kit/test/test.js
+++ b/packages/kit/test/test.js
@@ -10,12 +10,25 @@ import { load_config } from '../src/core/load_config/index.js';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 async function setup({ port }) {
+	const base = `http://localhost:${port}`;
+
 	const browser = await chromium.launch();
 
 	const contexts = {
 		js: await browser.newContext({ javaScriptEnabled: true }),
 		nojs: await browser.newContext({ javaScriptEnabled: false })
 	};
+
+	const cookie = {
+		name: 'name',
+		value: 'SvelteKit',
+		domain: base,
+		path: '/',
+		httpOnly: true
+	};
+
+	await contexts.js.addCookies([cookie]);
+	await contexts.nojs.addCookies([cookie]);
 
 	const pages = {
 		js: await contexts.js.newPage(),
@@ -49,7 +62,6 @@ async function setup({ port }) {
 
 		return requests;
 	};
-	const base = `http://localhost:${port}`;
 
 	// Uncomment this for debugging
 	// pages.js.on('console', (msg) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,7 @@ importers:
       '@types/rimraf': 3.0.0
       '@types/sade': 1.7.2
       amphtml-validator: 1.0.34
+      cookie: 0.4.1
       devalue: 2.0.1
       eslint: 7.21.0
       kleur: 4.1.4
@@ -197,6 +198,7 @@ importers:
       '@types/sade': ^1.7.2
       amphtml-validator: ^1.0.34
       cheap-watch: ^1.0.3
+      cookie: ^0.4.1
       devalue: ^2.0.1
       eslint: ^7.21.0
       kleur: ^4.1.4
@@ -1187,7 +1189,6 @@ packages:
     resolution:
       integrity: sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
   /cookie/0.4.1:
-    dev: false
     engines:
       node: '>= 0.6'
     resolution:


### PR DESCRIPTION
#672. Adds the `cookie` header used to request the page, plus `authorization` if it's not explicitly provided, to a `fetch` request that happens inside `load` to an internal endpoint, if `credentials` is not set to `omit`.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
