### PR TITLE
Add trailingSlash option

### DIFF
--- a/.changeset/quiet-cherries-smile.md
+++ b/.changeset/quiet-cherries-smile.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add trailingSlash: 'never' | 'always' | 'ignore' option

--- a/documentation/docs/13-configuration.md
+++ b/documentation/docs/13-configuration.md
@@ -42,6 +42,7 @@ const config = {
 		router: true,
 		ssr: true,
 		target: null,
+		trailingSlash: 'never',
 		vite: () => ({})
 	},
 
@@ -137,6 +138,16 @@ Enables or disables [server-side rendering](#ssr-and-javascript-ssr) app-wide.
 ### target
 
 Specifies an element to mount the app to. It must be a DOM selector that identifies an element that exists in your template file. If unspecified, the app will be mounted to `document.body`.
+
+### trailingSlash
+
+Whether to remove, append, or ignore trailing slashes when resolving URLs to routes.
+
+- `"never"` — redirect `/x/` to `/x`
+- `"always"` — redirect `/x` to `/x/`
+- `"ignore"` — don't automatically add or remove trailing slashes. `/x` and `/x/` will be treated equivalently
+
+> Ignoring trailing slashes is not recommended — the semantics of relative paths differ between the two cases (`./y` from `/x` is `/y`, but from `/x/` is `/x/y`), and `/x` and `/x/` are treated as separate URLs which is harmful to SEO. If you use this option, ensure that you implement logic for conditionally adding or removing trailing slashes from `request.path` inside your [`handle`](#hooks-handle) function.
 
 ### vite
 

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -317,7 +317,8 @@ async function build_server(
 					router: ${s(config.kit.router)},
 					ssr: ${s(config.kit.ssr)},
 					target: ${s(config.kit.target)},
-					template
+					template,
+					trailing_slash: ${s(config.kit.trailingSlash)}
 				};
 			}
 

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -290,7 +290,8 @@ class Watcher extends EventEmitter {
 								}
 
 								return rendered;
-							}
+							},
+							trailing_slash: this.config.kit.trailingSlash
 						}
 					);
 

--- a/packages/kit/src/core/load_config/index.spec.js
+++ b/packages/kit/src/core/load_config/index.spec.js
@@ -39,7 +39,8 @@ test('fills in defaults', () => {
 			},
 			router: true,
 			ssr: true,
-			target: null
+			target: null,
+			trailingSlash: 'never'
 		},
 		preprocess: null
 	});
@@ -122,7 +123,8 @@ test('fills in partial blanks', () => {
 			},
 			router: true,
 			ssr: true,
-			target: null
+			target: null,
+			trailingSlash: 'never'
 		},
 		preprocess: null
 	});

--- a/packages/kit/src/core/load_config/options.js
+++ b/packages/kit/src/core/load_config/options.js
@@ -122,6 +122,8 @@ const options = {
 
 			target: expect_string(null),
 
+			trailingSlash: expect_enum(['never', 'always', 'ignore']),
+
 			vite: {
 				type: 'leaf',
 				default: () => ({}),
@@ -180,6 +182,28 @@ function expect_boolean(boolean) {
 		validate: (option, keypath) => {
 			if (typeof option !== 'boolean') {
 				throw new Error(`${keypath} should be true or false, if specified`);
+			}
+			return option;
+		}
+	};
+}
+
+/**
+ * @param {string[]} options
+ * @returns {ConfigDefinition}
+ */
+function expect_enum(options, def = options[0]) {
+	return {
+		type: 'leaf',
+		default: def,
+		validate: (option, keypath) => {
+			if (!options.includes(option)) {
+				// prettier-ignore
+				const msg = options.length > 2
+					? `${keypath} should be one of ${options.slice(0, -1).map(option => `"${option}"`).join(', ')} or "${options[options.length - 1]}"`
+					: `${keypath} should be either "${options[0]}" or "${options[1]}"`;
+
+				throw new Error(msg);
 			}
 			return option;
 		}

--- a/packages/kit/src/core/load_config/test/index.js
+++ b/packages/kit/src/core/load_config/test/index.js
@@ -41,7 +41,8 @@ async function testLoadDefaultConfig(path) {
 			prerender: { crawl: true, enabled: true, force: false, pages: ['*'] },
 			router: true,
 			ssr: true,
-			target: null
+			target: null,
+			trailingSlash: 'never'
 		},
 		preprocess: null
 	});

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -17,6 +17,7 @@ import { set_paths } from '../paths.js';
  *   host: string;
  *   route: boolean;
  *   spa: boolean;
+ *   trailing_slash: import('types/internal').TrailingSlash;
  *   hydrate: {
  *     status: number;
  *     error: Error;
@@ -24,7 +25,7 @@ import { set_paths } from '../paths.js';
  *     page: import('types/page').Page;
  *   };
  * }} opts */
