### PR TITLE
expand typechecking, rename builder -> utils

### DIFF
--- a/packages/adapter-begin/index.js
+++ b/packages/adapter-begin/index.js
@@ -25,27 +25,27 @@ export default function () {
 	const adapter = {
 		name: '@sveltejs/adapter-begin',
 
-		async adapt(builder) {
-			builder.log.minor('Parsing app.arc file');
+		async adapt(utils) {
+			utils.log.minor('Parsing app.arc file');
 			const { static: static_mount_point } = parse_arc('app.arc');
 
 			const lambda_directory = resolve(join('src', 'http', 'get-index'));
 			const static_directory = resolve(static_mount_point);
 			const server_directory = resolve(join('src', 'shared'));
 
-			builder.log.minor('Writing client application...');
-			builder.copy_static_files(static_directory);
-			builder.copy_client_files(static_directory);
+			utils.log.minor('Writing client application...');
+			utils.copy_static_files(static_directory);
+			utils.copy_client_files(static_directory);
 
-			builder.log.minor('Building lambda...');
+			utils.log.minor('Building lambda...');
 			const local_lambda_dir = join(__dirname, 'files');
-			builder.copy(local_lambda_dir, lambda_directory);
+			utils.copy(local_lambda_dir, lambda_directory);
 
-			builder.log.minor('Writing server application...');
-			builder.copy_server_files(server_directory);
+			utils.log.minor('Writing server application...');
+			utils.copy_server_files(server_directory);
 
-			builder.log.minor('Prerendering static pages...');
-			await builder.prerender({
+			utils.log.minor('Prerendering static pages...');
+			await utils.prerender({
 				dest: static_directory
 			});
 		}

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -9,7 +9,7 @@ module.exports = function () {
 	/** @type {import('@sveltejs/kit').Adapter} */
 	const adapter = {
 		name: '@sveltejs/adapter-cloudflare-workers',
-		async adapt(builder) {
+		async adapt(utils) {
 			let wrangler_config;
 
 			if (fs.existsSync('wrangler.toml')) {
@@ -35,29 +35,29 @@ module.exports = function () {
 			const bucket = path.resolve(wrangler_config.site.bucket);
 			const entrypoint = path.resolve(wrangler_config.site['entry-point'] ?? 'workers-site');
 
-			builder.copy_static_files(bucket);
-			builder.copy_client_files(bucket);
-			builder.copy_server_files(entrypoint);
+			utils.copy_static_files(bucket);
+			utils.copy_client_files(bucket);
+			utils.copy_server_files(entrypoint);
 
 			// copy the renderer
-			builder.copy(path.resolve(__dirname, 'files/render.js'), `${entrypoint}/index.js`);
-			builder.copy(path.resolve(__dirname, 'files/_package.json'), `${entrypoint}/package.json`);
+			utils.copy(path.resolve(__dirname, 'files/render.js'), `${entrypoint}/index.js`);
+			utils.copy(path.resolve(__dirname, 'files/_package.json'), `${entrypoint}/package.json`);
 
-			builder.log.info('Prerendering static pages...');
-			await builder.prerender({
+			utils.log.info('Prerendering static pages...');
+			await utils.prerender({
 				dest: bucket
 			});
 
-			builder.log.info('Installing Worker Dependencies...');
+			utils.log.info('Installing Worker Dependencies...');
 			exec(
 				'npm install',
 				{
 					cwd: entrypoint
 				},
 				(error, stdout, stderr) => {
-					builder.log.info(stderr);
+					utils.log.info(stderr);
 					if (error) {
-						builder.log.error(error);
+						utils.log.error(error);
 					}
 				}
 			);

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -7,7 +7,7 @@ module.exports = function () {
 	const adapter = {
 		name: '@sveltejs/adapter-netlify',
 
-		async adapt(builder) {
+		async adapt(utils) {
 			let netlify_config;
 
 			if (existsSync('netlify.toml')) {
@@ -37,9 +37,9 @@ module.exports = function () {
 			const publish = resolve(netlify_config.build.publish);
 			const functions = resolve(netlify_config.build.functions);
 
-			builder.copy_static_files(publish);
-			builder.copy_client_files(publish);
-			builder.copy_server_files(`${functions}/render`);
+			utils.copy_static_files(publish);
+			utils.copy_client_files(publish);
+			utils.copy_server_files(`${functions}/render`);
 
 			// rename app to .mjs
 			renameSync(`${functions}/render/app.js`, `${functions}/render/app.mjs`);
@@ -54,8 +54,8 @@ module.exports = function () {
 			writeFileSync(`${publish}/_redirects`, '/* /.netlify/functions/render 200');
 
 			// prerender
-			builder.log.info('Prerendering static pages...');
-			await builder.prerender({
+			utils.log.info('Prerendering static pages...');
+			await utils.prerender({
 				dest: publish
 			});
 		}

--- a/packages/adapter-node/index.cjs
+++ b/packages/adapter-node/index.cjs
@@ -11,19 +11,19 @@ module.exports = function ({ out = 'build' } = {}) {
 	const adapter = {
 		name: '@sveltejs/adapter-node',
 
-		async adapt(builder) {
-			builder.log.minor('Copying assets');
+		async adapt(utils) {
+			utils.log.minor('Copying assets');
 			const static_directory = join(out, 'assets');
-			builder.copy_client_files(static_directory);
-			builder.copy_static_files(static_directory);
+			utils.copy_client_files(static_directory);
+			utils.copy_static_files(static_directory);
 
-			builder.log.minor('Copying server');
-			builder.copy_server_files(out);
+			utils.log.minor('Copying server');
+			utils.copy_server_files(out);
 
 			copyFileSync(`${__dirname}/files/server.js`, `${out}/index.js`);
 
-			builder.log.minor('Prerendering static pages');
-			await builder.prerender({
+			utils.log.minor('Prerendering static pages');
+			await utils.prerender({
 				dest: `${out}/prerendered`
 			});
 		}

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -3,11 +3,11 @@ module.exports = function ({ pages = 'build', assets = 'build' } = {}) {
 	const adapter = {
 		name: '@sveltejs/adapter-static',
 
-		async adapt(builder) {
-			builder.copy_static_files(assets);
-			builder.copy_client_files(assets);
+		async adapt(utils) {
+			utils.copy_static_files(assets);
+			utils.copy_client_files(assets);
 
-			await builder.prerender({
+			await utils.prerender({
 				force: true,
 				dest: pages
 			});

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -6,29 +6,29 @@ module.exports = function () {
 	const adapter = {
 		name: '@sveltejs/adapter-vercel',
 
-		async adapt(builder) {
+		async adapt(utils) {
 			const vercel_output_directory = resolve('.vercel_build_output');
 			const config_directory = join(vercel_output_directory, 'config');
 			const static_directory = join(vercel_output_directory, 'static');
 			const lambda_directory = join(vercel_output_directory, 'functions', 'node', 'render');
 			const server_directory = join(lambda_directory, 'server');
 
-			builder.log.minor('Writing client application...');
-			builder.copy_static_files(static_directory);
-			builder.copy_client_files(static_directory);
+			utils.log.minor('Writing client application...');
+			utils.copy_static_files(static_directory);
+			utils.copy_client_files(static_directory);
 
-			builder.log.minor('Building lambda...');
-			builder.copy_server_files(server_directory);
+			utils.log.minor('Building lambda...');
+			utils.copy_server_files(server_directory);
 			renameSync(join(server_directory, 'app.js'), join(server_directory, 'app.mjs'));
 
-			builder.copy(join(__dirname, 'files'), lambda_directory);
+			utils.copy(join(__dirname, 'files'), lambda_directory);
 
-			builder.log.minor('Prerendering static pages...');
-			await builder.prerender({
+			utils.log.minor('Prerendering static pages...');
+			await utils.prerender({
 				dest: static_directory
 			});
 
-			builder.log.minor('Writing routes...');
+			utils.log.minor('Writing routes...');
 			try {
 				mkdirSync(config_directory);
 			} catch {

--- a/packages/kit/src/core/adapt/AdapterUtils.js
+++ b/packages/kit/src/core/adapt/AdapterUtils.js
@@ -1,7 +1,7 @@
 import { copy, rimraf, mkdirp } from '../filesystem/index.js';
 import { prerender } from './prerender.js';
 
-export default class Builder {
+export default class AdapterUtils {
 	#cwd;
 	#config;
 

--- a/packages/kit/src/core/adapt/index.js
+++ b/packages/kit/src/core/adapt/index.js
@@ -1,6 +1,6 @@
 import colors from 'kleur';
 import { logger } from '../utils.js';
-import Builder from './Builder.js';
+import AdapterUtils from './AdapterUtils.js';
 
 /**
  * @param {import('../../../types.internal').ValidatedConfig} config
@@ -12,8 +12,8 @@ export async function adapt(config, { cwd = process.cwd(), verbose }) {
 	console.log(colors.bold().cyan(`\n> Using ${name}`));
 
 	const log = logger({ verbose });
-	const builder = new Builder({ cwd, config, log });
-	await adapt(builder);
+	const utils = new AdapterUtils({ cwd, config, log });
+	await adapt(utils);
 
 	log.success('done');
 }

--- a/packages/kit/src/core/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/create_manifest_data/index.spec.js
@@ -16,6 +16,7 @@ const create = (dir, extensions = ['.svelte']) => {
 		config: {
 			extensions,
 			kit: {
+				// @ts-ignore
 				files: {
 					assets: path.resolve(cwd, 'static'),
 					routes: path.resolve(cwd, dir)

--- a/packages/kit/src/core/load_config/index.spec.js
+++ b/packages/kit/src/core/load_config/index.spec.js
@@ -48,6 +48,7 @@ test('errors on invalid values', () => {
 	assert.throws(() => {
 		validate_config({
 			kit: {
+				// @ts-ignore
 				target: 42
 			}
 		});
@@ -59,6 +60,7 @@ test('errors on invalid nested values', () => {
 		validate_config({
 			kit: {
 				files: {
+					// @ts-ignore
 					potato: 'blah'
 				}
 			}
@@ -158,11 +160,17 @@ test('fails if prerender.pages are invalid', () => {
 	}, /^Each member of config\.kit.prerender.pages must be either '\*' or an absolute path beginning with '\/' — saw 'foo'$/);
 });
 
+/**
+ * @param {string} name
+ * @param {{ base?: string, assets?: string }} input
+ * @param {{ base?: string, assets?: string }} output
+ */
 function validate_paths(name, input, output) {
 	test(name, () => {
 		assert.equal(
 			validate_config({
 				kit: {
+					// @ts-ignore
 					paths: input
 				}
 			}).kit.paths,

--- a/packages/kit/src/core/load_config/test/index.js
+++ b/packages/kit/src/core/load_config/test/index.js
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import * as uvu from 'uvu';
+import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { fileURLToPath } from 'url';
 import { load_config } from '../index.js';
@@ -7,9 +7,7 @@ import { load_config } from '../index.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = join(__filename, '..');
 
-const suite = uvu.suite('Builder');
-
-suite('load default config', async () => {
+test('load default config', async () => {
 	const cwd = join(__dirname, 'fixtures');
 
 	const config = await load_config({ cwd });
@@ -45,4 +43,4 @@ suite('load default config', async () => {
 	});
 });
 
-suite.run();
+test.run();

--- a/packages/kit/tsconfig.enforced.json
+++ b/packages/kit/tsconfig.enforced.json
@@ -13,6 +13,5 @@
 			"types.internal": ["./types.internal"]
 		}
 	},
-	"include": ["src/**/*"],
-	"exclude": ["src/**/test/*", "src/**/*.spec.js"]
+	"include": ["src/**/*"]
 }

--- a/packages/kit/types.d.ts
+++ b/packages/kit/types.d.ts
@@ -37,17 +37,18 @@ export type Config = {
 	preprocess?: any;
 };
 
-type Builder = {
+type AdapterUtils = {
 	copy_client_files: (dest: string) => void;
 	copy_server_files: (dest: string) => void;
 	copy_static_files: (dest: string) => void;
+	copy: (from: string, to: string, filter?: (basename: string) => boolean) => void;
 	prerender: ({ force, dest }: { force?: boolean; dest: string }) => Promise<void>;
 	log: Logger;
 };
 
 export type Adapter = {
 	name: string;
-	adapt: (builder: Builder) => Promise<void>;
+	adapt: (utils: AdapterUtils) => Promise<void>;
 };
 
 interface ReadOnlyFormData extends Iterator<[string, string]> {


### PR DESCRIPTION
no changes to any functionality, just tidying things up a tiny bit — renames `builder` to `utils` as previously discussed, and expands typechecking to everything in `kit/src`