### PR TITLE
fix(types): remove optional mark in RequestHandler args

### DIFF
--- a/.changeset/polite-worms-happen.md
+++ b/.changeset/polite-worms-happen.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix argument type for RequestHandler

--- a/packages/kit/types.d.ts
+++ b/packages/kit/types.d.ts
@@ -90,7 +90,7 @@ export type Response = {
 };
 
 export type RequestHandler<Context = any, Body = unknown> = (
-	request?: Request<Context, Body>
+	request: Request<Context, Body>
 ) => Response | Promise<Response>;
 
 export type Load = (input: LoadInput) => LoadOutput | Promise<LoadOutput>;


### PR DESCRIPTION
No open issue yet, but this will sync up types with the current [endpoint docs](https://kit.svelte.dev/docs#routing-endpoints)

Also, fixes TypeScript error
![image](https://user-images.githubusercontent.com/8156777/113833417-d2697980-97b3-11eb-93a7-121dcab1dff0.png)
