### PR TITLE
Build non-example packages before attempting release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
 
       - run: npm install -g pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm build
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
Run `pnpm build` on the workspace before attempting to publish packages which may depend on `kit`.