### PR TITLE
Improve RequestHandler and EndpointOutput type declarations

### DIFF
--- a/.changeset/tall-hotels-punch.md
+++ b/.changeset/tall-hotels-punch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Improve RequestHandler and EndpointOutput type declarations.

--- a/packages/kit/types/endpoint.d.ts
+++ b/packages/kit/types/endpoint.d.ts
@@ -12,14 +12,14 @@ type JSONValue =
 
 type DefaultBody = JSONValue | Uint8Array;
 
-export type EndpointOutput<ResBody = DefaultBody> = {
+export type EndpointOutput<Body extends DefaultBody = DefaultBody> = {
 	status?: number;
 	headers?: Partial<Headers>;
-	body?: ResBody;
+	body?: Body;
 };
 
 export type RequestHandler<
 	Locals = Record<string, any>,
-	ReqBody = unknown,
-	ResBody = DefaultBody
-> = (request: ServerRequest<Locals, ReqBody>) => MaybePromise<void | EndpointOutput<ResBody>>;
+	Input = unknown,
+	Output extends DefaultBody = DefaultBody
+> = (request: ServerRequest<Locals, Input>) => MaybePromise<void | EndpointOutput<Output>>;

--- a/packages/kit/types/endpoint.d.ts
+++ b/packages/kit/types/endpoint.d.ts
@@ -10,12 +10,16 @@ type JSONValue =
 	| JSONValue[]
 	| { [key: string]: JSONValue };
 
-export type EndpointOutput = {
+type DefaultBody = JSONValue | Uint8Array;
+
+export type EndpointOutput<ResBody = DefaultBody> = {
 	status?: number;
 	headers?: Partial<Headers>;
-	body?: JSONValue | Uint8Array;
+	body?: ResBody;
 };
 
-export type RequestHandler<Locals = Record<string, any>, Body = unknown> = (
-	request: ServerRequest<Locals, Body>
-) => MaybePromise<void | EndpointOutput>;
+export type RequestHandler<
+	Locals = Record<string, any>,
+	ReqBody = unknown,
+	ResBody = DefaultBody
+> = (request: ServerRequest<Locals, ReqBody>) => MaybePromise<void | EndpointOutput<ResBody>>;


### PR DESCRIPTION
If I wanted my `post` function to return a `number` as a response body and I accidentally return a `string`, there is no way I can let the type-checker prevent situations like these. There is no way I can tell it "hey, make sure the body property is always a number". So, the following typechecks:
```
export const post: RequestHandler<Locals, MyBody> = async (request) => {
  return {
    headers: { "set-cookie": "jwt=token; Path=/; HttpOnly" },
    body: "wrong type"
  };
};
```

This PR changes `RequestHandler` and `EndpointOutput` so that users can specify their response body type as `number` by making `number` the third generic argument to `RequestHandler`. As a result, this won't typecheck:
```
export const post: RequestHandler<Locals, MyReqBody, number> = async (request) => {
  return {
    headers: { "set-cookie": "jwt=token; Path=/; HttpOnly" },
    body: "wrong type",
  };
};
```
I wanted to make the second generic parameter to `RequestHander`, `ReqBody` be of default type `DefaultBody`, but this causes an error in `packages/kit/src/runtime/server/endpoint.js` on line 27, because the `request.body: BaseBody` is not type compatible with `BaseBody & DefaultBody`, which is the type it would end up with (per the type definitions of `ServerRequest` and `ParametrizedBody`).

There might be a better way to avoid the error and give `ReqBody` stronger typing than unknown, but I don't currently know enough about the codebase to do so.

Background for this PR: In the discord channel `contribute-to-svelte-kit`, I proposed this idea a few messages from the last.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
