### PR TITLE
[fix] adapter-netlify: return the right headers

### DIFF
--- a/.changeset/olive-socks-thank.md
+++ b/.changeset/olive-socks-thank.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-netlify": patch
+---
+
+return the correct headers

--- a/packages/adapter-netlify/files/entry.js
+++ b/packages/adapter-netlify/files/entry.js
@@ -29,7 +29,7 @@ export async function handler(event) {
 		return {
 			isBase64Encoded: false,
 			statusCode: rendered.status,
-			...splitHeaders(headers),
+			...splitHeaders(rendered.headers),
 			body: rendered.body
 		};
 	}


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

While looking at possible causes for #1911 I found a logical error inside the entry of `adapter-netlify`, it was returing the request headers instead of the response headers.

Idk if this should have a changelog.