### PR TITLE
More detailed explanation of initial_fetch caching

### DIFF
--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -79,7 +79,8 @@ So if the example above was `src/routes/blog/[slug].svelte` and the URL was `/bl
 
 `fetch` is equivalent to the native `fetch` web API, and can make credentialled requests. It can be used across both client and server contexts.
 
-> When `fetch` runs on the server, the resulting response will be serialized and inlined into the rendered HTML. This allows the subsequent client-side `load` to access identical data immediately without an additional network request.
+> When `fetch` runs on the server, the resulting response will be serialized and inlined into the rendered HTML. This allows the subsequent client-side `load` to access identical data immediately (keyed on URL) without an additional network request.
+> If you make multiple requests to the same URL with different parameters in the request body, you will need to adjust your request to use unique URL parameters to avoid deduplication.
 
 #### session
 


### PR DESCRIPTION
This CL adds some more explanation of how initial_fetch (the client-side "fetch" function in load) caches results *keyed on URL*.

I was really scratching my head when my client-side requests were returning bogus results, even when the server-side was working. It turns out, because I was making requests using parameters passed in the POST request body, semantically different requests to the same URL were getting deduped by svelte's client-side request caching. This documentation change adds a warning about this case, with a bit more detail about how initial_fetch works.
