### PR TITLE
Fix adapter-netlify query params splitting (#1466)

### DIFF
--- a/.changeset/cool-hounds-divide.md
+++ b/.changeset/cool-hounds-divide.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/adapter-netlify': minor
+'@sveltejs/adapter-netlify': patch
 ---
 
 Prevent adapter from splitting query params if they contain commas

--- a/.changeset/cool-hounds-divide.md
+++ b/.changeset/cool-hounds-divide.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': minor
+---
+
+Prevent adapter from splitting query params if they contain commas

--- a/.changeset/little-shirts-happen.md
+++ b/.changeset/little-shirts-happen.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-begin': patch
+---
+
+Prevent adapter from splitting query params if they contain commas

--- a/packages/adapter-begin/src/index.js
+++ b/packages/adapter-begin/src/index.js
@@ -4,15 +4,9 @@ import url from 'url';
 import app from '@architect/shared/app.js'; // eslint-disable-line import/no-unresolved
 
 async function handler(event) {
-	const { host, rawPath: path, httpMethod, headers, queryStringParameters, body } = event;
+	const { host, rawPath: path, httpMethod, rawQueryString, headers, body } = event;
 
-	const query = new url.URLSearchParams();
-	for (const k in queryStringParameters) {
-		const value = queryStringParameters[k];
-		value.split(', ').forEach((v) => {
-			query.append(k, v);
-		});
-	}
+	const query = new url.URLSearchParams(rawQueryString);
 
 	const rendered = await app.render({
 		host,

--- a/packages/adapter-netlify/files/entry.js
+++ b/packages/adapter-netlify/files/entry.js
@@ -4,15 +4,9 @@ import '@sveltejs/kit/install-fetch'; // eslint-disable-line import/no-unresolve
 import { render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
 
 export async function handler(event) {
-	const { path, httpMethod, headers, queryStringParameters, body, isBase64Encoded } = event;
+	const { path, httpMethod, headers, rawQuery, body, isBase64Encoded } = event;
 
-	const query = new URLSearchParams();
-	for (const k in queryStringParameters) {
-		const value = queryStringParameters[k];
-		value.split(', ').forEach((v) => {
-			query.append(k, v);
-		});
-	}
+	const query = new URLSearchParams(rawQuery);
 
 	const rawBody =
 		headers['content-type'] === 'application/octet-stream'


### PR DESCRIPTION
Instead of manually recreating the query parameters object from Netlify Functions' `queryStringParameters` object it is directly using the `rawQuery` object to create the `URLSearchParams`.

Fixes #1466


### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
