### PR TITLE
fix: construct query params from location.search on rehydrate

### DIFF
--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -136,7 +136,7 @@ export async function render_response({
 					page: {
 						host: ${page.host ? s(page.host) : 'location.host'}, // TODO this is redundant
 						path: ${s(page.path)},
-						query: new URLSearchParams(${page.query.toString().length > 0 ? s(page.query.toString()) : 'location.search'}),
+						query: new URLSearchParams(location.search),
 						params: ${s(page.params)}
 					}
 				}` : 'null'}

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -136,7 +136,7 @@ export async function render_response({
 					page: {
 						host: ${page.host ? s(page.host) : 'location.host'}, // TODO this is redundant
 						path: ${s(page.path)},
-						query: new URLSearchParams(${s(page.query.toString())}),
+						query: new URLSearchParams(${page.query.toString().length > 0 ? s(page.query.toString()) : 'location.search'}),
 						params: ${s(page.params)}
 					}
 				}` : 'null'}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/issues/669

When rehydrating a page, the query params were set to URLSearchParams(s(page.query.toString())). This change uses location.search when page.query is empty.
