### PR TITLE
Invalidate URLs

### DIFF
--- a/.changeset/mighty-garlics-pretend.md
+++ b/.changeset/mighty-garlics-pretend.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add invalidate(url) API for re-running load functions

--- a/documentation/docs/05-modules.md
+++ b/documentation/docs/05-modules.md
@@ -18,10 +18,11 @@ import { amp, browser, dev, prerendering } from '$app/env';
 ### $app/navigation
 
 ```js
-import { goto, prefetch, prefetchRoutes } from '$app/navigation';
+import { goto, invalidate, prefetch, prefetchRoutes } from '$app/navigation';
 ```
 
 - `goto(href, { replaceState, noscroll })` returns a `Promise` that resolves when SvelteKit navigates (or fails to navigate, in which case the promise rejects) to the specified `href`. The second argument is optional. If `replaceState` is true, a new history entry won't be created. If `noscroll` is true, the browser won't scroll to the top of the page after navigation.
+- `invalidate(href)` returns a `Promise` that causes any `load` functions belonging to the currently active page to re-run if they `fetch` the resource in question.
 - `prefetch(href)` programmatically prefetches the given page, which means a) ensuring that the code for the page is loaded, and b) calling the page's `load` function with the appropriate options. This is the same behaviour that SvelteKit triggers when the user taps or mouses over an `<a>` element with [sveltekit:prefetch](#anchor-options-sveltekit-prefetch). If the next navigation is to `href`, the values returned from `load` will be used, making navigation instantaneous. Returns a `Promise` that resolves when the prefetch is complete.
 - `prefetchRoutes(routes)` — programmatically prefetches the code for routes that haven't yet been fetched. Typically, you might call this to speed up subsequent navigation. If no argument is given, all routes will be fetched; otherwise, you can specify routes by any matching pathname such as `/about` (to match `src/routes/about.svelte`) or `/blog/*` (to match `src/routes/blog/[slug].svelte`). Unlike `prefetch`, this won't call `load` for individual pages. Returns a `Promise` that resolves when the routes have been prefetched.
 

--- a/packages/kit/.eslintrc.json
+++ b/packages/kit/.eslintrc.json
@@ -6,6 +6,7 @@
 	},
 	"globals": {
 		"goto": true,
+		"invalidate": true,
 		"prefetch": true,
 		"prefetchRoutes": true
 	}

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -25,10 +25,7 @@ async function goto_(href, opts) {
 /**
  * @type {import('$app/navigation').invalidate}
  */
-async function invalidate_(href) {
-	const info = router.parse(new URL(location.href));
-	return router.renderer.update({ ...info, invalidates: href });
-}
+async function invalidate_(href) {}
 
 /**
  * @type {import('$app/navigation').prefetch}

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -25,7 +25,10 @@ async function goto_(href, opts) {
 /**
  * @type {import('$app/navigation').invalidate}
  */
-async function invalidate_(href) {}
+async function invalidate_(resource) {
+	const { href } = new URL(resource, location.href);
+	return router.renderer.invalidate(href);
+}
 
 /**
  * @type {import('$app/navigation').prefetch}

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -14,7 +14,6 @@ export const goto = import.meta.env.SSR ? guard('goto') : goto_;
 export const invalidate = import.meta.env.SSR ? guard('invalidate') : invalidate_;
 export const prefetch = import.meta.env.SSR ? guard('prefetch') : prefetch_;
 export const prefetchRoutes = import.meta.env.SSR ? guard('prefetchRoutes') : prefetchRoutes_;
-export const invalidate = import.meta.env.SSR ? guard('invalidate') : invalidate_;
 
 /**
  * @type {import('$app/navigation').goto}
@@ -26,7 +25,10 @@ async function goto_(href, opts) {
 /**
  * @type {import('$app/navigation').invalidate}
  */
-async function invalidate_(href) {}
+async function invalidate_(href) {
+	const info = router.parse(new URL(location.href));
+	return router.renderer.update({ ...info, invalidates: href });
+}
 
 /**
  * @type {import('$app/navigation').prefetch}
@@ -46,9 +48,4 @@ async function prefetchRoutes_(pathnames) {
 	const promises = matching.map((r) => r.length !== 1 && Promise.all(r[1].map((load) => load())));
 
 	await Promise.all(promises);
-}
-
-async function invalidate_(resource) {
-	const info = router.parse(new URL(location.href));
-	return router.renderer.update({ ...info, invalidates: resource });
 }

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -11,6 +11,7 @@ function guard(name) {
 }
 
 export const goto = import.meta.env.SSR ? guard('goto') : goto_;
+export const invalidate = import.meta.env.SSR ? guard('invalidate') : invalidate_;
 export const prefetch = import.meta.env.SSR ? guard('prefetch') : prefetch_;
 export const prefetchRoutes = import.meta.env.SSR ? guard('prefetchRoutes') : prefetchRoutes_;
 
@@ -20,6 +21,11 @@ export const prefetchRoutes = import.meta.env.SSR ? guard('prefetchRoutes') : pr
 async function goto_(href, opts) {
 	return router.goto(href, opts, []);
 }
+
+/**
+ * @type {import('$app/navigation').invalidate}
+ */
+async function invalidate_(href) {}
 
 /**
  * @type {import('$app/navigation').prefetch}

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -69,6 +69,8 @@ export class Renderer {
 		this.started = false;
 
 		this.session_id = 1;
+		this.invalid = new Set();
+		this.invalidating = null;
 
 		/** @type {import('./types').NavigationState} */
 		this.current = {
@@ -103,7 +105,7 @@ export class Renderer {
 			this.session_id += 1;
 
 			const info = this.router.parse(new URL(location.href));
-			this.update(info, []);
+			this.update(info, [], true);
 		});
 		ready = true;
 	}
