### PR TITLE
Add output option to adapter-vercel

### DIFF
--- a/.changeset/few-carpets-dress.md
+++ b/.changeset/few-carpets-dress.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+Add output option to adapter-vercel

--- a/packages/adapter-vercel/README.md
+++ b/packages/adapter-vercel/README.md
@@ -14,7 +14,7 @@ const vercel = require('@sveltejs/adapter-vercel');
 module.exports = {
 	kit: {
 		...
-		adapter: vercel()	// outputs to `.vercel_build_output`
+		adapter: vercel()
 	}
 };
 ```
@@ -22,5 +22,5 @@ module.exports = {
 You can set a custom build output directory by passing an option to the adapter:
 
 ```js
-vercel({ out: 'my-output-directory' });
+vercel({ out: 'my-output-directory' }); // defaults to `.vercel_build_output`
 ```

--- a/packages/adapter-vercel/README.md
+++ b/packages/adapter-vercel/README.md
@@ -14,7 +14,13 @@ const vercel = require('@sveltejs/adapter-vercel');
 module.exports = {
 	kit: {
 		...
-		adapter: vercel()
+		adapter: vercel()	// outputs to `.vercel_build_output`
 	}
 };
+```
+
+You can set a custom build output directory by passing an option to the adapter:
+
+```js
+vercel({ out: 'my-output-directory' });
 ```

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -1,13 +1,18 @@
 const { writeFileSync, mkdirSync, renameSync } = require('fs');
 const { resolve, join } = require('path');
 
-module.exports = function () {
+/**
+ * @param {{
+ *   out?: string;
+ * }} options
+ */
+module.exports = function ({ out = '.vercel_build_output' } = {}) {
 	/** @type {import('@sveltejs/kit').Adapter} */
 	const adapter = {
 		name: '@sveltejs/adapter-vercel',
 
 		async adapt(utils) {
-			const vercel_output_directory = resolve('.vercel_build_output');
+			const vercel_output_directory = resolve(out);
 			const config_directory = join(vercel_output_directory, 'config');
 			const static_directory = join(vercel_output_directory, 'static');
 			const lambda_directory = join(vercel_output_directory, 'functions', 'node', 'render');


### PR DESCRIPTION
This PR adds the ability to set a build output directory when using `adapter-vercel`.

The Vercel deployment app doesn't have a default build directory set for SvelteKit: it has one for "Svelte" and "Sapper", but it's not `.vercel_build_output` as it's set on this adapter, so I didn't see a reason not to allow setting a different one 😃 

I noticed that this option existed on `adapter-node` and it's even [officially documented](https://kit.svelte.dev/docs#adapters), so I just copied the approach for this adapter and left the previous default as is.