### PR TITLE
type fixes for adapter-node and adapter-static

### DIFF
--- a/packages/adapter-node/index.d.ts
+++ b/packages/adapter-node/index.d.ts
@@ -1,3 +1,3 @@
-declare function plugin(options: { out?: string }): import('@sveltejs/kit').Adapter;
+declare function plugin(options?: { out?: string }): import('@sveltejs/kit').Adapter;
 
 export = plugin;

--- a/packages/adapter-static/index.d.ts
+++ b/packages/adapter-static/index.d.ts
@@ -1,7 +1,7 @@
 declare function plugin(options?: {
 	pages?: string;
 	assets?: string;
-	fallback?: string | null;
+	fallback?: string;
 }): import('@sveltejs/kit').Adapter;
 
 export = plugin;

--- a/packages/adapter-static/index.d.ts
+++ b/packages/adapter-static/index.d.ts
@@ -1,7 +1,7 @@
-declare function plugin(options: {
+declare function plugin(options?: {
 	pages?: string;
 	assets?: string;
-	fallback?: string;
+	fallback?: string | null;
 }): import('@sveltejs/kit').Adapter;
 
 export = plugin;

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -5,7 +5,7 @@
  *   fallback?: string;
  * }} [opts]
  */
-export default function ({ pages = 'build', assets = pages, fallback = null } = {}) {
+export default function ({ pages = 'build', assets = pages, fallback } = {}) {
 	/** @type {import('@sveltejs/kit').Adapter} */
 	const adapter = {
 		name: '@sveltejs/adapter-static',


### PR DESCRIPTION
The adapter-node and adapter-static do not actually require any arguments, which is shown in the documentation here: https://github.com/quentin-fox/kit/blob/3f82e80f14b8ebfe0d004c004b5109d70f902a47/documentation/docs/10-adapters.md#L9-L18

The Typescript types for the adapters do not indicate that the options object are optional, even though they are not required.

I also added the null type to the fallback param, since the default value is null. 