### PR TITLE
remove navigated to text from announcer

### DIFF
--- a/.changeset/stale-humans-cough.md
+++ b/.changeset/stale-humans-cough.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Remove 'Navigated to' text from announcer'

--- a/packages/kit/src/core/create_app/index.js
+++ b/packages/kit/src/core/create_app/index.js
@@ -180,7 +180,7 @@ function generate_app(manifest_data, base) {
 		{#if mounted}
 			<div id="svelte-announcer" aria-live="assertive" aria-atomic="true">
 				{#if navigated}
-					Navigated to {title}
+					{title}
 				{/if}
 			</div>
 		{/if}

--- a/packages/kit/test/apps/basics/src/routes/accessibility/__tests__.js
+++ b/packages/kit/test/apps/basics/src/routes/accessibility/__tests__.js
@@ -33,7 +33,7 @@ export default function (test) {
 			assert.equal(await page.innerHTML('[aria-live]'), '');
 
 			await clicknav('[href="/accessibility/b"]');
-			assert.equal(await page.innerHTML('[aria-live]'), 'Navigated to b'); // TODO i18n
+			assert.equal(await page.innerHTML('[aria-live]'), 'b'); // TODO i18n
 		} else {
 			assert.ok(!has_live_region);
 		}


### PR DESCRIPTION
we decided that the quickest way to fix #879 would be to remove the 'Navigated to' text from the announcer contents, so that it just announces the title. Later, when our i18n story is more fleshed out, we can use it to provide a way to customise this text.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
