### PR TITLE
[fix] handle `Uint8Array` output in adapter-node endpoints

### DIFF
--- a/.changeset/cool-ducks-cheat.md
+++ b/.changeset/cool-ducks-cheat.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Handle Uint8Array bodies from endpoints

--- a/packages/adapter-node/src/server.js
+++ b/packages/adapter-node/src/server.js
@@ -82,7 +82,8 @@ export function createServer({ render }) {
 
 			if (rendered) {
 				res.writeHead(rendered.status, rendered.headers);
-				res.end(rendered.body);
+				if (rendered.body) res.write(rendered.body);
+				res.end();
 			} else {
 				res.statusCode = 404;
 				res.end('Not found');


### PR DESCRIPTION
Following #1382 approach, we'll extract and write the body separately.

Fixes #1873 