### PR TITLE
Add `prerendering` to `$app/env` typings

### DIFF
--- a/.changeset/strong-cooks-turn.md
+++ b/.changeset/strong-cooks-turn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add prerendering to \$app/env typings

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -11,6 +11,10 @@ declare module '$app/env' {
 	 * `true` in development mode, `false` in production.
 	 */
 	export const dev: boolean;
+	/**
+	 * `true` when prerendering, `false` otherwise.
+	 */
+	export const prerendering: boolean;
 }
 
 declare module '$app/navigation' {


### PR DESCRIPTION
This change makes TypeScript stop yelling at you if you use `prerendering` from `src/hooks.ts` or wherever.

Since this doesn't affect anything at runtime I wasn't sure if it should have a changeset from `pnpx changeset`; should I add one?