### PR TITLE
[breaking] standardize final output dir as /build (vs /.svelte-kit)

### DIFF
--- a/.changeset/funny-trainers-hammer.md
+++ b/.changeset/funny-trainers-hammer.md
@@ -1,0 +1,8 @@
+---
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-static': patch
+'create-svelte': patch
+---
+
+[breaking] standardize final output dir as /build (vs /.svelte-kit)

--- a/documentation/docs/10-adapters.md
+++ b/documentation/docs/10-adapters.md
@@ -17,7 +17,7 @@ export default {
 };
 ```
 
-With this, [svelte-kit build](#command-line-interface-svelte-kit-build) will generate a self-contained Node app inside `.svelte-kit/node/build`. You can pass options to adapters, such as customising the output directory in `adapter-node`:
+With this, [svelte-kit build](#command-line-interface-svelte-kit-build) will generate a self-contained Node app inside `build`. You can pass options to adapters, such as customising the output directory in `adapter-node`:
 
 ```diff
 // svelte.config.js

--- a/documentation/docs/80-adapter-api.md
+++ b/documentation/docs/80-adapter-api.md
@@ -34,6 +34,6 @@ Within the `adapt` method, there are a number of things that an adapter should d
 - Call `utils.prerender`
 - Put the user's static files and the generated JS/CSS in the correct location for the target platform
 
-If possible, we recommend putting the adapter output under `'.svelte-kit/' + adapterName` with any intermediate output under `'.svelte-kit/' + adapterName + '/intermediate'`.
+If possible, we recommend putting the adapter output under the `build/` directory with any intermediate output placed under `'.svelte-kit/' + adapterName`.
 
 > The adapter API may change before 1.0.

