### PR TITLE
Fix navbar style for active page on example

### DIFF
--- a/examples/svelte-kit-demo/src/lib/Nav.svelte
+++ b/examples/svelte-kit-demo/src/lib/Nav.svelte
@@ -1,11 +1,11 @@
 <script>
-	export let path;
+	import { page } from '$app/stores';
 </script>
 
 <nav>
-	<a href="/" sveltekit:prefetch class:active={path === '/'}>home</a>
-	<a href="/about" sveltekit:prefetch class:active={path === '/about'}>about</a>
-	<a href="/blog" sveltekit:prefetch class:active={path === '/blog'}>blog</a>
+	<a href="/" sveltekit:prefetch class:active={$page.path === '/'}>home</a>
+	<a href="/about" sveltekit:prefetch class:active={$page.path === '/about'}>about</a>
+	<a href="/blog" sveltekit:prefetch class:active={$page.path === '/blog'}>blog</a>
 </nav>
 
 <style>
@@ -24,18 +24,18 @@
 	a {
 		display: block;
 		float: left;
-		color: rgba(0,0,0,0.4);
+		color: rgba(0, 0, 0, 0.4);
 		margin: 0 1em 0 0;
 		text-decoration: none;
 	}
 
 	a + a::before {
 		content: '•';
-		color: rgba(0,0,0,0.4);
+		color: rgba(0, 0, 0, 0.4);
 		margin: 0 1em 0 0;
 	}
 
 	.active {
-		color: rgba(0,0,0,0.9);
+		color: rgba(0, 0, 0, 0.9);
 	}
 </style>

--- a/examples/svelte-kit-demo/src/routes/$layout.svelte
+++ b/examples/svelte-kit-demo/src/routes/$layout.svelte
@@ -4,13 +4,12 @@
 
 <script>
 	import Nav from '$lib/Nav.svelte';
-	export let segment;
 </script>
 
-<Nav {segment}/>
+<Nav />
 
 <main>
-	<slot></slot>
+	<slot />
 </main>
 
 <style>


### PR DESCRIPTION
The current navbar of svelte-kit-demo example it's not working properly since it uses the legacy `segment` prop on layout. This PR just fix it using the new page store.