### PR TITLE
generate etags for binary responses

### DIFF
--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -98,7 +98,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 		if (seen.has(path)) return;
 		seen.add(path);
 
-		/** @type {Map<string, import('types/endpoint').ServerResponse>} */
+		/** @type {Map<string, import('types/hooks').ServerResponse>} */
 		const dependencies = new Map();
 
 		const rendered = await app.render(
@@ -172,7 +172,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 			});
 
 			if (is_html && config.kit.prerender.crawl) {
-				const cleaned = clean_html(rendered.body);
+				const cleaned = clean_html(/** @type {string} */ (rendered.body));
 
 				let match;
 				const pattern = /<(a|img|link|source)\s+([\s\S]+?)>/gm;

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -296,16 +296,18 @@ class Watcher extends EventEmitter {
 
 					if (rendered) {
 						res.writeHead(rendered.status, rendered.headers);
-						res.end(rendered.body);
+						res.write(rendered.body);
 					} else {
 						res.statusCode = 404;
-						res.end('Not found');
+						res.write('Not found');
 					}
 				} catch (e) {
 					this.vite.ssrFixStacktrace(e);
 					res.statusCode = 500;
-					res.end(e.stack);
+					res.write(e.stack);
 				}
+
+				res.end();
 			});
 		});
 	}

