### PR TITLE
attempt to fix dev mode FOUC

### DIFF
--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -230,8 +230,14 @@ class Watcher extends EventEmitter {
 								const styles = new Set();
 
 								for (const dep of deps) {
+									const parsed = parse(dep.url);
+									const query = new URLSearchParams(parsed.query);
+
 									// TODO what about .scss files, etc?
-									if (dep.file.endsWith('.css')) {
+									if (
+										dep.file.endsWith('.css') ||
+										(query.has('svelte') && query.get('type') === 'style')
+									) {
 										try {
 											const mod = await this.vite.ssrLoadModule(dep.url);
 											css.add(dep.url);


### PR DESCRIPTION
Alternative to #1026. It seems to work for apps once they're running, but the first load after the server starts always results in this:

![image](https://user-images.githubusercontent.com/1162160/114798954-91013d00-9d64-11eb-9c1a-c2ba92fcd9d5.png)

I have no idea why — @dominikg does this look familiar?

<details>
  <summary>admin</summary>

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
</details>