### PR TITLE
`create-svelte`: fix global.d.ts rename, Windows build issue, missing `adapter-node`

### DIFF
--- a/.changeset/thin-planets-obey.md
+++ b/.changeset/thin-planets-obey.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Fix global.d.ts rename, Windows build issue, missing adapter-node

--- a/packages/create-svelte/scripts/build-templates.js
+++ b/packages/create-svelte/scripts/build-templates.js
@@ -64,10 +64,7 @@ async function generate_templates(shared) {
 			// also needed for JS projects if people turn on "checkJs" in their jsonfig
 			if (file.name.endsWith('.d.ts')) {
 				if (file.name.endsWith('global.d.ts')) js.push(file);
-				continue;
-			}
-
-			if (file.name.endsWith('.ts')) {
+			} else if (file.name.endsWith('.ts')) {
 				const transformed = transform(file.contents, {
 					transforms: ['typescript']
 				});
@@ -161,7 +158,7 @@ async function generate_shared() {
 			let name = file;
 
 			if (file.startsWith('+') || file.startsWith('-')) {
-				const [conditions, ...rest] = file.split('/');
+				const [conditions, ...rest] = file.split(path.sep);
 
 				const pattern = /([+-])([a-z]+)/g;
 				let match;

--- a/packages/create-svelte/templates/default/package.template.json
+++ b/packages/create-svelte/templates/default/package.template.json
@@ -7,6 +7,7 @@
 		"start": "svelte-kit start"
 	},
 	"devDependencies": {
+		"@sveltejs/adapter-node": "workspace:*",
 		"@sveltejs/kit": "workspace:*",
 		"svelte": "^3.29.0",
 		"vite": "^2.1.0"


### PR DESCRIPTION
- Fixes #1093
- Fix `global.d.ts` getting renamed to `global.d.js`
- Fix `create-svelte` build script on Windows
- ~~Make `svelte.config.cjs` adapter-agnostic~~
- ~~Remove default `adapter-node` from `package.json`~~
- ~~Version updates for dependencies~~
