### PR TITLE
chore: tidying up types

### DIFF
--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -95,10 +95,10 @@ type Response = {
 	body?: any;
 };
 
-type Handle<Context = any> = (
+type Handle<Context = any> = ({
 	request: Request<Context>,
 	render: (request: Request<Context>) => Promise<Response>
-) => Response | Promise<Response>;
+}) => Response | Promise<Response>;
 ```
 
 ```js

--- a/packages/kit/types.d.ts
+++ b/packages/kit/types.d.ts
@@ -104,10 +104,7 @@ export type GetSession<Context = any, Session = any> = {
 	({ context }: { context: Context }): Session | Promise<Session>;
 };
 
-export type Handle<Context = any> = ({
-	request,
-	render
-}: {
+export type Handle<Context = any> = (handle: {
 	request: Request<Context>;
 	render: (request: Request<Context>) => Response | Promise<Response>;
 }) => Response | Promise<Response>;

--- a/packages/kit/types.d.ts
+++ b/packages/kit/types.d.ts
@@ -104,7 +104,7 @@ export type GetSession<Context = any, Session = any> = {
 	({ context }: { context: Context }): Session | Promise<Session>;
 };
 
-export type Handle<Context = any> = (handle: {
+export type Handle<Context = any> = (input: {
 	request: Request<Context>;
 	render: (request: Request<Context>) => Response | Promise<Response>;
 }) => Response | Promise<Response>;

--- a/packages/kit/types.d.ts
+++ b/packages/kit/types.d.ts
@@ -61,17 +61,17 @@ interface ReadOnlyFormData extends Iterator<[string, string]> {
 	values: () => Iterator<string>;
 }
 
+type BaseBody = string | Buffer | ReadOnlyFormData;
+type ParameterizedBody<Body = unknown> = BaseBody & Body;
+
 export type Incoming = {
 	method: string;
 	host: string;
 	headers: Headers;
 	path: string;
 	query: URLSearchParams;
-	body: string | Buffer | ReadOnlyFormData;
+	body: BaseBody;
 };
-
-type BaseBody = string | Buffer | ReadOnlyFormData;
-type ParameterizedBody<Body = unknown> = BaseBody & Body;
 
 export type Request<Context = any, Body = unknown> = {
 	method: string;

--- a/packages/kit/types.internal.d.ts
+++ b/packages/kit/types.internal.d.ts
@@ -10,7 +10,6 @@ import {
 	Response as SSRResponse
 } from './types';
 import { UserConfig as ViteConfig } from 'vite';
-import { Response as NodeFetchResponse } from 'node-fetch';
 
 declare global {
 	interface ImportMeta {


### PR DESCRIPTION
A prelude before moving types into its own folder as mentioned in https://github.com/sveltejs/kit/pull/980#issuecomment-818492644. This PR actions consists of

- removing unused type introduced in https://github.com/sveltejs/kit/pull/901#discussion_r612271006
- syncing up handle hooks type docs
- merging unnecessary destructuring/duplication in types

No tests or changeset should be needed as this should not change anything

***

There's also a couple more things I'd like to do but not sure what the general opinion here is, this suggestions could be applied here or in a separate PR (or not at all)

1. only exported types from `types.d.ts` are exposed to the end-user
    a. it might be better to have not-`export`ed to be placed in other file (maybe `internal` or `config`), _or_
    b. just put it directly in the arguments since it's only used once, e.g. `AdapterUtils`
2. continuing 1b, types used only once like `ParameterizedBody` can be removed and placed directly (inline)
