### PR TITLE
chore: switch to playwright-chromium from playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/cache@main
         with:
           path: ${{ steps.paths.outputs.browser_cache_path }}
-          key: bbb-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: pw-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - run: npm install -g pnpm
       - run: pnpm install --frozen-lockfile
         env:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"eslint": "^7.22.0",
 		"eslint-plugin-import": "^2.22.1",
 		"eslint-plugin-svelte3": "^3.1.2",
-		"playwright": "^1.9.2",
+		"playwright-chromium": "^1.10.0",
 		"prettier": "2.2.1",
 		"rollup": "^2.42.3",
 		"typescript": "^4.2.3"

--- a/packages/kit/test/test.js
+++ b/packages/kit/test/test.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import glob from 'tiny-glob/sync.js';
 import ports from 'port-authority';
 import fetch from 'node-fetch';
-import { chromium } from 'playwright';
+import { chromium } from 'playwright-chromium';
 import { dev } from '../src/core/dev/index.js';
 import { build } from '../src/core/build/index.js';
 import { start } from '../src/core/start/index.js';

--- a/packages/kit/test/types.d.ts
+++ b/packages/kit/test/types.d.ts
@@ -1,4 +1,4 @@
-import { Page, Response } from 'playwright';
+import { Page, Response } from 'playwright-chromium';
 
 // TODO passing `page` used to break uvu because it gets mutated, but it
 // seems like that's no longer an issue? in which case we don't need

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ importers:
       eslint: 7.22.0
       eslint-plugin-import: 2.22.1_eslint@7.22.0
       eslint-plugin-svelte3: 3.1.2_eslint@7.22.0
-      playwright: 1.9.2
+      playwright-chromium: 1.10.0
       prettier: 2.2.1
       rollup: 2.42.3
       typescript: 4.2.3
@@ -26,7 +26,7 @@ importers:
       eslint: ^7.22.0
       eslint-plugin-import: ^2.22.1
       eslint-plugin-svelte3: ^3.1.2
-      playwright: ^1.9.2
+      playwright-chromium: ^1.10.0
       prettier: 2.2.1
       rollup: ^2.42.3
       typescript: ^4.2.3
@@ -695,6 +695,11 @@ packages:
     dev: true
     resolution:
       integrity: sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
+  /@types/node/14.14.37:
+    dev: true
+    optional: true
+    resolution:
+      integrity: sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==
   /@types/normalize-package-data/2.4.0:
     dev: true
     resolution:
@@ -724,7 +729,7 @@ packages:
       integrity: sha512-RxAwYt4rGwK5GyoRwuP0jT6ZHAVTdz2EqgsHmX0PYNjGsko+OeT4WFXXTs/lM3teJUJodM+SNtAL5/pXIJ61IQ==
   /@types/yauzl/2.9.1:
     dependencies:
-      '@types/node': 14.14.35
+      '@types/node': 14.14.37
     dev: true
     optional: true
     resolution:
@@ -2912,7 +2917,7 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
-  /playwright/1.9.2:
+  /playwright-chromium/1.10.0:
     dependencies:
       commander: 6.2.1
       debug: 4.3.1
@@ -2933,7 +2938,7 @@ packages:
     hasBin: true
     requiresBuild: true
     resolution:
-      integrity: sha512-Hsgfk3GZO+hgewRNW9xl9/tHjdZvVwxTseHagbiNpDf90PXICEh8UHXy/2eykeIXrZFMA6W6petEtRWNPi3gfQ==
+      integrity: sha512-ry/60/YKGJfrnaS7j5C3+xmA2DAMv6pBE351FoTHe4Llq0WU92IL0rBYK3TkK3PzSHYtp1KdCRsRjDnJhImA3g==
   /pngjs/5.0.0:
     dev: true
     engines:


### PR DESCRIPTION
- Switch to `playwright-chromium` from `playwright`.  This will only try to install a single browser binary speeding up uncached runs and speeding up cache restoration. It has the same api, only the module name is different.
- Tweak browser cache key to ensure the old cache with all browsers goes away.