### PR TITLE
Codify parameter matching behaviour

### DIFF
--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -41,6 +41,8 @@ A file called either `src/routes/about.svelte` or `src/routes/about/index.svelte
 
 Dynamic parameters are encoded using `[brackets]`. For example, a blog post might be defined by `src/routes/blog/[slug].svelte`. Soon, we'll see how to access that parameter in a [load function](#loading) or the [page store](#modules-$app-stores).
 
+A file or directory can have multiple dynamic parts, like `[id]-[category].svelte`. (Paramters are 'non-greedy'; in an ambiguous case like `x-y-z`, `id` would be `x` and `category` would be `y-z`.)
+
 ### Endpoints
 
 Endpoints are modules written in `.js` (or `.ts`) files that export functions corresponding to HTTP methods. For example, our hypothetical blog page, `/blog/cool-article`, might request data from `/blog/cool-article.json`, which could be represented by a `src/routes/blog/[slug].json.js` endpoint:

--- a/packages/kit/test/apps/basics/src/routes/routing/__tests__.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/__tests__.js
@@ -190,4 +190,14 @@ export default function (test) {
 		await clicknav('[href="/routing/fallthrough/potato"]');
 		assert.equal(await page.textContent('h1'), '404');
 	});
+
+	test(
+		'last parameter in a segment wins in cases of ambiguity',
+		'/routing/split-params',
+		async ({ page, clicknav }) => {
+			await clicknav('[href="/routing/split-params/x-y-z"]');
+			assert.equal(await page.textContent('h1'), 'x');
+			assert.equal(await page.textContent('h2'), 'y-z');
+		}
+	);
 }

--- a/packages/kit/test/apps/basics/src/routes/routing/split-params/[a]-[b].svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/split-params/[a]-[b].svelte
@@ -1,0 +1,6 @@
+<script>
+	import { page } from '$app/stores';
+</script>
+
+<h1>{$page.params.a}</h1>
+<h2>{$page.params.b}</h2>

--- a/packages/kit/test/apps/basics/src/routes/routing/split-params/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/split-params/index.svelte
@@ -1,0 +1,1 @@
+<a href="/routing/split-params/x-y-z">/routing/split-params/x-y-z</a>


### PR DESCRIPTION
Resolves #1268 by adding docs and a test. It _doesn't_ change the behaviour — we could do that just by remove the `?` here... https://github.com/sveltejs/kit/blob/6979df096b70a9f5c931f88dbef9c046186eaff0/packages/kit/src/core/create_manifest_data/index.js#L335 ...but in the absence of a clear rationale for preferring greedy matches over non-greedy matches it seems prudent to opt for the one without the bad worst-case performance scenario (greedy matches frequently make backtracking necessary, which probably isn't an issue in our case but _could_ be, given a particularly long URL)

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
