### PR TITLE
unpin vite and update to ^2.3.8

### DIFF
--- a/.changeset/serious-vans-arrive.md
+++ b/.changeset/serious-vans-arrive.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+update vite to 2.3.8 and unpin

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -6,7 +6,7 @@
 		"@sveltejs/vite-plugin-svelte": "^1.0.0-next.11",
 		"cheap-watch": "^1.0.3",
 		"sade": "^1.7.4",
-		"vite": "2.3.7"
+		"vite": "^2.3.8"
 	},
 	"devDependencies": {
 		"@rollup/plugin-replace": "^2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,12 +232,12 @@ importers:
       tiny-glob: ^0.2.8
       typescript: ^4.2.4
       uvu: ^0.5.1
-      vite: 2.3.7
+      vite: ^2.3.8
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 1.0.0-next.11_74e52d7dcd586025195c15edb3940938
+      '@sveltejs/vite-plugin-svelte': 1.0.0-next.11_263f9b0c76b2aa4f42ad7af7d509f124
       cheap-watch: 1.0.3
       sade: 1.7.4
-      vite: 2.3.7
+      vite: 2.3.8
     devDependencies:
       '@rollup/plugin-replace': 2.4.2_rollup@2.47.0
       '@types/amphtml-validator': 1.0.1
@@ -642,7 +642,7 @@ packages:
       rollup: 2.47.0
     dev: false
 
-  /@sveltejs/vite-plugin-svelte/1.0.0-next.11_74e52d7dcd586025195c15edb3940938:
+  /@sveltejs/vite-plugin-svelte/1.0.0-next.11_263f9b0c76b2aa4f42ad7af7d509f124:
     resolution: {integrity: sha512-EYR1I145k5rflVqhPwk3442m3bkYimTKSHM9uO5KdomXzt+GS9ZSBJQE3/wy1Di9V8OnGa3oKpckI3OZsHkTIA==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
@@ -655,7 +655,7 @@ packages:
       require-relative: 0.8.7
       svelte: 3.38.2
       svelte-hmr: 0.14.4_svelte@3.38.2
-      vite: 2.3.7
+      vite: 2.3.8
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -2868,8 +2868,8 @@ packages:
     resolution: {integrity: sha512-me2dL+chJVb88zpE228MvA6wIRy1CuXxGTwI5hYe4DnSnXRbtJT+9ggRj+49kgHgs/AKMTKOt/EkTHSvQJmRXA==}
     dev: true
 
-  /postcss/8.3.2:
-    resolution: {integrity: sha512-y1FK/AWdZlBF5lusS5j5l4/vF67+vQZt1SXPVJ32y1kRGDQyrs1zk32hG1cInRTu14P0V+orPz+ifwW/7rR4bg==}
+  /postcss/8.3.5:
+    resolution: {integrity: sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       colorette: 1.2.2
@@ -3739,13 +3739,13 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /vite/2.3.7:
-    resolution: {integrity: sha512-Y0xRz11MPYu/EAvzN94+FsOZHbSvO6FUvHv127CyG7mV6oDoay2bw+g5y9wW3Blf8OY3chaz3nc/DcRe1IQ3Nw==}
+  /vite/2.3.8:
+    resolution: {integrity: sha512-QiEx+iqNnJntSgSF2fWRQvRey9pORIrtNJzNyBJXwc+BdzWs83FQolX84cTBo393cfhObrtWa6180dAa4NLDiQ==}
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
       esbuild: 0.12.8
-      postcss: 8.3.2
+      postcss: 8.3.5
       resolve: 1.20.0
       rollup: 2.47.0
     optionalDependencies:


### PR DESCRIPTION
vite 2.3.8 fixed an issue with tailwind 2.2 jit mode, see https://github.com/tailwindlabs/tailwindcss/issues/4683

unpinned vite aswell (we pinned it a bit back to avoid other issues that were resolved since)

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
