### PR TITLE
Rename `handle`'s `render` parameter to `resolve`

### DIFF
--- a/.changeset/tender-buckets-turn.md
+++ b/.changeset/tender-buckets-turn.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Rename handle's render parameter to respond
+Rename handle's render parameter to resolve

--- a/.changeset/tender-buckets-turn.md
+++ b/.changeset/tender-buckets-turn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Rename handle's render parameter to respond

--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -8,7 +8,7 @@ An optional `src/hooks.js` (or `src/hooks.ts`, or `src/hooks/index.js`) file exp
 
 ### handle
 
-This function runs on every request, for both pages and endpoints, and determines the response. It receives the `request` object and `resolve` method, which calls SvelteKit's default renderer. This allows you to modify response headers or bodies, or bypass SvelteKit entirely (for implementing endpoints programmatically, for example).
+This function runs on every request, for both pages and endpoints, and determines the response. It receives the `request` object and a function called `resolve`, which invokes SvelteKit's router and generates a response accordingly. This allows you to modify response headers or bodies, or bypass SvelteKit entirely (for implementing endpoints programmatically, for example).
 
 If unimplemented, defaults to `({ request, resolve }) => resolve(request)`.
 

--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -8,9 +8,9 @@ An optional `src/hooks.js` (or `src/hooks.ts`, or `src/hooks/index.js`) file exp
 
 ### handle
 
-This function runs on every request, and determines the response. It receives the `request` object and `render` method, which calls SvelteKit's default renderer. This allows you to modify response headers or bodies, or bypass SvelteKit entirely (for implementing endpoints programmatically, for example).
+This function runs on every request, for both pages and endpoints, and determines the response. It receives the `request` object and `respond` method, which calls SvelteKit's default renderer. This allows you to modify response headers or bodies, or bypass SvelteKit entirely (for implementing endpoints programmatically, for example).
 
-If unimplemented, defaults to `({ request, render }) => render(request)`.
+If unimplemented, defaults to `({ request, respond }) => respond(request)`.
 
 To add custom data to the request, which is passed to endpoints, populate the `request.locals` object, as shown below.
 
