### PR TITLE
docs: use level 3 headings

### DIFF
--- a/documentation/docs/12-packaging.md
+++ b/documentation/docs/12-packaging.md
@@ -25,7 +25,7 @@ import { Foo } from 'your-library';
 import Foo from 'your-library/Foo.svelte';
 ```
 
-## Publishing
+### Publishing
 
 To publish the generated package:
 
@@ -35,7 +35,7 @@ npm publish package
 
 If you configure a custom [`package.dir`](#configuration-package), change `package` accordingly.
 
-## Caveats
+### Caveats
 
 This is a relatively experimental feature and is not yet fully implemented:
 


### PR DESCRIPTION
Docs cannot have level 2 headings, they must be level 3+. Closes #1600

https://github.com/sveltejs/sites/runs/2702180894?check_suite_focus=true

Would be good to surface these errors a little better if possible. I'll look into that.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
