### PR TITLE
[chore] update Netlify build output locations

### DIFF
--- a/.changeset/many-pugs-work.md
+++ b/.changeset/many-pugs-work.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+update build output locations"

--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -32,11 +32,11 @@ Then, make sure you have a [netlify.toml](https://docs.netlify.com/configure-bui
 ```toml
 [build]
   command = "npm run build"
-  publish = "build/"
-  functions = "functions/"
+  publish = ".svelte-kit/netlify/build/"
+  functions = ".svelte-kit/netlify/functions/"
 ```
 
-It's recommended that you add the `build` and `functions` folders (or whichever other folders you specify) to your `.gitignore`.
+In this example, we placed the `build` and `functions` folders under `.svelte-kit/netlify`. If you specify another location, you will probably also want to add them to your `.gitignore`.
 
 ## Netlify alternatives to SvelteKit functionality
 

--- a/packages/adapter-netlify/files/entry.js
+++ b/packages/adapter-netlify/files/entry.js
@@ -1,5 +1,5 @@
 // TODO hardcoding the relative location makes this brittle
-import { init, render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
+import { init, render } from '../../output/server/app.js'; // eslint-disable-line import/no-unresolved
 import { isContentTypeTextual } from '@sveltejs/kit/adapter-utils'; // eslint-disable-line import/no-unresolved
 
 init();

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -29,11 +29,11 @@ export default function (options) {
 			utils.update_ignores({ patterns: [publish, functions] });
 
 			utils.log.minor('Generating serverless function...');
-			utils.copy(join(files, 'entry.js'), '.svelte-kit/netlify/entry.js');
+			utils.copy(join(files, 'entry.js'), '.svelte-kit/netlify/intermediate/entry.js');
 
 			/** @type {BuildOptions} */
 			const defaultOptions = {
-				entryPoints: ['.svelte-kit/netlify/entry.js'],
+				entryPoints: ['.svelte-kit/netlify/intermediate/entry.js'],
 				outfile: join(functions, 'render/index.js'),
 				bundle: true,
 				inject: [join(files, 'shims.js')],


### PR DESCRIPTION
This removes the need for calling `update_ignores`. I did not remove that call to avoid conflicting with https://github.com/sveltejs/kit/pull/2055

I only updated this one adapter for now to get a consensus on the pattern and because it's the one where I have an app setup and felt safe changing it since I have an app deployed there

CC @sw-yx since this affects Netlify