### PR TITLE
Add faq docs about limitation in vite-plugin-svelte

### DIFF
--- a/documentation/faq/70-packages.md
+++ b/documentation/faq/70-packages.md
@@ -12,4 +12,6 @@ Old beta versions of the SvelteKit template included the configuration value `no
 
 The second most commonly-encountered issue is having a Svelte component that imports a CommonJS library. In this case, you should try to work with the library authors to distribute an ESM version of the dependency. However, in the meantime, you can workaround this issue by adding the dependency to `vite.optimizeDeps.include` in `svelte.config.js`.
 
+Also, some Svelte libraries doesn't work nicely with Vite's pre-bundling process, do check out `@sveltejs/vite-plugin-svelte`'s docs on its current [limitation and workaround](https://github.com/sveltejs/vite-plugin-svelte/tree/main/packages/vite-plugin-svelte#importing-third-party-svelte-libraries).
+
 If you are still encountering issues we recommend searching both [the Vite issue tracker](https://github.com/vitejs/vite/issues) and the issue tracker of the library in question. Sometimes issues can be worked around by fiddling with the [`optimizeDeps`](https://vitejs.dev/config/#dep-optimization-options) or [`ssr`](https://vitejs.dev/config/#ssr-options) config values.


### PR DESCRIPTION
Add paragraph under FAQ package section about `@sveltejs/vite-plugin-svelte`'s docs regarding the `optimizeDeps.exclude` [trick](https://github.com/sveltejs/vite-plugin-svelte/tree/main/packages/vite-plugin-svelte#importing-third-party-svelte-libraries).

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
