### PR TITLE
Fix $layout.svelte styles being imported in routes having $layout.reset.svelte

### DIFF
--- a/.changeset/chilly-cars-protect.md
+++ b/.changeset/chilly-cars-protect.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Changed manifest.js fallback from array to a function returning the array

--- a/packages/kit/src/core/create_app/index.js
+++ b/packages/kit/src/core/create_app/index.js
@@ -103,7 +103,7 @@ function generate_client_manifest(manifest_data, base) {
 
 		export const routes = ${routes};
 
-		export const fallback = [c[0](), c[1]()];
+		export const fallback = () => [c[0](), c[1]()];
 	`);
 }
 

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -51,7 +51,7 @@ function initial_fetch(resource, opts) {
 export class Renderer {
 	/** @param {{
 	 *   Root: CSRComponent;
-	 *   fallback: [CSRComponent, CSRComponent];
+	 *   fallback: () => [CSRComponent, CSRComponent];
 	 *   target: Node;
 	 *   session: any;
 	 *   host: string;
@@ -688,7 +688,7 @@ export class Renderer {
 		};
 
 		const node = await this._load_node({
-			module: await this.fallback[0],
+			module: (await this.fallback())[0],
 			page,
 			context: {}
 		});
@@ -698,7 +698,7 @@ export class Renderer {
 			await this._load_node({
 				status,
 				error,
-				module: await this.fallback[1],
+				module: (await this.fallback())[1],
 				page,
 				context: node && node.loaded && node.loaded.context
 			})


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts


This PR fixes https://github.com/sveltejs/kit/issues/1100 , More Details :
- The imported CSS inside `$layout.svelte` was applying in pages with `$layout.reset.svelte` as well.
- This was happening because of `manifest.js` file having an export `fallback = [c[0](), c[1]()]`. 
- Because of `c[0]()` the `$layout.svelte` was being executed at the start without it being required in a page or not.
- This PR fixes this by changing the code to `fallback = () => [c[0](), c[1]()]`. So, the code does not execute at the start.
