### PR TITLE
[feat] allow chaining of `handle` hooks

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -71,6 +71,9 @@
 		"./node": {
 			"import": "./dist/node.js"
 		},
+		"./hooks": {
+			"import": "./dist/hooks.js"
+		},
 		"./install-fetch": {
 			"import": "./dist/install-fetch.js"
 		},

--- a/packages/kit/rollup.config.js
+++ b/packages/kit/rollup.config.js
@@ -48,6 +48,7 @@ export default [
 			cli: 'src/cli.js',
 			ssr: 'src/runtime/server/index.js',
 			node: 'src/core/node/index.js',
+			hooks: 'src/runtime/hooks.js',
 			'install-fetch': 'src/install-fetch.js',
 			'adapter-utils': 'src/core/adapter-utils.js'
 		},

--- a/packages/kit/src/runtime/hooks.js
+++ b/packages/kit/src/runtime/hooks.js
@@ -1,0 +1,23 @@
+/**
+ * @param {...import('types/hooks').Handle} handles
+ * @returns {import('types/hooks').Handle}
+ */
+export function sequence(...handles) {
+	const length = handles.length;
+	if (!length) return ({ request, resolve }) => resolve(request);
+
+	return ({ request, resolve }) => {
+		return apply_handle(0);
+
+		/**
+		 * @param {number} i
+		 * @returns {import('types/helper').MaybePromise<import('types/hooks').ServerResponse>}
+		 */
+		function apply_handle(i) {
+			const handle = handles[i];
+			const next = i >= length - 1 ? resolve : () => apply_handle(i + 1);
+
+			return handle({ request, resolve: next });
+		}
+	};
+}

--- a/packages/kit/src/runtime/hooks.js
+++ b/packages/kit/src/runtime/hooks.js
@@ -7,17 +7,20 @@ export function sequence(...handles) {
 	if (!length) return ({ request, resolve }) => resolve(request);
 
 	return ({ request, resolve }) => {
-		return apply_handle(0);
+		return apply_handle(0, request);
 
 		/**
 		 * @param {number} i
+		 * @param {import('types/hooks').ServerRequest} request
 		 * @returns {import('types/helper').MaybePromise<import('types/hooks').ServerResponse>}
 		 */
-		function apply_handle(i) {
+		function apply_handle(i, request) {
 			const handle = handles[i];
-			const next = i >= length - 1 ? resolve : () => apply_handle(i + 1);
 
-			return handle({ request, resolve: next });
+			return handle({
+				request,
+				resolve: i < length - 1 ? (request) => apply_handle(i + 1, request) : resolve
+			});
 		}
 	};
 }

--- a/packages/kit/test/apps/hooks/package.json
+++ b/packages/kit/test/apps/hooks/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "test-hooks",
+	"private": true,
+	"version": "0.0.1",
+	"scripts": {
+		"dev": "../../../svelte-kit.js dev",
+		"build": "../../../svelte-kit.js build",
+		"preview": "../../../svelte-kit.js preview"
+	},
+	"devDependencies": {
+		"@sveltejs/adapter-node": "workspace:*",
+		"@sveltejs/kit": "workspace:*",
+		"svelte": "^3.40.0"
+	},
+	"type": "module"
+}

--- a/packages/kit/test/apps/hooks/src/app.html
+++ b/packages/kit/test/apps/hooks/src/app.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%svelte.head%
+	</head>
+	<body>
+		%svelte.body%
+	</body>
+</html>

--- a/packages/kit/test/apps/hooks/src/hooks.js
+++ b/packages/kit/test/apps/hooks/src/hooks.js
@@ -1,6 +1,6 @@
 // The following line does not work with vite resolution. Why?
 // import { sequence } from '@sveltejs/kit/hooks';
-import { sequence } from '../../../../dist/hooks';
+import { sequence } from '../../../../src/runtime/hooks';
 
 /** @type {import('@sveltejs/kit').Handle} */
 export const handle = sequence(

--- a/packages/kit/test/apps/hooks/src/hooks.js
+++ b/packages/kit/test/apps/hooks/src/hooks.js
@@ -1,0 +1,39 @@
+// The following line does not work with vite resolution. Why?
+// import { sequence } from '@sveltejs/kit/hooks';
+import { sequence } from '../../../../dist/hooks';
+
+/** @type {import('@sveltejs/kit').Handle} */
+export const handle = sequence(
+	({ request, resolve }) => {
+		request.locals.first = true;
+		return resolve(request);
+	},
+	({ request, resolve }) => {
+		request.locals.second = 'str';
+		return resolve(request);
+	},
+	async ({ request, resolve }) => {
+		request.locals.third = 3;
+
+		const response = await resolve(request);
+
+		return {
+			...response,
+			headers: {
+				...response.headers,
+				'X-Handle-Header': 'hello'
+			}
+		};
+	},
+	async ({ request, resolve }) => {
+		const response = await resolve(request);
+
+		return {
+			...response,
+			headers: {
+				...response.headers,
+				'X-Request-Locals': JSON.stringify(request.locals)
+			}
+		};
+	}
+);

--- a/packages/kit/test/apps/hooks/src/routes/_tests.js
+++ b/packages/kit/test/apps/hooks/src/routes/_tests.js
@@ -7,10 +7,10 @@ export default function (test) {
 
 		const headers = await response.headers();
 		assert.equal(
-			headers['X-Request-Locals'],
+			headers['x-request-locals'],
 			JSON.stringify({ first: true, second: 'str', third: 3 })
 		);
 
-		assert.equal(headers['X-Handle-Header'], 'hello');
+		assert.equal(headers['x-handle-header'], 'hello');
 	});
 }

