### PR TITLE
Make router-handled scrolling work with CSS properties

### DIFF
--- a/.changeset/wild-badgers-brake.md
+++ b/.changeset/wild-badgers-brake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Scrolling to an anchor via a hash now supports `scroll-*` CSS properties

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -269,8 +269,10 @@ export class Router {
 		if (scroll) {
 			scrollTo(scroll.x, scroll.y);
 		} else if (deep_linked) {
-			// scroll is an element id (from a hash), we need to compute y
-			scrollTo(0, deep_linked.getBoundingClientRect().top + scrollY);
+			// Here we use `scrollIntoView` on the element instead of `scrollTo`
+			// because it natively supports the `scroll-margin` and `scroll-behavior`
+			// CSS properties.
+			deep_linked.scrollIntoView();
 		} else {
 			scrollTo(0, 0);
 		}


### PR DESCRIPTION
Fixes #1863.

Using `scrollIntoView` instead `scrollTo` naturally adds
support for more CSS scrolling properties when scrolling to IDs.

Properties like `scroll-margin` and `scroll-behavior` are supported by `scrollIntoView`.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test`
- [x] Lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
