### PR TITLE
account for POST bodies when serializing fetches

### DIFF
--- a/.changeset/young-apricots-dance.md
+++ b/.changeset/young-apricots-dance.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Account for POST bodies when serializing fetches

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -1,5 +1,6 @@
 import { writable } from 'svelte/store';
-import { normalize } from '../load';
+import { hash } from '../hash.js';
+import { normalize } from '../load.js';
 
 /** @param {any} value */
 function page_store(value) {
@@ -37,7 +38,14 @@ function page_store(value) {
  */
 function initial_fetch(resource, opts) {
 	const url = typeof resource === 'string' ? resource : resource.url;
-	const script = document.querySelector(`script[type="svelte-data"][url="${url}"]`);
+
+	let selector = `script[type="svelte-data"][url="${url}"]`;
+
+	if (opts && typeof opts.body === 'string') {
+		selector += `[body="${hash(opts.body)}"]`;
+	}
+
+	const script = document.querySelector(selector);
 	if (script) {
 		const { body, ...init } = JSON.parse(script.textContent);
 		return Promise.resolve(new Response(body, init));

--- a/packages/kit/src/runtime/hash.js
+++ b/packages/kit/src/runtime/hash.js
@@ -1,0 +1,13 @@
+/** @param {string | Uint8Array} value */
+export function hash(value) {
+	let hash = 5381;
+	let i = value.length;
+
+	if (typeof value === 'string') {
+		while (i) hash = (hash * 33) ^ value.charCodeAt(--i);
+	} else {
+		while (i) hash = (hash * 33) ^ value[--i];
+	}
+
+	return (hash >>> 0).toString(36);
+}

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -146,16 +146,21 @@ export async function load_node({
 							}
 						}
 
+						if (opts.body && typeof opts.body !== 'string') {
+							// per https://developer.mozilla.org/en-US/docs/Web/API/Request/Request, this can be a
+							// Blob, BufferSource, FormData, URLSearchParams, USVString, or ReadableStream object.
+							// non-string bodies are irksome to deal with, but luckily aren't particularly useful
+							// in this context anyway, so we take the easy route and ban them
+							throw new Error('Request body must be a string');
+						}
+
 						const rendered = await respond(
 							{
 								host: request.host,
 								method: opts.method || 'GET',
 								headers,
 								path: resolved,
-								// TODO per https://developer.mozilla.org/en-US/docs/Web/API/Request/Request, this can be a
-								// Blob, BufferSource, FormData, URLSearchParams, USVString, or ReadableStream object
-								// @ts-ignore
-								rawBody: opts.body,
+								rawBody: /** @type {string} */ (opts.body),
 								query: new URLSearchParams(search)
 							},
 							options,

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -42,6 +42,7 @@ export async function load_node({
 
 	/** @type {Array<{
 	 *   url: string;
+	 *   body: string;
 	 *   json: string;
 	 * }>} */
 	const fetched = [];
@@ -189,11 +190,14 @@ export async function load_node({
 									if (key !== 'etag' && key !== 'set-cookie') headers[key] = value;
 								}
 
-								// prettier-ignore
-								fetched.push({
-									url,
-									json: `{"status":${response.status},"statusText":${s(response.statusText)},"headers":${s(headers)},"body":${escape(body)}}`
-								});
+								if (!opts.body || typeof opts.body === 'string') {
+									// prettier-ignore
+									fetched.push({
+										url,
+										body: /** @type {string} */ (opts.body),
+										json: `{"status":${response.status},"statusText":${s(response.statusText)},"headers":${s(headers)},"body":${escape(body)}}`
+									});
+								}
 
 								return body;
 							}

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -1,5 +1,6 @@
 import devalue from 'devalue';
 import { writable } from 'svelte/store';
+import { hash } from '../../hash.js';
 
 const s = JSON.stringify;
 
@@ -29,7 +30,7 @@ export async function render_response({
 	const js = new Set(options.entry.js);
 	const styles = new Set();
 
-	/** @type {Array<{ url: string, json: string }>} */
+	/** @type {Array<{ url: string, body: string, json: string }>} */
 	const serialized_data = [];
 
 	let rendered;
@@ -156,7 +157,11 @@ export async function render_response({
 		: `${rendered.html}
 
 			${serialized_data
-				.map(({ url, json }) => `<script type="svelte-data" url="${url}">${json}</script>`)
+				.map(({ url, body, json }) => {
+					return body
+						? `<script type="svelte-data" url="${url}" body="${hash(body)}">${json}</script>`
+						: `<script type="svelte-data" url="${url}">${json}</script>`;
+				})
 				.join('\n\n\t\t\t')}
 		`.replace(/^\t{2}/gm, '');
 

--- a/packages/kit/src/runtime/server/page/types.d.ts
+++ b/packages/kit/src/runtime/server/page/types.d.ts
@@ -4,6 +4,6 @@ export type Loaded = {
 	node: SSRNode;
 	loaded: NormalizedLoadOutput;
 	context: Record<string, any>;
-	fetched: Array<{ url: string; json: string }>;
+	fetched: Array<{ url: string; body: string; json: string }>;
 	uses_credentials: boolean;
 };

--- a/packages/kit/test/apps/basics/src/routes/load/serialization-post.json.js
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization-post.json.js
@@ -1,0 +1,6 @@
+/** @type {import('@sveltejs/kit').RequestHandler<any, string>} */
+export function post(request) {
+	return {
+		body: request.body.toUpperCase()
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/serialization-post.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization-post.svelte
@@ -1,0 +1,34 @@
+<script context="module">
+	/** @type {import('@sveltejs/kit').Load} */
+	export async function load({ fetch }) {
+		/** @param {string} body */
+		async function post(body) {
+			const res = await fetch('/load/serialization-post.json', {
+				method: 'POST',
+				headers: {
+					'content-type': 'text/plain'
+				},
+				body
+			});
+
+			return await res.text();
+		}
+		const a = await post('x');
+		const b = await post('y');
+
+		return {
+			props: { a, b }
+		};
+	}
+</script>
+
+<script>
+	/** @type {string} */
+	export let a;
+
+	/** @type {string} */
+	export let b;
+</script>
+
+<h1>a: {a}</h1>
+<h2>b: {b}</h2>


### PR DESCRIPTION
fixes #633. Figured the pragmatic choice is to ignore requests with a non-string body (as in, they don't get serialized; those fetches are repeated in the client) since other kinds are unlikely in `load` (presumably the main situation where this is useful is with GraphQL, which uses a JSON payload) and it would be undesirable to buffer streams, etc. 

Handling other kinds of bodies is a TODO in any case: https://github.com/sveltejs/kit/blob/7679399ff965760bdf7f44a100087b597d753d9d/packages/kit/src/runtime/server/page/load_node.js#L148-L159

In fact, I think for now it might be best to throw an error if non-string bodies are sent in `fetch` in `load`. Better than silently failing. Though either way it should affect roughly zero people.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