--- a/packages/kit/test/apps/hooks/src/routes/_tests.js
+++ b/packages/kit/test/apps/hooks/src/routes/_tests.js
@@ -1,0 +1,16 @@
+import * as assert from 'uvu/assert';
+
+/** @type {import('test').TestMaker} */
+export default function (test) {
+	test('serves /', '/', async ({ page, response }) => {
+		assert.equal(await page.textContent('h1'), 'Hello world!');
+
+		const headers = await response.headers();
+		assert.equal(
+			headers['X-Request-Locals'],
+			JSON.stringify({ first: true, second: 'str', third: 3 })
+		);
+
+		assert.equal(headers['X-Handle-Header'], 'hello');
+	});
+}

--- a/packages/kit/test/apps/hooks/src/routes/index.svelte
+++ b/packages/kit/test/apps/hooks/src/routes/index.svelte
@@ -1,0 +1,5 @@
+<script>
+	let message = 'Hello world!';
+</script>
+
+<h1>{message}</h1>

--- a/packages/kit/test/apps/hooks/svelte.config.js
+++ b/packages/kit/test/apps/hooks/svelte.config.js
@@ -1,0 +1,6 @@
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	kit: {}
+};
+
+export default config;

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -129,3 +129,15 @@ declare module '$service-worker' {
 	 */
 	export const timestamp: number;
 }
+
+declare module '@sveltejs/kit/hooks' {
+	type Handle = import('@sveltejs/kit').Handle;
+
+	/**
+	 * Utility function that allows chaining `hooks` `Handle` functions in a
+	 * middleware-like manner.
+	 *
+	 * @param handles The chain of `Handle` functions
+	 */
+	export function sequence(...handles: Handle[]): Handle;
+}


### PR DESCRIPTION
Hi svelte kit team,

This is my first PR on this wonderful project.

## Problem

I tried svelte kit on some internal projects and I noticed something that was missing. It was not possible to compose the `handle` hook with middlewares.

Middlewares allow to better compose and reuse handlers and ensure Single Responsibility Principle. I noticed that some contributors already built some package to handle cookies, session, auth... (eg: `svelte-kit-session`) but it is hard to make different modules works together.

## Solution

That's why I would like to introduce, in this PR, the concept of middleware.
Now you can write the `handle` hook like this:

```javascript
export const handle = [
    ({ request, resolve }) => {
        request.locals.first = true;
        return resolve(request);
    },
    ({ request, resolve }) => {
        request.locals.second = true;
        return resolve(request);
    },
    ({ request, resolve }) => {
        console.log(request.locals); // print { first: true, second: true }
        return resolve(request);
    }
];
```

Of course, this is an example, a better way would be to separate middlewares in modules like this:

```javascript
import session from "./middlewares/session";
import auth from "./middlewares/auth";
import i18n from "./middlewares/i18n";

export const handle = [session, auth, i18n];
```

You can notice that the signature of a middleware is exactly the same as the signature of the `handle` hook. It allows to use a middleware directly as the `handle` hook if you do not need to compose it with others middlewares.

Any middleware can respond directly by returning a `ServerResponse` object. eg:

```javascript
export default function auth_middleware({ request, resolve }) {
    if (isAuthenticated(request)) {
        return resolve(request);
    }

    return {
        status: 401,
        body: ""
    };
}
```

#### UPDATE 1

After some discussion on this PR, the API changed. Now, a `sequence` method is exported by `@sveltejs/kit/hooks`. It allows to chain `Handle` functions.

```javascript
import { sequence } from '@sveltejs/kit/hooks';

export const handle = sequence(
  ({ request, resolve }) => {
    request.locals.first = true;
    return resolve(request);
  },
  ({ request, resolve }) => {
    request.locals.second = true;
    return resolve(request);
  },
  ({ request, resolve }) => {
    console.log(request.locals); // print { first: true, second: true }
    return resolve(request);
  }
);
```
## Technical details

For now, this implementation has an issue, the middleware code is duplicated in `src/runtime/hooks.js` and `src/build/index.js`.
Do you have any idea to avoid this duplication?

Also, I don't have a good understanding of the testing framework in the project. Can you help me writting a test suite?

---

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

_Note: I will add the changeset after changes are reviewed to ensure that the changeset is targetting the good commit_
