### PR TITLE
chore: remove ignored package from changeset

### DIFF
--- a/.changeset/mean-bananas-live.md
+++ b/.changeset/mean-bananas-live.md
@@ -1,5 +1,4 @@
 ---
-'hn.svelte.dev': patch
 '@sveltejs/adapter-begin': patch
 '@sveltejs/adapter-cloudflare-workers': patch
 '@sveltejs/adapter-netlify': patch


### PR DESCRIPTION
Changesets cannot contain ignore and not-ignored packages in the same changeset. This hopefully fixes the release CI step.