### PR TITLE
Allow sirv to looks for precompiled gzip and brotli files by default

### DIFF
--- a/.changeset/heavy-ways-agree.md
+++ b/.changeset/heavy-ways-agree.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': minor
+---
+
+Allow sirv to looks for precompiled gzip and brotli files by default

--- a/packages/adapter-node/src/server.js
+++ b/packages/adapter-node/src/server.js
@@ -30,7 +30,9 @@ export function createServer({ render }) {
 	const assets_handler = fs.existsSync(paths.assets)
 		? sirv(paths.assets, {
 				maxAge: 31536000,
-				immutable: true
+				immutable: true,
+				gzip: true,
+				brotli: true
 		  })
 		: noop_handler;
 


### PR DESCRIPTION
This should not change anyting for users who doesnt use brotli or gzip precompiled asset files. But brotli gives real advantages over gzip in compression size.

In absense of sirv config, probably it can be a good default. 

For compressing we use following script. 

```typescript
import * as zlib from 'zlib';
import { pipeline } from 'stream';
import { promisify } from 'util';

import * as fs from 'fs';
import { totalist } from 'totalist/sync/index.js';
import yargs from 'yargs';

const supportedAlgs = ['gz', 'br'];

const argv = yargs(process.argv.slice(2))
  .describe('alg', 'Compression algorithm gz or br')
  .choices('alg', supportedAlgs)
  .describe('dir', 'Directory to compress files')
  .string('dir')
  .array('ext')
  .default('ext', ['js', 'css', 'json', 'svg'])
  .demandOption(['alg', 'dir'], 'alg and dir must be provided')
  .check(argv => {
    if (!fs.statSync(argv.dir).isDirectory()) {
      throw new Error(`"${argv.dir}" is not directory`);
    }

    return true; // tell Yargs that the arguments passed the check
  })
  .example([
    ['$0 --alg br --dir .build/assets', 'Use brotli compression'],
    ['$0 --alg gz --dir .build/assets', 'Use gz compression'],
    [
      '$0 --alg gz --dir .build/assets --ext css json',
      'Use gz compression for files with css and json extensions',
    ],
  ]).argv;

const files: string[] = [];

if (!('dir' in argv)) {
  throw new Error('argv is a promise');
}

totalist(argv.dir, (_, abs) => {
  files.push(abs);
});

const pipe = promisify(pipeline);

const compress = async () => {
  const sizes = [];
  for (const file of files) {
    if (
      argv.ext.some(ext => file.endsWith(`.${ext}`)) &&
      !supportedAlgs.some(alg => file.endsWith(`.${alg}`))
    ) {
      const destFile = `${file}.${argv.alg}`;
      const compressionMethod =
        argv.alg === 'gz' ? zlib.createGzip() : zlib.createBrotliCompress();
      const source = fs.createReadStream(file);
      const destination = fs.createWriteStream(destFile);
      await pipe(source, compressionMethod, destination);
      const inSize = Math.round((100 * fs.statSync(file).size) / 1024) / 100;
      const outSize =
        Math.round((100 * fs.statSync(destFile).size) / 1024) / 100;

      sizes.push({ inSize, outSize, file });
    }
  }

  console.table(sizes);
};

compress().then(() => null);
```



