### PR TITLE
fix: Externalize app initialization to adapters

### DIFF
--- a/.changeset/polite-ducks-notice.md
+++ b/.changeset/polite-ducks-notice.md
@@ -1,0 +1,9 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-vercel': patch
+'@sveltejs/kit': patch
+---
+
+Externalize app initialization to adapters

--- a/packages/adapter-begin/src/index.js
+++ b/packages/adapter-begin/src/index.js
@@ -3,6 +3,8 @@
 import url from 'url';
 import app from '@architect/shared/app.js'; // eslint-disable-line import/no-unresolved
 
+// TODO: run init() on the app before handling routes
+
 async function handler(event) {
 	const { host, rawPath: path, httpMethod, rawQueryString, headers, body } = event;
 

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -1,7 +1,8 @@
 // TODO hardcoding the relative location makes this brittle
-import { render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
+import { init, render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
 import { getAssetFromKV, NotFoundError } from '@cloudflare/kv-asset-handler'; // eslint-disable-line import/no-unresolved
 
+init();
 addEventListener('fetch', (event) => {
 	event.respondWith(handle(event));
 });

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -3,6 +3,7 @@ import { init, render } from '../output/server/app.js'; // eslint-disable-line i
 import { getAssetFromKV, NotFoundError } from '@cloudflare/kv-asset-handler'; // eslint-disable-line import/no-unresolved
 
 init();
+
 addEventListener('fetch', (event) => {
 	event.respondWith(handle(event));
 });

--- a/packages/adapter-netlify/files/entry.js
+++ b/packages/adapter-netlify/files/entry.js
@@ -4,6 +4,7 @@ import '@sveltejs/kit/install-fetch'; // eslint-disable-line import/no-unresolve
 import { init, render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
 
 init();
+
 export async function handler(event) {
 	const { path, httpMethod, headers, rawQuery, body, isBase64Encoded } = event;
 

--- a/packages/adapter-netlify/files/entry.js
+++ b/packages/adapter-netlify/files/entry.js
@@ -1,8 +1,9 @@
 import '@sveltejs/kit/install-fetch'; // eslint-disable-line import/no-unresolved
 
 // TODO hardcoding the relative location makes this brittle
-import { render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
+import { init, render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
 
+init();
 export async function handler(event) {
 	const { path, httpMethod, headers, rawQuery, body, isBase64Encoded } = event;
 

--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -5,6 +5,7 @@ import { init, render } from '../output/server/app.js'; // eslint-disable-line i
 import { host, port } from './env.js'; // eslint-disable-line import/no-unresolved
 
 init();
+
 const instance = createServer({ render }).listen(port, host, () => {
 	console.log(`Listening on port ${port}`);
 });

--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -1,9 +1,10 @@
 import './require_shim';
 import { createServer } from './server';
 // TODO hardcoding the relative location makes this brittle
-import { render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
+import { init, render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
 import { host, port } from './env.js'; // eslint-disable-line import/no-unresolved
 
+init();
 const instance = createServer({ render }).listen(port, host, () => {
 	console.log(`Listening on port ${port}`);
 });

--- a/packages/adapter-node/src/require_shim.js
+++ b/packages/adapter-node/src/require_shim.js
@@ -1,2 +1,2 @@
 import { createRequire } from 'module';
-global.require = createRequire(import.meta.url);
+globalThis.require = createRequire(import.meta.url);

--- a/packages/adapter-vercel/files/entry.js
+++ b/packages/adapter-vercel/files/entry.js
@@ -2,8 +2,9 @@ import { getRawBody } from '@sveltejs/kit/node'; // eslint-disable-line import/n
 import '@sveltejs/kit/install-fetch'; // eslint-disable-line import/no-unresolved
 
 // TODO hardcoding the relative location makes this brittle
-import { render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
+import { init, render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
 
+init();
 export default async (req, res) => {
 	const { pathname, searchParams } = new URL(req.url || '', 'http://localhost');
 

--- a/packages/adapter-vercel/files/entry.js
+++ b/packages/adapter-vercel/files/entry.js
@@ -5,6 +5,7 @@ import '@sveltejs/kit/install-fetch'; // eslint-disable-line import/no-unresolve
 import { init, render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
 
 init();
+
 export default async (req, res) => {
 	const { pathname, searchParams } = new URL(req.url || '', 'http://localhost');
 

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -285,9 +285,11 @@ async function build_server(
 
 			let options = null;
 
+			const default_settings = { paths: ${s(config.kit.paths)} };
+
 			// allow paths to be overridden in svelte-kit preview
 			// and in prerendering
-			export function init(settings) {
+			export function init(settings = default_settings) {
 				set_paths(settings.paths);
 				set_prerendering(settings.prerendering || false);
 
@@ -379,8 +381,6 @@ async function build_server(
 					...metadata_lookup[file]
 				};
 			}
-
-			init({ paths: ${s(config.kit.paths)} });
 
 			export function render(request, {
 				prerender

--- a/packages/kit/src/install-fetch.js
+++ b/packages/kit/src/install-fetch.js
@@ -1,7 +1,20 @@
-// @ts-nocheck
 import fetch, { Response, Request, Headers } from 'node-fetch';
 
-globalThis.fetch = fetch;
-globalThis.Response = Response;
-globalThis.Request = Request;
-globalThis.Headers = Headers;
+Object.defineProperties(globalThis, {
+    fetch: {
+        enumerable: true,
+        value: fetch
+    },
+    Response: {
+        enumerable: true,
+        value: Response
+    },
+    Request: {
+        enumerable: true,
+        value: Request
+    },
+    Headers: {
+        enumerable: true,
+        value: Headers
+    }
+});

--- a/packages/kit/src/install-fetch.js
+++ b/packages/kit/src/install-fetch.js
@@ -1,20 +1,20 @@
 import fetch, { Response, Request, Headers } from 'node-fetch';
 
 Object.defineProperties(globalThis, {
-    fetch: {
-        enumerable: true,
-        value: fetch
-    },
-    Response: {
-        enumerable: true,
-        value: Response
-    },
-    Request: {
-        enumerable: true,
-        value: Request
-    },
-    Headers: {
-        enumerable: true,
-        value: Headers
-    }
+	fetch: {
+		enumerable: true,
+		value: fetch
+	},
+	Response: {
+		enumerable: true,
+		value: Response
+	},
+	Request: {
+		enumerable: true,
+		value: Request
+	},
+	Headers: {
+		enumerable: true,
+		value: Headers
+	}
 });


### PR DESCRIPTION
Fixes #1784. Closes #1786 as its alternative.

This PR contains a **breaking change** to the adapter API.

## Current Behavior

https://github.com/sveltejs/kit/blob/559aad5f9dae6037a2d5fc4a63de0440634f41f2/packages/kit/src/core/build/index.js#L383

The built `app.js` file contains a side effect of calling the `init` function, which ends up running before polyfills like `@sveltejs/kit/install-fetch`. Although ESM (supposedly) guarantees a top-down order for import side effects, this is currently not necessarily true with esbuild nor rollup (see https://github.com/evanw/esbuild/issues/399#issuecomment-695967781).

## Proposed Behavior

https://github.com/sveltejs/kit/blob/e2f1b3f98124bb99606dcc0016e0072ed5e0e192/packages/kit/src/core/build/index.js#L288-L292

The `init` call is removed from the built `app.js`, and instead it becomes the responsibility of the adapters to call it at least once. This lets it control when the initialization happens, allowing us to guarantee that it happens after any polyfills:

https://github.com/sveltejs/kit/blob/e2f1b3f98124bb99606dcc0016e0072ed5e0e192/packages/adapter-node/src/index.js#L4-L8

This may also be useful in the future should the `init` function need to perform other side effects.

## Non-breaking alternate solutions

1. Use `require()` and the require shim to import the app to force it to run last:
    ```js
    const { render } = require('../output/server/app.js');
    ```
    This is not a great long-term solution considering we're forging ahead with ESM anyway.
2. Call `init` from `render` the first time it's called:
    ```js
    let initialized = false;
    export function render(/* ... */) {
      if (!initialized) {
        initialized = true;
        init(/* ... */);
      }
      // ...
    }
    ```
    In environments such as `adapter-node` it won't be evaluated until the server handles the quest, which may delay the initial response. May also affect serverless environments where lambdas may live longer than a single request.
    