### PR TITLE
fix: ssr method expects rawBody instead of body

### DIFF
--- a/.changeset/warm-jars-move.md
+++ b/.changeset/warm-jars-move.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+fix body parsing

--- a/packages/adapter-vercel/files/entry.js
+++ b/packages/adapter-vercel/files/entry.js
@@ -12,7 +12,7 @@ export default async (req, res) => {
 		headers: req.headers,
 		path: pathname,
 		query: searchParams,
-		body: await getRawBody(req)
+		rawBody: await getRawBody(req)
 	});
 
 	if (rendered) {


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/1143

When the app runs in Vercel the body content is undefined. This relates to the changes done [here](https://github.com/sveltejs/kit/pull/1109). 

This package now becomes consistent with the [other packages](https://github.com/sveltejs/kit/blob/master/packages/adapter-netlify/files/entry.js#L29) where `rawBody` is exposed instead of `body`

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
