### PR TITLE
adjust .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-	"editor.formatOnSave": true
+	"cSpell.language": "en-GB",
+	"editor.formatOnSave": true,
+	"files.insertFinalNewline": true
 }


### PR DESCRIPTION
This sets the default language for the popular 'Code Spell Checker' extension to en-GB (overriding my user-level setting of en-US), and also enables adding trailing newlines to files on save.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
