### PR TITLE
bump: polka and sirv versions

### DIFF
--- a/.changeset/rich-clocks-chew.md
+++ b/.changeset/rich-clocks-chew.md
@@ -1,0 +1,8 @@
+---
+'@sveltejs/adapter-begin': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-static': patch
+'@sveltejs/kit': patch
+---
+
+bump `polka` and `sirv` dependency versions

--- a/packages/adapter-begin/package.json
+++ b/packages/adapter-begin/package.json
@@ -24,7 +24,7 @@
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:*",
 		"rollup": "^2.47.0",
-		"sirv": "^1.0.11",
+		"sirv": "^1.0.12",
 		"typescript": "^4.2.4"
 	},
 	"exports": {

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -28,7 +28,7 @@
 		"node-fetch": "^3.0.0-beta.9",
 		"polka": "^1.0.0-next.15",
 		"rollup": "^2.47.0",
-		"sirv": "^1.0.11",
+		"sirv": "^1.0.12",
 		"typescript": "^4.2.4",
 		"uvu": "^0.5.1"
 	},

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -26,7 +26,7 @@
 		"c8": "^7.7.2",
 		"compression": "^1.7.4",
 		"node-fetch": "^3.0.0-beta.9",
-		"polka": "^1.0.0-next.14",
+		"polka": "^1.0.0-next.15",
 		"rollup": "^2.47.0",
 		"sirv": "^1.0.11",
 		"typescript": "^4.2.4",

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -21,7 +21,7 @@
 		"@sveltejs/kit": "workspace:*",
 		"playwright-chromium": "^1.10.0",
 		"port-authority": "^1.1.2",
-		"sirv": "^1.0.11",
+		"sirv": "^1.0.12",
 		"typescript": "^4.2.4"
 	}
 }

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -31,7 +31,7 @@
 		"rimraf": "^3.0.2",
 		"rollup": "^2.47.0",
 		"selfsigned": "^1.10.11",
-		"sirv": "^1.0.11",
+		"sirv": "^1.0.12",
 		"svelte": "^3.38.2",
 		"svelte-check": "^1.5.2",
 		"tiny-glob": "^0.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
       c8: ^7.7.2
       compression: ^1.7.4
       node-fetch: ^3.0.0-beta.9
-      polka: ^1.0.0-next.14
+      polka: ^1.0.0-next.15
       rollup: ^2.47.0
       sirv: ^1.0.11
       typescript: ^4.2.4
@@ -107,7 +107,7 @@ importers:
       c8: 7.7.2
       compression: 1.7.4
       node-fetch: 3.0.0-beta.9
-      polka: 1.0.0-next.14
+      polka: 1.0.0-next.15
       rollup: 2.47.0
       sirv: 1.0.11
       typescript: 4.2.4
@@ -564,6 +564,10 @@ packages:
 
   /@polka/url/1.0.0-next.12:
     resolution: {integrity: sha512-6RglhutqrGFMO1MNUXp95RBuYIuc8wTnMAV5MUhLmjTOy78ncwOw7RgeQ/HeymkKXRhZd0s2DNrM1rL7unk3MQ==}
+    dev: true
+
+  /@polka/url/1.0.0-next.15:
+    resolution: {integrity: sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA==}
     dev: true
 
   /@rollup/plugin-commonjs/17.1.0_rollup@2.47.0:
@@ -2859,11 +2863,11 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: true
 
-  /polka/1.0.0-next.14:
-    resolution: {integrity: sha512-nRxh6lifEred8F973wMJ3YA7z8EBAf+lWFLbhIh4MnYJXmZododD8FDGj+R81xnuNNG8b4PDqNXvrB5ShKcStA==}
-    engines: {node: '>=6'}
+  /polka/1.0.0-next.15:
+    resolution: {integrity: sha512-zBCZO40+USkSj0GDHMqufthqk4TIRc9xVGd50LbMvYNEwGHK8dZczLBQtw9pPHBM+i/Xg7ed7+c+r6J68XkWLg==}
+    engines: {node: '>=8'}
     dependencies:
