### PR TITLE
fix build command in main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pnpm i
 ...then build SvelteKit and the other packages:
 
 ```bash
-pnpm -r build
+pnpm build
 ```
 
 You should now be able to run the [examples](examples) by navigating to one of the directories and doing `pnpm dev`.


### PR DESCRIPTION
The build command in the main readme needed updating. `pnpm -r build` now fails on a fresh clone, because certain projects depend on built versions of other projects that don't exist yet. `pnpm build` is, I believe, now more explicitly defined to handle this correctly.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
