### PR TITLE
Polka: remove err param from .listen() callback

### DIFF
--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -4,12 +4,8 @@ import * as app from './app.js';
 
 const { HOST = '0.0.0.0', PORT = 3000 } = process.env;
 
-const instance = createServer({ render: app.render }).listen(PORT, HOST, (err) => {
-	if (err) {
-		console.log('error', err);
-	} else {
-		console.log(`Listening on port ${PORT}`);
-	}
+const instance = createServer({ render: app.render }).listen(PORT, HOST, () => {
+	console.log(`Listening on port ${PORT}`);
 });
 
 export { instance };


### PR DESCRIPTION
`err` param has been removed from .listen() callback, in latest Polka.

See https://github.com/lukeed/polka/commit/0424bb5587332d5e2bbf19a1e869af471f50f4ba
