### PR TITLE
Use global URLSearchParams instead of import from url

### DIFF
--- a/.changeset/beige-teachers-end.md
+++ b/.changeset/beige-teachers-end.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Use global URLSearchParams instead of import from node url

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join, resolve as resolve_path, sep as path_separator } from 'path';
-import { parse, pathToFileURL, resolve, URLSearchParams } from 'url';
+import { parse, pathToFileURL, resolve } from 'url';
 import glob from 'tiny-glob/sync.js';
 import { mkdirp } from '../filesystem/index.js';
 

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { parse, URLSearchParams } from 'url';
+import { parse } from 'url';
 import { EventEmitter } from 'events';
 import CheapWatch from 'cheap-watch';
 import amp_validator from 'amphtml-validator';

--- a/packages/kit/src/core/start/index.js
+++ b/packages/kit/src/core/start/index.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { parse, pathToFileURL, URLSearchParams } from 'url';
+import { parse, pathToFileURL } from 'url';
 import sirv from 'sirv';
 import { get_body } from '../http/index.js';
 import { join, resolve } from 'path';

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -1,5 +1,5 @@
 import fetch, { Response } from 'node-fetch';
-import { parse, resolve, URLSearchParams } from 'url';
+import { parse, resolve } from 'url';
 import { normalize } from '../../load.js';
 import { ssr } from '../index.js';
 


### PR DESCRIPTION
URLSearchParams is [globally available since Node 10](https://nodejs.org/api/url.html#url_class_urlsearchparams), and importing from `url` introduces issues with Cloudflare Workers; webpack seems to bring its own version that does not have `url.URLSearchParams`.