### PR TITLE
Ability to imperatively parse the path params, at clientside runtime

### DIFF
--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -14,6 +14,7 @@ export const goto = import.meta.env.SSR ? guard('goto') : goto_;
 export const invalidate = import.meta.env.SSR ? guard('invalidate') : invalidate_;
 export const prefetch = import.meta.env.SSR ? guard('prefetch') : prefetch_;
 export const prefetchRoutes = import.meta.env.SSR ? guard('prefetchRoutes') : prefetchRoutes_;
+export const routeParams = import.meta.env.SSR ? guard('routeParams') : routeParams_;
 
 /**
  * @type {import('$app/navigation').goto}
@@ -48,4 +49,14 @@ async function prefetchRoutes_(pathnames) {
 	const promises = matching.map((r) => r.length !== 1 && Promise.all(r[1].map((load) => load())));
 
 	await Promise.all(promises);
+}
+
+/**
+ * @returns {Record<string, string>}
+ */
+function routeParams_() {
+	const { routes } = router.parse(new URL(location.href));
+	if (routes.length === 0) return {};
+	const match = routes[0][0].exec(location.pathname);
+	return routes[0][3](match);
 }


### PR DESCRIPTION
Normally, client-side code would get the path params from `$page.params`. For pre-rendered pages however, those values are the values as they were at pre-render time, which isn't useful if you're using a single pre-rendered HTML artifact to handle an entire parameterized route with path params which vary at runtime.

In such case, you'd want look at the details of the particular request, by inspecting `window.location`. This is fine for path and query string, but not currently possible for path params because we don't have the information about its pattern or param names.

This simply adds that ability, and should be considered in conjunction with just-now submitted https://github.com/sveltejs/kit/pull/1870.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
