### PR TITLE
adjust .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,9 +5,10 @@
 	"printWidth": 100,
 	"overrides": [
 		{
-			"files": ["*.svelte"],
+			"files": [
+				"*.svelte"
+			],
 			"options": {
-				"svelteSortOrder": "scripts-markup-styles-options",
 				"svelteBracketNewLine": true
 			}
 		}


### PR DESCRIPTION
This just removes the `svelteSortOrder` option from `.prettierrc`. The default of `options-scripts-markup-styles` was chosen because we liked it as the official/blessed/encouraged ordering, and it should work fine for us here (and, until we have some sample code with a component with `<svelte:options>`, will be equivalent to what's set there now).

VS Code's format-on-save also wanted me to split the `files` array over multiple lines.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
