### PR TITLE
Adding a Recipes section to the docs

### DIFF
--- a/documentation/docs/14-recipes.md
+++ b/documentation/docs/14-recipes.md
@@ -1,0 +1,23 @@
+---
+title: Recipes
+---
+
+### Redirect a user in an endpoint
+
+If you want to redirect a user after they hit one of your Svelte endpoints in the browser, 
+you can return a [`Location` header](developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location) in your endpoint like so:
+
+```js
+export async function get() {
+  // Do something in your endpoint here...
+  return {
+    headers: { Location: '/success' },
+    body: 'Redirecting you...',
+    status: 302
+  }
+}
+```
+
+### Accessing environment variables
+
+See [this section in the FAQ](https://kit.svelte.dev/faq#how-do-i-use-environment-variables).


### PR DESCRIPTION
I'm not sure if this is the right place to put such content, but I feel it is useful to users to be able to refer to usage examples and since we don't have a REPL yet, maybe we could have a "recipes" section that we could place common solutions to issues users are facing?

Consider this a proposal; can move wherever it makes sense

Relates to #1008