### PR TITLE
i18n: localized / translated routes

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -520,7 +520,6 @@
     "sixty-pianos-fix",
     "sixty-rice-cough",
     "sixty-terms-decide",
-    "slimy-cougars-double",
     "slow-buses-beam",
     "slow-fans-own",
     "slow-suns-reply",

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -520,6 +520,7 @@
     "sixty-pianos-fix",
     "sixty-rice-cough",
     "sixty-terms-decide",
+    "slimy-cougars-double",
     "slow-buses-beam",
     "slow-fans-own",
     "slow-suns-reply",

--- a/packages/create-svelte/templates/default/i18n.config.js
+++ b/packages/create-svelte/templates/default/i18n.config.js
@@ -1,0 +1,37 @@
+import locales from './src/locales.js';
+
+export const defaultLocale = locales[0];
+
+/** @typedef {{
+ *   content: string;
+ *   dynamic: boolean;
+ *   spread: boolean;
+ * }} Part */
+
+/**
+ * Create localized routes prefixed with locale
+ * @param {Part[][]} segments
+ * @param {'page' | 'endpoint'} type
+ * @returns {Part[][][]}
+ */
+export function localizeRoutes(segments, type) {
+	if (type === 'endpoint') return [segments];
+	return locales.map((locale) =>
+		locale === defaultLocale
+			? segments
+			: [
+					[{ content: locale, dynamic: false, spread: false }],
+					...segments.map((segment) => segment.map((part) => translate(part)))
+			  ]
+	);
+}
+
+/**
+ * Translate part of a route segment
+ * @param {Part} part
+ * @returns {Part}
+ */
+function translate(part) {
+	if (part.content === 'about') return { ...part, content: 'ueber' };
+	return part;
+}

--- a/packages/create-svelte/templates/default/src/lib/header/Header.svelte
+++ b/packages/create-svelte/templates/default/src/lib/header/Header.svelte
@@ -1,7 +1,20 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import logo from './svelte-logo.svg';
+	import { l, localizedPaths, locale as currentLocale, defaultLocale } from '$lib/i18n';
+
+	$: alternatePaths = $localizedPaths($page.url.pathname);
+	$: defaultPath = alternatePaths[defaultLocale];
 </script>
