### PR TITLE
fix: match up ambient modules for goto

### DIFF
--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -178,8 +178,10 @@ export class Router {
 	}
 
 	/**
-	 * @param {string} href
-	 * @param {Parameters<typeof import('$app/navigation').goto>[1]} opts
+	 * @typedef {Parameters<typeof import('$app/navigation').goto>} GotoParams
+	 *
+	 * @param {GotoParams[0]} href
+	 * @param {GotoParams[1]} opts
 	 * @param {string[]} chain
 	 */
 	async goto(href, { noscroll = false, replaceState = false, state = {} } = {}, chain) {

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -179,7 +179,7 @@ export class Router {
 
 	/**
 	 * @param {string} href
-	 * @param {{ noscroll?: boolean, replaceState?: boolean, state?: any }} opts
+	 * @param {Parameters<typeof import('$app/navigation').goto>[1]} opts
 	 * @param {string[]} chain
 	 */
 	async goto(href, { noscroll = false, replaceState = false, state = {} } = {}, chain) {

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -26,7 +26,7 @@ declare module '$app/navigation' {
 	 */
 	export function goto(
 		href: string,
-		opts?: { replaceState?: boolean; noscroll?: boolean }
+		opts?: { replaceState?: boolean; noscroll?: boolean; state?: any }
 	): Promise<any>;
 	/**
 	 * Returns a Promise that resolves when SvelteKit re-runs any current `load` functions that depend on `href`

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -22,7 +22,7 @@ declare module '$app/navigation' {
 	 * Returns a Promise that resolves when SvelteKit navigates (or fails to navigate, in which case the promise rejects) to the specified href.
 	 *
 	 * @param href Where to navigate to
-	 * @param opts Optional. If `replaceState` is `true`, a new history entry won't be created. If `noscroll` is `true`, the browser won't scroll to the top of the page after navigation.
+	 * @param opts Optional. If `replaceState` is `true`, a new history entry won't be created. If `noscroll` is `true`, the browser won't scroll to the top of the page after navigation. If state is set, its value will be used to set the initital state of the new history entry, it defaults to `{}`
 	 */
 	export function goto(
 		href: string,


### PR DESCRIPTION
The recent addition from #1643 missed to update ambient types, and with more proposed additions coming up in the PRs, it can be quite a handful to manage this manually. In the meantime, this PR should make it easier to make changes by only needing to update JSDoc and markdown docs.