### PR TITLE
Prefer native `fetch` when available

### DIFF
--- a/.changeset/chatty-clouds-listen.md
+++ b/.changeset/chatty-clouds-listen.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Prefer native fetch over node-fetch when available

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -1,7 +1,19 @@
-import fetch, { Response } from 'node-fetch';
+import nodeFetch from 'node-fetch';
 import { parse, resolve } from 'url';
 import { normalize } from '../../load.js';
 import { ssr } from '../index.js';
+
+// only use node-fetch when native unavailable
+if (typeof fetch !== 'function') {
+	// @ts-ignore mismatch between native fetch and node-fetch
+	globalThis.fetch = nodeFetch.bind({});
+	// @ts-ignore
+	globalThis.Response = nodeFetch.Response;
+	// @ts-ignore
+	globalThis.Request = nodeFetch.Request;
+	// @ts-ignore
+	globalThis.Headers = nodeFetch.Headers;
+}
 
 const s = JSON.stringify;
 
@@ -98,6 +110,7 @@ export async function load_node({
 					// external fetch
 					response = await fetch(
 						parsed.href,
+						// @ts-ignore mismatch between native fetch and node-fetch
 						/** @type {import('node-fetch').RequestInit} */ (opts)
 					);
 				} else {
@@ -125,6 +138,7 @@ export async function load_node({
 							// TODO we need to know what protocol to use
 							response = await fetch(
 								`http://${page.host}/${asset.file}`,
+								// @ts-ignore mismatch between native fetch and node-fetch
 								/** @type {import('node-fetch').RequestInit} */ (opts)
 							);
 						}

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -1,4 +1,8 @@
-import nodeFetch from 'node-fetch';
+import nodeFetch, {
+	Response as NodeResponse,
+	Request as NodeRequest,
+	Headers as NodeHeaders
+} from 'node-fetch';
 import { parse, resolve } from 'url';
 import { normalize } from '../../load.js';
 import { ssr } from '../index.js';
@@ -6,13 +10,13 @@ import { ssr } from '../index.js';
 // only use node-fetch when native unavailable
 if (typeof fetch !== 'function') {
 	// @ts-ignore mismatch between native fetch and node-fetch
-	globalThis.fetch = nodeFetch.bind({});
+	globalThis.fetch = nodeFetch;
 	// @ts-ignore
-	globalThis.Response = nodeFetch.Response;
+	globalThis.Response = NodeResponse;
 	// @ts-ignore
-	globalThis.Request = nodeFetch.Request;
+	globalThis.Request = NodeRequest;
 	// @ts-ignore
-	globalThis.Headers = nodeFetch.Headers;
+	globalThis.Headers = NodeHeaders;
 }
 
 const s = JSON.stringify;

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -71,7 +71,6 @@ export async function load_node({
 			 * @param {RequestInfo} resource
 			 * @param {RequestInit} opts
 			 */
-			// @ts-ignore mismatch between client fetch and node-fetch
 			fetch: async (resource, opts = {}) => {
 				/** @type {string} */
 				let url;
@@ -108,11 +107,7 @@ export async function load_node({
 
 				if (parsed.protocol) {
 					// external fetch
-					response = await fetch(
-						parsed.href,
-						// @ts-ignore mismatch between native fetch and node-fetch
-						/** @type {import('node-fetch').RequestInit} */ (opts)
-					);
+					response = await fetch(parsed.href, /** @type {RequestInit} */ (opts));
 				} else {
 					// otherwise we're dealing with an internal fetch
 					const resolved = resolve(request.path, parsed.pathname);
@@ -138,8 +133,7 @@ export async function load_node({
 							// TODO we need to know what protocol to use
 							response = await fetch(
 								`http://${page.host}/${asset.file}`,
-								// @ts-ignore mismatch between native fetch and node-fetch
-								/** @type {import('node-fetch').RequestInit} */ (opts)
+								/** @type {RequestInit} */ (opts)
 							);
 						}
 					}


### PR DESCRIPTION
Really not happy with all the `ts-ignore` directives. Anyway.
- Fixes #1019
- Prefers native fetch when provided by the environment ([Cloudflare Workers](https://developers.cloudflare.com/workers/runtime-apis/fetch), [Deno Deploy](https://deno.com/deploy/docs/runtime-fetch))
- Based off [`cross-fetch` polyfill](https://github.com/lquixada/cross-fetch/blob/072e898175019a513b789d17d5b5aa10e19146d4/dist/node-polyfill.js)

Alternative solutions:
- #1066 Move server-side `fetch` responsibility to adapters instead of build step

Unsolved problems:
- Use of `fetch` inside server endpoints - do we want to re-export `node-fetch` or is this a userland problem?
- This probably still includes unused `node-fetch` code in the built output for `adapter-cloudflare-workers`, which is a waste of space, bandwidth, and potentially cost.