### PR TITLE
chore: Enable `vite.server.fs.strict` internally by default

### DIFF
--- a/.changeset/silly-grapes-cover.md
+++ b/.changeset/silly-grapes-cover.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Enable Vite's server.fs.strict by default

--- a/documentation/faq/90-fs-strict.md
+++ b/documentation/faq/90-fs-strict.md
@@ -1,0 +1,10 @@
+---
+question: "Internal server error: The request url [...] is outside of Vite serving allow list"
+---
+
+For security reasons, Vite has been configured to only allow filesystem access when the request file fulfils one of these requirements:
+- Within workspace root
+- Within the listed `server.fs.allow` exceptions
+- Part of the dependency graph of your application code
+
+Refer to Vite documentation for [`server.fs.allow`](https://vitejs.dev/config/#server-fs-allow) for configuration and more details.

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -134,8 +134,16 @@ async function build_client({
 	/** @type {any} */
 	const user_config = config.kit.vite();
 
+	const default_config = {
+		server: {
+			fs: {
+				strict: true
+			}
+		}
+	};
+
 	/** @type {[any, string[]]} */
-	const [merged_config, conflicts] = deep_merge(user_config, {
+	const [merged_config, conflicts] = deep_merge(default_config, user_config, {
 		configFile: false,
 		root: cwd,
 		base,
@@ -408,8 +416,16 @@ async function build_server(
 	/** @type {any} */
 	const user_config = config.kit.vite();
 
+	const default_config = {
+		server: {
+			fs: {
+				strict: true
+			}
+		}
+	};
+
 	/** @type {[any, string[]]} */
-	const [merged_config, conflicts] = deep_merge(user_config, {
+	const [merged_config, conflicts] = deep_merge(default_config, user_config, {
 		configFile: false,
 		root: cwd,
 		base,
@@ -515,8 +531,16 @@ async function build_service_worker(
 	/** @type {any} */
 	const user_config = config.kit.vite();
 
+	const default_config = {
+		server: {
+			fs: {
+				strict: true
+			}
+		}
+	};
+
 	/** @type {[any, string[]]} */
-	const [merged_config, conflicts] = deep_merge(user_config, {
+	const [merged_config, conflicts] = deep_merge(default_config, user_config, {
 		configFile: false,
 		root: cwd,
 		base,

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -142,8 +142,11 @@ async function build_client({
 		}
 	};
 
+	// don't warn on overriding defaults
+	const [modified_user_config] = deep_merge(default_config, user_config);
+
 	/** @type {[any, string[]]} */
-	const [merged_config, conflicts] = deep_merge(default_config, user_config, {
+	const [merged_config, conflicts] = deep_merge(modified_user_config, {
 		configFile: false,
 		root: cwd,
 		base,
@@ -424,8 +427,11 @@ async function build_server(
 		}
 	};
 
+	// don't warn on overriding defaults
+	const [modified_user_config] = deep_merge(default_config, user_config);
+
 	/** @type {[any, string[]]} */
-	const [merged_config, conflicts] = deep_merge(default_config, user_config, {
+	const [merged_config, conflicts] = deep_merge(modified_user_config, {
 		configFile: false,
 		root: cwd,
 		base,
@@ -539,8 +545,11 @@ async function build_service_worker(
 		}
 	};
 
+	// don't warn on overriding defaults
+	const [modified_user_config] = deep_merge(default_config, user_config);
+
 	/** @type {[any, string[]]} */
-	const [merged_config, conflicts] = deep_merge(default_config, user_config, {
+	const [merged_config, conflicts] = deep_merge(modified_user_config, {
 		configFile: false,
 		root: cwd,
 		base,

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -82,6 +82,14 @@ class Watcher extends EventEmitter {
 		/** @type {any} */
 		const user_config = (this.config.kit.vite && this.config.kit.vite()) || {};
 
+		const default_config = {
+			server: {
+				fs: {
+					strict: true
+				}
+			}
+		};
+
 		/** @type {(req: import("http").IncomingMessage, res: import("http").ServerResponse) => void} */
 		let handler = (req, res) => {};
 
@@ -90,7 +98,7 @@ class Watcher extends EventEmitter {
 		const alias = user_config.resolve && user_config.resolve.alias;
 
 		/** @type {[any, string[]]} */
-		const [merged_config, conflicts] = deep_merge(user_config, {
+		const [merged_config, conflicts] = deep_merge(default_config, user_config, {
 			configFile: false,
 			root: this.cwd,
 			resolve: {

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -97,8 +97,11 @@ class Watcher extends EventEmitter {
 
 		const alias = user_config.resolve && user_config.resolve.alias;
 
+		// don't warn on overriding defaults
+		const [modified_user_config] = deep_merge(default_config, user_config);
+
 		/** @type {[any, string[]]} */
-		const [merged_config, conflicts] = deep_merge(default_config, user_config, {
+		const [merged_config, conflicts] = deep_merge(modified_user_config, {
 			configFile: false,
 			root: this.cwd,
 			resolve: {


### PR DESCRIPTION
### Purpose
> #### [server.fs.strict](https://vitejs.dev/config/#server-fs-strict)
> - **Experimental**
> - **Type:** `boolean`
> - **Default:** `false` (will change to `true` in future versions)
>    Restrict serving files outside of workspace root.

This setting remains user-configurable and does not emit warnings when overridden. An FAQ entry has been added about the behavior should someone encounter a blocked import.

In the future, when Vite makes this the default behavior, we can remove it from the internal default.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
