### PR TITLE
Fix type error in config.d.ts (one-liner)

### DIFF
--- a/.changeset/thick-lies-think.md
+++ b/.changeset/thick-lies-think.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fixed typing error in config.kit.prerender

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -79,7 +79,7 @@ export interface Config {
 		prerender?: {
 			crawl?: boolean;
 			enabled?: ScriptablePageOpt<boolean>;
-			force?: boolean;
+			onError?: PrerenderOnErrorValue;
 			pages?: string[];
 		};
 		router?: ScriptablePageOpt<boolean>;


### PR DESCRIPTION
Type bug introduced in #2007 

I missed the fact that there were two spots that `force` was defined. 

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
