### PR TITLE
add serverUrl to fetch options

### DIFF
--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -34,10 +34,15 @@ function page_store(value) {
 
 /**
  * @param {RequestInfo} resource
- * @param {RequestInit} opts
+ * @param {RequestInit & {serverUrl: string}} opts
  */
 function initial_fetch(resource, opts) {
-	const url = typeof resource === 'string' ? resource : resource.url;
+	let url = resource;
+	if (opts && opts.serverUrl) {
+		url = opts.serverUrl;
+	} else if (typeof resource !== 'string') {
+		url = resource.url;
+	}
 
 	let selector = `script[type="svelte-data"][url="${url}"]`;
 

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-server-url-server.json.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-server-url-server.json.js
@@ -1,0 +1,7 @@
+export function get() {
+	return {
+		body: {
+			answer: 42
+		}
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-server-url.json.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-server-url.json.js
@@ -1,0 +1,7 @@
+export function get() {
+	return {
+		body: {
+			answer: 42
+		}
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-server-url.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-server-url.svelte
@@ -1,0 +1,23 @@
+<script context="module">
+	import { browser } from '$app/env';
+
+	/** @type {import('@sveltejs/kit').Load} */
+	export async function load({ fetch }) {
+		const res = await fetch(
+			browser ? '/load/fetch-server-url.json' : '/load/fetch-server-url-server.json',
+			{
+				serverUrl: '/load/fetch-server-url-server.json'
+			}
+		);
+		return {
+			props: await res.json()
+		};
+	}
+</script>
+
+<script>
+	/** @type {number} */
+	export let answer;
+</script>
+
+<h1>{answer}</h1>

--- a/packages/kit/test/apps/basics/src/routes/load/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/index.svelte
@@ -22,5 +22,6 @@
 
 <a href="/load/fetch-request">fetch request</a>
 <a href="/load/fetch-credentialed">fetch credentialed</a>
+<a href="/load/fetch-server-url">fetch server url</a>
 <a href="/load/large-response">large response</a>
 <a href="/load/raw-body">raw body</a>


### PR DESCRIPTION
Hello, a very long time of people including me asked about support different URLs for the backend and frontend for the same data.  
It's very common if server-side code should communicate with the internal backend directly by the internal path. 
Hopefully, it's now possible with SvelteKit but in the current implementation, it produces double load on the frontend side.
This PR adds the `serverUrl` property to `fetch` options, it helps SvelteKit find a resource on the browser and avoid double load. 
Maybe, we can add this as the third argument for the `fetch` method but I suppose is too radical. 
Thanks. 