### PR TITLE
add config.kit.package.emitTypes option

### DIFF
--- a/.changeset/happy-actors-camp.md
+++ b/.changeset/happy-actors-camp.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/kit': minor
+'@sveltejs/kit': patch
 ---
 
 add config.kit.package.emitTypes

--- a/.changeset/happy-actors-camp.md
+++ b/.changeset/happy-actors-camp.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+add config.kit.package.emitTypes

--- a/documentation/docs/12-packaging.md
+++ b/documentation/docs/12-packaging.md
@@ -30,11 +30,13 @@ import Foo from 'your-library/Foo.svelte';
 
 To publish the generated package:
 
-```
+```sh
 npm publish package
 ```
 
 The `package` above is referring to the directory name generated, change accordingly if you configure a custom [`package.dir`](#configuration-package). If you're having problems publishing a package that is not yours, add a trailing slash at the end (e.g. `package/`).
+
+By default, `svelte-kit package` will automatically generate types for your package in the form of `d.ts.` files. This requires `svelte2tsx` and `typescript` to be installed. While generating types is configurable, we believe it is best for ecosystem quality to generate types, always. Please make sure you have a good reason to author a package without types when setting `config.kit.package.emitTypes = false`.
 
 ### Caveats
 

--- a/documentation/docs/12-packaging.md
+++ b/documentation/docs/12-packaging.md
@@ -11,7 +11,7 @@ A SvelteKit component library has the exact same structure as a SvelteKit app, e
 Running `svelte-kit package` will take the contents of `src/lib` and generate a `package` directory (which can be [configured](#configuration-package)) containing the following:
 
 - All the files in `src/lib`, unless you [configure](#configuration-package) custom `include`/`exclude` options. Svelte components will be preprocessed, TypeScript files will be transpiled to JavaScript.
-- Type definitions (`d.ts` files) which are generated for Svelte, JavaScript and TypeScript files. You need to install `typescript >= 4.0.0` and `svelte2tsx >= 0.4.1` for this. Type definitions are placed next to their implementation, hand-written `d.ts` files are copied over as is.
+- Type definitions (`d.ts` files) which are generated for Svelte, JavaScript and TypeScript files. You need to install `typescript >= 4.0.0` and `svelte2tsx >= 0.4.1` for this. Type definitions are placed next to their implementation, hand-written `d.ts` files are copied over as is. You can [disable generation](#configuration-package), but we strongly recommend against it.
 - A `package.json` that copies the `name`, `version`, `description`, `keywords`, `homepage`, `bugs`, `license`, `author`, `contributors`, `funding`, `repository`, `dependencies`, `private` and `publishConfig` fields from the root of the project, and adds a `"type": "module"` and an `"exports"` field
 
 The `"exports"` field contains the package's entry points. By default, all files in `src/lib` will be treated as an entry point unless they start with (or live in a directory that starts with) an underscore, but you can [configure](#configuration-package) this behaviour. If you have a `src/lib/index.js` or `src/lib/index.svelte` file, it will be treated as the package root.
@@ -35,8 +35,6 @@ npm publish package
 ```
 
 The `package` above is referring to the directory name generated, change accordingly if you configure a custom [`package.dir`](#configuration-package). If you're having problems publishing a package that is not yours, add a trailing slash at the end (e.g. `package/`).
-
-By default, `svelte-kit package` will automatically generate types for your package in the form of `d.ts.` files. This requires `svelte2tsx` and `typescript` to be installed. While generating types is configurable, we believe it is best for ecosystem quality to generate types, always. Please make sure you have a good reason to author a package without types when setting `config.kit.package.emitTypes = false`.
 
 ### Caveats
 

--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -177,6 +177,7 @@ Options related to [creating a package](#packaging).
 - `dir` - output directory
 - `exports` - contains a `includes` and a `excludes` array which specifies which files to mark as exported from the `exports` field of the `package.json`
 - `files` - contains a `includes` and a `excludes` array which specifies which files to process and copy over when packaging
+- `emitTypes` - by default, `svelte-kit package` will automatically generate types for your package in the form of `d.ts.` files. While generating types is configurable, we believe it is best for the ecosystem quality to generate types, always. Please make sure you have a good reason when setting it to `false` (for example when you want to provide handwritten type definitions instead).
 
 ### vite
 

--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -55,7 +55,8 @@ const config = {
 			files: {
 				include: ['**'],
 				exclude: []
-			}
+			},
+			emitTypes: true
 		},
 		vite: () => ({})
 	},

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -36,7 +36,8 @@ test('fills in defaults', () => {
 				files: {
 					include: ['**'],
 					exclude: []
-				}
+				},
+				emitTypes: true
 			},
 			serviceWorker: {
 				exclude: []
@@ -134,7 +135,8 @@ test('fills in partial blanks', () => {
 				files: {
 					include: ['**'],
 					exclude: []
-				}
+				},
+				emitTypes: true
 			},
 			serviceWorker: {
 				exclude: []

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -103,7 +103,8 @@ const options = {
 							include: expect_array_of_strings(['**']),
 							exclude: expect_array_of_strings([])
 						}
-					}
+					},
+					emitTypes: expect_boolean(true)
 				}
 			},
 

