### PR TITLE
[fix] use 302 for dev redirects in hn.svelte.dev example (fixes #2118)

### DIFF
--- a/examples/hn.svelte.dev/src/routes/index.svelte
+++ b/examples/hn.svelte.dev/src/routes/index.svelte
@@ -1,5 +1,6 @@
 <script context="module">
+	import {dev} from '$app/env';
 	export function load() {
-		return { redirect: '/top/1', status: 301 };
+		return { redirect: '/top/1', status: dev ? 302 : 301 };
 	}
 </script>

--- a/examples/hn.svelte.dev/src/routes/rss.js
+++ b/examples/hn.svelte.dev/src/routes/rss.js
@@ -1,9 +1,10 @@
+import {dev} from '$app/env';
 /**
  * @type {import('@sveltejs/kit').RequestHandler}
  */
 export function get() {
 	return {
 		headers: { Location: '/top/rss' },
-		status: 301
+		status: dev ? 302 : 301
 	};
 }


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0


* no changeset as hn example is private. 
* I'm not sure how/if it is deployed to actual hn.svelte.dev, but as this change is only relevant for `npm run dev`  it won't affect its output.
* http://localhost:3000/rss redirects to http://localhost:3000/top/rss but that page results in a 500 error (trying to parse non-json as json), which is unrelated to this change