### PR TITLE
docs: clarifying session/locals key difference

### DIFF
--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -12,7 +12,9 @@ This function runs on every request, and determines the response. It receives th
 
 If unimplemented, defaults to `({ request, render }) => render(request)`.
 
-To add custom data to the request, which is passed to endpoints, populate the `request.locals` object, as shown below.
+To add custom data to the request, which is passed to endpoints, populate the `request.locals` object, as shown below. 
+
+> Unlike in `getSession` below, `request.locals` does _not_ have to be serializable, meaning you _can_ pass around functions and custom classes.
 
 ```ts
 type Request<Locals = Record<string, any>> = {


### PR DESCRIPTION
For newbies, wrapping your head around the data flow of SvelteKit takes a minute. Calling out specifically that locals don't have to be serializable like session does can clarify some of this (speaking from experience!).

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts


Just proposing a one-line change to the documentation on `request.locals`. When I dove into SvelteKit for the first time, `handle` (then `getContext`) _felt_ like it was making a HTTP request when it passed its response on to the endpoints. This gave me the impression that `locals` (then `context`) had to be serializable like `session` does. When I realized it didn't, it _significantly_ simplified my auth/persistent session implementation. Calling this out clarifies this issue, especially for other newbies.
