### PR TITLE
Passing the Rollup output options through to Vite

### DIFF
--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -149,6 +149,9 @@ async function build_client({
 				...(user_config.build && user_config.build.rollupOptions),
 				input,
 				output: {
+					...(user_config.build &&
+						user_config.build.rollupOptions &&
+						user_config.build.rollupOptions.output),
 					entryFileNames: '[name]-[hash].js',
 					chunkFileNames: 'chunks/[name]-[hash].js',
 					assetFileNames: 'assets/[name]-[hash][extname]'


### PR DESCRIPTION
This allows us to have more control of the rollup chunking when doing a production build. In particular, it allows us to specify `manualChunks` so we can decide what goes in the vendor chunk, or to not have a vendor chunk at all and simply have large page-specific bundles.

`vite.build()` does occur in three places in that file, I only updated in the one place, and verified it took effect when doing an "npm run build". Not sure if I should also update in the other places.

Fixes #1571

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
