### PR TITLE
adapter-vercel should respect esbuild configs

### DIFF
--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -8,7 +8,7 @@ export default function () {
 	const adapter = {
 		name: '@sveltejs/adapter-vercel',
 
-		async adapt({ utils }) {
+		async adapt({ utils, config }) {
 			const dir = '.vercel_build_output';
 			utils.rimraf(dir);
 
@@ -31,7 +31,8 @@ export default function () {
 				entryPoints: ['.svelte-kit/vercel/entry.js'],
 				outfile: join(dirs.lambda, 'index.js'),
 				bundle: true,
-				platform: 'node'
+				platform: 'node',
+				...config?.kit?.vite()?.esbuild
 			});
 
 			writeFileSync(join(dirs.lambda, 'package.json'), JSON.stringify({ type: 'commonjs' }));


### PR DESCRIPTION
This patch attempts to solve https://github.com/sveltejs/kit/issues/1706
We pass through the esbuild configurations in svelte.config.cjs into the
esbuild step of the vercel adapter.

This is primarily to solve the case where we have external packages that
are skipped by esbuild in adapater-node, but not adpater-vercel.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
