### PR TITLE
Always return something from `render`

### DIFF
--- a/.changeset/quiet-mangos-shop.md
+++ b/.changeset/quiet-mangos-shop.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Always return a response from render function in handle

--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -97,7 +97,7 @@ type Response = {
 
 type Handle<Context = any> = (
 	request: Request<Context>,
-	render: (request: Request<Context>) => Response | Promise<Response>
+	render: (request: Request<Context>) => Promise<Response>
 ) => Response | Promise<Response>;
 ```
 

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -123,10 +123,10 @@ export async function prerender({ cwd, out, log, config, force }) {
 				return;
 			}
 
-			if (response_type === OK) {
+			if (rendered.status === 200) {
 				log.info(`${rendered.status} ${path}`);
 				writeFileSync(file, rendered.body); // TODO minify where possible?
-			} else {
+			} else if (response_type !== OK) {
 				error(rendered.status, path);
 			}
 

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -354,6 +354,7 @@ async function build_server(
 			export function render(request, {
 				paths = ${s(config.kit.paths)},
 				local = false,
+				dependencies,
 				only_render_prerenderable_pages = false,
 				get_static_file
 			} = {}) {
@@ -371,6 +372,7 @@ async function build_server(
 					hooks,
 					dev: false,
 					amp: ${config.kit.amp},
+					dependencies,
 					only_render_prerenderable_pages,
 					app_dir: ${s(config.kit.appDir)},
 					get_component_path: id => ${s(`${config.kit.paths.assets}/${config.kit.appDir}/`)} + client_component_lookup[id],

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -1,7 +1,7 @@
 /**
  * @param {import('types').Request} request
  * @param {import('types.internal').SSREndpoint} route
- * @returns {Promise<import('types.internal').ResponseWithDependencies>}
+ * @returns {Promise<import('types').Response>}
  */
 export default async function render_route(request, route) {
 	const mod = await route.load();

--- a/packages/kit/src/runtime/server/page.js
+++ b/packages/kit/src/runtime/server/page.js
@@ -240,11 +240,23 @@ async function get_response({ request, options, $session, route, status = 200, e
 	};
 
 	if (options.only_render_prerenderable_pages) {
-		if (error) return; // don't prerender an error page
+		if (error) {
+			return {
+				status,
+				headers: {},
+				body: error.message
+			};
+		}
 
 		// if the page has `export const prerender = true`, continue,
 		// otherwise bail out at this point
-		if (!page_component.prerender) return;
+		if (!page_component.prerender) {
+			return {
+				status: 204,
+				headers: {},
+				body: null
+			};
+		}
 	}
 
 	/** @type {{ head: string, html: string, css: string }} */

--- a/packages/kit/src/runtime/server/page.js
+++ b/packages/kit/src/runtime/server/page.js
@@ -16,12 +16,9 @@ const s = JSON.stringify;
  *   status: number;
  *   error: Error
  * }} opts
- * @returns {Promise<import('types.internal').ResponseWithDependencies>}
+ * @returns {Promise<import('types').Response>}
  */
 async function get_response({ request, options, $session, route, status = 200, error }) {
-	/** @type {Record<string, import('types.internal').ResponseWithDependencies>} */
-	const dependencies = {};
-
 	const serialized_session = try_serialize($session, (error) => {
 		throw new Error(`Failed to serialize session data: ${error.message}`);
 	});
@@ -146,9 +143,9 @@ async function get_response({ request, options, $session, route, status = 200, e
 				);
 
 				if (rendered) {
-					// TODO this is primarily for the benefit of the static case,
-					// but could it be used elsewhere?
-					dependencies[resolved] = rendered;
+					if (options.dependencies) {
+						options.dependencies.set(resolved, rendered);
+					}
 
 					response = new Response(rendered.body, {
 						status: rendered.status,
@@ -480,8 +477,7 @@ async function get_response({ request, options, $session, route, status = 200, e
 	return {
 		status,
 		headers,
-		body: options.template({ head, body }),
-		dependencies
+		body: options.template({ head, body })
 	};
 }
 
@@ -489,7 +485,7 @@ async function get_response({ request, options, $session, route, status = 200, e
  * @param {import('types').Request} request
  * @param {import('types.internal').SSRPage} route
  * @param {import('types.internal').SSRRenderOptions} options
- * @returns {Promise<import('types.internal').ResponseWithDependencies>}
+ * @returns {Promise<import('types').Response>}
  */
 export default async function render_page(request, route, options) {
 	if (options.initiator === route) {

--- a/packages/kit/types.internal.d.ts
+++ b/packages/kit/types.internal.d.ts
@@ -65,7 +65,7 @@ export type App = {
 		};
 		prerendering: boolean;
 	}) => void;
-	render: (incoming: Incoming, options: SSRRenderOptions) => ResponseWithDependencies;
+	render: (incoming: Incoming, options: SSRRenderOptions) => Response;
 };
 
 // TODO we want to differentiate between request headers, which
@@ -73,10 +73,6 @@ export type App = {
 // 'set-cookie' is a `string[]` (or at least `string | string[]`)
 // but this can't happen until TypeScript 4.3
 export type Headers = Record<string, string>;
-
-export type ResponseWithDependencies = Response & {
-	dependencies?: Record<string, Response>;
-};
 
 export type Page = {
 	host: string;
@@ -185,6 +181,7 @@ export type SSRRenderOptions = {
 	hooks?: Hooks;
 	dev?: boolean;
 	amp?: boolean;
+	dependencies?: Map<string, Response>;
 	only_render_prerenderable_pages?: boolean;
 	app_dir?: string;
 	get_component_path?: (id: string) => string;


### PR DESCRIPTION
This fixes #763 in two ways:

1. The `render` function in `handle` always returns a `Promise<Response>`, which means the developer no longer has to handle the case where nothing is returned because we tried to prerender a non-prerenderable page (in which case we now get a `204`).
2. The `dependencies` object that used to accompany page responses now lives on the `options` that are passed in to `app.render`, bypassing the developer entirely. This eliminates a potential class of bugs arising from someone selectively returning properties of the response in `handle`.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
