### PR TITLE
fix parsing endpoint json body

### DIFF
--- a/.changeset/real-bikes-matter.md
+++ b/.changeset/real-bikes-matter.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Not calling JSON.stringify on endpoint's body if its content-type is json
+Not calling JSON.stringify on endpoint's body if it's a string and the content-type header denotes json

--- a/.changeset/real-bikes-matter.md
+++ b/.changeset/real-bikes-matter.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Not calling JSON.stringify on endpoint's body if its content-type is json

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -19,7 +19,7 @@ export default async function render_route(request, route) {
 			if (typeof response !== 'object') {
 				return {
 					status: 500,
-					body: `Invalid response from route ${request.path}; 
+					body: `Invalid response from route ${request.path};
 						 expected an object, got ${typeof response}`,
 					headers: {}
 				};
@@ -29,10 +29,7 @@ export default async function render_route(request, route) {
 
 			headers = lowercase_keys(headers);
 
-			if (
-				(typeof body === 'object' && !('content-type' in headers)) ||
-				headers['content-type'] === 'application/json'
-			) {
+			if (typeof body === 'object' && !('content-type' in headers)) {
 				headers = { ...headers, 'content-type': 'application/json' };
 				body = JSON.stringify(body);
 			}

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -29,7 +29,10 @@ export default async function render_route(request, route) {
 
 			headers = lowercase_keys(headers);
 
-			if (typeof body === 'object' && !('content-type' in headers)) {
+			if (
+				typeof body === 'object' &&
+				(!('content-type' in headers) || headers['content-type'] === 'application/json')
+			) {
 				headers = { ...headers, 'content-type': 'application/json' };
 				body = JSON.stringify(body);
 			}

--- a/packages/kit/test/apps/basics/src/routes/load/__tests__.js
+++ b/packages/kit/test/apps/basics/src/routes/load/__tests__.js
@@ -29,6 +29,10 @@ export default function (test, is_dev) {
 		);
 	});
 
+	test('json string is returned', '/load/relay', async ({ page }) => {
+		assert.equal(await page.textContent('h1'), '42');
+	});
+
 	test('prefers static data over endpoint', '/load/foo', async ({ page }) => {
 		assert.equal(await page.textContent('h1'), 'static file');
 	});

--- a/packages/kit/test/apps/basics/src/routes/load/relay.json.js
+++ b/packages/kit/test/apps/basics/src/routes/load/relay.json.js
@@ -1,0 +1,8 @@
+export function get() {
+	return {
+		headers: {
+			'content-type': 'application/json'
+		},
+		body: '42'
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/relay.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/relay.svelte
@@ -1,8 +1,11 @@
 <script context="module">
+	/** @type {import('@sveltejs/kit').Load} */
 	export async function load({ fetch }) {
-		const res = await fetch('/load/serialization.json');
+		const res = await fetch('/load/relay.json');
 		return {
-			props: await res.json()
+			props: {
+				answer: await res.json()
+			}
 		}
 	}
 </script>


### PR DESCRIPTION
Converting to JSON string also when the 'content-type' header is 'application/json'
prevents the endpoint from functioning as a relay, that is, it can't fetch
an API that returns a JSON string and then forwards the headers and the body
as they are, because svelte kit would call JSON.stringify on the string again.

Closes #1226

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
