### PR TITLE
Fix returning null from endpoints

### DIFF
--- a/.changeset/heavy-turkeys-report.md
+++ b/.changeset/heavy-turkeys-report.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix returning null from endpoints

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -63,7 +63,7 @@ export default async function render_route(request, route) {
 				(!type || type.startsWith('application/json'))
 			) {
 				headers = { ...headers, 'content-type': 'application/json; charset=utf-8' };
-				normalized_body = JSON.stringify(body || {});
+				normalized_body = JSON.stringify(typeof body === 'undefined' ? {} : body);
 			} else {
 				normalized_body = /** @type {import('types/hooks').StrictBody} */ (body);
 			}

--- a/packages/kit/test/apps/basics/src/routes/endpoint-output/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-output/_tests.js
@@ -36,4 +36,10 @@ export default function (test) {
 		const res = await fetch('/endpoint-output/empty');
 		assert.type(await res.buffer(), 'object');
 	});
+
+	test('null body returns null json value', null, async ({ fetch }) => {
+		const res = await fetch('/endpoint-output/null');
+		assert.equal(res.status, 200);
+		assert.equal(await res.json(), null);
+	});
 }

--- a/packages/kit/test/apps/basics/src/routes/endpoint-output/null.js
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-output/null.js
@@ -1,0 +1,4 @@
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export function get() {
+	return { body: null };
+}


### PR DESCRIPTION
https://github.com/sveltejs/kit/pull/1808 introduced a bug which converts `null` to `{}` (empty object) when returned from endpoints. This PR fixes it and includes a test for the fix.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
