### PR TITLE
Fix Windows build output containing backslashes

### DIFF
--- a/.changeset/witty-ligers-listen.md
+++ b/.changeset/witty-ligers-listen.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix Windows build output containing backward slashes

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -124,7 +124,9 @@ async function build_client({
 		const resolved = path.resolve(cwd, file);
 		const relative = path.relative(config.kit.files.routes, resolved);
 
-		const name = relative.startsWith('..') ? path.basename(file) : path.join('pages', relative);
+		const name = relative.startsWith('..')
+			? path.basename(file)
+			: posixify(path.join('pages', relative));
 		input[name] = resolved;
 	});
 


### PR DESCRIPTION
Fix #1079 (`path.join` on URLs uses backslashes on Windows)