### PR TITLE
Add button:focus CSS styles to template Counter button

### DIFF
--- a/.changeset/curvy-sloths-brake.md
+++ b/.changeset/curvy-sloths-brake.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Add button:focus CSS styles to index page of default app

--- a/packages/create-svelte/template/src/lib/Counter.svelte
+++ b/packages/create-svelte/template/src/lib/Counter.svelte
@@ -25,6 +25,7 @@
 		font-variant-numeric: tabular-nums;
 	}
 
+	button:focus,
 	button:hover {
 		border: 3px solid #ff3e00;
 	}


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts

Anytime a <button> has specific CSS styles for hover state, it should also have those CSS styles for focus state. This helps to highlight interactivity for keyboard users as well as those who use a mouse.