### PR TITLE
Fix LoadOutput type to allow string for error

### DIFF
--- a/packages/kit/types/page.d.ts
+++ b/packages/kit/types/page.d.ts
@@ -12,7 +12,7 @@ export type ErrorLoadInput = LoadInput & {
 
 export type LoadOutput = {
 	status?: number;
-	error?: Error;
+	error?: Error | string;
 	redirect?: string;
 	props?: Record<string, any> | Promise<Record<string, any>>;
 	context?: Record<string, any>;


### PR DESCRIPTION
Return value of load function, LoadOutput, allows using string in addition to Error. This simply fixes the type file to allow for that.

Documentation mentioning string is allowed: https://kit.svelte.dev/docs#loading-output-error
Code that handles string values: https://github.com/sveltejs/kit/blob/1d76d66038647c8a67dbb011cf9c0e231fd086a6/packages/kit/src/runtime/load.js#L9