### PR TITLE
fix --open on WSL; fix --open with --https

### DIFF
--- a/.changeset/cool-spoons-dress.md
+++ b/.changeset/cool-spoons-dress.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Make --open option work with --https

--- a/.changeset/olive-frogs-drive.md
+++ b/.changeset/olive-frogs-drive.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Make --open option work on WSL

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -3,7 +3,7 @@ import sade from 'sade';
 import colors from 'kleur';
 import * as ports from 'port-authority';
 import { load_config } from './core/load_config/index.js';
-import { networkInterfaces } from 'os';
+import { networkInterfaces, release } from 'os';
 
 async function get_config() {
 	// TODO this is temporary, for the benefit of early adopters
@@ -51,16 +51,23 @@ function handle_error(error) {
 	process.exit(1);
 }
 
-/** @param {number} port */
-async function launch(port) {
+/**
+ * @param {number} port
+ * @param {boolean} https
+ */
+async function launch(port, https) {
 	const { exec } = await import('child_process');
 	let cmd = 'open';
 	if (process.platform == 'win32') {
 		cmd = 'start';
 	} else if (process.platform == 'linux') {
-		cmd = 'xdg-open';
+		if (/microsoft/i.test(release())) {
+			cmd = 'cmd.exe /c start';
+		} else {
+			cmd = 'xdg-open';
+		}
 	}
-	exec(`${cmd} http://localhost:${port}`);
+	exec(`${cmd} ${https ? 'https' : 'http'}://localhost:${port}`);
 }
 
 const prog = sade('svelte-kit').version('__VERSION__');
@@ -187,7 +194,7 @@ async function check_port(port) {
  * }} param0
  */
 function welcome({ port, host, https, open }) {
-	if (open) launch(port);
+	if (open) launch(port, https);
 
 	console.log(colors.bold().cyan(`\n  SvelteKit v${'__VERSION__'}\n`));
 


### PR DESCRIPTION
This adds a check to `--open` on Linux that sees whether we're really on WSL and runs a separate command in that case. It also makes `--open` respect `--https` when deciding what URL to open. Changesets are included for both.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
