### PR TITLE
Attempt to fix peerDependencies specification

### DIFF
--- a/.changeset/lovely-mice-search.md
+++ b/.changeset/lovely-mice-search.md
@@ -1,0 +1,10 @@
+---
+'@sveltejs/adapter-begin': patch
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-static': patch
+'@sveltejs/adapter-vercel': patch
+---
+
+Attempt to fix peerDependencies specification

--- a/packages/adapter-begin/package.json
+++ b/packages/adapter-begin/package.json
@@ -19,7 +19,7 @@
 		"@architect/parser": "^3.0.1"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "workspace:*"
+		"@sveltejs/kit": "workspace:^"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:*",

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -24,6 +24,6 @@
 		"@sveltejs/kit": "workspace:*"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "workspace:*"
+		"@sveltejs/kit": "workspace:^"
 	}
 }

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -21,7 +21,7 @@
 		"@iarna/toml": "^2.2.5"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "workspace:*"
+		"@sveltejs/kit": "workspace:^"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:*",

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -33,6 +33,6 @@
 		"uvu": "^0.5.1"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "workspace:*"
+		"@sveltejs/kit": "workspace:^"
 	}
 }

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -15,7 +15,7 @@
 		"test": "uvu test test.js"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "workspace:*"
+		"@sveltejs/kit": "workspace:^"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:*",

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -20,7 +20,7 @@
 		"esbuild": "^0.11.18"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "workspace:*"
+		"@sveltejs/kit": "workspace:^"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:*",


### PR DESCRIPTION
Maybe fixes https://github.com/sveltejs/kit/issues/1618

We tried something similar in https://github.com/sveltejs/kit/pull/1434 where `^` did not work in `devDependencies` due to a bug in pnpm. Let's see if it works in `peerDependencies` :shrug: 