### PR TITLE
feat(adapter-node): support all esbuild build options

### DIFF
--- a/.changeset/stale-books-flash.md
+++ b/.changeset/stale-books-flash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+support all esbuild build options

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -14,14 +14,18 @@ export default {
 	kit: {
 		adapter: adapter({
 			// default options are shown below
-			outdir: 'build',
+			out: 'build',
 			precompress: false,
-			outfile: join(outdir, 'index.js')
-			bundle: true,
-			format: 'esm',
-			platform: 'node',
-			target: 'node12',
-			external: Object.keys(JSON.parse(readFileSync('package.json', 'utf8')).dependencies || {}),
+			esbuildOptions: {
+				outdir: out,
+				bundle: true,
+				format: 'esm',
+				platform: 'node',
+				target: 'node12',
+				external: [
+					/* package.json#dependencies */
+				]
+			}
 		})
 	}
 };
@@ -29,13 +33,28 @@ export default {
 
 ## Options
 
-All [esbuild build](https://esbuild.github.io/api/#build-api) options except for `entryPoints` are supported.
+### out
 
-The [outdir](https://esbuild.github.io/api/#outdir) is the directory to build the server to. It defaults to `build` — i.e. `node build` would start the server locally after it has been created.
+The directory to build the server to. It defaults to `build` — i.e. `node build` would start the server locally after it has been created.
 
 ### precompress
 
 Enables precompressing using gzip and brotli for assets and prerendered pages. It defaults to `false`.
+
+### esbuildOptions
+
+Any custom [esbuild build](https://esbuild.github.io/api/#build-api) options. It defaults to:
+
+```js
+{
+	outdir: out /* = 'build' */, // Unless a outfile is specified
+	bundle: true,
+	format: 'esm',
+	platform: 'node',
+	target: 'node12',
+	external: [ /* package.json#dependencies */ ]
+}
+```
 
 ## Environment variables
 

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -13,9 +13,15 @@ import adapter from '@sveltejs/adapter-node';
 export default {
 	kit: {
 		adapter: adapter({
-			// default options are shown
-			out: 'build',
-			precompress: false
+			// default options are shown below
+			outdir: 'build',
+			precompress: false,
+			outfile: join(outdir, 'index.js')
+			bundle: true,
+			format: 'esm',
+			platform: 'node',
+			target: 'node12',
+			external: Object.keys(JSON.parse(readFileSync('package.json', 'utf8')).dependencies || {}),
 		})
 	}
 };
@@ -23,9 +29,9 @@ export default {
 
 ## Options
 
-### out
+All [esbuild build](https://esbuild.github.io/api/#build-api) options except for `entryPoints` are supported.
 
-The directory to build the server to. It defaults to `build` — i.e. `node build` would start the server locally after it has been created.
+The [outdir](https://esbuild.github.io/api/#outdir) is the directory to build the server to. It defaults to `build` — i.e. `node build` would start the server locally after it has been created.
 
 ### precompress
 

--- a/packages/adapter-node/index.d.ts
+++ b/packages/adapter-node/index.d.ts
@@ -1,6 +1,3 @@
-declare function plugin(options?: {
-	out?: string;
-	precompress?: boolean;
-}): import('@sveltejs/kit').Adapter;
+declare function plugin(options?: {precompress?: boolean} & import('esbuild').BuildOptions): import('@sveltejs/kit').Adapter;
 
 export = plugin;

--- a/packages/adapter-node/index.d.ts
+++ b/packages/adapter-node/index.d.ts
@@ -1,3 +1,7 @@
-declare function plugin(options?: {precompress?: boolean} & import('esbuild').BuildOptions): import('@sveltejs/kit').Adapter;
+declare function plugin(options?: {
+	out?: string;
+	precompress?: boolean;
+	esbuildOptions?: import('esbuild').BuildOptions;
+}): import('@sveltejs/kit').Adapter;
 
 export = plugin;


### PR DESCRIPTION
This PR allows changing the options passed to esbuild build which allows to customize the server generation like target node version, sourcemap, inject, and more.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
