### PR TITLE
Fix navigation when `base` path is set and validate that option's value

### DIFF
--- a/.changeset/soft-bikes-bake.md
+++ b/.changeset/soft-bikes-bake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix redirect URLs when removing/adding trailing slash when `base` path is set

--- a/.changeset/soft-bikes-bake.md
+++ b/.changeset/soft-bikes-bake.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Fix redirect URLs when removing/adding trailing slash when `base` path is set
+Fix navigation when `base` path is set and validate that option's value

--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -116,7 +116,7 @@ Whether to [hydrate](#ssr-and-javascript-hydrate) the server-rendered HTML with 
 An object containing zero or more of the following `string` values:
 
 - `assets` — an absolute path, or a path relative to `base`, where your app's files are served from. This is useful if your files are served from a storage bucket of some kind
-- `base` — a root-relative (i.e. starts with `/`) path that specifies where your app is served from. This allows the app to live on a non-root path
+- `base` — a root-relative path that must be prefixed with `/`. This specifies where your app is served from and allows the app to live on a non-root path
 
 ### prerender
 

--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -116,7 +116,7 @@ Whether to [hydrate](#ssr-and-javascript-hydrate) the server-rendered HTML with 
 An object containing zero or more of the following `string` values:
 
 - `assets` — an absolute path, or a path relative to `base`, where your app's files are served from. This is useful if your files are served from a storage bucket of some kind
-- `base` — a root-relative path that must starts, but doesn't end with `/` (e.g. `/base-path`). This specifies where your app is served from and allows the app to live on a non-root path
+- `base` — a root-relative path that must start, but not end with `/` (e.g. `/base-path`). This specifies where your app is served from and allows the app to live on a non-root path
 
 ### prerender
 

--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -116,7 +116,7 @@ Whether to [hydrate](#ssr-and-javascript-hydrate) the server-rendered HTML with 
 An object containing zero or more of the following `string` values:
 
 - `assets` — an absolute path, or a path relative to `base`, where your app's files are served from. This is useful if your files are served from a storage bucket of some kind
-- `base` — a root-relative path that must be prefixed with `/`. This specifies where your app is served from and allows the app to live on a non-root path
+- `base` — a root-relative path that must starts, but doesn't end with `/` (e.g. `/base-path`). This specifies where your app is served from and allows the app to live on a non-root path
 
 ### prerender
 

--- a/packages/kit/src/core/load_config/index.js
+++ b/packages/kit/src/core/load_config/index.js
@@ -135,9 +135,9 @@ export function validate_config(config) {
 	// resolve paths
 	const { paths } = validated.kit;
 
-	if (paths.base !== '' && (paths.base === '/' || !paths.base.startsWith('/'))) {
+	if (paths.base !== '' && paths.base.endsWith('/') && !paths.base.startsWith('/')) {
 		throw new Error(
-			'config.kit.paths.base must be a root-relative path. See https://kit.svelte.dev/docs#configuration-paths'
+			"config.kit.paths.base must be a root-relative path and does not ends with '/'. See https://kit.svelte.dev/docs#configuration-paths"
 		);
 	}
 

--- a/packages/kit/src/core/load_config/index.js
+++ b/packages/kit/src/core/load_config/index.js
@@ -137,7 +137,7 @@ export function validate_config(config) {
 
 	if (paths.base !== '' && (paths.base.endsWith('/') || !paths.base.startsWith('/'))) {
 		throw new Error(
-			"config.kit.paths.base must be a root-relative path and does not ends with '/'. See https://kit.svelte.dev/docs#configuration-paths"
+			"config.kit.paths.base must be a root-relative path and doesn't end with '/'. See https://kit.svelte.dev/docs#configuration-paths"
 		);
 	}
 

--- a/packages/kit/src/core/load_config/index.js
+++ b/packages/kit/src/core/load_config/index.js
@@ -135,7 +135,7 @@ export function validate_config(config) {
 	// resolve paths
 	const { paths } = validated.kit;
 
-	if (paths.base !== '' && !paths.base.startsWith('/')) {
+	if (paths.base !== '' && paths.base === '/' && !paths.base.startsWith('/')) {
 		throw new Error('config.kit.paths.base must be a root-relative path');
 	}
 

--- a/packages/kit/src/core/load_config/index.js
+++ b/packages/kit/src/core/load_config/index.js
@@ -136,7 +136,9 @@ export function validate_config(config) {
 	const { paths } = validated.kit;
 
 	if (paths.base !== '' && paths.base === '/' && !paths.base.startsWith('/')) {
-		throw new Error('config.kit.paths.base must be a root-relative path');
+		throw new Error(
+			'config.kit.paths.base must be a root-relative path. See https://kit.svelte.dev/docs#configuration-paths'
+		);
 	}
 
 	paths.assets = resolve(paths.base, paths.assets);

--- a/packages/kit/src/core/load_config/index.js
+++ b/packages/kit/src/core/load_config/index.js
@@ -135,7 +135,7 @@ export function validate_config(config) {
 	// resolve paths
 	const { paths } = validated.kit;
 
-	if (paths.base !== '' && paths.base.endsWith('/') && !paths.base.startsWith('/')) {
+	if (paths.base !== '' && (paths.base.endsWith('/') || !paths.base.startsWith('/'))) {
 		throw new Error(
 			"config.kit.paths.base must be a root-relative path and does not ends with '/'. See https://kit.svelte.dev/docs#configuration-paths"
 		);

--- a/packages/kit/src/core/load_config/index.js
+++ b/packages/kit/src/core/load_config/index.js
@@ -135,7 +135,7 @@ export function validate_config(config) {
 	// resolve paths
 	const { paths } = validated.kit;
 
-	if (paths.base !== '' && paths.base === '/' && !paths.base.startsWith('/')) {
+	if (paths.base !== '' && (paths.base === '/' || !paths.base.startsWith('/'))) {
 		throw new Error(
 			'config.kit.paths.base must be a root-relative path. See https://kit.svelte.dev/docs#configuration-paths'
 		);

--- a/packages/kit/src/core/load_config/index.js
+++ b/packages/kit/src/core/load_config/index.js
@@ -137,7 +137,7 @@ export function validate_config(config) {
 
 	if (paths.base !== '' && (paths.base.endsWith('/') || !paths.base.startsWith('/'))) {
 		throw new Error(
-			"config.kit.paths.base must be a root-relative path and doesn't end with '/'. See https://kit.svelte.dev/docs#configuration-paths"
+			"config.kit.paths.base must be a root-relative path that starts but doesn't end with '/'. See https://kit.svelte.dev/docs#configuration-paths"
 		);
 	}
 

--- a/packages/kit/src/core/load_config/index.js
+++ b/packages/kit/src/core/load_config/index.js
@@ -137,7 +137,7 @@ export function validate_config(config) {
 
 	if (paths.base !== '' && (paths.base.endsWith('/') || !paths.base.startsWith('/'))) {
 		throw new Error(
-			"config.kit.paths.base must be a root-relative path that starts but doesn't end with '/'. See https://kit.svelte.dev/docs#configuration-paths"
+			"kit.paths.base option must be a root-relative path that starts but doesn't end with '/'. See https://kit.svelte.dev/docs#configuration-paths"
 		);
 	}
 

--- a/packages/kit/src/core/load_config/index.spec.js
+++ b/packages/kit/src/core/load_config/index.spec.js
@@ -174,6 +174,18 @@ test('fails if paths.base is not root-relative', () => {
 	}, /^config\.kit\.paths\.base must be a root-relative path. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
 });
 
+test('fails if paths.base ends with /', () => {
+	assert.throws(() => {
+		validate_config({
+			kit: {
+				paths: {
+					base: '/basePath/'
+				}
+			}
+		});
+	}, /^config\.kit\.paths\.base must not end with \/$/);
+});
+
 test('fails if prerender.pages are invalid', () => {
 	assert.throws(() => {
 		validate_config({

--- a/packages/kit/src/core/load_config/index.spec.js
+++ b/packages/kit/src/core/load_config/index.spec.js
@@ -171,7 +171,7 @@ test('fails if paths.base is not root-relative', () => {
 				}
 			}
 		});
-	}, /^config\.kit\.paths\.base must be a root-relative path that starts but doesn't end with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
+	}, /^kit\.paths\.base option must be a root-relative path that starts but doesn't end with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
 });
 
 test("fails if paths.base ends with '/'", () => {

--- a/packages/kit/src/core/load_config/index.spec.js
+++ b/packages/kit/src/core/load_config/index.spec.js
@@ -183,7 +183,7 @@ test("fails if paths.base ends with '/'", () => {
 				}
 			}
 		});
-	}, /^config\.kit\.paths\.base must be a root-relative path and doesn't end with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
+	}, /^config\.kit\.paths\.base must be a root-relative path that starts but doesn't end with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
 });
 
 test('fails if prerender.pages are invalid', () => {

--- a/packages/kit/src/core/load_config/index.spec.js
+++ b/packages/kit/src/core/load_config/index.spec.js
@@ -183,7 +183,7 @@ test("fails if paths.base ends with '/'", () => {
 				}
 			}
 		});
-	}, /^config\.kit\.paths\.base must be a root-relative path that starts but doesn't end with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
+	}, /^kit\.paths\.base option must be a root-relative path that starts but doesn't end with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
 });
 
 test('fails if prerender.pages are invalid', () => {

--- a/packages/kit/src/core/load_config/index.spec.js
+++ b/packages/kit/src/core/load_config/index.spec.js
@@ -171,7 +171,7 @@ test('fails if paths.base is not root-relative', () => {
 				}
 			}
 		});
-	}, /^config\.kit\.paths\.base must be a root-relative path$/);
+	}, /^config\.kit\.paths\.base must be a root-relative path. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
 });
 
 test('fails if prerender.pages are invalid', () => {

--- a/packages/kit/src/core/load_config/index.spec.js
+++ b/packages/kit/src/core/load_config/index.spec.js
@@ -171,7 +171,7 @@ test('fails if paths.base is not root-relative', () => {
 				}
 			}
 		});
-	}, /^config\.kit\.paths\.base must be a root-relative path and doesn't end with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
+	}, /^config\.kit\.paths\.base must be a root-relative path that starts but doesn't end with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
 });
 
 test("fails if paths.base ends with '/'", () => {

--- a/packages/kit/src/core/load_config/index.spec.js
+++ b/packages/kit/src/core/load_config/index.spec.js
@@ -171,19 +171,19 @@ test('fails if paths.base is not root-relative', () => {
 				}
 			}
 		});
