### PR TITLE
fix: include esbuild config in adapter type definition

### DIFF
--- a/.changeset/tasty-cars-love.md
+++ b/.changeset/tasty-cars-love.md
@@ -1,0 +1,8 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-vercel': patch
+---
+
+fix: include esbuild config in adapter type definition

--- a/packages/adapter-cloudflare-workers/index.d.ts
+++ b/packages/adapter-cloudflare-workers/index.d.ts
@@ -1,5 +1,5 @@
 type BuildOptions = import('esbuild').BuildOptions;
-declare function plugin(options: {
+declare function plugin(options?: {
 	esbuild?: (defaultOptions: BuildOptions) => Promise<BuildOptions> | BuildOptions;
 }): import('@sveltejs/kit').Adapter;
 

--- a/packages/adapter-cloudflare-workers/index.d.ts
+++ b/packages/adapter-cloudflare-workers/index.d.ts
@@ -1,3 +1,6 @@
-declare function plugin(): import('@sveltejs/kit').Adapter;
+type BuildOptions = import('esbuild').BuildOptions;
+declare function plugin(options: {
+	esbuild?: (defaultOptions: BuildOptions) => Promise<BuildOptions> | BuildOptions;
+}): import('@sveltejs/kit').Adapter;
 
 export = plugin;

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -11,9 +11,9 @@ import { fileURLToPath } from 'url';
 /**
  * @param {{
  *   esbuild?: (defaultOptions: BuildOptions) => Promise<BuildOptions> | BuildOptions;
- * }} options
+ * }} [options]
  **/
-export default function (options = { esbuild: (opts) => opts }) {
+export default function (options) {
 	/** @type {import('@sveltejs/kit').Adapter} */
 	const adapter = {
 		name: '@sveltejs/adapter-cloudflare-workers',
@@ -38,13 +38,17 @@ export default function (options = { esbuild: (opts) => opts }) {
 			utils.log.minor('Generating worker...');
 			utils.copy(`${files}/entry.js`, '.svelte-kit/cloudflare-workers/entry.js');
 
-			const buildOptions = await options.esbuild({
+			/** @type {BuildOptions} */
+			const defaultOptions = {
 				entryPoints: ['.svelte-kit/cloudflare-workers/entry.js'],
 				outfile: `${entrypoint}/index.js`,
 				bundle: true,
 				target: 'es2020',
-				platform: 'browser' // TODO would be great if we could generate ESM and use type = "javascript"
-			});
+				platform: 'browser'
+			};
+
+			const buildOptions =
+				options && options.esbuild ? await options.esbuild(defaultOptions) : defaultOptions;
 
 			await esbuild.build(buildOptions);
 

--- a/packages/adapter-netlify/index.d.ts
+++ b/packages/adapter-netlify/index.d.ts
@@ -1,5 +1,5 @@
 type BuildOptions = import('esbuild').BuildOptions;
-declare function plugin(options: {
+declare function plugin(options?: {
 	esbuild?: (defaultOptions: BuildOptions) => Promise<BuildOptions> | BuildOptions;
 }): import('@sveltejs/kit').Adapter;
 

--- a/packages/adapter-netlify/index.d.ts
+++ b/packages/adapter-netlify/index.d.ts
@@ -1,3 +1,6 @@
-declare function plugin(): import('@sveltejs/kit').Adapter;
+type BuildOptions = import('esbuild').BuildOptions;
+declare function plugin(options: {
+	esbuild?: (defaultOptions: BuildOptions) => Promise<BuildOptions> | BuildOptions;
+}): import('@sveltejs/kit').Adapter;
 
 export = plugin;

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -11,9 +11,9 @@ import toml from '@iarna/toml';
 /**
  * @param {{
  *   esbuild?: (defaultOptions: BuildOptions) => Promise<BuildOptions> | BuildOptions;
- * }} options
+ * }} [options]
  **/
-export default function (options = { esbuild: (opts) => opts }) {
+export default function (options) {
 	/** @type {import('@sveltejs/kit').Adapter} */
 	const adapter = {
 		name: '@sveltejs/adapter-netlify',
@@ -29,13 +29,17 @@ export default function (options = { esbuild: (opts) => opts }) {
 			utils.log.minor('Generating serverless function...');
 			utils.copy(join(files, 'entry.js'), '.svelte-kit/netlify/entry.js');
 
-			const buildOptions = await options.esbuild({
+			/** @type {BuildOptions} */
+			const defaultOptions = {
 				entryPoints: ['.svelte-kit/netlify/entry.js'],
 				outfile: join(functions, 'render/index.js'),
 				bundle: true,
 				inject: [join(files, 'shims.js')],
 				platform: 'node'
-			});
+			};
+
+			const buildOptions =
+				options && options.esbuild ? await options.esbuild(defaultOptions) : defaultOptions;
 
 			await esbuild.build(buildOptions);
 

--- a/packages/adapter-node/index.d.ts
+++ b/packages/adapter-node/index.d.ts
@@ -1,3 +1,4 @@
+type BuildOptions = import('esbuild').BuildOptions;
 declare function plugin(options?: {
 	out?: string;
 	precompress?: boolean;
@@ -5,6 +6,7 @@ declare function plugin(options?: {
 		host?: string;
 		port?: string;
 	};
+	esbuild?: (defaultOptions: BuildOptions) => Promise<BuildOptions> | BuildOptions;
 }): import('@sveltejs/kit').Adapter;
 
 export = plugin;

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -31,14 +31,12 @@ const pipe = promisify(pipeline);
  *   esbuild?: (defaultOptions: BuildOptions) => Promise<BuildOptions> | BuildOptions;
  * }} options
  */
-export default function (
-	{
-		out = 'build',
-		precompress,
-		env: { host: host_env = 'HOST', port: port_env = 'PORT' } = {},
-		esbuild: esbuildConfig
-	} = { esbuild: (opts) => opts }
-) {
+export default function ({
+	out = 'build',
+	precompress,
+	env: { host: host_env = 'HOST', port: port_env = 'PORT' } = {},
+	esbuild: esbuildConfig
+} = {}) {
 	/** @type {import('@sveltejs/kit').Adapter} */
 	const adapter = {
 		name: '@sveltejs/adapter-node',
@@ -63,7 +61,8 @@ export default function (
 					host_env
 				)}] || '0.0.0.0';\nexport const port = process.env[${JSON.stringify(port_env)}] || 3000;`
 			);
-			const buildOptions = await esbuildConfig({
+			/** @type {BuildOptions} */
+			const defaultOptions = {
 				entryPoints: ['.svelte-kit/node/index.js'],
 				outfile: join(out, 'index.js'),
 				bundle: true,
@@ -75,7 +74,8 @@ export default function (
 				define: {
 					esbuild_app_dir: '"' + config.kit.appDir + '"'
 				}
-			});
+			};
+			const buildOptions = esbuildConfig ? await esbuildConfig(defaultOptions) : defaultOptions;
 			await esbuild.build(buildOptions);
 
 			utils.log.minor('Prerendering static pages');

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -1,5 +1,5 @@
 type BuildOptions = import('esbuild').BuildOptions;
-declare function plugin(options: {
+declare function plugin(options?: {
 	esbuild?: (defaultOptions: BuildOptions) => Promise<BuildOptions> | BuildOptions;
 }): import('@sveltejs/kit').Adapter;
 

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -1,3 +1,6 @@
-declare function plugin(): import('@sveltejs/kit').Adapter;
+type BuildOptions = import('esbuild').BuildOptions;
+declare function plugin(options: {
+	esbuild?: (defaultOptions: BuildOptions) => Promise<BuildOptions> | BuildOptions;
+}): import('@sveltejs/kit').Adapter;
 
 export = plugin;

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -10,9 +10,9 @@ import esbuild from 'esbuild';
 /**
  * @param {{
  *   esbuild?: (defaultOptions: BuildOptions) => Promise<BuildOptions> | BuildOptions;
- * }} options
+ * }} [options]
  **/
-export default function (options = { esbuild: (opts) => opts }) {
+export default function (options) {
 	/** @type {import('@sveltejs/kit').Adapter} */
 	const adapter = {
 		name: '@sveltejs/adapter-vercel',
@@ -36,13 +36,17 @@ export default function (options = { esbuild: (opts) => opts }) {
 			utils.log.minor('Generating serverless function...');
 			utils.copy(join(files, 'entry.js'), '.svelte-kit/vercel/entry.js');
 
-			const buildOptions = await options.esbuild({
+			/** @type {BuildOptions} */
+			const defaultOptions = {
 				entryPoints: ['.svelte-kit/vercel/entry.js'],
 				outfile: join(dirs.lambda, 'index.js'),
 				bundle: true,
 				inject: [join(files, 'shims.js')],
 				platform: 'node'
-			});
+			};
+
+			const buildOptions =
+				options && options.esbuild ? await options.esbuild(defaultOptions) : defaultOptions;
 
 			await esbuild.build(buildOptions);
 


### PR DESCRIPTION
- Added missing type definitions to adapters.
- Fix adapter-node requiring esbuild to be defined if any options were specified.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
