### PR TITLE
make the --host flag provision unnecessary for production deployments

### DIFF
--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -131,7 +131,7 @@ prog
 	.command('start')
 	.describe('Serve an already-built app')
 	.option('-p, --port', 'Port', 3000)
-	.option('-h, --host', 'Host (only use this on trusted networks)', 'localhost')
+	.option('-h, --host', 'Host (only use this on trusted networks)', '0.0.0.0')
 	.option('-H, --https', 'Use self-signed HTTPS certificate', false)
 	.option('-o, --open', 'Open a browser tab', false)
 	.action(async ({ port, host, https, open }) => {


### PR DESCRIPTION
While the ability to avoid dev deployment of SvelteKit to not be exposed to an untrusted network. wherever the developer has to reside at the moment of dev work, such as in a mall, on a train or in a coffee shop using the available Wi-Fi network, is great. The same ability is not so great for production deployments where currently the `package.json` has to be modified before each deployment with the `--host 0.0.0.0` flag.

This PR attempts to make the `--host 0.0.0.0` the default suitable for deployments which leverage `npm start` or `npx svelte-kit start` command.