### PR TITLE
fix(adapter-netlify): Append to _redirects

### DIFF
--- a/.changeset/selfish-ligers-allow.md
+++ b/.changeset/selfish-ligers-allow.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-netlify': patch
 ---
 
-fix: Append to \_redirects
+Allow `_redirects` to be placed in root directory

--- a/.changeset/selfish-ligers-allow.md
+++ b/.changeset/selfish-ligers-allow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+fix: Append to \_redirects

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -39,6 +39,7 @@ export default function () {
 			utils.copy_client_files(publish);
 
 			utils.log.minor('Writing redirects...');
+			utils.copy('_redirects', `${publish}/_redirects`);
 			appendFileSync(`${publish}/_redirects`, '\n\n/* /.netlify/functions/render 200');
 		}
 	};


### PR DESCRIPTION
This was easier to fix than expected. The fix should allow users to have their own `_redirects` file in the project root. If this file exists, it gets copied to `build/` before `adapter-netlify` appends the catchall rule to it.

This behaviour is [already documented](https://github.com/sveltejs/kit/tree/master/packages/adapter-netlify#using-netlify-redirect-rules), but [currently broken](https://github.com/sveltejs/kit/issues/1585).

How can I write an automated test for this adapter?

I did the following to test this manually:

1. Use `yarn link "@sveltejs/kit"` and `yarn link "@sveltejs/adapter-netlify"` in my application repository to point the two node modules to my modified versions.
2. Run `svelte-kit build` with a `_redirects` file in the project root.
3. Check if content of `build/_redirects` is expected.
4. Run `svelte-kit build` *without* a `_redirects` file in the project root.
5. Check if content of `build/_redirects` is expected.

Any guidance or help how to match the desired code quality to get this PR merged is appreciated.

close #1585

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
