### PR TITLE
Re-bundle server app in adapter-node

### DIFF
--- a/.changeset/tiny-socks-sparkle.md
+++ b/.changeset/tiny-socks-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Bundle server-side app during adapt phase

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -1,6 +1,7 @@
-import { copyFileSync } from 'fs';
+import { readFileSync } from 'fs';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
+import esbuild from 'esbuild';
 
 /**
  * @param {{
@@ -18,11 +19,17 @@ export default function ({ out = 'build' } = {}) {
 			utils.copy_client_files(static_directory);
 			utils.copy_static_files(static_directory);
 
-			utils.log.minor('Copying server');
-			utils.copy_server_files(out);
-
+			utils.log.minor('Building server');
 			const files = fileURLToPath(new URL('./files', import.meta.url));
-			copyFileSync(`${files}/server.js`, `${out}/index.js`);
+			utils.copy(files, '.svelte-kit/node');
+			await esbuild.build({
+				entryPoints: ['.svelte-kit/node/index.js'],
+				outfile: join(out, 'index.js'),
+				bundle: true,
+				external: Object.keys(JSON.parse(readFileSync('package.json', 'utf8')).dependencies || {}),
+				format: 'esm',
+				platform: 'node'
+			});
 
 			utils.log.minor('Prerendering static pages');
 			await utils.prerender({

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -20,6 +20,9 @@
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"prepublishOnly": "npm run build"
 	},
+	"dependencies": {
+		"esbuild": "^0.12.5"
+	},
 	"devDependencies": {
 		"@rollup/plugin-json": "^4.1.0",
 		"@sveltejs/kit": "workspace:*",

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -5,10 +5,10 @@ import json from '@rollup/plugin-json';
 export default {
 	input: 'src/index.js',
 	output: {
-		file: 'files/server.js',
+		file: 'files/index.js',
 		format: 'esm',
 		sourcemap: true
 	},
 	plugins: [nodeResolve(), commonjs(), json()],
-	external: ['./app.js', ...require('module').builtinModules]
+	external: ['../output/server/app.js', ...require('module').builtinModules]
 };

--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -1,3 +1,4 @@
+import './require_shim';
 import { createServer } from './server';
 // TODO hardcoding the relative location makes this brittle
 import { render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved

--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -1,10 +1,10 @@
 import { createServer } from './server';
-/*eslint import/no-unresolved: [2, { ignore: ['\.\/app\.js$'] }]*/
-import * as app from './app.js';
+// TODO hardcoding the relative location makes this brittle
+import { render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
 
 const { HOST = '0.0.0.0', PORT = 3000 } = process.env;
 
-const instance = createServer({ render: app.render }).listen(PORT, HOST, () => {
+const instance = createServer({ render }).listen(PORT, HOST, () => {
 	console.log(`Listening on port ${PORT}`);
 });
 

--- a/packages/adapter-node/src/require_shim.js
+++ b/packages/adapter-node/src/require_shim.js
@@ -1,0 +1,2 @@
+import { createRequire } from 'module';
+global.require = createRequire(import.meta.url);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,12 +95,15 @@ importers:
       '@sveltejs/kit': workspace:*
       c8: ^7.7.2
       compression: ^1.7.4
+      esbuild: ^0.12.5
       node-fetch: ^3.0.0-beta.9
       polka: ^1.0.0-next.15
       rollup: ^2.47.0
       sirv: ^1.0.12
       typescript: ^4.2.4
       uvu: ^0.5.1
+    dependencies:
+      esbuild: 0.12.5
     devDependencies:
       '@rollup/plugin-json': 4.1.0_rollup@2.47.0
       '@sveltejs/kit': link:../kit


### PR DESCRIPTION
Fixes #1257. This makes adapter-node run the server-side app through esbuild as part of the build process, treating anything in (prod) `dependencies` as external, and bundling everything else. This means that, for example, `@sveltejs/kit` will no longer need to be installed when deploying the production app - and any other dependencies that the app adds as `devDependencies` will also be bundled in. This means that, in production, you should be able to copy over your `package.json` and `build/`, run `npm install --production`, and run `node build` - which is what you'd expect to be able to do.

These changes seem to behave as expected on the project I have at work (which adds a number of dependencies, some of which should be bundled on the server and some of which should not) - but I'd still appreciate some more eyes on this PR.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
