### PR TITLE
ci: skip chrome installs in ci

### DIFF
--- a/.github/actions/env/action.yaml
+++ b/.github/actions/env/action.yaml
@@ -1,0 +1,13 @@
+name: 'Environment'
+
+description: 'Set variables based on the environment'
+
+outputs:
+  pnpm_cache_path:
+    description: 'the pnpm cache path'
+  browser_cache_path":
+    description: 'The browser cache path'
+
+runs:
+  using: 'node12'
+  main: 'action/main.js'

--- a/.github/actions/env/action.yaml
+++ b/.github/actions/env/action.yaml
@@ -5,7 +5,7 @@ description: 'Set variables based on the environment'
 outputs:
   pnpm_cache_path:
     description: 'the pnpm cache path'
-  browser_cache_path":
+  browser_cache_path:
     description: 'The browser cache path'
 
 runs:

--- a/.github/actions/env/action/main.js
+++ b/.github/actions/env/action/main.js
@@ -1,0 +1,434 @@
+'use strict';
+
+var require$$0 = require('os');
+var require$$0$1 = require('fs');
+var require$$1 = require('path');
+
+function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
+
+var require$$0__default = /*#__PURE__*/_interopDefaultLegacy(require$$0);
+var require$$0__default$1 = /*#__PURE__*/_interopDefaultLegacy(require$$0$1);
+var require$$1__default = /*#__PURE__*/_interopDefaultLegacy(require$$1);
+
+var commonjsGlobal = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
+
+function getDefaultExportFromCjs (x) {
+	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+}
+
+function createCommonjsModule(fn) {
+  var module = { exports: {} };
+	return fn(module, module.exports), module.exports;
+}
+
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Sanitizes an input into a string so it can be passed into issueCommand safely
+ * @param input input to sanitize into a string
+ */
+function toCommandValue(input) {
+    if (input === null || input === undefined) {
+        return '';
+    }
+    else if (typeof input === 'string' || input instanceof String) {
+        return input;
+    }
+    return JSON.stringify(input);
+}
+var toCommandValue_1 = toCommandValue;
+
+
+var utils = /*#__PURE__*/Object.defineProperty({
+	toCommandValue: toCommandValue_1
+}, '__esModule', {value: true});
+
+var __importStar$1 = (commonjsGlobal && commonjsGlobal.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+
+const os$1 = __importStar$1(require$$0__default['default']);
+
+/**
+ * Commands
+ *
+ * Command Format:
+ *   ::name key=value,key=value::message
+ *
+ * Examples:
+ *   ::warning::This is the message
+ *   ::set-env name=MY_VAR::some value
+ */
+function issueCommand$1(command, properties, message) {
+    const cmd = new Command(command, properties, message);
+    process.stdout.write(cmd.toString() + os$1.EOL);
+}
+var issueCommand_1$1 = issueCommand$1;
+function issue(name, message = '') {
+    issueCommand$1(name, {}, message);
+}
+var issue_1 = issue;
+const CMD_STRING = '::';
+class Command {
+    constructor(command, properties, message) {
+        if (!command) {
+            command = 'missing.command';
+        }
+        this.command = command;
+        this.properties = properties;
+        this.message = message;
+    }
+    toString() {
+        let cmdStr = CMD_STRING + this.command;
+        if (this.properties && Object.keys(this.properties).length > 0) {
+            cmdStr += ' ';
+            let first = true;
+            for (const key in this.properties) {
+                if (this.properties.hasOwnProperty(key)) {
+                    const val = this.properties[key];
+                    if (val) {
+                        if (first) {
+                            first = false;
+                        }
+                        else {
+                            cmdStr += ',';
+                        }
+                        cmdStr += `${key}=${escapeProperty(val)}`;
+                    }
+                }
+            }
+        }
+        cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
+        return cmdStr;
+    }
+}
+function escapeData(s) {
+    return utils.toCommandValue(s)
+        .replace(/%/g, '%25')
+        .replace(/\r/g, '%0D')
+        .replace(/\n/g, '%0A');
+}
+function escapeProperty(s) {
+    return utils.toCommandValue(s)
+        .replace(/%/g, '%25')
+        .replace(/\r/g, '%0D')
+        .replace(/\n/g, '%0A')
+        .replace(/:/g, '%3A')
+        .replace(/,/g, '%2C');
+}
+
+
+var command = /*#__PURE__*/Object.defineProperty({
+	issueCommand: issueCommand_1$1,
+	issue: issue_1
+}, '__esModule', {value: true});
+
+// For internal use, subject to change.
+var __importStar = (commonjsGlobal && commonjsGlobal.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const fs = __importStar(require$$0__default$1['default']);
+const os = __importStar(require$$0__default['default']);
+
+function issueCommand(command, message) {
+    const filePath = process.env[`GITHUB_${command}`];
+    if (!filePath) {
+        throw new Error(`Unable to find environment variable for file command ${command}`);
+    }
+    if (!fs.existsSync(filePath)) {
+        throw new Error(`Missing file at path: ${filePath}`);
+    }
+    fs.appendFileSync(filePath, `${utils.toCommandValue(message)}${os.EOL}`, {
+        encoding: 'utf8'
+    });
+}
+var issueCommand_1 = issueCommand;
+
+
+var fileCommand = /*#__PURE__*/Object.defineProperty({
+	issueCommand: issueCommand_1
+}, '__esModule', {value: true});
+
+var core = createCommonjsModule(function (module, exports) {
+var __awaiter = (commonjsGlobal && commonjsGlobal.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importStar = (commonjsGlobal && commonjsGlobal.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+
+
+
+const os = __importStar(require$$0__default['default']);
+const path = __importStar(require$$1__default['default']);
+/**
+ * The code to exit an action
+ */
+var ExitCode;
+(function (ExitCode) {
+    /**
+     * A code indicating that the action was successful
+     */
+    ExitCode[ExitCode["Success"] = 0] = "Success";
+    /**
+     * A code indicating that the action was a failure
+     */
+    ExitCode[ExitCode["Failure"] = 1] = "Failure";
+})(ExitCode = exports.ExitCode || (exports.ExitCode = {}));
+//-----------------------------------------------------------------------
+// Variables
+//-----------------------------------------------------------------------
+/**
+ * Sets env variable for this action and future actions in the job
+ * @param name the name of the variable to set
+ * @param val the value of the variable. Non-string values will be converted to a string via JSON.stringify
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function exportVariable(name, val) {
+    const convertedVal = utils.toCommandValue(val);
+    process.env[name] = convertedVal;
+    const filePath = process.env['GITHUB_ENV'] || '';
+    if (filePath) {
+        const delimiter = '_GitHubActionsFileCommandDelimeter_';
+        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
+        fileCommand.issueCommand('ENV', commandValue);
+    }
+    else {
+        command.issueCommand('set-env', { name }, convertedVal);
+    }
+}
+exports.exportVariable = exportVariable;
+/**
+ * Registers a secret which will get masked from logs
+ * @param secret value of the secret
+ */
+function setSecret(secret) {
+    command.issueCommand('add-mask', {}, secret);
+}
+exports.setSecret = setSecret;
+/**
+ * Prepends inputPath to the PATH (for this action and future actions)
+ * @param inputPath
+ */
+function addPath(inputPath) {
+    const filePath = process.env['GITHUB_PATH'] || '';
+    if (filePath) {
+        fileCommand.issueCommand('PATH', inputPath);
+    }
+    else {
+        command.issueCommand('add-path', {}, inputPath);
+    }
+    process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
+}
+exports.addPath = addPath;
+/**
+ * Gets the value of an input.  The value is also trimmed.
+ *
+ * @param     name     name of the input to get
+ * @param     options  optional. See InputOptions.
+ * @returns   string
+ */
+function getInput(name, options) {
+    const val = process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || '';
+    if (options && options.required && !val) {
+        throw new Error(`Input required and not supplied: ${name}`);
+    }
+    return val.trim();
+}
+exports.getInput = getInput;
+/**
+ * Sets the value of an output.
+ *
+ * @param     name     name of the output to set
+ * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setOutput(name, value) {
+    command.issueCommand('set-output', { name }, value);
+}
+exports.setOutput = setOutput;
+/**
+ * Enables or disables the echoing of commands into stdout for the rest of the step.
+ * Echoing is disabled by default if ACTIONS_STEP_DEBUG is not set.
+ *
+ */
+function setCommandEcho(enabled) {
+    command.issue('echo', enabled ? 'on' : 'off');
+}
+exports.setCommandEcho = setCommandEcho;
+//-----------------------------------------------------------------------
+// Results
+//-----------------------------------------------------------------------
+/**
+ * Sets the action status to failed.
+ * When the action exits it will be with an exit code of 1
+ * @param message add error issue message
+ */
+function setFailed(message) {
+    process.exitCode = ExitCode.Failure;
+    error(message);
+}
+exports.setFailed = setFailed;
+//-----------------------------------------------------------------------
+// Logging Commands
+//-----------------------------------------------------------------------
+/**
+ * Gets whether Actions Step Debug is on or not
+ */
+function isDebug() {
+    return process.env['RUNNER_DEBUG'] === '1';
+}
+exports.isDebug = isDebug;
+/**
+ * Writes debug message to user log
+ * @param message debug message
+ */
+function debug(message) {
+    command.issueCommand('debug', {}, message);
+}
+exports.debug = debug;
+/**
+ * Adds an error issue
+ * @param message error issue message. Errors will be converted to string via toString()
+ */
+function error(message) {
+    command.issue('error', message instanceof Error ? message.toString() : message);
+}
+exports.error = error;
+/**
+ * Adds an warning issue
+ * @param message warning issue message. Errors will be converted to string via toString()
+ */
+function warning(message) {
+    command.issue('warning', message instanceof Error ? message.toString() : message);
+}
+exports.warning = warning;
+/**
+ * Writes info to log with console.log.
+ * @param message info message
+ */
+function info(message) {
+    process.stdout.write(message + os.EOL);
+}
+exports.info = info;
+/**
+ * Begin an output group.
+ *
+ * Output until the next `groupEnd` will be foldable in this group
+ *
+ * @param name The name of the output group
+ */
+function startGroup(name) {
+    command.issue('group', name);
+}
+exports.startGroup = startGroup;
+/**
+ * End an output group.
+ */
+function endGroup() {
+    command.issue('endgroup');
+}
+exports.endGroup = endGroup;
+/**
+ * Wrap an asynchronous function call in a group.
+ *
+ * Returns the same type as the function itself.
+ *
+ * @param name The name of the group
+ * @param fn The function to wrap in the group
+ */
+function group(name, fn) {
+    return __awaiter(this, void 0, void 0, function* () {
+        startGroup(name);
+        let result;
+        try {
+            result = yield fn();
+        }
+        finally {
+            endGroup();
+        }
+        return result;
+    });
+}
+exports.group = group;
+//-----------------------------------------------------------------------
+// Wrapper action state
+//-----------------------------------------------------------------------
+/**
+ * Saves state for current action, the state can only be retrieved by this action's post job execution.
+ *
+ * @param     name     name of the state to store
+ * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function saveState(name, value) {
+    command.issueCommand('save-state', { name }, value);
+}
+exports.saveState = saveState;
+/**
+ * Gets the value of an state set by this action's main execution.
+ *
+ * @param     name     name of the state to get
+ * @returns   string
+ */
+function getState(name) {
+    return process.env[`STATE_${name}`] || '';
+}
+exports.getState = getState;
+//# sourceMappingURL=core.js.map
+});
+
+var core$1 = /*@__PURE__*/getDefaultExportFromCjs(core);
+
+const WINDOWS_CACHE_PATH = 'D:\\.pnpm-store\\v3';
+const NIX_CACHE_PATH = '~/.pnpm-store/v3';
+const WINDOWS_BROWSER_PATH = '%USERPROFILE%\\AppData\\Local\\ms-playwright';
+const LINUX_BROWSER_PATH = '~/.cache/ms-playwright';
+const MACOS_BROWSER_PATH = '~/Library/Caches/ms-playwright';
+
+const paths = {
+	win32: {
+		browser: WINDOWS_BROWSER_PATH,
+		cache: WINDOWS_CACHE_PATH
+	},
+	linux: {
+		browser: LINUX_BROWSER_PATH,
+		cache: NIX_CACHE_PATH
+	},
+	darwin: {
+		browser: MACOS_BROWSER_PATH,
+		cache: NIX_CACHE_PATH
+	}
+};
+
+function run() {
+	const os = require$$0.platform();
+
+	core$1.setOutput('pnpm_cache_path', paths[os].cache);
+	core$1.setOutput('browser_cache_path', paths[os].browser);
+}
+
+run();

--- a/.github/actions/env/main.js
+++ b/.github/actions/env/main.js
@@ -1,0 +1,32 @@
+import core from '@actions/core';
+import { platform } from 'os';
+
+const WINDOWS_CACHE_PATH = 'D:\\.pnpm-store\\v3';
+const NIX_CACHE_PATH = '~/.pnpm-store/v3';
+const WINDOWS_BROWSER_PATH = '%USERPROFILE%\\AppData\\Local\\ms-playwright';
+const LINUX_BROWSER_PATH = '~/.cache/ms-playwright';
+const MACOS_BROWSER_PATH = '~/Library/Caches/ms-playwright';
+
+const paths = {
+	win32: {
+		browser: WINDOWS_BROWSER_PATH,
+		cache: WINDOWS_CACHE_PATH
+	},
+	linux: {
+		browser: LINUX_BROWSER_PATH,
+		cache: NIX_CACHE_PATH
+	},
+	darwin: {
+		browser: MACOS_BROWSER_PATH,
+		cache: NIX_CACHE_PATH
+	}
+};
+
+function run() {
+	const os = platform();
+
+	core.setOutput('pnpm_cache_path', paths[os].cache);
+	core.setOutput('browser_cache_path', paths[os].browser);
+}
+
+run();

--- a/.github/actions/env/package.json
+++ b/.github/actions/env/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "set-env-action",
+	"version": "1.0.0",
+	"description": "Action to set environment",
+	"main": "action/main.js",
+	"scripts": {
+		"build": "rollup -c"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/sveltejs/kit.git"
+	},
+	"license": "MIT",
+	"devDependencies": {
+		"@actions/core": "^1.2.6"
+	}
+}

--- a/.github/actions/env/rollup.config.js
+++ b/.github/actions/env/rollup.config.js
@@ -1,0 +1,16 @@
+import resolve from '@rollup/plugin-node-resolve';
+import cjs from '@rollup/plugin-commonjs';
+
+export default [
+	{
+		plugins: [cjs(), resolve()],
+		input: 'main.js',
+		output: [
+			{
+				file: 'action/main.js',
+				format: 'cjs',
+				sourcemap: false
+			}
+		]
+	}
+];

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
 env:
   CI: true
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
 jobs:
   Lint:
@@ -30,7 +31,6 @@ jobs:
       - run: pnpm check
   Tests:
     runs-on: ${{ matrix.os }}
-    needs: Lint
     timeout-minutes: 6
     strategy:
       matrix:
@@ -47,26 +47,31 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Get windows pnpm cache path
-        if: runner.os == 'windows'
-        run: echo "cache_path=D:\.pnpm-store\v3" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-      - name: Get non-windows pnpm cache path
-        if: runner.os != 'windows'
-        run: echo "cache_path=~/.pnpm-store/v3" >> $GITHUB_ENV
+      - name: Get paths for OS
+        uses: ./.github/actions/env
+        id: paths
       - name: Cache ~/.pnpm-store
+        id: cache
         uses: actions/cache@main
         with:
-          path: ${{ env.cache_path }}
+          path: ${{ steps.paths.outputs.pnpm_cache_path }}
           key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.node-version }}
+      - name: Cache browsers
+        id: browser_cache
+        uses: actions/cache@main
+        with:
+          path: ${{ steps.paths.outputs.browser_cache_path }}
+          key: bbb-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - run: npm install -g pnpm
       - run: pnpm install --frozen-lockfile
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: ${{ steps.browser_cache.outputs.cache-hit == 'true' }}
       - run: pnpm build --filter ./packages
       - run: pnpm test
   Examples:
     runs-on: ${{ matrix.os }}
-    needs: Tests
     timeout-minutes: 6
     strategy:
       matrix:
@@ -83,16 +88,13 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Get windows pnpm cache path
-        if: runner.os == 'windows'
-        run: echo "cache_path=D:\.pnpm-store\v3" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-      - name: Get non-windows pnpm cache path
-        if: runner.os != 'windows'
-        run: echo "cache_path=~/.pnpm-store/v3" >> $GITHUB_ENV
+      - name: Get paths for OS
+        uses: ./.github/actions/env
+        id: paths
       - name: Cache ~/.pnpm-store
         uses: actions/cache@main
         with:
-          path: ${{ env.cache_path }}
+          path: ${{ steps.paths.outputs.pnpm_cache_path }}
           key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 		"check": "pnpm -r check",
 		"lint": "pnpm -r lint",
 		"format": "pnpm -r format",
-		"release": "pnpm publish --tag=next --filter=\"@sveltejs/*\" --filter=\"create-svelte\""
+		"release": "pnpm publish --tag=next --filter=\"@sveltejs/*\" --filter=\"create-svelte\"",
+		"playwright": "pnpm add playwright -w"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
 		"check": "pnpm -r check",
 		"lint": "pnpm -r lint",
 		"format": "pnpm -r format",
-		"release": "pnpm publish --tag=next --filter=\"@sveltejs/*\" --filter=\"create-svelte\"",
-		"playwright": "pnpm add playwright -w"
+		"release": "pnpm publish --tag=next --filter=\"@sveltejs/*\" --filter=\"create-svelte\""
 	},
 	"repository": {
 		"type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,11 @@ importers:
       prettier: 2.2.1
       rollup: ^2.42.3
       typescript: ^4.2.3
+  .github/actions/env:
+    devDependencies:
+      '@actions/core': 1.2.6
+    specifiers:
+      '@actions/core': ^1.2.6
   examples/hn.svelte.dev:
     devDependencies:
       '@sveltejs/adapter-netlify': link:../../packages/adapter-netlify
@@ -218,6 +223,10 @@ importers:
       vite: ^2.1.0
 lockfileVersion: 5.2
 packages:
+  /@actions/core/1.2.6:
+    dev: true
+    resolution:
+      integrity: sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA==
   /@architect/parser/3.0.1:
     dev: false
     engines:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'packages/*'
   - 'examples/*'
+  - '.github/actions/*'


### PR DESCRIPTION
**CI improvements**

- Caches playwright browser installs (based on the lockfile so bumping playwright will invalidate the cache, different versions of playwright install different browser versions).
- Adds a custom js action to handle the different cache paths on different platforms (uses step outputs rather than env variables). It adds more files to the repo but cleans up the workflow file a bit. dist folder unfortunately has to be checked in.