### PR TITLE
[feat] use Netlify internal functions directory for generated functions

### DIFF
--- a/.changeset/brave-clouds-protect.md
+++ b/.changeset/brave-clouds-protect.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+Deploy generated Netlify entrypoint to the internal functions directory. This allows it to co-exist with other Netlify functions.

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ yarn.lock
 .svelte-kit
 .cloudflare
 .pnpm-debug.log
+.netlify

--- a/examples/hn.svelte.dev/.gitignore
+++ b/examples/hn.svelte.dev/.gitignore
@@ -2,5 +2,4 @@
 node_modules
 /.svelte
 /build
-/functions
 /.netlify/functions*

--- a/examples/hn.svelte.dev/.gitignore
+++ b/examples/hn.svelte.dev/.gitignore
@@ -3,3 +3,4 @@ node_modules
 /.svelte
 /build
 /functions
+/.netlify/functions*

--- a/examples/hn.svelte.dev/.netlify/netlify-plugin-pnpm/index.js
+++ b/examples/hn.svelte.dev/.netlify/netlify-plugin-pnpm/index.js
@@ -1,8 +1,9 @@
-export default {
+module.exports = {
   onPreBuild: async ({ utils: { build, run } }) => {
     try {
       await run.command("npm install -g pnpm")
-      await run.command("pnpm install")
+      await run.command("pnpm -w install")
+      await run.command("pnpm -w build")
     } catch (error) {
       return build.failBuild(error)
     }

--- a/examples/hn.svelte.dev/.netlify/netlify-plugin-pnpm/package.json
+++ b/examples/hn.svelte.dev/.netlify/netlify-plugin-pnpm/package.json
@@ -1,0 +1,1 @@
+{"type":"commonjs"}

--- a/examples/hn.svelte.dev/netlify.toml
+++ b/examples/hn.svelte.dev/netlify.toml
@@ -7,7 +7,3 @@
 
 [[plugins]]
   package = "/.netlify/netlify-plugin-pnpm"
-
-[dev]
-# Disable svelte-kit dev so we can test functions
-framework = "#static"

--- a/examples/hn.svelte.dev/netlify.toml
+++ b/examples/hn.svelte.dev/netlify.toml
@@ -1,10 +1,13 @@
 [build]
   command = "npm run build"
   publish = ".svelte-kit/netlify/build/"
-  functions = ".svelte-kit/netlify/functions/"
 
 [build.environment]
   NPM_FLAGS="--prefix=/dev/null"
 
 [[plugins]]
   package = "/.netlify/netlify-plugin-pnpm"
+
+[dev]
+# Disable svelte-kit dev so we can test functions
+framework = "#static"

--- a/examples/hn.svelte.dev/netlify.toml
+++ b/examples/hn.svelte.dev/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   command = "npm run build"
-  publish = ".svelte-kit/netlify/build/"
+  publish = "build"
 
 [build.environment]
   NPM_FLAGS="--prefix=/dev/null"

--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -27,13 +27,15 @@ export default {
 };
 ```
 
-Then, make sure you have a [netlify.toml](https://docs.netlify.com/configure-builds/file-based-configuration) file in the project root. This will determine where to write static assets and functions to based on the `build.publish` settings, as per this sample configuration:
+Then, make sure you have a [netlify.toml](https://docs.netlify.com/configure-builds/file-based-configuration) file in the project root. This will determine where to write static assets based on the `build.publish` settings, as per this sample configuration:
 
 ```toml
 [build]
   command = "npm run build"
-  publish = "build/publish/"
+  publish = "build"
 ```
+
+If the `netlify.toml` file or the `build.publish` value is missing, a default value of `"build"` will be used. Note that if you have set the publish directory in the Netlify UI to something else then you will need to set it in `netlify.toml` too, or use the default value of `"build"`.
 
 ## Netlify alternatives to SvelteKit functionality
 
@@ -51,6 +53,20 @@ During compilation a required "catch all" redirect rule is automatically appende
 1. Create your Netlify HTML form as described [here](https://docs.netlify.com/forms/setup/#html-forms), e.g. as `/routes/contact.svelte`. (Don't forget to add the hidden `form-name` input element!)
 2. Netlify's build bot parses your HTML files at deploy time, which means your form must be [prerendered](https://kit.svelte.dev/docs#ssr-and-javascript-prerender) as HTML. You can either add `export const prerender = true` to your `contact.svelte` to prerender just that page or set the `kit.prerender.force: true` option to prerender all pages.
 3. If your Netlify form has a [custom success message](https://docs.netlify.com/forms/setup/#success-messages) like `<form netlify ... action="/success">` then ensure the corresponding `/routes/success.svelte` exists and is prerendered.
+
+### Using Netlify Functions
+
+[Netlify Functions](https://docs.netlify.com/functions/overview/) can be used alongside your SvelteKit routes. If you would like to add them to your site, you should create a directory for them and add the configuration to your `netlify.toml` file. For example:
+
+```toml
+[build]
+  command = "npm run build"
+  publish = "build"
+
+[functions]
+  directory = "functions"
+  node_bundler = "esbuild"
+```
 
 ## Advanced Configuration
 
@@ -76,7 +92,8 @@ The default options for this version are as follows:
 ```js
 {
 	entryPoints: ['.svelte-kit/netlify/entry.js'],
-	outfile: `pathToFunctionsFolder/render/index.js`,
+	// This is Netlify's internal functions directory, not the one for user functions.
+	outfile: '.netlify/functions-internal/__render.js',
 	bundle: true,
 	inject: ['pathTo/shims.js'],
 	platform: 'node'

--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -27,16 +27,15 @@ export default {
 };
 ```
 
-Then, make sure you have a [netlify.toml](https://docs.netlify.com/configure-builds/file-based-configuration) file in the project root. This will determine where to write static assets and functions to based on the `build.publish` and `build.functions` settings, as per this sample configuration:
+Then, make sure you have a [netlify.toml](https://docs.netlify.com/configure-builds/file-based-configuration) file in the project root. This will determine where to write static assets and functions to based on the `build.publish` settings, as per this sample configuration:
 
 ```toml
 [build]
   command = "npm run build"
   publish = ".svelte-kit/netlify/build/"
-  functions = ".svelte-kit/netlify/functions/"
 ```
 
-In this example, we placed the `build` and `functions` folders under `.svelte-kit/netlify`. If you specify another location, you will probably also want to add them to your `.gitignore`.
+There should be no need to change the publish location, but if you specify another location, you will probably also want to add it to your `.gitignore`.
 
 ## Netlify alternatives to SvelteKit functionality
 

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -32,6 +32,7 @@ export default function (options) {
 			const defaultOptions = {
 				entryPoints: ['.svelte-kit/netlify/entry.js'],
 				// Any functions in ".netlify/functions-internal" are bundled in addition to user-defined Netlify functions.
+				// See https://github.com/netlify/build/pull/3213 for more details
 				outfile: '.netlify/functions-internal/__render.js',
 				bundle: true,
 				inject: [join(files, 'shims.js')],

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -95,7 +95,7 @@ function get_publish_directory(utils) {
 		}
 		if (resolve(netlify_config.build.publish) === process.cwd()) {
 			throw new Error(
-				'The publish directory cannot be set to the site root. Please change it to "build" in netlify.toml.'
+				'The publish directory cannot be set to the site root. Please change it to another value such as "build" in netlify.toml.'
 			);
 		}
 		return netlify_config.build.publish;

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -31,6 +31,7 @@ export default function (options) {
 			/** @type {BuildOptions} */
 			const defaultOptions = {
 				entryPoints: ['.svelte-kit/netlify/entry.js'],
+				// Any functions in ".netlify/functions-internal" are bundled in addition to user-defined Netlify functions.
 				outfile: '.netlify/functions-internal/__render.js',
 				bundle: true,
 				inject: [join(files, 'shims.js')],

--- a/packages/create-svelte/templates/default/netlify.toml
+++ b/packages/create-svelte/templates/default/netlify.toml
@@ -1,4 +1,3 @@
 [build]
   command = "npm run build"
-  publish = ".svelte-kit/netlify/build/"
-  functions = ".svelte-kit/netlify/functions/"
+  publish = "build"


### PR DESCRIPTION
## Description
This changes the location of generated Netlify render function to the internal functions directory (`.netlify/functions-internal`), rather than using the user functions directory. This means the user can use the normal functions directory for their own Netlify functions without them being deleted at build time.
Fixes #1249

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
