### PR TITLE
ignore URLs that the app does not own

### DIFF
--- a/.changeset/wise-bees-juggle.md
+++ b/.changeset/wise-bees-juggle.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Ignore URLs that the app does not own

--- a/packages/kit/test/apps/basics/src/routes/routing/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/_tests.js
@@ -121,6 +121,15 @@ export default function (test) {
 
 			const requests2 = await capture_requests(() => app.goto('/routing/prefetched'));
 			assert.equal(requests2, []);
+
+			try {
+				await app.prefetch('https://example.com');
+				throw new Error('Error was not thrown');
+			} catch (e) {
+				assert.ok(
+					e.message.includes('Attempted to prefetch a URL that does not belong to this app')
+				);
+			}
 		}
 	});
 
@@ -198,6 +207,15 @@ export default function (test) {
 			await clicknav('[href="/routing/split-params/x-y-z"]');
 			assert.equal(await page.textContent('h1'), 'x');
 			assert.equal(await page.textContent('h2'), 'y-z');
+		}
+	);
+
+	test(
+		'ignores navigation to URLs the app does not own',
+		'/routing',
+		async ({ page, clicknav }) => {
+			await clicknav('[href="https://www.google.com"]');
+			assert.equal(await page.url(), 'https://www.google.com/');
 		}
 	);
 }

--- a/packages/kit/test/apps/basics/src/routes/routing/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/index.svelte
@@ -2,5 +2,6 @@
 
 <a href="/routing/a">a</a>
 <a href="/routing/ambiguous/ok.json">ok</a>
+<a href="https://www.google.com">elsewhere</a>
 
 <div class='hydrate-test'></div>


### PR DESCRIPTION
Need to expedite a fix to this... if you have `<a>` elements on the page that have the same origin but don't share a `base` path with the app (to take a _completely random_ example, a link to https://nytimes.com from https://www.nytimes.com/interactive/2021/us/covid-cases.html), the router will try to intercept the navigation but crashes. The same goes for `prefetch`.

This PR adds a concept of URL 'ownership' that makes it possible to prevent situations like this from occurring.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
