### PR TITLE
Test with the latest version of Svelte

### DIFF
--- a/examples/hn.svelte.dev/package.json
+++ b/examples/hn.svelte.dev/package.json
@@ -11,6 +11,6 @@
 	"devDependencies": {
 		"@sveltejs/adapter-netlify": "workspace:*",
 		"@sveltejs/kit": "workspace:*",
-		"svelte": "^3.38.2"
+		"svelte": "^3.38.3"
 	}
 }

--- a/packages/adapter-static/test/apps/prerendered/package.json
+++ b/packages/adapter-static/test/apps/prerendered/package.json
@@ -8,7 +8,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "next",
-		"svelte": "^3.29.0"
+		"svelte": "^3.38.3"
 	},
 	"type": "module"
 }

--- a/packages/adapter-static/test/apps/spa/package.json
+++ b/packages/adapter-static/test/apps/spa/package.json
@@ -9,7 +9,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-node": "next",
 		"@sveltejs/kit": "next",
-		"svelte": "^3.29.0"
+		"svelte": "^3.38.3"
 	},
 	"type": "module"
 }

--- a/packages/create-svelte/templates/default/package.json
+++ b/packages/create-svelte/templates/default/package.json
@@ -11,7 +11,7 @@
 		"@sveltejs/adapter-netlify": "next",
 		"@sveltejs/adapter-vercel": "next",
 		"@sveltejs/kit": "next",
-		"svelte": "^3.38.2",
+		"svelte": "^3.34.0",
 		"svelte-preprocess": "^4.7.3",
 		"typescript": "^4.2.4"
 	},

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -32,7 +32,7 @@
 		"rollup": "^2.47.0",
 		"selfsigned": "^1.10.11",
 		"sirv": "^1.0.12",
-		"svelte": "^3.38.2",
+		"svelte": "^3.38.3",
 		"svelte-check": "^2.2.0",
 		"svelte2tsx": "~0.4.1",
 		"tiny-glob": "^0.2.8",

--- a/packages/kit/test/apps/basics/package.json
+++ b/packages/kit/test/apps/basics/package.json
@@ -10,7 +10,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-node": "workspace:*",
 		"@sveltejs/kit": "workspace:*",
-		"svelte": "^3.29.0"
+		"svelte": "^3.38.3"
 	},
 	"type": "module"
 }

