### PR TITLE
tweak endpoint docs

### DIFF
--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -93,7 +93,16 @@ export async function get({ params }) {
 
 > Returning nothing is equivalent to an explicit 404 response.
 
-The job of this function is to return a `{status, headers, body}` object representing the response. If the returned `body` is an object, and no `content-type` header is returned, it will automatically be turned into a JSON response. (Don't worry about `$lib`, we'll get to that [later](#$lib).)
+The job of this function is to return a `{status, headers, body}` object representing the response, where `status` is an [HTTP status code](https://httpstatusdogs.com):
+
+* `2xx` — successful response (default is `200`)
+* `3xx` — redirection (should be accompanied by a `location` header)
+* `4xx` — client error
+* `5xx` — server error
+
+> For successful responses, SvelteKit will generate 304s automatically
+
+If the returned `body` is an object, and no `content-type` header is returned, it will automatically be turned into a JSON response. (Don't worry about `$lib`, we'll get to that [later](#modules-lib).)
 
 For endpoints that handle other HTTP methods, like POST, export the corresponding function:
 
@@ -116,6 +125,7 @@ return {
 	}
 };
 ```
+
 
 ### Private modules
 


### PR DESCRIPTION
alternative to #1011. will hopefully help people trying to figure out how to redirect from endpoints, without adding a new recipes section. also, i will take any opportunity to link to https://httpstatusdogs.com/

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
