### PR TITLE
[fix] revert adapters automatically updating .gitignore (#1924)

### DIFF
--- a/.changeset/six-comics-report.md
+++ b/.changeset/six-comics-report.md
@@ -1,0 +1,10 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-static': patch
+'@sveltejs/adapter-vercel': patch
+'@sveltejs/kit': patch
+---
+
+revert adapters automatically updating .gitignore (#1924)

--- a/documentation/docs/10-adapters.md
+++ b/documentation/docs/10-adapters.md
@@ -31,15 +31,6 @@ export default {
 };
 ```
 
-Some adapters may modify your project's `.gitignore` to include their build output. In case you don't want those patterns included you can comment them out: 
-
-```diff
-.svelte-kit
-.env
-
-- build
-+ # build
-```
 A variety of official adapters exist for serverless platforms...
 
 - [`adapter-cloudflare-workers`](https://github.com/sveltejs/kit/tree/master/packages/adapter-cloudflare-workers) — for [Cloudflare Workers](https://developers.cloudflare.com/workers/)

--- a/documentation/docs/80-adapter-api.md
+++ b/documentation/docs/80-adapter-api.md
@@ -26,7 +26,6 @@ The types for `Adapter` and its parameters are available in [types/config.d.ts](
 Within the `adapt` method, there are a number of things that an adapter should do:
 
 - Clear out the build directory
-- Call `utils.update_ignores` to ignore build output in existing `.gitignore` files at the location of `svelte.config.js`
 - Output code that:
   - Calls `init`
   - Converts from the platform's request to a [SvelteKit request](#hooks-handle), calls `render`, and converts from a [SvelteKit response](#hooks-handle) to the platform's
@@ -34,5 +33,7 @@ Within the `adapt` method, there are a number of things that an adapter should d
 - Bundle the output to avoid needing to install dependencies on the target platform, if desired
 - Call `utils.prerender`
 - Put the user's static files and the generated JS/CSS in the correct location for the target platform
+
+If possible, we recommend putting the adapter output under `'.svelte-kit/' + adapterName` with any intermediate output under `'.svelte-kit/' + adapterName + '/intermediate'`.
 
 > The adapter API may change before 1.0.

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -25,8 +25,6 @@ export default function (options) {
 
 			const files = fileURLToPath(new URL('./files', import.meta.url));
 
-			utils.update_ignores({ patterns: [bucket, entrypoint] });
-
 			utils.rimraf(bucket);
 			utils.rimraf(entrypoint);
 

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -26,8 +26,6 @@ export default function (options) {
 
 			const files = fileURLToPath(new URL('./files', import.meta.url));
 
-			utils.update_ignores({ patterns: [publish, functions] });
-
 			utils.log.minor('Generating serverless function...');
 			utils.copy(join(files, 'entry.js'), '.svelte-kit/netlify/entry.js');
 

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -42,7 +42,6 @@ export default function ({
 		name: '@sveltejs/adapter-node',
 
 		async adapt({ utils, config }) {
-			utils.update_ignores({ patterns: [out] });
 			utils.log.minor('Copying assets');
 			const static_directory = join(out, 'assets');
 			utils.copy_client_files(static_directory);

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -11,7 +11,6 @@ export default function ({ pages = 'build', assets = pages, fallback } = {}) {
 		name: '@sveltejs/adapter-static',
 
 		async adapt({ utils }) {
-			utils.update_ignores({ patterns: [pages, assets] });
 			utils.copy_static_files(assets);
 			utils.copy_client_files(assets);
 

--- a/packages/adapter-static/test/apps/prerendered/.gitignore
+++ b/packages/adapter-static/test/apps/prerendered/.gitignore
@@ -3,5 +3,3 @@ node_modules
 /.svelte-kit
 /build
 /functions
-
-build

--- a/packages/adapter-static/test/apps/spa/.gitignore
+++ b/packages/adapter-static/test/apps/spa/.gitignore
@@ -3,5 +3,3 @@ node_modules
 /.svelte-kit
 /build
 /functions
-
-build

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -19,8 +19,6 @@ export default function (options) {
 
 		async adapt({ utils }) {
 			const dir = '.vercel_build_output';
-
-			utils.update_ignores({ patterns: [dir] });
 			utils.rimraf(dir);
 
 			const files = fileURLToPath(new URL('./files', import.meta.url));

--- a/packages/kit/src/core/adapt/utils.js
+++ b/packages/kit/src/core/adapt/utils.js
@@ -1,7 +1,6 @@
 import { SVELTE_KIT } from '../constants.js';
 import { copy, rimraf, mkdirp } from '../filesystem/index.js';
 import { prerender } from './prerender.js';
-import fs from 'fs';
 
 /**
  * @param {{
@@ -43,25 +42,6 @@ export function get_utils({ cwd, config, build_data, log }) {
 					log
 				});
 			}
-		},
-
-		/** @param {{patterns: string[], log?: boolean}} options */
-		update_ignores({ patterns, log = true }) {
-			const target = '.gitignore';
-			if (!fs.existsSync(target)) return;
-
-			const file = fs.readFileSync(target, { encoding: 'utf-8' });
-			const eol = file.includes('\r\n') ? '\r\n' : '\n';
-			const lines = file.split(eol);
-			const new_lines = new Set(patterns);
-			// remove repeated lines
-			for (const line of lines) {
-				// this will prevent commented ignores to be reinserted
-				new_lines.delete(line.replace(/#\s*/, ''));
-			}
-			if (new_lines.size === 0) return;
-			fs.writeFileSync(target, [...lines, ...new_lines].join(eol));
-			if (log) this.log.success(`Updated ${target}`);
 		}
 	};
 }

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -11,8 +11,15 @@ export interface AdapterUtils {
 	copy_server_files: (dest: string) => void;
 	copy_static_files: (dest: string) => void;
 	copy: (from: string, to: string, filter?: (basename: string) => boolean) => void;
-	update_ignores: ({ patterns, log }: { patterns: string[]; log?: boolean }) => void;
-	prerender: (options: { all?: boolean; dest: string; fallback?: string }) => Promise<void>;
+	prerender: ({
+		all,
+		dest,
+		fallback
+	}: {
+		all?: boolean;
+		dest: string;
+		fallback?: string;
+	}) => Promise<void>;
 }
 
 export interface Adapter {


### PR DESCRIPTION
Apologies for missing this when #1924 was still open. It violates something I've learned the hard way to be a sacrosanct rule: a given file in a project should be edited by humans, or by machines, but never by both after the project has been created (`package.json` might seem like an obvious counter-example, but appending dependencies is something the package manager does as a direct consequence of your command; it doesn't get unexpected edits anywhere else). We really can't go around editing people's code, even in trivial-seeming ways in ignore files. 

Adding ignored directories _seems_ simple and uncontroversial enough to be a no-brainer. But even in #1924 _itself_ it introduced unwanted changes:

```diff
/.svelte-kit
/build
/functions

+build
```

Here, the `/build` line already excluded the `build` directory from version control. The inserted line is duplicative. Worse than that, it will cover any folder called `build` anywhere in your project, so if your app had a route whose name coincided with that fairly common English word, it would now be excluded as well. As someone who has lost work because of incorrectly-excluded folders in the past, I would be pretty irate if it happened again because my framework took it upon itself to 'fix' my ignore file. We could robustify it, but there'll always be some edge case. 

Beyond that, someone might actually want the build artifacts to be checked in. In fact I work on a team where that's the norm! (It's a practice I've railed against, but there _are_ reasons that it's done that way, and the fact that it's a thing that people do, however unconventional, outweighs any arguments about why they shouldn't.) While the documentation tells you that you can comment the line out, most people would simply delete the line, only for it to be reinserted. Fighting your tools is a bad feeling.

Here's what I think we should do instead:

* [ ] Where it makes sense, adapters should place their output inside `.svelte-kit` (i.e. `.svelte-kit/netlify`, etc) so that they are already ignored by ignore files
* [ ] Check ignore files to see if we're writing to locations that aren't already excluded, and print a loud warning if they're not. We're using `gitignore-parser` in create-svelte to do this robustly: https://github.com/sveltejs/kit/blob/3e30a1b7d3f47f1c37221e21be50819a06fe5ead/packages/create-svelte/scripts/build-templates.js#L49-L50

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
