### PR TITLE
[chore] Cleanup CHANGELOG history

### DIFF
--- a/.changeset/fuzzy-jeans-join.md
+++ b/.changeset/fuzzy-jeans-join.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/adapter-node': minor
+'@sveltejs/adapter-node': patch
 ---
 
 Make adapter node work under esm

--- a/.changeset/heavy-ways-agree.md
+++ b/.changeset/heavy-ways-agree.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/adapter-node': minor
+'@sveltejs/adapter-node': patch
 ---
 
 Allow sirv to looks for precompiled gzip and brotli files by default

--- a/.changeset/olive-maps-join.md
+++ b/.changeset/olive-maps-join.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/kit': minor
+'@sveltejs/kit': patch
 ---
 
 fix attribute validation in generated script tag

--- a/.changeset/wild-cooks-drive.md
+++ b/.changeset/wild-cooks-drive.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/kit': minor
+'@sveltejs/kit': patch
 ---
 
 Remove endpoints from the files built for the client


### PR DESCRIPTION
The changelog is messy to read with stuff split between `minor` and `patch`. We've generally made everything `patch`, but some people have done otherwise without us noticing