+
+<svelte:head>
+	{#if defaultPath}
+		<link rel="alternate" hreflang="x-default" href={defaultPath} />
+	{/if}
+	{#each Object.entries(alternatePaths) as [locale, path]}
+		<link rel="alternate" hreflang={locale} href={path} />
+	{/each}
+</svelte:head>
 
 <header>
 	<div class="corner">
@@ -15,12 +28,14 @@
 			<path d="M0,0 L1,2 C1.5,3 1.5,3 2,3 L2,0 Z" />
 		</svg>
 		<ul>
-			<li class:active={$page.url.pathname === '/'}><a sveltekit:prefetch href="/">Home</a></li>
-			<li class:active={$page.url.pathname === '/about'}>
-				<a sveltekit:prefetch href="/about">About</a>
+			<li class:active={$page.url.pathname === $l('/')}>
+				<a sveltekit:prefetch href={$l('/')}>Home</a>
 			</li>
-			<li class:active={$page.url.pathname === '/todos'}>
-				<a sveltekit:prefetch href="/todos">Todos</a>
+			<li class:active={$page.url.pathname === $l('/about')}>
+				<a sveltekit:prefetch href={$l('/about')}>About</a>
+			</li>
+			<li class:active={$page.url.pathname === $l('/todos')}>
+				<a sveltekit:prefetch href={$l('/todos')}>Todos</a>
 			</li>
 		</ul>
 		<svg viewBox="0 0 2 3" aria-hidden="true">
@@ -30,6 +45,11 @@
 
 	<div class="corner">
 		<!-- TODO put something else here? github link? -->
+		<nav>
+			{#each Object.entries(alternatePaths) as [locale, path]}
+				<a class:active={$currentLocale === locale} href={path}>{locale}</a>
+			{/each}
+		</nav>
 	</div>
 </header>
 
@@ -40,7 +60,7 @@
 	}
 
 	.corner {
-		width: 3em;
+		display: flex;
 		height: 3em;
 	}
 
@@ -50,6 +70,23 @@
 		justify-content: center;
 		width: 100%;
 		height: 100%;
+		text-transform: uppercase;
+	}
+
+	.corner nav a {
+		position: relative;
+	}
+
+	.corner a.active::before {
+		--size: 6px;
+		content: '';
+		width: 0;
+		height: 0;
+		position: absolute;
+		top: 0;
+		left: calc(50% - var(--size));
+		border: var(--size) solid transparent;
+		border-top: var(--size) solid var(--accent-color);
 	}
 
 	.corner img {

--- a/packages/create-svelte/templates/default/src/lib/i18n.ts
+++ b/packages/create-svelte/templates/default/src/lib/i18n.ts
@@ -1,0 +1,29 @@
+import { derived, readable } from 'svelte/store';
+import { page } from '$app/stores';
+import { alternates } from '$app/navigation';
+
+import locales from '../locales';
+
+export const defaultLocale = locales[0];
+
+export const locale = derived(
+	page,
+	(page) => page.url.pathname.match(/^\/([a-z]{2})(\/|$)/)?.[1] || defaultLocale
+);
+
+export const localizedPaths = readable(
+	(path: string): Record<string, string> =>
+		alternates(path)?.reduce((result, alt) => {
+			result[alt.match(/^\/([a-z]{2})(\/|$)/)?.[1] || defaultLocale] = alt;
+			return result;
+		}, {})
+);
+
+export const l = derived(
+	[localizedPaths, locale],
+	([localizedPaths, locale]) =>
+		(path: string): string =>
+			localizedPaths(path)?.[locale] || path
+);
+
+export { l as localize };

--- a/packages/create-svelte/templates/default/src/locales.js
+++ b/packages/create-svelte/templates/default/src/locales.js
@@ -1,0 +1,1 @@
+export default ['en', 'de'];

--- a/packages/create-svelte/templates/default/svelte.config.js
+++ b/packages/create-svelte/templates/default/svelte.config.js
@@ -1,5 +1,6 @@
 import adapter from '@sveltejs/adapter-auto';
 import preprocess from 'svelte-preprocess';
+import { localizeRoutes } from './i18n.config.js';
 
 // This config is ignored and replaced with one of the configs in the shared folder when a project is created.
 
@@ -18,7 +19,9 @@ const config = {
 		// Override http methods in the Todo forms
 		methodOverride: {
 			allowed: ['PATCH', 'DELETE']
-		}
+		},
+
+		alternateRoutes: localizeRoutes
 	}
 };
 

--- a/packages/kit/.gitignore
+++ b/packages/kit/.gitignore
@@ -5,5 +5,6 @@
 /client/**/*.d.ts
 /test/**/.svelte-kit
 /test/**/build
