### PR TITLE
fix: Prettier not formatting .svelte files

### DIFF
--- a/.changeset/wicked-spies-invite.md
+++ b/.changeset/wicked-spies-invite.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+fix: Prettier not formatting .svelte files

--- a/packages/create-svelte/shared/+eslint+prettier/package.json
+++ b/packages/create-svelte/shared/+eslint+prettier/package.json
@@ -3,7 +3,7 @@
 		"eslint-config-prettier": "^8.1.0"
 	},
 	"scripts": {
-		"lint": "prettier --check . && eslint --ignore-path .gitignore .",
-		"format": "prettier --write ."
+		"lint": "prettier --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",
+		"format": "prettier --write --plugin-search-dir=. ."
 	}
 }

--- a/packages/create-svelte/shared/-eslint+prettier/package.json
+++ b/packages/create-svelte/shared/-eslint+prettier/package.json
@@ -1,6 +1,6 @@
 {
 	"scripts": {
-		"lint": "prettier --check .",
-		"format": "prettier --write ."
+		"lint": "prettier --check --plugin-search-dir=. .",
+		"format": "prettier --write --plugin-search-dir=. ."
 	}
 }


### PR DESCRIPTION
Adds `--plugin-search-dir=.` param to Prettier call in `package.json` scripts, so that Prettier will format `.svelte` files as well as `.ts`, `.js`, etc.

I assume Prettier is intended to be applied to `.svelte` files, since `prettier-plugin-svelte` is installed.

Fixes #1358.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
