### PR TITLE
use TypedArray.set as the "simpler way" to copy

### DIFF
--- a/.changeset/lucky-bottles-kick.md
+++ b/.changeset/lucky-bottles-kick.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Use TypedArray.set to copy from Uint8Array when getting raw body in core/http

--- a/packages/kit/src/core/http/index.js
+++ b/packages/kit/src/core/http/index.js
@@ -21,10 +21,8 @@ export function getRawBody(req) {
 			let i = 0;
 
 			req.on('data', (chunk) => {
-				// TODO maybe there's a simpler way to copy data between buffers?
-				for (let j = 0; j < chunk.length; j += 1) {
-					data[i++] = chunk[j];
-				}
+				data.set(chunk, i);
+				i += chunk.length;
 			});
 		} else {
 			// https://github.com/jshttp/type-is/blob/c1f4388c71c8a01f79934e68f630ca4a15fffcd6/index.js#L81-L95
@@ -37,15 +35,8 @@ export function getRawBody(req) {
 
 			req.on('data', (chunk) => {
 				const new_data = new Uint8Array(data.length + chunk.length);
-
-				for (let i = 0; i < data.length; i += 1) {
-					new_data[i] = data[i];
-				}
-
-				for (let i = 0; i < chunk.length; i += 1) {
-					new_data[i + data.length] = chunk[i];
-				}
-
+				new_data.set(data);
+				new_data.set(chunk, data.length);
 				data = new_data;
 			});
 		}


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

This PR addresses the TODO:

> // TODO maybe there's a simpler way to copy data between buffers?

...by replacing with [TypedArray.prototype.set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/set). 

This is a [built-in, in current v8](https://github.com/v8/v8/blob/master/src/builtins/typed-array-set.tq), seems to be [at least as performant as the loop](http://jsbench.github.io/#0ff5b7c3f39925b96849380f01d5c7e6), with gains increasing as the size of the buffer increases. 

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
