### PR TITLE
Don't check external links on prerender

### DIFF
--- a/.changeset/rare-pots-invite.md
+++ b/.changeset/rare-pots-invite.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+Don't check external links on prerender

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -33,9 +33,9 @@ function get_src(attrs) {
 }
 
 /** @param {string} attrs */
-function get_rel(attrs) {
-	const match = /rel\s*=\s*(?:"(.*?)"|'(.*?)'|([^\s>]*))/.exec(attrs);
-	return match && (match[1] || match[2] || match[3]);
+function is_rel_external(attrs) {
+	const match = /rel\s*=\s*(?:["'][^>]*(external)[^>]*["']|(external))/.exec(attrs);
+	return !!match;
 }
 
 /** @param {string} attrs */
@@ -231,8 +231,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 					const attrs = match[2];
 
 					if (element === 'a' || element === 'link') {
-						const rel = get_rel(attrs);
-						if (rel === 'external') continue;
+						if (is_rel_external(attrs)) continue;
 
 						hrefs.push(get_href(attrs));
 					} else {

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -33,7 +33,7 @@ function get_src(attrs) {
 }
 
 /** @param {string} attrs */
-function is_rel_external(attrs) {
+export function is_rel_external(attrs) {
 	const match = /rel\s*=\s*(?:["'][^>]*(external)[^>]*["']|(external))/.exec(attrs);
 	return !!match;
 }

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -233,7 +233,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 					if (element === 'a' || element === 'link') {
 						const rel = get_rel(attrs);
 						if (rel === 'external') continue;
-						
+
 						hrefs.push(get_href(attrs));
 					} else {
 						if (element === 'img') {

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -33,6 +33,12 @@ function get_src(attrs) {
 }
 
 /** @param {string} attrs */
+function get_rel(attrs) {
+	const match = /rel\s*=\s*(?:"(.*?)"|'(.*?)'|([^\s>]*))/.exec(attrs);
+	return match && (match[1] || match[2] || match[3]);
+}
+
+/** @param {string} attrs */
 function get_srcset_urls(attrs) {
 	const results = [];
 	// Note that the srcset allows any ASCII whitespace, including newlines.
@@ -225,6 +231,9 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 					const attrs = match[2];
 
 					if (element === 'a' || element === 'link') {
+						const rel = get_rel(attrs);
+						if (rel === 'external') continue;
+						
 						hrefs.push(get_href(attrs));
 					} else {
 						if (element === 'img') {

--- a/packages/kit/src/core/adapt/prerender.spec.js
+++ b/packages/kit/src/core/adapt/prerender.spec.js
@@ -1,10 +1,20 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import { get_href } from './prerender.js';
+import { get_href, is_rel_external } from './prerender.js';
 
 test('get_href', () => {
 	assert.equal(get_href('href="/foo" target=""'), '/foo');
 	assert.equal(get_href('target="" href="/foo"'), '/foo');
+});
+
+test('is_rel_external', () => {
+	assert.equal(is_rel_external('<a href="/foo" rel="external">'), true);
+	assert.equal(is_rel_external('<a href="/foo" rel = "external">'), true);
+	assert.equal(is_rel_external('<a href="/foo" rel="license external">'), true);
+	assert.equal(is_rel_external('<a href="/foo" rel=\'external license\'>'), true);
+	assert.equal(is_rel_external('<a href="/foo" rel=external>'), true);
+	assert.equal(is_rel_external('<a href="/foo" rel="stylesheet">'), false);
+	assert.equal(is_rel_external('<a href="/foo">'), false);
 });
 
 test.run();


### PR DESCRIPTION
Check if `a` element has attribute `rel` and if it's equal to `external` don't visit it