### PR TITLE
[fix] fulfil rawBody data once

### DIFF
--- a/packages/kit/src/core/node/index.js
+++ b/packages/kit/src/core/node/index.js
@@ -52,10 +52,10 @@ export function getRawBody(req) {
 
 			if (isContentTypeTextual(type)) {
 				const encoding = h['content-encoding'] || 'utf-8';
-				fulfil(new TextDecoder(encoding).decode(data));
+				return fulfil(new TextDecoder(encoding).decode(data));
 			}
 
-			return fulfil(data);
+			fulfil(data);
 		});
 	});
 }


### PR DESCRIPTION
Previous early `return` were to stop further fulfilments, the intent should be clearer by using else block here.

Related #1890, #1528