### PR TITLE
Link session sections in docs

### DIFF
--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -43,7 +43,7 @@ export async function getContext({ headers }) {
 
 ### getSession
 
-This function takes the [`context`](#hooks-getcontext) object and returns a `session` object that is safe to expose to the browser. It runs whenever SvelteKit server-renders a page.
+This function takes the [`context`](#hooks-getcontext) object and returns a `session` object that is [accessible on the client](#modules-$app-stores). It runs whenever SvelteKit server-renders a page.
 
 If unimplemented, session is `{}`.
 

--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -43,7 +43,7 @@ export async function getContext({ headers }) {
 
 ### getSession
 
-This function takes the [`context`](#hooks-getcontext) object and returns a `session` object that is [accessible on the client](#modules-$app-stores). It runs whenever SvelteKit server-renders a page.
+This function takes the [`context`](#hooks-getcontext) object and returns a `session` object that is [accessible on the client](#modules-$app-stores) and therefore must be safe to expose to users. It runs whenever SvelteKit server-renders a page.
 
 If unimplemented, session is `{}`.
 


### PR DESCRIPTION
A couple people on Discord mentioned having difficultly putting the pieces together here and that it would be helpful to reference the section describing how to use the result of `getSession`