-      '@polka/url': 1.0.0-next.12
+      '@polka/url': 1.0.0-next.15
       trouter: 3.2.0
     dev: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,14 +55,14 @@ importers:
       '@architect/parser': ^3.0.1
       '@sveltejs/kit': workspace:*
       rollup: ^2.47.0
-      sirv: ^1.0.11
+      sirv: ^1.0.12
       typescript: ^4.2.4
     dependencies:
       '@architect/parser': 3.0.1
     devDependencies:
       '@sveltejs/kit': link:../kit
       rollup: 2.47.0
-      sirv: 1.0.11
+      sirv: 1.0.12
       typescript: 4.2.4
 
   packages/adapter-cloudflare-workers:
@@ -98,7 +98,7 @@ importers:
       node-fetch: ^3.0.0-beta.9
       polka: ^1.0.0-next.15
       rollup: ^2.47.0
-      sirv: ^1.0.11
+      sirv: ^1.0.12
       typescript: ^4.2.4
       uvu: ^0.5.1
     devDependencies:
@@ -109,7 +109,7 @@ importers:
       node-fetch: 3.0.0-beta.9
       polka: 1.0.0-next.15
       rollup: 2.47.0
-      sirv: 1.0.11
+      sirv: 1.0.12
       typescript: 4.2.4
       uvu: 0.5.1
 
@@ -118,13 +118,13 @@ importers:
       '@sveltejs/kit': workspace:*
       playwright-chromium: ^1.10.0
       port-authority: ^1.1.2
-      sirv: ^1.0.11
+      sirv: ^1.0.12
       typescript: ^4.2.4
     devDependencies:
       '@sveltejs/kit': link:../kit
       playwright-chromium: 1.10.0
       port-authority: 1.1.2
-      sirv: 1.0.11
+      sirv: 1.0.12
       typescript: 4.2.4
 
   packages/adapter-vercel:
@@ -223,7 +223,7 @@ importers:
       rollup: ^2.47.0
       sade: ^1.7.4
       selfsigned: ^1.10.11
-      sirv: ^1.0.11
+      sirv: ^1.0.12
       svelte: ^3.38.2
       svelte-check: ^1.5.2
       tiny-glob: ^0.2.8
@@ -258,7 +258,7 @@ importers:
       rimraf: 3.0.2
       rollup: 2.47.0
       selfsigned: 1.10.11
-      sirv: 1.0.11
+      sirv: 1.0.12
       svelte: 3.38.2
       svelte-check: 1.5.2_svelte@3.38.2
       tiny-glob: 0.2.8
@@ -560,10 +560,6 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.4
       fastq: 1.11.0
-    dev: true
-
-  /@polka/url/1.0.0-next.12:
-    resolution: {integrity: sha512-6RglhutqrGFMO1MNUXp95RBuYIuc8wTnMAV5MUhLmjTOy78ncwOw7RgeQ/HeymkKXRhZd0s2DNrM1rL7unk3MQ==}
     dev: true
 
   /@polka/url/1.0.0-next.15:
@@ -3184,11 +3180,11 @@ packages:
     resolution: {integrity: sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==}
     dev: true
 
-  /sirv/1.0.11:
-    resolution: {integrity: sha512-SR36i3/LSWja7AJNRBz4fF/Xjpn7lQFI30tZ434dIy+bitLYSP+ZEenHg36i23V2SGEz+kqjksg0uOGZ5LPiqg==}
+  /sirv/1.0.12:
+    resolution: {integrity: sha512-+jQoCxndz7L2tqQL4ZyzfDhky0W/4ZJip3XoOuxyQWnAwMxindLl3Xv1qT4x1YX/re0leShvTm8Uk0kQspGhBg==}
     engines: {node: '>= 10'}
     dependencies:
-      '@polka/url': 1.0.0-next.12
+      '@polka/url': 1.0.0-next.15
       mime: 2.5.2
       totalist: 1.1.0
     dev: true


### PR DESCRIPTION
### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts

---

Closes #1523 
Does not exclude/replace #1528 

Updated `sirv` so that there weren't multiple copies of `@polka/url` floating around during CI/testing.
(Users would always get the latest `@polka/url`, but our CI suite wouldn't/doesn't because lockfiles.)