### PR TITLE
Add command to navigate to and run svelte-kit-demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pnpm i
 pnpm -r build
 ```
 
-You should now be able to run the [examples](examples) by navigating to one of the directories and doing `pnpm dev`. For example, to run `svelte-kit-demo` enter the following command:
+You should now be able to run the [examples](examples) by navigating to one of the directories and doing `pnpm dev`. For example, to run `svelte-kit-demo` enter the following commands:
 
 ```bash
 cd examples/svelte-kit-demo

--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ pnpm i
 pnpm -r build
 ```
 
-You should now be able to run the [examples](examples) by navigating to one of the directories and doing `pnpm dev`.
+You should now be able to run the [examples](examples) by navigating to one of the directories and doing `pnpm dev`. For example, to run `svelte-kit-demo` enter the following command:
+
+```bash
+cd examples/svelte-kit-demo && pnpm dev
+```
 
 Run `pnpm dev` inside the `packages/kit` directory to continually rebuild `@sveltejs/kit` as you make changes to SvelteKit. Restarting the example/test apps will cause the newly built version to be used.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ pnpm -r build
 You should now be able to run the [examples](examples) by navigating to one of the directories and doing `pnpm dev`. For example, to run `svelte-kit-demo` enter the following command:
 
 ```bash
-cd examples/svelte-kit-demo && pnpm dev
+cd examples/svelte-kit-demo
+pnpm dev
 ```
 
 Run `pnpm dev` inside the `packages/kit` directory to continually rebuild `@sveltejs/kit` as you make changes to SvelteKit. Restarting the example/test apps will cause the newly built version to be used.


### PR DESCRIPTION
Right now the README verbally explains how to navigate to an example project and run a development server, but it does not provide an example or command for doing so.

>You should now be able to run the examples by navigating to one of the directories and doing `pnpm dev`.

Newer developers who have not worked with monorepos before may not be as familiar with navigating to different directories of their project to run specific commands.

Assuming the reader knows how to `cd` into a directory is a very, very small assumption to make. Nonetheless, the faster and easier you can get someone to hello world the better, which is why I added two commands to navigate and start the server that can be easily copy pasted.

>You should now be able to run the examples by navigating to one of the directories and doing `pnpm dev`. For example, to run `svelte-kit-demo` enter the following command:
>
>```bash
>cd examples/svelte-kit-demo
>pnpm dev
>```

If this change is accepted it opens a large question of which of the three examples to pick for providing a happy path. I don't believe I'm the best person to make that decision and would welcome any input from the core team.

Thanks for all the work everyone has done on sveltekit, it's an awesome project!