### PR TITLE
[fix] Default body parsing to binary

### DIFF
--- a/.changeset/dry-jokes-explain.md
+++ b/.changeset/dry-jokes-explain.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/kit': patch
+---
+
+Default body parsing to binary

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -1,7 +1,7 @@
 // TODO hardcoding the relative location makes this brittle
 import { init, render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
 import { getAssetFromKV, NotFoundError } from '@cloudflare/kv-asset-handler'; // eslint-disable-line import/no-unresolved
-import { isContentTypeBinary } from '@sveltejs/kit/adapter-utils'; // eslint-disable-line import/no-unresolved
+import { isContentTypeTextual } from '@sveltejs/kit/adapter-utils'; // eslint-disable-line import/no-unresolved
 
 init();
 
@@ -58,9 +58,9 @@ async function handle(event) {
 /** @param {Request} request */
 async function read(request) {
 	const type = request.headers.get('content-type') || '';
-	if (isContentTypeBinary(type)) {
-		return new Uint8Array(await request.arrayBuffer());
+	if (isContentTypeTextual(type)) {
+		return request.text();
 	}
 
-	return request.text();
+	return new Uint8Array(await request.arrayBuffer());
 }

--- a/packages/adapter-netlify/files/entry.js
+++ b/packages/adapter-netlify/files/entry.js
@@ -1,6 +1,6 @@
 // TODO hardcoding the relative location makes this brittle
 import { init, render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
-import { isContentTypeBinary } from '@sveltejs/kit/adapter-utils'; // eslint-disable-line import/no-unresolved
+import { isContentTypeTextual } from '@sveltejs/kit/adapter-utils'; // eslint-disable-line import/no-unresolved
 
 init();
 
@@ -11,11 +11,11 @@ export async function handler(event) {
 
 	const type = headers['content-type'];
 	const rawBody =
-		type && isContentTypeBinary(type)
-			? new TextEncoder('base64').encode(body)
-			: isBase64Encoded
-			? Buffer.from(body, 'base64').toString()
-			: body;
+		type && isContentTypeTextual(type)
+			? isBase64Encoded
+				? Buffer.from(body, 'base64').toString()
+				: body
+			: new TextEncoder('base64').encode(body);
 
 	const rendered = await render({
 		method: httpMethod,

--- a/packages/kit/src/core/adapter-utils.js
+++ b/packages/kit/src/core/adapter-utils.js
@@ -3,12 +3,13 @@
  *
  * This is intended to be used with both requests and responses, to have a consistent body parsing across adapters.
  *
- * @param {string} content_type The `content-type` header of a request/response.
+ * @param {string?} content_type The `content-type` header of a request/response.
  * @returns {boolean}
  */
 export function isContentTypeTextual(content_type) {
+	if (!content_type) return true; // defaults to json
+	const [type] = content_type.split(';'); // get the mime type
 	return (
-		!content_type || // defaults to json
 		content_type === 'text/plain' ||
 		content_type === 'application/json' ||
 		content_type === 'application/x-www-form-urlencoded' ||

--- a/packages/kit/src/core/adapter-utils.js
+++ b/packages/kit/src/core/adapter-utils.js
@@ -1,16 +1,17 @@
 /**
- * Decides how the body should be parsed based on its mime type.
+ * Decides how the body should be parsed based on its mime type. Should match what's in parse_body
  *
  * This is intended to be used with both requests and responses, to have a consistent body parsing across adapters.
  *
  * @param {string} content_type The `content-type` header of a request/response.
  * @returns {boolean}
  */
-export function isContentTypeBinary(content_type) {
+export function isContentTypeTextual(content_type) {
 	return (
-		content_type.startsWith('image/') ||
-		content_type.startsWith('audio/') ||
-		content_type.startsWith('video/') ||
-		content_type.startsWith('application/octet-stream')
+		!content_type || // defaults to json
+		content_type === 'text/plain' ||
+		content_type === 'application/json' ||
+		content_type === 'application/x-www-form-urlencoded' ||
+		content_type === 'multipart/form-data'
 	);
 }

--- a/packages/kit/src/core/adapter-utils.js
+++ b/packages/kit/src/core/adapter-utils.js
@@ -10,9 +10,9 @@ export function isContentTypeTextual(content_type) {
 	if (!content_type) return true; // defaults to json
 	const [type] = content_type.split(';'); // get the mime type
 	return (
-		content_type === 'text/plain' ||
-		content_type === 'application/json' ||
-		content_type === 'application/x-www-form-urlencoded' ||
-		content_type === 'multipart/form-data'
+		type === 'text/plain' ||
+		type === 'application/json' ||
+		type === 'application/x-www-form-urlencoded' ||
+		type === 'multipart/form-data'
 	);
 }

--- a/packages/kit/src/core/node/index.js
+++ b/packages/kit/src/core/node/index.js
@@ -1,4 +1,4 @@
-import { isContentTypeBinary } from '../adapter-utils.js';
+import { isContentTypeTextual } from '../adapter-utils.js';
 
 /**
  * @param {import('http').IncomingMessage} req
@@ -50,12 +50,12 @@ export function getRawBody(req) {
 		req.on('end', () => {
 			const [type] = h['content-type'].split(/;\s*/);
 
-			if (isContentTypeBinary(type)) {
-				return fulfil(data);
+			if (isContentTypeTextual(type)) {
+				const encoding = h['content-encoding'] || 'utf-8';
+				fulfil(new TextDecoder(encoding).decode(data));
 			}
 
-			const encoding = h['content-encoding'] || 'utf-8';
-			fulfil(new TextDecoder(encoding).decode(data));
+			return fulfil(data);
 		});
 	});
 }

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -1,4 +1,4 @@
-import { isContentTypeBinary } from '../../core/adapter-utils.js';
+import { isContentTypeTextual } from '../../core/adapter-utils.js';
 import { lowercase_keys } from './utils.js';
 
 /** @param {string} body */
@@ -38,18 +38,12 @@ export default async function render_route(request, route) {
 			headers = lowercase_keys(headers);
 			const type = headers['content-type'];
 
-			const is_type_binary = type && isContentTypeBinary(type);
+			const is_type_textual = isContentTypeTextual(type);
 
 			// validation
-			if (is_type_binary && !(body instanceof Uint8Array)) {
+			if (!is_type_textual && !(body instanceof Uint8Array)) {
 				return error(
-					`${preface}: body must be an instance of Uint8Array if content type is image/*, audio/*, video/* or application/octet-stream`
-				);
-			}
-
-			if (body instanceof Uint8Array && !is_type_binary) {
-				return error(
-					`${preface}: Uint8Array body must have content-type header of image/*, audio/*, video/* or application/octet-stream`
+					`${preface}: body must be an instance of Uint8Array if content-type is not a supported textual content-type`
 				);
 			}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,7 +194,7 @@ importers:
       '@sveltejs/adapter-cloudflare-workers': link:../../../adapter-cloudflare-workers
       '@sveltejs/adapter-netlify': link:../../../adapter-netlify
       '@sveltejs/adapter-vercel': link:../../../adapter-vercel
-      '@sveltejs/kit': 1.0.0-next.123_rollup@2.47.0+svelte@3.38.2
+      '@sveltejs/kit': link:../../../kit
       svelte: 3.38.2
       svelte-preprocess: 4.7.3_svelte@3.38.2+typescript@4.2.4
       typescript: 4.2.4
@@ -642,43 +642,7 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.2.3
       rollup: 2.47.0
-
-  /@sveltejs/kit/1.0.0-next.123_rollup@2.47.0+svelte@3.38.2:
-    resolution: {integrity: sha512-C9UZ5yYdU94hjpmwTPmDpCWphPc9RsSR4TxV67JM+SqDrSCMKx65JI3+goQQzY2ZHARUGukoc1+ijaRxW48AWQ==}
-    engines: {node: ^12.20 || >=14.13}
-    hasBin: true
-    peerDependencies:
-      svelte: ^3.34.0
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 1.0.0-next.12_521dee33336505fa0c0cfefe092a237f
-      cheap-watch: 1.0.3
-      sade: 1.7.4
-      svelte: 3.38.2
-      vite: 2.4.1
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-    dev: true
-
-  /@sveltejs/vite-plugin-svelte/1.0.0-next.12_521dee33336505fa0c0cfefe092a237f:
-    resolution: {integrity: sha512-cuyNkJ6leptfv+7qL/fWQ7EpGWdguosFOUI0z93oQUmFTcX7QxJ5h+QI3NQyktBzlKL/761L8BbG2hHNkVbLIQ==}
-    engines: {node: ^12.20 || ^14.13.1 || >= 16}
-    peerDependencies:
-      svelte: ^3.34.0
-      vite: ^2.3.7
-    dependencies:
-      '@rollup/pluginutils': 4.1.0_rollup@2.47.0
-      debug: 4.3.2
-      kleur: 4.1.4
-      magic-string: 0.25.7
-      require-relative: 0.8.7
-      svelte: 3.38.2
-      svelte-hmr: 0.14.5_svelte@3.38.2
-      vite: 2.4.1
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-    dev: true
+    dev: false
 
   /@sveltejs/vite-plugin-svelte/1.0.0-next.12_7f2c501a1382bf91518307aaca32f4f7:
     resolution: {integrity: sha512-cuyNkJ6leptfv+7qL/fWQ7EpGWdguosFOUI0z93oQUmFTcX7QxJ5h+QI3NQyktBzlKL/761L8BbG2hHNkVbLIQ==}
@@ -1232,6 +1196,7 @@ packages:
   /cheap-watch/1.0.3:
     resolution: {integrity: sha512-xC5CruMhLzjPwJ5ecUxGu1uGmwJQykUhqd2QrCrYbwvsFYdRyviu6jG9+pccwDXJR/OpmOTOJ9yLFunVgQu9wg==}
     engines: {node: '>=8'}
+    dev: false
 
   /chokidar/3.5.1:
     resolution: {integrity: sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==}
@@ -1301,6 +1266,7 @@ packages:
 
   /colorette/1.2.2:
     resolution: {integrity: sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==}
+    dev: false
 
   /colors/1.4.0:
     resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
@@ -1436,6 +1402,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+    dev: false
 
   /decamelize-keys/1.1.0:
     resolution: {integrity: sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=}
@@ -1575,6 +1542,7 @@ packages:
     resolution: {integrity: sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==}
     hasBin: true
     requiresBuild: true
+    dev: false
 
   /esbuild/0.12.5:
     resolution: {integrity: sha512-vcuP53pA5XiwUU4FnlXM+2PnVjTfHGthM7uP1gtp+9yfheGvFFbq/KyuESThmtoHPUrfZH5JpxGVJIFDVD1Egw==}
@@ -2585,6 +2553,7 @@ packages:
     resolution: {integrity: sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+    dev: false
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
@@ -2937,6 +2906,7 @@ packages:
       colorette: 1.2.2
       nanoid: 3.1.23
       source-map-js: 0.6.2
+    dev: false
 
   /preferred-pm/3.0.3:
     resolution: {integrity: sha512-+wZgbxNES/KlJs9q40F/1sfOd/j7f1O9JaHcW5Dsn3aUUOZg3L2bjpVUcKV2jvtElYfoTuQiNeMfQJ4kwUAhCQ==}
@@ -3121,6 +3091,7 @@ packages:
 
   /require-relative/0.8.7:
     resolution: {integrity: sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=}
+    dev: false
 
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3169,6 +3140,7 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: false
 
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -3288,6 +3260,7 @@ packages:
   /source-map-js/0.6.2:
     resolution: {integrity: sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==}
     engines: {node: '>=0.10.0'}
+    dev: false
 
   /source-map/0.7.3:
     resolution: {integrity: sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==}
@@ -3464,14 +3437,6 @@ packages:
       - sass
       - stylus
       - sugarss
-    dev: true
-
-  /svelte-hmr/0.14.5_svelte@3.38.2:
-    resolution: {integrity: sha512-3O+kkbT1XKAomKB0LRcdY8JUTzONoNZ8rSH4iEdG7piIYsw+KkXpTkbbU1Sc1yPY4onfXkmCrHElYsxr0V1Snw==}
-    peerDependencies:
-      svelte: '>=3.19.0'
-    dependencies:
-      svelte: 3.38.2
     dev: true
 
   /svelte-hmr/0.14.5_svelte@3.38.3:
@@ -3896,6 +3861,7 @@ packages:
       rollup: 2.52.7
     optionalDependencies:
       fsevents: 2.3.2
+    dev: false
 
   /wcwidth/1.0.1:
     resolution: {integrity: sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=}


### PR DESCRIPTION
In response to @drzax's comment (https://github.com/sveltejs/kit/pull/1687/files#r667643869) it occurs to me that the way we're treating body content type is a bit backwards. We should treat is as bytes unless it's a known type. The user can always convert bytes into whatever they're expecting. But if we try to treat it as text unless we detect a known `content-type`, we're doomed to failure since it would be hard to create a super exhaustive list of mime types to ensure we're handling them all correctly

(This is PR aligns with [how Play Framework works](https://www.playframework.com/documentation/2.8.x/JavaBodyParsers), which is one of the web frameworks I'm most familiar with. It also aligns with how our own `parse_body` works)