### PR TITLE
fix: attribute validation for generated script tag

### DIFF
--- a/.changeset/olive-maps-join.md
+++ b/.changeset/olive-maps-join.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+fix attribute validation in generated script tag

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -39,10 +39,10 @@ function page_store(value) {
 function initial_fetch(resource, opts) {
 	const url = typeof resource === 'string' ? resource : resource.url;
 
-	let selector = `script[type="svelte-data"][url="${url}"]`;
+	let selector = `script[data-type="svelte-data"][data-url="${url}"]`;
 
 	if (opts && typeof opts.body === 'string') {
-		selector += `[body="${hash(opts.body)}"]`;
+		selector += `[data-body="${hash(opts.body)}"]`;
 	}
 
 	const script = document.querySelector(selector);

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -159,9 +159,10 @@ export async function render_response({
 
 			${serialized_data
 				.map(({ url, body, json }) => {
-					return body
-						? `<script type="svelte-data" url="${url}" body="${hash(body)}">${json}</script>`
-						: `<script type="svelte-data" url="${url}">${json}</script>`;
+					const attrTag = 'data-type="svelte-data"';
+					const attrUrl = `data-url="${url}"`;
+					const attrBody = body ? `data-body="${hash(body)}"` : '';
+					return `<script type="application/json" ${attrTag} ${attrUrl} ${attrBody}>${json}</script>`;
 				})
 				.join('\n\n\t\t\t')}
 		`.replace(/^\t{2}/gm, '');

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -159,10 +159,10 @@ export async function render_response({
 
 			${serialized_data
 				.map(({ url, body, json }) => {
-					const attrTag = 'data-type="svelte-data"';
-					const attrUrl = `data-url="${url}"`;
-					const attrBody = body ? `data-body="${hash(body)}"` : '';
-					return `<script type="application/json" ${attrTag} ${attrUrl} ${attrBody}>${json}</script>`;
+					let attributes = `type="application/json" data-type="svelte-data" data-url="${url}"`;
+					if (body) attributes += ` data-body="${hash(body)}"`;
+
+					return `<script ${attributes}>${json}</script>`;
 				})
 				.join('\n\n\t\t\t')}
 		`.replace(/^\t{2}/gm, '');

--- a/packages/kit/test/apps/amp/src/routes/valid/_tests.js
+++ b/packages/kit/test/apps/amp/src/routes/valid/_tests.js
@@ -11,7 +11,7 @@ export default function (test, is_dev) {
 		assert.equal(await page.innerHTML('h2'), 'The answer is 42');
 		assert.equal(await page.innerHTML('p'), 'amp is true');
 
-		const script = await page.$('script[type="svelte-data"]');
+		const script = await page.$('script[data-type="svelte-data"]');
 		assert.ok(!script, 'Should not include serialized data');
 	});
 

--- a/packages/kit/test/apps/basics/src/routes/load/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/load/_tests.js
@@ -18,7 +18,7 @@ export default function (test, is_dev) {
 
 		if (!js) {
 			// by the time JS has run, hydration will have nuked these scripts
-			const script_contents = await page.innerHTML('script[type="svelte-data"]');
+			const script_contents = await page.innerHTML('script[data-type="svelte-data"]');
 
 			assert.equal(script_contents, payload, 'Page should contain serialized data');
 		}
@@ -46,11 +46,11 @@ export default function (test, is_dev) {
 		if (!js) {
 			// by the time JS has run, hydration will have nuked these scripts
 			const script_contents_a = await page.innerHTML(
-				'script[type="svelte-data"][url="/load/serialization-post.json"][body="3t25"]'
+				'script[data-type="svelte-data"][data-url="/load/serialization-post.json"][data-body="3t25"]'
 			);
 
 			const script_contents_b = await page.innerHTML(
-				'script[type="svelte-data"][url="/load/serialization-post.json"][body="3t24"]'
+				'script[data-type="svelte-data"][data-url="/load/serialization-post.json"][data-body="3t24"]'
 			);
 
 			assert.equal(script_contents_a, payload_a, 'Page should contain serialized data');

--- a/packages/kit/test/apps/basics/src/routes/no-hydrate/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/no-hydrate/_tests.js
@@ -15,7 +15,9 @@ export default function (test, is_dev) {
 		} else {
 			// ensure data wasn't inlined
 			assert.equal(
-				await page.evaluate(() => document.querySelectorAll('script[type="svelte-data"]').length),
+				await page.evaluate(
+					() => document.querySelectorAll('script[data-type="svelte-data"]').length
+				),
 				0
 			);
 		}


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
fixes https://github.com/sveltejs/kit/issues/1767

Strictly speaking the attributes `type`, `url` and `body` in the generated script tag are invalid. This PR replaces them with `data-type`, `data-url` and `data-body`.

### Tests
Adjusted the existing test cases.

### Changesets
Generated a minor changeset.