### PR TITLE
Specify actual Svelte version requirement

### DIFF
--- a/.changeset/rich-pumpkins-applaud.md
+++ b/.changeset/rich-pumpkins-applaud.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Specify actual Svelte version requirement

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -39,7 +39,7 @@
 		"uvu": "^0.5.1"
 	},
 	"peerDependencies": {
-		"svelte": "^3.24.0"
+		"svelte": "^3.34.0"
 	},
 	"bin": {
 		"svelte-kit": "svelte-kit.js"

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -39,7 +39,7 @@
 		"uvu": "^0.5.1"
 	},
 	"peerDependencies": {
-		"svelte": "^3.38.2"
+		"svelte": "^3.24.0"
 	},
 	"bin": {
 		"svelte-kit": "svelte-kit.js"


### PR DESCRIPTION
I wanted to check if an issue I'm facing is a regression in Svelte, but can't use an older version. It seems Rich frequently bumps the peerDependency to be the latest ([example](https://github.com/sveltejs/kit/pull/1374/files#diff-0ac36eb0a5cc3505c582d3959e4bb51093770685d0de4a864f7cd9b68bd50b8fL40)), but I don't think there's actually a reason the latest is required. This PR sets it equal to the version required by Sapper