### PR TITLE
[chore] update build output location

### DIFF
--- a/.changeset/many-cups-report.md
+++ b/.changeset/many-cups-report.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-static': patch
+---
+
+[chore] update build output location

--- a/documentation/docs/10-adapters.md
+++ b/documentation/docs/10-adapters.md
@@ -17,7 +17,7 @@ export default {
 };
 ```
 
-With this, [svelte-kit build](#command-line-interface-svelte-kit-build) will generate a self-contained Node app inside `build`. You can pass options to adapters, such as customising the output directory in `adapter-node`:
+With this, [svelte-kit build](#command-line-interface-svelte-kit-build) will generate a self-contained Node app inside `.svelte-kit/node/build`. You can pass options to adapters, such as customising the output directory in `adapter-node`:
 
 ```diff
 // svelte.config.js

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -14,7 +14,7 @@ export default {
 	kit: {
 		adapter: adapter({
 			// default options are shown
-			out: 'build',
+			out: '.svelte-kit/node/build',
 			precompress: false,
 			env: {
 				host: 'HOST',
@@ -29,7 +29,7 @@ export default {
 
 ### out
 
-The directory to build the server to. It defaults to `build` — i.e. `node build` would start the server locally after it has been created.
+The directory to build the server to. It defaults to `.svelte-kit/node/build` — i.e. `node .svelte-kit/node/build` would start the server locally after it has been created.
 
 ### precompress
 

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -32,7 +32,7 @@ const pipe = promisify(pipeline);
  * }} options
  */
 export default function ({
-	out = 'build',
+	out = '.svelte-kit/node/build',
 	precompress,
 	env: { host: host_env = 'HOST', port: port_env = 'PORT' } = {},
 	esbuild: esbuildConfig
@@ -54,16 +54,16 @@ export default function ({
 
 			utils.log.minor('Building server');
 			const files = fileURLToPath(new URL('./files', import.meta.url));
-			utils.copy(files, '.svelte-kit/node');
+			utils.copy(files, '.svelte-kit/node/intermediate');
 			writeFileSync(
-				'.svelte-kit/node/env.js',
+				'.svelte-kit/node/intermediate/env.js',
 				`export const host = process.env[${JSON.stringify(
 					host_env
 				)}] || '0.0.0.0';\nexport const port = process.env[${JSON.stringify(port_env)}] || 3000;`
 			);
 			/** @type {BuildOptions} */
 			const defaultOptions = {
-				entryPoints: ['.svelte-kit/node/index.js'],
+				entryPoints: ['.svelte-kit/node/intermediate/index.js'],
 				outfile: join(out, 'index.js'),
 				bundle: true,
 				external: Object.keys(JSON.parse(readFileSync('package.json', 'utf8')).dependencies || {}),

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -14,8 +14,8 @@ export default {
 	kit: {
 		adapter: adapter({
 			// default options are shown
-			pages: 'build',
-			assets: 'build',
+			pages: '.svelte-kit/static/build',
+			assets: '.svelte-kit/static/build',
 			fallback: null
 		})
 	}
@@ -28,7 +28,7 @@ Unless you're in [SPA mode](#spa-mode), the adapter will attempt to prerender ev
 
 ### pages
 
-The directory to write prerendered pages to. It defaults to `build`.
+The directory to write prerendered pages to. It defaults to `.svelte-kit/static/build`.
 
 ### assets
 

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -5,7 +5,7 @@
  *   fallback?: string;
  * }} [opts]
  */
-export default function ({ pages = 'build', assets = pages, fallback } = {}) {
+export default function ({ pages = '.svelte-kit/static/build', assets = pages, fallback } = {}) {
 	/** @type {import('@sveltejs/kit').Adapter} */
 	const adapter = {
 		name: '@sveltejs/adapter-static',

--- a/packages/adapter-static/test/test.js
+++ b/packages/adapter-static/test/test.js
@@ -4,7 +4,7 @@ import { run } from './utils.js';
 
 run('prerendered', (test) => {
 	test('generates HTML files', ({ cwd }) => {
-		assert.ok(fs.existsSync(`${cwd}/build/index.html`));
+		assert.ok(fs.existsSync(`${cwd}/.svelte-kit/static/build/index.html`));
 	});
 
 	test('prerenders content', async ({ base, page }) => {
@@ -15,15 +15,15 @@ run('prerendered', (test) => {
 
 run('spa', (test) => {
 	test('generates a fallback page', ({ cwd }) => {
-		assert.ok(fs.existsSync(`${cwd}/build/200.html`));
+		assert.ok(fs.existsSync(`${cwd}/.svelte-kit/static/build/200.html`));
 	});
 
 	test('does not prerender pages without prerender=true', ({ cwd }) => {
-		assert.ok(!fs.existsSync(`${cwd}/build/index.html`));
+		assert.ok(!fs.existsSync(`${cwd}/.svelte-kit/static/build/index.html`));
 	});
 
 	test('prerenders page with prerender=true', ({ cwd }) => {
-		assert.ok(fs.existsSync(`${cwd}/build/about/index.html`));
+		assert.ok(fs.existsSync(`${cwd}/.svelte-kit/static/build/about/index.html`));
 	});
 
 	test('renders content in fallback page when JS runs', async ({ base, page }) => {

--- a/packages/adapter-static/test/utils.js
+++ b/packages/adapter-static/test/utils.js
@@ -31,7 +31,7 @@ export function run(app, callback) {
 			const cwd = fileURLToPath(new URL(`apps/${app}`, import.meta.url));
 			const cli_path = fileURLToPath(new URL('../../kit/src/cli.js', import.meta.url));
 
-			rimraf(`${cwd}/build`);
+			rimraf(`${cwd}/.svelte-kit/static/build`);
 
 			await spawn(`"${process.execPath}" ${cli_path} build`, {
 				cwd,
@@ -41,7 +41,7 @@ export function run(app, callback) {
 
 			context.cwd = cwd;
 			context.port = await ports.find(4000);
-			const handler = sirv(`${cwd}/build`, {
+			const handler = sirv(`${cwd}/.svelte-kit/static/build`, {
 				single: '200.html'
 			});
 			context.server = await create_server(context.port, handler);


### PR DESCRIPTION
Matching what we did for Netlify in https://github.com/sveltejs/kit/pull/2058

Cloudflare output already lived under `.svelte-kit`. Vercel output looks to live in a special directory I was too scared to touch