### PR TITLE
handle URLs that need to be decoded

### DIFF
--- a/.changeset/proud-needles-shake.md
+++ b/.changeset/proud-needles-shake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Handle URLs that need to be decoded

--- a/packages/kit/src/core/create_manifest_data/index.js
+++ b/packages/kit/src/core/create_manifest_data/index.js
@@ -333,7 +333,8 @@ function get_pattern(segments, add_trailing_slash) {
 							.map((part) => {
 								return part.dynamic
 									? '([^/]+?)'
-									: encodeURI(part.content.normalize())
+									: part.content
+											.normalize()
 											.replace(/\?/g, '%3F')
 											.replace(/#/g, '%23')
 											.replace(/%5B/g, '[')

--- a/packages/kit/src/core/start/index.js
+++ b/packages/kit/src/core/start/index.js
@@ -57,7 +57,7 @@ export async function start({ port, host, config, https: use_https = false, cwd 
 						req.headers[config.kit.hostHeader || 'host']),
 					method: req.method,
 					headers: /** @type {import('types/helper').Headers} */ (req.headers),
-					path: parsed.pathname,
+					path: decodeURIComponent(parsed.pathname),
 					rawBody: await getRawBody(req),
 					query: new URLSearchParams(parsed.query || '')
 				});

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -161,7 +161,7 @@ export class Router {
 		if (url.origin !== location.origin) return null;
 		if (!url.pathname.startsWith(this.base)) return null;
 
-		const path = url.pathname.slice(this.base.length) || '/';
+		const path = decodeURIComponent(url.pathname.slice(this.base.length) || '/');
 
 		const routes = this.routes.filter(([pattern]) => pattern.test(path));
 

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -15,7 +15,7 @@ export async function respond(incoming, options, state = {}) {
 		return {
 			status: 301,
 			headers: {
-				location: incoming.path.slice(0, -1) + (q ? `?${q}` : '')
+				location: encodeURI(incoming.path.slice(0, -1) + (q ? `?${q}` : ''))
 			}
 		};
 	}

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -100,7 +100,7 @@ export async function respond({ request, options, state, $session, route }) {
 						return {
 							status: loaded.loaded.status,
 							headers: {
-								location: loaded.loaded.redirect
+								location: encodeURI(loaded.loaded.redirect)
 							}
 						};
 					}

--- a/packages/kit/test/apps/basics/src/routes/encoded/[slug].svelte
+++ b/packages/kit/test/apps/basics/src/routes/encoded/[slug].svelte
@@ -1,0 +1,25 @@
+<script context="module">
+	/** @type {import('@sveltejs/kit').Load} */
+	export function load({ page }) {
+		return {
+			props: {
+				path: page.path,
+				slug: page.params.slug
+			}
+		};
+	}
+</script>
+
+<script>
+	import { page } from '$app/stores';
+
+	/** @type {string} */
+	export let path;
+
+	/** @type {string} */
+	export let slug;
+</script>
+
+<h1>dynamic</h1>
+<h2>{path}: {slug}</h2>
+<h3>{$page.path}: {$page.params.slug}</h3>

--- a/packages/kit/test/apps/basics/src/routes/encoded/__tests__.js
+++ b/packages/kit/test/apps/basics/src/routes/encoded/__tests__.js
@@ -1,0 +1,30 @@
+import * as assert from 'uvu/assert';
+
+/** @type {import('test').TestMaker} */
+export default function (test) {
+	test('visits a route with non-ASCII character', '/encoded', async ({ page, clicknav }) => {
+		await clicknav('[href="/encoded/苗条"]');
+		assert.equal(await page.innerHTML('h1'), 'static');
+		assert.equal(await page.innerHTML('h2'), '/encoded/苗条');
+		assert.equal(await page.innerHTML('h3'), '/encoded/苗条');
+	});
+
+	test(
+		'visits a dynamic route with non-ASCII character',
+		'/encoded',
+		async ({ page, clicknav }) => {
+			await clicknav('[href="/encoded/土豆"]');
+			assert.equal(await page.innerHTML('h1'), 'dynamic');
+			assert.equal(await page.innerHTML('h2'), '/encoded/土豆: 土豆');
+			assert.equal(await page.innerHTML('h3'), '/encoded/土豆: 土豆');
+		}
+	);
+
+	test('redirects correctly with non-ASCII location', '/encoded', async ({ page, clicknav }) => {
+		await clicknav('[href="/encoded/反应"]');
+
+		assert.equal(await page.innerHTML('h1'), 'static');
+		assert.equal(await page.innerHTML('h2'), '/encoded/苗条');
+		assert.equal(await page.innerHTML('h3'), '/encoded/苗条');
+	});
+}

--- a/packages/kit/test/apps/basics/src/routes/encoded/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/encoded/index.svelte
@@ -1,0 +1,3 @@
+<a href="/encoded/苗条">苗条</a>
+<a href="/encoded/土豆">土豆</a>
+<a href="/encoded/反应">反应</a>

--- a/packages/kit/test/apps/basics/src/routes/encoded/反应.svelte
+++ b/packages/kit/test/apps/basics/src/routes/encoded/反应.svelte
@@ -1,0 +1,8 @@
+<script context="module">
+	export function load() {
+		return {
+			status: 307,
+			redirect: '苗条'
+		};
+	}
+</script>

--- a/packages/kit/test/apps/basics/src/routes/encoded/苗条.svelte
+++ b/packages/kit/test/apps/basics/src/routes/encoded/苗条.svelte
@@ -1,0 +1,21 @@
+<script context="module">
+	/** @type {import('@sveltejs/kit').Load} */
+	export function load({ page }) {
+		return {
+			props: {
+				path: page.path
+			}
+		};
+	}
+</script>
+
+<script>
+	import { page } from '$app/stores';
+
+	/** @type {string} */
+	export let path;
+</script>
+
+<h1>static</h1>
+<h2>{path}</h2>
+<h3>{$page.path}</h3>


### PR DESCRIPTION
Fixes #1228 and various other things related to non-ASCII pathnames.

I guess adapters need to ensure that they're passing decoded pathnames to `respond`; I haven't checked if any are currently doing it wrong.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
