### PR TITLE
docs: sync up types

### DIFF
--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -48,27 +48,27 @@ A file or directory can have multiple dynamic parts, like `[id]-[category].svelt
 Endpoints are modules written in `.js` (or `.ts`) files that export functions corresponding to HTTP methods. For example, our hypothetical blog page, `/blog/cool-article`, might request data from `/blog/cool-article.json`, which could be represented by a `src/routes/blog/[slug].json.js` endpoint:
 
 ```ts
-type Request<Context = any> = {
-	host: string;
+type Request<Locals = Record<string, any>> = {
 	method: 'GET';
-	headers: Record<string, string>;
+	host: string;
+	headers: Headers;
 	path: string;
-	params: Record<string, string | string[]>;
+	params: Record<string, string>;
 	query: URLSearchParams;
 	rawBody: string | Uint8Array;
 	body: string | Uint8Array | JSONValue;
-	locals: Record<string, any>; // see below
+	locals: Locals; // see hooks handle
 };
 
-type Response = {
+type EndpointOutput = {
 	status?: number;
-	headers?: Record<string, string>;
-	body?: any;
+	headers?: Headers;
+	body?: string | Uint8Array | JSONValue;
 };
 
-type RequestHandler<Context = any> = {
-	(request: Request<Context>) => Response | Promise<Response>;
-}
+type RequestHandler<Locals = Record<string, any>> = (
+	request: Request<Context>
+) => void | EndpointOutput | Promise<EndpointOutput>;
 ```
 
 ```js

--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -48,16 +48,18 @@ A file or directory can have multiple dynamic parts, like `[id]-[category].svelt
 Endpoints are modules written in `.js` (or `.ts`) files that export functions corresponding to HTTP methods. For example, our hypothetical blog page, `/blog/cool-article`, might request data from `/blog/cool-article.json`, which could be represented by a `src/routes/blog/[slug].json.js` endpoint:
 
 ```ts
-type Request<Locals = Record<string, any>> = {
-	method: 'GET';
+type Headers = Record<string, string>;
+
+type Request<Locals = Record<string, any>, Body = unknown> = {
+	method: string;
 	host: string;
 	headers: Headers;
 	path: string;
 	params: Record<string, string>;
 	query: URLSearchParams;
 	rawBody: string | Uint8Array;
-	body: string | Uint8Array | JSONValue;
-	locals: Locals; // see hooks handle
+	body: ParameterizedBody<Body>;
+	locals: Locals; // populated by hooks handle
 };
 
 type EndpointOutput = {
@@ -67,7 +69,7 @@ type EndpointOutput = {
 };
 
 type RequestHandler<Locals = Record<string, any>> = (
-	request: Request<Context>
+	request: Request<Locals>
 ) => void | EndpointOutput | Promise<EndpointOutput>;
 ```
 

--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -11,7 +11,7 @@ type LoadInput = {
 	page: {
 		host: string;
 		path: string;
-		params: Record<string, string | string[]>;
+		params: Record<string, string>;
 		query: URLSearchParams;
 	};
 	fetch: (info: RequestInfo, init?: RequestInit) => Promise<Response>;
@@ -21,7 +21,7 @@ type LoadInput = {
 
 type LoadOutput = {
 	status?: number;
-	error?: Error;
+	error?: string | Error;
 	redirect?: string;
 	props?: Record<string, any>;
 	context?: Record<string, any>;

--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -15,6 +15,8 @@ If unimplemented, defaults to `({ request, render }) => render(request)`.
 To add custom data to the request, which is passed to endpoints, populate the `request.locals` object, as shown below.
 
 ```ts
+type Headers = Record<string, string>;
+
 type Request<Locals = Record<string, any>> = {
 	method: string;
 	host: string;
@@ -23,8 +25,8 @@ type Request<Locals = Record<string, any>> = {
 	params: Record<string, string>;
 	query: URLSearchParams;
 	rawBody: string | Uint8Array;
-	body: string | Uint8Array | JSONValue;
-	locals: Locals; // see hooks handle
+	body: ParameterizedBody<Body>;
+	locals: Locals; // populated by hooks handle
 };
 
 type Response = {

--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -23,19 +23,19 @@ type Request<Locals = Record<string, any>> = {
 	params: Record<string, string>;
 	query: URLSearchParams;
 	rawBody: string | Uint8Array;
-	body: string | Uint8Array | ReadOnlyFormData | JSONValue;
-	locals: Locals;
+	body: string | Uint8Array | JSONValue;
+	locals: Locals; // see hooks handle
 };
 
 type Response = {
-	status?: number;
-	headers?: Headers;
-	body?: any;
+	status: number;
+	headers: Headers;
+	body?: string | Uint8Array;
 };
 
-type Handle<Locals = Record<string, any>> = ({
-	request: Request<Locals>,
-	render: (request: Request<Locals>) => Promise<Response>
+type Handle<Locals = Record<string, any>> = (input: {
+	request: Request<Locals>;
+	render: (request: Request<Locals>) => Response | Promise<Response>;
 }) => Response | Promise<Response>;
 ```
 


### PR DESCRIPTION
Some might still be missed or not as intended, especially `body` types.

Also, is `type Request` intended to be identical? seems the same to me, perhaps we could just put it in either `routing` or `hooks` to remove duplication and additional maintenance.