### PR TITLE
Docs: Global `fetch`

### DIFF
--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -43,7 +43,9 @@ Dynamic parameters are encoded using `[brackets]`. For example, a blog post migh
 
 ### Endpoints
 
-Endpoints are modules written in `.js` (or `.ts`) files that export functions corresponding to HTTP methods. For example, our hypothetical blog page, `/blog/cool-article`, might request data from `/blog/cool-article.json`, which could be represented by a `src/routes/blog/[slug].json.js` endpoint:
+Endpoints are modules written in `.js` (or `.ts`) files that export functions corresponding to HTTP methods. All endpoints have access to `fetch` globally without needing to import an external dependency.
+
+For example, our hypothetical blog page, `/blog/cool-article`, might request data from `/blog/cool-article.json`, which could be represented by a `src/routes/blog/[slug].json.js` endpoint:
 
 ```ts
 type Request<Context = any> = {
@@ -80,11 +82,16 @@ export async function get({ params }) {
 	// is called [slug].json.js
 	const { slug } = params;
 
+	// global fetch without imports
+	const response = await fetch('/my-api');
+	const apiData = await response.json();
+
 	const article = await db.get(slug);
 
 	if (article) {
 		return {
 			body: {
+				apiData,
 				article
 			}
 		};

--- a/documentation/migrating/05-endpoints.md
+++ b/documentation/migrating/05-endpoints.md
@@ -5,3 +5,5 @@ title: Endpoints
 In Sapper, 'server routes' — now referred to as [endpoints](/docs#routing-endpoints) — received the `req` and `res` objects exposed by Node's `http` module (or the augmented versions provided by frameworks like Polka and Express).
 
 SvelteKit is designed to be agnostic as to where the app is running — it could be running on a Node server, but could equally be running on a serverless platform or in a Cloudflare Worker. For that reason, you no longer interact directly with `req` and `res`. Your endpoints will need to be updated to match the new signature.
+
+To support this environment-agnostic behavior, `fetch` is now available in the global context, so you don't need to import `node-fetch`, `cross-fetch`, or similar server-side fetch implementations in order to use it.


### PR DESCRIPTION
- Closes #618
- Closes #1221

One additional behavior that might not be clear here is that the global fetch is truly available *globally*. This means pages also have access to them.

```svelte
<script context="module">
  export async function load({ fetch: kitFetch }) {
    // fetch is still globally available
    // if you need to opt out of the server-side inlining
    // ...
  }
</script>
<script>
  // fetch available on both server and client, so cross-fetch isn't needed
  // this is extra convenient e.g. if you're using a GraphQL client
</script>
```

Not sure where to put this, or if it should be left out to encourage the usage of the special `fetch` from `load` instead.