### PR TITLE
[feat] Change index.js exports to directory exports when packaging

### DIFF
--- a/.changeset/tough-forks-carry.md
+++ b/.changeset/tough-forks-carry.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Change index.js exports to directory exports when packaging

--- a/packages/kit/src/core/make_package/index.js
+++ b/packages/kit/src/core/make_package/index.js
@@ -83,7 +83,8 @@ export async function make_package(config, cwd = process.cwd()) {
 
 		if (!user_defined_exports && exports_filter(file)) {
 			const entry = `./${out_file.replace(/\\/g, '/')}`;
-			pkg.exports[entry] = entry;
+			const key = entry.endsWith('/index.js') ? entry.slice(0, -'/index.js'.length) : entry;
+			pkg.exports[key] = entry;
 		}
 	}
 

--- a/packages/kit/src/core/make_package/test/fixtures/casing/expected/package.json
+++ b/packages/kit/src/core/make_package/test/fixtures/casing/expected/package.json
@@ -5,7 +5,6 @@
 	"type": "module",
 	"exports": {
 		"./package.json": "./package.json",
-		"./index.js": "./index.js",
 		"./Test.svelte": "./Test.svelte",
 		".": "./index.js"
 	}

--- a/packages/kit/src/core/make_package/test/fixtures/javascript/expected/package.json
+++ b/packages/kit/src/core/make_package/test/fixtures/javascript/expected/package.json
@@ -5,7 +5,6 @@
 	"type": "module",
 	"exports": {
 		"./package.json": "./package.json",
-		"./index.js": "./index.js",
 		"./Test.svelte": "./Test.svelte",
 		"./Test2.svelte": "./Test2.svelte",
 		".": "./index.js"

--- a/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/expected/package.json
+++ b/packages/kit/src/core/make_package/test/fixtures/javascript_no_types/expected/package.json
@@ -5,7 +5,6 @@
 	"type": "module",
 	"exports": {
 		"./package.json": "./package.json",
-		"./index.js": "./index.js",
 		"./Test.svelte": "./Test.svelte",
 		"./Test2.svelte": "./Test2.svelte",
 		".": "./index.js"

--- a/packages/kit/src/core/make_package/test/fixtures/nested/expected/internal/index.d.ts
+++ b/packages/kit/src/core/make_package/test/fixtures/nested/expected/internal/index.d.ts
@@ -1,0 +1,1 @@
+export const foo: 'bar';

--- a/packages/kit/src/core/make_package/test/fixtures/nested/expected/internal/index.js
+++ b/packages/kit/src/core/make_package/test/fixtures/nested/expected/internal/index.js
@@ -1,0 +1,1 @@
+export const foo = 'bar';

--- a/packages/kit/src/core/make_package/test/fixtures/nested/expected/package.json
+++ b/packages/kit/src/core/make_package/test/fixtures/nested/expected/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"exports": {
 		"./package.json": "./package.json",
-		"./index.js": "./index.js",
+		"./internal": "./internal/index.js",
 		"./internal/Test.svelte": "./internal/Test.svelte",
 		"./Test.svelte": "./Test.svelte",
 		".": "./index.js"

--- a/packages/kit/src/core/make_package/test/fixtures/nested/src/lib/internal/index.js
+++ b/packages/kit/src/core/make_package/test/fixtures/nested/src/lib/internal/index.js
@@ -1,0 +1,1 @@
+export const foo = 'bar';

--- a/packages/kit/src/core/make_package/test/fixtures/typescript/expected/package.json
+++ b/packages/kit/src/core/make_package/test/fixtures/typescript/expected/package.json
@@ -5,7 +5,6 @@
 	"type": "module",
 	"exports": {
 		"./package.json": "./package.json",
-		"./index.js": "./index.js",
 		"./Test.svelte": "./Test.svelte",
 		"./Test2.svelte": "./Test2.svelte",
 		".": "./index.js"


### PR DESCRIPTION
Node encourages this via its resolution algorithm, and it makes for nicer imports
Closes #1891

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
