### PR TITLE
[docs] clarify that you must use `@next` version of adapter

### DIFF
--- a/documentation/docs/10-adapters.md
+++ b/documentation/docs/10-adapters.md
@@ -4,7 +4,7 @@ title: Adapters
 
 Before you can deploy your SvelteKit app, you need to _adapt_ it for your deployment target. Adapters are small plugins that take the built app as input and generate output for deployment. Many adapters are optimised for a specific hosting provider, and you can generally find information about deployment in your adapter's documentation. However, some adapters, like `adapter-static`, build output that can be hosted on numerous hosting providers, so it may also be helpful to reference the documentation of your hosting provider in these cases.
 
-For example, if you want to run your app as a simple Node server, you would use the `@sveltejs/adapter-node` package:
+For example, if you want to run your app as a simple Node server, you would use the `@sveltejs/adapter-node@next` package:
 
 ```js
 // svelte.config.js


### PR DESCRIPTION
the package name for node adapter appears to be wrong, `@sveltejs/adapter-node` returns an error during build. 

```
config.kit.adapter should be an object with an "adapt" method.
```

adapter repository suggests to use `@sveltejs/adapter-node@next`

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
