### PR TITLE
a11y improvements for template to-do list

### DIFF
--- a/.changeset/lovely-apricots-fail.md
+++ b/.changeset/lovely-apricots-fail.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Improve a11y on to-do list in template

--- a/packages/create-svelte/templates/default/src/routes/todos/index.svelte
+++ b/packages/create-svelte/templates/default/src/routes/todos/index.svelte
@@ -63,7 +63,7 @@
 		<input name="text" aria-label="Add todo" placeholder="+ tap to add a todo">
 	</form>
 
-	{#each todos as todo, i (todo.uid)}
+	{#each todos as todo (todo.uid)}
 		<div class="todo" class:done={todo.done} transition:scale|local={{start:0.7}} animate:flip={{duration:200}}>
 			<form action="/todos/{todo.uid}.json?_method=patch" method="post" use:enhance={{
 				pending: (data) => {
@@ -83,7 +83,7 @@
 			</form>
 
 			<form action="/todos/{todo.uid}.json?_method=delete" method="post" use:enhance={{
-				result: async () => {
+				result: () => {
 					todos = todos.filter(t => t.uid !== todo.uid);
 				}
 			}}>

--- a/packages/create-svelte/templates/default/src/routes/todos/index.svelte
+++ b/packages/create-svelte/templates/default/src/routes/todos/index.svelte
@@ -1,5 +1,4 @@
 <script context="module" lang="ts">
-	import { tick } from 'svelte';
 	import { enhance } from '$lib/form';
 	import type { Load } from '@sveltejs/kit';
 
@@ -44,21 +43,6 @@
 			return t;
 		});
 	}
-
-	let addInput;
-	let todoInputs = [];
-	async function manageFocus(i) {
-		await tick();
-		const nextInput = todoInputs[i + 1];
-		const previousInput = todoInputs[i - 1];
-		if (nextInput) {
-			nextInput.focus();
-		} else if (previousInput) {
-			previousInput.focus();
-		} else {
-			addInput.focus();
-		}
-	}
 </script>
 
 <svelte:head>
@@ -76,7 +60,7 @@
 			form.reset();
 		}
 	}}>
-		<input name="text" aria-label="Add todo" placeholder="+ tap to add a todo" bind:this={addInput}>
+		<input name="text" aria-label="Add todo" placeholder="+ tap to add a todo">
 	</form>
 
 	{#each todos as todo, i (todo.uid)}
@@ -94,13 +78,12 @@
 			<form class="text" action="/todos/{todo.uid}.json?_method=patch" method="post" use:enhance={{
 				result: patch
 			}}>
-				<input aria-label="Edit todo" type="text" name="text" value={todo.text} bind:this={todoInputs[i]}>
+				<input aria-label="Edit todo" type="text" name="text" value={todo.text}>
 				<button class="save" aria-label="Save todo"/>
 			</form>
 
 			<form action="/todos/{todo.uid}.json?_method=delete" method="post" use:enhance={{
 				result: async () => {
-					await manageFocus(i);
 					todos = todos.filter(t => t.uid !== todo.uid);
 				}
 			}}>

--- a/packages/create-svelte/templates/default/src/routes/todos/index.svelte
+++ b/packages/create-svelte/templates/default/src/routes/todos/index.svelte
@@ -43,6 +43,8 @@
 			return t;
 		});
 	}
+
+	let heading;
 </script>
 
 <svelte:head>
@@ -50,7 +52,7 @@
 </svelte:head>
 
 <div class="todos">
-	<h1>Todos</h1>
+	<h1 tabindex="-1" bind:this={heading}>Todos</h1>
 
 	<form class="new" action="/todos.json" method="post" use:enhance={{
 		result: async (res, form) => {
@@ -60,7 +62,7 @@
 			form.reset();
 		}
 	}}>
-		<input name="text" placeholder="+ tap to add a todo">
+		<input name="text" aria-label="Add todo" placeholder="+ tap to add a todo">
 	</form>
 
 	{#each todos as todo (todo.uid)}
@@ -78,13 +80,14 @@
 			<form class="text" action="/todos/{todo.uid}.json?_method=patch" method="post" use:enhance={{
 				result: patch
 			}}>
-				<input type="text" name="text" value={todo.text}>
+				<input aria-label="Edit todo" type="text" name="text" value={todo.text}>
 				<button class="save" aria-label="Save todo"/>
 			</form>
 
 			<form action="/todos/{todo.uid}.json?_method=delete" method="post" use:enhance={{
 				result: () => {
 					todos = todos.filter(t => t.uid !== todo.uid);
+					heading.focus();
 				}
 			}}>
 				<button class="delete" aria-label="Delete todo"/>
@@ -184,7 +187,8 @@
 		opacity: 0.2;
 	}
 
-	.delete:hover {
+	.delete:hover,
+	.delete:focus {
 		transition: opacity 0.2s;
 		opacity: 1;
 	}
@@ -196,8 +200,13 @@
 		background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M20.5 2H3.5C2.67158 2 2 2.67157 2 3.5V20.5C2 21.3284 2.67158 22 3.5 22H20.5C21.3284 22 22 21.3284 22 20.5V3.5C22 2.67157 21.3284 2 20.5 2Z' fill='%23676778' stroke='%23676778' stroke-width='1.5' stroke-linejoin='round'/%3E%3Cpath d='M17 2V11H7.5V2H17Z' fill='white' stroke='white' stroke-width='1.5' stroke-linejoin='round'/%3E%3Cpath d='M13.5 5.5V7.5' stroke='%23676778' stroke-width='1.5' stroke-linecap='round'/%3E%3Cpath d='M5.99844 2H18.4992' stroke='%23676778' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E%0A");
 	}
 
-	.todo input:focus + .save {
+	.todo input:focus + .save,
+	.save:focus {
 		transition: opacity 0.2s;
 		opacity: 1;
+	}
+
+	[tabindex="-1"] {
+		outline: none;
 	}
 </style>

--- a/packages/create-svelte/templates/default/src/routes/todos/index.svelte
+++ b/packages/create-svelte/templates/default/src/routes/todos/index.svelte
@@ -49,7 +49,6 @@
 	let todoInputs = [];
 	async function manageFocus(i) {
 		await tick();
-		console.log(todoInputs);
 		const nextInput = todoInputs[i + 1];
 		const previousInput = todoInputs[i - 1];
 		if (nextInput) {


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts

This PR improves the accessibility of the to-do list in the starter template.

- Add label to to-do list input
- Add label to to-do list edit field
- Show the save button when focused. Before this change, the save button would be focused while navigating with the keyboard but would not be visible
- Make delete button focus state the same as hover state. Before this change, the delete button was hard to see when focused.
- ~Programmatically manage focus on delete. Since the focused element is removed from the DOM, we should explicitly focus an element since browsers can be inconsistent. I chose to focus the heading at the top of the list.~ EDIT: Removed this, it was adding too much complexity for not enough benefit.