--- a/packages/kit/src/core/config/test/index.js
+++ b/packages/kit/src/core/config/test/index.js
@@ -46,7 +46,8 @@ async function testLoadDefaultConfig(path) {
 				files: {
 					include: ['**'],
 					exclude: []
-				}
+				},
+				emitTypes: true
 			},
 			serviceWorker: {
 				exclude: []

--- a/packages/kit/src/core/make_package/index.js
+++ b/packages/kit/src/core/make_package/index.js
@@ -12,8 +12,10 @@ import { mkdirp, rimraf } from '../filesystem/index.js';
 export async function make_package(config, cwd = process.cwd()) {
 	rimraf(path.join(cwd, config.kit.package.dir));
 
-	// Generate type definitions first so hand-written types can overwrite generated ones
-	await emit_dts(config);
+	if (config.kit.package.emitTypes) {
+		// Generate type definitions first so hand-written types can overwrite generated ones
+		await emit_dts(config);
+	}
 
 	const files_filter = create_filter(config.kit.package.files);
 	const exports_filter = create_filter({

--- a/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/expected/Test.svelte
+++ b/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/expected/Test.svelte
@@ -1,0 +1,12 @@
+<script>
+    import { createEventDispatcher } from 'svelte';
+    /**
+     * @type {string}
+     */
+    export const astring;
+
+    const dispatch = createEventDispatcher();
+    dispatch('event', true);
+</script>
+
+<slot {astring} />

--- a/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/expected/Test2.svelte
+++ b/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/expected/Test2.svelte
@@ -1,0 +1,6 @@
+<script>
+    /**
+     * @type {import('./foo').Foo}
+     */
+    export let foo;
+</script>

--- a/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/expected/foo.d.ts
+++ b/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/expected/foo.d.ts
@@ -1,0 +1,1 @@
+export type Foo = boolean;

--- a/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/expected/index.js
+++ b/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/expected/index.js
@@ -1,0 +1,1 @@
+export { default as Test } from './Test.svelte';

--- a/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/expected/package.json
+++ b/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/expected/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "javascript",
+	"version": "1.0.0",
+	"description": "package-javascript-test",
+	"type": "module",
+	"exports": {
+		"./package.json": "./package.json",
+		"./index.js": "./index.js",
+		"./Test.svelte": "./Test.svelte",
+		"./Test2.svelte": "./Test2.svelte",
+		".": "./index.js"
+	}
+}

--- a/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/expected/package.json
+++ b/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/expected/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "javascript",
+	"name": "javascript-no-types",
 	"version": "1.0.0",
-	"description": "package-javascript-test",
+	"description": "package-javascript-no-types-test",
 	"type": "module",
 	"exports": {
 		"./package.json": "./package.json",

--- a/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/package.json
+++ b/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "javascript-no-types",
+	"version": "1.0.0",
+	"description": "package-javascript-no-types-test"
+}

--- a/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/src/app.html
+++ b/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/src/app.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" href="/favicon.ico" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%svelte.head%
+	</head>
+	<body>
+		<div id="svelte">%svelte.body%</div>
+	</body>
+</html>

--- a/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/src/lib/Test.svelte
+++ b/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/src/lib/Test.svelte
@@ -1,0 +1,12 @@
+<script>
+    import { createEventDispatcher } from 'svelte';
+    /**
+     * @type {string}
+     */
+    export const astring;
+
+    const dispatch = createEventDispatcher();
+    dispatch('event', true);
+</script>
+
+<slot {astring} />

--- a/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/src/lib/Test2.svelte
+++ b/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/src/lib/Test2.svelte
@@ -1,0 +1,6 @@
+<script>
+    /**
+     * @type {import('./foo').Foo}
+     */
+    export let foo;
+</script>

--- a/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/src/lib/foo.d.ts
+++ b/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/src/lib/foo.d.ts
@@ -1,0 +1,1 @@
+export type Foo = boolean;

--- a/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/src/lib/index.js
+++ b/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/src/lib/index.js
@@ -1,0 +1,1 @@
+export { default as Test } from './Test.svelte';

--- a/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/svelte.config.cjs
+++ b/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/svelte.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+	kit: {
+		package: {
+			emitTypes: false
+		}
+	}
+};

--- a/packages/kit/src/core/make_package/test/fixtures/typescript/expected/package.json
+++ b/packages/kit/src/core/make_package/test/fixtures/typescript/expected/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "javascript",
+	"name": "typescript",
 	"version": "1.0.0",
-	"description": "package-javascript-test",
+	"description": "package-typescript-test",
 	"type": "module",
 	"exports": {
 		"./package.json": "./package.json",

--- a/packages/kit/src/core/make_package/test/fixtures/typescript/package.json
+++ b/packages/kit/src/core/make_package/test/fixtures/typescript/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "javascript",
+	"name": "typescript",
 	"version": "1.0.0",
-	"description": "package-javascript-test"
+	"description": "package-typescript-test"
 }

--- a/packages/kit/src/core/make_package/test/index.js
+++ b/packages/kit/src/core/make_package/test/index.js
@@ -74,4 +74,8 @@ test('create package (typescript)', async () => {
 	await test_make_package('typescript');
 });
 
+test('create package (javascript without types)', async () => {
+	await test_make_package('javascript_no_types');
+});
+
 test.run();

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -110,6 +110,7 @@ export type ValidatedConfig = {
 				include: string[];
 				exclude: string[];
 			};
+			emitTypes: boolean;
 		};
 		paths: {
 			base: string;

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -57,6 +57,7 @@ export type Config = {
 				include?: string[];
 				exclude?: string[];
 			};
+			emitTypes?: boolean;
 		};
 		paths?: {
 			base?: string;


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] #1851 
- [x] Makes emitting types during `svelte-kit package` configurable.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. _Does this apply?_
