### PR TITLE
Fix Cloudflare Workers adapter issues

### DIFF
--- a/.changeset/chilled-books-dress.md
+++ b/.changeset/chilled-books-dress.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+---
+
+Aligns request/response API of cloudflare-workers adapter with others

--- a/packages/adapter-cloudflare-workers/files/render.js
+++ b/packages/adapter-cloudflare-workers/files/render.js
@@ -48,7 +48,7 @@ async function handleEvent(event) {
 			path: request_url.pathname,
 			query: request_url.searchParams,
 			body: request.body ? await readRequestBody(request) : null,
-			headers: request.headers,
+			headers: Object.fromEntries(request.headers),
 			method: request.method
 		});
 

--- a/packages/adapter-cloudflare-workers/files/render.js
+++ b/packages/adapter-cloudflare-workers/files/render.js
@@ -6,7 +6,7 @@ async function readRequestBody(request) {
 	const { headers } = request;
 	const contentType = headers.get('content-type') || '';
 	if (contentType.includes('application/json')) {
-		return JSON.stringify(await request.json());
+		return await request.json();
 	} else if (contentType.includes('application/text')) {
 		return await request.text();
 	} else if (contentType.includes('text/html')) {


### PR DESCRIPTION
Prevents the Cloudflare Workers adapter re-stringifying a JSON request body after parsing with `await request.json()`.

Currently, defensive code needs to be written when running locally vs running in a worker, e.g.

```
export function post(request) {
  let data;

  try {
    // Workers
    ({ data } = JSON.parse(request.body));
  } catch (e) {
    // Locally
    ({ data } = request.body);
  }
  
  ...
}
```

instead of

```
export function post(request) {
  const { data } = request.body;

  ...
}
```

Converts Headers object to POJO prior to passing to `render` method, so that `getContext` hooks etc can access properties via dot notation, rather than using `get`/`has` Headers methods.