### PR TITLE
feat(ssr): Same-origin fetch cookie passthrough

### DIFF
--- a/.changeset/thick-steaks-sneeze.md
+++ b/.changeset/thick-steaks-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Passthrough server-side fetch cookies for most same-origin scenarios

--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -98,6 +98,8 @@ So if the example above was `src/routes/blog/[slug].svelte` and the URL was `htt
 
 > When `fetch` runs on the server, the resulting response will be serialized and inlined into the rendered HTML. This allows the subsequent client-side `load` to access identical data immediately without an additional network request.
 
+> Cookies will only be passed through if the target host is the same as the SvelteKit application or a higher subdomain of it.
+
 #### session
 
 `session` can be used to pass data from the server related to the current request, e.g. the current user. By default it is `undefined`. See [`getSession`](#hooks-getsession) to learn how to use it.

--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -98,7 +98,7 @@ So if the example above was `src/routes/blog/[slug].svelte` and the URL was `htt
 
 > When `fetch` runs on the server, the resulting response will be serialized and inlined into the rendered HTML. This allows the subsequent client-side `load` to access identical data immediately without an additional network request.
 
-> Cookies will only be passed through if the target host is the same as the SvelteKit application or a higher subdomain of it.
+> Cookies will only be passed through if the target host is the same as the SvelteKit application or a more specific subdomain of it.
 
 #### session
 

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -98,9 +98,32 @@ export async function load_node({
 				let response;
 
 				if (/^[a-zA-Z]+:/.test(url)) {
-					// external fetch
-					const request = new Request(url, /** @type {RequestInit} */ (opts));
-					response = await options.hooks.serverFetch.call(null, request);
+					// possibly external fetch
+					if (typeof request.host !== 'undefined') {
+						const { hostname: fetchHostname } = new URL(url);
+						const [serverHostname] = request.host.split(':');
+
+						// allow cookie passthrough for "same-origin"
+						// if SvelteKit is serving my.domain.com:
+						// -        domain.com WILL NOT receive cookies
+						// -     my.domain.com WILL receive cookies
+						// -    amy.domain.com WILL NOT receive cookies
+						// -    api.domain.dom WILL NOT receive cookies
+						// - sub.my.domain.com WILL receive cookies
+						// ports do not affect the resolution
+						// leading dot prevents mydomain.com matching domain.com
+						if (`.${fetchHostname}`.endsWith(`.${serverHostname}`) && opts.credentials !== 'omit') {
+							uses_credentials = true;
+
+							opts.headers = {
+								...opts.headers,
+								cookie: request.headers.cookie
+							};
+						}
+					}
+
+					const externalRequest = new Request(url, /** @type {RequestInit} */ (opts));
+					response = await options.hooks.serverFetch.call(null, externalRequest);
 				} else {
 					const [path, search] = url.split('?');
 

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -4,6 +4,8 @@ import { resolve } from './resolve.js';
 
 const s = JSON.stringify;
 
+const hasScheme = (/** @type {string} */ url) => /^[a-zA-Z]+:/.test(url);
+
 /**
  *
  * @param {{
@@ -97,7 +99,7 @@ export async function load_node({
 
 				let response;
 
-				if (/^[a-zA-Z]+:/.test(url)) {
+				if (hasScheme(url)) {
 					// possibly external fetch
 					if (typeof request.host !== 'undefined') {
 						const { hostname: fetchHostname } = new URL(url);
@@ -107,7 +109,6 @@ export async function load_node({
 						// if SvelteKit is serving my.domain.com:
 						// -        domain.com WILL NOT receive cookies
 						// -     my.domain.com WILL receive cookies
-						// -    amy.domain.com WILL NOT receive cookies
 						// -    api.domain.dom WILL NOT receive cookies
 						// - sub.my.domain.com WILL receive cookies
 						// ports do not affect the resolution


### PR DESCRIPTION
Closes #1777. Mostly.

Proper subdomain testing would need fudging with the `hosts` file, which would be unreasonable to include in automated tests.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts
