### PR TITLE
Adapter-static documentation: Github pages

### DIFF
--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -67,18 +67,14 @@ When building for Github Pages, make sure to update the [basepaths](https://kit.
 
 Also note that you will have to prevent Github's provided Jekyll from managing your site by putting an empty `.nojekyll` file in your static folder. If you do not want to disable Jekyll, change the kit's `appdir` configuration option to `"app_"` or anything not starting by an underscore. For more information, see Github's documentation about [configuring jekyll](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#configuring-jekyll-in-your-github-pages-site).
 
-A valid configuration file for Github Pages:
+A config for Github Pages might look like:
 
 ```js
-import preprocess from 'svelte-preprocess';
-import adapter from '@sveltejs/adapter-static';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	preprocess: preprocess(),
+	...
 	kit: {
-		adapter: adapter(),
-		target: '#svelte',
+		...
 		// Since your Github Pages' default url will be https://your-username.github.io/your-repo-name,
 		// you'll have the change the basepaths.
 		// Note that you may have to comment these in dev mode.
@@ -89,10 +85,8 @@ const config = {
 		// If you are not using a .nojekyll file, change your appDir to something not starting with an underscore.
 		// For example, instead of "_app", use "app_", "internal", etc.
 		appDir: "internal",
-	},
+	}
 };
-
-export default config;
 ```
 
 ## Changelog

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -65,7 +65,7 @@ When operating in SPA mode, only pages that have the [`prerender`](https://kit.s
 
 When building for Github Pages, make sure to update the [basepaths](https://kit.svelte.dev/docs#configuration) (see `paths.base` and `paths.assets`).
 
-Also note that you will have to prevent github's provided jekyll to manage your site by putting an empty `.nojekyll` file in your static folder. If you do not want to disable jekyll, change the kit's `appdir` configuration option to `"app_"` or anything not starting by an underscore. For more information, see github's documentation about [configuring jekyll](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#configuring-jekyll-in-your-github-pages-site).
+Also note that you will have to prevent Github's provided Jekyll from managing your site by putting an empty `.nojekyll` file in your static folder. If you do not want to disable Jekyll, change the kit's `appdir` configuration option to `"app_"` or anything not starting by an underscore. For more information, see Github's documentation about [configuring jekyll](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#configuring-jekyll-in-your-github-pages-site).
 
 A valid configuration file for Github Pages:
 

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -61,13 +61,13 @@ export default {
 
 When operating in SPA mode, only pages that have the [`prerender`](https://kit.svelte.dev/docs#ssr-and-javascript-prerender) option set will be prerendered.
 
-## Github Pages
+## GitHub Pages
 
-When building for Github Pages, make sure to update the [basepaths](https://kit.svelte.dev/docs#configuration) (see `paths.base` and `paths.assets`).
+When building for GitHub Pages, make sure to update the [basepaths](https://kit.svelte.dev/docs#configuration) (see `paths.base` and `paths.assets`).
 
-Also note that you will have to prevent Github's provided Jekyll from managing your site by putting an empty `.nojekyll` file in your static folder. If you do not want to disable Jekyll, change the kit's `appdir` configuration option to `"app_"` or anything not starting by an underscore. For more information, see Github's documentation about [configuring jekyll](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#configuring-jekyll-in-your-github-pages-site).
+You will have to prevent GitHub's provided Jekyll from managing your site by putting an empty `.nojekyll` file in your static folder. If you do not want to disable Jekyll, change the kit's `appDir` configuration option to `"app_"` or anything not starting with an underscore. For more information, see GitHub's [Jekyll documentation](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#configuring-jekyll-in-your-github-pages-site).
 
-A config for Github Pages might look like:
+A config for GitHub Pages might look like the following:
 
 ```js
 /** @type {import('@sveltejs/kit').Config} */
@@ -75,16 +75,15 @@ const config = {
 	...
 	kit: {
 		...
-		// Since your Github Pages' default url will be https://your-username.github.io/your-repo-name,
-		// you'll have the change the basepaths.
+		// Since your GitHub Pages site will be served at https://your-username.github.io/your-repo-name,
+		// you will need to change the base paths
 		// Note that you may have to comment these in dev mode.
 		paths: {
 			base: '/your-repo-name',
-			assets: '/your-repo-name',
 		},
 		// If you are not using a .nojekyll file, change your appDir to something not starting with an underscore.
-		// For example, instead of "_app", use "app_", "internal", etc.
-		appDir: "internal",
+		// For example, instead of '_app', use 'app_', 'internal', etc.
+		appDir: 'internal',
 	}
 };
 ```

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -61,6 +61,40 @@ export default {
 
 When operating in SPA mode, only pages that have the [`prerender`](https://kit.svelte.dev/docs#ssr-and-javascript-prerender) option set will be prerendered.
 
+## Github Pages
+
+When building for Github Pages, make sure to update the [basepaths](https://kit.svelte.dev/docs#configuration) (see `paths.base` and `paths.assets`).
+
+Also note that you will have to prevent github's provided jekyll to manage your site by putting an empty `.nojekyll` file in your static folder. If you do not want to disable jekyll, change the kit's `appdir` configuration option to `"app_"` or anything not starting by an underscore. For more information, see github's documentation about [configuring jekyll](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#configuring-jekyll-in-your-github-pages-site).
+
+A valid configuration file for Github Pages:
+
+```js
+import preprocess from 'svelte-preprocess';
+import adapter from '@sveltejs/adapter-static';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	preprocess: preprocess(),
+	kit: {
+		adapter: adapter(),
+		target: '#svelte',
+		// Since your Github Pages' default url will be https://your-username.github.io/your-repo-name,
+		// you'll have the change the basepaths.
+		// Note that you may have to comment these in dev mode.
+		paths: {
+			base: '/your-repo-name',
+			assets: '/your-repo-name',
+		},
+		// If you are not using a .nojekyll file, change your appDir to something not starting with an underscore.
+		// For example, instead of "_app", use "app_", "internal", etc.
+		appDir: "internal",
+	},
+};
+
+export default config;
+```
+
 ## Changelog
 
 [The Changelog for this package is available on GitHub](https://github.com/sveltejs/kit/blob/master/packages/adapter-static/CHANGELOG.md).

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -63,9 +63,9 @@ When operating in SPA mode, only pages that have the [`prerender`](https://kit.s
 
 ## GitHub Pages
 
-When building for GitHub Pages, make sure to update the [basepaths](https://kit.svelte.dev/docs#configuration) (see `paths.base` and `paths.assets`).
+When building for GitHub Pages, make sure to update [`paths.base`](https://kit.svelte.dev/docs#configuration-paths) to match your repo name, since the site will be served from https://your-username.github.io/your-repo-name rather than from the root.
 
-You will have to prevent GitHub's provided Jekyll from managing your site by putting an empty `.nojekyll` file in your static folder. If you do not want to disable Jekyll, change the kit's `appDir` configuration option to `"app_"` or anything not starting with an underscore. For more information, see GitHub's [Jekyll documentation](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#configuring-jekyll-in-your-github-pages-site).
+You will have to prevent GitHub's provided Jekyll from managing your site by putting an empty `.nojekyll` file in your static folder. If you do not want to disable Jekyll, change the kit's `appDir` configuration option to `'app_'` or anything not starting with an underscore. For more information, see GitHub's [Jekyll documentation](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#configuring-jekyll-in-your-github-pages-site).
 
 A config for GitHub Pages might look like the following:
 
@@ -75,9 +75,6 @@ const config = {
 	...
 	kit: {
 		...
-		// Since your GitHub Pages site will be served at https://your-username.github.io/your-repo-name,
-		// you will need to change the base paths
-		// Note that you may have to comment these in dev mode.
 		paths: {
 			base: '/your-repo-name',
 		},


### PR DESCRIPTION
Add documentation for publishing to Github pages with adapter-static.
Would an `adapter-gh-pages` be possible?
