### PR TITLE
fix build warnings in user app about missing exports in hooks

### DIFF
--- a/.changeset/quiet-ants-report.md
+++ b/.changeset/quiet-ants-report.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix build warnings about missing exports in hooks file

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -300,6 +300,8 @@ async function build_server(
 				]
 			};
 
+			// this looks redundant, but the indirection allows us to access
+			// named imports without triggering Rollup's missing import detection
 			const get_hooks = hooks => ({
 				getContext: hooks.getContext || (() => ({})),
 				getSession: hooks.getSession || (() => ({})),

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -300,11 +300,13 @@ async function build_server(
 				]
 			};
 
-			const hooks = {
-				getContext: user_hooks.getContext || (() => ({})),
-				getSession: user_hooks.getSession || (() => ({})),
-				handle: user_hooks.handle || (({ request, render }) => render(request))
-			};
+			const get_hooks = hooks => ({
+				getContext: hooks.getContext || (() => ({})),
+				getSession: hooks.getSession || (() => ({})),
+				handle: hooks.handle || (({ request, render }) => render(request))
+			});
+
+			const hooks = get_hooks(user_hooks);
 
 			const module_lookup = {
 				${manifest.components.map(file => `${s(file)}: () => import(${s(app_relative(file))})`)}


### PR DESCRIPTION
Fixes #990 by reverting the removal of the so-called unnecessary indirection that I had done in #959.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
