### PR TITLE
fix init command in starter app on about page

### DIFF
--- a/.changeset/slow-fans-own.md
+++ b/.changeset/slow-fans-own.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Fix bootstrapping command on about page

--- a/packages/create-svelte/templates/default/src/routes/about.svelte
+++ b/packages/create-svelte/templates/default/src/routes/about.svelte
@@ -21,14 +21,24 @@
 <div class="content">
 	<h1>About this app</h1>
 
-	<p>This is a <a href="https://kit.svelte.dev">SvelteKit</a> app. You can make your own by typing the following into your command line and following the prompts:</p>
+	<p>
+		This is a <a href="https://kit.svelte.dev">SvelteKit</a> app. You can make your own by typing the
+		following into your command line and following the prompts:
+	</p>
 
 	<!-- TODO lose the @next! -->
-	<pre>npx init svelte@next</pre>
+	<pre>npm init svelte@next</pre>
 
-	<p>The page you're looking at is purely static HTML, with no client-side interactivity needed. Because of that, we don't need to load any JavaScript. Try viewing the page's source, or opening the devtools network panel and reloading.</p>
+	<p>
+		The page you're looking at is purely static HTML, with no client-side interactivity needed.
+		Because of that, we don't need to load any JavaScript. Try viewing the page's source, or opening
+		the devtools network panel and reloading.
+	</p>
 
-	<p>The <a href="/todos">TODOs</a> page illustrates SvelteKit's data loading and form handling. Try using it with JavaScript disabled!</p>
+	<p>
+		The <a href="/todos">TODOs</a> page illustrates SvelteKit's data loading and form handling. Try using
+		it with JavaScript disabled!
+	</p>
 </div>
 
 <style>


### PR DESCRIPTION
The about page on the create-svelte template said `npx init svelte@next` rather than `npm init svelte@next`. It also apparently hadn't been formatted correctly by Prettier when it was last saved. I'm torn about whether this should include a subdirectory to create, like we're doing elsewhere in the docs. Maybe?

Changesets are currently messed up, so for now one is not included in here. This package is called `~TODO~` as far as changesets can tell. I've manually edited the included changeset file and will try to look into what's going on here separately.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
