### PR TITLE
Fix default `$error.svelte` page

### DIFF
--- a/.changeset/great-queens-rule.md
+++ b/.changeset/great-queens-rule.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix default error page

--- a/packages/kit/assets/components/error.svelte
+++ b/packages/kit/assets/components/error.svelte
@@ -1,3 +1,11 @@
+<script context="module">
+	export async function load({ error, status }) {
+		return {
+			props: { error, status }
+		};
+	}
+</script>
+
 <script>
 	export let status;
 	export let error;

--- a/packages/kit/assets/components/error.svelte
+++ b/packages/kit/assets/components/error.svelte
@@ -1,5 +1,5 @@
 <script context="module">
-	export async function load({ error, status }) {
+	export function load({ error, status }) {
 		return {
 			props: { error, status }
 		};


### PR DESCRIPTION
Currently you get `Cannot read property 'message' of undefined` with the default error page, as the props are no longer passed in by default.