### PR TITLE
Call `load` when `page.path` changes, if referenced

### DIFF
--- a/.changeset/pretty-kids-watch.md
+++ b/.changeset/pretty-kids-watch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Call load when path changes if page.path is used

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -310,6 +310,7 @@ export class Renderer {
 		};
 
 		const changed = {
+			path: !this.current.page || page.path !== this.current.page.path,
 			params: Object.keys(page.params).filter((key) => {
 				return !this.current.page || this.current.page.params[key] !== page.params[key];
 			}),
@@ -341,6 +342,7 @@ export class Renderer {
 				const changed_since_last_render =
 					!previous ||
 					module !== previous.module ||
+					(changed.path && previous.uses.path) ||
 					changed.params.some((param) => previous.uses.params.has(param)) ||
 					(changed.query && previous.uses.query) ||
 					(changed.session && previous.uses.session) ||
@@ -366,6 +368,7 @@ export class Renderer {
 							module,
 							uses: {
 								params: new Set(),
+								path: false,
 								query: false,
 								session: false,
 								context: false
@@ -389,8 +392,11 @@ export class Renderer {
 							loaded = await module.load.call(null, {
 								page: {
 									host: page.host,
-									path: page.path,
 									params,
+									get path() {
+										node.uses.path = true;
+										return page.path;
+									},
 									get query() {
 										node.uses.query = true;
 										return page.query;

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -33,6 +33,7 @@ type PageNode = {
 	module: CSRComponent;
 	uses: {
 		params: Set<string>;
+		path: boolean;
 		query: boolean;
 		session: boolean;
 		context: boolean;

--- a/packages/kit/test/apps/basics/src/routes/routing/__tests__.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/__tests__.js
@@ -152,33 +152,6 @@ export default function (test) {
 		}
 	);
 
-	test('navigates to ...rest', '/routing/rest/abc/xyz', async ({ page, clicknav }) => {
-		assert.equal(await page.textContent('h1'), 'abc/xyz');
-
-		await clicknav('[href="/routing/rest/xyz/abc/def/ghi"]');
-		assert.equal(await page.textContent('h1'), 'xyz/abc/def/ghi');
-		assert.equal(await page.textContent('h2'), 'xyz/abc/def/ghi');
-
-		await clicknav('[href="/routing/rest/xyz/abc/def"]');
-		assert.equal(await page.textContent('h1'), 'xyz/abc/def');
-		assert.equal(await page.textContent('h2'), 'xyz/abc/def');
-
-		await clicknav('[href="/routing/rest/xyz/abc"]');
-		assert.equal(await page.textContent('h1'), 'xyz/abc');
-		assert.equal(await page.textContent('h2'), 'xyz/abc');
-
-		await clicknav('[href="/routing/rest"]');
-		assert.equal(await page.textContent('h1'), '');
-		assert.equal(await page.textContent('h2'), '');
-
-		await clicknav('[href="/routing/rest/xyz/abc/deep"]');
-		assert.equal(await page.textContent('h1'), 'xyz/abc');
-		assert.equal(await page.textContent('h2'), 'xyz/abc');
-
-		await clicknav('[href="/routing/rest/xyz/abc/qwe/deep.json"]');
-		assert.equal(await page.textContent('body'), 'xyz/abc/qwe');
-	});
-
 	test(
 		'navigates between dynamic routes with same segments',
 		'/routing/dirs/bar/xyz',

--- a/packages/kit/test/apps/basics/src/routes/routing/rest/[...rest]/__tests__.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/rest/[...rest]/__tests__.js
@@ -1,0 +1,31 @@
+import * as assert from 'uvu/assert';
+
+/** @type {import('../../../../../../../types').TestMaker} */
+export default function (test) {
+	test('navigates to ...rest', '/routing/rest/abc/xyz', async ({ page, clicknav }) => {
+		assert.equal(await page.textContent('h1'), 'abc/xyz');
+
+		await clicknav('[href="/routing/rest/xyz/abc/def/ghi"]');
+		assert.equal(await page.textContent('h1'), 'xyz/abc/def/ghi');
+		assert.equal(await page.textContent('h2'), 'xyz/abc/def/ghi');
+
+		await clicknav('[href="/routing/rest/xyz/abc/def"]');
+		assert.equal(await page.textContent('h1'), 'xyz/abc/def');
+		assert.equal(await page.textContent('h2'), 'xyz/abc/def');
+
+		await clicknav('[href="/routing/rest/xyz/abc"]');
+		assert.equal(await page.textContent('h1'), 'xyz/abc');
+		assert.equal(await page.textContent('h2'), 'xyz/abc');
+
+		await clicknav('[href="/routing/rest"]');
+		assert.equal(await page.textContent('h1'), '');
+		assert.equal(await page.textContent('h2'), '');
+
+		await clicknav('[href="/routing/rest/xyz/abc/deep"]');
+		assert.equal(await page.textContent('h1'), 'xyz/abc');
+		assert.equal(await page.textContent('h2'), 'xyz/abc');
+
+		await clicknav('[href="/routing/rest/xyz/abc/qwe/deep.json"]');
+		assert.equal(await page.textContent('body'), 'xyz/abc/qwe');
+	});
+}

--- a/packages/kit/test/apps/basics/src/routes/routing/rest/path/$layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/rest/path/$layout.svelte
@@ -1,0 +1,7 @@
+<a href="/routing/rest/path/one">one</a>
+<a href="/routing/rest/path/two">two</a>
+<a href="/routing/rest/path/three">three</a>
+<a href="/routing/rest/path/four">four</a>
+<a href="/routing/rest/path/five">five</a>
+
+<slot></slot>

--- a/packages/kit/test/apps/basics/src/routes/routing/rest/path/[...ignored].svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/rest/path/[...ignored].svelte
@@ -1,0 +1,17 @@
+<script context="module">
+	/** @type {import('../../../../../../../../types').Load} */
+	export function load({ page }) {
+		const { path } = page;
+
+		return {
+			props: { path }
+		};
+	}
+</script>
+
+<script>
+	/** @type {string} */
+	export let path;
+</script>
+
+<h1>path: {path}</h1>

--- a/packages/kit/test/apps/basics/src/routes/routing/rest/path/__tests__.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/rest/path/__tests__.js
@@ -1,0 +1,18 @@
+import * as assert from 'uvu/assert';
+
+/** @type {import('../../../../../../../types').TestMaker} */
+export default function (test) {
+	test(
+		'reloads when navigating between ...rest pages',
+		'/routing/rest/path/one',
+		async ({ page, clicknav }) => {
+			assert.equal(await page.textContent('h1'), 'path: /routing/rest/path/one');
+
+			await clicknav('[href="/routing/rest/path/two"]');
+			assert.equal(await page.textContent('h1'), 'path: /routing/rest/path/two');
+
+			await clicknav('[href="/routing/rest/path/three"]');
+			assert.equal(await page.textContent('h1'), 'path: /routing/rest/path/three');
+		}
+	);
+}


### PR DESCRIPTION
Fixes #643. Changes to `page.path` weren't being factored into whether or not to re-run `load`.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
