### PR TITLE
(feat) svelte package: transpile TS

### DIFF
--- a/.changeset/twenty-dryers-hope.md
+++ b/.changeset/twenty-dryers-hope.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+package command can now transpile TypeScript files

--- a/packages/kit/rollup.config.js
+++ b/packages/kit/rollup.config.js
@@ -9,7 +9,8 @@ import pkg from './package.json';
 const external = [].concat(
 	Object.keys(pkg.dependencies || {}),
 	Object.keys(pkg.peerDependencies || {}),
-	Object.keys(process.binding('natives'))
+	Object.keys(process.binding('natives')),
+	'typescript'
 );
 
 export default [

--- a/packages/kit/src/core/make_package/index.js
+++ b/packages/kit/src/core/make_package/index.js
@@ -144,7 +144,7 @@ function loadTsconfig(filename, ts) {
 	// Do this so TS will not search for initial files which might take a while
 	config.include = [];
 	config.files = [];
-	let { options } = ts.parseJsonConfigFileContent(
+	const { options } = ts.parseJsonConfigFileContent(
 		config,
 		ts.sys,
 		basePath,


### PR DESCRIPTION
This adds transpilation functionality for TypeScript files when using `svelte-kit package`.

It requires the user to have TypeScript installed, but that should be the case if he uses TS.