+/test/**/errors.json
 !/src/core/adapt/test/fixtures/*/.svelte-kit
 !/test/node_modules

--- a/packages/kit/CHANGELOG.md
+++ b/packages/kit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sveltejs/kit
 
+## 1.0.0-next.252
+
+### Patch Changes
+
+- remove nonexistent `url` store from `$app/stores` ambient types ([#3640](https://github.com/sveltejs/kit/pull/3640))
+
 ## 1.0.0-next.251
 
 ### Patch Changes

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sveltejs/kit",
-	"version": "1.0.0-next.251",
+	"version": "1.0.0-next.252",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/sveltejs/kit",

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -13,6 +13,7 @@ const get_defaults = (prefix = '') => ({
 	kit: {
 		adapter: null,
 		amp: false,
+		alternateRoutes: null,
 		appDir: '_app',
 		browser: {
 			hydrate: true,

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -41,6 +41,14 @@ const options = object(
 
 			amp: boolean(false),
 
+			alternateRoutes: validate(null, (option, keypath) => {
+				if (typeof option !== 'function') {
+					throw new Error(`${keypath} must be a function that processes route segments`);
+				}
+
+				return option;
+			}),
+
 			appDir: validate('_app', (input, keypath) => {
 				assert_string(input, keypath);
 

--- a/packages/kit/src/core/create_app/index.js
+++ b/packages/kit/src/core/create_app/index.js
@@ -83,7 +83,8 @@ function generate_client_manifest(manifest_data, base) {
 							'})';
 
 					const tuple = [route.pattern, get_indices(route.a), get_indices(route.b)];
-					if (params) tuple.push(params);
+					tuple.push(params || '');
+					tuple.push(route.id);
 
 					return `// ${route.a[route.a.length - 1]}\n\t\t[${tuple.join(', ')}]`;
 				}
@@ -149,6 +150,7 @@ function generate_app(manifest_data) {
 			// stores
 			export let stores;
 			export let page;
+			export let routes;
 
 			export let components;
 			${levels.map((l) => `export let props_${l} = null;`).join('\n\t\t\t')}
@@ -157,6 +159,8 @@ function generate_app(manifest_data) {
 
 			$: stores.page.set(page);
 			afterUpdate(stores.page.notify);
+
+			if (routes) setContext('__svelte_routes__', routes);
 
 			let mounted = false;
 			let navigated = false;

--- a/packages/kit/src/core/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/create_manifest_data/index.spec.js
@@ -40,6 +40,7 @@ test('creates routes', () => {
 
 	assert.equal(routes, [
 		{
+			id: '2',
 			type: 'page',
 			segments: [],
 			pattern: /^\/$/,
@@ -50,6 +51,7 @@ test('creates routes', () => {
 		},
 
 		{
+			id: '3',
 			type: 'page',
 			segments: [{ rest: false, dynamic: false, content: 'about' }],
 			pattern: /^\/about\/?$/,
@@ -68,6 +70,7 @@ test('creates routes', () => {
 		},
 
 		{
+			id: '4',
 			type: 'page',
 			segments: [{ rest: false, dynamic: false, content: 'blog' }],
 			pattern: /^\/blog\/?$/,
@@ -89,6 +92,7 @@ test('creates routes', () => {
 		},
 
 		{
+			id: '5',
 			type: 'page',
 			segments: [
 				{ rest: false, dynamic: false, content: 'blog' },
@@ -116,6 +120,7 @@ test('creates routes with layout', () => {
 
 	assert.equal(routes, [
 		{
+			id: '2',
 			type: 'page',
 			segments: [],
 			pattern: /^\/$/,
@@ -126,6 +131,7 @@ test('creates routes with layout', () => {
 		},
 
 		{
+			id: '4',
 			type: 'page',
 			segments: [{ rest: false, dynamic: false, content: 'foo' }],
 			pattern: /^\/foo\/?$/,
@@ -384,6 +390,7 @@ test('works with custom extensions', () => {
 
 	assert.equal(routes, [
 		{
+			id: '2',
 			type: 'page',
 			segments: [],
 			pattern: /^\/$/,
@@ -394,6 +401,7 @@ test('works with custom extensions', () => {
 		},
 
 		{
+			id: '3',
 			type: 'page',
 			segments: [{ rest: false, dynamic: false, content: 'about' }],
 			pattern: /^\/about\/?$/,
@@ -412,6 +420,7 @@ test('works with custom extensions', () => {
 		},
 
 		{
+			id: '4',
 			type: 'page',
 			segments: [{ rest: false, dynamic: false, content: 'blog' }],
 			pattern: /^\/blog\/?$/,
@@ -433,6 +442,7 @@ test('works with custom extensions', () => {
 		},
 
 		{
+			id: '5',
 			type: 'page',
 			segments: [
 				{ rest: false, dynamic: false, content: 'blog' },
@@ -469,6 +479,7 @@ test('includes nested error components', () => {
 
 	assert.equal(routes, [
 		{
+			id: '6',
 			type: 'page',
 			segments: [
 				{ rest: false, dynamic: false, content: 'foo' },
@@ -500,6 +511,7 @@ test('resets layout', () => {
 
 	assert.equal(routes, [
 		{
+			id: '2',
 			type: 'page',
 			segments: [],
 			pattern: /^\/$/,
@@ -509,6 +521,7 @@ test('resets layout', () => {
 			b: [error]
 		},
 		{
+			id: '4',
 			type: 'page',
 			segments: [{ rest: false, dynamic: false, content: 'foo' }],
 			pattern: /^\/foo\/?$/,
@@ -522,6 +535,7 @@ test('resets layout', () => {
 			b: [error]
 		},
 		{
+			id: '7',
 			type: 'page',
 			segments: [
 				{ rest: false, dynamic: false, content: 'foo' },

--- a/packages/kit/src/core/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/create_manifest_data/index.spec.js
@@ -216,6 +216,7 @@ test('disallows rest parameters inside segments', () => {
 
 	assert.equal(routes, [
 		{
+			id: '2',
 			type: 'page',
 			segments: [
 				{

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -101,6 +101,7 @@ export async function create_plugin(config, cwd) {
 						routes: manifest_data.routes.map((route) => {
 							if (route.type === 'page') {
 								return {
+									id: route.id,
 									type: 'page',
 									pattern: route.pattern,
 									params: get_params(route.params),

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -66,6 +66,7 @@ export function generate_manifest(
 				${routes.map(route => {
 					if (route.type === 'page') {
 						return `{
+							id: ${s(route.id)},
 							type: 'page',
 							pattern: ${route.pattern},
 							params: ${get_params(route.params)},

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -94,7 +94,8 @@ export async function render_response({
 				error,
 				stuff
 			},
-			components: branch.map(({ node }) => node.module.default)
+			components: branch.map(({ node }) => node.module.default),
+			routes: options.manifest._.routes
 		};
 
 		// TODO remove this for 1.0

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -85,6 +85,11 @@ declare module '$app/navigation' {
 	 * A lifecycle function that runs when the page mounts, and also whenever SvelteKit navigates to a new URL but stays on this component.
 	 */
 	export function afterNavigate(fn: ({ from, to }: { from: URL | null; to: URL }) => void): any;
