### PR TITLE
Remove Axios FAQ, add Firebase FAQ, and update preprocess and env FAQs

### DIFF
--- a/documentation/faq/60-env-vars.md
+++ b/documentation/faq/60-env-vars.md
@@ -16,4 +16,10 @@ Then you can access this variable in any of your components:
 <h1>Hello, {import.meta.env.VITE_MESSAGE}</h1>
 ```
 
+You can also use [Vite's `define` option](https://vitejs.dev/config/#define):
+
+```
+define: { 'process.env.FOO': 'process.env.FOO' }
+```
+
 Please see [the Vite documentation](https://vitejs.dev/guide/env-and-mode.html#env-files) for more info about environment variables.

--- a/documentation/faq/80-integrations.md
+++ b/documentation/faq/80-integrations.md
@@ -6,11 +6,15 @@ question: How do I use X with SvelteKit?
 
 Please see [sveltejs/integrations](https://github.com/sveltejs/integrations#sveltekit) for examples of using many popular libraries like Tailwind, PostCSS, Firebase, GraphQL, mdsvex, and more.
 
-### How do I use Babel, CoffeeScript, Less, PostCSS / SugarSS, Pug, scss/sass, Stylus, TypeScript, `global` styles, or replace?
+### How do I use `svelte-preprocess`?
 
-Adding [svelte-preprocess](https://github.com/sveltejs/svelte-preprocess) to your [`svelte.config.cjs`](#configuration) is the first step. For many of the tools listed above, you only need to install the corresponding library such as `npm install -D sass`or `npm install -D less`. See the svelte-preprocess docs for full details.
+`svelte-preprocess` provides support for Babel, CoffeeScript, Less, PostCSS / SugarSS, Pug, scss/sass, Stylus, TypeScript, `global` styles, and replace. Adding [svelte-preprocess](https://github.com/sveltejs/svelte-preprocess) to your [`svelte.config.cjs`](#configuration) is the first step. It is provided by the template if you're using TypeScript. JavaScript users will need to add it. For many of the tools listed above, you will then only need to install the corresponding library such as `npm install -D sass`or `npm install -D less`. See the [svelte-preprocess](https://github.com/sveltejs/svelte-preprocess) docs for full details.
 
-Also see [the examples above](#how-do-i-use-x-with-sveltekit-how-do-i-setup-library-x) of setting up these and similar libraries.
+Also see [sveltejs/integrations](https://github.com/sveltejs/integrations#sveltekit) for examples of setting up these and similar libraries.
+
+### How do I use Firebase?
+
+Please use SDK v9 which provides a modular SDK approach that's currently in beta. The old versions are very difficult to get working especially with SSR and also resulted in a much larger client download size.
 
 ### How do I use a client-side only library that depends on `document` or `window`?
 
@@ -44,10 +48,6 @@ You can also run code in `onMount` if you'd like to run it after the component h
 ### How do I setup a database?
 
 Put the code to query your database in [endpoints](/docs#routing-endpoints) - don't query the database in .svelte files. You can create a `db.js` or similar that sets up a connection immediately and makes the client accessible throughout the app as a singleton. You can execute any one-time setup code in `hooks.js` and import your database helpers into any endpoint that needs them.
-
-### How do I use Axios?
-
-You probably don't need it. We'd generally recommend you just use `fetch` instead. If you insist, you're probably better off using the ESM drop-in replacement `redaxios` [until axios utilizes ESM](https://github.com/axios/axios/issues/1879). Finally, if you still want to use Axios itself, try putting it in `optimizeDeps.include`.
 
 ### Does it work with Yarn 2?
 


### PR DESCRIPTION
Axios works now, so no longer need to mention it. The vast majority of Vite issues have been fixed now between removing `noExternal` from the template and a couple bug fixes in recent releases of Vite