### PR TITLE
fix: deep_merge shows false errors when using key names that happen to be Object prototype methods

### DIFF
--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -181,7 +181,13 @@ function merge_into(a, b, conflicts = [], path = []) {
 			}
 			a[prop].push(...b[prop]);
 		} else {
-			if (a[prop] !== undefined) {
+			// Since we're inside a for/in loop which loops over enumerable
+			// properties only, we want parity here and to check if 'a' has
+			// enumerable-only property 'prop'. Using 'hasOwnProperty' to
+			// exclude inherited properties is close enough. It is possible
+			// that someone uses Object.defineProperty to create a direct,
+			// non-enumerable property but let's not worry about that.
+			if (Object.prototype.hasOwnProperty.call(a, prop)) {
 				conflicts.push([...path, prop].join('.'));
 			}
 			a[prop] = b[prop];

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -446,7 +446,6 @@ deepMergeSuite('mutability safety', () => {
 	assert.snapshot(snapshot2, JSON.stringify(input2));
 });
 
-// This would have failed before #1698
 deepMergeSuite('merge buffer', () => {
 	const [merged, conflicts] = deep_merge(
 		{
@@ -460,9 +459,6 @@ deepMergeSuite('merge buffer', () => {
 	assert.equal(conflicts.length, 0);
 });
 
-// This test failed before the current commit which adds it,
-// because empty object already has a handful of inherited
-// properties.
 deepMergeSuite('merge including toString', () => {
 	const [merged, conflicts] = deep_merge(
 		{

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -446,4 +446,35 @@ deepMergeSuite('mutability safety', () => {
 	assert.snapshot(snapshot2, JSON.stringify(input2));
 });
 
+// This would have failed before #1698
+deepMergeSuite('merge buffer', () => {
+	const [merged, conflicts] = deep_merge(
+		{
+			x: Buffer.from('foo', 'utf-8')
+		},
+		{
+			y: 12345
+		}
+	);
+	assert.equal(Object.keys(merged), ['x', 'y']);
+	assert.equal(conflicts.length, 0);
+});
+
+// This test failed before the current commit which adds it,
+// because empty object already has a handful of inherited
+// properties.
+deepMergeSuite('merge including toString', () => {
+	const [merged, conflicts] = deep_merge(
+		{
+			toString: () => '',
+			constructor: () => ''
+		},
+		{
+			y: 12345
+		}
+	);
+	assert.equal(conflicts.length, 0);
+	assert.equal(Object.keys(merged), ['toString', 'constructor', 'y']);
+});
+
 deepMergeSuite.run();


### PR DESCRIPTION
#1572 introduced a couple of minor issues. One I fixed in #1698 but there was still a minor issue where, if your config has keys which happen to be Object prototypes like `toString`, `valueOf`, etc, you'd get false conflict errors reported. It's a simple one-line fix. Not super high priority and unlikely anyone would every hit that issue but good to be robust.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
