### PR TITLE
Use a consistent version of node-fetch

### DIFF
--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -25,7 +25,7 @@
 		"@sveltejs/kit": "workspace:*",
 		"c8": "^7.7.2",
 		"compression": "^1.7.4",
-		"node-fetch": "^2.6.1",
+		"node-fetch": "^3.0.0-beta.9",
 		"polka": "^1.0.0-next.14",
 		"rollup": "^2.47.0",
 		"sirv": "^1.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,7 +95,7 @@ importers:
       '@sveltejs/kit': workspace:*
       c8: ^7.7.2
       compression: ^1.7.4
-      node-fetch: ^2.6.1
+      node-fetch: ^3.0.0-beta.9
       polka: ^1.0.0-next.14
       rollup: ^2.47.0
       sirv: ^1.0.11
@@ -106,7 +106,7 @@ importers:
       '@sveltejs/kit': link:../kit
       c8: 7.7.2
       compression: 1.7.4
-      node-fetch: 2.6.1
+      node-fetch: 3.0.0-beta.9
       polka: 1.0.0-next.14
       rollup: 2.47.0
       sirv: 1.0.11
@@ -2532,11 +2532,6 @@ packages:
   /negotiator/0.6.2:
     resolution: {integrity: sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==}
     engines: {node: '>= 0.6'}
-    dev: true
-
-  /node-fetch/2.6.1:
-    resolution: {integrity: sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==}
-    engines: {node: 4.x || >=6.0.0}
     dev: true
 
   /node-fetch/3.0.0-beta.9:


### PR DESCRIPTION
I noticed that `adapter-node` was using a different version of `node-fetch` than `kit` is and figured it probably makes sense for them to use a consistent version