### PR TITLE
run lint, test and examples in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
       - run: pnpm check
   Tests:
     runs-on: ${{ matrix.os }}
-    needs: Lint
     timeout-minutes: 6
     strategy:
       matrix:
@@ -66,7 +65,6 @@ jobs:
       - run: pnpm test
   Examples:
     runs-on: ${{ matrix.os }}
-    needs: Tests
     timeout-minutes: 6
     strategy:
       matrix:


### PR DESCRIPTION
Is there any reason these need to run in sequence?