### PR TITLE
create-svelte: add svelte-check for TS

### DIFF
--- a/.changeset/seven-bags-sniff.md
+++ b/.changeset/seven-bags-sniff.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Add svelte-check to TS templates

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -184,8 +184,8 @@ function write_common_files(cwd, options) {
 	const pkg = /** @type {any} */ (JSON.parse(fs.readFileSync(pkg_file, 'utf-8')));
 
 	files.forEach((file) => {
-		const include = file.include.every((condition) => options[condition]);
-		const exclude = file.exclude.some((condition) => options[condition]);
+		const include = file.include.every((condition) => matchesCondition(condition, options));
+		const exclude = file.exclude.some((condition) => matchesCondition(condition, options));
 
 		if (exclude || !include) return;
 
@@ -203,6 +203,17 @@ function write_common_files(cwd, options) {
 	pkg.devDependencies = sort_keys(pkg.devDependencies);
 
 	fs.writeFileSync(pkg_file, JSON.stringify(pkg, null, '  '));
+}
+
+/**
+ * @param {import('./types/internal').Condition} condition
+ * @param {import('./types/internal').Options} options
+ * @returns {boolean}
+ */
+function matchesCondition(condition, options) {
+	return condition === 'default' || condition === 'skeleton'
+		? options.template === condition
+		: options[condition];
 }
 
 /**

--- a/packages/create-svelte/shared/+default+typescript/package.json
+++ b/packages/create-svelte/shared/+default+typescript/package.json
@@ -1,0 +1,5 @@
+{
+	"devDependencies": {
+		"@types/cookie": "^0.4.0"
+	}
+}

--- a/packages/create-svelte/shared/+typescript/package.json
+++ b/packages/create-svelte/shared/+typescript/package.json
@@ -1,7 +1,12 @@
 {
+	"scripts": {
+		"validate": "svelte-check --tsconfig ./tsconfig.json",
+		"validate:watch": "svelte-check --tsconfig ./tsconfig.json --watch"
+	},
 	"devDependencies": {
 		"typescript": "^4.0.0",
 		"tslib": "^2.0.0",
+		"svelte-check": "^1.6.0",
 		"svelte-preprocess": "^4.0.0"
 	}
 }

--- a/packages/create-svelte/shared/+typescript/package.json
+++ b/packages/create-svelte/shared/+typescript/package.json
@@ -6,7 +6,7 @@
 	"devDependencies": {
 		"typescript": "^4.0.0",
 		"tslib": "^2.0.0",
-		"svelte-check": "^1.6.0",
+		"svelte-check": "^2.0.0",
 		"svelte-preprocess": "^4.0.0"
 	}
 }

--- a/packages/create-svelte/shared/+typescript/package.json
+++ b/packages/create-svelte/shared/+typescript/package.json
@@ -1,7 +1,7 @@
 {
 	"scripts": {
-		"validate": "svelte-check --tsconfig ./tsconfig.json",
-		"validate:watch": "svelte-check --tsconfig ./tsconfig.json --watch"
+		"check": "svelte-check --tsconfig ./tsconfig.json",
+		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
 		"typescript": "^4.0.0",

--- a/packages/create-svelte/types/internal.d.ts
+++ b/packages/create-svelte/types/internal.d.ts
@@ -10,11 +10,13 @@ export type File = {
 	contents: string;
 };
 
+export type Condition = 'eslint' | 'prettier' | 'typescript' | 'skeleton' | 'default';
+
 export type Common = {
 	files: Array<{
 		name: string;
-		include: Array<'eslint' | 'prettier' | 'typescript'>;
-		exclude: Array<'eslint' | 'prettier' | 'typescript'>;
+		include: Array<Condition>;
+		exclude: Array<Condition>;
 		contents: string;
 	}>;
 };


### PR DESCRIPTION
This add svelte-check along with two validate scripts to the package.json if the user selects TS. This uncovered missing type definitions for the cookie package in the default template, which are now added as well if the user selects TS.

Closes #1536 , if noone has objections to doing it this way. Alternatives:
- add this to `svelte-kit`. This would add needless dependencies for those who don't want to use it, and does not bring any benefit to me as it only hides the invocation and cannot add any deeper integration
- adjust the TS templates so that `svelte-check` is always invoked prior to `svelte-kit`. I'm slightly in favor of this, but it slows down the build a little obviously