### PR TITLE
add $lib alias to js/tsconfig

### DIFF
--- a/.changeset/metal-avocados-lie.md
+++ b/.changeset/metal-avocados-lie.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Add \$lib alias to js/tsconfig

--- a/packages/create-svelte/shared/+typescript/tsconfig.json
+++ b/packages/create-svelte/shared/+typescript/tsconfig.json
@@ -23,6 +23,7 @@
 		"allowJs": true,
 		"checkJs": true,
 		"paths": {
+			"$lib": ["src/lib"],
 			"$lib/*": ["src/lib/*"]
 		}
 	},

--- a/packages/create-svelte/shared/-typescript/jsconfig.json
+++ b/packages/create-svelte/shared/-typescript/jsconfig.json
@@ -2,6 +2,7 @@
 	"compilerOptions": {
 		"baseUrl": ".",
 		"paths": {
+			"$lib": ["src/lib"],
 			"$lib/*": ["src/lib/*"]
 		}
 	},


### PR DESCRIPTION
When creating a package with SvelteKit, it's not uncommon to want to import from `$lib` directly, rather than one of its submodules:

```js
import thing from '$lib';
```

This works, but it causes red squigglies because the relevant alias doesn't exist in js/tsconfig.json.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
