### PR TITLE
fix: temporarily pin vite to 2.2.4

### DIFF
--- a/.changeset/curly-ravens-do.md
+++ b/.changeset/curly-ravens-do.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+temporarily pin vite to version 2.2.4 until issues with 2.3.0 are resolved

--- a/packages/create-svelte/templates/default/package.json
+++ b/packages/create-svelte/templates/default/package.json
@@ -14,7 +14,7 @@
 		"svelte": "^3.38.2",
 		"svelte-preprocess": "^4.7.3",
 		"typescript": "^4.2.4",
-		"vite": "^2.3.0"
+		"vite": "2.2.4"
 	},
 	"type": "module",
 	"dependencies": {

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -6,7 +6,7 @@
 		"@sveltejs/vite-plugin-svelte": "^1.0.0-next.10",
 		"cheap-watch": "^1.0.3",
 		"sade": "^1.7.4",
-		"vite": "^2.3.0"
+		"vite": "2.2.4"
 	},
 	"devDependencies": {
 		"@rollup/plugin-replace": "^2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,7 +181,7 @@ importers:
       svelte: ^3.38.2
       svelte-preprocess: ^4.7.3
       typescript: ^4.2.4
-      vite: ^2.3.0
+      vite: 2.2.4
     dependencies:
       '@fontsource/fira-mono': 4.2.2
       '@lukeed/uuid': 2.0.0
@@ -194,7 +194,7 @@ importers:
       svelte: 3.38.2
       svelte-preprocess: 4.7.3_svelte@3.38.2+typescript@4.2.4
       typescript: 4.2.4
-      vite: 2.3.0
+      vite: 2.2.4
 
   packages/kit:
     specifiers:
@@ -227,12 +227,12 @@ importers:
       tiny-glob: ^0.2.8
       typescript: ^4.2.4
       uvu: ^0.5.1
-      vite: ^2.3.0
+      vite: 2.2.4
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 1.0.0-next.10_efcdfa8c171e6a2446d3b40a697264be
+      '@sveltejs/vite-plugin-svelte': 1.0.0-next.10_e199ea43849c994a9b29d0b980598eb5
       cheap-watch: 1.0.3
       sade: 1.7.4
-      vite: 2.3.0
+      vite: 2.2.4
     devDependencies:
       '@rollup/plugin-replace': 2.4.2_rollup@2.47.0
       '@sveltejs/kit': 'link:'
@@ -631,7 +631,7 @@ packages:
       rollup: 2.47.0
     dev: false
 
-  /@sveltejs/vite-plugin-svelte/1.0.0-next.10_efcdfa8c171e6a2446d3b40a697264be:
+  /@sveltejs/vite-plugin-svelte/1.0.0-next.10_e199ea43849c994a9b29d0b980598eb5:
     resolution: {integrity: sha512-ImvxbhPePm2hWNTKBSA3LHAYGwiEjHjvvgfPLXm4R87sfZ+BMXql9jBmDpzUC/URBLT4BB3Jxos/i523qkJBHg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -647,7 +647,7 @@ packages:
       source-map: 0.7.3
       svelte: 3.38.2
       svelte-hmr: 0.14.3_svelte@3.38.2
-      vite: 2.3.0
+      vite: 2.2.4
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -1520,8 +1520,8 @@ packages:
     requiresBuild: true
     dev: false
 
-  /esbuild/0.11.20:
-    resolution: {integrity: sha512-QOZrVpN/Yz74xfat0H6euSgn3RnwLevY1mJTEXneukz1ln9qB+ieaerRMzSeETpz/UJWsBMzRVR/andBht5WKw==}
+  /esbuild/0.9.7:
+    resolution: {integrity: sha512-VtUf6aQ89VTmMLKrWHYG50uByMF4JQlVysb8dmg6cOgW8JnFCipmz7p+HNBl+RR3LLCuBxFGVauAe2wfnF9bLg==}
     hasBin: true
     requiresBuild: true
 
@@ -3725,12 +3725,12 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /vite/2.3.0:
-    resolution: {integrity: sha512-gsCy0t3X9nGGYDoNiE2NJgYq6BPxrtKeo6FkpMXdMvtUluYxnRhl7xfpHaYDmQLCnMbYTWhvWS1L/Hpw/V9L5w==}
+  /vite/2.2.4:
+    resolution: {integrity: sha512-vnIwSNci+phFMp6krhy+FbYzKL0R67Sdt9mVZ96S27AewrApSJjTqncJcalk8sf60BgcbW4+1C6DFIWkxquO9g==}
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
-      esbuild: 0.11.20
+      esbuild: 0.9.7
       postcss: 8.2.14
       resolve: 1.20.0
       rollup: 2.47.0


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts



In case vite 2.3 doesn't get fixed soon
