### PR TITLE
feat(cli): respect `NODE_ENV` when set by user

### DIFF
--- a/.changeset/shiny-teachers-nail.md
+++ b/.changeset/shiny-teachers-nail.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+feat(cli): respect NODE_ENV when set by user

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -79,7 +79,7 @@ prog
 	.action(async ({ port, host, https, open }) => {
 		await check_port(port);
 
-		process.env.NODE_ENV = 'development';
+		process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 		const config = await get_config();
 
 		const { dev } = await import('./core/dev/index.js');
@@ -106,7 +106,7 @@ prog
 	.describe('Create a production build of your app')
 	.option('--verbose', 'Log more stuff', false)
 	.action(async ({ verbose }) => {
-		process.env.NODE_ENV = 'production';
+		process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 		const config = await get_config();
 
 		try {
@@ -146,7 +146,7 @@ prog
 	.action(async ({ port, host, https, open }) => {
 		await check_port(port);
 
-		process.env.NODE_ENV = 'production';
+		process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 		const config = await get_config();
 
 		const { start } = await import('./core/start/index.js');


### PR DESCRIPTION
`svelte-kit dev`, `svelte-kit build`, and `svelte-kit preview` currently override any user-set `NODE_ENV`. This PR changes the overrides into defaults instead, and respects any user-set `NODE_ENV`. It is possible that the user might want to set another value, e.g. `staging`.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
