### PR TITLE
ci: deploy docs when merging to master

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - documentation/**
+      - packages/*/ README>md
+
+jobs:
+  release:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: my-app-install token
+        id: github-app
+        uses: getsentry/action-github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: run deploy docs workflow
+        uses: 'sveltejs/action-deploy-docs/dispatch@main'
+        with:
+          repo: 'kit'
+          branch: 'master'
+          token: ${{ steps.github-app.outputs.token }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ on:
       - master
     paths:
       - documentation/**
-      - packages/*/ README>md
+      - packages/*/README.md
 
 jobs:
   release:


### PR DESCRIPTION
Adds a workflow to deploy the docs when any files in the `documentation` folder or any of the `package/*/README.md` files are changed. Currently only runs on merge to master.