### PR TITLE
Clarify the use of svelte-kit preview and adapters

### DIFF
--- a/documentation/docs/10-adapters.md
+++ b/documentation/docs/10-adapters.md
@@ -2,7 +2,7 @@
 title: Adapters
 ---
 
-Before you can deploy your SvelteKit app, you need to _adapt_ it for your deployment target. Adapters are small plugins that take the built app as input and generate output that is optimised for a specific platform.
+Before you can deploy your SvelteKit app, you need to _adapt_ it for your deployment target. Adapters are small plugins that take the built app as input and generate output that is optimised for a specific platform. How the resulting app is served depends on the adapter and further instructions can be found in the documentation for each adapter.
 
 For example, if you want to run your app as a simple Node server, you would use the `@sveltejs/adapter-node` package:
 

--- a/documentation/docs/10-adapters.md
+++ b/documentation/docs/10-adapters.md
@@ -2,7 +2,7 @@
 title: Adapters
 ---
 
-Before you can deploy your SvelteKit app, you need to _adapt_ it for your deployment target. Adapters are small plugins that take the built app as input and generate output that is optimised for a specific platform. How the resulting app is served depends on the adapter and further instructions can be found in the documentation for each adapter.
+Before you can deploy your SvelteKit app, you need to _adapt_ it for your deployment target. Adapters are small plugins that take the built app as input and generate output for deployment. Many adapters are optimised for a specific hosting provider, and you can generally find information about deployment in your adapter's documentation. However, some adapters, like `adapter-static`, build output that can be hosted on numerous hosting providers, so it may also be helpful to reference the documentation of your hosting provider in these cases.
 
 For example, if you want to run your app as a simple Node server, you would use the `@sveltejs/adapter-node` package:
 

--- a/documentation/docs/13-cli.md
+++ b/documentation/docs/13-cli.md
@@ -27,7 +27,7 @@ Builds a production version of your app, and runs your adapter if you have one s
 
 ### svelte-kit preview
 
-After you've built your app with `svelte-kit build`, you can start the production version (irrespective of any adapter that has been applied) locally with `svelte-kit preview`. This is intended for testing the production build locally, **not for serving your app**, the way your app will be served is dependent on the adapter used, see the documentaion of your chosen adapter for specific instructions on how to run your app.
+After you've built your app with `svelte-kit build`, you can start the production version (irrespective of any adapter that has been applied) locally with `svelte-kit preview`. This is intended for testing the production build locally, **not for serving your app**, for which you should always use an adapter. The way your app will be served is dependent on the adapter used, see the documentation of your chosen adapter for specific instructions on how to run your app.
 
 Like `svelte-kit dev`, it accepts the following options:
 

--- a/documentation/docs/13-cli.md
+++ b/documentation/docs/13-cli.md
@@ -25,7 +25,7 @@ Builds a production version of your app, and runs your adapter if you have one s
 
 - `--verbose` — log more detail
 
-After building the app you can see the documentation of your chosen adapter for specific instructions on how to serve your app.
+After building the app, you can reference the documentation of your chosen [adapter](#adapters) and hosting platform for specific instructions on how to serve your app.
 
 ### svelte-kit preview
 

--- a/documentation/docs/13-cli.md
+++ b/documentation/docs/13-cli.md
@@ -25,9 +25,11 @@ Builds a production version of your app, and runs your adapter if you have one s
 
 - `--verbose` — log more detail
 
+After building the app you can see the documentation of your chosen adapter for specific instructions on how to serve your app.
+
 ### svelte-kit preview
 
-After you've built your app with `svelte-kit build`, you can start the production version (irrespective of any adapter that has been applied) locally with `svelte-kit preview`. This is intended for testing the production build locally, **not for serving your app**, for which you should always use an adapter. The way your app will be served is dependent on the adapter used, see the documentation of your chosen adapter for specific instructions on how to run your app.
+After you've built your app with `svelte-kit build`, you can start the production version (irrespective of any adapter that has been applied) locally with `svelte-kit preview`. This is intended for testing the production build locally, **not for serving your app**, for which you should always use an [adapter](#adapters). 
 
 Like `svelte-kit dev`, it accepts the following options:
 

--- a/documentation/docs/13-cli.md
+++ b/documentation/docs/13-cli.md
@@ -27,7 +27,7 @@ Builds a production version of your app, and runs your adapter if you have one s
 
 ### svelte-kit preview
 
-After you've built your app with `svelte-kit build`, you can start the production version (irrespective of any adapter that has been applied) locally with `svelte-kit preview`. This is intended for testing the production build locally, **not for serving your app**, for which you should always use an adapter.
+After you've built your app with `svelte-kit build`, you can start the production version (irrespective of any adapter that has been applied) locally with `svelte-kit preview`. This is intended for testing the production build locally, **not for serving your app**, the way your app will be served is dependent on the adapter used, see the documentaion of your chosen adapter for specific instructions on how to run your app.
 
 Like `svelte-kit dev`, it accepts the following options:
 


### PR DESCRIPTION
This PR simple adds an extra comment to `svelte-kit preview` noting that serving the final app is dependent on the adapter used and refers the developers to the documentation of the adapter to learn how to actually serve their app in production.

Reason for this change is that is a recurring question, the documentation tells that you should **not** use the preview command but does little in explaining where to get the information on how to do it.