### PR TITLE
hotfix: with nodeAdapter we should get fetch from globalThis

### DIFF
--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -215,7 +215,7 @@ class Watcher extends EventEmitter {
 							hooks: {
 								getSession: hooks.getSession || (() => ({})),
 								handle: hooks.handle || (({ request, resolve }) => resolve(request)),
-								serverFetch: hooks.serverFetch || fetch
+								serverFetch: hooks.serverFetch || globalThis.fetch
 							},
 							hydrate: this.config.kit.hydrate,
 							paths: this.config.kit.paths,


### PR DESCRIPTION
Base on #1784 issue. Basically, under real nodejs we have no direct access to `fetch` even if it's set to globalThis. 