### PR TITLE
Document minimum node v12 & v14 versions in README.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Please see [the documentation](https://kit.svelte.dev/docs) for information abou
 
 ## Developing
 
+Ensure that you have a recent version of node:
+
+```
+node -v
+```
+
+For node v12 you should have at least `v12.12.0` and for node v14 at least `v14.13.1`. 
+
 This monorepo uses [pnpm](https://pnpm.js.org/en/). Install it...
 
 ```bash


### PR DESCRIPTION
Further to my earlier comment:

> Edit: looks like the minimum versions are `v12.20` and `v14.13.1`. I will make a pull request to document this in the `README`.

https://github.com/sveltejs/kit/pull/1000#issuecomment-841808940

That references:

>Node.js 14.13.0 added support for named CJS exports, see #35249 and this change has also been backported to Node.js v12.20.0.

https://github.com/nodejs/node/issues/32137#issuecomment-742554710

and

>Yep, it was fixed after downloading 14.13.1, thank you

https://github.com/nodejs/node/pull/35249#issuecomment-707974416

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
