### PR TITLE
Fix: Add global.d.ts to create-svelte JS version

### DIFF
--- a/.changeset/gold-moles-hunt.md
+++ b/.changeset/gold-moles-hunt.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+add global.d.ts to js version

--- a/packages/create-svelte/scripts/build-templates.js
+++ b/packages/create-svelte/scripts/build-templates.js
@@ -49,7 +49,9 @@ async function generate_templates() {
 		const js = { meta, files: [] };
 
 		for (const file of ts.files) {
-			if (file.name.endsWith('.d.ts')) continue;
+			// The global.d.ts file makes TS/JS aware of some ambient modules, which are
+			// also needed for JS projects if people turn on "checkJs" in their jsonfig
+			if (file.name.endsWith('.d.ts') && !file.name.endsWith('global.d.ts')) continue;
 
 			if (file.name.endsWith('.ts')) {
 				const transformed = transform(file.contents, {


### PR DESCRIPTION
The global.d.ts file makes TS/JS aware of some ambient modules, which are also needed for JS projects if people turn on "checkJs" in their jsonfig
