### PR TITLE
Fix endpoint validation to allow returning string for all content types

### DIFF
--- a/.changeset/violet-mugs-brake.md
+++ b/.changeset/violet-mugs-brake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix endpoint validation to allow returning string for all content types

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ npm publish --access=public
 
 ### Testing
 
-Run `pnpm test` to run the tests from all subpackages. Browser tests live in subdirectories of `packages/kit/test` such as `packages/kit/test/apps/basics`. To run a single test, provide the `FILTER` env var with the test name `FILTER="includes paths" pnpm test`.
+Run `pnpm test` to run the tests from all subpackages. Browser tests live in subdirectories of `packages/kit/test` such as `packages/kit/test/apps/basics`.
+
+You can run the tests for only a single package by first moving to that directory. E.g. `cd packages/kit`.
+
+You must rebuild each time before running the tests if you've made code changes.
+
+To run a single integration test, provide the `FILTER` env var with the test name. E.g. `FILTER="includes paths" pnpm test:integration`. You're also supposed to be a open up the file and change `test` to `test.only`, but this doesn't work as well. Help would be appreciated in fixing that.
+
+You can run the test server with `cd packages/kit/test/apps/basics; pnpm run dev` to hit it with your browser.
 
 You may need to install some dependencies first e.g. with `npx playwright install-deps` (which only works on Ubuntu).

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -10,6 +10,7 @@ function error(body) {
 	};
 }
 
+/** @param {string} s */
 function is_string(s) {
 	return typeof s === 'string' || s instanceof String;
 }

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -10,7 +10,7 @@ function error(body) {
 	};
 }
 
-/** @param {string} s */
+/** @param {unknown} s */
 function is_string(s) {
 	return typeof s === 'string' || s instanceof String;
 }

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -10,6 +10,10 @@ function error(body) {
 	};
 }
 
+function is_string(s) {
+	return typeof s === 'string' || s instanceof String;
+}
+
 /**
  * @param {import('types/hooks').ServerRequest} request
  * @param {import('types/internal').SSREndpoint} route
@@ -40,10 +44,9 @@ export default async function render_route(request, route) {
 
 			const is_type_textual = isContentTypeTextual(type);
 
-			// validation
-			if (!is_type_textual && !(body instanceof Uint8Array)) {
+			if (!is_type_textual && !(body instanceof Uint8Array || is_string(body))) {
 				return error(
-					`${preface}: body must be an instance of Uint8Array if content-type is not a supported textual content-type`
+					`${preface}: body must be an instance of string or Uint8Array if content-type is not a supported textual content-type`
 				);
 			}
 

--- a/packages/kit/test/apps/basics/package.json
+++ b/packages/kit/test/apps/basics/package.json
@@ -3,9 +3,9 @@
 	"private": true,
 	"version": "0.0.1",
 	"scripts": {
-		"dev": "svelte-kit dev",
-		"build": "svelte-kit build",
-		"preview": "svelte-kit preview"
+		"dev": "../../../svelte-kit.js dev",
+		"build": "../../../svelte-kit.js build",
+		"preview": "../../../svelte-kit.js preview"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-node": "workspace:*",

--- a/packages/kit/test/apps/basics/src/routes/content-type-header/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/content-type-header/_tests.js
@@ -2,7 +2,7 @@ import * as assert from 'uvu/assert';
 
 /** @type {import('test').TestMaker} */
 export default function (test) {
-	test('sets Content-Type', null, async ({ fetch }) => {
+	test('sets Content-Type on page', null, async ({ fetch }) => {
 		const { headers } = await fetch('/content-type-header');
 
 		assert.equal(headers.get('content-type'), 'text/html');

--- a/packages/kit/test/apps/basics/src/routes/endpoint-output/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-output/_tests.js
@@ -42,4 +42,18 @@ export default function (test) {
 		assert.equal(res.status, 200);
 		assert.equal(await res.json(), null);
 	});
+
+	test('gets string response with XML Content-Type', null, async ({ fetch }) => {
+		const res = await fetch('/endpoint-output/xml-text');
+
+		assert.equal(res.headers.get('content-type'), 'application/xml');
+		assert.equal(await res.text(), '<foo />');
+	});
+
+	test.only('gets binary response with XML Content-Type', null, async ({ fetch }) => {
+		const res = await fetch('/endpoint-output/xml-bytes');
+
+		assert.equal(res.headers.get('content-type'), 'application/xml');
+		assert.equal(await res.text(), '<foo />');
+	});
 }

--- a/packages/kit/test/apps/basics/src/routes/endpoint-output/xml-bytes.js
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-output/xml-bytes.js
@@ -1,5 +1,5 @@
 /** @type {import('@sveltejs/kit').RequestHandler} */
 export const get = () => {
-    const body = '<foo />';
-    return { status: 200, headers: { 'content-type': 'application/xml' }, body };
+	const body = '<foo />';
+	return { status: 200, headers: { 'content-type': 'application/xml' }, body };
 };

--- a/packages/kit/test/apps/basics/src/routes/endpoint-output/xml-bytes.js
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-output/xml-bytes.js
@@ -1,0 +1,5 @@
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export const get = () => {
+    const body = '<foo />';
+    return { status: 200, headers: { 'content-type': 'application/xml' }, body };
+};

--- a/packages/kit/test/apps/basics/src/routes/endpoint-output/xml-bytes.js
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-output/xml-bytes.js
@@ -1,5 +1,9 @@
 /** @type {import('@sveltejs/kit').RequestHandler} */
 export const get = () => {
 	const body = '<foo />';
-	return { status: 200, headers: { 'content-type': 'application/xml' }, body };
+	return {
+		status: 200,
+		headers: { 'content-type': 'application/xml' },
+		body: new TextEncoder().encode(body)
+	};
 };

--- a/packages/kit/test/apps/basics/src/routes/endpoint-output/xml-text.js
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-output/xml-text.js
@@ -1,5 +1,5 @@
 /** @type {import('@sveltejs/kit').RequestHandler} */
 export const get = () => {
-    const body = '<foo />';
-    return { status: 200, headers: { 'content-type': 'application/xml' }, body };
+	const body = '<foo />';
+	return { status: 200, headers: { 'content-type': 'application/xml' }, body };
 };

--- a/packages/kit/test/apps/basics/src/routes/endpoint-output/xml-text.js
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-output/xml-text.js
@@ -1,0 +1,5 @@
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export const get = () => {
+    const body = '<foo />';
+    return { status: 200, headers: { 'content-type': 'application/xml' }, body };
+};


### PR DESCRIPTION
Allows you to do:
```
export const get = () => {
    const body = '<foo />';
    return { status: 200, headers: { 'content-type': 'application/xml' }, body }
};
```