### PR TITLE
Upgrade adapters esbuild to latest

### DIFF
--- a/.changeset/bright-dolphins-try.md
+++ b/.changeset/bright-dolphins-try.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-vercel': patch
+---
+
+Upgrade esbuild to ^0.12.5

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -17,8 +17,8 @@
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore"
 	},
 	"dependencies": {
-		"esbuild": "^0.11.18",
-		"@iarna/toml": "^2.2.5"
+		"@iarna/toml": "^2.2.5",
+		"esbuild": "^0.12.5"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:*"

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -17,8 +17,8 @@
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore"
 	},
 	"dependencies": {
-		"esbuild": "^0.11.18",
-		"@iarna/toml": "^2.2.5"
+		"@iarna/toml": "^2.2.5",
+		"esbuild": "^0.12.5"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:*",

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -17,7 +17,7 @@
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore"
 	},
 	"dependencies": {
-		"esbuild": "^0.11.18"
+		"esbuild": "^0.12.5"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,10 +69,10 @@ importers:
     specifiers:
       '@iarna/toml': ^2.2.5
       '@sveltejs/kit': workspace:*
-      esbuild: ^0.11.18
+      esbuild: ^0.12.5
     dependencies:
       '@iarna/toml': 2.2.5
-      esbuild: 0.11.18
+      esbuild: 0.12.5
     devDependencies:
       '@sveltejs/kit': link:../kit
 
@@ -80,11 +80,11 @@ importers:
     specifiers:
       '@iarna/toml': ^2.2.5
       '@sveltejs/kit': workspace:*
-      esbuild: ^0.11.18
+      esbuild: ^0.12.5
       typescript: ^4.2.4
     dependencies:
       '@iarna/toml': 2.2.5
-      esbuild: 0.11.18
+      esbuild: 0.12.5
     devDependencies:
       '@sveltejs/kit': link:../kit
       typescript: 4.2.4
@@ -130,10 +130,10 @@ importers:
   packages/adapter-vercel:
     specifiers:
       '@sveltejs/kit': workspace:*
-      esbuild: ^0.11.18
+      esbuild: ^0.12.5
       typescript: ^4.2.4
     dependencies:
-      esbuild: 0.11.18
+      esbuild: 0.12.5
     devDependencies:
       '@sveltejs/kit': link:../kit
       typescript: 4.2.4
@@ -1524,12 +1524,6 @@ packages:
       is-date-object: 1.0.2
       is-symbol: 1.0.3
     dev: true
-
-  /esbuild/0.11.18:
-    resolution: {integrity: sha512-KD7v4N9b5B8bxPUNn/3GA9r0HWo4nJk3iwjZ+2zG1ffg+r8ig+wqj7sW6zgI6Sn4/B2FnbzqWxcAokAGGM5zwQ==}
-    hasBin: true
-    requiresBuild: true
-    dev: false
 
   /esbuild/0.12.5:
     resolution: {integrity: sha512-vcuP53pA5XiwUU4FnlXM+2PnVjTfHGthM7uP1gtp+9yfheGvFFbq/KyuESThmtoHPUrfZH5JpxGVJIFDVD1Egw==}


### PR DESCRIPTION
The esbuild version of Vercel, Netlify, and Cloudflare Workers adapter has been `^0.11.18` for a while. It's been upgraded to `^0.12.5` in this PR.

Personally I'm using prisma 2 in my SvelteKit app on Vercel. Prisma client [depends on the module `undici`](https://github.com/prisma/prisma/issues/6564) which in turn depends on a Node internal module called `_http_common`. Since this node internal module was not in esbuild's Node internal module list, `svelte-kit build` failed due to esbuild not able to resolve `_http_common`. This is fixed in esbuild [0.12.1](https://github.com/evanw/esbuild/blob/master/CHANGELOG.md#0121).

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts