### PR TITLE
Docs for writing an adapter API

### DIFF
--- a/documentation/docs/10-adapters.md
+++ b/documentation/docs/10-adapters.md
@@ -33,7 +33,6 @@ export default {
 
 A variety of official adapters exist for serverless platforms...
 
-- [`adapter-begin`](https://github.com/sveltejs/kit/tree/master/packages/adapter-begin) — for [Begin](https://begin.com)
 - [`adapter-cloudflare-workers`](https://github.com/sveltejs/kit/tree/master/packages/adapter-cloudflare-workers) — for [Cloudflare Workers](https://developers.cloudflare.com/workers/)
 - [`adapter-netlify`](https://github.com/sveltejs/kit/tree/master/packages/adapter-netlify) — for [Netlify](https://netlify.com)
 - [`adapter-vercel`](https://github.com/sveltejs/kit/tree/master/packages/adapter-vercel) — for [Vercel](https://vercel.com)

--- a/documentation/docs/10-adapters.md
+++ b/documentation/docs/10-adapters.md
@@ -42,4 +42,4 @@ A variety of official adapters exist for serverless platforms...
 - [`adapter-node`](https://github.com/sveltejs/kit/tree/master/packages/adapter-node) — for creating self-contained Node apps
 - [`adapter-static`](https://github.com/sveltejs/kit/tree/master/packages/adapter-static) — for prerendering your entire site as a collection of static files
 
-You may also [write your own](#writing-an-adapter).
+As well as [community-provided adapters](https://github.com/sveltejs/integrations#sveltekit-adapters). You may also [write your own adapter](#writing-an-adapter).

--- a/documentation/docs/10-adapters.md
+++ b/documentation/docs/10-adapters.md
@@ -38,9 +38,9 @@ A variety of official adapters exist for serverless platforms...
 - [`adapter-netlify`](https://github.com/sveltejs/kit/tree/master/packages/adapter-netlify) — for [Netlify](https://netlify.com)
 - [`adapter-vercel`](https://github.com/sveltejs/kit/tree/master/packages/adapter-vercel) — for [Vercel](https://vercel.com)
 
-...and others:
+...and traditional platforms:
 
 - [`adapter-node`](https://github.com/sveltejs/kit/tree/master/packages/adapter-node) — for creating self-contained Node apps
 - [`adapter-static`](https://github.com/sveltejs/kit/tree/master/packages/adapter-static) — for prerendering your entire site as a collection of static files
 
-> The adapter API is still in flux and will likely change before 1.0.
+You may also [write your own](#writing-an-adapter).

--- a/documentation/docs/80-adapter-api.md
+++ b/documentation/docs/80-adapter-api.md
@@ -25,7 +25,7 @@ Within the `adapt` method, there are a number of things that an adapter should d
 - Clear out the build directory
 - Provide code that:
   - Calls `init`
-  - Converts from the patform's request to a SvelteKit request, call `render`, convert from a SveteKit reponse to the platform's
+  - Converts from the patform's request to a [SvelteKit request](#hooks-handle), call `render`, convert from a [SvelteKit response](#hooks-handle) to the platform's
 - Bundle the output to avoid needing to install dependencies on the target platform, etc. if desired
 - Globally shim `fetch` to work on the target platform. SvelteKit provides a `@sveltejs/kit/install-fetch` helper to use `node-fetch`
 - Call `prerender`

--- a/documentation/docs/80-adapter-api.md
+++ b/documentation/docs/80-adapter-api.md
@@ -25,10 +25,10 @@ Within the `adapt` method, there are a number of things that an adapter should d
 - Clear out the build directory
 - Output code that:
   - Calls `init`
-  - Converts from the patform's request to a [SvelteKit request](#hooks-handle), call `render`, convert from a [SvelteKit response](#hooks-handle) to the platform's
-  - Globally shims `fetch` to work on the target platform. SvelteKit provides a `@sveltejs/kit/install-fetch` helper to use `node-fetch`
-- Bundle the output to avoid needing to install dependencies on the target platform, etc. if desired
-- Call `prerender`
+  - Converts from the patform's request to a [SvelteKit request](#hooks-handle), calls `render`, and converts from a [SvelteKit response](#hooks-handle) to the platform's
+  - Globally shims `fetch` to work on the target platform. SvelteKit provides a `@sveltejs/kit/install-fetch` helper for platforms that can use `node-fetch`
+- Bundle the output to avoid needing to install dependencies on the target platform, if desired
+- Call `utils.prerender`
 - Put the user's static files and the generated JS/CSS in the correct location for the target platform
 
 > The adapter API may change before 1.0.

--- a/documentation/docs/80-adapter-api.md
+++ b/documentation/docs/80-adapter-api.md
@@ -23,11 +23,11 @@ The types for `Adapter` and its parameters are available in [types/config.d.ts](
 
 Within the `adapt` method, there are a number of things that an adapter should do:
 - Clear out the build directory
-- Provide code that:
+- Output code that:
   - Calls `init`
   - Converts from the patform's request to a [SvelteKit request](#hooks-handle), call `render`, convert from a [SvelteKit response](#hooks-handle) to the platform's
+  - Globally shims `fetch` to work on the target platform. SvelteKit provides a `@sveltejs/kit/install-fetch` helper to use `node-fetch`
 - Bundle the output to avoid needing to install dependencies on the target platform, etc. if desired
-- Globally shim `fetch` to work on the target platform. SvelteKit provides a `@sveltejs/kit/install-fetch` helper to use `node-fetch`
 - Call `prerender`
 - Put the user's static files and the generated JS/CSS in the correct location for the target platform
 

--- a/documentation/docs/80-adapter-api.md
+++ b/documentation/docs/80-adapter-api.md
@@ -1,0 +1,29 @@
+---
+title: Writing an Adapter
+---
+
+We recommend [looking at the source for an adapter](https://github.com/sveltejs/kit/tree/master/packages) to a platform similar to yours and copying it as a starting point.
+
+Adapters must implement the following API:
+```
+export default function () {
+	/** @type {import('@sveltejs/kit').Adapter} */
+	return {
+		name: '',
+		async adapt({ utils, config }) {
+		}
+	};
+}
+```
+
+Within the `adapt` method, there are a number of things that an adapter should do:
+- Clear out the build directory
+- Provide code that:
+  - Calls `init`
+  - Converts from the patform's request to a SvelteKit request, call `render`, convert from a SveteKit reponse to the platform's
+- Bundle the output to avoid needing to install dependencies on the target platform, etc. if desired
+- Globally shim `fetch` to work on the target platform. SvelteKit provides a `@sveltejs/kit/install-fetch` helper to use `node-fetch`
+- Call `prerender`
+- Put the user's static files and the generated JS/CSS in the correct location for the target platform
+
+> The adapter API may change before 1.0.

--- a/documentation/docs/80-adapter-api.md
+++ b/documentation/docs/80-adapter-api.md
@@ -9,7 +9,7 @@ Adapters packages must implement the following API, which creates an `Adapter`:
 /**
  * @param {AdapterSpecificOptions} options
  */
-export default function () {
+export default function (options) {
 	/** @type {import('@sveltejs/kit').Adapter} */
 	return {
 		name: '',

--- a/documentation/docs/80-adapter-api.md
+++ b/documentation/docs/80-adapter-api.md
@@ -6,6 +6,9 @@ We recommend [looking at the source for an adapter](https://github.com/sveltejs/
 
 Adapters must implement the following API:
 ```
+/**
+ * @param {AdapterSpecificOptions} options
+ */
 export default function () {
 	/** @type {import('@sveltejs/kit').Adapter} */
 	return {

--- a/documentation/docs/80-adapter-api.md
+++ b/documentation/docs/80-adapter-api.md
@@ -4,7 +4,7 @@ title: Writing an Adapter
 
 We recommend [looking at the source for an adapter](https://github.com/sveltejs/kit/tree/master/packages) to a platform similar to yours and copying it as a starting point.
 
-Adapters must implement the following API:
+Adapters packages must implement the following API, which creates an `Adapter`:
 ```
 /**
  * @param {AdapterSpecificOptions} options
@@ -18,6 +18,8 @@ export default function () {
 	};
 }
 ```
+
+The types for `Adapter` and its parameters are available in [types/config.d.ts](https://github.com/sveltejs/kit/blob/master/packages/kit/types/config.d.ts).
 
 Within the `adapt` method, there are a number of things that an adapter should do:
 - Clear out the build directory


### PR DESCRIPTION
People have always written adapters by copying an existing one. We should probably provide more guidance. This can probably be fleshed out a bit more, but hopefully it's a starting point that we can add to

@jthegedus @jpaquim let me know if you have any suggestions from your work on writing the Firebase and Deno adapters

@ryanb I hope this helps as you take a look at writing a Begin adapter. Let me know as you go through the process if there are things missing