### PR TITLE
Register service worker even with no client-side router or hydration

### DIFF
--- a/.changeset/three-windows-push.md
+++ b/.changeset/three-windows-push.md
@@ -1,0 +1,14 @@
+---
+'@sveltejs/kit': patch
+---
+
+Generate service worker registration code even with `router` and `hydration` disabled
+
+Remove service worker registration code from `start.js`, and instead inject it
+in the HTML `<head>`, removing the `VITE_SVELTEKIT_SERVICE_WORKER` environment
+variable definition in the process.
+
+Service worker registration code is now always included in the HTML response, if
+the specified `config.kit.files.serviceWorker` or the default
+`src/service-worker.js` file exists, and decoupled from the Rollup-generated
+client-side JS bundle.

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -323,7 +323,7 @@ async function build_server(
 					paths: settings.paths,
 					read: settings.read,
 					root,
-					${service_worker_entry_file ? "service_worker: '/service-worker.js'" : ''},
+					service_worker: ${service_worker_entry_file ? "'/service-worker.js'" : 'null'},
 					router: ${s(config.kit.router)},
 					ssr: ${s(config.kit.ssr)},
 					target: ${s(config.kit.target)},

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -109,7 +109,6 @@ async function build_client({
 	copy_assets(build_dir);
 
 	process.env.VITE_SVELTEKIT_AMP = config.kit.amp ? 'true' : '';
-	process.env.VITE_SVELTEKIT_SERVICE_WORKER = service_worker_entry_file ? '/service-worker.js' : '';
 
 	const client_out_dir = `${output_dir}/client/${config.kit.appDir}`;
 	const client_manifest_file = `${client_out_dir}/manifest.json`;

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -195,7 +195,16 @@ async function build_client({
  * @param {string} runtime
  */
 async function build_server(
-	{ cwd, base, config, manifest, build_dir, output_dir, client_entry_file },
+	{
+		cwd,
+		base,
+		config,
+		manifest,
+		build_dir,
+		output_dir,
+		client_entry_file,
+		service_worker_entry_file
+	},
 	client_manifest,
 	runtime
 ) {
@@ -315,6 +324,7 @@ async function build_server(
 					paths: settings.paths,
 					read: settings.read,
 					root,
+					${service_worker_entry_file ? "service_worker: '/service-worker.js'" : ''},
 					router: ${s(config.kit.router)},
 					ssr: ${s(config.kit.ssr)},
 					target: ${s(config.kit.target)},

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -56,11 +56,3 @@ export async function start({ paths, target, session, host, route, spa, trailing
 
 	dispatchEvent(new CustomEvent('sveltekit:start'));
 }
-
-if (import.meta.env.VITE_SVELTEKIT_SERVICE_WORKER) {
-	if ('serviceWorker' in navigator) {
-		navigator.serviceWorker.register(
-			/** @type {string} */ (import.meta.env.VITE_SVELTEKIT_SERVICE_WORKER)
-		);
-	}
-}

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -142,6 +142,14 @@ export async function render_response({
 				}` : 'null'}
 			});
 		</script>`;
+	} else if (options.service_worker) {
+		// a service worker will usually be registered inside the call to `start()` above, but not when
+		// `include_js` is false (both router = false and hydrate = false)
+		init = `<script type="module">
+			if ('serviceWorker' in navigator) {
+				navigator.serviceWorker.register('${options.service_worker}');
+			}
+		</script>`;
 	}
 
 	const head = [

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -142,10 +142,10 @@ export async function render_response({
 				}` : 'null'}
 			});
 		</script>`;
-	} else if (options.service_worker) {
-		// a service worker will usually be registered inside the call to `start()` above, but not when
-		// `include_js` is false (both router = false and hydrate = false)
-		init = `<script type="module">
+	}
+
+	if (options.service_worker) {
+		init += `<script>
 			if ('serviceWorker' in navigator) {
 				navigator.serviceWorker.register('${options.service_worker}');
 			}

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -144,6 +144,7 @@ export type SSRRenderOptions = {
 	read: (file: string) => Buffer;
 	root: SSRComponent['default'];
 	router: boolean;
+	service_worker?: string;
 	ssr: boolean;
 	target: string;
 	template: ({ head, body }: { head: string; body: string }) => string;


### PR DESCRIPTION
When testing the behavior of the different page config options in a minimal PWA, I was caught up by the fact that if `router` and `hydrate` are both false (leading to no client-side bundle being added to the page), the service worker is implicitly not registered.

From what I understand, client-side routing and hydration should be orthogonal to service worker registration, so I tried to adapt the server rendering code to support simultaneously using a service worker and disabling other client-side code.

I would appreciate some discussion around the general use-case of using service workers in this context, as well as feedback on the implementation (there is currently a bit of duplication between the `service_worker` SSR render option and the `VITE_SVELTEKIT_SERVICE_WORKER` build environment variable, as well as in the output `service-worker.js` location itself)