### PR TITLE
Add generic type for session

### DIFF
--- a/.changeset/sharp-geckos-beam.md
+++ b/.changeset/sharp-geckos-beam.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add generic type for session

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -81,10 +81,10 @@ declare module '$app/stores' {
 	 * A convenience function around `getContext` that returns `{ navigating, page, session }`.
 	 * Most of the time, you won't need to use it.
 	 */
-	export function getStores(): {
+	export function getStores<Session = any>(): {
 		navigating: Readable<Navigating | null>;
 		page: Readable<Page>;
-		session: Writable<any>;
+		session: Writable<Session>;
 	};
 	/**
 	 * A readable store whose value reflects the object passed to load functions.

--- a/packages/kit/types/page.d.ts
+++ b/packages/kit/types/page.d.ts
@@ -2,11 +2,12 @@ import { Location as Page, MaybePromise, InferValue } from './helper';
 
 export type LoadInput<
 	PageParams extends Record<string, string> = Record<string, string>,
-	Context extends Record<string, any> = Record<string, any>
+	Context extends Record<string, any> = Record<string, any>,
+	Session = any
 > = {
 	page: Page<PageParams>;
 	fetch: (info: RequestInfo, init?: RequestInit) => Promise<Response>;
-	session: any;
+	session: Session;
 	context: Context;
 };
 

--- a/packages/kit/types/page.d.ts
+++ b/packages/kit/types/page.d.ts
@@ -13,8 +13,9 @@ export type LoadInput<
 
 export type ErrorLoadInput<
 	PageParams extends Record<string, string> = Record<string, string>,
-	Context extends Record<string, any> = Record<string, any>
-> = LoadInput<PageParams, Context> & {
+	Context extends Record<string, any> = Record<string, any>,
+	Session = any
+> = LoadInput<PageParams, Context, Session> & {
 	status: number;
 	error: Error;
 };
@@ -33,12 +34,17 @@ export type LoadOutput<
 
 // Publicized Types
 export type Load<
-	Input extends { context?: Record<string, any>; pageParams?: Record<string, string> } = {},
+	Input extends {
+		context?: Record<string, any>;
+		pageParams?: Record<string, string>;
+		session?: any;
+	} = {},
 	Output extends { context?: Record<string, any>; props?: Record<string, any> } = {}
 > = (
 	input: LoadInput<
 		InferValue<Input, 'pageParams', Record<string, string>>,
-		InferValue<Input, 'context', Record<string, any>>
+		InferValue<Input, 'context', Record<string, any>>,
+		InferValue<Input, 'session', any>
 	>
 ) => MaybePromise<void | LoadOutput<
 	InferValue<Output, 'props', Record<string, any>>,
@@ -46,12 +52,17 @@ export type Load<
 >>;
 
 export type ErrorLoad<
-	Input extends { context?: Record<string, any>; pageParams?: Record<string, string> } = {},
+	Input extends {
+		context?: Record<string, any>;
+		pageParams?: Record<string, string>;
+		session?: any;
+	} = {},
 	Output extends { context?: Record<string, any>; props?: Record<string, any> } = {}
 > = (
 	input: ErrorLoadInput<
 		InferValue<Input, 'pageParams', Record<string, string>>,
-		InferValue<Input, 'context', Record<string, any>>
+		InferValue<Input, 'context', Record<string, any>>,
+		InferValue<Input, 'session', any>
 	>
 ) => MaybePromise<
 	LoadOutput<


### PR DESCRIPTION
Previously, in Sapper, we could use generics to ensure our session type was used correctly:

E.g. if I had a session type that was `{ foo: string; }`

```
import { stores } from "@sapper/app";

const { session } = stores<MySessionType>();

$session.foo; // correct usage
$session.bar; // invalid, compiler shows error
```

This PR adds the same generic support in `getStores` as well as a 3rd param in the generic for `LoadInput`

SvelteKit:
```
import { getStores } from "$app/stores";

const { session } = getStores<MySessionType>();
```



### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
