### PR TITLE
chore: update the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 - [ ] Ideally, include a test that fails without this PR but passes with it.
 
 ### Tests
-- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`
+- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
 
 ### Changesets
 - [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts


### PR DESCRIPTION
The old template doesn't remind you to run `pnpm check`, but it is run
by the CI pipeline and can thus cause avoidable pr check failures.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts