### PR TITLE
[feat] Friendlier error messages for common config errors

### DIFF
--- a/.changeset/little-boats-allow.md
+++ b/.changeset/little-boats-allow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+feat(config): Friendlier error messages for common errors

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -13,6 +13,17 @@ import options from './options.js';
  * @returns {any}
  */
 function validate(definition, option, keypath) {
+	if (typeof option !== 'object') {
+		if (typeof option === 'undefined') {
+			throw new Error(
+				'Your config is missing default exports. Make sure to include "export default config;"'
+			);
+		} else {
+			throw new Error(
+				`Unexpected config type "${typeof option}", make sure your default export is an object.`
+			);
+		}
+	}
 	for (const key in option) {
 		if (!(key in definition)) {
 			let message = `Unexpected option ${keypath}.${key}`;

--- a/packages/kit/src/core/config/test/fixtures/export-missing/src/app.html
+++ b/packages/kit/src/core/config/test/fixtures/export-missing/src/app.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" href="/favicon.ico" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%svelte.head%
+	</head>
+	<body>
+		<div id="svelte">%svelte.body%</div>
+	</body>
+</html>

--- a/packages/kit/src/core/config/test/fixtures/export-string/src/app.html
+++ b/packages/kit/src/core/config/test/fixtures/export-string/src/app.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" href="/favicon.ico" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%svelte.head%
+	</head>
+	<body>
+		<div id="svelte">%svelte.body%</div>
+	</body>
+</html>

--- a/packages/kit/src/core/config/test/fixtures/export-string/svelte.config.js
+++ b/packages/kit/src/core/config/test/fixtures/export-string/svelte.config.js
@@ -1,0 +1,1 @@
+export default 'invalid';

--- a/packages/kit/src/core/config/test/index.js
+++ b/packages/kit/src/core/config/test/index.js
@@ -71,4 +71,34 @@ test('load default config (esm)', async () => {
 	await testLoadDefaultConfig('default-esm');
 });
 
+test('errors on loading config without default export', async () => {
+	let errorMessage = null;
+	try {
+		const cwd = join(__dirname, 'fixtures', 'export-missing');
+		await load_config({ cwd });
+	} catch (e) {
+		errorMessage = e.message;
+	}
+
+	assert.equal(
+		errorMessage,
+		'Your config is missing default exports. Make sure to include "export default config;"'
+	);
+});
+
+test('errors on loading config with incorrect default export', async () => {
+	let errorMessage = null;
+	try {
+		const cwd = join(__dirname, 'fixtures', 'export-string');
+		await load_config({ cwd });
+	} catch (e) {
+		errorMessage = e.message;
+	}
+
+	assert.equal(
+		errorMessage,
+		'Unexpected config type "string", make sure your default export is an object.'
+	);
+});
+
 test.run();


### PR DESCRIPTION
### Current Behavior

When someone forgets to `export default` their config, they currently get a mysterious error message:
```
Cannot read property 'compilerOptions' of undefined
TypeError: Cannot read property 'compilerOptions' of undefined
```

When someone exports a non-object as their default config, they also get a similarly mysterious message:
```
Unexpected option config.0
```

### Proposed Behavior
This PR improves the error messages to hint to the user what's going on:
```
Your config is missing default exports. Make sure to include "export default config;"
```
and
```
Unexpected config type "string", make sure your default export is an object.
```

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
