### PR TITLE
adapter-netlify: Add multiValueHeaders key to handler returned object

### DIFF
--- a/packages/adapter-netlify/files/entry.js
+++ b/packages/adapter-netlify/files/entry.js
@@ -27,6 +27,7 @@ export async function handler(event) {
 		return {
 			isBase64Encoded: false,
 			statusCode: rendered.status,
+			multiValueHeaders: rendered.multiValueHeaders,
 			headers: rendered.headers,
 			body: rendered.body
 		};


### PR DESCRIPTION
Netlify Functions allow a `multiValueHeaders` key in the returned object of the handler function. This key is specifically made for array values.  This PR adds the `multiValueHeaders` key to the returned object from the handler function in `render.js`. 

For exemple, as the Svelte-kit docs say, in order to set multiple cookies in a response, you can do the following:

```javascript
  headers: {
    'set-cookie': [cookie1, cookie2]
  }
```

However, this fails when deployed to Netlify. In order to set multiple cookies in a Netlify function, you have to do this:

```javascript
return {
  multiValueHeaders: {
    'set-cookie': [cookie1, cookie2]
  }
}
```

This is documented here: https://docs.netlify.com/functions/build-with-javascript/#synchronous-function-format.

If this passes, I am also willing to update to documentation for this use case.