### PR TITLE
Better error logging

### DIFF
--- a/.changeset/lazy-actors-add.md
+++ b/.changeset/lazy-actors-add.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Better error logging

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -279,20 +279,13 @@ async function build_server(
 				.replace('%svelte.head%', '" + head + "')
 				.replace('%svelte.body%', '" + body + "')};
 
-			let paths = ${s(config.kit.paths)};
-			set_paths(paths);
-
 			let options = null;
 
 			// allow paths to be overridden in svelte-kit start
+			// and in prerendering
 			export function init(settings) {
-				if ('paths' in settings) {
-					set_paths(paths = settings.paths);
-				}
-
-				if ('prerendering' in settings) {
-					set_prerendering(settings.prerendering);
-				}
+				set_paths(settings.paths);
+				set_prerendering(settings.prerendering || false);
 
 				options = {
 					amp: ${config.kit.amp},
@@ -319,6 +312,8 @@ async function build_server(
 					template
 				};
 			}
+
+			init({ paths: ${s(config.kit.paths)} });
 
 			const d = decodeURIComponent;
 			const empty = () => ({});

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -298,7 +298,7 @@ async function build_server(
 					fetched: undefined,
 					get_component_path: id => ${s(`${config.kit.paths.assets}/${config.kit.appDir}/`)} + entry_lookup[id],
 					get_stack: error => error.stack,
-					hooks,
+					hooks: get_hooks(user_hooks),
 					hydrate: ${s(config.kit.hydrate)},
 					initiator: undefined,
 					load_component,
@@ -312,8 +312,6 @@ async function build_server(
 					template
 				};
 			}
-
-			init({ paths: ${s(config.kit.paths)} });
 
 			const d = decodeURIComponent;
 			const empty = () => ({});
@@ -359,8 +357,6 @@ async function build_server(
 				handle: hooks.handle || (({ request, render }) => render(request))
 			});
 
-			const hooks = get_hooks(user_hooks);
-
 			const module_lookup = {
 				${manifest.components.map(file => `${s(file)}: () => import(${s(app_relative(file))})`)}
 			};
@@ -376,6 +372,8 @@ async function build_server(
 					...metadata_lookup[file]
 				};
 			}
