### PR TITLE
[docs] update $app/paths configuration path

### DIFF
--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -69,11 +69,11 @@ declare module '$app/navigation' {
 
 declare module '$app/paths' {
 	/**
-	 * A root-relative (i.e. begins with a `/`) string that matches `config.kit.files.base` in your project configuration.
+	 * A root-relative (i.e. begins with a `/`) string that matches `config.kit.paths.base` in your project configuration.
 	 */
 	export const base: string;
 	/**
-	 * A root-relative or absolute path that matches `config.kit.files.assets` (after it has been resolved against base).
+	 * A root-relative or absolute path that matches `config.kit.paths.assets` (after it has been resolved against base).
 	 */
 	export const assets: string;
 }


### PR DESCRIPTION
This change streamlines the TypeScript documentation with the actual configuration value listed at https://kit.svelte.dev/docs#modules-$app-paths.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
