### PR TITLE
Fix adapter-node regression

### DIFF
--- a/.changeset/chilled-kiwis-drop.md
+++ b/.changeset/chilled-kiwis-drop.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Fix regression caused by writing `env.js` to the wrong path

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -43,7 +43,7 @@ export default function ({
 			const files = fileURLToPath(new URL('./files', import.meta.url));
 			utils.copy(files, '.svelte-kit/node');
 			writeFileSync(
-				join(files, 'env.js'),
+				'.svelte-kit/node/env.js',
 				`export const host = process.env[${JSON.stringify(
 					host_env
 				)}] || '0.0.0.0';\nexport const port = process.env[${JSON.stringify(port_env)}] || 3000;`


### PR DESCRIPTION
Followup to #1754. Oops. I was writing `env.js` to the wrong place. It worked locally because where I wrote it to was the `files` directory that was copied over _next_ build. This should be getting written directly to `.svelte-kit/node/env.js` after copying over everything in `files` in the package.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
