### PR TITLE
fix browser forward/backward nav when router is disabled

### DIFF
--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -15,7 +15,7 @@ export default {
 		adapter: adapter({
 			// default options are shown
 			out: 'build',
-			precompress: false,
+			precompress: false
 		})
 	}
 };

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -142,7 +142,9 @@ export class Router {
 		});
 
 		addEventListener('popstate', (event) => {
-			if (event.state && this.enabled) {
+			if (!this.enabled) return (window.location.href = location.href);
+
+			if (event.state) {
 				const url = new URL(location.href);
 				this._navigate(url, event.state['sveltekit:scroll'], []);
 			}

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -142,6 +142,10 @@ export async function render_response({
 				}` : 'null'}
 			});
 		</script>`;
+	} else if (!page_config.router) {
+		init = `<script>
+			addEventListener('popstate', () => location.reload());
+		</script>`;
 	}
 
 	const head = [


### PR DESCRIPTION
Refers to #1262
The page wouldn't reload or render when navigating back from a page of which the router was disabled on.
I believe this is the only way to achieve desired behaviour.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`