### PR TITLE
ensure router is initialized when subscribing to session

### DIFF
--- a/.changeset/hip-elephants-judge.md
+++ b/.changeset/hip-elephants-judge.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Ensure router is initialized before parsing location

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -109,7 +109,7 @@ export class Renderer {
 		this.stores.session.subscribe(async (value) => {
 			this.$session = value;
 
-			if (!ready) return;
+			if (!ready || !this.router) return;
 			this.session_id += 1;
 
 			const info = this.router.parse(new URL(location.href));


### PR DESCRIPTION
Fixes #1658 

This will make sure that renderer is ready and the router is initialized as well on session subscription. This should fix and silence the `TypeError` thrown at runtime. It doesn't really breaks the application AFAICT, but it's still quite annoying and concerning.