### PR TITLE
Include `charset=utf-8` by default in `application/json` endpoints.

### DIFF
--- a/.changeset/fuzzy-kids-turn.md
+++ b/.changeset/fuzzy-kids-turn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Use UTF-8 encoding for JSON endpoint responses by default

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -54,8 +54,8 @@ export default async function render_route(request, route) {
 			/** @type {import('types/hooks').StrictBody} */
 			let normalized_body;
 
-			if (typeof body === 'object' && (!type || type === 'application/json')) {
-				headers = { ...headers, 'content-type': 'application/json' };
+			if (typeof body === 'object' && (!type || type === 'application/json' || type === 'application/json; charset=utf-8')) {
+				headers = { ...headers, 'content-type': 'application/json; charset=utf-8' };
 				normalized_body = JSON.stringify(body);
 			} else {
 				normalized_body = /** @type {import('types/hooks').StrictBody} */ (body);

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -54,7 +54,10 @@ export default async function render_route(request, route) {
 			/** @type {import('types/hooks').StrictBody} */
 			let normalized_body;
 
-			if (typeof body === 'object' && (!type || type === 'application/json' || type === 'application/json; charset=utf-8')) {
+			if (
+				typeof body === 'object' &&
+				(!type || type === 'application/json' || type === 'application/json; charset=utf-8')
+			) {
 				headers = { ...headers, 'content-type': 'application/json; charset=utf-8' };
 				normalized_body = JSON.stringify(body);
 			} else {

--- a/packages/kit/test/apps/basics/src/routes/encoded/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/encoded/_tests.js
@@ -31,8 +31,5 @@ export default function (test) {
 	test('sets charset on JSON Content-Type', null, async ({ fetch }) => {
 		const response = await fetch('/encoded/endpoint');
 		assert.equal(response.headers.get('content-type'), 'application/json; charset=utf-8');
-		/** @type {{ fruit?: string }} */
-		const body = await response.json();
-		assert.equal(body['fruit'], '🍎🍇🍌');
 	});
 }

--- a/packages/kit/test/apps/basics/src/routes/encoded/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/encoded/_tests.js
@@ -27,4 +27,12 @@ export default function (test) {
 		assert.equal(await page.innerHTML('h2'), '/encoded/苗条');
 		assert.equal(await page.innerHTML('h3'), '/encoded/苗条');
 	});
+
+	test('sets charset on JSON Content-Type', null, async ({ fetch }) => {
+		const response = await fetch('/encoded/endpoint');
+		assert.equal(response.headers.get('content-type'), 'application/json; charset=utf-8');
+		/** @type {{ fruit?: string }} */
+		const body = await response.json();
+		assert.equal(body['fruit'], '🍎🍇🍌');
+	});
 }

--- a/packages/kit/test/apps/basics/src/routes/encoded/endpoint.js
+++ b/packages/kit/test/apps/basics/src/routes/encoded/endpoint.js
@@ -1,0 +1,7 @@
+export async function get() {
+	return {
+		body: {
+			fruit: '🍎🍇🍌',
+		},
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/encoded/endpoint.js
+++ b/packages/kit/test/apps/basics/src/routes/encoded/endpoint.js
@@ -1,7 +1,7 @@
 export async function get() {
 	return {
 		body: {
-			fruit: '🍎🍇🍌',
-		},
+			fruit: '🍎🍇🍌'
+		}
 	};
 }

--- a/packages/kit/test/apps/basics/src/routes/load/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/load/_tests.js
@@ -14,7 +14,7 @@ export default function (test, is_dev) {
 		});
 
 		const payload =
-			'{"status":200,"statusText":"","headers":{"content-type":"application/json"},"body":"{\\"answer\\":42}"}';
+			'{"status":200,"statusText":"","headers":{"content-type":"application/json; charset=utf-8"},"body":"{\\"answer\\":42}"}';
 
 		if (!js) {
 			// by the time JS has run, hydration will have nuked these scripts


### PR DESCRIPTION
Hey there 👋 

I was getting [Mojibake](https://en.wikipedia.org/wiki/Mojibake) when returning unicode data from my endpoints, so I checked the headers and noticed the `charset=utf-8` option was missing from `Content-Type`. This in turn was causing the response to incorrectly be interpreted as Windows-1252.

This PR changes `src/runtime/server/endpoint.js` to include that by default for `typeof body === 'object'`.

I couldn't find any tickets about this, believe this change is simple enough that it's okay for me to open a PR without filing a ticket first.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
