### PR TITLE
Makes Node adapter respect HOST (#1365)

### DIFF
--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -2,9 +2,9 @@ import { createServer } from './server';
 /*eslint import/no-unresolved: [2, { ignore: ['\.\/app\.js$'] }]*/
 import * as app from './app.js';
 
-const { PORT = 3000 } = process.env; // TODO configure via svelte.config.js
+const { HOST='127.0.0.1', PORT = 3000 } = process.env; // TODO configure via svelte.config.js
 
-const instance = createServer({ render: app.render }).listen(PORT, (err) => {
+const instance = createServer({ render: app.render }).listen(PORT, HOST, (err) => {
 	if (err) {
 		console.log('error', err);
 	} else {


### PR DESCRIPTION
By default, the HOST variable is set to 127.0.0.1, for safety.

I lack the experience to set up a test runnable via `pnpm test`, but I've tested this as follows:
- I add in my PR.
- `npm run build`
- `HOST=192.168.1.64 npm start`
- Verify that I can reach my server only from its IPv4 address
- Back out my PR
- `npm run build`
- `HOST=192.168.1.64 npm start`
- Verify that I can reach my server from all of 1) localhost, 2) IPv4,  and 3) IPv6

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
