### PR TITLE
Improve a11y for template counter component

### DIFF
--- a/.changeset/ten-plants-sleep.md
+++ b/.changeset/ten-plants-sleep.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Hide out-of-view counter from assistive tech

--- a/packages/create-svelte/templates/default/src/lib/Counter/index.svelte
+++ b/packages/create-svelte/templates/default/src/lib/Counter/index.svelte
@@ -15,21 +15,20 @@
 
 <div class="counter">
 	<button on:click={() => (count -= 1)} aria-label="Decrease the counter by one">
-		<svg role="img" aria-label="Minus" viewBox="0 0 1 1">
+		<svg aria-hidden="true" viewBox="0 0 1 1">
 			<path d="M0,0.5 L1,0.5"></path>
 		</svg>
 	</button>
 
 	<div class="counter-viewport">
 		<div class="counter-digits" style="transform: translate(0, {100 * offset}%)">
-			<strong style="top: -100%">{Math.floor($displayed_count + 1)}</strong>
+			<strong style="top: -100%" aria-hidden="true">{Math.floor($displayed_count + 1)}</strong>
 			<strong>{Math.floor($displayed_count)}</strong>
 		</div>
 	</div>
 
 	<button on:click={() => (count += 1)} aria-label="Increase the counter by one">
-		<!-- <img src={plus} alt="Plus icon"> -->
-		<svg role="img" aria-label="Plus" viewBox="0 0 1 1">
+		<svg aria-hidden="true" viewBox="0 0 1 1">
 			<path d="M0,0.5 L1,0.5 M0.5,0 L0.5,1"></path>
 		</svg>
 	</button>


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts

This PR includes the following a11y improvements for the default template:
- The Counter component renders the next number out-of-view so it can slide the next number in. This number was still visible to assistive tech such as screen readers, which read out both numbers as if they were one. For example, NVDA read out "10" in the starting state, when only "0" was visible on screen. Adding the aria-hidden attribute to the next number hides it from screen readers so they only read out the visible number.
- I also added aria-hidden to the SVGs in the + and - buttons. The aria-label on the buttons overrides the label on the SVGs, and they don't need to be read out to screen readers.
