### PR TITLE
[docs] highlight importance of context="module"

### DIFF
--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -62,7 +62,7 @@ Our example blog page might contain a `load` function like the following:
 	}
 </script>
 ```
-> Note the `<script context="module">` — this is necessary because `load` runs before the component is rendered. Your "regular" code should go into a second `<script>` tag.  
+> Note the `<script context="module">` — this is necessary because `load` runs before the component is rendered. Code that is per-component instance should go into a second `<script>` tag.  
 
 `load` is similar to `getStaticProps` or `getServerSideProps` in Next.js, except that it runs on both the server and the client.
 

--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -36,7 +36,7 @@ type LoadOutput<
 };
 ```
 
-Our example blog page might contain a `load` function like the following. Note the `context="module"` — this is necessary because `load` runs before the component is rendered:
+Our example blog page might contain a `load` function like the following:
 
 ```html
 <script context="module">
@@ -62,6 +62,7 @@ Our example blog page might contain a `load` function like the following. Note t
 	}
 </script>
 ```
+> Note the `<script context="module">` — this is necessary because `load` runs before the component is rendered. Your "regular" code should go into a second `<script>` tag.  
 
 `load` is similar to `getStaticProps` or `getServerSideProps` in Next.js, except that it runs on both the server and the client.
 


### PR DESCRIPTION
It took me 30 minutes to figure out why my load function was not called. I ended up downloading the SvelteKit template to sport any difference. The `context="module"` went completely unnoticed. It was not until directly copy and pasted the todos load function that I noticed two script tags. The `load` function being called in the `context="module"` script tag. 

In the proposed change I highlighted the importance of the `context="module"` script tag and mentioned that two script tags can (and should?) be created.


