### PR TITLE
Remove the `start` command from the CLI in favor of a `--preview` flag on `build`

### DIFF
--- a/.changeset/friendly-camels-reflect.md
+++ b/.changeset/friendly-camels-reflect.md
@@ -1,0 +1,6 @@
+---
+'create-svelte': patch
+'@sveltejs/kit': patch
+---
+
+Remove the `start` command from the CLI in favor of a `--preview` flag on `build`

--- a/documentation/docs/06-service-workers.md
+++ b/documentation/docs/06-service-workers.md
@@ -10,4 +10,4 @@ In SvelteKit, if you have a `src/service-worker.js` file (or `src/service-worker
 
 Inside the service worker you have access to the [`$service-worker` module](#modules-service-worker).
 
-Because it needs to be bundled (since browsers don't yet support `import` in this context), and depends on the client-side app's build manifest, **service workers only work in the production build, not in development**. To test it locally, use [`svelte-kit start`](#command-line-interface-svelte-kit-start).
+Because it needs to be bundled (since browsers don't yet support `import` in this context), and depends on the client-side app's build manifest, **service workers only work in the production build, not in development**. To test it locally, use [`svelte-kit build --preview`](#command-line-interface-svelte-kit-build).

--- a/documentation/docs/12-cli.md
+++ b/documentation/docs/12-cli.md
@@ -4,7 +4,7 @@ title: Command Line Interface
 
 SvelteKit includes a command line interface for building and running your app.
 
-In the default project template `svelte-kit dev`, `svelte-kit build` and `svelte-kit start` are aliased as `npm run dev`, `npm run build` and `npm start` respectively. You can also invoke the CLI with [npx](https://www.npmjs.com/package/npx):
+In the default project template `svelte-kit dev`, `svelte-kit build` and `svelte-kit build --preview` are aliased as `npm run dev`, `npm run build` and `npm preview` respectively. You can also invoke the CLI with [npx](https://www.npmjs.com/package/npx):
 
 ```bash
 npx svelte-kit dev
@@ -25,13 +25,13 @@ Builds a production version of your app, and runs your adapter if you have one s
 
 - `--verbose` — log more detail
 
-### svelte-kit start
+It also has a preview mode for testing the production build locally (irrespective of any adapter that has been applied). It accepts the following options (with the same meaning as in `svelte-kit dev`):
 
-After you've built your app with `svelte-kit build`, you can start the production version (irrespective of any adapter that has been applied) locally with `svelte-kit start`. This is intended for testing the production build locally, **not for serving your app**, for which you should always use an adapter.
-
-Like `svelte-kit dev`, it accepts the following options:
+- `-P`/`--preview` — serve the app after building
 
 - `-p`/`--port`
 - `-o`/`--open`
 - `-h`/`--host` (note the security caveat [above](#command-line-interface-svelte-kit-dev))
 - `-H`/`--https`
+
+> Preview mode should _not_ be used to serve your app in production. Instead, [specify an appropriate adapter](#adapters) and deploy its output to the production environment.

--- a/documentation/migrating/02-pkg.md
+++ b/documentation/migrating/02-pkg.md
@@ -18,7 +18,7 @@ Remove `sapper` from your `devDependencies` and replace it with `@sveltejs/kit`,
 
 Any scripts that reference the `sapper` binary should be updated:
 
-* `sapper build` or `sapper export` should become [`svelte-kit build`](/docs#command-line-interface-svelte-kit-build)
+* `sapper build` should become [`svelte-kit build`](/docs#command-line-interface-svelte-kit-build) using the Node [adapter](/docs#adapters)
+* `sapper export` should become [`svelte-kit build`](/docs#command-line-interface-svelte-kit-build) using the static [adapter](/docs#adapters)
 * `sapper dev` should become [`svelte-kit dev`](/docs#command-line-interface-svelte-kit-dev)
-
-Additionally, [`svelte-kit start`](/docs#command-line-interface-svelte-kit-start) replaces any command that invokes your Sapper-built server.
+* `node __sapper__/build` should become `node build`

--- a/examples/hn.svelte.dev/README.md
+++ b/examples/hn.svelte.dev/README.md
@@ -12,6 +12,5 @@ pnpm dev
 ...then open [localhost:3000](http://localhost:3000). To build and start in prod mode:
 
 ```bash
-pnpm build
-pnpm start
+pnpm preview
 ```

--- a/examples/hn.svelte.dev/package.json
+++ b/examples/hn.svelte.dev/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build --verbose",
-		"start": "svelte-kit start"
+		"preview": "svelte-kit build --preview"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-netlify": "workspace:*",

--- a/examples/svelte-kit-demo/package.json
+++ b/examples/svelte-kit-demo/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build --verbose",
-		"start": "svelte-kit start",
+		"start": "svelte-kit build --preview",
 		"build:vercel": "ADAPTER=@sveltejs/adapter-vercel OPTIONS={} npm run build",
 		"build:cloudflare-workers": "ADAPTER=@sveltejs/adapter-cloudflare-workers OPTIONS={} npm run build"
 	},

--- a/examples/svelte-kit-demo/package.json
+++ b/examples/svelte-kit-demo/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build --verbose",
-		"start": "svelte-kit build --preview",
+		"preview": "svelte-kit build --preview",
 		"build:vercel": "ADAPTER=@sveltejs/adapter-vercel OPTIONS={} npm run build",
 		"build:cloudflare-workers": "ADAPTER=@sveltejs/adapter-cloudflare-workers OPTIONS={} npm run build"
 	},

--- a/packages/create-svelte/shared/README.md
+++ b/packages/create-svelte/shared/README.md
@@ -35,4 +35,5 @@ Before creating a production version of your app, install an [adapter](https://k
 npm run build
 ```
 
-> You can preview the built app with `npm start`, regardless of whether you installed an adapter. This should _not_ be used to serve your app in production.
+> Alternatively, you can preview the built app with `npm preview`, regardless of whether you installed an adapter. This should _not_ be used to serve your app in production. Instead, [specify an appropriate adapter](#adapters) and deploy its output to the production environment.
+

--- a/packages/create-svelte/shared/README.md
+++ b/packages/create-svelte/shared/README.md
@@ -36,4 +36,3 @@ npm run build
 ```
 
 > Alternatively, you can preview the built app with `npm preview`, regardless of whether you installed an adapter. This should _not_ be used to serve your app in production. Instead, [specify an appropriate adapter](#adapters) and deploy its output to the production environment.
-

--- a/packages/create-svelte/templates/default/package.template.json
+++ b/packages/create-svelte/templates/default/package.template.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",
-		"start": "svelte-kit start"
+		"preview": "svelte-kit build --preview"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-node": "workspace:*",

--- a/packages/create-svelte/templates/skeleton/package.template.json
+++ b/packages/create-svelte/templates/skeleton/package.template.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",
-		"start": "svelte-kit start"
+		"preview": "svelte-kit build --preview"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-node": "workspace:*",

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -121,8 +121,6 @@ prog
 			const { build } = await import('./core/build/index.js');
 			const build_data = await build(config);
 
-			console.log(`\nRun ${colors.bold().cyan('npm start')} to try your app locally.`);
-
 			if (preview) {
 				await check_port(port);
 

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -283,7 +283,7 @@ async function build_server(
 
 			let options = null;
 
-			// allow paths to be overridden in svelte-kit start
+			// allow paths to be overridden in svelte-kit build --preview
 			// and in prerendering
 			export function init(settings) {
 				set_paths(settings.paths);

--- a/packages/kit/test/apps/basics/package.json
+++ b/packages/kit/test/apps/basics/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",
-		"start": "svelte-kit start"
+		"preview": "svelte-kit build --preview"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-node": "workspace:*",


### PR DESCRIPTION
People get confused about using `svelte-kit start` for production: https://github.com/sveltejs/kit/pull/866, and countless mistakes in the Discord server

This adds friction to the `start` functionality by always requiring a build to proceed it; this should hopefully make people ask "should this really build every time I want to start the server?" to which they hopefully conclude "no" and figure out the right way to start their app in production. There has also been some documentation changes to (hopefully) better address this.

Testing the production build locally is now easier (less friction) because `svelte-kit build` and `svelte-kit start` have been combined into a single command immediately accessible with the `preview` package script. I am not particularly attached to the `preview` name (neither for the flag nor the package script), so if anyone wants to change it, we can.

I don't believe we have CLI tests. I ran the examples locally and it works as expected. I would worry about a race condition if not all files are flushed to the filesystem before the `start` function runs, but I have no evidence to back up that this is a possibility.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs 
- [x] This message body should clearly illustrate what problems it solves. 
- [ ] Ideally, include a test that fails without this PR but passes with it. 

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
