### PR TITLE
Update CSS for default template counter button

### DIFF
--- a/.changeset/sour-countries-reply.md
+++ b/.changeset/sour-countries-reply.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Remove hard-coded width and height for default template counter button

--- a/packages/create-svelte/template/src/lib/Counter.svelte
+++ b/packages/create-svelte/template/src/lib/Counter.svelte
@@ -20,8 +20,6 @@
 		border-radius: 2em;
 		border: 2px solid #ff3e00;
 		outline: none;
-		width: 200px;
-		height: 60px;
 		font-variant-numeric: tabular-nums;
 	}
 

--- a/packages/create-svelte/template/src/lib/Counter.svelte
+++ b/packages/create-svelte/template/src/lib/Counter.svelte
@@ -14,7 +14,7 @@
 	button {
 		font-family: inherit;
 		font-size: inherit;
-		padding: 1em 2em;
+		padding: 1em 4em;
 		color: #ff3e00;
 		background-color: rgba(255, 62, 0, 0.1);
 		border-radius: 2em;

--- a/packages/create-svelte/template/src/lib/Counter.svelte
+++ b/packages/create-svelte/template/src/lib/Counter.svelte
@@ -26,7 +26,7 @@
 	}
 
 	button:hover {
-		border: 3px solid #ff3e00;
+		border-width: 3px;
 	}
 
 	button:active {


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts

I've made two changes:

1. You should remove the hard-coded width and height from the example button

When you set exact width and height on elements, and users increase their font size in their browser, it might make their text bigger than the width and height set for the element. When this happens, text can be cut off because it goes outside, for example, the button's 200 by 60 pixel area. Removing the hard-coded width is not as important in this example because at least with an undefined height the text can move downwards. But, since the hard-set width isn't necessary for this example, and this might be code that people re-use a lot, I believe its best to not set an example of setting width and height.

2. I optimized the button:hover CSS since it's only changing the border width.

This way the border color doesn't have to be managed twice.
