### PR TITLE
[feat] explicitly set compilerOptions.hydratable to config.kit.ssr

### DIFF
--- a/.changeset/nervous-items-kiss.md
+++ b/.changeset/nervous-items-kiss.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+explicitly set compilerOptions.hydratable to config.kit.ssr

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -174,7 +174,10 @@ async function build_client({
 		plugins: [
 			svelte({
 				extensions: config.extensions,
-				emitCss: !config.kit.amp
+				emitCss: !config.kit.amp,
+				compilerOptions: {
+					hydratable: config.kit.ssr
+				}
 			})
 		]
 	});
@@ -462,7 +465,10 @@ async function build_server(
 		},
 		plugins: [
 			svelte({
-				extensions: config.extensions
+				extensions: config.extensions,
+				compilerOptions: {
+					hydratable: config.kit.ssr
+				}
 			})
 		],
 		// this API is marked as @alpha https://github.com/vitejs/vite/blob/27785f7fcc5b45987b5f0bf308137ddbdd9f79ea/packages/vite/src/node/config.ts#L129

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -176,7 +176,7 @@ async function build_client({
 				extensions: config.extensions,
 				emitCss: !config.kit.amp,
 				compilerOptions: {
-					hydratable: config.kit.ssr
+					hydratable: !!config.kit.hydrate
 				}
 			})
 		]
@@ -467,7 +467,7 @@ async function build_server(
 			svelte({
 				extensions: config.extensions,
 				compilerOptions: {
-					hydratable: config.kit.ssr
+					hydratable: !!config.kit.hydrate
 				}
 			})
 		],

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -138,7 +138,7 @@ class Watcher extends EventEmitter {
 					extensions: this.config.extensions,
 					emitCss: !this.config.kit.amp,
 					compilerOptions: {
-						hydratable: this.config.kit.ssr
+						hydratable: !!this.config.kit.hydrate
 					}
 				})
 			],

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -136,7 +136,10 @@ class Watcher extends EventEmitter {
 			plugins: [
 				svelte({
 					extensions: this.config.extensions,
-					emitCss: !this.config.kit.amp
+					emitCss: !this.config.kit.amp,
+					compilerOptions: {
+						hydratable: this.config.kit.ssr
+					}
 				})
 			],
 			publicDir: this.config.kit.files.assets,


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0


Until now vite-plugin-svelte defaults to `hydratable: true`, but that is going to change. 
See https://github.com/sveltejs/vite-plugin-svelte/pull/122

To avoid breaking, kit has to set hydratable explicitly.
vite-plugin-svelte also offers a new option `experimental.dynamicCompileOptions` that could be used to implement a more finegrained solution of which components need hydration. see https://github.com/sveltejs/vite-plugin-svelte/issues/121
