### PR TITLE
Fix create-svelte build-template script

### DIFF
--- a/.changeset/weak-parents-guess.md
+++ b/.changeset/weak-parents-guess.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Adjust build-template script to include package.json


### PR DESCRIPTION
With the addition of `/package` to `.gitignore`, the `package.template.json` is filtered out. Put it at the top to avoid that.

