### PR TITLE
docs: fix where to set base & asset paths in config

### DIFF
--- a/documentation/docs/05-modules.md
+++ b/documentation/docs/05-modules.md
@@ -31,8 +31,8 @@ import { goto, prefetch, prefetchRoutes } from '$app/navigation';
 import { base, assets } from '$app/paths';
 ```
 
-- `base` — a root-relative (i.e. begins with a `/`) string that matches `config.kit.files.base` in your [project configuration](#configuration)
-- `assets` — a root-relative or absolute path that matches `config.kit.files.assets` (after it has been resolved against `base`)
+- `base` — a root-relative (i.e. begins with a `/`) string that matches `config.kit.paths.base` in your [project configuration](#configuration)
+- `assets` — a root-relative or absolute path that matches `config.kit.paths.assets` (after it has been resolved against `base`)
 
 ### $app/stores
 


### PR DESCRIPTION
Not sure if these used to be in `config.kit.files`, but it looks like they're now expected in `config.kit.paths` https://github.com/sveltejs/kit/blob/353afa1bbc8799abc9247544422dd9b2f240f878/packages/kit/src/core/load_config/index.spec.js#L30-L33