### PR TITLE
Change config `prerender.force` to `prerender.onError`

### DIFF
--- a/.changeset/tame-guests-collect.md
+++ b/.changeset/tame-guests-collect.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Remove the `prerender.force` option in favor of `prerender.onError`

--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -48,7 +48,7 @@ const config = {
 		prerender: {
 			crawl: true,
 			enabled: true,
-			force: false,
+			onError: 'fail',
 			pages: ['*']
 		},
 		router: true,
@@ -148,7 +148,30 @@ See [Prerendering](#ssr-and-javascript-prerender). An object containing zero or 
 
 - `crawl` — determines whether SvelteKit should find pages to prerender by following links from the seed page(s)
 - `enabled` — set to `false` to disable prerendering altogether
-- `force` — if `true`, a page that fails to render will _not_ cause the entire build to fail
+- `onError`
+
+  - `'fail'` — (default) fails the build when a routing error is encountered when following a link
+  - `'continue'` — allows the build to continue, despite routing errors
+  - `function` — custom error handler allowing you to log, `throw` and fail the build, or take other action of your choosing based on the details of the crawl
+
+    ```ts
+    /** @type {import('@sveltejs/kit').PrerenderErrorHandler} */
+    const handleError = ({ status, path, referrer, referenceType }) => {
+    	if (path.startsWith('/blog')) throw new Error('Missing a blog page!');
+    	console.warn(`${status} ${path}${referrer ? ` (${referenceType} from ${referrer})` : ''}`);
+    };
+
+    export default {
+    	kit: {
+    		adapter: static(),
+    		target: '#svelte',
+    		prerender: {
+    			onError: handleError
+    		}
+    	}
+    };
+    ```
+
 - `pages` — an array of pages to prerender, or start crawling from (if `crawl: true`). The `*` string includes all non-dynamic routes (i.e. pages with no `[parameters]` )
 
 ### router

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -50,6 +50,8 @@ test('fills in defaults', () => {
 			prerender: {
 				crawl: true,
 				enabled: true,
+				// TODO: remove this for the 1.0 release
+				force: undefined,
 				onError: 'fail',
 				pages: ['*']
 			},
@@ -150,6 +152,8 @@ test('fills in partial blanks', () => {
 			prerender: {
 				crawl: true,
 				enabled: true,
+				// TODO: remove this for the 1.0 release
+				force: undefined,
 				onError: 'fail',
 				pages: ['*']
 			},

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -50,7 +50,7 @@ test('fills in defaults', () => {
 			prerender: {
 				crawl: true,
 				enabled: true,
-				force: false,
+				onError: 'fail',
 				pages: ['*']
 			},
 			router: true,
@@ -150,7 +150,7 @@ test('fills in partial blanks', () => {
 			prerender: {
 				crawl: true,
 				enabled: true,
-				force: false,
+				onError: 'fail',
 				pages: ['*']
 			},
 			router: true,

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -121,6 +121,22 @@ const options = {
 				children: {
 					crawl: expect_boolean(true),
 					enabled: expect_boolean(true),
+					// TODO: remove this for the 1.0 release
+					force: {
+						type: 'leaf',
+						default: undefined,
+						validate: (option, keypath) => {
+							if (typeof option !== undefined) {
+								const newSetting = option ? 'continue' : 'fail';
+								const needsSetting = newSetting === 'continue';
+								throw new Error(
+									`${keypath} has been removed in favor of \`onError\`. In your case, set \`onError\` to "${newSetting}"${
+										needsSetting ? '' : ' (or leave it undefined)'
+									} to get the same behavior as you would with \`force: ${JSON.stringify(option)}\``
+								);
+							}
+						}
+					},
 					onError: {
 						type: 'leaf',
 						default: 'fail',

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -121,7 +121,17 @@ const options = {
 				children: {
 					crawl: expect_boolean(true),
 					enabled: expect_boolean(true),
-					force: expect_boolean(false),
+					onError: {
+						type: 'leaf',
+						default: 'fail',
+						validate: (option, keypath) => {
+							if (typeof option === 'function') return option;
+							if (['continue', 'fail'].includes(option)) return option;
+							throw new Error(
+								`${keypath} should be either a custom function or one of "continue" or "fail"`
+							);
+						}
+					},
 					pages: {
 						type: 'leaf',
 						default: ['*'],

--- a/packages/kit/src/core/config/test/index.js
+++ b/packages/kit/src/core/config/test/index.js
@@ -54,7 +54,7 @@ async function testLoadDefaultConfig(path) {
 				exclude: []
 			},
 			paths: { base: '', assets: '/.' },
-			prerender: { crawl: true, enabled: true, force: false, pages: ['*'] },
+			prerender: { crawl: true, enabled: true, onError: 'fail', pages: ['*'] },
 			router: true,
 			ssr: true,
 			target: null,

--- a/packages/kit/src/core/config/test/index.js
+++ b/packages/kit/src/core/config/test/index.js
@@ -54,7 +54,7 @@ async function testLoadDefaultConfig(path) {
 				exclude: []
 			},
 			paths: { base: '', assets: '/.' },
-			prerender: { crawl: true, enabled: true, onError: 'fail', pages: ['*'] },
+			prerender: { crawl: true, enabled: true, force: undefined, onError: 'fail', pages: ['*'] },
 			router: true,
 			ssr: true,
 			target: null,

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -78,6 +78,15 @@ export interface Config {
 	preprocess?: any;
 }
 
+export type PrerenderErrorHandler = (errorDetails: {
+	status: number;
+	path: string;
+	referrer: string | null;
+	referenceType: 'linked' | 'fetched';
+}) => void | never;
+
+export type PrerenderOnErrorValue = 'fail' | 'continue' | PrerenderErrorHandler;
+
 export interface ValidatedConfig {
 	compilerOptions: any;
 	extensions: string[];
@@ -117,7 +126,7 @@ export interface ValidatedConfig {
 		prerender: {
 			crawl: boolean;
 			enabled: boolean;
-			force: boolean;
+			onError: PrerenderOnErrorValue;
 			pages: string[];
 		};
 		router: boolean;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3,7 +3,7 @@
 
 import './ambient-modules';
 
-export { Adapter, AdapterUtils, Config, ValidatedConfig } from './config';
+export { Adapter, AdapterUtils, Config, ValidatedConfig, PrerenderErrorHandler } from './config';
 export { EndpointOutput, RequestHandler } from './endpoint';
 export { ErrorLoad, ErrorLoadInput, Load, LoadInput, LoadOutput, Page } from './page';
 export {


### PR DESCRIPTION
fixes sveltejs/kit#1940

Essentially, we are doing this:

```diff
kit: {
  prerender: {
    crawl: boolean;
    enabled: boolean;
-   force: boolean;
+   onError: 'fail' | 'continue' | ((details: RequestDetails) => void | never);
    pages: string[];
  }
}
```

- Changing from `force` to `onError` gives a somewhat more descriptive
  name to the option.
- Using the strings "fail" and "continue" further clarifies what the
  option does.
- Providing your own function to deal with an error allows for
  fine-tuning which errors fail the build and which do not.

The original ticket suggested that the custom function return a boolean,
but after seeing the implementation of the error handler in svelteKit, I
thought it more fitting to just allow it the exact same API: throw if
you want the build to fail.

## Teaching the new option via error message:

This PR also adds a failing option check for using the old `force` property, and gives you the proper value to use in its place as well. This should help when people version bump to the latest build.

<img width="883" alt="CleanShot 2021-07-24 at 20 53 16@2x" src="https://user-images.githubusercontent.com/3663628/126884394-dd6e7f19-871e-495e-bf2c-348273aff92a.png">

<img width="893" alt="CleanShot 2021-07-24 at 22 43 13@2x" src="https://user-images.githubusercontent.com/3663628/126885928-ec308bb2-185f-4fd7-8034-e2a6f54c0985.png">




## Examples of various acceptable options, and the output when a link is broken

### The new handler function option
#### Throw to fail

![CleanShot 2021-07-26 at 20 53 51@2x](https://user-images.githubusercontent.com/3663628/127078061-901a59bc-fed9-43b7-b0d6-8145c462739f.png)

#### Anything but throwing will continue the build

![CleanShot 2021-07-26 at 21 00 43@2x](https://user-images.githubusercontent.com/3663628/127078434-e72cd333-895a-4f87-9cb7-16a5bb74ef5e.png)

### The old behavior via the new settings
#### fail
<img width="901" alt="CleanShot 2021-07-24 at 20 59 05@2x" src="https://user-images.githubusercontent.com/3663628/126884478-49b9f86a-2b28-4297-bb07-d46b7404c26a.png">

#### continue
<img width="881" alt="CleanShot 2021-07-24 at 20 58 22@2x" src="https://user-images.githubusercontent.com/3663628/126884479-98d99512-0b4d-4d03-adf5-ca5f904285b9.png">

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
