### PR TITLE
fix(kit): export AdapterUtils type

### DIFF
--- a/.changeset/large-cats-press.md
+++ b/.changeset/large-cats-press.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Export AdapterUtils type for use in adapters

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1,6 +1,6 @@
 import './ambient-modules';
 
-export { Adapter, Config } from './config';
+export { Adapter, AdapterUtils, Config } from './config';
 export { ErrorLoad, Load, Page } from './page';
 export { Incoming, GetContext, GetSession, Handle } from './hooks';
 export { ServerRequest as Request, ServerResponse as Response, RequestHandler } from './endpoint';


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

Export `AdapterUtils` from the root config type file for use in Adapters.

I am updating the [Firebase](https://github.com/jthegedus/svelte-adapter-firebase) adapter to the latest API and would like to utilise this AdapterUtils types internally.

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
