### PR TITLE
allow customisation of HOST and PORT env vars in adapter-node

### DIFF
--- a/.changeset/curvy-eggs-sip.md
+++ b/.changeset/curvy-eggs-sip.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Allow the environment variables containing the host and port to serve on to be customised

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -15,7 +15,11 @@ export default {
 		adapter: adapter({
 			// default options are shown
 			out: 'build',
-			precompress: false
+			precompress: false,
+			env: {
+				host: 'HOST',
+				port: 'PORT'
+			}
 		})
 	}
 };
@@ -31,13 +35,15 @@ The directory to build the server to. It defaults to `build` — i.e. `node buil
 
 Enables precompressing using gzip and brotli for assets and prerendered pages. It defaults to `false`.
 
-## Environment variables
+### env
 
 By default, the server will accept connections on `0.0.0.0` using port 3000. These can be customised with the `PORT` and `HOST` environment variables:
 
 ```
 HOST=127.0.0.1 PORT=4000 node build
 ```
+
+However, which environment variables are used can also be customised by setting the `env` option. If specified, TKTKTK. It defaults to `{ host: 'HOST', port: 'PORT' }`.
 
 ## License
 

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -43,7 +43,7 @@ By default, the server will accept connections on `0.0.0.0` using port 3000. The
 HOST=127.0.0.1 PORT=4000 node build
 ```
 
-However, which environment variables are used can also be customised by setting the `env` option. If specified, TKTKTK. It defaults to `{ host: 'HOST', port: 'PORT' }`.
+You can specify different environment variables if necessary using the `env` option.
 
 ## License
 

--- a/packages/adapter-node/index.d.ts
+++ b/packages/adapter-node/index.d.ts
@@ -1,6 +1,10 @@
 declare function plugin(options?: {
 	out?: string;
 	precompress?: boolean;
+	env?: {
+		host?: string;
+		port?: string;
+	};
 }): import('@sveltejs/kit').Adapter;
 
 export = plugin;

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -1,4 +1,4 @@
-import { readFileSync, statSync, createReadStream, createWriteStream } from 'fs';
+import { readFileSync, statSync, createReadStream, createWriteStream, writeFileSync } from 'fs';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
 import { pipeline } from 'stream';
@@ -12,10 +12,18 @@ const pipe = promisify(pipeline);
 /**
  * @param {{
  *   out?: string;
- *   precompress?: boolean
+ *   precompress?: boolean;
+ *   env?: {
+ *     host?: string;
+ *     port?: string;
+ *   };
  * }} options
  */
-export default function ({ out = 'build', precompress } = {}) {
+export default function ({
+	out = 'build',
+	precompress,
+	env: { host: hostEnv = 'HOST', port: portEnv = 'PORT' } = {}
+} = {}) {
 	/** @type {import('@sveltejs/kit').Adapter} */
 	const adapter = {
 		name: '@sveltejs/adapter-node',
@@ -34,6 +42,12 @@ export default function ({ out = 'build', precompress } = {}) {
 			utils.log.minor('Building server');
 			const files = fileURLToPath(new URL('./files', import.meta.url));
 			utils.copy(files, '.svelte-kit/node');
+			writeFileSync(
+				join(files, 'env.js'),
+				`export const host = process.env[${JSON.stringify(
+					hostEnv
+				)}] || '0.0.0.0';\nexport const port = process.env[${JSON.stringify(portEnv)}] || 3000;`
+			);
 			await esbuild.build({
 				entryPoints: ['.svelte-kit/node/index.js'],
 				outfile: join(out, 'index.js'),

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -22,7 +22,7 @@ const pipe = promisify(pipeline);
 export default function ({
 	out = 'build',
 	precompress,
-	env: { host: hostEnv = 'HOST', port: portEnv = 'PORT' } = {}
+	env: { host: host_env = 'HOST', port: port_env = 'PORT' } = {}
 } = {}) {
 	/** @type {import('@sveltejs/kit').Adapter} */
 	const adapter = {
@@ -45,8 +45,8 @@ export default function ({
 			writeFileSync(
 				join(files, 'env.js'),
 				`export const host = process.env[${JSON.stringify(
-					hostEnv
-				)}] || '0.0.0.0';\nexport const port = process.env[${JSON.stringify(portEnv)}] || 3000;`
+					host_env
+				)}] || '0.0.0.0';\nexport const port = process.env[${JSON.stringify(port_env)}] || 3000;`
 			);
 			await esbuild.build({
 				entryPoints: ['.svelte-kit/node/index.js'],

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -10,5 +10,5 @@ export default {
 		sourcemap: true
 	},
 	plugins: [nodeResolve(), commonjs(), json()],
-	external: ['../output/server/app.js', ...require('module').builtinModules]
+	external: ['../output/server/app.js', './env.js', ...require('module').builtinModules]
 };

--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -2,11 +2,10 @@ import './require_shim';
 import { createServer } from './server';
 // TODO hardcoding the relative location makes this brittle
 import { render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
+import { host, port } from './env.js'; // eslint-disable-line import/no-unresolved
 
-const { HOST = '0.0.0.0', PORT = 3000 } = process.env;
-
-const instance = createServer({ render }).listen(PORT, HOST, () => {
-	console.log(`Listening on port ${PORT}`);
+const instance = createServer({ render }).listen(port, host, () => {
+	console.log(`Listening on port ${port}`);
 });
 
 export { instance };


### PR DESCRIPTION
Resolves #1752.

I'm definitely open to other names for this configuration, because I'm not thrilled on what I currently have. If someone has a better idea of what to say in the adapter's readme, I'd also like to hear about that.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts