### PR TITLE
validate app.html, and throw in dev if target is missing

### DIFF
--- a/.changeset/yellow-meals-agree.md
+++ b/.changeset/yellow-meals-agree.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Validate template file on startup

--- a/packages/kit/src/core/load_config/test/fixtures/default-cjs/src/app.html
+++ b/packages/kit/src/core/load_config/test/fixtures/default-cjs/src/app.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" href="/favicon.ico" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%svelte.head%
+	</head>
+	<body>
+		<div id="svelte">%svelte.body%</div>
+	</body>
+</html>

--- a/packages/kit/src/core/load_config/test/fixtures/default-esm/src/app.html
+++ b/packages/kit/src/core/load_config/test/fixtures/default-esm/src/app.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" href="/favicon.ico" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%svelte.head%
+	</head>
+	<body>
+		<div id="svelte">%svelte.body%</div>
+	</body>
+</html>

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -25,6 +25,10 @@ import { set_paths } from '../paths.js';
  *   };
  * }} opts */
 export async function start({ paths, target, session, host, route, spa, hydrate }) {
+	if (import.meta.env.DEV && !target) {
+		throw new Error('Missing target element. See https://kit.svelte.dev/docs#configuration-target');
+	}
+
 	const router =
 		route &&
 		new Router({


### PR DESCRIPTION
fixes #1301. alternative to #1302 that does the validation earlier, so that it applies to `build` as well as `dev`, and throws an error in dev if the target element can't be found.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
