### PR TITLE
Replace outdated TODO with migration docs

### DIFF
--- a/documentation/migrating/99-integrations.md
+++ b/documentation/migrating/99-integrations.md
@@ -2,4 +2,42 @@
 title: Integrations
 ---
 
-See [sveltejs/integrations](https://github.com/sveltejs/integrations#sveltekit) for examples of setting up popular tools like PostCSS, Tailwind CSS, mdsvex, Firebase, GraphQL, and Bulma.
+See [the FAQ](/faq#integrations) for detailed information about integrations.
+
+### HTML minifier
+
+Sapper includes `html-minifier` by default. SvelteKit does not include this, but it can be added as a [hook](/docs#hooks-handle):
+
+```
+import { minify } from 'html-minifier';
+import { prerendering } from '$app/env';
+
+const minification_options = {
+	collapseBooleanAttributes: true,
+	collapseWhitespace: true,
+	conservativeCollapse: true,
+	decodeEntities: true,
+	html5: true,
+	ignoreCustomComments: [/^#/],
+	minifyCSS: true,
+	minifyJS: false,
+	removeAttributeQuotes: true,
+	removeComments: true,
+	removeOptionalTags: true,
+	removeRedundantAttributes: true,
+	removeScriptTypeAttributes: true,
+	removeStyleLinkTypeAttributes: true,
+	sortAttributes: true,
+	sortClassName: true
+};
+
+export async function handle({ request, render }) {
+  const response = await render(request);
+
+  if (prerendering && response.headers['content-type'] === 'text/html') {
+    response.body = minify(response.body, minification_options);
+  }
+
+  return response;
+}
+```

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -143,7 +143,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 
 			if (rendered.status === 200) {
 				log.info(`${rendered.status} ${path}`);
-				writeFileSync(file, rendered.body); // TODO minify where possible?
+				writeFileSync(file, rendered.body);
 			} else if (response_type !== OK) {
 				error(rendered.status, path, parent, 'linked');
 			}


### PR DESCRIPTION
I think we decided in https://github.com/sveltejs/kit/issues/568 that we're not going to do this