@@ -37,16 +37,16 @@ type Response = {
 
 type Handle<Locals = Record<string, any>> = (input: {
 	request: Request<Locals>;
-	render: (request: Request<Locals>) => Response | Promise<Response>;
+	respond: (request: Request<Locals>) => Response | Promise<Response>;
 }) => Response | Promise<Response>;
 ```
 
 ```js
 /** @type {import('@sveltejs/kit').Handle} */
-export async function handle({ request, render }) {
+export async function handle({ request, respond }) {
 	request.locals.user = await getUserInformation(request.headers.cookie);
 
-	const response = await render(request);
+	const response = await respond(request);
 
 	return {
 		...response,

--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -8,9 +8,9 @@ An optional `src/hooks.js` (or `src/hooks.ts`, or `src/hooks/index.js`) file exp
 
 ### handle
 
-This function runs on every request, for both pages and endpoints, and determines the response. It receives the `request` object and `respond` method, which calls SvelteKit's default renderer. This allows you to modify response headers or bodies, or bypass SvelteKit entirely (for implementing endpoints programmatically, for example).
+This function runs on every request, for both pages and endpoints, and determines the response. It receives the `request` object and `resolve` method, which calls SvelteKit's default renderer. This allows you to modify response headers or bodies, or bypass SvelteKit entirely (for implementing endpoints programmatically, for example).
 
-If unimplemented, defaults to `({ request, respond }) => respond(request)`.
+If unimplemented, defaults to `({ request, resolve }) => resolve(request)`.
 
 To add custom data to the request, which is passed to endpoints, populate the `request.locals` object, as shown below.
 
@@ -37,16 +37,16 @@ type Response = {
 
 type Handle<Locals = Record<string, any>> = (input: {
 	request: Request<Locals>;
-	respond: (request: Request<Locals>) => Response | Promise<Response>;
+	resolve: (request: Request<Locals>) => Response | Promise<Response>;
 }) => Response | Promise<Response>;
 ```
 
 ```js
 /** @type {import('@sveltejs/kit').Handle} */
-export async function handle({ request, respond }) {
+export async function handle({ request, resolve }) {
 	request.locals.user = await getUserInformation(request.headers.cookie);
 
-	const response = await respond(request);
+	const response = await resolve(request);
 
 	return {
 		...response,

--- a/packages/create-svelte/templates/default/src/hooks.ts
+++ b/packages/create-svelte/templates/default/src/hooks.ts
@@ -2,7 +2,7 @@ import cookie from 'cookie';
 import { v4 as uuid } from '@lukeed/uuid';
 import type { Handle } from '@sveltejs/kit';
 
-export const handle: Handle = async ({ request, render }) => {
+export const handle: Handle = async ({ request, respond }) => {
 	const cookies = cookie.parse(request.headers.cookie || '');
 	request.locals.userid = cookies.userid || uuid();
 
@@ -11,7 +11,7 @@ export const handle: Handle = async ({ request, render }) => {
 		request.method = request.query.get('_method').toUpperCase();
 	}
 
-	const response = await render(request);
+	const response = await respond(request);
 
 	if (!cookies.userid) {
 		// if this is the first time the user has visited this app,

--- a/packages/create-svelte/templates/default/src/hooks.ts
+++ b/packages/create-svelte/templates/default/src/hooks.ts
@@ -2,7 +2,7 @@ import cookie from 'cookie';
 import { v4 as uuid } from '@lukeed/uuid';
 import type { Handle } from '@sveltejs/kit';
 
-export const handle: Handle = async ({ request, respond }) => {
+export const handle: Handle = async ({ request, resolve }) => {
 	const cookies = cookie.parse(request.headers.cookie || '');
 	request.locals.userid = cookies.userid || uuid();
 
@@ -11,7 +11,7 @@ export const handle: Handle = async ({ request, respond }) => {
 		request.method = request.query.get('_method').toUpperCase();
 	}
 
-	const response = await respond(request);
+	const response = await resolve(request);
 
 	if (!cookies.userid) {
 		// if this is the first time the user has visited this app,

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -363,7 +363,7 @@ async function build_server(
 			// named imports without triggering Rollup's missing import detection
 			const get_hooks = hooks => ({
 				getSession: hooks.getSession || (() => ({})),
-				handle: hooks.handle || (({ request, respond }) => respond(request))
+				handle: hooks.handle || (({ request, resolve }) => resolve(request))
 			});
 
 			const module_lookup = {

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -363,7 +363,7 @@ async function build_server(
 			// named imports without triggering Rollup's missing import detection
 			const get_hooks = hooks => ({
 				getSession: hooks.getSession || (() => ({})),
-				handle: hooks.handle || (({ request, render }) => render(request))
+				handle: hooks.handle || (({ request, respond }) => respond(request))
 			});
 
 			const module_lookup = {

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -187,7 +187,7 @@ class Watcher extends EventEmitter {
 							},
 							hooks: {
 								getSession: hooks.getSession || (() => ({})),
-								handle: hooks.handle || (({ request, render }) => render(request))
+								handle: hooks.handle || (({ request, respond }) => respond(request))
 							},
 							hydrate: this.config.kit.hydrate,
 							paths: this.config.kit.paths,

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -187,7 +187,7 @@ class Watcher extends EventEmitter {
 							},
 							hooks: {
 								getSession: hooks.getSession || (() => ({})),
-								handle: hooks.handle || (({ request, respond }) => respond(request))
+								handle: hooks.handle || (({ request, resolve }) => resolve(request))
 							},
 							hydrate: this.config.kit.hydrate,
 							paths: this.config.kit.paths,

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -41,7 +41,7 @@ export async function respond(incoming, options, state = {}) {
 				params: null,
 				locals: {}
 			},
-			render: async (request) => {
+			respond: async (request) => {
 				if (state.prerender && state.prerender.fallback) {
 					return await render_response({
 						options,

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -41,7 +41,7 @@ export async function respond(incoming, options, state = {}) {
 				params: null,
 				locals: {}
 			},
-			respond: async (request) => {
+			resolve: async (request) => {
 				if (state.prerender && state.prerender.fallback) {
 					return await render_response({
 						options,

--- a/packages/kit/test/apps/basics/src/hooks.js
+++ b/packages/kit/test/apps/basics/src/hooks.js
@@ -6,13 +6,13 @@ export function getSession(request) {
 }
 
 /** @type {import('@sveltejs/kit').Handle} */
-export async function handle({ request, respond }) {
+export async function handle({ request, resolve }) {
 	const cookies = cookie.parse(request.headers.cookie || '');
 
 	request.locals.answer = 42;
 	request.locals.name = cookies.name;
 
-	const response = await respond(request);
+	const response = await resolve(request);
 
 	if (response) {
 		return {

--- a/packages/kit/test/apps/basics/src/hooks.js
+++ b/packages/kit/test/apps/basics/src/hooks.js
@@ -6,13 +6,13 @@ export function getSession(request) {
 }
 
 /** @type {import('@sveltejs/kit').Handle} */
-export async function handle({ request, render }) {
+export async function handle({ request, respond }) {
 	const cookies = cookie.parse(request.headers.cookie || '');
 
 	request.locals.answer = 42;
 	request.locals.name = cookies.name;
 
-	const response = await render(request);
+	const response = await respond(request);
 
 	if (response) {
 		return {

--- a/packages/kit/types/hooks.d.ts
+++ b/packages/kit/types/hooks.d.ts
@@ -29,5 +29,5 @@ export type GetSession<Locals = Record<string, any>, Session = any> = {
 
 export type Handle<Locals = Record<string, any>> = (input: {
 	request: ServerRequest<Locals>;
-	respond: (request: ServerRequest<Locals>) => ServerResponse | Promise<ServerResponse>;
+	resolve: (request: ServerRequest<Locals>) => ServerResponse | Promise<ServerResponse>;
 }) => ServerResponse | Promise<ServerResponse>;

--- a/packages/kit/types/hooks.d.ts
+++ b/packages/kit/types/hooks.d.ts
@@ -29,5 +29,5 @@ export type GetSession<Locals = Record<string, any>, Session = any> = {
 
 export type Handle<Locals = Record<string, any>> = (input: {
 	request: ServerRequest<Locals>;
-	render: (request: ServerRequest<Locals>) => ServerResponse | Promise<ServerResponse>;
+	respond: (request: ServerRequest<Locals>) => ServerResponse | Promise<ServerResponse>;
 }) => ServerResponse | Promise<ServerResponse>;


### PR DESCRIPTION
I was a bit confused by the name `render` because it had a heavy page connotation in my mind ([another user stated the same](https://github.com/sveltejs/kit/pull/1457#issuecomment-849871654)), so I wasn't sure if you'd be calling it for endpoints as well. Rich had suggested `respond` could be a more neutral alternative. I like that name, so wanted to raise the question of renaming it here