--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -32,11 +32,9 @@ Then, make sure you have a [netlify.toml](https://docs.netlify.com/configure-bui
 ```toml
 [build]
   command = "npm run build"
-  publish = ".svelte-kit/netlify/build/"
-  functions = ".svelte-kit/netlify/functions/"
+  publish = "build/publish/"
+  functions = "build/functions/"
 ```
-
-In this example, we placed the `build` and `functions` folders under `.svelte-kit/netlify`. If you specify another location, you will probably also want to add them to your `.gitignore`.
 
 ## Netlify alternatives to SvelteKit functionality
 

--- a/packages/adapter-netlify/files/entry.js
+++ b/packages/adapter-netlify/files/entry.js
@@ -1,5 +1,5 @@
 // TODO hardcoding the relative location makes this brittle
-import { init, render } from '../../output/server/app.js'; // eslint-disable-line import/no-unresolved
+import { init, render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
 import { isContentTypeTextual } from '@sveltejs/kit/adapter-utils'; // eslint-disable-line import/no-unresolved
 
 init();

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -27,11 +27,11 @@ export default function (options) {
 			const files = fileURLToPath(new URL('./files', import.meta.url));
 
 			utils.log.minor('Generating serverless function...');
-			utils.copy(join(files, 'entry.js'), '.svelte-kit/netlify/intermediate/entry.js');
+			utils.copy(join(files, 'entry.js'), '.svelte-kit/netlify/entry.js');
 
 			/** @type {BuildOptions} */
 			const defaultOptions = {
-				entryPoints: ['.svelte-kit/netlify/intermediate/entry.js'],
+				entryPoints: ['.svelte-kit/netlify/entry.js'],
 				outfile: join(functions, 'render/index.js'),
 				bundle: true,
 				inject: [join(files, 'shims.js')],

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -14,7 +14,7 @@ export default {
 	kit: {
 		adapter: adapter({
 			// default options are shown
-			out: '.svelte-kit/node/build',
+			out: 'build',
 			precompress: false,
 			env: {
 				host: 'HOST',
@@ -29,7 +29,7 @@ export default {
 
 ### out
 
-The directory to build the server to. It defaults to `.svelte-kit/node/build` — i.e. `node .svelte-kit/node/build` would start the server locally after it has been created.
+The directory to build the server to. It defaults to `build` — i.e. `node build` would start the server locally after it has been created.
 
 ### precompress
 

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -32,7 +32,7 @@ const pipe = promisify(pipeline);
  * }} options
  */
 export default function ({
-	out = '.svelte-kit/node/build',
+	out = 'build',
 	precompress,
 	env: { host: host_env = 'HOST', port: port_env = 'PORT' } = {},
 	esbuild: esbuildConfig
@@ -54,16 +54,16 @@ export default function ({
 
 			utils.log.minor('Building server');
 			const files = fileURLToPath(new URL('./files', import.meta.url));
-			utils.copy(files, '.svelte-kit/node/intermediate');
+			utils.copy(files, '.svelte-kit/node');
 			writeFileSync(
-				'.svelte-kit/node/intermediate/env.js',
+				'.svelte-kit/node/env.js',
 				`export const host = process.env[${JSON.stringify(
 					host_env
 				)}] || '0.0.0.0';\nexport const port = process.env[${JSON.stringify(port_env)}] || 3000;`
 			);
 			/** @type {BuildOptions} */
 			const defaultOptions = {
-				entryPoints: ['.svelte-kit/node/intermediate/index.js'],
+				entryPoints: ['.svelte-kit/node/index.js'],
 				outfile: join(out, 'index.js'),
 				bundle: true,
 				external: Object.keys(JSON.parse(readFileSync('package.json', 'utf8')).dependencies || {}),

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -11,7 +11,7 @@ export default [
 			sourcemap: true
 		},
 		plugins: [nodeResolve(), commonjs(), json()],
-		external: ['../../output/server/app.js', './env.js', ...require('module').builtinModules]
+		external: ['../output/server/app.js', './env.js', ...require('module').builtinModules]
 	},
 	{
 		input: 'src/shims.js',

--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -1,5 +1,5 @@
 // TODO hardcoding the relative location makes this brittle
-import { init, render } from '../../output/server/app.js'; // eslint-disable-line import/no-unresolved
+import { init, render } from '../output/server/app.js'; // eslint-disable-line import/no-unresolved
 import { host, port } from './env.js'; // eslint-disable-line import/no-unresolved
 import { createServer } from './server';
 

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -14,8 +14,8 @@ export default {
 	kit: {
 		adapter: adapter({
 			// default options are shown
-			pages: '.svelte-kit/static/build',
-			assets: '.svelte-kit/static/build',
+			pages: 'build',
+			assets: 'build',
 			fallback: null
 		})
 	}
@@ -28,7 +28,7 @@ Unless you're in [SPA mode](#spa-mode), the adapter will attempt to prerender ev
 
 ### pages
 
-The directory to write prerendered pages to. It defaults to `.svelte-kit/static/build`.
+The directory to write prerendered pages to. It defaults to `build`.
 
 ### assets
 

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -5,7 +5,7 @@
  *   fallback?: string;
  * }} [opts]
  */
-export default function ({ pages = '.svelte-kit/static/build', assets = pages, fallback } = {}) {
+export default function ({ pages = 'build', assets = pages, fallback } = {}) {
 	/** @type {import('@sveltejs/kit').Adapter} */
 	const adapter = {
 		name: '@sveltejs/adapter-static',

--- a/packages/adapter-static/test/test.js
+++ b/packages/adapter-static/test/test.js
@@ -4,7 +4,7 @@ import { run } from './utils.js';
 
 run('prerendered', (test) => {
 	test('generates HTML files', ({ cwd }) => {
-		assert.ok(fs.existsSync(`${cwd}/.svelte-kit/static/build/index.html`));
+		assert.ok(fs.existsSync(`${cwd}/build/index.html`));
 	});
 
 	test('prerenders content', async ({ base, page }) => {
@@ -15,15 +15,15 @@ run('prerendered', (test) => {
 
 run('spa', (test) => {
 	test('generates a fallback page', ({ cwd }) => {
-		assert.ok(fs.existsSync(`${cwd}/.svelte-kit/static/build/200.html`));
+		assert.ok(fs.existsSync(`${cwd}/build/200.html`));
 	});
 
 	test('does not prerender pages without prerender=true', ({ cwd }) => {
-		assert.ok(!fs.existsSync(`${cwd}/.svelte-kit/static/build/index.html`));
+		assert.ok(!fs.existsSync(`${cwd}/build/index.html`));
 	});
 
 	test('prerenders page with prerender=true', ({ cwd }) => {
-		assert.ok(fs.existsSync(`${cwd}/.svelte-kit/static/build/about/index.html`));
+		assert.ok(fs.existsSync(`${cwd}/build/about/index.html`));
 	});
 
 	test('renders content in fallback page when JS runs', async ({ base, page }) => {

--- a/packages/adapter-static/test/utils.js
+++ b/packages/adapter-static/test/utils.js
@@ -31,7 +31,7 @@ export function run(app, callback) {
 			const cwd = fileURLToPath(new URL(`apps/${app}`, import.meta.url));
 			const cli_path = fileURLToPath(new URL('../../kit/src/cli.js', import.meta.url));
 
-			rimraf(`${cwd}/.svelte-kit/static/build`);
+			rimraf(`${cwd}/build`);
 
 			await spawn(`"${process.execPath}" ${cli_path} build`, {
 				cwd,
@@ -41,7 +41,7 @@ export function run(app, callback) {
 
 			context.cwd = cwd;
 			context.port = await ports.find(4000);
-			const handler = sirv(`${cwd}/.svelte-kit/static/build`, {
+			const handler = sirv(`${cwd}/build`, {
 				single: '200.html'
 			});
 			context.server = await create_server(context.port, handler);

--- a/packages/create-svelte/templates/default/.gitignore
+++ b/packages/create-svelte/templates/default/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 node_modules
+/build
 /.svelte-kit
 /package

--- a/packages/create-svelte/templates/skeleton/.gitignore
+++ b/packages/create-svelte/templates/skeleton/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 node_modules
+/build
 /.svelte-kit
 /package


### PR DESCRIPTION
**Background**

We changed the output location to `.svelte-kit` yesterday because that directory was in the default `.gitignore` and we had gotten numerous requests that an adapter's output should be ignored without need to take user action. It turned out that standardizing under `.svelte-kit` has been an unpopular change. Instead we will add `build` to the default `.gitignore` alongside `.svelte-kit` and standardize on writing the final output there with intermediate output going to `.svelte-kit`

**Multi-cloud**

For the past 24 hours output has been written in a namespaced manner. The consensus on this seems to be that a more deeply nested output location is a worse experience for the majority of users. Adapters will now be standardized to writing in a non-namespaced manner. If users would like two build with two or more adapters, they can either clear out the `build` directory between builds or change the default output location using adapter options to set namespaced build directories

**Apologies**

We're very sorry for the churn this has caused. Changing the output location is a breaking change and breaking changes are a bad user experience, but two breaking changes in a row on the same feature is especially bad. We have added a new "breaking change" label on Github and made it hot pink to stand out. We will label breaking PRs with this in the future and leave them open for a longer comment period to gather more feedback. However, this PR will be merged quickly as we're aiming to get this PR in before too many people update their projects so that most people will be unaffected. For people that updated their projects in the past 24 hours, we're very sorry for the two breaking changes in a row. This will not change again. We've got only a couple dozen open issues left before 1.0 and at that point will be able to follow semver