### PR TITLE
only inline data if hydrate=true

### DIFF
--- a/.changeset/wild-beans-happen.md
+++ b/.changeset/wild-beans-happen.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Only inline data if hydrate=true

--- a/packages/kit/src/runtime/server/page.js
+++ b/packages/kit/src/runtime/server/page.js
@@ -150,7 +150,7 @@ async function get_response({ request, options, $session, route, status = 200, e
 			}
 		}
 
-		if (response) {
+		if (response && page_config.hydrate) {
 			const proxy = new Proxy(response, {
 				get(response, key, receiver) {
 					async function text() {
@@ -190,9 +190,12 @@ async function get_response({ request, options, $session, route, status = 200, e
 			return proxy;
 		}
 
-		return new Response('Not found', {
-			status: 404
-		});
+		return (
+			response ||
+			new Response('Not found', {
+				status: 404
+			})
+		);
 	};
 
 	const component_promises = error

--- a/packages/kit/test/apps/basics/src/routes/hydrate/__tests__.js
+++ b/packages/kit/test/apps/basics/src/routes/hydrate/__tests__.js
@@ -12,6 +12,12 @@ export default function (test, is_dev) {
 
 			await page.click('button');
 			assert.equal(await page.textContent('button'), 'clicks: 1');
+		} else {
+			// ensure data wasn't inlined
+			assert.equal(
+				await page.evaluate(() => document.querySelectorAll('script[type="svelte-data"]').length),
+				0
+			);
 		}
 	});
 }

--- a/packages/kit/test/apps/basics/src/routes/hydrate/index.json.js
+++ b/packages/kit/test/apps/basics/src/routes/hydrate/index.json.js
@@ -1,0 +1,7 @@
+export function get() {
+	return {
+		body: {
+			type: 'hydrate'
+		}
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/hydrate/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/hydrate/index.svelte
@@ -1,8 +1,23 @@
 <script context="module">
 	export const hydrate = false;
+
+	/** @type {import('../../../../../../types').Load} */
+	export async function load({ fetch }) {
+		const res = await fetch('/hydrate.json');
+
+		/** @type {any} */
+		const { type } = await res.json();
+
+		return {
+			props: { type }
+		}
+	}
 </script>
 
 <script>
+	/** @type {string} */
+	export let type;
+
 	let n = 0;
 </script>
 
@@ -10,4 +25,4 @@
 	clicks: {n}
 </button>
 
-<a href="/hydrate/other">other</a>
+<a href="/{type}/other">other</a>


### PR DESCRIPTION
#823. Skips inlining `<script type="svelte-data">` blocks if the page isn't going to be hydrated.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
