### PR TITLE
Enhancements to docs around the `query` page attribute

### DIFF
--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -66,14 +66,15 @@ The `load` function receives an object containing four fields — `page`, `fetch
 
 #### page
 
-`page` is a `{ host, path, params, query }` object where `host` is the URL's host, `path` is its pathname, `params` is derived from `path` and the route filename, and `query` is an instance of `URLSearchParams`.
+`page` is a `{ host, path, params, query }` object where `host` is the URL's host, `path` is its pathname, `params` is derived from `path` and the route filename, and `query` is an instance of [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams).
 
-So if the example above was `src/routes/blog/[slug].svelte` and the URL was `/blog/some-post?foo=bar&baz`, the following would be true:
+So if the example above was `src/routes/blog/[slug].svelte` and the URL was `/blog/some-post?foo=bar&baz&bizz=a&bizz=b`, the following would be true:
 
 - `page.path === '/blog/some-post'`
 - `page.params.slug === 'some-post'`
 - `page.query.get('foo') === 'bar'`
 - `page.query.has('baz')`
+- `page.query.getAll('bizz') === ['a', 'b']`
 
 #### fetch
 

--- a/documentation/docs/05-modules.md
+++ b/documentation/docs/05-modules.md
@@ -49,7 +49,7 @@ Because of that, the stores are not free-floating objects: they must be accessed
 The stores themselves attach to the correct context at the point of subscription, which means you can import and use them directly in components without boilerplate.
 
 - `navigating` is a [readable store](https://svelte.dev/tutorial/readable-stores). When navigating starts, its value is `{ from, to }`, where `from` and `to` both mirror the `page` store value. When navigating finishes, its value reverts to `null`.
-- `page` is a readable store whose value reflects the object passed to `load` functions — it contains `host`, `path`, `params` and `query`. 
+- `page` is a readable store whose value reflects the object passed to `load` functions — it contains `host`, `path`, `params` and `query`. See the [`page` section](#loading-input-page) above for more details.
   - Please see the [Loading section](#loading-input-page) for info on accessing `query` values.
 - `session` is a [writable store](https://svelte.dev/tutorial/writable-stores) whose initial value is whatever was returned from [`getSession`](#hooks-getsession). It can be written to, but this will _not_ cause changes to persist on the server — this is something you must implement yourself.
 

--- a/documentation/docs/05-modules.md
+++ b/documentation/docs/05-modules.md
@@ -49,7 +49,8 @@ Because of that, the stores are not free-floating objects: they must be accessed
 The stores themselves attach to the correct context at the point of subscription, which means you can import and use them directly in components without boilerplate.
 
 - `navigating` is a [readable store](https://svelte.dev/tutorial/readable-stores). When navigating starts, its value is `{ from, to }`, where `from` and `to` both mirror the `page` store value. When navigating finishes, its value reverts to `null`.
-- `page` is a readable store whose value reflects the object passed to `load` functions — it contains `host`, `path`, `params` and `query`
+- `page` is a readable store whose value reflects the object passed to `load` functions — it contains `host`, `path`, `params` and `query`. 
+  - Please see the [Loading section](#loading-input-page) for info on accessing `query` values.
 - `session` is a [writable store](https://svelte.dev/tutorial/writable-stores) whose initial value is whatever was returned from [`getSession`](#hooks-getsession). It can be written to, but this will _not_ cause changes to persist on the server — this is something you must implement yourself.
 
 ### $lib

--- a/documentation/docs/05-modules.md
+++ b/documentation/docs/05-modules.md
@@ -50,7 +50,6 @@ The stores themselves attach to the correct context at the point of subscription
 
 - `navigating` is a [readable store](https://svelte.dev/tutorial/readable-stores). When navigating starts, its value is `{ from, to }`, where `from` and `to` both mirror the `page` store value. When navigating finishes, its value reverts to `null`.
 - `page` is a readable store whose value reflects the object passed to `load` functions — it contains `host`, `path`, `params` and `query`. See the [`page` section](#loading-input-page) above for more details.
-  - Please see the [Loading section](#loading-input-page) for info on accessing `query` values.
 - `session` is a [writable store](https://svelte.dev/tutorial/writable-stores) whose initial value is whatever was returned from [`getSession`](#hooks-getsession). It can be written to, but this will _not_ cause changes to persist on the server — this is something you must implement yourself.
 
 ### $lib


### PR DESCRIPTION
- Add MDN link for `URLSearchParams`
- Add a `getAll` example
- Cross link from the `$page` store to Location => page section

Follow up to #1012