--- a/packages/kit/test/apps/basics/src/routes/imports/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/imports/_tests.js
@@ -4,9 +4,6 @@ import * as assert from 'uvu/assert';
 export default function (test) {
 	test('imports from node_modules', '/imports', async ({ page, clicknav }) => {
 		await clicknav('[href="/imports/markdown"]');
-		assert.equal(
-			(await page.innerHTML('main')).trim(),
-			'<p>this is some <strong>markdown</strong></p>'
-		);
+		assert.equal((await page.innerHTML('p')).trim(), 'this is some <strong>markdown</strong>');
 	});
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,11 +44,11 @@ importers:
     specifiers:
       '@sveltejs/adapter-netlify': workspace:*
       '@sveltejs/kit': workspace:*
-      svelte: ^3.38.2
+      svelte: ^3.38.3
     devDependencies:
       '@sveltejs/adapter-netlify': link:../../packages/adapter-netlify
       '@sveltejs/kit': link:../../packages/kit
-      svelte: 3.38.2
+      svelte: 3.38.3
 
   packages/adapter-begin:
     specifiers:
@@ -183,7 +183,7 @@ importers:
       '@sveltejs/adapter-vercel': next
       '@sveltejs/kit': next
       cookie: ^0.4.1
-      svelte: ^3.38.2
+      svelte: ^3.34.0
       svelte-preprocess: ^4.7.3
       typescript: ^4.2.4
     dependencies:
@@ -227,7 +227,7 @@ importers:
       sade: ^1.7.4
       selfsigned: ^1.10.11
       sirv: ^1.0.12
-      svelte: ^3.38.2
+      svelte: ^3.38.3
       svelte-check: ^2.2.0
       svelte2tsx: ~0.4.1
       tiny-glob: ^0.2.8
@@ -235,7 +235,7 @@ importers:
       uvu: ^0.5.1
       vite: ^2.4.1
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 1.0.0-next.11_521dee33336505fa0c0cfefe092a237f
+      '@sveltejs/vite-plugin-svelte': 1.0.0-next.11_7f2c501a1382bf91518307aaca32f4f7
       cheap-watch: 1.0.3
       sade: 1.7.4
       vite: 2.4.1
@@ -263,9 +263,9 @@ importers:
       rollup: 2.47.0
       selfsigned: 1.10.11
       sirv: 1.0.12
-      svelte: 3.38.2
-      svelte-check: 2.2.0_svelte@3.38.2
-      svelte2tsx: 0.4.1_svelte@3.38.2+typescript@4.2.4
+      svelte: 3.38.3
+      svelte-check: 2.2.0_svelte@3.38.3
+      svelte2tsx: 0.4.1_svelte@3.38.3+typescript@4.2.4
       tiny-glob: 0.2.8
       typescript: 4.2.4
       uvu: 0.5.1
@@ -644,7 +644,7 @@ packages:
       rollup: 2.47.0
     dev: false
 
-  /@sveltejs/vite-plugin-svelte/1.0.0-next.11_521dee33336505fa0c0cfefe092a237f:
+  /@sveltejs/vite-plugin-svelte/1.0.0-next.11_7f2c501a1382bf91518307aaca32f4f7:
     resolution: {integrity: sha512-EYR1I145k5rflVqhPwk3442m3bkYimTKSHM9uO5KdomXzt+GS9ZSBJQE3/wy1Di9V8OnGa3oKpckI3OZsHkTIA==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
@@ -655,8 +655,8 @@ packages:
       chalk: 4.1.1
       debug: 4.3.2
       require-relative: 0.8.7
-      svelte: 3.38.2
-      svelte-hmr: 0.14.4_svelte@3.38.2
+      svelte: 3.38.3
+      svelte-hmr: 0.14.4_svelte@3.38.3
       vite: 2.4.1
     transitivePeerDependencies:
       - rollup
@@ -3405,7 +3405,7 @@ packages:
     dependencies:
       has-flag: 4.0.0
 
-  /svelte-check/2.2.0_svelte@3.38.2:
+  /svelte-check/2.2.0_svelte@3.38.3:
     resolution: {integrity: sha512-6Lo5h/I2LlygtKn9sl2n5hAPBZgeY99wlsz0+6f5K3qCpMwYC8rkcbrZkNpNEMwbMABQkcWOKb5cfEew6Q/Kpg==}
     hasBin: true
     peerDependencies:
@@ -3418,8 +3418,8 @@ packages:
       minimist: 1.2.5
       sade: 1.7.4
       source-map: 0.7.3
-      svelte: 3.38.2
-      svelte-preprocess: 4.7.3_svelte@3.38.2+typescript@4.2.4
+      svelte: 3.38.3
+      svelte-preprocess: 4.7.3_svelte@3.38.3+typescript@4.2.4
       typescript: 4.2.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -3434,12 +3434,12 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-hmr/0.14.4_svelte@3.38.2:
+  /svelte-hmr/0.14.4_svelte@3.38.3:
     resolution: {integrity: sha512-kItFF7vqzStckSigoFmMnxJpTOdB9TWnQAW6Js+yAB4277tLbJIIE5KBlGHNmJNpA7MguqidsPB27Uw5UzQPCA==}
     peerDependencies:
       svelte: '>=3.19.0'
     dependencies:
-      svelte: 3.38.2
+      svelte: 3.38.3
     dev: false
 
   /svelte-preprocess/4.7.3_svelte@3.38.2+typescript@4.2.4:
@@ -3488,6 +3488,55 @@ packages:
       detect-indent: 6.0.0
       strip-indent: 3.0.0
       svelte: 3.38.2
+      typescript: 4.2.4
+    dev: true
+
+  /svelte-preprocess/4.7.3_svelte@3.38.3+typescript@4.2.4:
+    resolution: {integrity: sha512-Zx1/xLeGOIBlZMGPRCaXtlMe4ZA0faato5Dc3CosEqwu75MIEPuOstdkH6cy+RYTUYynoxzNaDxkPX4DbrPwRA==}
+    engines: {node: '>= 9.11.2'}
+    requiresBuild: true
+    peerDependencies:
+      '@babel/core': ^7.10.2
+      coffeescript: ^2.5.1
+      less: ^3.11.3
+      node-sass: '*'
+      postcss: ^7 || ^8
+      postcss-load-config: ^2.1.0 || ^3.0.0
+      pug: ^3.0.0
+      sass: ^1.26.8
+      stylus: ^0.54.7
+      sugarss: ^2.0.0
+      svelte: ^3.23.0
+      typescript: ^3.9.5 || ^4.0.0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      coffeescript:
+        optional: true
+      less:
+        optional: true
+      node-sass:
+        optional: true
+      postcss:
+        optional: true
+      postcss-load-config:
+        optional: true
+      pug:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@types/pug': 2.0.4
+      '@types/sass': 1.16.0
+      detect-indent: 6.0.0
+      strip-indent: 3.0.0
+      svelte: 3.38.3
       typescript: 4.2.4
     dev: true
 
@@ -3544,7 +3593,12 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
-  /svelte2tsx/0.4.1_svelte@3.38.2+typescript@4.2.4:
+  /svelte/3.38.3:
+    resolution: {integrity: sha512-N7bBZJH0iF24wsalFZF+fVYMUOigaAUQMIcEKHO3jstK/iL8VmP9xE+P0/a76+FkNcWt+TDv2Gx1taUoUscrvw==}
+    engines: {node: '>= 8'}
+    dev: true
+
+  /svelte2tsx/0.4.1_svelte@3.38.3+typescript@4.2.4:
     resolution: {integrity: sha512-qqXWg+wlsYXhtolKI2NGL52rK7ACejNzEKn98qcz2T6Fd1e73+YPZMw/FNeGRSZLCdNxzGf7QJDhzIiK3MXihA==}
     peerDependencies:
       svelte: ^3.24
@@ -3552,7 +3606,7 @@ packages:
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 3.38.2
+      svelte: 3.38.3
       typescript: 4.2.4
     dev: true
 


### PR DESCRIPTION
One of the tests was failing with the latest version of Svelte because it detected new hydration marker tags that weren't previously there. This bumps Svelte and updates that test so that it will pass

>        Actual:
>        --<!--·HTML_TAG_START·--><p>this·is·some·<strong>markdown</strong></p>
>        --<!--·HTML_TAG_END·-->
>        Expected:
>        ++<p>this·is·some·<strong>markdown</strong></p>