+
+			init({ paths: ${s(config.kit.paths)} });
 
 			export function render(request, {
 				prerender

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -297,9 +297,10 @@ async function build_server(
 					},
 					fetched: undefined,
 					get_component_path: id => ${s(`${config.kit.paths.assets}/${config.kit.appDir}/`)} + entry_lookup[id],
+					get_stack: error => String(error), // for security
 					handle_error: error => {
 						console.error(error.stack);
-						error.stack = error.message; // for security
+						error.stack = options.get_stack(error);
 					},
 					hooks: get_hooks(user_hooks),
 					hydrate: ${s(config.kit.hydrate)},

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -297,7 +297,10 @@ async function build_server(
 					},
 					fetched: undefined,
 					get_component_path: id => ${s(`${config.kit.paths.assets}/${config.kit.appDir}/`)} + entry_lookup[id],
-					get_stack: error => error.stack,
+					handle_error: error => {
+						console.error(error.stack);
+						error.stack = error.message; // for security
+					},
 					hooks: get_hooks(user_hooks),
 					hydrate: ${s(config.kit.hydrate)},
 					initiator: undefined,

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -166,7 +166,6 @@ class Watcher extends EventEmitter {
 								css: [],
 								js: []
 							},
-							fetched: undefined,
 							get_stack: (error) => {
 								this.vite.ssrFixStacktrace(error);
 								return error.stack;
@@ -177,7 +176,6 @@ class Watcher extends EventEmitter {
 								handle: hooks.handle || (({ request, render }) => render(request))
 							},
 							hydrate: this.config.kit.hydrate,
-							initiator: undefined,
 							paths: this.config.kit.paths,
 							load_component: async (id) => {
 								const url = path.resolve(this.cwd, id);
@@ -219,7 +217,6 @@ class Watcher extends EventEmitter {
 								};
 							},
 							manifest: this.manifest,
-							prerender: null,
 							read: (file) => fs.readFileSync(path.join(this.config.kit.files.assets, file)),
 							root,
 							router: this.config.kit.router,

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -167,6 +167,10 @@ class Watcher extends EventEmitter {
 								css: [],
 								js: []
 							},
+							get_stack: (error) => {
+								this.vite.ssrFixStacktrace(error);
+								return error.stack;
+							},
 							handle_error: (error) => {
 								this.vite.ssrFixStacktrace(error);
 								console.error(colors.bold().red(error.message));

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -5,6 +5,7 @@ import { EventEmitter } from 'events';
 import CheapWatch from 'cheap-watch';
 import amp_validator from 'amphtml-validator';
 import vite from 'vite';
+import colors from 'kleur';
 import create_manifest_data from '../../core/create_manifest_data/index.js';
 import { create_app } from '../../core/create_app/index.js';
 import { rimraf } from '../filesystem/index.js';
@@ -166,9 +167,10 @@ class Watcher extends EventEmitter {
 								css: [],
 								js: []
 							},
-							get_stack: (error) => {
+							handle_error: (error) => {
 								this.vite.ssrFixStacktrace(error);
-								return error.stack;
+								console.error(colors.bold().red(error.message));
+								console.error(colors.gray(error.stack));
 							},
 							hooks: {
 								getContext: hooks.getContext || (() => ({})),

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -130,9 +130,6 @@ class Watcher extends EventEmitter {
 
 					if (req.url === '/favicon.ico') return;
 
-					// handle dynamic requests - i.e. pages and endpoints
-					const template = fs.readFileSync(this.config.kit.files.template, 'utf-8');
-
 					const hooks = /** @type {import('types/internal').Hooks} */ (await this.vite
 						.ssrLoadModule(`/${this.config.kit.files.hooks}`)
 						.catch(() => ({})));
@@ -162,9 +159,75 @@ class Watcher extends EventEmitter {
 							body
 						},
 						{
+							amp: this.config.kit.amp,
+							dev: true,
+							entry: {
+								file: '/.svelte/dev/runtime/internal/start.js',
+								css: [],
+								js: []
+							},
+							fetched: undefined,
+							get_stack: (error) => {
+								this.vite.ssrFixStacktrace(error);
+								return error.stack;
+							},
+							hooks: {
+								getContext: hooks.getContext || (() => ({})),
+								getSession: hooks.getSession || (() => ({})),
+								handle: hooks.handle || (({ request, render }) => render(request))
+							},
+							hydrate: this.config.kit.hydrate,
+							initiator: undefined,
 							paths: this.config.kit.paths,
+							load_component: async (id) => {
+								const url = path.resolve(this.cwd, id);
+
+								const module = /** @type {SSRComponent} */ (await this.vite.ssrLoadModule(url));
+								const node = await this.vite.moduleGraph.getModuleByUrl(url);
+
+								const deps = new Set();
+								find_deps(node, deps);
+
+								const styles = new Set();
+
+								for (const dep of deps) {
+									const parsed = parse(dep.url);
+									const query = new URLSearchParams(parsed.query);
+
+									// TODO what about .scss files, etc?
+									if (
+										dep.file.endsWith('.css') ||
+										(query.has('svelte') && query.get('type') === 'style')
+									) {
+										try {
+											const mod = await this.vite.ssrLoadModule(dep.url);
+											styles.add(mod.default);
+										} catch {
+											// this can happen with dynamically imported modules, I think
+											// because the Vite module graph doesn't distinguish between
+											// static and dynamic imports? TODO investigate, submit fix
+										}
+									}
+								}
+
+								return {
+									module,
+									entry: `/${id}?import`,
+									css: [],
+									js: [],
+									styles: Array.from(styles)
+								};
+							},
+							manifest: this.manifest,
+							prerender: null,
+							read: (file) => fs.readFileSync(path.join(this.config.kit.files.assets, file)),
+							root,
+							router: this.config.kit.router,
+							ssr: this.config.kit.ssr,
+							target: this.config.kit.target,
 							template: ({ head, body }) => {
-								let rendered = template
+								let rendered = fs
+									.readFileSync(this.config.kit.files.template, 'utf8')
 									.replace('%svelte.head%', () => head)
 									.replace('%svelte.body%', () => body);
 
@@ -213,69 +276,7 @@ class Watcher extends EventEmitter {
 								}
 
 								return rendered;
-							},
-							manifest: this.manifest,
-							load_component: async (id) => {
-								const url = path.resolve(this.cwd, id);
-
-								const module = /** @type {SSRComponent} */ (await this.vite.ssrLoadModule(url));
-								const node = await this.vite.moduleGraph.getModuleByUrl(url);
-
-								const deps = new Set();
-								find_deps(node, deps);
-
-								const styles = new Set();
-
-								for (const dep of deps) {
-									const parsed = parse(dep.url);
-									const query = new URLSearchParams(parsed.query);
-
-									// TODO what about .scss files, etc?
-									if (
-										dep.file.endsWith('.css') ||
-										(query.has('svelte') && query.get('type') === 'style')
-									) {
-										try {
-											const mod = await this.vite.ssrLoadModule(dep.url);
-											styles.add(mod.default);
-										} catch {
-											// this can happen with dynamically imported modules, I think
-											// because the Vite module graph doesn't distinguish between
-											// static and dynamic imports? TODO investigate, submit fix
-										}
-									}
-								}
-
-								return {
-									module,
-									entry: `/${id}?import`,
-									css: [],
-									js: [],
-									styles: Array.from(styles)
-								};
-							},
-							target: this.config.kit.target,
-							entry: '/.svelte/dev/runtime/internal/start.js',
-							css: [],
-							js: [],
-							dev: true,
-							amp: this.config.kit.amp,
-							root,
-							hooks: {
-								getContext: hooks.getContext || (() => ({})),
-								getSession: hooks.getSession || (() => ({})),
-								handle: hooks.handle || (({ request, render }) => render(request))
-							},
-							only_render_prerenderable_pages: false,
-							get_stack: (error) => {
-								this.vite.ssrFixStacktrace(error);
-								return error.stack;
-							},
-							get_static_file: (file) =>
-								fs.readFileSync(path.join(this.config.kit.files.assets, file)),
-							ssr: this.config.kit.ssr,
-							router: this.config.kit.router,
-							hydrate: this.config.kit.hydrate
+							}
 						}
 					);
 

--- a/packages/kit/src/core/start/index.js
+++ b/packages/kit/src/core/start/index.js
@@ -37,30 +37,29 @@ export async function start({ port, host, config, https: use_https = false, cwd 
 		immutable: true
 	});
 
+	app.init({
+		paths: {
+			base: '',
+			assets: '/.'
+		},
+		prerendering: false,
+		read: (file) => fs.readFileSync(join(config.kit.files.assets, file))
+	});
+
 	return get_server(port, host, use_https, (req, res) => {
 		const parsed = parse(req.url || '');
 
 		assets_handler(req, res, () => {
 			static_handler(req, res, async () => {
-				const rendered = await app.render(
-					{
-						host: /** @type {string} */ (config.kit.host ||
-							req.headers[config.kit.hostHeader || 'host']),
-						method: req.method,
-						headers: /** @type {import('types/helper').Headers} */ (req.headers),
-						path: parsed.pathname,
-						body: await get_body(req),
-						query: new URLSearchParams(parsed.query || '')
-					},
-					{
-						paths: {
-							base: '',
-							assets: '/.'
-						},
-						get_stack: (error) => error.stack, // TODO should this return a sourcemapped stacktrace?
-						get_static_file: (file) => fs.readFileSync(join(config.kit.files.assets, file))
-					}
-				);
+				const rendered = await app.render({
+					host: /** @type {string} */ (config.kit.host ||
+						req.headers[config.kit.hostHeader || 'host']),
+					method: req.method,
+					headers: /** @type {import('types/helper').Headers} */ (req.headers),
+					path: parsed.pathname,
+					body: await get_body(req),
+					query: new URLSearchParams(parsed.query || '')
+				});
 
 				if (rendered) {
 					res.writeHead(rendered.status, rendered.headers);

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -10,8 +10,9 @@ function md5(body) {
 /**
  * @param {import('types/hooks').Incoming} incoming
  * @param {import('types/internal').SSRRenderOptions} options
+ * @param {import('types/internal').SSRRenderState} [state]
  */
-export async function ssr(incoming, options) {
+export async function ssr(incoming, options, state = {}) {
 	if (incoming.path.endsWith('/') && incoming.path !== '/') {
 		const q = incoming.query.toString();
 
@@ -39,7 +40,7 @@ export async function ssr(incoming, options) {
 					const response =
 						route.type === 'endpoint'
 							? await render_endpoint(request, route)
-							: await render_page(request, route, options);
+							: await render_page(request, route, options, state);
 
 					if (response) {
 						// inject ETags for 200 responses
@@ -63,7 +64,7 @@ export async function ssr(incoming, options) {
 					}
 				}
 
-				return await render_page(request, null, options);
+				return await render_page(request, null, options, state);
 			}
 		});
 	} catch (e) {

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -68,11 +68,7 @@ export async function ssr(incoming, options, state = {}) {
 			}
 		});
 	} catch (e) {
-		if (e && e.stack) {
-			e.stack = await options.get_stack(e);
-		}
-
-		console.error((e && e.stack) || e);
+		options.handle_error(e);
 
 		return {
 			status: 500,

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -83,7 +83,7 @@ export async function load_node({
 					};
 				}
 
-				if (options.local && url.startsWith(options.paths.assets)) {
+				if (options.read && url.startsWith(options.paths.assets)) {
 					// when running `start`, or prerendering, `assets` should be
 					// config.kit.paths.assets, but we should still be able to fetch
 					// assets directly from `static`
@@ -114,9 +114,9 @@ export async function load_node({
 
 					if (asset) {
 						// we don't have a running server while prerendering because jumping between
-						// processes would be inefficient so we have get_static_file instead
-						if (options.get_static_file) {
-							response = new Response(options.get_static_file(asset.file), {
+						// processes would be inefficient so we have options.read instead
+						if (options.read) {
+							response = new Response(options.read(asset.file), {
 								headers: {
 									'content-type': asset.type
 								}
@@ -161,8 +161,8 @@ export async function load_node({
 						);
 
 						if (rendered) {
-							if (options.dependencies) {
-								options.dependencies.set(resolved, rendered);
+							if (options.prerender) {
+								options.prerender.dependencies.set(resolved, rendered);
 							}
 
 							response = new Response(rendered.body, {

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -10,6 +10,7 @@ const s = JSON.stringify;
  * @param {{
  *   request: import('types/endpoint').ServerRequest;
  *   options: import('types/internal').SSRRenderOptions;
+ *   state: import('types/internal').SSRRenderState;
  *   route: import('types/internal').SSRPage;
  *   page: import('types/page').Page;
  *   node: import('types/internal').SSRNode;
@@ -25,6 +26,7 @@ const s = JSON.stringify;
 export async function load_node({
 	request,
 	options,
+	state,
 	route,
 	page,
 	node,
@@ -153,16 +155,16 @@ export async function load_node({
 								body: /** @type {any} */ (opts.body),
 								query: new URLSearchParams(parsed.query || '')
 							},
+							options,
 							{
-								...options,
 								fetched: url,
 								initiator: route
 							}
 						);
 
 						if (rendered) {
-							if (options.prerender) {
-								options.prerender.dependencies.set(resolved, rendered);
+							if (state.prerender) {
+								state.prerender.dependencies.set(resolved, rendered);
 							}
 
 							response = new Response(rendered.body, {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -26,8 +26,8 @@ export async function render_response({
 	branch,
 	page
 }) {
-	const css = new Set(options.css);
-	const js = new Set(options.js);
+	const css = new Set(options.entry.css);
+	const js = new Set(options.entry.js);
 	const styles = new Set();
 
 	/** @type {Array<{ url: string, json: string }>} */
@@ -116,7 +116,7 @@ export async function render_response({
 	} else if (page_config.router || page_config.hydrate) {
 		// prettier-ignore
 		init = `<script type="module">
-			import { start } from ${s(options.entry)};
+			import { start } from ${s(options.entry.file)};
 			start({
 				target: ${options.target ? `document.querySelector(${s(options.target)})` : 'document.body'},
 				paths: ${s(options.paths)},

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -52,15 +52,6 @@ export async function render_response({
 			maxage = loaded.maxage;
 		});
 
-		if (error) {
-			if (options.dev) {
-				error.stack = await options.get_stack(error);
-			} else {
-				// remove error.stack in production
-				error.stack = String(error);
-			}
-		}
-
 		const session = writable($session);
 
 		/** @type {Record<string, any>} */

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -38,6 +38,10 @@ export async function render_response({
 	let is_private = false;
 	let maxage;
 
+	if (error) {
+		error.stack = options.get_stack(error);
+	}
+
 	if (branch) {
 		branch.forEach(({ node, loaded, fetched, uses_credentials }) => {
 			if (node.css) node.css.forEach((url) => css.add(url));

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -30,6 +30,8 @@ export async function respond({ request, options, state, $session, route }) {
 	try {
 		nodes = await Promise.all(route.a.map((id) => id && options.load_component(id)));
 	} catch (error) {
+		options.handle_error(error);
+
 		return await respond_with_error({
 			request,
 			options,
@@ -107,6 +109,8 @@ export async function respond({ request, options, state, $session, route }) {
 						({ status, error } = loaded.loaded);
 					}
 				} catch (e) {
+					options.handle_error(e);
+
 					status = 500;
 					error = e;
 				}
@@ -147,6 +151,8 @@ export async function respond({ request, options, state, $session, route }) {
 								branch = branch.slice(0, j + 1).concat(error_loaded);
 								break ssr;
 							} catch (e) {
+								options.handle_error(e);
+
 								continue;
 							}
 						}
@@ -190,6 +196,8 @@ export async function respond({ request, options, state, $session, route }) {
 			page
 		});
 	} catch (error) {
+		options.handle_error(error);
+
 		return await respond_with_error({
 			request,
 			options,

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -46,7 +46,7 @@ export async function respond({ request, options, $session, route }) {
 		hydrate: 'hydrate' in leaf ? leaf.hydrate : options.hydrate
 	};
 
-	if (options.only_render_prerenderable_pages && !leaf.prerender) {
+	if (!leaf.prerender && options.prerender && !options.prerender.force) {
 		// if the page has `export const prerender = true`, continue,
 		// otherwise bail out at this point
 		return {

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -8,12 +8,13 @@ import { respond_with_error } from './respond_with_error.js';
  * @param {{
  *   request: import('types/endpoint').ServerRequest;
  *   options: import('types/internal').SSRRenderOptions;
+ *   state: import('types/internal').SSRRenderState;
  *   $session: any;
  *   route: import('types/internal').SSRPage;
  * }} opts
  * @returns {Promise<import('types/endpoint').ServerResponse>}
  */
-export async function respond({ request, options, $session, route }) {
+export async function respond({ request, options, state, $session, route }) {
 	const match = route.pattern.exec(request.path);
 	const params = route.params(match);
 
@@ -32,6 +33,7 @@ export async function respond({ request, options, $session, route }) {
 		return await respond_with_error({
 			request,
 			options,
+			state,
 			$session,
 			status: 500,
 			error
@@ -46,7 +48,7 @@ export async function respond({ request, options, $session, route }) {
 		hydrate: 'hydrate' in leaf ? leaf.hydrate : options.hydrate
 	};
 
-	if (!leaf.prerender && options.prerender && !options.prerender.force) {
+	if (!leaf.prerender && state.prerender && !state.prerender.force) {
 		// if the page has `export const prerender = true`, continue,
 		// otherwise bail out at this point
 		return {
@@ -80,6 +82,7 @@ export async function respond({ request, options, $session, route }) {
 					loaded = await load_node({
 						request,
 						options,
+						state,
 						route,
 						page,
 						node,
@@ -125,6 +128,7 @@ export async function respond({ request, options, $session, route }) {
 								error_loaded = await load_node({
 									request,
 									options,
+									state,
 									route,
 									page,
 									node: error_node,
@@ -154,6 +158,7 @@ export async function respond({ request, options, $session, route }) {
 					return await respond_with_error({
 						request,
 						options,
+						state,
 						$session,
 						status,
 						error
@@ -188,6 +193,7 @@ export async function respond({ request, options, $session, route }) {
 		return await respond_with_error({
 			request,
 			options,
+			state,
 			$session,
 			status: 500,
 			error

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -69,10 +69,12 @@ export async function respond_with_error({ request, options, state, $session, st
 			page
 		});
 	} catch (error) {
+		options.handle_error(error);
+
 		return {
 			status: 500,
 			headers: {},
-			body: options.dev ? error.stack : error.message
+			body: error.stack
 		};
 	}
 }

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -5,12 +5,13 @@ import { load_node } from './load_node.js';
  * @param {{
  *   request: import('types/endpoint').ServerRequest;
  *   options: import('types/internal').SSRRenderOptions;
+ *   state: import('types/internal').SSRRenderState;
  *   $session: any;
  *   status: number;
  *   error: Error;
  * }} opts
  */
-export async function respond_with_error({ request, options, $session, status, error }) {
+export async function respond_with_error({ request, options, state, $session, status, error }) {
 	const default_layout = await options.load_component(options.manifest.layout);
 	const default_error = await options.load_component(options.manifest.error);
 
@@ -24,6 +25,7 @@ export async function respond_with_error({ request, options, $session, status, e
 	const loaded = await load_node({
 		request,
 		options,
+		state,
 		route: null,
 		page,
 		node: default_layout,
@@ -38,6 +40,7 @@ export async function respond_with_error({ request, options, $session, status, e
 		await load_node({
 			request,
 			options,
+			state,
 			route: null,
 			page,
 			node: default_error,

--- a/packages/kit/test/apps/basics/src/routes/errors/__tests__.js
+++ b/packages/kit/test/apps/basics/src/routes/errors/__tests__.js
@@ -188,21 +188,11 @@ export default function (test, is_dev) {
 		assert.match(await res.text(), /PUT is not implemented/);
 	});
 
-	test('error in endpoint', null, async ({ base, page }) => {
-		let console_error = '';
-		const { error: original_error } = console;
-
-		/** @param {string} text */
-		console.error = (text) => {
-			console_error += `${text}\n`;
-		};
-
+	test('error in endpoint', null, async ({ base, page, errors }) => {
 		const res = await page.goto(`${base}/errors/endpoint`);
 
-		console.error = original_error;
-
 		// should include stack trace
-		const lines = console_error.split('\n');
+		const lines = errors().split('\n');
 		assert.ok(lines[0].includes('nope'), 'Logs error message');
 		if (is_dev) {
 			assert.ok(lines[2].includes('endpoint.json'), 'Logs error stack in dev');

--- a/packages/kit/test/apps/basics/src/routes/errors/__tests__.js
+++ b/packages/kit/test/apps/basics/src/routes/errors/__tests__.js
@@ -189,13 +189,12 @@ export default function (test, is_dev) {
 	});
 
 	test('error in endpoint', null, async ({ base, page }) => {
-		/** @type {string[]} */
-		const console_errors = [];
+		let console_error = '';
 		const { error: original_error } = console;
 
 		/** @param {string} text */
 		console.error = (text) => {
-			console_errors.push(text);
+			console_error += `${text}\n`;
 		};
 
 		const res = await page.goto(`${base}/errors/endpoint`);
@@ -203,10 +202,10 @@ export default function (test, is_dev) {
 		console.error = original_error;
 
 		// should include stack trace
-		const lines = (console_errors[0] || '').split('\n');
-		assert.equal(lines[0], 'Error: nope');
+		const lines = console_error.split('\n');
+		assert.ok(lines[0].includes('nope'), 'Logs error message');
 		if (is_dev) {
-			assert.ok(lines[1].includes('endpoint.json'));
+			assert.ok(lines[2].includes('endpoint.json'), 'Logs error stack in dev');
 		}
 
 		assert.equal(res.status(), 500);

--- a/packages/kit/test/types.d.ts
+++ b/packages/kit/test/types.d.ts
@@ -11,6 +11,7 @@ export type TestContext = {
 	back: () => Promise<void>;
 	fetch: (url: RequestInfo, opts: RequestInit) => Promise<Response>;
 	capture_requests: (fn: () => void) => Promise<string[]>;
+	errors: () => string;
 	js: boolean;
 
 	// these are assumed to have been put in the global scope by the layout

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -125,7 +125,6 @@ export type SSRNode = {
 	styles: string[];
 };
 
-// TODO separate out runtime options from the ones fixed in dev/build
 export type SSRRenderOptions = {
 	amp: boolean;
 	dev: boolean;
@@ -134,21 +133,14 @@ export type SSRRenderOptions = {
 		css: string[];
 		js: string[];
 	};
-	fetched: string;
 	get_stack: (error: Error) => string;
 	hooks: Hooks;
 	hydrate: boolean;
-	initiator: SSRPage;
 	load_component: (id: PageId) => Promise<SSRNode>;
 	manifest: SSRManifest;
 	paths: {
 		base: string;
 		assets: string;
-	};
-	prerender: {
-		force: boolean;
-		dependencies: Map<string, ServerResponse>;
-		error: Error;
 	};
 	read: (file: string) => Buffer;
 	root: SSRComponent['default'];
@@ -156,6 +148,16 @@ export type SSRRenderOptions = {
 	ssr: boolean;
 	target: string;
 	template: ({ head, body }: { head: string; body: string }) => string;
+};
+
+export type SSRRenderState = {
+	fetched?: string;
+	initiator?: SSRPage;
+	prerender?: {
+		force: boolean;
+		dependencies: Map<string, ServerResponse>;
+		error: Error;
+	};
 };
 
 export type Asset = {

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -133,6 +133,7 @@ export type SSRRenderOptions = {
 		css: string[];
 		js: string[];
 	};
+	get_stack: (error: Error) => string;
 	handle_error: (error: Error) => void;
 	hooks: Hooks;
 	hydrate: boolean;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -22,15 +22,26 @@ export type Logger = {
 export type App = {
 	init: ({
 		paths,
-		prerendering
+		prerendering,
+		read
 	}: {
 		paths: {
 			base: string;
 			assets: string;
 		};
 		prerendering: boolean;
+		read: (file: string) => Buffer;
 	}) => void;
-	render: (incoming: Incoming, options: SSRRenderOptions) => ServerResponse;
+	render: (
+		incoming: Incoming,
+		options?: {
+			prerender: {
+				force: boolean;
+				dependencies: Map<string, ServerResponse>;
+				error: Error;
+			};
+		}
+	) => ServerResponse;
 };
 
 export type SSRComponent = {
@@ -116,31 +127,35 @@ export type SSRNode = {
 
 // TODO separate out runtime options from the ones fixed in dev/build
 export type SSRRenderOptions = {
-	paths?: {
+	amp: boolean;
+	dev: boolean;
+	entry: {
+		file: string;
+		css: string[];
+		js: string[];
+	};
+	fetched: string;
+	get_stack: (error: Error) => string;
+	hooks: Hooks;
+	hydrate: boolean;
+	initiator: SSRPage;
+	load_component: (id: PageId) => Promise<SSRNode>;
+	manifest: SSRManifest;
+	paths: {
 		base: string;
 		assets: string;
 	};
-	local?: boolean;
-	template?: ({ head, body }: { head: string; body: string }) => string;
-	manifest?: SSRManifest;
-	load_component?: (id: PageId) => Promise<SSRNode>;
-	target?: string;
-	entry?: string;
-	css?: string[];
-	js?: string[];
-	root?: SSRComponent['default'];
-	hooks?: Hooks;
-	dev?: boolean;
-	amp?: boolean;
-	dependencies?: Map<string, ServerResponse>;
-	only_render_prerenderable_pages?: boolean;
-	get_stack?: (error: Error) => string;
-	get_static_file?: (file: string) => Buffer;
-	fetched?: string;
-	initiator?: SSRPage;
-	ssr?: boolean;
-	router?: boolean;
-	hydrate?: boolean;
+	prerender: {
+		force: boolean;
+		dependencies: Map<string, ServerResponse>;
+		error: Error;
+	};
+	read: (file: string) => Buffer;
+	root: SSRComponent['default'];
+	router: boolean;
+	ssr: boolean;
+	target: string;
+	template: ({ head, body }: { head: string; body: string }) => string;
 };
 
 export type Asset = {

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -133,7 +133,7 @@ export type SSRRenderOptions = {
 		css: string[];
 		js: string[];
 	};
-	get_stack: (error: Error) => string;
+	handle_error: (error: Error) => void;
 	hooks: Hooks;
 	hydrate: boolean;
 	load_component: (id: PageId) => Promise<SSRNode>;


### PR DESCRIPTION
This started out as a PR to address #982 specifically, but I ended up fixing a bunch of adjacent code:

* the `SSRRenderOptions` type is much neater, with the options passed to `app.render` separated out
* added `SSRRenderState` as distinct from `SSRRenderOptions` — this is used for tracking prerender dependencies and preventing infinite fetch loops. It means that the built app only needs to create the render options object once
* exceptions are always console-logged, whether from endpoints or pages. This fixes #982 without adding any additional machinery
* error logging is more readable in dev
* error responses (whether explicit or triggered by exceptions) in prerender will show which page linked to the erroring page, or which page fetched the erroring endpoint. This makes it much easier to find broken links etc

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
