### PR TITLE
Option to pre-render the dynamic routes

### DIFF
--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -236,6 +236,12 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 			for (const entry of build_data.entries) {
 				await visit(entry, null);
 			}
+		} else if (entry === '**') {
+			for (const route of build_data.dynamic_routes) {
+				const svelte_path = route.a[route.a.length - 1];
+				const match = svelte_path.match(/^src\/routes(.*)\.svelte$/);
+				await visit(match[1], null);
+			}
 		} else {
 			await visit(entry, null);
 		}

--- a/packages/kit/src/core/adapt/test/index.js
+++ b/packages/kit/src/core/adapt/test/index.js
@@ -40,7 +40,7 @@ suite('copy files', () => {
 	};
 
 	/** @type {import('types/internal').BuildData} */
-	const build_data = { client: [], server: [], static: [], entries: [] };
+	const build_data = { client: [], server: [], static: [], entries: [], dynamic_routes: [] };
 
 	const utils = get_utils({ cwd, config, build_data, log });
 
@@ -91,7 +91,13 @@ suite('prerender', async () => {
 	};
 
 	/** @type {import('types/internal').BuildData} */
-	const build_data = { client: [], server: [], static: [], entries: ['/nested'] };
+	const build_data = {
+		client: [],
+		server: [],
+		static: [],
+		entries: ['/nested'],
+		dynamic_routes: []
+	};
 
 	const utils = get_utils({ cwd, config, build_data, log });
 

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -74,7 +74,10 @@ export async function build(config, { cwd = process.cwd(), runtime = '@sveltejs/
 		static: options.manifest.assets.map((asset) => posixify(asset.file)),
 		entries: options.manifest.routes
 			.map((route) => route.type === 'page' && route.path)
-			.filter(Boolean)
+			.filter(Boolean),
+		// prettier-ignore
+		/** @type import('types/internal').PageData[] */
+		dynamic_routes: (options.manifest.routes.filter((route) => route.type === 'page' && !route.path))
 	};
 }
 

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -130,7 +130,7 @@ const options = {
 							}
 
 							option.forEach((page) => {
-								if (page !== '*' && page[0] !== '/') {
+								if (page !== '*' && page !== '**' && page[0] !== '/') {
 									throw new Error(
 										`Each member of ${keypath} must be either '*' or an absolute path beginning with '/' — saw '${page}'`
 									);

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -200,6 +200,7 @@ export type BuildData = {
 	server: string[];
 	static: string[];
 	entries: string[];
+	dynamic_routes: PageData[];
 };
 
 export type NormalizedLoadOutput = {


### PR DESCRIPTION
Currently you can use a `'*'` as a wildcard in [kit.prerender.pages](https://kit.svelte.dev/docs#configuration-prerender) to specify all non-dynamic routes. This adds a new token to do the dynamic routes, initially picked to be `'**'` but could be anything.

When pre-rendering a dynamic route, also creates the convention that params are filled in with the param name in square brackets, such that if you have a route like:

    /article/[slug].svelte

Which would be concretely referenced by the user as say "https://mysite.com/article/cool-article", the resulting HTML artifact in the /build folder lives at:

    /build/article/[slug]/index.html

This relates to https://github.com/sveltejs/rfcs/pull/52 and https://github.com/sveltejs/kit/issues/1561, and enables one to use adapter-static to generate artifacts which can be used in any type of server runtime, even if you have dynamic routes. Obviously in such a scenario, any parts of the page that depend on request-specific data would need to be client-rendered. This essentially enables a "static SSR / client-rendered" hybrid, where the shell of the page is static prerendered and some inner data-driven part is client-rendered.

Not very optimistic this will get approved, but taking a shot anyway. If this needs to go in a fork of SvelteKit, that's understandable.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
