### PR TITLE
chore: rm function dir in template ignore files

### DIFF
--- a/packages/create-svelte/templates/default/.gitignore
+++ b/packages/create-svelte/templates/default/.gitignore
@@ -2,4 +2,3 @@
 node_modules
 /.svelte-kit
 /build
-/functions

--- a/packages/create-svelte/templates/skeleton/.gitignore
+++ b/packages/create-svelte/templates/skeleton/.gitignore
@@ -2,4 +2,3 @@
 node_modules
 /.svelte-kit
 /build
-/functions


### PR DESCRIPTION
Remove `/function` from the ignore file.

This seems to no longer be used for anything and currently conflicts with the [Firebase Adapter](https://github.com/jthegedus/svelte-adapter-firebase) ~standard~ default usage (Cloud Functions are defined by a dir called `functions` but is configurable) so requires a documentation/manual step to rectify.

---

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