-export async function start({ paths, target, session, host, route, spa, hydrate }) {
+export async function start({ paths, target, session, host, route, spa, trailing_slash, hydrate }) {
 	if (import.meta.env.DEV && !target) {
 		throw new Error('Missing target element. See https://kit.svelte.dev/docs#configuration-target');
 	}
@@ -33,7 +34,8 @@ export async function start({ paths, target, session, host, route, spa, hydrate 
 		route &&
 		new Router({
 			base: paths.base,
-			routes
+			routes,
+			trailing_slash
 		});
 
 	const renderer = new Renderer({

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -11,15 +11,25 @@ import { hash } from '../hash.js';
  * @param {import('types/internal').SSRRenderState} [state]
  */
 export async function respond(incoming, options, state = {}) {
-	if (incoming.path.endsWith('/') && incoming.path !== '/') {
-		const q = incoming.query.toString();
+	if (incoming.path !== '/' && options.trailing_slash !== 'ignore') {
+		const has_trailing_slash = incoming.path.endsWith('/');
 
-		return {
-			status: 301,
-			headers: {
-				location: encodeURI(incoming.path.slice(0, -1) + (q ? `?${q}` : ''))
-			}
-		};
+		if (
+			(has_trailing_slash && options.trailing_slash === 'never') ||
+			(!has_trailing_slash &&
+				options.trailing_slash === 'always' &&
+				!incoming.path.split('/').pop().includes('.'))
+		) {
+			const path = has_trailing_slash ? incoming.path.slice(0, -1) : incoming.path + '/';
+			const q = incoming.query.toString();
+
+			return {
+				status: 301,
+				headers: {
+					location: encodeURI(path + (q ? `?${q}` : ''))
+				}
+			};
+		}
 	}
 
 	try {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -124,6 +124,7 @@ export async function render_response({
 				host: ${page && page.host ? s(page.host) : 'location.host'},
 				route: ${!!page_config.router},
 				spa: ${!page_config.ssr},
+				trailing_slash: ${s(options.trailing_slash)},
 				hydrate: ${page_config.ssr && page_config.hydrate? `{
 					status: ${status},
 					error: ${serialize_error(error)},

--- a/packages/kit/test/apps/options/source/pages/headers/_tests.js
+++ b/packages/kit/test/apps/options/source/pages/headers/_tests.js
@@ -2,7 +2,7 @@ import * as assert from 'uvu/assert';
 
 /** @type {import('test').TestMaker} */
 export default function (test) {
-	test('enables floc', '/headers', async ({ response }) => {
+	test('enables floc', '/headers/', async ({ response }) => {
 		const headers = response.headers();
 		assert.equal(headers['permissions-policy'], undefined);
 	});

--- a/packages/kit/test/apps/options/source/pages/host/_tests.js
+++ b/packages/kit/test/apps/options/source/pages/host/_tests.js
@@ -2,7 +2,7 @@ import * as assert from 'uvu/assert';
 
 /** @type {import('test').TestMaker} */
 export default function (test) {
-	test('sets host', '/host', async ({ page }) => {
+	test('sets host', '/host/', async ({ page }) => {
 		assert.equal(await page.textContent('[data-source="load"]'), 'example.com');
 		assert.equal(await page.textContent('[data-source="store"]'), 'example.com');
 		assert.equal(await page.textContent('[data-source="endpoint"]'), 'example.com');

--- a/packages/kit/test/apps/options/source/pages/slash/_tests.js
+++ b/packages/kit/test/apps/options/source/pages/slash/_tests.js
@@ -1,0 +1,9 @@
+import * as assert from 'uvu/assert';
+
+/** @type {import('test').TestMaker} */
+export default function (test) {
+	test('adds trailing slash', '/slash', async ({ base, page }) => {
+		assert.equal(page.url(), `${base}/slash/`);
+		assert.equal(await page.textContent('h2'), '/slash/');
+	});
+}

--- a/packages/kit/test/apps/options/source/pages/slash/_tests.js
+++ b/packages/kit/test/apps/options/source/pages/slash/_tests.js
@@ -2,8 +2,12 @@ import * as assert from 'uvu/assert';
 
 /** @type {import('test').TestMaker} */
 export default function (test) {
-	test('adds trailing slash', '/slash', async ({ base, page }) => {
+	test('adds trailing slash', '/slash', async ({ base, page, clicknav }) => {
 		assert.equal(page.url(), `${base}/slash/`);
 		assert.equal(await page.textContent('h2'), '/slash/');
+
+		await clicknav('[href="/slash/child"]');
+		assert.equal(page.url(), `${base}/slash/child/`);
+		assert.equal(await page.textContent('h2'), '/slash/child/');
 	});
 }

--- a/packages/kit/test/apps/options/source/pages/slash/child.svelte
+++ b/packages/kit/test/apps/options/source/pages/slash/child.svelte
@@ -3,5 +3,3 @@
 </script>
 
 <h2>{$page.path}</h2>
-
-<a href="/slash/child">/slash/child</a>

--- a/packages/kit/test/apps/options/source/pages/slash/index.svelte
+++ b/packages/kit/test/apps/options/source/pages/slash/index.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { page } from '$app/stores';
+</script>
+
+<h2>{$page.path}</h2>

--- a/packages/kit/test/apps/options/svelte.config.js
+++ b/packages/kit/test/apps/options/svelte.config.js
@@ -11,6 +11,7 @@ const config = {
 		floc: true,
 		target: '#content-goes-here',
 		host: 'example.com',
+		trailingSlash: 'always',
 		vite: {
 			build: {
 				minify: false

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -1,4 +1,4 @@
-import { Logger } from './internal';
+import { Logger, TrailingSlash } from './internal';
 import { UserConfig as ViteConfig } from 'vite';
 
 export type AdapterUtils = {
@@ -57,6 +57,7 @@ export type Config = {
 		router?: boolean;
 		ssr?: boolean;
 		target?: string;
+		trailingSlash?: TrailingSlash;
 		vite?: ViteConfig | (() => ViteConfig);
 	};
 	preprocess?: any;
@@ -95,6 +96,7 @@ export type ValidatedConfig = {
 		router: boolean;
 		ssr: boolean;
 		target: string;
+		trailingSlash: TrailingSlash;
 		vite: () => ViteConfig;
 	};
 	preprocess: any;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -143,6 +143,7 @@ export type SSRRenderOptions = {
 	ssr: boolean;
 	target: string;
 	template: ({ head, body }: { head: string; body: string }) => string;
+	trailing_slash: TrailingSlash;
 };
 
 export type SSRRenderState = {
@@ -204,3 +205,5 @@ export type NormalizedLoadOutput = {
 	context?: Record<string, any>;
 	maxage?: number;
 };
+
+export type TrailingSlash = 'never' | 'always' | 'ignore';


### PR DESCRIPTION
Closes #733 (though I'll open a new issue for the `"smart"` option).

This adds `trailingSlash: 'never' | 'always' | 'ignore'`, which keeps the existing default behaviour but also makes it easy to build sites that work with static hosting providers that expect a trailing slash for `index.html` pages, and provides an escape hatch for anyone that needs more complex behaviour.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
