### PR TITLE
add support for multiple rel values when checking for external links

### DIFF
--- a/.changeset/fast-goats-argue.md
+++ b/.changeset/fast-goats-argue.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Support multiple rel values on anchor tag

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -118,8 +118,12 @@ export class Router {
 
 			// Ignore if tag has
 			// 1. 'download' attribute
-			// 2. rel='external' attribute
-			if (a.hasAttribute('download') || a.getAttribute('rel') === 'external') return;
+			// 2. 'rel' attribute includes external
+			const rel = a.getAttribute('rel')?.split(/\s+/);
+
+			if (a.hasAttribute('download') || (rel && rel.includes('external'))) {
+				return;
+			}
 
 			// Ignore if <a> has a target
 			if (svg ? /** @type {SVGAElement} */ (a).target.baseVal : a.target) return;


### PR DESCRIPTION
This PR proposes two changes:

1. Add "noopener" and "noreferrer" to the checklist in router.js in order to bail on navigation if one of these is present
2. In the process I found that the spec says [1] that the `rel` attribute should be parsed as a list of values that are seperated by a white space. So this PR tries to address that. Which in turn makes it possible to write stuff like `rel="external nofollow"` without breaking the SvelteKit navigation check

[1] https://html.spec.whatwg.org/#linkTypes
> To determine which link types apply to a link, a, area, or form element, the element's rel attribute must be split on ASCII whitespace. The resulting tokens are the keywords for the link types that apply to that element.
