### PR TITLE
[fix] enable Vite pre-bundling except for Svelte packages

### DIFF
--- a/.changeset/cuddly-files-decide.md
+++ b/.changeset/cuddly-files-decide.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] enable Vite pre-bundling except for Svelte packages

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { rimraf } from '../filesystem/index.js';
 import create_manifest_data from '../../core/create_manifest_data/index.js';
-import { copy_assets, get_no_external, posixify, resolve_entry } from '../utils.js';
+import { copy_assets, get_svelte_packages, posixify, resolve_entry } from '../utils.js';
 import { deep_merge, print_config_conflicts } from '../config/index.js';
 import { create_app } from '../../core/create_app/index.js';
 import vite from 'vite';
@@ -33,6 +33,7 @@ export async function build(config, { cwd = process.cwd(), runtime = '@sveltejs/
 	rimraf(build_dir);
 
 	const output_dir = path.resolve(cwd, `${SVELTE_KIT}/output`);
+	const svelte_packages = get_svelte_packages(cwd);
 
 	const options = {
 		cwd,
@@ -49,7 +50,8 @@ export async function build(config, { cwd = process.cwd(), runtime = '@sveltejs/
 		}),
 		output_dir,
 		client_entry_file: `${SVELTE_KIT}/build/runtime/internal/start.js`,
-		service_worker_entry_file: resolve_entry(config.kit.files.serviceWorker)
+		service_worker_entry_file: resolve_entry(config.kit.files.serviceWorker),
+		svelte_packages
 	};
 
 	const client_manifest = await build_client(options);
@@ -132,7 +134,7 @@ async function build_client({
 	});
 
 	/** @type {any} */
-	const user_config = config.kit.vite();
+	const vite_config = config.kit.vite();
 
 	const default_config = {
 		server: {
@@ -143,10 +145,10 @@ async function build_client({
 	};
 
 	// don't warn on overriding defaults
-	const [modified_user_config] = deep_merge(default_config, user_config);
+	const [modified_vite_config] = deep_merge(default_config, vite_config);
 
 	/** @type {[any, string[]]} */
-	const [merged_config, conflicts] = deep_merge(modified_user_config, {
+	const [merged_config, conflicts] = deep_merge(modified_vite_config, {
 		configFile: false,
 		root: cwd,
 		base,
@@ -203,6 +205,7 @@ async function build_client({
  *   output_dir: string;
  *   client_entry_file: string;
  *   service_worker_entry_file: string | null;
+ *   svelte_packages: string[];
  * }} options
  * @param {ClientManifest} client_manifest
  * @param {string} runtime
@@ -216,7 +219,8 @@ async function build_server(
 		build_dir,
 		output_dir,
 		client_entry_file,
-		service_worker_entry_file
+		service_worker_entry_file,
+		svelte_packages
 	},
 	client_manifest,
 	runtime
@@ -419,8 +423,8 @@ async function build_server(
 			.trim()
 	);
 
-	/** @type {any} */
-	const user_config = config.kit.vite();
+	/** @type {import('vite').UserConfig} */
+	const vite_config = config.kit.vite();
 
 	const default_config = {
 		server: {
@@ -431,10 +435,10 @@ async function build_server(
 	};
 
 	// don't warn on overriding defaults
-	const [modified_user_config] = deep_merge(default_config, user_config);
+	const [modified_vite_config] = deep_merge(default_config, vite_config);
 
 	/** @type {[any, string[]]} */
-	const [merged_config, conflicts] = deep_merge(modified_user_config, {
+	const [merged_config, conflicts] = deep_merge(modified_vite_config, {
 		configFile: false,
 		root: cwd,
 		base,
@@ -457,11 +461,13 @@ async function build_server(
 				preserveEntrySignatures: 'strict'
 			}
 		},
-		resolve: {
-			alias: {
-				$app: path.resolve(`${build_dir}/runtime/app`),
-				$lib: config.kit.files.lib
-			}
+		optimizeDeps: {
+			// exclude Svelte packages because optimizer skips .svelte files leading to half-bundled
+			// broken packages https://github.com/vitejs/vite/issues/3910
+			exclude: [
+				...((vite_config.optimizeDeps && vite_config.optimizeDeps.exclude) || []),
+				...svelte_packages
+			]
 		},
 		plugins: [
 			svelte({
@@ -471,16 +477,17 @@ async function build_server(
 				}
 			})
 		],
-		// this API is marked as @alpha https://github.com/vitejs/vite/blob/27785f7fcc5b45987b5f0bf308137ddbdd9f79ea/packages/vite/src/node/config.ts#L129
-		// it's not exposed in the typescript definitions as a result
-		// so we need to ignore the fact that it's missing
+		resolve: {
+			alias: {
+				$app: path.resolve(`${build_dir}/runtime/app`),
+				$lib: config.kit.files.lib
+			}
+		},
 		ssr: {
 			// note to self: this _might_ need to be ['svelte', '@sveltejs/kit', ...get_no_external()]
 			// but I'm honestly not sure. roll with this for now and see if it's ok
-			noExternal: get_no_external(cwd, user_config.ssr && user_config.ssr.noExternal)
-		},
-		optimizeDeps: {
-			entries: []
+			// @ts-expect-error ssr is considered in alpha, so not yet exposed by Vite
+			noExternal: [...((vite_config.ssr && vite_config.ssr.noExternal) || []), ...svelte_packages]
 		}
 	});
 
@@ -499,11 +506,21 @@ async function build_server(
  *   output_dir: string;
  *   client_entry_file: string;
  *   service_worker_entry_file: string | null;
+ *   svelte_packages: string[];
  * }} options
  * @param {ClientManifest} client_manifest
  */
 async function build_service_worker(
-	{ cwd, base, config, manifest, build_dir, output_dir, service_worker_entry_file },
+	{
+		cwd,
+		base,
+		config,
+		manifest,
+		build_dir,
+		output_dir,
+		service_worker_entry_file,
+		svelte_packages
+	},
 	client_manifest
 ) {
 	// TODO add any assets referenced in template .html file, e.g. favicon?
@@ -540,7 +557,7 @@ async function build_service_worker(
 	);
 
 	/** @type {any} */
-	const user_config = config.kit.vite();
+	const vite_config = config.kit.vite();
 
 	const default_config = {
 		server: {
@@ -551,10 +568,10 @@ async function build_service_worker(
 	};
 
 	// don't warn on overriding defaults
-	const [modified_user_config] = deep_merge(default_config, user_config);
+	const [modified_vite_config] = deep_merge(default_config, vite_config);
 
 	/** @type {[any, string[]]} */
-	const [merged_config, conflicts] = deep_merge(modified_user_config, {
+	const [merged_config, conflicts] = deep_merge(modified_vite_config, {
 		configFile: false,
 		root: cwd,
 		base,
@@ -572,13 +589,18 @@ async function build_service_worker(
 			outDir: `${output_dir}/client`,
 			emptyOutDir: false
 		},
+		optimizeDeps: {
+			// exclude Svelte packages because optimizer skips .svelte files leading to half-bundled
+			// broken packages https://github.com/vitejs/vite/issues/3910
+			exclude: [
+				...((vite_config.optimizeDeps && vite_config.optimizeDeps.exclude) || []),
+				...svelte_packages
+			]
+		},
 		resolve: {
 			alias: {
 				'$service-worker': path.resolve(`${build_dir}/runtime/service-worker`)
 			}
-		},
-		optimizeDeps: {
-			entries: []
 		}
 	});
 

--- a/packages/kit/src/core/utils.js
+++ b/packages/kit/src/core/utils.js
@@ -82,7 +82,7 @@ export function posixify(str) {
  * @param {string} cwd
  * @returns {string[]}
  */
-function find_svelte_packages(cwd) {
+export function get_svelte_packages(cwd) {
 	const pkg_file = path.join(cwd, 'package.json');
 	if (!fs.existsSync(pkg_file)) return [];
 
@@ -97,12 +97,4 @@ function find_svelte_packages(cwd) {
 		const dep_pkg = JSON.parse(fs.readFileSync(dep_pkg_file, 'utf-8'));
 		return !!dep_pkg.svelte;
 	});
-}
-
-/**
- * @param {string} cwd
- * @param {string[]} [user_specified_deps]
- */
-export function get_no_external(cwd, user_specified_deps = []) {
-	return [...user_specified_deps, ...find_svelte_packages(cwd)];
 }

--- a/packages/kit/test/apps/basics/src/routes/load/change-detection/__layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/change-detection/__layout.svelte
@@ -1,18 +1,18 @@
 <script context="module">
-	let loads = 0;
+	let count = 0;
 
 	/** @type {import('@sveltejs/kit').Load} */
 	export async function load({ fetch }) {
 		const res = await fetch('/load/change-detection/data.json');
 		const { type } = await res.json();
 
-		loads += 1;
+		count += 1;
 
 		return {
 			maxage: 5,
 			props: {
 				type,
-				loads
+				loads: count
 			}
 		};
 	}

--- a/packages/kit/test/apps/basics/src/routes/load/change-detection/one/[x].svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/change-detection/one/[x].svelte
@@ -1,15 +1,15 @@
 <script context="module">
-	let loads = 0;
+	let count = 0;
 
 	/** @type {import('@sveltejs/kit').Load} */
 	export async function load({ page }) {
-		loads += 1;
+		count += 1;
 
 		return {
 			maxage: 5,
 			props: {
 				x: page.params.x,
-				loads
+				loads: count
 			}
 		};
 	}

--- a/packages/kit/test/apps/basics/src/routes/load/change-detection/two/[y].svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/change-detection/two/[y].svelte
@@ -1,15 +1,15 @@
 <script context="module">
-	let loads = 0;
+	let count = 0;
 
 	/** @type {import('@sveltejs/kit').Load} */
 	export async function load({ page }) {
-		loads += 1;
+		count += 1;
 
 		return {
 			maxage: 5,
 			props: {
 				y: page.params.y,
-				loads
+				loads: count
 			}
 		};
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,7 +188,7 @@ importers:
       '@sveltejs/adapter-cloudflare-workers': link:../../../adapter-cloudflare-workers
       '@sveltejs/adapter-netlify': link:../../../adapter-netlify
       '@sveltejs/adapter-vercel': link:../../../adapter-vercel
-      '@sveltejs/kit': link:../../../kit
+      '@sveltejs/kit': 1.0.0-next.144_svelte@3.40.0
       svelte: 3.40.0
       svelte-preprocess: 4.7.3_svelte@3.40.0+typescript@4.3.5
       typescript: 4.3.5
@@ -665,7 +665,23 @@ packages:
     dependencies:
       estree-walker: 2.0.2
       picomatch: 2.2.3
-    dev: false
+
+  /@sveltejs/kit/1.0.0-next.144_svelte@3.40.0:
+    resolution: {integrity: sha512-c+UX7Xp3PUzkGvXgkXAJpM8+zbouTMukhWIIqehUUFMXJlRlbRiO1YkiZRWFqbb7aV80d8klCWGprFXQVcwlbw==}
+    engines: {node: ^12.20 || >=14.13}
+    hasBin: true
+    peerDependencies:
+      svelte: ^3.34.0
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 1.0.0-next.14_svelte@3.40.0+vite@2.4.3
+      cheap-watch: 1.0.3
+      sade: 1.7.4
+      svelte: 3.40.0
+      vite: 2.4.3
+    transitivePeerDependencies:
+      - diff-match-patch
+      - supports-color
+    dev: true
 
   /@sveltejs/vite-plugin-svelte/1.0.0-next.14_svelte@3.40.0+vite@2.4.3:
     resolution: {integrity: sha512-46IKPtoGcdo6YLyUhvsXyC1Dg3m2HlbgreZqxM/h5DzavgUa75c/WHT5cIxxLppG+gxtct7V08/WNEdpFdmM3Q==}
@@ -688,7 +704,6 @@ packages:
       vite: 2.4.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@types/amphtml-validator/1.0.1:
     resolution: {integrity: sha512-DWE7fy6KtC+Uw0KV/HAmjuH2GB/o8yskXlvmVWR7mOVsLDybp+XrwkzEeRFU9wGjWKeRMBNGsx+5DRq7sUsAwA==}
@@ -1221,7 +1236,6 @@ packages:
   /cheap-watch/1.0.3:
     resolution: {integrity: sha512-xC5CruMhLzjPwJ5ecUxGu1uGmwJQykUhqd2QrCrYbwvsFYdRyviu6jG9+pccwDXJR/OpmOTOJ9yLFunVgQu9wg==}
     engines: {node: '>=8'}
-    dev: false
 
   /chokidar/3.5.1:
     resolution: {integrity: sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==}
@@ -1291,7 +1305,6 @@ packages:
 
   /colorette/1.2.2:
     resolution: {integrity: sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==}
-    dev: false
 
   /colors/1.4.0:
     resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
@@ -1566,7 +1579,6 @@ packages:
     resolution: {integrity: sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==}
     hasBin: true
     requiresBuild: true
-    dev: false
 
   /esbuild/0.12.5:
     resolution: {integrity: sha512-vcuP53pA5XiwUU4FnlXM+2PnVjTfHGthM7uP1gtp+9yfheGvFFbq/KyuESThmtoHPUrfZH5JpxGVJIFDVD1Egw==}
@@ -2654,7 +2666,6 @@ packages:
     resolution: {integrity: sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: false
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
@@ -3015,7 +3026,6 @@ packages:
       colorette: 1.2.2
       nanoid: 3.1.23
       source-map-js: 0.6.2
-    dev: false
 
   /preferred-pm/3.0.3:
     resolution: {integrity: sha512-+wZgbxNES/KlJs9q40F/1sfOd/j7f1O9JaHcW5Dsn3aUUOZg3L2bjpVUcKV2jvtElYfoTuQiNeMfQJ4kwUAhCQ==}
@@ -3201,7 +3211,6 @@ packages:
 
   /require-relative/0.8.7:
     resolution: {integrity: sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=}
-    dev: false
 
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3242,7 +3251,6 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
-    dev: false
 
   /rollup/2.55.0:
     resolution: {integrity: sha512-Atc3QqelKzrKwRkqnSdq0d2Mi8e0iGuL+kZebKMZ4ysyWHD5hw9VfVCAuODIW5837RENV8LXcbAEHurYf+ArvA==}
@@ -3370,7 +3378,6 @@ packages:
   /source-map-js/0.6.2:
     resolution: {integrity: sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /source-map/0.7.3:
     resolution: {integrity: sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==}
@@ -3555,7 +3562,6 @@ packages:
       svelte: '>=3.19.0'
     dependencies:
       svelte: 3.40.0
-    dev: false
 
   /svelte-preprocess/4.7.3_svelte@3.40.0+typescript@4.2.4:
     resolution: {integrity: sha512-Zx1/xLeGOIBlZMGPRCaXtlMe4ZA0faato5Dc3CosEqwu75MIEPuOstdkH6cy+RYTUYynoxzNaDxkPX4DbrPwRA==}
@@ -3924,7 +3930,6 @@ packages:
       rollup: 2.52.7
     optionalDependencies:
       fsevents: 2.3.2
-    dev: false
 
   /wcwidth/1.0.1:
     resolution: {integrity: sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=}


### PR DESCRIPTION
This is part of why you can't use any Svelte packages with CJS dependencies (https://github.com/vitejs/vite/issues/3024), which is probably the top issue we encounter using Vite.

We need to exclude Svelte packages due to https://github.com/vitejs/vite/issues/3910. Pnpm users may need to either (1) set pnpm shamefully-hoist=true or (2) install that dependency in package.json so we can import it.

This PR alone doesn't actually fix much due to https://github.com/vitejs/vite/issues/3910. However, it does allow me to make more progress in working on Vite issues because it allows me to use the `kit.vite.optimizeDeps` options. When `optimizeDeps` is set to `[]` then none of the other options work and there's no way to unset that from the config. Since it shouldn't actually be set anyway, let's go ahead and remove it