### PR TITLE
Switch to @iarna/toml package with better TOML language features support

### DIFF
--- a/.changeset/bright-sheep-promise.md
+++ b/.changeset/bright-sheep-promise.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+---
+
+change toml parser to support dotted keys and other language features added after the TOML v0.4.0 spec

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { execSync } from 'child_process';
 import esbuild from 'esbuild';
-import toml from 'toml';
+import toml from '@iarna/toml';
 import { fileURLToPath } from 'url';
 
 export default function () {

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -18,7 +18,7 @@
 	},
 	"dependencies": {
 		"esbuild": "^0.11.18",
-		"toml": "^3.0.0"
+		"@iarna/toml": "^2.2.5"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:*"

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -2,7 +2,7 @@ import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
-import toml from 'toml';
+import toml from '@iarna/toml';
 
 export default function () {
 	/** @type {import('@sveltejs/kit').Adapter} */

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -19,7 +19,7 @@
 	"dependencies": {
 		"@sveltejs/kit": "workspace:*",
 		"esbuild": "^0.11.18",
-		"toml": "^3.0.0"
+		"@iarna/toml": "^2.2.5"
 	},
 	"devDependencies": {
 		"typescript": "^4.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,25 +67,25 @@ importers:
 
   packages/adapter-cloudflare-workers:
     specifiers:
+      '@iarna/toml': ^2.2.5
       '@sveltejs/kit': workspace:*
       esbuild: ^0.11.18
-      toml: ^3.0.0
     dependencies:
+      '@iarna/toml': 2.2.5
       esbuild: 0.11.18
-      toml: 3.0.0
     devDependencies:
       '@sveltejs/kit': link:../kit
 
   packages/adapter-netlify:
     specifiers:
+      '@iarna/toml': ^2.2.5
       '@sveltejs/kit': workspace:*
       esbuild: ^0.11.18
-      toml: ^3.0.0
       typescript: ^4.2.4
     dependencies:
+      '@iarna/toml': 2.2.5
       '@sveltejs/kit': link:../kit
       esbuild: 0.11.18
-      toml: 3.0.0
     devDependencies:
       typescript: 4.2.4
 
@@ -495,6 +495,10 @@ packages:
 
   /@fontsource/fira-mono/4.2.2:
     resolution: {integrity: sha512-t2WRThg+eLkQNQCtPG2sCCq40lz3xeb7nsL7P8l4+wfSRbdLQXAY5IebMftI2YEZR4MRRhdgrg0p5fi/2yXypA==}
+    dev: false
+
+  /@iarna/toml/2.2.5:
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
     dev: false
 
   /@istanbuljs/schema/0.1.3:
@@ -3568,10 +3572,6 @@ packages:
     dependencies:
       is-number: 7.0.0
     dev: true
-
-  /toml/3.0.0:
-    resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
-    dev: false
 
   /totalist/1.1.0:
     resolution: {integrity: sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==}


### PR DESCRIPTION
Fixes #1493 and allows Cloudflare Workers users and Netlify users to use features added to the TOML spec after v0.4.0 such as [dotted keys](https://toml.io/en/v0.5.0#keys) like those described in https://developers.cloudflare.com/workers/cli-wrangler/configuration#service-workers

https://github.com/BinaryMuse/toml-node has gone stale at TOML spec v0.4.0
This PR switches to using https://github.com/iarna/iarna-toml as a lighter-weight, more up to date and equally used package.
https://github.com/LongTengDao/j-toml is slightly more up to date with the TOML spec (v1.0.0-rc.1 vs v1.0.0) but with very low usage and a bundle size 10x as large, I did not look into using it.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
