### PR TITLE
Collect adapter version in GitHub template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -18,9 +18,9 @@ change, please create an [RFC](https://github.com/sveltejs/rfcs).
 If you're filing an issue about a bug please include as much information
 as you can, including the following.
 
-- The output of `npx envinfo --system --npmPackages svelte,@sveltejs/kit,vite --binaries --browsers`
+- The output of `npx envinfo --system --npmPackages svelte,@sveltejs/kit,@sveltejs/adapter-node,@sveltejs/adapter-static,@sveltejs/adapter-begin,@sveltejs/adapter-netlify,@sveltejs/adapter-vercel vite --binaries --browsers`
 - Your browser
-- Your adapter (e.g. Node, static, Vercel, Begin, etc...)
+- If using an unofficial adapter, the adapter and version
 
 - _Repeatable steps to reproduce the issue_
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -20,7 +20,7 @@ as you can, including the following.
 
 - The output of `npx envinfo --system --npmPackages svelte,@sveltejs/kit,@sveltejs/adapter-node,@sveltejs/adapter-static,@sveltejs/adapter-begin,@sveltejs/adapter-netlify,@sveltejs/adapter-vercel vite --binaries --browsers`
 - Your browser
-- If using an unofficial adapter, the adapter and version
+- If using a community adapter, the adapter and version
 
 - _Repeatable steps to reproduce the issue_
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -40,11 +40,9 @@ Stack trace goes here...
 <details>
   <summary>Diagnostics</summary>
 
-- The output of `npx envinfo --system --npmPackages svelte,@sveltejs/kit,vite --binaries --browsers`
-
+- The output of `npx envinfo --system --npmPackages svelte,@sveltejs/kit,@sveltejs/adapter-node,@sveltejs/adapter-static,@sveltejs/adapter-begin,@sveltejs/adapter-netlify,@sveltejs/adapter-vercel vite --binaries --browsers`
 - Your browser
-
-- Your adapter (e.g. Node, static, Vercel, Begin, etc...)
+- If using an unofficial adapter, the adapter and version
 </details>
 
 **Severity**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -42,7 +42,7 @@ Stack trace goes here...
 
 - The output of `npx envinfo --system --npmPackages svelte,@sveltejs/kit,@sveltejs/adapter-node,@sveltejs/adapter-static,@sveltejs/adapter-begin,@sveltejs/adapter-netlify,@sveltejs/adapter-vercel vite --binaries --browsers`
 - Your browser
-- If using an unofficial adapter, the adapter and version
+- If using a community adapter, the adapter and version
 </details>
 
 **Severity**


### PR DESCRIPTION
This makes the command longer, but we still have a lot of people installing the `latest` version of the adapters. It'd be a lot easier to identify which bug reports are caused by that with the version number included