### PR TITLE
CI: Fix Windows Playwright Cache

### DIFF
--- a/.github/actions/env/action/main.js
+++ b/.github/actions/env/action/main.js
@@ -405,7 +405,7 @@ var core$1 = /*@__PURE__*/getDefaultExportFromCjs(core);
 
 const WINDOWS_CACHE_PATH = 'D:\\.pnpm-store\\v3';
 const NIX_CACHE_PATH = '~/.pnpm-store/v3';
-const WINDOWS_BROWSER_PATH = '%USERPROFILE%\\AppData\\Local\\ms-playwright';
+const WINDOWS_BROWSER_PATH = require$$1.join(require$$0.homedir(), 'AppData', 'Local', 'ms-playwright');
 const LINUX_BROWSER_PATH = '~/.cache/ms-playwright';
 const MACOS_BROWSER_PATH = '~/Library/Caches/ms-playwright';
 

--- a/.github/actions/env/main.js
+++ b/.github/actions/env/main.js
@@ -3,7 +3,7 @@ import { platform } from 'os';
 
 const WINDOWS_CACHE_PATH = 'D:\\.pnpm-store\\v3';
 const NIX_CACHE_PATH = '~/.pnpm-store/v3';
-const WINDOWS_BROWSER_PATH = '%USERPROFILE%\\AppData\\Local\\ms-playwright';
+const WINDOWS_BROWSER_PATH = '%LOCALAPPDATA%\\ms-playwright';
 const LINUX_BROWSER_PATH = '~/.cache/ms-playwright';
 const MACOS_BROWSER_PATH = '~/Library/Caches/ms-playwright';
 

--- a/.github/actions/env/main.js
+++ b/.github/actions/env/main.js
@@ -1,9 +1,10 @@
 import core from '@actions/core';
-import { platform } from 'os';
+import { homedir, platform } from 'os';
+import { join } from 'path';
 
 const WINDOWS_CACHE_PATH = 'D:\\.pnpm-store\\v3';
 const NIX_CACHE_PATH = '~/.pnpm-store/v3';
-const WINDOWS_BROWSER_PATH = '%LOCALAPPDATA%\\ms-playwright';
+const WINDOWS_BROWSER_PATH = join(homedir(), 'AppData', 'Local', 'ms-playwright');
 const LINUX_BROWSER_PATH = '~/.cache/ms-playwright';
 const MACOS_BROWSER_PATH = '~/Library/Caches/ms-playwright';
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/cache@main
         with:
           path: ${{ steps.paths.outputs.browser_cache_path }}
-          key: asdfafd-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: chromium-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - run: npm install -g pnpm
       - run: pnpm install --frozen-lockfile
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/cache@main
         with:
           path: ${{ steps.paths.outputs.browser_cache_path }}
-          key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: kasndfansd-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - run: npm install -g pnpm
       - run: pnpm install --frozen-lockfile
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/cache@main
         with:
           path: ${{ steps.paths.outputs.browser_cache_path }}
-          key: kasndfansd-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: asdfafd-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - run: npm install -g pnpm
       - run: pnpm install --frozen-lockfile
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/cache@main
         with:
           path: ${{ steps.paths.outputs.browser_cache_path }}
-          key: pw-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
       - run: npm install -g pnpm
       - run: pnpm install --frozen-lockfile
         env:


### PR DESCRIPTION
The [last successful Windows CI run](https://github.com/sveltejs/kit/runs/2423924312#step:20:1) has unfortunately broken the CI by incorrectly caching nothing as the browser:

```powershell
Post job cleanup.
C:\Windows\System32\tar.exe --posix -z -cf cache.tgz -P -C D:/a/kit/kit --files-from manifest.txt
Cache Size: ~0 MB (30 B)
Cache saved successfully
Cache saved with key: pw-Windows-84213962f52cb541e4092ca888c1aa986057dc2ba0a2bed78a1292e3ee88eaa1
```

All CI runs are currently using this broken 30 byte cache for its Windows runs and promptly failing.

This PR works around this issue by changing the playwright key, because GitHub provides no way to manually evict caches and we'd have to wait 7 days with zero CI usage for it to automatically clear the cached browser.