### PR TITLE
simplify code in `adapter-node`

### DIFF
--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -73,7 +73,7 @@ export default function ({
 				target: 'node12',
 				inject: [join(files, 'shims.js')],
 				define: {
-					esbuild_app_dir: '"' + config.kit.appDir + '"'
+					APP_DIR: `"/${config.kit.appDir}/"`
 				}
 			};
 			const buildOptions = esbuildConfig ? await esbuildConfig(defaultOptions) : defaultOptions;

--- a/packages/adapter-node/src/server.js
+++ b/packages/adapter-node/src/server.js
@@ -16,25 +16,6 @@ const paths = {
 };
 
 export function createServer({ render }) {
-	const immutable_path = (pathname) => {
-		// eslint-disable-next-line no-undef
-		let app_dir = esbuild_app_dir;
-
-		// hard to tell when app_dir is mixed with static
-		if (app_dir === '/') {
-			return false;
-		}
-
-		if (app_dir.startsWith('/')) {
-			app_dir = app_dir.slice(1);
-		}
-		if (app_dir.endsWith('/')) {
-			app_dir = app_dir.slice(0, -1);
-		}
-
-		return pathname.startsWith(`/${app_dir}/`);
-	};
-
 	const prerendered_handler = fs.existsSync(paths.prerendered)
 		? sirv(paths.prerendered, {
 				etag: true,
@@ -47,7 +28,8 @@ export function createServer({ render }) {
 	const assets_handler = fs.existsSync(paths.assets)
 		? sirv(paths.assets, {
 				setHeaders: (res, pathname, stats) => {
-					if (immutable_path(pathname)) {
+					// eslint-disable-next-line no-undef
+					if (pathname.startsWith(APP_DIR)) {
 						res.setHeader('cache-control', 'public, max-age=31536000, immutable');
 					}
 				},


### PR DESCRIPTION
a lot of the code added in #1416 is now wholly unnecessary; `appDir` is already guaranteed to be a non-empty string that doesn't begin or end with `/`. no changeset because this is purely internal

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
