### PR TITLE
[fix] `ReadOnlyFormData` types

### DIFF
--- a/.changeset/real-pens-watch.md
+++ b/.changeset/real-pens-watch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix type errors inside ReadOnlyFormData that didn't allow it to be used inside for..of loops

--- a/packages/kit/types/helper.d.ts
+++ b/packages/kit/types/helper.d.ts
@@ -2,9 +2,9 @@ interface ReadOnlyFormData {
 	get: (key: string) => string;
 	getAll: (key: string) => string[];
 	has: (key: string) => boolean;
-	entries: () => Iterator<[string, string]>;
-	keys: () => Iterator<string>;
-	values: () => Iterator<string>;
+	entries: () => Generator<[string, string], void>;
+	keys: () => Generator<string, void>;
+	values: () => Generator<string, void>;
 	[Symbol.iterator]: () => Generator<[string, string], void>;
 }
 

--- a/packages/kit/types/helper.d.ts
+++ b/packages/kit/types/helper.d.ts
@@ -1,10 +1,11 @@
-interface ReadOnlyFormData extends Iterator<[string, string]> {
+interface ReadOnlyFormData {
 	get: (key: string) => string;
 	getAll: (key: string) => string[];
 	has: (key: string) => boolean;
 	entries: () => Iterator<[string, string]>;
 	keys: () => Iterator<string>;
 	values: () => Iterator<string>;
+	[Symbol.iterator]: () => Generator<[string, string], void>;
 }
 
 type BaseBody = string | Buffer | ReadOnlyFormData;


### PR DESCRIPTION
Fixes types of the `ReadOnlyFormData` interface. 
The changes allow instances of the class and its methods to be used inside a `for ... of` loop without receiving an error like:
`TS2495: Type 'ReadOnlyFormData' is not an array type or a string type.`

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
