### PR TITLE
docs: fix introduction in js-disabled view

### DIFF
--- a/documentation/docs/00-introduction.md
+++ b/documentation/docs/00-introduction.md
@@ -23,6 +23,7 @@ You don't need to know Svelte to understand the rest of this guide, but it will 
 
 The easiest way to start building a SvelteKit app is to run `npm init`:
 
+<!---email_off--->
 ```bash
 mkdir my-app
 cd my-app
@@ -30,5 +31,6 @@ npm init svelte@next
 npm install
 npm run dev
 ```
+<!---/email_off--->
 
 This will scaffold a new project in the `my-app` directory, install its dependencies, and start a server on [localhost:3000](http://localhost:3000). Try editing the files to get a feel for how everything works – you may not need to bother reading the rest of this guide!


### PR DESCRIPTION
Fix the "Getting Started" section of the introduction documentation to
display `svelte@next` when browsing with JS disabled.

This is happening due to CloudFlare's email obfuscation, and can be
disabled with HTML comments surrounding the text which would otherwise
be obfuscated.

Closes #910

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
