### PR TITLE
Fix regex for getting links to crawl during prerendering

### DIFF
--- a/.changeset/eighty-candles-grow.md
+++ b/.changeset/eighty-candles-grow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix regex for getting links to crawl during prerendering

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -16,13 +16,13 @@ function clean_html(html) {
 
 /** @param {string} attrs */
 function get_href(attrs) {
-	const match = /[\s'"]href\s*=\s*(?:"(.*?)"|'(.*?)'|([^\s>]*))/.exec(attrs);
+	const match = /([\s'"]|^)href\s*=\s*(?:"(.*?)"|'(.*?)'|([^\s>]*))/.exec(attrs);
 	return match && (match[1] || match[2] || match[3]);
 }
 
 /** @param {string} attrs */
 function get_src(attrs) {
-	const match = /[\s'"]src\s*=\s*(?:"(.*?)"|'(.*?)'|([^\s>]*))/.exec(attrs);
+	const match = /([\s'"]|^)src\s*=\s*(?:"(.*?)"|'(.*?)'|([^\s>]*))/.exec(attrs);
 	return match && (match[1] || match[2] || match[3]);
 }
 
@@ -30,7 +30,7 @@ function get_src(attrs) {
 function get_srcset_urls(attrs) {
 	const results = [];
 	// Note that the srcset allows any ASCII whitespace, including newlines.
-	const match = /[\s'"]srcset\s*=\s*(?:"(.*?)"|'(.*?)'|([^\s>]*))/s.exec(attrs);
+	const match = /([\s'"]|^)srcset\s*=\s*(?:"(.*?)"|'(.*?)'|([^\s>]*))/s.exec(attrs);
 	if (match) {
 		const attr_content = match[1] || match[2] || match[3];
 		// Parse the content of the srcset attribute.


### PR DESCRIPTION
crawl first attribute during prerendering

