### PR TITLE
Remove the instructions to install vite when migrating

### DIFF
--- a/documentation/migrating/02-pkg.md
+++ b/documentation/migrating/02-pkg.md
@@ -12,7 +12,7 @@ Remove `polka` or `express`, if you're using one of those, and any middleware su
 
 ### devDependencies
 
-Remove `sapper` from your `devDependencies` and replace it with `@sveltejs/kit`, `vite`, and whichever [adapter](/docs#adapters) you plan to use (see [next section](#project-files-configuration)).
+Remove `sapper` from your `devDependencies` and replace it with `@sveltejs/kit` and whichever [adapter](/docs#adapters) you plan to use (see [next section](#project-files-configuration)).
 
 ### scripts
 


### PR DESCRIPTION
Vite is now a production dependency (https://github.com/sveltejs/kit/pull/1374, https://github.com/sveltejs/kit/issues/1239) and does not need to be installed separately. This PR updates the migration docs accordingly. The docs no longer state to install vite.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
