### PR TITLE
fix: accept FormData as ReadOnlyFormData

### DIFF
--- a/.changeset/gorgeous-radios-matter.md
+++ b/.changeset/gorgeous-radios-matter.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Allow FormData to be passed as RequestHandler type Body argument

--- a/packages/kit/types/helper.d.ts
+++ b/packages/kit/types/helper.d.ts
@@ -8,7 +8,9 @@ interface ReadOnlyFormData extends Iterator<[string, string]> {
 }
 
 export type BaseBody = string | Buffer | ReadOnlyFormData;
-export type ParameterizedBody<Body = unknown> = BaseBody & Body;
+export type ParameterizedBody<Body = unknown> = Body extends FormData
+	? ReadOnlyFormData
+	: BaseBody & Body;
 
 // TODO we want to differentiate between request headers, which
 // always follow this type, and response headers, in which


### PR DESCRIPTION
Closes #1215

This will enable users to pass in `FormData` in `RequestHandler` as `RequestHandler<any, FormData>`, while still restricting it to allow readable methods only.

![image](https://user-images.githubusercontent.com/8156777/116381254-eb0f0180-a83e-11eb-9810-06f5c14b21da.png)

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
