### PR TITLE
Add failing test for load status code bug

### DIFF
--- a/packages/kit/test/apps/basics/src/routes/errors/__tests__.js
+++ b/packages/kit/test/apps/basics/src/routes/errors/__tests__.js
@@ -112,6 +112,34 @@ export default function (test, is_dev) {
 	);
 
 	test(
+		'server-side error from load() is a 4XX/5XX status code',
+		'/errors/load-error-code-server',
+		async ({ page, response }) => {
+			assert.equal(await page.textContent('footer'), 'Custom layout');
+			assert.equal(
+				await page.textContent('#message'),
+				'This is your custom error page saying: "Internal Server Error"'
+			);
+			assert.equal(response.status(), 500);
+		}
+	);
+
+	test(
+		'client-side error from load() is a 4XX/5XX status code',
+		'/errors/load-error-code-client',
+		async ({ page, js }) => {
+			if (js) {
+				assert.equal(await page.textContent('footer'), 'Custom layout');
+				assert.equal(
+					await page.textContent('#message'),
+					'This is your custom error page saying: "Internal Server Error"'
+				);
+				assert.equal(await page.innerHTML('h1'), '500', 'Should set status code');
+			}
+		}
+	);
+
+	test(
 		'server-side error from load() is an Error',
 		'/errors/load-error-server',
 		async ({ page, response }) => {

--- a/packages/kit/test/apps/basics/src/routes/errors/load-error-code-client.svelte
+++ b/packages/kit/test/apps/basics/src/routes/errors/load-error-code-client.svelte
@@ -1,0 +1,9 @@
+<script context="module">
+	export async function load() {
+		if (typeof window !== 'undefined') {
+			return { status: 500 };
+		}
+
+		return {};
+	}
+</script>

--- a/packages/kit/test/apps/basics/src/routes/errors/load-error-code-server.svelte
+++ b/packages/kit/test/apps/basics/src/routes/errors/load-error-code-server.svelte
@@ -1,0 +1,5 @@
+<script context="module">
+	export async function load() {
+		return { status: 500 };
+	}
+</script>


### PR DESCRIPTION
Failing test for #1161. When the `load()` function returns a 4XX/5XX status code, but no `error`, the response resolves with status `200`. The specified status code should be passed through instead.

As this relates to an instance where no error (apart from the status code) is provided, I have assumed that the error message should default to the standard http response string (e.g. specifying a `500` status code should result in an `error.message` of `Internal Server Error`.

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
