### PR TITLE
Create-Svelte - Fixing sucrase issue while running build script

### DIFF
--- a/packages/create-svelte/scripts/build-templates.js
+++ b/packages/create-svelte/scripts/build-templates.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import parser from 'gitignore-parser';
 import prettier from 'prettier';
-import Sucrase from 'sucrase';
+import sucrase from 'sucrase';
 import glob from 'tiny-glob/sync.js';
 
 async function generate_templates() {
@@ -52,7 +52,7 @@ async function generate_templates() {
 			if (file.name.endsWith('.d.ts')) continue;
 
 			if (file.name.endsWith('.ts')) {
-				const transformed = Sucrase.transform(file.contents, {
+				const transformed = sucrase.transform(file.contents, {
 					transforms: ['typescript']
 				});
 
@@ -92,7 +92,7 @@ async function generate_templates() {
 
 						const suffix = `\n${imports.join(',')}`;
 
-						const transformed = Sucrase.transform(typescript + suffix, {
+						const transformed = sucrase.transform(typescript + suffix, {
 							transforms: ['typescript']
 						}).code.slice(0, -suffix.length);
 

--- a/packages/create-svelte/scripts/build-templates.js
+++ b/packages/create-svelte/scripts/build-templates.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import parser from 'gitignore-parser';
 import prettier from 'prettier';
-import { transform } from 'sucrase';
+import Sucrase from 'sucrase';
 import glob from 'tiny-glob/sync.js';
 
 async function generate_templates() {
@@ -52,7 +52,7 @@ async function generate_templates() {
 			if (file.name.endsWith('.d.ts')) continue;
 
 			if (file.name.endsWith('.ts')) {
-				const transformed = transform(file.contents, {
+				const transformed = Sucrase.transform(file.contents, {
 					transforms: ['typescript']
 				});
 
@@ -92,7 +92,7 @@ async function generate_templates() {
 
 						const suffix = `\n${imports.join(',')}`;
 
-						const transformed = transform(typescript + suffix, {
+						const transformed = Sucrase.transform(typescript + suffix, {
 							transforms: ['typescript']
 						}).code.slice(0, -suffix.length);
 

--- a/packages/create-svelte/scripts/build-templates.js
+++ b/packages/create-svelte/scripts/build-templates.js
@@ -92,9 +92,11 @@ async function generate_templates() {
 
 						const suffix = `\n${imports.join(',')}`;
 
-						const transformed = sucrase.transform(typescript + suffix, {
-							transforms: ['typescript']
-						}).code.slice(0, -suffix.length);
+						const transformed = sucrase
+							.transform(typescript + suffix, {
+								transforms: ['typescript']
+							})
+							.code.slice(0, -suffix.length);
 
 						const contents = prettier
 							.format(transformed, {


### PR DESCRIPTION
I was trying to run the `create-svelte` CLI locally but I was not able to do it with success. I realized that we got the #989 merged and, with this, we were not able to run `npm run build` in order to build the `dist` folder (and then run the CLI to set a project).

```
import { transform } from 'sucrase';
         ^^^^^^^^^
SyntaxError: The requested module 'sucrase' is expected to be of type CommonJS, which does not support named exports. CommonJS modules can be imported by importing the default export.
For example:
import pkg from 'sucrase';
const { transform } = pkg;
```


### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`