-	}, /^config\.kit\.paths\.base must be a root-relative path. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
+	}, /^config\.kit\.paths\.base must be a root-relative path and does not ends with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
 });
 
-test('fails if paths.base ends with /', () => {
+test("fails if paths.base ends with '/'", () => {
 	assert.throws(() => {
 		validate_config({
 			kit: {
 				paths: {
-					base: '/basePath/'
+					base: '/github-pages/'
 				}
 			}
 		});
-	}, /^config\.kit\.paths\.base must not end with \/$/);
+	}, /^config\.kit\.paths\.base must be a root-relative path and does not ends with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
 });
 
 test('fails if prerender.pages are invalid', () => {

--- a/packages/kit/src/core/load_config/index.spec.js
+++ b/packages/kit/src/core/load_config/index.spec.js
@@ -171,7 +171,7 @@ test('fails if paths.base is not root-relative', () => {
 				}
 			}
 		});
-	}, /^config\.kit\.paths\.base must be a root-relative path and does not ends with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
+	}, /^config\.kit\.paths\.base must be a root-relative path and doesn't end with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
 });
 
 test("fails if paths.base ends with '/'", () => {
@@ -183,7 +183,7 @@ test("fails if paths.base ends with '/'", () => {
 				}
 			}
 		});
-	}, /^config\.kit\.paths\.base must be a root-relative path and does not ends with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
+	}, /^config\.kit\.paths\.base must be a root-relative path and doesn't end with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
 });
 
 test('fails if prerender.pages are invalid', () => {

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -245,7 +245,7 @@ export class Router {
 
 			if (incorrect) {
 				info.path = has_trailing_slash ? info.path.slice(0, -1) : info.path + '/';
-				history.replaceState({}, '', `${info.path}${location.search}`);
+				history.replaceState({}, '', `${this.base}${info.path}${location.search}`);
 			}
 		}
 


### PR DESCRIPTION
Closes #1359 
Fixes #1476 
Closes #1608 

Updating the docs in this case would be better than manipulating the paths at runtime. Changing the regex or url slicing solves the problem for dev, but still throws when adapters starts building (I tried). Rather than adding checks for all possible uses at runtime or (worse) changing the config passed from the user, it would be clearer for the user to just make sure that the config is correct.