### PR TITLE
Permit exclusion of arbitrary directory prefixes when using kit.files.{routes,etc.} in config

### DIFF
--- a/.changeset/dry-parrots-punch.md
+++ b/.changeset/dry-parrots-punch.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Ignore node_modules when configuring routes and lib paths, permitting paths at root of project
+Provide escape hatch to ignore node_modules (or any user defined prefixes) when configuring routes and lib paths, permitting paths at root of project

--- a/.changeset/dry-parrots-punch.md
+++ b/.changeset/dry-parrots-punch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Ignore node_modules when configuring routes and lib paths, permitting paths at root of project

--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -77,7 +77,7 @@ An object containing zero or more of the following `string` values:
 - `template` — the location of the template for HTML responses
 
 You can ignore prefixes using the `SVELTE_KIT_FILES_IGNORE_PREFIX` (for example: `SVELTE_KIT_FILES_IGNORE_PREFIX=node_modules yarn build`,
-which will ignore any file that starts with node_modules)
+which will ignore any file that starts with the string `node_modules`)
 
 ### floc
 

--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -76,6 +76,9 @@ An object containing zero or more of the following `string` values:
 - `hooks` — the location of your hooks module (see [Hooks](#hooks))
 - `template` — the location of the template for HTML responses
 
+You can ignore prefixes using the `SVELTE_KIT_FILES_IGNORE_PREFIX` (for example: `SVELTE_KIT_FILES_IGNORE_PREFIX=node_modules yarn build`,
+which will ignore any file that starts with node_modules)
+
 ### floc
 
 Google's [FLoC](https://github.com/WICG/floc) is a technology for targeted advertising that the [Electronic Frontier Foundation](https://www.eff.org/) has deemed [harmful](https://www.eff.org/deeplinks/2021/03/googles-floc-terrible-idea) to user privacy. [Browsers other than Chrome](https://www.theverge.com/2021/4/16/22387492/google-floc-ad-tech-privacy-browsers-brave-vivaldi-edge-mozilla-chrome-safari) have declined to implement it.

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -1,6 +1,7 @@
 import { test, suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { validate_config, deep_merge } from './index.js';
+import { ignoreFilePrefixes } from '../../core/create_manifest_data/index.js';
 
 test('fills in defaults', () => {
 	const validated = validate_config({});
@@ -196,6 +197,16 @@ test('fails if prerender.pages are invalid', () => {
 			}
 		});
 	}, /^Each member of config\.kit.prerender.pages must be either '\*' or an absolute path beginning with '\/' — saw 'foo'$/);
+});
+
+test('properly filters out ignored prefixes', () => {
+    const files = [ 'node_modules/filterme', 'abc/node_modules/ok', 'special_prefix/maybefilterme' ];
+    let filtered = files.filter(f => ignoreFilePrefixes(undefined, f));
+    assert.equal(filtered, files);
+    filtered = files.filter(f => ignoreFilePrefixes("node_modules", f));
+    assert.equal(filtered, ['abc/node_modules/ok', 'special_prefix/maybefilterme']);
+    filtered = files.filter(f => ignoreFilePrefixes("node_modules,special_prefix", f));
+    assert.equal(filtered, ['abc/node_modules/ok']);
 });
 
 /**

--- a/packages/kit/src/core/create_manifest_data/index.js
+++ b/packages/kit/src/core/create_manifest_data/index.js
@@ -22,6 +22,9 @@ import { posixify } from '../utils.js';
 
 const specials = new Set(['__layout', '__layout.reset', '__error']);
 
+const ignoreFilePrefixes = (f) =>
+	!process.env.SVELTE_KIT_FILES_IGNORE_PREFIX.split(',').find((g) => f.startsWith(g));
+
 /**
  * @param {{
  *   config: import('types/config').ValidatedConfig;
@@ -60,11 +63,7 @@ export default function create_manifest_data({ config, output, cwd = process.cwd
 		/** @type {Item[]} */
 		const items = fs
 			.readdirSync(dir)
