### PR TITLE
exclude deploy artifacts from create-svelte

### DIFF
--- a/.changeset/tame-kangaroos-rush.md
+++ b/.changeset/tame-kangaroos-rush.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Exclude deploy artifacts from create-svelte package

--- a/packages/create-svelte/templates/default/.ignore
+++ b/packages/create-svelte/templates/default/.ignore
@@ -2,3 +2,5 @@
 package.json
 netlify.toml
 wrangler.toml
+.cloudflare
+.netlify


### PR DESCRIPTION
not a huge deal since we release via an action, but when i built this package locally it included the contents of `.cloudflare`. No harm in guarding against that happening during a manual release

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
