### PR TITLE
chore: Enable `vite.server.fs.strict` by default

### DIFF
--- a/.changeset/fluffy-adults-happen.md
+++ b/.changeset/fluffy-adults-happen.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Enable vite.server.fs.strict by default

--- a/examples/hn.svelte.dev/svelte.config.js
+++ b/examples/hn.svelte.dev/svelte.config.js
@@ -3,6 +3,13 @@ import netlify from '@sveltejs/adapter-netlify';
 export default {
 	kit: {
 		adapter: netlify(),
-		target: '#svelte'
+		target: '#svelte',
+		vite: {
+			server: {
+				fs: {
+					strict: true
+				}
+			}
+		}
 	}
 };

--- a/packages/adapter-static/test/apps/prerendered/svelte.config.js
+++ b/packages/adapter-static/test/apps/prerendered/svelte.config.js
@@ -4,7 +4,14 @@ import adapter from '../../../index.js';
 const config = {
 	kit: {
 		adapter: adapter(),
-		target: '#svelte'
+		target: '#svelte',
+		vite: {
+			server: {
+				fs: {
+					strict: true
+				}
+			}
+		}
 	}
 };
 

--- a/packages/adapter-static/test/apps/spa/svelte.config.js
+++ b/packages/adapter-static/test/apps/spa/svelte.config.js
@@ -6,7 +6,14 @@ const config = {
 		adapter: adapter({
 			fallback: '200.html'
 		}),
-		target: '#svelte'
+		target: '#svelte',
+		vite: {
+			server: {
+				fs: {
+					strict: true
+				}
+			}
+		}
 	}
 };
 

--- a/packages/create-svelte/shared/+typescript/svelte.config.js
+++ b/packages/create-svelte/shared/+typescript/svelte.config.js
@@ -8,7 +8,14 @@ const config = {
 
 	kit: {
 		// hydrate the <div id="svelte"> element in src/app.html
-		target: '#svelte'
+		target: '#svelte',
+		vite: {
+			server: {
+				fs: {
+					strict: true
+				}
+			}
+		}
 	}
 };
 

--- a/packages/create-svelte/shared/-typescript/svelte.config.js
+++ b/packages/create-svelte/shared/-typescript/svelte.config.js
@@ -2,7 +2,14 @@
 const config = {
 	kit: {
 		// hydrate the <div id="svelte"> element in src/app.html
-		target: '#svelte'
+		target: '#svelte',
+		vite: {
+			server: {
+				fs: {
+					strict: true
+				}
+			}
+		}
 	}
 };
 

--- a/packages/create-svelte/templates/default/svelte.config.js
+++ b/packages/create-svelte/templates/default/svelte.config.js
@@ -11,7 +11,14 @@ const config = {
 
 	kit: {
 		// hydrate the <div id="svelte"> element in src/app.html
-		target: '#svelte'
+		target: '#svelte',
+		vite: {
+			server: {
+				fs: {
+					strict: true
+				}
+			}
+		}
 	}
 };
 

--- a/packages/create-svelte/templates/skeleton/svelte.config.js
+++ b/packages/create-svelte/templates/skeleton/svelte.config.js
@@ -9,7 +9,14 @@ const config = {
 		adapter: node(),
 
 		// hydrate the <div id="svelte"> element in src/app.html
-		target: '#svelte'
+		target: '#svelte',
+		vite: {
+			server: {
+				fs: {
+					strict: true
+				}
+			}
+		}
 	}
 };
 

--- a/packages/kit/test/apps/amp/svelte.config.js
+++ b/packages/kit/test/apps/amp/svelte.config.js
@@ -1,7 +1,14 @@
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		amp: true
+		amp: true,
+		vite: {
+			server: {
+				fs: {
+					strict: true
+				}
+			}
+		}
 	}
 };
 

--- a/packages/kit/test/apps/basics/svelte.config.js
+++ b/packages/kit/test/apps/basics/svelte.config.js
@@ -11,6 +11,11 @@ const config = {
 				// for CI, we need to explicitly prebundle deps, since
 				// the reload confuses Playwright
 				include: ['cookie', 'marked']
+			},
+			server: {
+				fs: {
+					strict: true
+				}
 			}
 		}
 	}

--- a/packages/kit/test/apps/options/svelte.config.js
+++ b/packages/kit/test/apps/options/svelte.config.js
@@ -17,7 +17,12 @@ const config = {
 			build: {
 				minify: false
 			},
-			clearScreen: false
+			clearScreen: false,
+			server: {
+				fs: {
+					strict: true
+				}
+			}
 		}
 	}
 };


### PR DESCRIPTION
### Purpose
> #### [server.fs.strict](https://vitejs.dev/config/#server-fs-strict)
> - **Experimental**
> - **Type:** `boolean`
> - **Default:** `false` (will change to `true` in future versions)
>    Restrict serving files outside of workspace root.

- All tests (except the default config test) involving a `svelte.config.js` have been changed to enable this parameter
- `create-svelte` was updated to include this parameter by default

In the future, when Vite makes this the default behavior, we can remove it from the configs.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