--- a/packages/kit/src/core/start/index.js
+++ b/packages/kit/src/core/start/index.js
@@ -65,11 +65,13 @@ export async function start({ port, host, config, https: use_https = false, cwd 
 
 				if (rendered) {
 					res.writeHead(rendered.status, rendered.headers);
-					res.end(rendered.body);
+					res.write(rendered.body);
 				} else {
 					res.statusCode = 404;
-					res.end('Not found');
+					res.write('Not found');
 				}
+
+				res.end();
 			});
 		});
 	});

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -3,7 +3,7 @@ import { lowercase_keys } from './utils.js';
 /**
  * @param {import('types/endpoint').ServerRequest} request
  * @param {import('types/internal').SSREndpoint} route
- * @returns {Promise<import('types/endpoint').ServerResponse>}
+ * @returns {Promise<import('types/hooks').ServerResponse>}
  */
 export default async function render_route(request, route) {
 	const mod = await route.load();
@@ -21,8 +21,8 @@ export default async function render_route(request, route) {
 			if (typeof response !== 'object') {
 				return {
 					status: 500,
-					body: `Invalid response from route ${request.path};
-						 expected an object, got ${typeof response}`,
+					// prettier-ignore
+					body: `Invalid response from route ${request.path}: expected an object, got ${typeof response}`,
 					headers: {}
 				};
 			}
@@ -37,6 +37,15 @@ export default async function render_route(request, route) {
 			) {
 				headers = { ...headers, 'content-type': 'application/json' };
 				body = JSON.stringify(body);
+			}
+
+			if (typeof body !== 'string' && !(body instanceof Uint8Array)) {
+				return {
+					status: 500,
+					// prettier-ignore
+					body: `Invalid response from route ${request.path}: body must be a string or Uint8Array`,
+					headers: {}
+				};
 			}
 
 			return { status, body, headers };

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -8,6 +8,7 @@ import { lowercase_keys } from './utils.js';
  * @param {import('types/hooks').Incoming} incoming
  * @param {import('types/internal').SSRRenderOptions} options
  * @param {import('types/internal').SSRRenderState} [state]
+ * @returns {Promise<import('types/hooks').ServerResponse>}
  */
 export async function respond(incoming, options, state = {}) {
 	if (incoming.path.endsWith('/') && incoming.path !== '/') {
@@ -87,10 +88,16 @@ export async function respond(incoming, options, state = {}) {
 	}
 }
 
-/** @param {string} str */
-function hash(str) {
-	let hash = 5381,
-		i = str.length;
-	while (i) hash = (hash * 33) ^ str.charCodeAt(--i);
+/** @param {string | Uint8Array} value */
+function hash(value) {
+	let hash = 5381;
+	let i = value.length;
+
+	if (typeof value === 'string') {
+		while (i) hash = (hash * 33) ^ value.charCodeAt(--i);
+	} else {
+		while (i) hash = (hash * 33) ^ value[--i];
+	}
+
 	return (hash >>> 0).toString(36);
 }

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -6,7 +6,7 @@ import { respond_with_error } from './respond_with_error.js';
  * @param {import('types/internal').SSRPage} route
  * @param {import('types/internal').SSRRenderOptions} options
  * @param {import('types/internal').SSRRenderState} state
- * @returns {Promise<import('types/endpoint').ServerResponse>}
+ * @returns {Promise<import('types/hooks').ServerResponse>}
  */
 export default async function render_page(request, route, options, state) {
 	if (state.initiator === route) {

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -12,7 +12,7 @@ import { respond_with_error } from './respond_with_error.js';
  *   $session: any;
  *   route: import('types/internal').SSRPage;
  * }} opts
- * @returns {Promise<import('types/endpoint').ServerResponse>}
+ * @returns {Promise<import('types/hooks').ServerResponse>}
  */
 export async function respond({ request, options, state, $session, route }) {
 	const match = route.pattern.exec(request.path);

--- a/packages/kit/test/apps/basics/src/routes/etag/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/etag/_tests.js
@@ -1,0 +1,46 @@
+import * as assert from 'uvu/assert';
+
+/** @type {import('test').TestMaker} */
+export default function (test) {
+	test(
+		'generates etag/304 for text body',
+		null,
+		async ({ response, fetch }) => {
+			const r1 = await fetch('/etag/text');
+			const etag = r1.headers.get('etag');
+			assert.ok(!!etag);
+
+			const r2 = await fetch('/etag/text', {
+				headers: {
+					'if-none-match': etag
+				}
+			});
+
+			assert.equal(r2.status, 304);
+		},
+		{
+			js: false
+		}
+	);
+
+	test(
+		'generates etag/304 for binary body',
+		null,
+		async ({ fetch }) => {
+			const r1 = await fetch('/etag/binary');
+			const etag = r1.headers.get('etag');
+			assert.ok(!!etag);
+
+			const r2 = await fetch('/etag/binary', {
+				headers: {
+					'if-none-match': etag
+				}
+			});
+
+			assert.equal(r2.status, 304);
+		},
+		{
+			js: false
+		}
+	);
+}

--- a/packages/kit/test/apps/basics/src/routes/etag/binary.js
+++ b/packages/kit/test/apps/basics/src/routes/etag/binary.js
@@ -1,0 +1,9 @@
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export function get() {
+	return {
+		headers: {
+			'content-type': 'application/octet-stream'
+		},
+		body: new Uint8Array([1, 2, 3, 4, 5])
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/etag/text.js
+++ b/packages/kit/test/apps/basics/src/routes/etag/text.js
@@ -1,0 +1,6 @@
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export function get() {
+	return {
+		body: 'some text'
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/raw-body.json.js
+++ b/packages/kit/test/apps/basics/src/routes/load/raw-body.json.js
@@ -2,8 +2,8 @@
 export function post(request) {
 	return {
 		body: {
-			body: request.body,
-			rawBody: request.rawBody
+			body: /** @type {string} */ (request.body),
+			rawBody: /** @type {string} */ (request.rawBody)
 		}
 	};
 }

--- a/packages/kit/types/endpoint.d.ts
+++ b/packages/kit/types/endpoint.d.ts
@@ -12,12 +12,21 @@ export type ServerRequest<Locals = Record<string, any>, Body = unknown> = {
 	locals: Locals;
 };
 
-export type ServerResponse = {
+type JSONValue =
+	| string
+	| number
+	| boolean
+	| null
+	| Date
+	| JSONValue[]
+	| { [key: string]: JSONValue };
+
+export type EndpointOutput = {
 	status?: number;
 	headers?: Headers;
-	body?: any;
+	body?: string | Uint8Array | JSONValue;
 };
 
 export type RequestHandler<Locals = Record<string, any>, Body = unknown> = (
 	request: ServerRequest<Locals, Body>
-) => void | ServerResponse | Promise<ServerResponse>;
+) => void | EndpointOutput | Promise<EndpointOutput>;

--- a/packages/kit/types/helper.d.ts
+++ b/packages/kit/types/helper.d.ts
@@ -7,7 +7,7 @@ interface ReadOnlyFormData extends Iterator<[string, string]> {
 	values: () => Iterator<string>;
 }
 
-export type BaseBody = string | Buffer | ReadOnlyFormData;
+export type BaseBody = string | Uint8Array | ReadOnlyFormData;
 export type ParameterizedBody<Body = unknown> = Body extends FormData
 	? ReadOnlyFormData
 	: BaseBody & Body;

--- a/packages/kit/types/hooks.d.ts
+++ b/packages/kit/types/hooks.d.ts
@@ -1,5 +1,5 @@
 import { BaseBody, Headers } from './helper';
-import { ServerRequest, ServerResponse } from './endpoint';
+import { ServerRequest } from './endpoint';
 
 export type Incoming = {
 	method: string;
@@ -19,3 +19,9 @@ export type Handle<Locals = Record<string, any>> = (input: {
 	request: ServerRequest<Locals>;
 	render: (request: ServerRequest<Locals>) => ServerResponse | Promise<ServerResponse>;
 }) => ServerResponse | Promise<ServerResponse>;
+
+export type ServerResponse = {
+	status?: number;
+	headers?: Headers;
+	body?: string | Uint8Array;
+};

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -5,5 +5,5 @@ import './ambient-modules';
 
 export { Adapter, AdapterUtils, Config } from './config';
 export { ErrorLoad, Load, Page } from './page';
-export { Incoming, GetSession, Handle } from './hooks';
-export { ServerRequest as Request, ServerResponse as Response, RequestHandler } from './endpoint';
+export { Incoming, GetSession, Handle, ServerResponse } from './hooks';
+export { ServerRequest as Request, EndpointOutput, RequestHandler } from './endpoint';

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -1,6 +1,6 @@
 import { Load } from './page';
-import { Incoming, GetSession, Handle } from './hooks';
-import { RequestHandler, ServerResponse } from './endpoint';
+import { Incoming, GetSession, Handle, ServerResponse } from './hooks';
+import { RequestHandler } from './endpoint';
 
 type PageId = string;
 


### PR DESCRIPTION
#1136. seeing some test failures that I can't explain so I'm not going to merge this, instead I'm going to reimplement it more carefully. Just leaving this here for reference.

it involves a few changes:

* separating `ServerResponse` from the new `EndpointOutput` type (both types are public)
* `ServerResponse` body can be `string` or `Uint8Array` (the latter only/always when `content-type` is `application/octet-stream`)
* `EndpointOutput` body can also be a `JSONValue`
* `handle` response must be `ServerResponse` (i.e. `body` must be `string` or `Uint8Array` here, not `JSONValue`)
* `rawBody` can be `string` or `Uint8Array` (less sure about this bit)

Aside: brilliantly, in Node, when you call `res.end(uint8Array)` you get the following error:

> The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received an instance of Uint8Array

Slow clap. It turns out you _can_ do `res.write(uint8Array), res.end()` though.


### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
