### PR TITLE
remove dependence of create-svelte build on kit build

### DIFF
--- a/.changeset/smooth-shrimps-fly.md
+++ b/.changeset/smooth-shrimps-fly.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Fix build so that the package can be automatically published

--- a/packages/create-svelte/cli/global.d.ts
+++ b/packages/create-svelte/cli/global.d.ts
@@ -1,6 +1,3 @@
 declare module 'prompts/lib/index';
 
 declare module '*.json';
-
-// TODO make this depend on the real types from the kit package
-declare module '@sveltejs/kit/filesystem';

--- a/packages/create-svelte/cli/index.js
+++ b/packages/create-svelte/cli/index.js
@@ -1,7 +1,6 @@
 //eslint-disable-next-line import/no-unresolved
 import fs from 'fs';
 import path from 'path';
-import { mkdirp } from '@sveltejs/kit/filesystem'; // eslint-disable-line
 import { bold, cyan, gray, green, red } from 'kleur/colors';
 import prompts from 'prompts/lib/index';
 import { fileURLToPath } from 'url';
@@ -217,6 +216,16 @@ function sort_keys(obj) {
 		});
 
 	return sorted;
+}
+
+/** @param {string} dir */
+function mkdirp(dir) {
+	try {
+		fs.mkdirSync(dir, { recursive: true });
+	} catch (e) {
+		if (e.code === 'EEXIST') return;
+		throw e;
+	}
 }
 
 main();


### PR DESCRIPTION
The automated builds were failing because create-svelte now depended on kit being built first. Rather than building all of kit just for this, I've copied over the tiny utility function which is all that create-svelte really needed.

Closes https://github.com/sveltejs/kit/pull/1000

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
