### PR TITLE
[fix] add DOM lib to create-svelte tsconfig

### DIFF
--- a/.changeset/mean-pets-confess.md
+++ b/.changeset/mean-pets-confess.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Add DOM to lib in tsconfig

--- a/packages/create-svelte/shared/+typescript/tsconfig.json
+++ b/packages/create-svelte/shared/+typescript/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"moduleResolution": "node",
 		"module": "es2020",
-		"lib": ["es2020"],
+		"lib": ["es2020", "DOM"],
 		"target": "es2019",
 		/**
 			svelte-preprocess cannot figure out whether you have a value or a type, so tell TypeScript


### PR DESCRIPTION
This makes the DOM ambient typings available to the user without errors. This is not 100% correct because on the server most of the typings are not available, but as soon as you want to use one of these, you need to add this to the lib list anyway. It also makes the svelte-kit package command export the correct dispatcher event types (#1943).

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
