### PR TITLE
[feat] Add configurable cache to worker responses

### DIFF
--- a/packages/adapter-cloudflare-workers/README.md
+++ b/packages/adapter-cloudflare-workers/README.md
@@ -22,6 +22,13 @@ bucket = "./build"
 entry-point = "./workers-site"
 ```
 
+The adapter accepts the following configuration properties:
+| property | default | description |
+|---|---|---|
+| `pageCacheTTL` | `null` | Sets `cache-control` `max-age` for rendered responses if not defined. WARNING: this will apply to all page/request routes, disabled by default for security reasons. |
+| `staticCacheTTL` | `60 * 60 * 24 * 90` (90 days) | Sets `cache-control` `max-age` for static assets. |
+| `edgeCacheTTL` | `60 * 60 * 24 * 90` (90 days) | Sets CloudFlare Edge Cache TTL for static assets. |
+
 It's recommended that you add the `build` and `workers-site` folders (or whichever other folders you specify) to your `.gitignore`.
 
 More info on configuring a cloudflare worker site can be found [here](https://developers.cloudflare.com/workers/platform/sites/start-from-existing)

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -23,8 +23,10 @@ async function handle(event) {
 			// use the asset manifest to see if it exists
 			return await getAssetFromKV(event, {
 				cacheControl: {
+					// eslint-disable-next-line no-undef
 					browserTTL: STATIC_CACHE_TTL,
-					edgeTTL: EDGE_CACHE_TTL,
+					// eslint-disable-next-line no-undef
+					edgeTTL: EDGE_CACHE_TTL
 				}
 			});
 		} catch (e) {
@@ -49,7 +51,9 @@ async function handle(event) {
 		if (rendered) {
 			const { headers } = rendered;
 			// inject cache-control header
+			// eslint-disable-next-line no-undef
 			if (!!PAGE_CACHE_TTL && !(headers['Cache-Control'] || headers['cache-control'])) {
+				// eslint-disable-next-line no-undef
 				rendered.headers['cache-control'] = `max-age=${PAGE_CACHE_TTL}`;
 			}
 			return new Response(rendered.body, {


### PR DESCRIPTION
### New breaking change here

- **Who does this affect**: Anyone using the cloudflare adapter.
- **How to migrate**: Users that want to maintain the existing behavior will have to set all cache options to `null`. Otherwise defaults will apply. Any static assets without file extensions will break.
- **Why make this breaking change**: The existing implementation of the cloudflare worker adapter has slow page response and does not return cache-control headers for static assets like the default does, so browser cache is not utilized for static assets.
- **Severity (number of people affected x effort)**: Fairly low impact. Very simple to revert to original behavior.

I have been using svelte-kit to rebuild my personal site/blog and noticed a few areas for improvement.

### Slow page response

The problem here is having to wait for asset fetch to fail before moving on to try to render. The solution I put in place is more of a stop-gap. It is just checking for a file extension at the end of the request path.

By adding this gate, page request time dropped by 60-80%. However, static assets without file extensions will break. I'd like to improve upon my approach and would appreciate feedback here.

### Static assets are not returned with cache-control header

The default svelte-kit adapter returns this header so that browser cache can be utilized.

Refer to the updated README documenting the properties and their purpose. 

### Testing

I did not see tests in any of the adapters, don't mind writing some, but would appreciate input here.

That aside. I'm currently using this adapter code on a production site without issues.