### PR TITLE
[fix] fallback should still be generated when prerender is disabled

### DIFF
--- a/.changeset/grumpy-onions-applaud.md
+++ b/.changeset/grumpy-onions-applaud.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+[fix] fallback should still be generated when prerender is disabled

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -225,7 +225,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 			});
 
 			if (is_html && config.kit.prerender.crawl) {
-				const cleaned = clean_html(/** @type {string} */(rendered.body));
+				const cleaned = clean_html(/** @type {string} */ (rendered.body));
 
 				let match;
 				const pattern = /<(a|img|link|source)\s+([\s\S]+?)>/gm;

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -264,16 +264,6 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 		}
 	}
 
-	for (const entry of config.kit.prerender.pages) {
-		if (entry === '*') {
-			for (const entry of build_data.entries) {
-				await visit(entry, null);
-			}
-		} else {
-			await visit(entry, null);
-		}
-	}
-
 	if (fallback) {
 		const rendered = await app.render(
 			{
@@ -295,5 +285,15 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 		const file = join(out, fallback);
 		mkdirp(dirname(file));
 		writeFileSync(file, rendered.body || '');
+	} else {
+		for (const entry of config.kit.prerender.pages) {
+			if (entry === '*') {
+				for (const entry of build_data.entries) {
+					await visit(entry, null);
+				}
+			} else {
+				await visit(entry, null);
+			}
+		}
 	}
 }

--- a/packages/kit/src/core/adapt/utils.js
+++ b/packages/kit/src/core/adapt/utils.js
@@ -31,17 +31,15 @@ export function get_utils({ cwd, config, build_data, log }) {
 		},
 
 		async prerender({ all = false, dest, fallback }) {
-			if (config.kit.prerender.enabled || fallback) {
-				await prerender({
-					out: dest,
-					all,
-					cwd,
-					config,
-					build_data,
-					fallback,
-					log
-				});
-			}
+			await prerender({
+				out: dest,
+				all,
+				cwd,
+				config,
+				build_data,
+				fallback,
+				log
+			});
 		}
 	};
 }

--- a/packages/kit/src/core/adapt/utils.js
+++ b/packages/kit/src/core/adapt/utils.js
@@ -31,7 +31,7 @@ export function get_utils({ cwd, config, build_data, log }) {
 		},
 
 		async prerender({ all = false, dest, fallback }) {
-			if (config.kit.prerender.enabled) {
+			if (config.kit.prerender.enabled || fallback) {
 				await prerender({
 					out: dest,
 					all,


### PR DESCRIPTION
## Fixes #1588 

The bug described in #1588 is about the adapter-static in SPA-mode (-> fallback set) not outputting the {fallback}.html file into the build directory when config.kit.prerender.enabled is set to ``false``.

This PR is an easy fix for this behavior, as config.kit.prerender.enabled can be ignored in the SPA mode. It bypasses the check for ``config.kit.prerender.enabled`` in the getter for the prerender function by modifying the expression to be true by default when a fallback is defined.

### You can see that this fixes the bug on the branch ``bug-demonstration`` on my fork of sveltejs/kit.

For this, 
1. clone the repo ``git clone https://github.com/Theo-Steiner/kit.git``
2. run ``checkout bug-demonstration``, ``pnpm i``, ``pnpm build``
3. navigate to `` cd examples/kit-bug`` 
4. execute ``pnpm build`` and do ``ls build`` and you will see that index.html was in fact created!

- [ ] Ideally, include a test that fails without this PR but passes with it.

I did not include a test, since I honestly don't know how I would test for this behavior. 

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
