### PR TITLE
Use @ts-expect-error over @ts-ignore

### DIFF
--- a/packages/kit/src/core/adapt/test/index.js
+++ b/packages/kit/src/core/adapt/test/index.js
@@ -30,7 +30,7 @@ suite('copy files', () => {
 	/** @type {import('types/config').ValidatedConfig} */
 	const config = {
 		kit: {
-			// @ts-ignore
+			// @ts-expect-error
 			files: {
 				assets: join(__dirname, 'fixtures/basic/static')
 			},
@@ -76,13 +76,13 @@ suite('prerender', async () => {
 	const config = {
 		extensions: ['.svelte'],
 		kit: {
-			// @ts-ignore
+			// @ts-expect-error
 			files: {
 				assets: join(__dirname, 'fixtures/prerender/static'),
 				routes: join(__dirname, 'fixtures/prerender/src/routes')
 			},
 			appDir: '_app',
-			// @ts-ignore
+			// @ts-expect-error
 			prerender: {
 				pages: ['*'],
 				enabled: true

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -468,7 +468,6 @@ async function build_server(
 		// this API is marked as @alpha https://github.com/vitejs/vite/blob/27785f7fcc5b45987b5f0bf308137ddbdd9f79ea/packages/vite/src/node/config.ts#L129
 		// it's not exposed in the typescript definitions as a result
 		// so we need to ignore the fact that it's missing
-		// @ts-ignore
 		ssr: {
 			// note to self: this _might_ need to be ['svelte', '@sveltejs/kit', ...get_no_external()]
 			// but I'm honestly not sure. roll with this for now and see if it's ok

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -5,7 +5,7 @@ import { deep_merge, validate_config } from './index.js';
 test('fills in defaults', () => {
 	const validated = validate_config({});
 
-	// @ts-ignore
+	// @ts-expect-error
 	delete validated.kit.vite;
 
 	assert.equal(validated, {
@@ -66,7 +66,7 @@ test('errors on invalid values', () => {
 	assert.throws(() => {
 		validate_config({
 			kit: {
-				// @ts-ignore
+				// @ts-expect-error
 				target: 42
 			}
 		});
@@ -78,7 +78,7 @@ test('errors on invalid nested values', () => {
 		validate_config({
 			kit: {
 				files: {
-					// @ts-ignore
+					// @ts-expect-error
 					potato: 'blah'
 				}
 			}
@@ -105,7 +105,7 @@ test('fills in partial blanks', () => {
 
 	assert.equal(validated.kit.vite(), {});
 
-	// @ts-ignore
+	// @ts-expect-error
 	delete validated.kit.vite;
 
 	assert.equal(validated, {
@@ -248,7 +248,6 @@ function validate_paths(name, input, output) {
 		assert.equal(
 			validate_config({
 				kit: {
-					// @ts-ignore
 					paths: input
 				}
 			}).kit.paths,

--- a/packages/kit/src/core/config/test/index.js
+++ b/packages/kit/src/core/config/test/index.js
@@ -15,7 +15,7 @@ async function testLoadDefaultConfig(path) {
 
 	const config = await load_config({ cwd });
 
-	// @ts-ignore
+	// @ts-expect-error
 	delete config.kit.vite; // can't test equality of a function
 
 	assert.equal(config, {

--- a/packages/kit/src/core/create_manifest_data/index.js
+++ b/packages/kit/src/core/create_manifest_data/index.js
@@ -247,11 +247,11 @@ export default function create_manifest_data({ config, output, cwd = process.cwd
 					type: 'page',
 					pattern,
 					params,
-					// @ts-ignore
+					// @ts-expect-error
 					path,
-					// @ts-ignore
+					// @ts-expect-error
 					a,
-					// @ts-ignore
+					// @ts-expect-error
 					b
 				});
 			} else {

--- a/packages/kit/src/core/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/create_manifest_data/index.spec.js
@@ -16,7 +16,7 @@ const create = (dir, extensions = ['.svelte']) => {
 		config: {
 			extensions,
 			kit: {
-				// @ts-ignore
+				// @ts-expect-error
 				files: {
 					assets: path.resolve(cwd, 'static'),
 					routes: path.resolve(cwd, dir)

--- a/packages/kit/src/core/server/cert.js
+++ b/packages/kit/src/core/server/cert.js
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error
 import { generate } from 'selfsigned';
 
 /**

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -19,7 +19,7 @@ export const prefetchRoutes = import.meta.env.SSR ? guard('prefetchRoutes') : pr
  * @type {import('$app/navigation').goto}
  */
 async function goto_(href, opts) {
-	// @ts-ignore
+	// @ts-expect-error
 	return router.goto(href, opts, []);
 }
 
@@ -28,7 +28,7 @@ async function goto_(href, opts) {
  */
 async function invalidate_(resource) {
 	const { href } = new URL(resource, location.href);
-	// @ts-ignore
+	// @ts-expect-error
 	return router.renderer.invalidate(href);
 }
 
@@ -36,7 +36,7 @@ async function invalidate_(resource) {
  * @type {import('$app/navigation').prefetch}
  */
 function prefetch_(href) {
-	// @ts-ignore
+	// @ts-expect-error
 	return router.prefetch(new URL(href, get_base_uri(document)));
 }
 
@@ -45,14 +45,14 @@ function prefetch_(href) {
  */
 async function prefetchRoutes_(pathnames) {
 	const matching = pathnames
-		? // @ts-ignore
+		? // @ts-expect-error
 		  router.routes.filter((route) => pathnames.some((pathname) => route[0].test(pathname)))
-		: // @ts-ignore
+		: // @ts-expect-error
 		  router.routes;
 
 	const promises = matching
 		.filter((r) => r && r.length > 1)
-		// @ts-ignore
+		// @ts-expect-error
 		.map((r) => Promise.all(r[1].map((load) => load())));
 
 	await Promise.all(promises);

--- a/packages/kit/src/runtime/app/stores.js
+++ b/packages/kit/src/runtime/app/stores.js
@@ -26,7 +26,7 @@ export const getStores = () => {
 		navigating: {
 			subscribe: stores.navigating.subscribe
 		},
-		// @ts-ignore - deprecated, not part of type definitions, but still callable
+		// @ts-expect-error - deprecated, not part of type definitions, but still callable
 		get preloading() {
 			console.error('stores.preloading is deprecated; use stores.navigating instead');
 			return {

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -82,9 +82,9 @@ export class Renderer {
 
 		/** @type {import('./types').NavigationState} */
 		this.current = {
-			// @ts-ignore
+			// @ts-expect-error
 			page: null,
-			// @ts-ignore
+			// @ts-expect-error
 			session_id: null,
 			branch: []
 		};
@@ -198,7 +198,7 @@ export class Renderer {
 		dispatchEvent(new CustomEvent('sveltekit:navigation-start'));
 
 		if (this.started) {
-			// @ts-ignore
+			// @ts-expect-error
 			this.stores.navigating.set({
 				from: {
 					path: this.current.page.path,
@@ -327,7 +327,7 @@ export class Renderer {
 	 */
 	async _get_navigation_result(info, no_cache) {
 		if (this.loading.id === info.id) {
-			// @ts-ignore if the id is defined then the promise is too
+			// @ts-expect-error if the id is defined then the promise is too
 			return this.loading.promise;
 		}
 
@@ -544,7 +544,7 @@ export class Renderer {
 		}
 
 		const [pattern, a, b, get_params] = route;
-		// @ts-ignore - the pattern is for the route which we've already matched to this path
+		// @ts-expect-error - the pattern is for the route which we've already matched to this path
 		const params = get_params ? get_params(pattern.exec(path)) : {};
 
 		const changed = this.current.page && {

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -221,7 +221,7 @@ export class Router {
 			throw new Error('Attempted to prefetch a URL that does not belong to this app');
 		}
 
-		// @ts-ignore
+		// @ts-expect-error
 		return this.renderer.load(info);
 	}
 
@@ -255,13 +255,13 @@ export class Router {
 			}
 		}
 
-		// @ts-ignore6
+		// @ts-expect-error
 		this.renderer.notify({
 			path: info.path,
 			query: info.query
 		});
 
-		// @ts-ignore
+		// @ts-expect-error
 		await this.renderer.update(info, chain, false);
 
 		if (!keepfocus) {

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -1,6 +1,6 @@
-// @ts-ignore
+// @ts-expect-error
 import Root from 'ROOT'; // eslint-disable-line import/no-unresolved
-// @ts-ignore
+// @ts-expect-error
 import { routes, fallback } from 'MANIFEST'; // eslint-disable-line import/no-unresolved
 import { Router } from './router.js';
 import { Renderer } from './renderer.js';

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -17,7 +17,7 @@ import { coalesce_to_error } from '../utils.js';
  */
 export async function respond({ request, options, state, $session, route }) {
 	const match = route.pattern.exec(request.path);
-	// @ts-ignore we already know there's a match
+	// @ts-expect-error we already know there's a match
 	const params = route.params(match);
 
 	const page = {

--- a/packages/kit/test/apps/basics/src/routes/caching/private/uses-fetch.svelte
+++ b/packages/kit/test/apps/basics/src/routes/caching/private/uses-fetch.svelte
@@ -2,7 +2,7 @@
 	/** @type {import('@sveltejs/kit').Load} */
 	export async function load({ page, fetch }) {
 		const res = await fetch('/caching/private/uses-fetch.json', {
-			// @ts-ignore
+			// @ts-expect-error
 			credentials: page.query.get('credentials')
 		});
 

--- a/packages/kit/test/apps/basics/src/routes/errors/load-error-malformed-client.svelte
+++ b/packages/kit/test/apps/basics/src/routes/errors/load-error-malformed-client.svelte
@@ -2,7 +2,7 @@
 	/** @type {import('@sveltejs/kit').Load} */
 	export async function load() {
 		if (typeof window !== 'undefined') {
-			// @ts-ignore
+			// @ts-expect-error
 			return { status: 555, error: {} };
 		}
 

--- a/packages/kit/test/apps/basics/src/routes/errors/load-error-malformed-server.svelte
+++ b/packages/kit/test/apps/basics/src/routes/errors/load-error-malformed-server.svelte
@@ -1,7 +1,7 @@
 <script context="module">
 	/** @type {import('@sveltejs/kit').Load} */
 	export async function load() {
-		// @ts-ignore
+		// @ts-expect-error
 		return { status: 555, error: {} };
 	}
 </script>

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-request.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-request.svelte
@@ -8,7 +8,7 @@
 		// this is contrived, but saves us faffing about with node-fetch here
 		const resource = browser ? new Request(url) : { url };
 
-		// @ts-ignore
+		// @ts-expect-error
 		const res = await fetch(resource);
 		const { answer } = await res.json();
 

--- a/packages/kit/test/apps/basics/src/routes/load/server-fetch-request.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/server-fetch-request.svelte
@@ -3,7 +3,6 @@
 	export async function load({ page, fetch }) {
 		const url = `http://localhost:${page.query.get('port')}/server-fetch-request.json`;
 
-		// @ts-ignore
 		const res = await fetch(url);
 		const { answer } = await res.json();
 		return {

--- a/packages/kit/test/apps/basics/src/routes/routing/shadow/action.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/shadow/action.js
@@ -2,7 +2,7 @@ let random = 0;
 
 /** @type {import('@sveltejs/kit').RequestHandler} */
 export function post({ body }) {
-	// @ts-ignore (TODO make the types work somehow)
+	// @ts-expect-error (TODO make the types work somehow)
 	random = body.get('random');
 }
 

--- a/packages/kit/test/apps/basics/src/routes/xss/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/xss/_tests.js
@@ -9,7 +9,7 @@ export default function (test) {
 		);
 
 		if (!js) {
-			// @ts-ignore
+			// @ts-expect-error
 			assert.ok(!(await page.evaluate(() => window.pnwed)), 'pwned');
 		}
 	});

--- a/packages/kit/test/apps/basics/src/service-worker.js
+++ b/packages/kit/test/apps/basics/src/service-worker.js
@@ -3,12 +3,12 @@ import { timestamp, build } from '$service-worker';
 const name = `cache-${timestamp}`;
 
 self.addEventListener('install', (event) => {
-	// @ts-ignore
+	// @ts-expect-error
 	event.waitUntil(caches.open(name).then((cache) => cache.addAll(build)));
 });
 
 self.addEventListener('activate', (event) => {
-	// @ts-ignore
+	// @ts-expect-error
 	event.waitUntil(
 		caches.keys().then(async (keys) => {
 			for (const key of keys) {
@@ -19,7 +19,7 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
-	// @ts-ignore
+	// @ts-expect-error
 	const { request } = event;
 
 	if (request.method !== 'GET' || request.headers.has('range')) return;
@@ -29,7 +29,7 @@ self.addEventListener('fetch', (event) => {
 
 	if (url.origin === location.origin && build.includes(url.pathname)) {
 		// always return build files from cache
-		// @ts-ignore
+		// @ts-expect-error
 		event.respondWith(cached);
 	} else if (url.protocol === 'https:' || location.hostname === 'localhost') {
 		// hit the network for everything else...
@@ -47,7 +47,7 @@ self.addEventListener('fetch', (event) => {
 		});
 
 		// ...but if it fails, fall back to cache if available
-		// @ts-ignore
+		// @ts-expect-error
 		event.respondWith(promise.catch(() => cached || promise));
 	}
 });

--- a/packages/kit/test/test.js
+++ b/packages/kit/test/test.js
@@ -180,7 +180,7 @@ function duplicate(test_fn, config, is_build) {
 					page: context.pages.nojs,
 					clicknav: (selector) => context.pages.nojs.click(selector),
 					back: () => context.pages.nojs.goBack().then(() => void 0),
-					// @ts-ignore TODO: fix this and document wtf start is
+					// @ts-expect-error TODO: fix this and document wtf start is
 					response,
 					js: false
 				});
@@ -230,7 +230,7 @@ function duplicate(test_fn, config, is_build) {
 						await context.pages.js.evaluate(() => window.navigated);
 					},
 					js: true,
-					// @ts-ignore TODO: fix this and document wtf start is
+					// @ts-expect-error TODO: fix this and document wtf start is
 					response
 				});
 			});
@@ -239,7 +239,7 @@ function duplicate(test_fn, config, is_build) {
 }
 
 async function main() {
-	// @ts-ignore
+	// @ts-expect-error
 	globalThis.UVU_DEFER = 1;
 	const uvu = await import('uvu');
 
@@ -257,9 +257,9 @@ async function main() {
 		const name = `dev:${app}`;
 
 		// manually replicate uvu global state
-		// @ts-ignore
+		// @ts-expect-error
 		const count = globalThis.UVU_QUEUE.push([name]);
-		// @ts-ignore
+		// @ts-expect-error
 		globalThis.UVU_INDEX = count - 1;
 
 		/** @type {import('uvu').Test<import('./types').TestContext>} */
@@ -292,9 +292,9 @@ async function main() {
 
 		/** @type {import('test').TestFunction} */
 		const test = Object.assign(duplicate(suite, config, false), {
-			// @ts-ignore
+			// @ts-expect-error
 			skip: duplicate(suite.skip, config, false),
-			// @ts-ignore
+			// @ts-expect-error
 			only: duplicate(suite.only, config, false)
 		});
 
@@ -315,9 +315,9 @@ async function main() {
 		const name = `build:${app}`;
 
 		// manually replicate uvu global state
-		// @ts-ignore
+		// @ts-expect-error
 		const count = globalThis.UVU_QUEUE.push([name]);
-		// @ts-ignore
+		// @ts-expect-error
 		globalThis.UVU_INDEX = count - 1;
 
 		/** @type {import('uvu').Test<import('./types').TestContext>} */
@@ -356,9 +356,9 @@ async function main() {
 
 		/** @type {import('test').TestFunction} */
 		const test = Object.assign(duplicate(suite, config, true), {
-			// @ts-ignore
+			// @ts-expect-error
 			skip: duplicate(suite.skip, config, true),
-			// @ts-ignore
+			// @ts-expect-error
 			only: duplicate(suite.only, config, true)
 		});
 


### PR DESCRIPTION
Rationale: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#ts-ignore-or-ts-expect-error

> Pick ts-expect-error if:
> * you’re writing test code where you actually want the type system to error on an operation
> * you expect a fix to be coming in fairly quickly and you just need a quick workaround
> * you’re in a reasonably-sized project with a proactive team that wants to remove suppression comments as soon affected code is valid again

There were a few unnecessary @ts-ignore which this change pointed out (which is why the diff has more removals than insertions).

cc @benmccann, #1998

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