@@ -208,13 +210,16 @@ export class Renderer {
 	/**
 	 * @param {import('./types').NavigationInfo} info
 	 * @param {string[]} chain
+	 * @param {boolean} no_cache
 	 */
-	async update(info, chain) {
+	async update(info, chain, no_cache) {
 		const token = (this.token = {});
-		let navigation_result = await this._get_navigation_result(info);
+		let navigation_result = await this._get_navigation_result(info, no_cache);
 
 		// abort if user navigated during update
 		if (token !== this.token) return;
+
+		this.invalid.clear();
 
 		if (navigation_result.redirect) {
 			if (chain.length > 10 || chain.includes(info.path)) {
@@ -268,10 +273,26 @@ export class Renderer {
 	 * @returns {Promise<import('./types').NavigationResult>}
 	 */
 	load(info) {
-		this.loading.promise = this._get_navigation_result(info);
+		this.loading.promise = this._get_navigation_result(info, false);
 		this.loading.id = info.id;
 
 		return this.loading.promise;
+	}
+
+	/** @param {string} href */
+	invalidate(href) {
+		this.invalid.add(href);
+
+		if (!this.invalidating) {
+			this.invalidating = Promise.resolve().then(async () => {
+				const info = this.router.parse(new URL(location.href));
+				await this.update(info, [], true);
+
+				this.invalidating = null;
+			});
+		}
+
+		return this.invalidating;
 	}
 
 	/** @param {import('./types').NavigationResult} result */
@@ -295,9 +316,10 @@ export class Renderer {
 
 	/**
 	 * @param {import('./types').NavigationInfo} info
+	 * @param {boolean} no_cache
 	 * @returns {Promise<import('./types').NavigationResult>}
 	 */
-	async _get_navigation_result(info) {
+	async _get_navigation_result(info, no_cache) {
 		if (this.loading.id === info.id) {
 			return this.loading.promise;
 		}
@@ -322,11 +344,14 @@ export class Renderer {
 				}
 			}
 
-			const result = await this._load({
-				route,
-				path: info.path,
-				query: info.query
-			});
+			const result = await this._load(
+				{
+					route,
+					path: info.path,
+					query: info.query
+				},
+				no_cache
+			);
 			if (result) return result;
 		}
 
@@ -376,12 +401,12 @@ export class Renderer {
 		const maxage = leaf.loaded && leaf.loaded.maxage;
 
 		if (maxage) {
-			const hash = `${page.path}?${page.query}`;
+			const key = `${page.path}?${page.query}`;
 			let ready = false;
 
 			const clear = () => {
-				if (this.cache.get(hash) === result) {
-					this.cache.delete(hash);
+				if (this.cache.get(key) === result) {
+					this.cache.delete(key);
 				}
 
 				unsubscribe();
@@ -396,7 +421,7 @@ export class Renderer {
 
 			ready = true;
 
-			this.cache.set(hash, result);
+			this.cache.set(key, result);
 		}
 
 		return result;
@@ -423,7 +448,7 @@ export class Renderer {
 				query: false,
 				session: false,
 				context: false,
-				dependencies: new Set()
+				dependencies: []
 			},
 			loaded: null,
 			context
@@ -469,6 +494,10 @@ export class Renderer {
 					return { ...context };
 				},
 				fetch(resource, info) {
+					const url = typeof resource === 'string' ? resource : resource.url;
+					const { href } = new URL(url, new URL(page.path, document.baseURI));
+					node.uses.dependencies.push(href);
+
 					return started ? fetch(resource, info) : initial_fetch(resource, info);
 				}
 			};
@@ -492,13 +521,14 @@ export class Renderer {
 
 	/**
 	 * @param {import('./types').NavigationCandidate} selected
+	 * @param {boolean} no_cache
 	 * @returns {Promise<import('./types').NavigationResult>}
 	 */
-	async _load({ route, path, query }) {
-		const hash = `${path}?${query}`;
+	async _load({ route, path, query }, no_cache) {
+		const key = `${path}?${query}`;
 
-		if (this.cache.has(hash)) {
-			return this.cache.get(hash);
+		if (!no_cache && this.cache.has(key)) {
+			return this.cache.get(key);
 		}
 
 		const [pattern, a, b, get_params] = route;
@@ -547,6 +577,7 @@ export class Renderer {
 					changed.params.some((param) => previous.uses.params.has(param)) ||
 					(changed.query && previous.uses.query) ||
 					(changed.session && previous.uses.session) ||
+					previous.uses.dependencies.some((dep) => this.invalid.has(dep)) ||
 					(context_changed && previous.uses.context);
 
 				if (changed_since_last_render) {

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -423,7 +423,7 @@ export class Renderer {
 				query: false,
 				session: false,
 				context: false,
-				invalidates: new Set()
+				dependencies: new Set()
 			},
 			loaded: null,
 			context

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -445,6 +445,8 @@ export class Renderer {
 		const session = this.$session;
 
 		if (module.load) {
+			const { started } = this;
+
 			/** @type {import('types/page').LoadInput | import('types/page').ErrorLoadInput} */
 			const load_input = {
 				page: {
@@ -469,7 +471,7 @@ export class Renderer {
 				},
 				fetch(resource, info) {
 					node.uses.invalidates.add(resource);
-					return this.started ? fetch(resource, info) : initial_fetch(resource, info);
+					return started ? fetch(resource, info) : initial_fetch(resource, info);
 				}
 			};
 

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -325,8 +325,7 @@ export class Renderer {
 			const result = await this._load({
 				route,
 				path: info.path,
-				query: info.query,
-				invalidates: info.invalidates
+				query: info.query
 			});
 			if (result) return result;
 		}
@@ -470,7 +469,6 @@ export class Renderer {
 					return { ...context };
 				},
 				fetch(resource, info) {
-					node.uses.invalidates.add(resource);
 					return started ? fetch(resource, info) : initial_fetch(resource, info);
 				}
 			};
@@ -496,7 +494,7 @@ export class Renderer {
 	 * @param {import('./types').NavigationCandidate} selected
 	 * @returns {Promise<import('./types').NavigationResult>}
 	 */
-	async _load({ route, path, query, invalidates }) {
+	async _load({ route, path, query }) {
 		const hash = `${path}?${query}`;
 
 		if (this.cache.has(hash)) {
@@ -549,7 +547,6 @@ export class Renderer {
 					changed.params.some((param) => previous.uses.params.has(param)) ||
 					(changed.query && previous.uses.query) ||
 					(changed.session && previous.uses.session) ||
-					(invalidates && previous.uses.invalidates.has(invalidates)) ||
 					(context_changed && previous.uses.context);
 
 				if (changed_since_last_render) {

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -225,7 +225,7 @@ export class Router {
 			history.replaceState({}, '', `${location.pathname.slice(0, -1)}${location.search}`);
 		}
 
-		await this.renderer.update(info, chain);
+		await this.renderer.update(info, chain, false);
 
 		document.body.focus();
 

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -30,7 +30,7 @@ export type BranchNode = {
 		query: boolean;
 		session: boolean;
 		context: boolean;
-		invalidates: Set<string>;
+		dependencies: Set<string>;
 	};
 	context: Record<string, any>;
 };

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -30,7 +30,7 @@ export type BranchNode = {
 		query: boolean;
 		session: boolean;
 		context: boolean;
-		dependencies: Set<string>;
+		dependencies: string[];
 	};
 	context: Record<string, any>;
 };

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -2,41 +2,41 @@ import { Page, LoadOutput } from '../../../types/page';
 import { CSRComponent, CSRRoute } from '../../../types/internal';
 
 export type NavigationInfo = {
-  id: string;
-  routes: CSRRoute[];
-  path: string;
-  query: URLSearchParams;
+	id: string;
+	routes: CSRRoute[];
+	path: string;
+	query: URLSearchParams;
 };
 
 export type NavigationCandidate = {
-  route: CSRRoute;
-  path: string;
-  query: URLSearchParams;
+	route: CSRRoute;
+	path: string;
+	query: URLSearchParams;
 };
 
 export type NavigationResult = {
-  reload?: boolean;
-  redirect?: string;
-  state?: NavigationState;
-  props?: Record<string, any>;
+	reload?: boolean;
+	redirect?: string;
+	state?: NavigationState;
+	props?: Record<string, any>;
 };
 
 export type BranchNode = {
-  module: CSRComponent;
-  loaded: LoadOutput;
-  uses: {
-    params: Set<string>;
-    path: boolean;
-    query: boolean;
-    session: boolean;
-    context: boolean;
-    invalidates: Set<string>;
-  };
-  context: Record<string, any>;
+	module: CSRComponent;
+	loaded: LoadOutput;
+	uses: {
+		params: Set<string>;
+		path: boolean;
+		query: boolean;
+		session: boolean;
+		context: boolean;
+		invalidates: Set<string>;
+	};
+	context: Record<string, any>;
 };
 
 export type NavigationState = {
-  page: Page;
-  branch: BranchNode[];
-  session_id: number;
+	page: Page;
+	branch: BranchNode[];
+	session_id: number;
 };

--- a/packages/kit/test/ambient.d.ts
+++ b/packages/kit/test/ambient.d.ts
@@ -12,6 +12,7 @@ declare global {
 		}
 	) => Promise<void>;
 
+	const invalidate: (url: string) => Promise<void>;
 	const prefetch: (url: string) => Promise<void>;
 	const prefetchRoutes: (urls?: string[]) => Promise<void>;
 }

--- a/packages/kit/test/apps/basics/src/routes/$layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/$layout.svelte
@@ -12,10 +12,10 @@
 </script>
 
 <script>
-	import { goto, prefetch, prefetchRoutes } from '$app/navigation';
+	import { goto, invalidate, prefetch, prefetchRoutes } from '$app/navigation';
 
 	if (typeof window !== 'undefined') {
-		Object.assign(window, { goto, prefetch, prefetchRoutes });
+		Object.assign(window, { goto, invalidate, prefetch, prefetchRoutes });
 	}
 
 	export let foo;

--- a/packages/kit/test/apps/basics/src/routes/load/__tests__.js
+++ b/packages/kit/test/apps/basics/src/routes/load/__tests__.js
@@ -82,6 +82,10 @@ export default function (test, is_dev) {
 				await app.invalidate('/load/change-detection/data.json');
 				assert.equal(await page.textContent('h1'), 'layout loads: 2');
 				assert.equal(await page.textContent('h2'), 'x: b: 2');
+
+				await app.invalidate('/load/change-detection/data.json');
+				assert.equal(await page.textContent('h1'), 'layout loads: 3');
+				assert.equal(await page.textContent('h2'), 'x: b: 2');
 			}
 		}
 	);

--- a/packages/kit/test/apps/basics/src/routes/load/__tests__.js
+++ b/packages/kit/test/apps/basics/src/routes/load/__tests__.js
@@ -63,20 +63,25 @@ export default function (test, is_dev) {
 		'load function is only called when necessary',
 		'/load/change-detection/one/a',
 		async ({ app, page, js }) => {
-			assert.equal(await page.textContent('h1'), 'x: a: 1');
+			assert.equal(await page.textContent('h1'), 'layout loads: 1');
+			assert.equal(await page.textContent('h2'), 'x: a: 1');
 
 			if (js) {
 				await app.goto('/load/change-detection/one/a?unused=whatever');
-				assert.equal(await page.textContent('h1'), 'x: a: 1');
+				assert.equal(await page.textContent('h2'), 'x: a: 1');
 
 				await app.goto('/load/change-detection/two/b');
-				assert.equal(await page.textContent('h1'), 'y: b: 1');
+				assert.equal(await page.textContent('h2'), 'y: b: 1');
 
 				await app.goto('/load/change-detection/one/a');
-				assert.equal(await page.textContent('h1'), 'x: a: 1');
+				assert.equal(await page.textContent('h2'), 'x: a: 1');
 
 				await app.goto('/load/change-detection/one/b');
-				assert.equal(await page.textContent('h1'), 'x: b: 2');
+				assert.equal(await page.textContent('h2'), 'x: b: 2');
+
+				await app.invalidate('/load/change-detection/data.json');
+				assert.equal(await page.textContent('h1'), 'layout loads: 2');
+				assert.equal(await page.textContent('h2'), 'x: b: 2');
 			}
 		}
 	);

--- a/packages/kit/test/apps/basics/src/routes/load/change-detection/$layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/change-detection/$layout.svelte
@@ -2,13 +2,16 @@
 	let loads = 0;
 
 	/** @type {import('@sveltejs/kit').Load} */
-	export async function load({ page }) {
+	export async function load({ fetch }) {
+		const res = await fetch('/load/change-detection/data.json');
+		const { type } = await res.json();
+
 		loads += 1;
 
 		return {
 			maxage: 5,
 			props: {
-				x: page.params.x,
+				type,
 				loads
 			}
 		};
@@ -17,10 +20,11 @@
 
 <script>
 	/** @type {string} */
-	export let x;
+	export let type;
 
 	/** @type {number} */
 	export let loads;
 </script>
 
-<h2>x: {x}: {loads}</h2>
+<h1>{type} loads: {loads}</h1>
+<slot></slot>

--- a/packages/kit/test/apps/basics/src/routes/load/change-detection/data.json.js
+++ b/packages/kit/test/apps/basics/src/routes/load/change-detection/data.json.js
@@ -1,0 +1,7 @@
+export function get() {
+	return {
+		body: {
+			type: 'layout'
+		}
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/change-detection/two/[y].svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/change-detection/two/[y].svelte
@@ -1,6 +1,7 @@
 <script context="module">
 	let loads = 0;
 
+	/** @type {import('@sveltejs/kit').Load} */
 	export async function load({ page }) {
 		loads += 1;
 
@@ -15,8 +16,11 @@
 </script>
 
 <script>
+	/** @type {string} */
 	export let y;
+
+	/** @type {number} */
 	export let loads;
 </script>
 
-<h1>y: {y}: {loads}</h1>
+<h2>y: {y}: {loads}</h2>

--- a/packages/kit/test/test.js
+++ b/packages/kit/test/test.js
@@ -110,6 +110,12 @@ async function setup({ port }) {
 			 * @param {string} url
 			 * @returns {Promise<void>}
 			 */
+			invalidate: (url) => pages.js.evaluate((url) => invalidate(url), url),
+
+			/**
+			 * @param {string} url
+			 * @returns {Promise<void>}
+			 */
 			prefetch: (url) => pages.js.evaluate((url) => prefetch(url), url),
 
 			/**

--- a/packages/kit/test/types.d.ts
+++ b/packages/kit/test/types.d.ts
@@ -23,6 +23,7 @@ export type TestContext = {
 	// these are assumed to have been put in the global scope by the layout
 	app: {
 		goto: (url: string) => Promise<void>;
+		invalidate: (url: string) => Promise<void>;
 		prefetch: (url: string) => Promise<void>;
 		prefetchRoutes: (urls?: string[]) => Promise<void>;
 	};

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -25,6 +25,11 @@ declare module '$app/navigation' {
 		opts?: { replaceState?: boolean; noscroll?: boolean }
 	): Promise<any>;
 	/**
+	 * Returns a Promise that resolves when SvelteKit re-runs any current `load` functions that depend on `href`
+	 * @param href The invalidated resource
+	 */
+	export function invalidate(href: string): Promise<any>;
+	/**
 	 * Programmatically prefetches the given page, which means a) ensuring that the code for the page is loaded, and b) calling the page's load function with the appropriate options.
 	 * This is the same behaviour that SvelteKit triggers when the user taps or mouses over an `<a>` element with `sveltekit:prefetch`.
 	 * If the next navigation is to `href`, the values returned from load will be used, making navigation instantaneous.


### PR DESCRIPTION
Picks up where #1280 left off. Fixes #1277, and also fixes a subtle bug where updating `session` wouldn't re-run `load` functions if `maxage` was used.

`invalidate(url)` calls are batched, so you can do things like `urls.forEach(invalidate)` without penalty.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
