### PR TITLE
Duplicate style

### DIFF
--- a/.changeset/seven-impalas-march.md
+++ b/.changeset/seven-impalas-march.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Remove duplicate <style> element

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -263,14 +263,8 @@ export class Renderer {
 	_init(result) {
 		this.current = result.state;
 
-		// remove dev-mode SSR <style> insert, since it doesn't apply
-		// to hydrated markup (HMR requires hashes to be rewritten)
-		// TODO only in dev
-		// TODO it seems this doesn't always work with the classname
-		// stabilisation in vite-plugin-svelte? see e.g.
-		// hn.svelte.dev
-		// const style = document.querySelector('style[data-svelte]');
-		// if (style) style.remove();
+		const style = document.querySelector('style[data-svelte]');
+		if (style) style.remove();
 
 		this.root = new this.Root({
 			target: this.target,


### PR DESCRIPTION
In dev, the SSR'd page has a `<style>` element injected. When the page hydrates, an additional `<style>` with the same content is added. This PR removes the SSR'd CSS once hydration has occurred, to keep devtools tidy.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