-			.filter((f) =>
-				process.env.SVELTE_KIT_FILES_IGNORE_PREFIX
-					? !process.env.SVELTE_KIT_FILES_IGNORE_PREFIX.split(',').find((g) => f.startsWith(g))
-					: true
-			)
+			.filter((f) => (process.env.SVELTE_KIT_FILES_IGNORE_PREFIX ? ignoreFilePrefixes(f) : true))
 			.map((basename) => {
 				const resolved = path.join(dir, basename);
 				const file = posixify(path.relative(cwd, resolved));

--- a/packages/kit/src/core/create_manifest_data/index.js
+++ b/packages/kit/src/core/create_manifest_data/index.js
@@ -22,8 +22,10 @@ import { posixify } from '../utils.js';
 
 const specials = new Set(['__layout', '__layout.reset', '__error']);
 
-const ignoreFilePrefixes = (f) =>
-	!process.env.SVELTE_KIT_FILES_IGNORE_PREFIX.split(',').find((g) => f.startsWith(g));
+export const ignoreFilePrefixes = (prefixes, f) => {
+	if (!prefixes) return true;
+	return !prefixes.split(',').find((g) => f.startsWith(g));
+};
 
 /**
  * @param {{
@@ -63,7 +65,7 @@ export default function create_manifest_data({ config, output, cwd = process.cwd
 		/** @type {Item[]} */
 		const items = fs
 			.readdirSync(dir)
-			.filter((f) => (process.env.SVELTE_KIT_FILES_IGNORE_PREFIX ? ignoreFilePrefixes(f) : true))
+			.filter((f) => ignoreFilePrefixes(process.env.SVELTE_KIT_FILES_IGNORE_PREFIX))
 			.map((basename) => {
 				const resolved = path.join(dir, basename);
 				const file = posixify(path.relative(cwd, resolved));

--- a/packages/kit/src/core/create_manifest_data/index.js
+++ b/packages/kit/src/core/create_manifest_data/index.js
@@ -60,6 +60,7 @@ export default function create_manifest_data({ config, output, cwd = process.cwd
 		/** @type {Item[]} */
 		const items = fs
 			.readdirSync(dir)
+			.filter((f) => !f.startsWith('node_modules'))
 			.map((basename) => {
 				const resolved = path.join(dir, basename);
 				const file = posixify(path.relative(cwd, resolved));

--- a/packages/kit/src/core/create_manifest_data/index.js
+++ b/packages/kit/src/core/create_manifest_data/index.js
@@ -60,7 +60,11 @@ export default function create_manifest_data({ config, output, cwd = process.cwd
 		/** @type {Item[]} */
 		const items = fs
 			.readdirSync(dir)
-			.filter((f) => !f.startsWith('node_modules'))
+			.filter((f) =>
+				process.env.SVELTE_KIT_FILES_IGNORE_PREFIX
+					? !process.env.SVELTE_KIT_FILES_IGNORE_PREFIX.split(',').find((g) => f.startsWith(g))
+					: true
+			)
 			.map((basename) => {
 				const resolved = path.join(dir, basename);
 				const file = posixify(path.relative(cwd, resolved));

--- a/packages/kit/test/apps/basics/src/routes/routing/dirs/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/dirs/_tests.js
@@ -1,8 +1,0 @@
-import * as assert from 'uvu/assert';
-
-/** @type {import('test').TestMaker} */
-export default function (test) {
-	test('test that file ignore works', '/', async ({ page }) => {
-		assert.equal(await page.textContent('h1'), 'the answer is 42');
-	});
-}

--- a/packages/kit/test/apps/basics/src/routes/routing/dirs/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/dirs/_tests.js
@@ -1,0 +1,8 @@
+import * as assert from 'uvu/assert';
+
+/** @type {import('test').TestMaker} */
+export default function (test) {
+	test('test that file ignore works', '/', async ({ page }) => {
+		assert.equal(await page.textContent('h1'), 'the answer is 42');
+	});
+}


### PR DESCRIPTION
Changes:

* Add function `ignoreFilePrefixes` which takes a comma-separated list of prefixes to ignore, and a filename; if the filename starts with any of those prefixes, return false so filter removes that item.
* Add tests to prove functionality
* Add documentation on usage of SVELTE_KIT_FILES_IGNORE_PREFIX variable.

This only works if you then run your build command with `SVELTE_KIT_FILES_IGNORE_PREFIXES=node_modules pnpm build` which will then filter out files starting with `node_modules` in the filename. If the variable is not present, the list of files is unchanged.

Re: https://github.com/sveltejs/kit/issues/1781
