### PR TITLE
types: allow void return in `LoadOutput`

### DIFF
--- a/packages/kit/src/core/node/index.js
+++ b/packages/kit/src/core/node/index.js
@@ -1,6 +1,6 @@
 /**
  * @param {import('http').IncomingMessage} req
- * @returns {Promise<import('types/hooks').StrictBody | null>}
+ * @returns {Promise<import('types/hooks').StrictBody>}
  */
 export function getRawBody(req) {
 	return new Promise((fulfil, reject) => {

--- a/packages/kit/types/endpoint.d.ts
+++ b/packages/kit/types/endpoint.d.ts
@@ -18,4 +18,4 @@ export type EndpointOutput = {
 
 export type RequestHandler<Locals = Record<string, any>, Body = unknown> = (
 	request: ServerRequest<Locals, Body>
-) => void | MaybePromise<EndpointOutput>;
+) => MaybePromise<void | EndpointOutput>;

--- a/packages/kit/types/hooks.d.ts
+++ b/packages/kit/types/hooks.d.ts
@@ -1,18 +1,18 @@
 import { Headers, Location, MaybePromise, ParameterizedBody } from './helper';
 
-export type StrictBody = string | Uint8Array;
+export type StrictBody = string | Uint8Array | null;
 
 export type Incoming = Omit<Location, 'params'> & {
 	method: string;
 	headers: Headers;
-	rawBody: StrictBody | null;
+	rawBody: StrictBody;
 	body?: ParameterizedBody;
 };
 
 export type ServerRequest<Locals = Record<string, any>, Body = unknown> = Location & {
 	method: string;
 	headers: Headers;
-	rawBody: StrictBody | null;
+	rawBody: StrictBody;
 	body: ParameterizedBody<Body>;
 	locals: Locals;
 };

--- a/packages/kit/types/page.d.ts
+++ b/packages/kit/types/page.d.ts
@@ -39,12 +39,10 @@ export type Load<
 		InferValue<Input, 'pageParams', Record<string, string>>,
 		InferValue<Input, 'context', Record<string, any>>
 	>
-) => MaybePromise<
-	LoadOutput<
-		InferValue<Output, 'props', Record<string, any>>,
-		InferValue<Output, 'context', Record<string, any>>
-	>
->;
+) => MaybePromise<void | LoadOutput<
+	InferValue<Output, 'props', Record<string, any>>,
+	InferValue<Output, 'context', Record<string, any>>
+>>;
 
 export type ErrorLoad<
 	Input extends { context?: Record<string, any>; pageParams?: Record<string, string> } = {},


### PR DESCRIPTION
Fixes #1606, and cleans up some more types