### PR TITLE
docs: clarify package publish command

### DIFF
--- a/documentation/docs/12-packaging.md
+++ b/documentation/docs/12-packaging.md
@@ -33,7 +33,7 @@ To publish the generated package:
 npm publish package
 ```
 
-The `package` above is referring to the directory name generated, change accordingly if you configure a custom [`package.dir`](#configuration-package). If you're having problem publishing, add a trailing slash at the end (e.g. `package/`).
+The `package` above is referring to the directory name generated, change accordingly if you configure a custom [`package.dir`](#configuration-package). If you're having problems publishing, add a trailing slash at the end (e.g. `package/`).
 
 ### Caveats
 

--- a/documentation/docs/12-packaging.md
+++ b/documentation/docs/12-packaging.md
@@ -33,7 +33,7 @@ To publish the generated package:
 npm publish package
 ```
 
-The `package` above is referring to the directory name generated, change accordingly if you configure a custom [`package.dir`](#configuration-package). If you're having problems publishing package that is not yours, add a trailing slash at the end (e.g. `package/`).
+The `package` above is referring to the directory name generated, change accordingly if you configure a custom [`package.dir`](#configuration-package). If you're having problems publishing a package that is not yours, add a trailing slash at the end (e.g. `package/`).
 
 ### Caveats
 

--- a/documentation/docs/12-packaging.md
+++ b/documentation/docs/12-packaging.md
@@ -33,7 +33,7 @@ To publish the generated package:
 npm publish package
 ```
 
-If you configure a custom [`package.dir`](#configuration-package), change `package` accordingly.
+The `package` above is referring to the directory name generated, change accordingly if you configure a custom [`package.dir`](#configuration-package).
 
 ### Caveats
 

--- a/documentation/docs/12-packaging.md
+++ b/documentation/docs/12-packaging.md
@@ -33,7 +33,7 @@ To publish the generated package:
 npm publish package
 ```
 
-The `package` above is referring to the directory name generated, change accordingly if you configure a custom [`package.dir`](#configuration-package). If you're having problems publishing, add a trailing slash at the end (e.g. `package/`).
+The `package` above is referring to the directory name generated, change accordingly if you configure a custom [`package.dir`](#configuration-package). If you're having problems publishing package that is not yours, add a trailing slash at the end (e.g. `package/`).
 
 ### Caveats
 

--- a/documentation/docs/12-packaging.md
+++ b/documentation/docs/12-packaging.md
@@ -33,7 +33,7 @@ To publish the generated package:
 npm publish package
 ```
 
-The `package` above is referring to the directory name generated, change accordingly if you configure a custom [`package.dir`](#configuration-package).
+The `package` above is referring to the directory name generated, change accordingly if you configure a custom [`package.dir`](#configuration-package). If you're having problem publishing, add a trailing slash at the end (e.g. `package/`).
 
 ### Caveats
 


### PR DESCRIPTION
It was pretty hard (for me) to understand on first read what `package` actually meant and needed to look up for publish command on the npm docs itself. Also added a second sentence for windows users, couldn't quite figure out how to word it properly* without straight up mentioning windows. Suggestions are welcome!

*publishing on windows with just `npm publish package` command, npm would straight up try to publish the package named **package**, even when it's not in the local `node_modules` folder. Adding trailing slash as a suffix would solve this, either forward or backwards.