### PR TITLE
fix: deep_merge should stop recursing at class instances

### DIFF
--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -157,13 +157,15 @@ export function validate_config(config) {
  */
 function merge_into(a, b, conflicts = [], path = []) {
 	/**
+	 * Checks for "plain old Javascript object", typically made as an object
+	 * literal. Excludes Arrays and built-in types like Buffer.
 	 * @param {any} x
 	 */
-	const is_object = (x) => typeof x === 'object' && !Array.isArray(x);
+	const is_plain_object = (x) => typeof x === 'object' && x.constructor === Object;
 
 	for (const prop in b) {
-		if (is_object(b[prop])) {
-			if (!is_object(a[prop])) {
+		if (is_plain_object(b[prop])) {
+			if (!is_plain_object(a[prop])) {
 				if (a[prop] !== undefined) {
 					conflicts.push([...path, prop].join('.'));
 				}


### PR DESCRIPTION
In #1662 @JBusillo notes that my #1572 is causing an issue when you pass key and cert values in `kit.vite.server.https`.

I see that he's passing buffers like this:

```
const config = {
  kit: {
    // hydrate the <div id="svelte"> element in src/app.html
    target: "#svelte",
    vite: {
      server: {
        https: {
          key: fs.readFileSync("example.key"),
          cert: fs.readFileSync("example.crt"),
        },
      },
    },
  },
};
```

which my deep_merge function tries to deeply clone. Those Buffer objects have a ton of methods on them. Not sure why this doesn't work (need to look more deeply into it), but it seems like we'd want to not clone those rich object and only clone "plain old JS objects" who's constructor is Object. Things that aren't class instances or built-ins.

This is a quick fix. I need to add tests but I'm on the road, won't get to it until this weekend.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
