### PR TITLE
fix: append trailing slash in manifest

### DIFF
--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -92,9 +92,24 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 
 	/**
 	 * @param {string} path
+	 */
+	function normalizeTrailingSlash(path) {
+		if (config.kit.trailingSlash === 'always') {
+			return path.endsWith('/') ? path : `${path}/`;
+		}
+		if (config.kit.trailingSlash === 'never') {
+			return !path.endsWith('/') || path === '/' ? path : path.slice(0, -1);
+		}
+		return path;
+	}
+
+	/**
+	 * @param {string} path
 	 * @param {string} parent
 	 */
 	async function visit(path, parent) {
+		path = normalizeTrailingSlash(path);
+
 		if (seen.has(path)) return;
 		seen.add(path);
 

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -93,13 +93,13 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 	/**
 	 * @param {string} path
 	 */
-	function normalizeTrailingSlash(path) {
+	function normalize(path) {
 		if (config.kit.trailingSlash === 'always') {
 			return path.endsWith('/') ? path : `${path}/`;
-		}
-		if (config.kit.trailingSlash === 'never') {
+		} else if (config.kit.trailingSlash === 'never') {
 			return !path.endsWith('/') || path === '/' ? path : path.slice(0, -1);
 		}
+
 		return path;
 	}
 
@@ -108,7 +108,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 	 * @param {string} parent
 	 */
 	async function visit(path, parent) {
-		path = normalizeTrailingSlash(path);
+		path = normalize(path);
 
 		if (seen.has(path)) return;
 		seen.add(path);


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/issues/1486

This will fix #1486 by adding a trailing slash to the pages' path if _config.kit.trailingSlash_ is "always".
