### PR TITLE
Fix adapter-node build in presence of tsconfig.json

### DIFF
--- a/.changeset/wild-pumas-jam.md
+++ b/.changeset/wild-pumas-jam.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Fix build when using TypeScript and there is a `tsconfig.json` with `target: 'es2019'` or earlier

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -28,7 +28,8 @@ export default function ({ out = 'build' } = {}) {
 				bundle: true,
 				external: Object.keys(JSON.parse(readFileSync('package.json', 'utf8')).dependencies || {}),
 				format: 'esm',
-				platform: 'node'
+				platform: 'node',
+				target: 'node12'
 			});
 
 			utils.log.minor('Prerendering static pages');


### PR DESCRIPTION
Fixes #1667 in a way that (as far as I can tell) does not break compatibility with Node 12.

In Kit apps written in TypeScript, esbuild was seeing the `tsconfig.json` in the user's app and the `target` in there was being used since the call to `esbuild.build()` did not explicitly specify one. This was a problem because the starter app uses `es2019`, which does not support `import.meta.url`, and so the references to this (including the ones in the code introduced by the adapter) were being replaced with `undefined`.

We don't want to tell the adapter to bundle for `target: 'es2020'` because that would then mean we wouldn't be transpiling features not supported by Node 12. Luckily, esbuild lets us do `target: 'node12'`, which transpiles specifically the features not supported in Node 12. This lets us use `?.` (which will get transpiled) and also use `import.meta.url` (which is left as-is since it is supported natively in Node 12, even though it doesn't support all of ES2020).

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
