### PR TITLE
[fix] expose Vite.js `mode` from `$app/env`

### DIFF
--- a/.changeset/silly-jokes-hug.md
+++ b/.changeset/silly-jokes-hug.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Expose Vite.js mode from \$app/env

--- a/documentation/docs/05-modules.md
+++ b/documentation/docs/05-modules.md
@@ -13,7 +13,7 @@ import { amp, browser, dev, mode, prerendering } from '$app/env';
 - `amp` is `true` or `false` depending on the corresponding value in your [project configuration](#configuration)
 - `browser` is `true` or `false` depending on whether the app is running in the browser or on the server
 - `dev` is `true` in development mode, `false` in production
-- `mode` is `development` in development mode or `production` during build, unless otherwise configured in `config.kit.vite.mode`.
+- `mode` is the [Vite mode](https://vitejs.dev/guide/env-and-mode.html#modes), which is `development` in dev mode or `production` during build unless configured otherwise in `config.kit.vite.mode`.
 - `prerendering` is `true` when [prerendering](#ssr-and-javascript-prerender), `false` otherwise
 
 ### $app/navigation

--- a/documentation/docs/05-modules.md
+++ b/documentation/docs/05-modules.md
@@ -7,12 +7,13 @@ SvelteKit makes a number of modules available to your application.
 ### $app/env
 
 ```js
-import { amp, browser, dev, prerendering } from '$app/env';
+import { amp, browser, dev, mode, prerendering } from '$app/env';
 ```
 
 - `amp` is `true` or `false` depending on the corresponding value in your [project configuration](#configuration)
 - `browser` is `true` or `false` depending on whether the app is running in the browser or on the server
 - `dev` is `true` in development mode, `false` in production
+- `mode` is `development` in development mode or `production` during build, unless otherwise configured in `config.kit.vite.mode`.
 - `prerendering` is `true` when [prerendering](#ssr-and-javascript-prerender), `false` otherwise
 
 ### $app/navigation

--- a/packages/kit/src/runtime/app/env.js
+++ b/packages/kit/src/runtime/app/env.js
@@ -9,7 +9,7 @@ export const dev = !!import.meta.env.DEV;
 /**
  * @type {import('$app/env').mode}
  */
-export const mode = import.meta.env.MODE
+export const mode = import.meta.env.MODE;
 /**
  * @type {import('$app/env').amp}
  */

--- a/packages/kit/src/runtime/app/env.js
+++ b/packages/kit/src/runtime/app/env.js
@@ -7,7 +7,7 @@ export const browser = !import.meta.env.SSR;
  */
 export const dev = !!import.meta.env.DEV;
 /**
- * @type {import('$app/env).mode}
+ * @type {import('$app/env').mode}
  */
 export const mode = import.meta.env.MODE
 /**

--- a/packages/kit/src/runtime/app/env.js
+++ b/packages/kit/src/runtime/app/env.js
@@ -7,6 +7,10 @@ export const browser = !import.meta.env.SSR;
  */
 export const dev = !!import.meta.env.DEV;
 /**
+ * @type {import('$app/env).mode}
+ */
+export const mode = import.meta.env.MODE
+/**
  * @type {import('$app/env').amp}
  */
 export const amp = !!import.meta.env.VITE_SVELTEKIT_AMP;

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -16,7 +16,9 @@ declare module '$app/env' {
 	 */
 	export const prerendering: boolean;
 	/**
-	 * The Vite.js mode the app is running in. Configure in `config.kit.vite.mode`. By default, `svelte-kit dev` runs in `development` mode and `svelte-kit build` runs in `production` mode.
+	 * The Vite.js mode the app is running in. Configure in `config.kit.vite.mode`.
+	 * Vite.js loads the dotenv file associated with the provided mode, `.env.[mode]` or `.env.[mode].local`.
+	 * By default, `svelte-kit dev` runs with `mode=development` and `svelte-kit build` runs with `mode=production`.
 	 */
 	export const mode: string;
 }

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -15,6 +15,10 @@ declare module '$app/env' {
 	 * `true` when prerendering, `false` otherwise.
 	 */
 	export const prerendering: boolean;
+	/**
+	 * The Vite.js mode the app is running in. Configure in `config.kit.vite.mode`. By default, `svelte-kit dev` runs in `development` mode and `svelte-kit build` runs in `production` mode.
+	 */
+	export const mode: string;
 }
 
 declare module '$app/navigation' {


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts

---

**Summary**

`dev` utility is great, but projects often have more than two environments (`dev`, `prod`). Exposing the Vite.js [Mode](https://vitejs.dev/guide/env-and-mode.html#modes) value would simplify the code for these multi-envs projects.

- `mode` can be set in `config.kit.vite.mode`
- `svelte-kit dev` defaults this val to `development`
- `svelte-kit build` defaults this val to `production`

**Related**

This is related to https://github.com/sveltejs/kit/issues/1258 which asks for the CLI flag `--mode` to be exposed.

**Other**

Not sure how to write a test for this, maybe:

```js
import { dev, mode } from '$app/env';

if (dev && mode !== 'development') {
	throw Error('mode should equal development when dev is true');
}
```

I am unclear on how the test suite operates.