+
+	/**
+	 * Returns alternate routes for the given page
+	 */
+	export function alternates(href: string): string[];
 }
 
 declare module '$app/paths' {

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -3,6 +3,7 @@ import { UserConfig as ViteConfig } from 'vite';
 import { CspDirectives } from './csp';
 import { RecursiveRequired } from './helper';
 import { HttpMethod, Logger, RouteSegment, TrailingSlash } from './internal';
+import { Part } from '../src/core/create_manifest_data';
 
 export interface RouteDefinition {
 	type: 'page' | 'endpoint';
@@ -117,6 +118,7 @@ export interface Config {
 	kit?: {
 		adapter?: Adapter;
 		amp?: boolean;
+		alternateRoutes?: (segments: Part[][], type: 'page' | 'endpoint') => Part[][][];
 		appDir?: string;
 		browser?: {
 			hydrate?: boolean;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -71,6 +71,7 @@ export interface SSRPagePart {
 export type GetParams = (match: RegExpExecArray) => Record<string, string>;
 
 export interface SSRPage {
+	id: string;
 	type: 'page';
 	pattern: RegExp;
 	params: GetParams;
@@ -96,7 +97,7 @@ export interface SSREndpoint {
 
 export type SSRRoute = SSREndpoint | SSRPage;
 
-export type CSRRoute = [RegExp, CSRComponentLoader[], CSRComponentLoader[], GetParams?];
+export type CSRRoute = [RegExp, CSRComponentLoader[], CSRComponentLoader[], GetParams?, string?];
 
 export type SSRNodeLoader = () => Promise<SSRNode>;
 
@@ -179,6 +180,7 @@ export interface RouteSegment {
 export type HttpMethod = 'get' | 'head' | 'post' | 'put' | 'delete' | 'patch';
 
 export interface PageData {
+	id: string;
 	type: 'page';
 	segments: RouteSegment[];
 	pattern: RegExp;


### PR DESCRIPTION
This is now just a part of what #1037 implemented and also in a different way. The goal was to make alternate routes for the same page configurable.

There is a new configuration property "alternateRoutes" in the "kit" section of svelte.config.cjs. It optionally takes a function that receives a page's Part[][] and returns Part[][][], so the routes can be multiplied and the segments in Part[][] changed. This can be used e.g. to translate the routes or add a locale prefix.

Since the router has all the routes on the client, there is an alternates() function in "$app/navigation" that will return all alternate paths of a path. This is useful for language choosers for example.

I also added a usage example to "examples/svelte-kit-demo". Currently no translation is happening. This can be dealt with using translation libraries like svelte-i18n or svelte-intl-precompile.