### PR TITLE
Fix workspace dependencies

### DIFF
--- a/.changeset/mean-bananas-live.md
+++ b/.changeset/mean-bananas-live.md
@@ -1,0 +1,13 @@
+---
+'hn.svelte.dev': patch
+'@sveltejs/adapter-begin': patch
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-static': patch
+'@sveltejs/adapter-vercel': patch
+'create-svelte': patch
+'@sveltejs/kit': patch
+---
+
+Fix workspace dependencies

--- a/examples/hn.svelte.dev/package.json
+++ b/examples/hn.svelte.dev/package.json
@@ -9,8 +9,8 @@
 		"preview": "svelte-kit preview"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-netlify": "workspace:*",
-		"@sveltejs/kit": "workspace:*",
+		"@sveltejs/adapter-netlify": "workspace:^",
+		"@sveltejs/kit": "workspace:^",
 		"svelte": "^3.38.2"
 	}
 }

--- a/packages/adapter-begin/package.json
+++ b/packages/adapter-begin/package.json
@@ -19,7 +19,7 @@
 		"@architect/parser": "^3.0.1"
 	},
 	"devDependencies": {
-		"@sveltejs/kit": "workspace:*",
+		"@sveltejs/kit": "workspace:^",
 		"rollup": "^2.47.0",
 		"sirv": "^1.0.11",
 		"typescript": "^4.2.4"

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -21,6 +21,6 @@
 		"toml": "^3.0.0"
 	},
 	"devDependencies": {
-		"@sveltejs/kit": "workspace:*"
+		"@sveltejs/kit": "workspace:^"
 	}
 }

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -17,7 +17,7 @@
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore"
 	},
 	"dependencies": {
-		"@sveltejs/kit": "workspace:*",
+		"@sveltejs/kit": "workspace:^",
 		"esbuild": "^0.11.18",
 		"toml": "^3.0.0"
 	},

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {
 		"@rollup/plugin-json": "^4.1.0",
-		"@sveltejs/kit": "workspace:*",
+		"@sveltejs/kit": "workspace:^",
 		"c8": "^7.7.2",
 		"compression": "^1.7.4",
 		"node-fetch": "^3.0.0-beta.9",

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -15,7 +15,7 @@
 		"test": "uvu test test.js"
 	},
 	"devDependencies": {
-		"@sveltejs/kit": "workspace:*",
+		"@sveltejs/kit": "workspace:^",
 		"playwright-chromium": "^1.10.0",
 		"port-authority": "^1.1.2",
 		"sirv": "^1.0.11",

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -17,7 +17,7 @@
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore"
 	},
 	"dependencies": {
-		"@sveltejs/kit": "workspace:*",
+		"@sveltejs/kit": "workspace:^",
 		"esbuild": "^0.11.18"
 	},
 	"devDependencies": {

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -7,7 +7,7 @@
 		"prompts": "^2.4.1"
 	},
 	"devDependencies": {
-		"@sveltejs/kit": "workspace:*",
+		"@sveltejs/kit": "workspace:^",
 		"@types/gitignore-parser": "^0.0.0",
 		"@types/prettier": "^2.2.3",
 		"@types/prompts": "^2.0.11",

--- a/packages/create-svelte/scripts/build-templates.js
+++ b/packages/create-svelte/scripts/build-templates.js
@@ -46,7 +46,7 @@ async function generate_templates(shared) {
 
 				if (name === 'package.template.json') {
 					// TODO package-specific versions
-					contents = contents.replace(/workspace:\*/g, 'next');
+					contents = contents.replace(/workspace:\^/g, 'next');
 					fs.writeFileSync(`${dir}/package.json`, contents);
 				} else {
 					ts.push({

--- a/packages/create-svelte/templates/default/package.template.json
+++ b/packages/create-svelte/templates/default/package.template.json
@@ -7,7 +7,7 @@
 		"preview": "svelte-kit preview"
 	},
 	"devDependencies": {
-		"@sveltejs/kit": "workspace:*",
+		"@sveltejs/kit": "workspace:^",
 		"svelte": "^3.34.0"
 	},
 	"type": "module",

--- a/packages/create-svelte/templates/skeleton/package.template.json
+++ b/packages/create-svelte/templates/skeleton/package.template.json
@@ -7,7 +7,7 @@
 		"preview": "svelte-kit preview"
 	},
 	"devDependencies": {
-		"@sveltejs/kit": "workspace:*",
+		"@sveltejs/kit": "workspace:^",
 		"svelte": "^3.34.0"
 	},
 	"type": "module"

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -10,7 +10,7 @@
 	},
 	"devDependencies": {
 		"@rollup/plugin-replace": "^2.4.2",
-		"@sveltejs/kit": "workspace:*",
+		"@sveltejs/kit": "workspace:^",
 		"@types/amphtml-validator": "^1.0.1",
 		"@types/cookie": "^0.4.0",
 		"@types/marked": "^2.0.2",

--- a/packages/kit/test/apps/basics/package.json
+++ b/packages/kit/test/apps/basics/package.json
@@ -8,8 +8,8 @@
 		"preview": "svelte-kit preview"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-node": "workspace:*",
-		"@sveltejs/kit": "workspace:*",
+		"@sveltejs/adapter-node": "workspace:^",
+		"@sveltejs/kit": "workspace:^",
 		"svelte": "^3.29.0"
 	},
 	"type": "module"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
 
   examples/hn.svelte.dev:
     specifiers:
-      '@sveltejs/adapter-netlify': workspace:*
-      '@sveltejs/kit': workspace:*
+      '@sveltejs/adapter-netlify': workspace:^
+      '@sveltejs/kit': workspace:^
       svelte: ^3.38.2
     devDependencies:
       '@sveltejs/adapter-netlify': link:../../packages/adapter-netlify
@@ -53,7 +53,7 @@ importers:
   packages/adapter-begin:
     specifiers:
       '@architect/parser': ^3.0.1
-      '@sveltejs/kit': workspace:*
+      '@sveltejs/kit': workspace:^
       rollup: ^2.47.0
       sirv: ^1.0.11
       typescript: ^4.2.4
@@ -67,7 +67,7 @@ importers:
 
   packages/adapter-cloudflare-workers:
     specifiers:
-      '@sveltejs/kit': workspace:*
+      '@sveltejs/kit': workspace:^
       esbuild: ^0.11.18
       toml: ^3.0.0
     dependencies:
@@ -78,7 +78,7 @@ importers:
 
   packages/adapter-netlify:
     specifiers:
-      '@sveltejs/kit': workspace:*
+      '@sveltejs/kit': workspace:^
       esbuild: ^0.11.18
       toml: ^3.0.0
       typescript: ^4.2.4
@@ -92,7 +92,7 @@ importers:
   packages/adapter-node:
     specifiers:
       '@rollup/plugin-json': ^4.1.0
-      '@sveltejs/kit': workspace:*
+      '@sveltejs/kit': workspace:^
       c8: ^7.7.2
       compression: ^1.7.4
       node-fetch: ^3.0.0-beta.9
@@ -115,7 +115,7 @@ importers:
 
   packages/adapter-static:
     specifiers:
-      '@sveltejs/kit': workspace:*
+      '@sveltejs/kit': workspace:^
       playwright-chromium: ^1.10.0
       port-authority: ^1.1.2
       sirv: ^1.0.11
@@ -129,7 +129,7 @@ importers:
 
   packages/adapter-vercel:
     specifiers:
-      '@sveltejs/kit': workspace:*
+      '@sveltejs/kit': workspace:^
       esbuild: ^0.11.18
       typescript: ^4.2.4
     dependencies:
@@ -140,7 +140,7 @@ importers:
 
   packages/create-svelte:
     specifiers:
-      '@sveltejs/kit': workspace:*
+      '@sveltejs/kit': workspace:^
       '@types/gitignore-parser': ^0.0.0
       '@types/prettier': ^2.2.3
       '@types/prompts': ^2.0.11
@@ -199,7 +199,7 @@ importers:
   packages/kit:
     specifiers:
       '@rollup/plugin-replace': ^2.4.2
-      '@sveltejs/kit': workspace:*
+      '@sveltejs/kit': workspace:^
       '@sveltejs/vite-plugin-svelte': ^1.0.0-next.10
       '@types/amphtml-validator': ^1.0.1
       '@types/cookie': ^0.4.0


### PR DESCRIPTION
Fixes #1422

`workspace:*` dependencies were replaced by `workspace:^` dependencies.
pnpm documentation: https://pnpm.io/workspaces#publishing-workspace-packages

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
