### PR TITLE
update links to modules section

### DIFF
--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -39,7 +39,7 @@ A file called either `src/routes/about.svelte` or `src/routes/about/index.svelte
 <p>TODO...</p>
 ```
 
-Dynamic parameters are encoded using `[brackets]`. For example, a blog post might be defined by `src/routes/blog/[slug].svelte`. Soon, we'll see how to access that parameter in a [load function](#loading) or the [page store](#modules-app-stores).
+Dynamic parameters are encoded using `[brackets]`. For example, a blog post might be defined by `src/routes/blog/[slug].svelte`. Soon, we'll see how to access that parameter in a [load function](#loading) or the [page store](#modules-$app-stores).
 
 ### Endpoints
 
@@ -103,7 +103,7 @@ The job of this function is to return a `{ status, headers, body }` object repre
 
 > For successful responses, SvelteKit will generate 304s automatically.
 
-If the returned `body` is an object, and no `content-type` header is returned, it will automatically be turned into a JSON response. (Don't worry about `$lib`, we'll get to that [later](#modules-lib).)
+If the returned `body` is an object, and no `content-type` header is returned, it will automatically be turned into a JSON response. (Don't worry about `$lib`, we'll get to that [later](#modules-$lib).)
 
 > Returning nothing is equivalent to an explicit 404 response.
 

--- a/documentation/docs/06-service-workers.md
+++ b/documentation/docs/06-service-workers.md
@@ -8,6 +8,6 @@ In SvelteKit, if you have a `src/service-worker.js` file (or `src/service-worker
 
 > You can change the location of your service worker in your [project configuration](#configuration-files).
 
-Inside the service worker you have access to the [`$service-worker` module](#modules-service-worker).
+Inside the service worker you have access to the [`$service-worker` module](#modules-$service-worker).
 
 Because it needs to be bundled (since browsers don't yet support `import` in this context), and depends on the client-side app's build manifest, **service workers only work in the production build, not in development**. To test it locally, use [`svelte-kit preview`](#command-line-interface-svelte-kit-preview).


### PR DESCRIPTION
This PR updates some of the links in the docs that go to `modules-app` and replace it with `modules-$app`. This will provide a smoother experience to a doc reader and would help Svelte beginner like me to quickly understand some of the concepts. 

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
