### PR TITLE
prompt to npm install before prompting to npm init

### DIFF
--- a/.changeset/two-ties-begin.md
+++ b/.changeset/two-ties-begin.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Prompt to npm install before prompting to git init

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -136,9 +136,9 @@ async function main() {
 		console.log(`  ${i++}: ${bold(cyan(`cd ${relative}`))}`);
 	}
 
+	console.log(`  ${i++}: ${bold(cyan('npm install'))} (or pnpm install, etc)`);
 	// prettier-ignore
 	console.log(`  ${i++}: ${bold(cyan('git init && git add -A && git commit -m "Initial commit"'))} (optional step)`);
-	console.log(`  ${i++}: ${bold(cyan('npm install'))} (or pnpm install, etc)`);
 	console.log(`  ${i++}: ${bold(cyan('npm run dev -- --open'))}`);
 
 	console.log(`\nTo close the dev server, hit ${bold(cyan('Ctrl-C'))}`);


### PR DESCRIPTION
If you `npm install` first, then the package-lock.json file gets included in the initial commit, which seems preferable

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
