### PR TITLE
remove filesystem subpackage

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -66,10 +66,6 @@
 		"./http": {
 			"import": "./dist/http.js"
 		},
-		"./filesystem": {
-			"import": "./dist/filesystem.js",
-			"require": "./dist/filesystem.cjs"
-		},
 		"./types": "./types/index.d.ts"
 	},
 	"types": "types/index.d.ts",

--- a/packages/kit/rollup.config.js
+++ b/packages/kit/rollup.config.js
@@ -42,7 +42,6 @@ export default [
 		input: {
 			cli: 'src/cli.js',
 			ssr: 'src/runtime/server/index.js',
-			filesystem: 'src/core/filesystem/index.js',
 			http: 'src/core/http/index.js'
 		},
 		output: {
@@ -56,31 +55,6 @@ export default [
 		plugins: [
 			replace({
 				preventAssignment: true,
-				values: {
-					__VERSION__: pkg.version
-				}
-			}),
-			resolve({
-				extensions: ['.mjs', '.js', '.ts']
-			}),
-			commonjs()
-		],
-		preserveEntrySignatures: true
-	},
-
-	{
-		input: 'src/core/filesystem/index.js',
-		output: {
-			format: 'cjs',
-			file: 'dist/filesystem.cjs'
-		},
-		external: (id) => {
-			return external.includes(id);
-		},
-		plugins: [
-			replace({
-				preventAssignment: true,
-				delimiters: ['', ''],
 				values: {
 					__VERSION__: pkg.version
 				}


### PR DESCRIPTION
in https://github.com/sveltejs/kit/pull/1001 we removed the last place where a non-kit package depended on `@sveltejs/kit/filesystem`. we can therefore remove it from `pkg.exports` and simplify the rollup config