### PR TITLE
[chore] Add PRs to changelog

### DIFF
--- a/.changeset/smart-papayas-look.md
+++ b/.changeset/smart-papayas-look.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-[fix] solve regression parsing unicode URLs"
+[fix] solve regression parsing unicode URLs

--- a/packages/adapter-begin/CHANGELOG.md
+++ b/packages/adapter-begin/CHANGELOG.md
@@ -4,15 +4,15 @@
 
 ### Patch Changes
 
-- edc307d: Remove peerDependencies due to pnpm bug
-- 2636e68: Attempt to fix peerDependencies specification
+- edc307d: Remove peerDependencies due to pnpm bug (#1621)
+- 2636e68: Attempt to fix peerDependencies specification (#1620)
 
 ## 1.0.0-next.10
 
 ### Patch Changes
 
-- bf77940: bump `polka` and `sirv` dependency versions
-- 028abd9: Pass validated svelte config to adapter adapt function
+- bf77940: bump `polka` and `sirv` dependency versions (#1548)
+- 028abd9: Pass validated svelte config to adapter adapt function (#1559)
 - Updated dependencies [6372690]
 - Updated dependencies [c3d36a3]
 - Updated dependencies [bf77940]
@@ -24,8 +24,8 @@
 
 ### Patch Changes
 
-- 1ba1784: Prevent adapter from splitting query params if they contain commas
-- dca4946: Make kit a peerDependency of the adapters
+- 1ba1784: Prevent adapter from splitting query params if they contain commas (#1467)
+- dca4946: Make kit a peerDependency of the adapters (#1505)
 - Updated dependencies [261ee1c]
 - Updated dependencies [ec156c6]
 - Updated dependencies [586785d]
@@ -35,43 +35,43 @@
 
 ### Patch Changes
 
-- dad93fc: Fix workspace dependencies
+- dad93fc: Fix workspace dependencies (#1434)
 
 ## 1.0.0-next.7
 
 ### Patch Changes
 
-- c6fde99: Convert to ESM
+- c6fde99: Convert to ESM (#1323)
 
 ## 1.0.0-next.6
 
 ### Patch Changes
 
-- 2e72a94: Add type declarations
+- 2e72a94: Add type declarations (#1230)
 
 ## 1.0.0-next.5
 
 ### Patch Changes
 
-- 8024178: remove @sveltejs/app-utils
+- 8024178: remove @sveltejs/app-utils (#600)
 
 ## 1.0.0-next.4
 
 ### Patch Changes
 
-- 8805c6d: Pass adapters directly to svelte.config.cjs
+- 8805c6d: Pass adapters directly to svelte.config.cjs (#579)
 
 ## 1.0.0-next.3
 
 ### Patch Changes
 
-- f35a5cd: Change adapter signature
+- f35a5cd: Change adapter signature (#505)
 
 ## 1.0.0-next.2
 
 ### Patch Changes
 
-- c3cf3f3: Bump deps
+- c3cf3f3: Bump deps (#492)
 - Updated dependencies [c3cf3f3]
   - @sveltejs/app-utils@1.0.0-next.3
 

--- a/packages/adapter-cloudflare-workers/CHANGELOG.md
+++ b/packages/adapter-cloudflare-workers/CHANGELOG.md
@@ -10,50 +10,50 @@
 
 ### Patch Changes
 
-- e9f78999: fix: include esbuild config in adapter type definition
+- e9f78999: fix: include esbuild config in adapter type definition (#1954)
 
 ## 1.0.0-next.16
 
 ### Patch Changes
 
-- e6995797: feat(adapters): expose esbuild configuration
+- e6995797: feat(adapters): expose esbuild configuration (#1914)
 
 ## 1.0.0-next.15
 
 ### Patch Changes
 
-- 4720b67: Default body parsing to binary
+- 4720b67: Default body parsing to binary (#1890)
 
 ## 1.0.0-next.14
 
 ### Patch Changes
 
-- 7faf52f: Update and consolidate checks for binary body types
+- 7faf52f: Update and consolidate checks for binary body types (#1687)
 
 ## 1.0.0-next.13
 
 ### Patch Changes
 
-- 9f0c54a: Externalize app initialization to adapters
+- 9f0c54a: Externalize app initialization to adapters (#1804)
 
 ## 1.0.0-next.12
 
 ### Patch Changes
 
-- c51ab7d: Upgrade esbuild to ^0.12.5
+- c51ab7d: Upgrade esbuild to ^0.12.5 (#1627)
 
 ## 1.0.0-next.11
 
 ### Patch Changes
 
-- edc307d: Remove peerDependencies due to pnpm bug
-- 2636e68: Attempt to fix peerDependencies specification
+- edc307d: Remove peerDependencies due to pnpm bug (#1621)
+- 2636e68: Attempt to fix peerDependencies specification (#1620)
 
 ## 1.0.0-next.10
 
 ### Patch Changes
 
-- 028abd9: Pass validated svelte config to adapter adapt function
+- 028abd9: Pass validated svelte config to adapter adapt function (#1559)
 - Updated dependencies [6372690]
 - Updated dependencies [c3d36a3]
 - Updated dependencies [bf77940]
@@ -65,8 +65,8 @@
 
 ### Patch Changes
 
-- 71e293d: change toml parser to support dotted keys and other language features added after the TOML v0.4.0 spec
-- dca4946: Make kit a peerDependency of the adapters
+- 71e293d: change toml parser to support dotted keys and other language features added after the TOML v0.4.0 spec (#1509)
+- dca4946: Make kit a peerDependency of the adapters (#1505)
 - Updated dependencies [261ee1c]
 - Updated dependencies [ec156c6]
 - Updated dependencies [586785d]
@@ -76,52 +76,52 @@
 
 ### Patch Changes
 
-- dad93fc: Fix workspace dependencies
+- dad93fc: Fix workspace dependencies (#1434)
 
 ## 1.0.0-next.7
 
 ### Patch Changes
 
-- 11e7840: Ensure rawBody is a string or Uint8Array
+- 11e7840: Ensure rawBody is a string or Uint8Array (#1382)
 
 ## 0.0.2-next.6
 
 ### Patch Changes
 
-- c6fde99: Convert to ESM
+- c6fde99: Convert to ESM (#1323)
 
 ## 0.0.2-next.5
 
 ### Patch Changes
 
-- 9e67505: Add es2020 target to esbuild function to solve Unexpected character '#' error
+- 9e67505: Add es2020 target to esbuild function to solve Unexpected character '#' error (#1287)
 
 ## 0.0.2-next.4
 
 ### Patch Changes
 
-- 2e72a94: Add type declarations
+- 2e72a94: Add type declarations (#1230)
 
 ## 0.0.2-next.3
 
 ### Patch Changes
 
-- b372d61: Generate required package.json
+- b372d61: Generate required package.json (#1116)
 
 ## 0.0.2-next.2
 
 ### Patch Changes
 
-- 1237eb3: Pass rawBody to SvelteKit, bundle worker with esbuild
+- 1237eb3: Pass rawBody to SvelteKit, bundle worker with esbuild (#1109)
 
 ## 0.0.2-next.1
 
 ### Patch Changes
 
-- 4325b39: Aligns request/response API of cloudflare-workers adapter with others
+- 4325b39: Aligns request/response API of cloudflare-workers adapter with others (#946)
 
 ## 0.0.2-next.0
 
 ### Patch Changes
 
-- e890031: Fix dev/prod deps (oops)
+- e890031: Fix dev/prod deps (oops) (#749)

--- a/packages/adapter-netlify/CHANGELOG.md
+++ b/packages/adapter-netlify/CHANGELOG.md
@@ -4,82 +4,82 @@
 
 ### Patch Changes
 
-- 94b34fa6: [breaking] standardize final output dir as /build (vs /.svelte-kit)
+- 94b34fa6: [breaking] standardize final output dir as /build (vs /.svelte-kit) (#2109)
 
 ## 1.0.0-next.26
 
 ### Patch Changes
 
-- 4cb4e749: update build output locations
+- 4cb4e749: update build output locations (#2058)
 - d81de603: revert adapters automatically updating .gitignore (#1924)
 
 ## 1.0.0-next.25
 
 ### Patch Changes
 
-- e9f78999: fix: include esbuild config in adapter type definition
+- e9f78999: fix: include esbuild config in adapter type definition (#1954)
 
 ## 1.0.0-next.24
 
 ### Patch Changes
 
-- e6995797: feat(adapters): expose esbuild configuration
+- e6995797: feat(adapters): expose esbuild configuration (#1914)
 
 ## 1.0.0-next.23
 
 ### Patch Changes
 
-- 67ca3a39: return the correct headers
+- 67ca3a39: return the correct headers (#1913)
 
 ## 1.0.0-next.22
 
 ### Patch Changes
 
-- 9461178: Use multivalue headers to set multiple cookies
+- 9461178: Use multivalue headers to set multiple cookies (#1906)
 
 ## 1.0.0-next.21
 
 ### Patch Changes
 
-- 4720b67: Default body parsing to binary
+- 4720b67: Default body parsing to binary (#1890)
 
 ## 1.0.0-next.20
 
 ### Patch Changes
 
-- 7faf52f: Update and consolidate checks for binary body types
+- 7faf52f: Update and consolidate checks for binary body types (#1687)
 
 ## 1.0.0-next.19
 
 ### Patch Changes
 
-- 2ac5781: Use esbuild inject API to insert shims
+- 2ac5781: Use esbuild inject API to insert shims (#1822)
 
 ## 1.0.0-next.18
 
 ### Patch Changes
 
-- 9f0c54a: Externalize app initialization to adapters
+- 9f0c54a: Externalize app initialization to adapters (#1804)
 
 ## 1.0.0-next.17
 
 ### Patch Changes
 
-- c51ab7d: Upgrade esbuild to ^0.12.5
+- c51ab7d: Upgrade esbuild to ^0.12.5 (#1627)
 
 ## 1.0.0-next.16
 
 ### Patch Changes
 
-- edc307d: Remove peerDependencies due to pnpm bug
-- 2636e68: Attempt to fix peerDependencies specification
-- 3b988a4: Allow `_redirects` to be placed in root directory
+- edc307d: Remove peerDependencies due to pnpm bug (#1621)
+- 2636e68: Attempt to fix peerDependencies specification (#1620)
+- 3b988a4: Allow `_redirects` to be placed in root directory (#1586)
 
 ## 1.0.0-next.15
 
 ### Patch Changes
 
-- 028abd9: Pass validated svelte config to adapter adapt function
+- 028abd9: Pass validated svelte config to adapter adapt function (#1559)
 - Updated dependencies [6372690]
 - Updated dependencies [c3d36a3]
 - Updated dependencies [bf77940]
@@ -92,9 +92,9 @@
 ### Patch Changes
 
 - f59530f: Allow custom redirects for Netlify Adapter
-- 71e293d: change toml parser to support dotted keys and other language features added after the TOML v0.4.0 spec
-- 1ba1784: Prevent adapter from splitting query params if they contain commas
-- dca4946: Make kit a peerDependency of the adapters
+- 71e293d: change toml parser to support dotted keys and other language features added after the TOML v0.4.0 spec (#1509)
+- 1ba1784: Prevent adapter from splitting query params if they contain commas (#1467)
+- dca4946: Make kit a peerDependency of the adapters (#1505)
 - Updated dependencies [261ee1c]
 - Updated dependencies [ec156c6]
 - Updated dependencies [586785d]
@@ -104,7 +104,7 @@
 
 ### Patch Changes
 
-- dad93fc: Fix workspace dependencies
+- dad93fc: Fix workspace dependencies (#1434)
 - Updated dependencies [dad93fc]
 - Updated dependencies [37fc04f]
   - @sveltejs/kit@1.0.0-next.108
@@ -113,7 +113,7 @@
 
 ### Patch Changes
 
-- 11e7840: Ensure rawBody is a string or Uint8Array
+- 11e7840: Ensure rawBody is a string or Uint8Array (#1382)
 - Updated dependencies [11e7840]
 - Updated dependencies [11e7840]
 - Updated dependencies [9e20873]
@@ -124,7 +124,7 @@
 
 ### Patch Changes
 
-- c6fde99: Convert to ESM
+- c6fde99: Convert to ESM (#1323)
 - Updated dependencies [694f5de]
 - Updated dependencies [0befffb]
 - Updated dependencies [c6fde99]
@@ -134,7 +134,7 @@
 
 ### Patch Changes
 
-- 2e72a94: Add type declarations
+- 2e72a94: Add type declarations (#1230)
 - Updated dependencies [82955ec]
   - @sveltejs/kit@1.0.0-next.91
 
@@ -142,7 +142,7 @@
 
 ### Patch Changes
 
-- d3cb858: Convert body to string, unless type is octet-stream
+- d3cb858: Convert body to string, unless type is octet-stream (#1121)
 - Updated dependencies [4af45e1]
   - @sveltejs/kit@1.0.0-next.82
 
@@ -150,8 +150,8 @@
 
 ### Patch Changes
 
-- 1237eb3: Fix dependencies
-- 1237eb3: Pass rawBody from netlify adapter
+- 1237eb3: Fix dependencies (#1109)
+- 1237eb3: Pass rawBody from netlify adapter (#1109)
 - Updated dependencies [1237eb3]
 - Updated dependencies [1237eb3]
   - @sveltejs/kit@1.0.0-next.81
@@ -160,37 +160,37 @@
 
 ### Patch Changes
 
-- 0db2cf7: Fix serverless function
+- 0db2cf7: Fix serverless function (#1102)
 
 ## 1.0.0-next.6
 
 ### Patch Changes
 
-- 7a4b351: Bundle serverless functions with esbuild
+- 7a4b351: Bundle serverless functions with esbuild (#1091)
 
 ## 1.0.0-next.5
 
 ### Patch Changes
 
-- 6e27880: Move server-side fetch to adapters instead of build step
+- 6e27880: Move server-side fetch to adapters instead of build step (#1066)
 
 ## 1.0.0-next.4
 
 ### Patch Changes
 
-- 8805c6d: Pass adapters directly to svelte.config.cjs
+- 8805c6d: Pass adapters directly to svelte.config.cjs (#579)
 
 ## 1.0.0-next.3
 
 ### Patch Changes
 
-- f35a5cd: Change adapter signature
+- f35a5cd: Change adapter signature (#505)
 
 ## 1.0.0-next.2
 
 ### Patch Changes
 
-- 512b8c9: adapter-netlify: Use CJS entrypoint
+- 512b8c9: adapter-netlify: Use CJS entrypoint (#485)
 
 ## 1.0.0-next.1
 
@@ -208,7 +208,7 @@
 
 ### Patch Changes
 
-- b475ed4: Overhaul adapter API - fixes #166
+- b475ed4: Overhaul adapter API - fixes #166 (#180)
 
 ## 0.0.11
 

--- a/packages/adapter-node/CHANGELOG.md
+++ b/packages/adapter-node/CHANGELOG.md
@@ -4,19 +4,19 @@
 
 ### Patch Changes
 
-- 94b34fa6: [breaking] standardize final output dir as /build (vs /.svelte-kit)
+- 94b34fa6: [breaking] standardize final output dir as /build (vs /.svelte-kit) (#2109)
 
 ## 1.0.0-next.38
 
 ### Patch Changes
 
-- a12beb04: [fix] update broken file path
+- a12beb04: [fix] update broken file path (#2096)
 
 ## 1.0.0-next.37
 
 ### Patch Changes
 
-- b3e7c8b3: [chore] update build output location
+- b3e7c8b3: [chore] update build output location (#2082)
 
 ## 1.0.0-next.36
 
@@ -28,85 +28,85 @@
 
 ### Patch Changes
 
-- e9f78999: fix: include esbuild config in adapter type definition
+- e9f78999: fix: include esbuild config in adapter type definition (#1954)
 
 ## 1.0.0-next.34
 
 ### Patch Changes
 
-- e6995797: feat(adapters): expose esbuild configuration
+- e6995797: feat(adapters): expose esbuild configuration (#1914)
 
 ## 1.0.0-next.33
 
 ### Patch Changes
 
-- 463199c: Handle Uint8Array bodies from endpoints
-- 0db0889: log both host and port
+- 463199c: Handle Uint8Array bodies from endpoints (#1875)
+- 0db0889: log both host and port (#1877)
 
 ## 1.0.0-next.32
 
 ### Patch Changes
 
-- 2ac5781: Use esbuild inject API to insert shims
+- 2ac5781: Use esbuild inject API to insert shims (#1822)
 
 ## 1.0.0-next.31
 
 ### Patch Changes
 
-- c639586: Check if '[out]/prerendered' exists, before precompressing
+- c639586: Check if '[out]/prerendered' exists, before precompressing (#1806)
 
 ## 1.0.0-next.30
 
 ### Patch Changes
 
-- 9f0c54a: Externalize app initialization to adapters
+- 9f0c54a: Externalize app initialization to adapters (#1804)
 
 ## 1.0.0-next.29
 
 ### Patch Changes
 
-- aa5cf15: Fix regression caused by writing `env.js` to the wrong path
+- aa5cf15: Fix regression caused by writing `env.js` to the wrong path (#1756)
 
 ## 1.0.0-next.28
 
 ### Patch Changes
 
-- 1c8bdba: Allow the environment variables containing the host and port to serve on to be customised
+- 1c8bdba: Allow the environment variables containing the host and port to serve on to be customised (#1754)
 
 ## 1.0.0-next.27
 
 ### Patch Changes
 
-- 926481f: precompress assets and prerendered pages (html,js,json,css,svg,xml)
-- 318cdd7: Only cache files in config.kit.appDir
+- 926481f: precompress assets and prerendered pages (html,js,json,css,svg,xml) (#1693)
+- 318cdd7: Only cache files in config.kit.appDir (#1416)
 
 ## 1.0.0-next.26
 
 ### Patch Changes
 
-- 9a7195b: Allow sirv to looks for precompiled gzip and brotli files by default
-- 53f3322: Fix build when using TypeScript and there is a `tsconfig.json` with `target: 'es2019'` or earlier
+- 9a7195b: Allow sirv to looks for precompiled gzip and brotli files by default (#1672)
+- 53f3322: Fix build when using TypeScript and there is a `tsconfig.json` with `target: 'es2019'` or earlier (#1675)
 
 ## 1.0.0-next.25
 
 ### Patch Changes
 
-- 0b780a6: Bundle server-side app during adapt phase
+- 0b780a6: Bundle server-side app during adapt phase (#1648)
 
 ## 1.0.0-next.24
 
 ### Patch Changes
 
-- edc307d: Remove peerDependencies due to pnpm bug
-- 2636e68: Attempt to fix peerDependencies specification
+- edc307d: Remove peerDependencies due to pnpm bug (#1621)
+- 2636e68: Attempt to fix peerDependencies specification (#1620)
 
 ## 1.0.0-next.23
 
 ### Patch Changes
 
-- c3d36a3: ensure `content-length` limit respected; handle `getRawBody` error(s)
-- bf77940: bump `polka` and `sirv` dependency versions
-- 028abd9: Pass validated svelte config to adapter adapt function
+- c3d36a3: ensure `content-length` limit respected; handle `getRawBody` error(s) (#1528)
+- bf77940: bump `polka` and `sirv` dependency versions (#1548)
+- 028abd9: Pass validated svelte config to adapter adapt function (#1559)
 - Updated dependencies [6372690]
 - Updated dependencies [c3d36a3]
 - Updated dependencies [bf77940]
@@ -118,7 +118,7 @@
 
 ### Patch Changes
 
-- dca4946: Make kit a peerDependency of the adapters
+- dca4946: Make kit a peerDependency of the adapters (#1505)
 - Updated dependencies [261ee1c]
 - Updated dependencies [ec156c6]
 - Updated dependencies [586785d]
@@ -128,103 +128,103 @@
 
 ### Patch Changes
 
-- dad93fc: Fix workspace dependencies
+- dad93fc: Fix workspace dependencies (#1434)
 
 ## 1.0.0-next.20
 
 ### Patch Changes
 
-- 9b448a6: Rename @sveltejs/kit/http to @sveltejs/kit/node
+- 9b448a6: Rename @sveltejs/kit/http to @sveltejs/kit/node (#1391)
 
 ## 1.0.0-next.19
 
 ### Patch Changes
 
-- 0e09581: Make host configurable via process.env.HOST
+- 0e09581: Make host configurable via process.env.HOST (#1366)
 
 ## 1.0.0-next.18
 
 ### Patch Changes
 
-- c6fde99: Convert to ESM
+- c6fde99: Convert to ESM (#1323)
 
 ## 1.0.0-next.17
 
 ### Patch Changes
 
-- 2e72a94: Add type declarations
+- 2e72a94: Add type declarations (#1230)
 
 ## 1.0.0-next.16
 
 ### Patch Changes
 
-- 1237eb3: Use getRawBody
+- 1237eb3: Use getRawBody (#1109)
 
 ## 1.0.0-next.15
 
 ### Patch Changes
 
-- 7a4b351: Use install-fetch helper
+- 7a4b351: Use install-fetch helper (#1091)
 
 ## 1.0.0-next.14
 
 ### Patch Changes
 
-- 8e61e84: Include missing entrypoint
+- 8e61e84: Include missing entrypoint (#1071)
 
 ## 1.0.0-next.13
 
 ### Patch Changes
 
-- 6e27880: Move server-side fetch to adapters instead of build step
+- 6e27880: Move server-side fetch to adapters instead of build step (#1066)
 
 ## 1.0.0-next.12
 
 ### Patch Changes
 
-- feb2db7: Fix fatal error when trying to parse URLs of incoming requests
+- feb2db7: Fix fatal error when trying to parse URLs of incoming requests (#802)
 
 ## 1.0.0-next.11
 
 ### Patch Changes
 
-- ca33a35: Fix adapter-vercel query parsing and update adapter-node's
+- ca33a35: Fix adapter-vercel query parsing and update adapter-node's (#774)
 
 ## 1.0.0-next.10
 
 ### Patch Changes
 
-- 8024178: remove @sveltejs/app-utils
+- 8024178: remove @sveltejs/app-utils (#600)
 
 ## 1.0.0-next.9
 
 ### Patch Changes
 
-- 8805c6d: Pass adapters directly to svelte.config.cjs
+- 8805c6d: Pass adapters directly to svelte.config.cjs (#579)
 
 ## 1.0.0-next.8
 
 ### Patch Changes
 
-- 9212aa5: Add options to adapter-node, and add adapter types
+- 9212aa5: Add options to adapter-node, and add adapter types (#531)
 
 ## 1.0.0-next.7
 
 ### Patch Changes
 
-- f35a5cd: Change adapter signature
+- f35a5cd: Change adapter signature (#505)
 
 ## 1.0.0-next.6
 
 ### Patch Changes
 
-- c3cf3f3: Bump deps
+- c3cf3f3: Bump deps (#492)
 
 ## 1.0.0-next.5
 
 ### Patch Changes
 
-- 222fe9d: Compress adapter-node responses
+- 222fe9d: Compress adapter-node responses (#367)
 
 ## 1.0.0-next.4
 
@@ -236,7 +236,7 @@
 
 ### Patch Changes
 
-- ab2367d: Convert to ESM
+- ab2367d: Convert to ESM (#387)
 
 ## 1.0.0-next.2
 
@@ -272,7 +272,7 @@
 
 ### Patch Changes
 
-- b475ed4: Overhaul adapter API - fixes #166
+- b475ed4: Overhaul adapter API - fixes #166 (#180)
 - Updated dependencies [b475ed4]
   - @sveltejs/app-utils@0.0.18
 

--- a/packages/adapter-static/CHANGELOG.md
+++ b/packages/adapter-static/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### Patch Changes
 
-- 94b34fa6: [breaking] standardize final output dir as /build (vs /.svelte-kit)
+- 94b34fa6: [breaking] standardize final output dir as /build (vs /.svelte-kit) (#2109)
 
 ## 1.0.0-next.15
 
 ### Patch Changes
 
-- b3e7c8b3: [chore] update build output location
+- b3e7c8b3: [chore] update build output location (#2082)
 
 ## 1.0.0-next.14
 
@@ -22,15 +22,15 @@
 
 ### Patch Changes
 
-- edc307d: Remove peerDependencies due to pnpm bug
-- 2636e68: Attempt to fix peerDependencies specification
+- edc307d: Remove peerDependencies due to pnpm bug (#1621)
+- 2636e68: Attempt to fix peerDependencies specification (#1620)
 
 ## 1.0.0-next.12
 
 ### Patch Changes
 
-- bf77940: bump `polka` and `sirv` dependency versions
-- 028abd9: Pass validated svelte config to adapter adapt function
+- bf77940: bump `polka` and `sirv` dependency versions (#1548)
+- 028abd9: Pass validated svelte config to adapter adapt function (#1559)
 - Updated dependencies [6372690]
 - Updated dependencies [c3d36a3]
 - Updated dependencies [bf77940]
@@ -42,7 +42,7 @@
 
 ### Patch Changes
 
-- dca4946: Make kit a peerDependency of the adapters
+- dca4946: Make kit a peerDependency of the adapters (#1505)
 - Updated dependencies [261ee1c]
 - Updated dependencies [ec156c6]
 - Updated dependencies [586785d]
@@ -52,49 +52,49 @@
 
 ### Patch Changes
 
-- dad93fc: Fix workspace dependencies
+- dad93fc: Fix workspace dependencies (#1434)
 
 ## 1.0.0-next.9
 
 ### Patch Changes
 
-- d871213: Remove Vite dependency from apps
+- d871213: Remove Vite dependency from apps (#1374)
 
 ## 1.0.0-next.8
 
 ### Patch Changes
 
-- c6fde99: Convert to ESM
+- c6fde99: Convert to ESM (#1323)
 
 ## 1.0.0-next.7
 
 ### Patch Changes
 
-- 2e72a94: Add type declarations
+- 2e72a94: Add type declarations (#1230)
 
 ## 1.0.0-next.6
 
 ### Patch Changes
 
-- 6f2b4a6: Remove references to npm start
+- 6f2b4a6: Remove references to npm start (#1196)
 
 ## 1.0.0-next.5
 
 ### Patch Changes
 
-- 4131467: Prerender fallback page for SPAs
+- 4131467: Prerender fallback page for SPAs (#1181)
 
 ## 1.0.0-next.4
 
 ### Patch Changes
 
-- 8805c6d: Pass adapters directly to svelte.config.cjs
+- 8805c6d: Pass adapters directly to svelte.config.cjs (#579)
 
 ## 1.0.0-next.3
 
 ### Patch Changes
 
-- f35a5cd: Change adapter signature
+- f35a5cd: Change adapter signature (#505)
 
 ## 1.0.0-next.2
 
@@ -124,7 +124,7 @@
 
 ### Patch Changes
 
-- b475ed4: Overhaul adapter API - fixes #166
+- b475ed4: Overhaul adapter API - fixes #166 (#180)
 
 ## 0.0.14
 

--- a/packages/adapter-vercel/CHANGELOG.md
+++ b/packages/adapter-vercel/CHANGELOG.md
@@ -10,45 +10,45 @@
 
 ### Patch Changes
 
-- e9f78999: fix: include esbuild config in adapter type definition
+- e9f78999: fix: include esbuild config in adapter type definition (#1954)
 
 ## 1.0.0-next.25
 
 ### Patch Changes
 
-- e6995797: feat(adapters): expose esbuild configuration
+- e6995797: feat(adapters): expose esbuild configuration (#1914)
 
 ## 1.0.0-next.24
 
 ### Patch Changes
 
-- 2ac5781: Use esbuild inject API to insert shims
+- 2ac5781: Use esbuild inject API to insert shims (#1822)
 
 ## 1.0.0-next.23
 
 ### Patch Changes
 
-- 9f0c54a: Externalize app initialization to adapters
+- 9f0c54a: Externalize app initialization to adapters (#1804)
 
 ## 1.0.0-next.22
 
 ### Patch Changes
 
-- c51ab7d: Upgrade esbuild to ^0.12.5
+- c51ab7d: Upgrade esbuild to ^0.12.5 (#1627)
 
 ## 1.0.0-next.21
 
 ### Patch Changes
 
-- edc307d: Remove peerDependencies due to pnpm bug
-- 2636e68: Attempt to fix peerDependencies specification
+- edc307d: Remove peerDependencies due to pnpm bug (#1621)
+- 2636e68: Attempt to fix peerDependencies specification (#1620)
 
 ## 1.0.0-next.20
 
 ### Patch Changes
 
-- c3d36a3: ensure `content-length` limit respected; handle `getRawBody` error(s)
-- 028abd9: Pass validated svelte config to adapter adapt function
+- c3d36a3: ensure `content-length` limit respected; handle `getRawBody` error(s) (#1528)
+- 028abd9: Pass validated svelte config to adapter adapt function (#1559)
 - Updated dependencies [6372690]
 - Updated dependencies [c3d36a3]
 - Updated dependencies [bf77940]
@@ -60,7 +60,7 @@
 
 ### Patch Changes
 
-- dca4946: Make kit a peerDependency of the adapters
+- dca4946: Make kit a peerDependency of the adapters (#1505)
 - Updated dependencies [261ee1c]
 - Updated dependencies [ec156c6]
 - Updated dependencies [586785d]
@@ -70,7 +70,7 @@
 
 ### Patch Changes
 
-- dad93fc: Fix workspace dependencies
+- dad93fc: Fix workspace dependencies (#1434)
 - Updated dependencies [dad93fc]
 - Updated dependencies [37fc04f]
   - @sveltejs/kit@1.0.0-next.108
@@ -79,7 +79,7 @@
 
 ### Patch Changes
 
-- 9b448a6: Rename @sveltejs/kit/http to @sveltejs/kit/node
+- 9b448a6: Rename @sveltejs/kit/http to @sveltejs/kit/node (#1391)
 - Updated dependencies [9b448a6]
   - @sveltejs/kit@1.0.0-next.104
 
@@ -87,7 +87,7 @@
 
 ### Patch Changes
 
-- c6fde99: Convert to ESM
+- c6fde99: Convert to ESM (#1323)
 - Updated dependencies [694f5de]
 - Updated dependencies [0befffb]
 - Updated dependencies [c6fde99]
@@ -97,7 +97,7 @@
 
 ### Patch Changes
 
-- 2e72a94: Add type declarations
+- 2e72a94: Add type declarations (#1230)
 - Updated dependencies [82955ec]
   - @sveltejs/kit@1.0.0-next.91
 
@@ -105,14 +105,14 @@
 
 ### Patch Changes
 
-- 59f9277: fix body parsing
+- 59f9277: fix body parsing (#1146)
 
 ## 1.0.0-next.13
 
 ### Patch Changes
 
-- 1237eb3: Fix dependencies
-- 1237eb3: Use getRawBody in adapter-vercel
+- 1237eb3: Fix dependencies (#1109)
+- 1237eb3: Use getRawBody in adapter-vercel (#1109)
 - Updated dependencies [1237eb3]
 - Updated dependencies [1237eb3]
   - @sveltejs/kit@1.0.0-next.81
@@ -121,56 +121,56 @@
 
 ### Patch Changes
 
-- 7a4b351: Bundle serverless functions with esbuild
+- 7a4b351: Bundle serverless functions with esbuild (#1091)
 
 ## 1.0.0-next.11
 
 ### Patch Changes
 
-- 6e27880: Move server-side fetch to adapters instead of build step
+- 6e27880: Move server-side fetch to adapters instead of build step (#1066)
 
 ## 1.0.0-next.10
 
 ### Patch Changes
 
-- feb2db7: Simplify parsing of URLS of incoming requests
+- feb2db7: Simplify parsing of URLS of incoming requests (#802)
 
 ## 1.0.0-next.9
 
 ### Patch Changes
 
-- ca33a35: Fix adapter-vercel query parsing and update adapter-node's
+- ca33a35: Fix adapter-vercel query parsing and update adapter-node's (#774)
 
 ## 1.0.0-next.8
 
 ### Patch Changes
 
-- 8024178: remove @sveltejs/app-utils
+- 8024178: remove @sveltejs/app-utils (#600)
 
 ## 1.0.0-next.7
 
 ### Patch Changes
 
-- 17e82eb: Fix adapter-vercel imports
+- 17e82eb: Fix adapter-vercel imports (#588)
 
 ## 1.0.0-next.6
 
 ### Patch Changes
 
-- 8805c6d: Pass adapters directly to svelte.config.cjs
+- 8805c6d: Pass adapters directly to svelte.config.cjs (#579)
 
 ## 1.0.0-next.5
 
 ### Patch Changes
 
-- f35a5cd: Change adapter signature
+- f35a5cd: Change adapter signature (#505)
 
 ## 1.0.0-next.4
 
 ### Patch Changes
 
-- c3cf3f3: Bump deps
-- d742029: Fix mixed usage of CJS and ESM
+- c3cf3f3: Bump deps (#492)
+- d742029: Fix mixed usage of CJS and ESM (#483)
 - Updated dependencies [c3cf3f3]
   - @sveltejs/app-utils@1.0.0-next.3
 
@@ -178,7 +178,7 @@
 
 ### Patch Changes
 
-- 8123929: Fix adapter-vercel using the wrong directory
+- 8123929: Fix adapter-vercel using the wrong directory (#450)
 - Updated dependencies [73dd998]
 - Updated dependencies [b800049]
   - @sveltejs/app-utils@1.0.0-next.2

--- a/packages/create-svelte/CHANGELOG.md
+++ b/packages/create-svelte/CHANGELOG.md
@@ -4,74 +4,74 @@
 
 ### Patch Changes
 
-- 94b34fa6: [breaking] standardize final output dir as /build (vs /.svelte-kit)
+- 94b34fa6: [breaking] standardize final output dir as /build (vs /.svelte-kit) (#2109)
 
 ## 2.0.0-next.76
 
 ### Patch Changes
 
-- b9e63381: Add DOM to lib in tsconfig
+- b9e63381: Add DOM to lib in tsconfig (#1956)
 
 ## 2.0.0-next.75
 
 ### Patch Changes
 
-- fe68e13: Simplify component file names
+- fe68e13: Simplify component file names (#1878)
 
 ## 2.0.0-next.74
 
 ### Patch Changes
 
-- 4c7ccfd: Add \$lib alias to js/tsconfig
+- 4c7ccfd: Add \$lib alias to js/tsconfig (#1860)
 
 ## 2.0.0-next.73
 
 ### Patch Changes
 
-- 2d2fab1: Add favicon to skeleton template
-- 6aa4988: Replace favicon
+- 2d2fab1: Add favicon to skeleton template (#1514)
+- 6aa4988: Replace favicon (#1589)
 
 ## 2.0.0-next.72
 
 ### Patch Changes
 
-- 1739443: Add svelte-check to TS templates
-- 6372690: gitignore package directory
-- f211906: Adjust build-template script to include package.json
+- 1739443: Add svelte-check to TS templates (#1556)
+- 6372690: gitignore package directory (#1499)
+- f211906: Adjust build-template script to include package.json (#1555)
 
 ## 2.0.0-next.71
 
 ### Patch Changes
 
-- dad93fc: Fix workspace dependencies
+- dad93fc: Fix workspace dependencies (#1434)
 
 ## 2.0.0-next.70
 
 ### Patch Changes
 
-- d871213: Remove Vite dependency from apps
+- d871213: Remove Vite dependency from apps (#1374)
 
 ## 2.0.0-next.69
 
 ### Patch Changes
 
-- 9cc2508: Ensure template files match Prettier settings
-- f5e626d: Reference Vite/Svelte types inside Kit types
-- 8a402a9: Exclude deploy artifacts from create-svelte package
-- e8bed05: Prompt to npm install before prompting to git init
-- 507e2c3: fix: Prettier not formatting .svelte files
+- 9cc2508: Ensure template files match Prettier settings (#1364)
+- f5e626d: Reference Vite/Svelte types inside Kit types (#1319)
+- 8a402a9: Exclude deploy artifacts from create-svelte package (#1363)
+- e8bed05: Prompt to npm install before prompting to git init (#1362)
+- 507e2c3: fix: Prettier not formatting .svelte files (#1360)
 
 ## 2.0.0-next.68
 
 ### Patch Changes
 
-- 5ed3ed2: Fix usage of request.locals in starter project
+- 5ed3ed2: Fix usage of request.locals in starter project (#1344)
 
 ## 2.0.0-next.67
 
 ### Patch Changes
 
-- d15b48a: Add renamed .svelte -> .svelte-kit directory to ignore files
+- d15b48a: Add renamed .svelte -> .svelte-kit directory to ignore files (#1339)
 
 ## 2.0.0-next.66
 
@@ -83,26 +83,26 @@
 
 ### Patch Changes
 
-- 0befffb: Rename .svelte to .svelte-kit
-- c6fde99: Switch to ESM in config files
+- 0befffb: Rename .svelte to .svelte-kit (#1321)
+- c6fde99: Switch to ESM in config files (#1323)
 
 ## 2.0.0-next.64
 
 ### Patch Changes
 
-- 3fb191c: Improved install prompts, turn confirms into toggle
+- 3fb191c: Improved install prompts, turn confirms into toggle (#1312)
 
 ## 2.0.0-next.63
 
 ### Patch Changes
 
-- d19f3de: bump minimum required Svelte version
+- d19f3de: bump minimum required Svelte version (#1192)
 
 ## 2.0.0-next.62
 
 ### Patch Changes
 
-- c44f231: Improve a11y on to-do list in template
+- c44f231: Improve a11y on to-do list in template (#1207)
 
 ## 2.0.0-next.61
 
@@ -114,9 +114,9 @@
 
 ### Patch Changes
 
-- 1b816b2: Update version of eslint-plugin-svelte3
-- 6f2b4a6: Update welcome message
-- 6f2b4a6: No adapter by default
+- 1b816b2: Update version of eslint-plugin-svelte3 (#1195)
+- 6f2b4a6: Update welcome message (#1196)
+- 6f2b4a6: No adapter by default (#1196)
 
 ## 2.0.0-next.59
 
@@ -128,198 +128,198 @@
 
 ### Patch Changes
 
-- 2bf4338: Add .gitignore files to new projects
+- 2bf4338: Add .gitignore files to new projects (#1167)
 
 ## 2.0.0-next.57
 
 ### Patch Changes
 
-- 4645ad5: Remove obsolete vite.ssr config from template
-- 872d734: Hide out-of-view counter from assistive tech
+- 4645ad5: Remove obsolete vite.ssr config from template (#1148)
+- 872d734: Hide out-of-view counter from assistive tech (#1150)
 
 ## 2.0.0-next.56
 
 ### Patch Changes
 
 - cdf4d5b: Show git init instructions when creating new project
-- 112d194: Uppercase method in template
+- 112d194: Uppercase method in template (#1119)
 
 ## 2.0.0-next.55
 
 ### Patch Changes
 
-- daf6913: Fix bootstrapping command on about page
+- daf6913: Fix bootstrapping command on about page (#1105)
 
 ## 2.0.0-next.54
 
 ### Patch Changes
 
-- a84cb88: Fix global.d.ts rename, Windows build issue, missing adapter-node
+- a84cb88: Fix global.d.ts rename, Windows build issue, missing adapter-node (#1095)
 
 ## 2.0.0-next.53
 
 ### Patch Changes
 
-- 27c2e1d: Fix CSS on demo app hero image
-- bbeb58f: Include dotfiles when creating new project
-- 6a8e73f: Remove large image from create-svelte
+- 27c2e1d: Fix CSS on demo app hero image (#1088)
+- bbeb58f: Include dotfiles when creating new project (#1084)
+- 6a8e73f: Remove large image from create-svelte (#1085)
 
 ## 2.0.0-next.52
 
 ### Patch Changes
 
-- f342372: Adding new Hello World templates (default with enhanced style and skeleton) to create-svelte
+- f342372: Adding new Hello World templates (default with enhanced style and skeleton) to create-svelte (#1014)
 
 ## 2.0.0-next.51
 
 ### Patch Changes
 
-- 4cffc14: add global.d.ts to js version
+- 4cffc14: add global.d.ts to js version (#1051)
 
 ## 2.0.0-next.50
 
 ### Patch Changes
 
-- 3802c64: Fix build so that the package can be automatically published
+- 3802c64: Fix build so that the package can be automatically published (#1001)
 
 ## 2.0.0-next.49
 
 ### Patch Changes
 
 - 3c41d07: Fix preprocess option in template
-- 9bb747f: Remove CSS option and simplify
+- 9bb747f: Remove CSS option and simplify (#989)
 
 ## 2.0.0-next.48
 
 ### Patch Changes
 
-- 4c45784: Add ambient types to published files
+- 4c45784: Add ambient types to published files (#980)
 
 ## 2.0.0-next.47
 
 ### Patch Changes
 
-- 59a1e06: Add button:focus CSS styles to index page of default app
-- 39b6967: Add ambient type definitions for \$app imports
-- dfbe62b: Add title tag to index page of default app
+- 59a1e06: Add button:focus CSS styles to index page of default app (#957)
+- 39b6967: Add ambient type definitions for \$app imports (#917)
+- dfbe62b: Add title tag to index page of default app (#954)
 
 ## 2.0.0-next.46
 
 ### Patch Changes
 
-- 570f90c: Update tsconfig to use module and lib es2020
-- 8d453c8: Specify minimum Node version number in @sveltejs/kit and add .npmrc to enforce it
+- 570f90c: Update tsconfig to use module and lib es2020 (#817)
+- 8d453c8: Specify minimum Node version number in @sveltejs/kit and add .npmrc to enforce it (#787)
 
 ## 2.0.0-next.45
 
 ### Patch Changes
 
-- dac29c5: allow importing JSON modules
-- 8dc89ba: Set target to es2019 in default tsconfig.json
+- dac29c5: allow importing JSON modules (#792)
+- 8dc89ba: Set target to es2019 in default tsconfig.json (#772)
 
 ## 2.0.0-next.44
 
 ### Patch Changes
 
 - 7e51473: fix eslint error in ts starter template, add eslint and prettier ignore config
-- 7d42f72: Add a global stylesheet during create-svelte depending on the chosen CSS preprocessor
+- 7d42f72: Add a global stylesheet during create-svelte depending on the chosen CSS preprocessor (#726)
 
 ## 2.0.0-next.43
 
 ### Patch Changes
 
-- bdf4ed9: Fix typo in `ignorePatterns` for the `.eslintrc.cjs` generated for TypeScript projects so that `.eslintrc.cjs` correctly ignores itself.
-- f7badf1: Add '\$service-worker' to paths in tsconfig.json
-- 9a664e1: Set `.eslintrc.cjs` to ignore all `.cjs` files.
-- df380e6: Add env options to eslint config
+- bdf4ed9: Fix typo in `ignorePatterns` for the `.eslintrc.cjs` generated for TypeScript projects so that `.eslintrc.cjs` correctly ignores itself. (#701)
+- f7badf1: Add '\$service-worker' to paths in tsconfig.json (#716)
+- 9a664e1: Set `.eslintrc.cjs` to ignore all `.cjs` files. (#707)
+- df380e6: Add env options to eslint config (#722)
 
 ## 2.0.0-next.42
 
 ### Patch Changes
 
-- a52cf82: add eslint and prettier setup options
+- a52cf82: add eslint and prettier setup options (#632)
 
 ## 2.0.0-next.41
 
 ### Patch Changes
 
-- 8024178: remove @sveltejs/app-utils
+- 8024178: remove @sveltejs/app-utils (#600)
 
 ## 2.0.0-next.40
 
 ### Patch Changes
 
-- 8805c6d: Pass adapters directly to svelte.config.cjs
+- 8805c6d: Pass adapters directly to svelte.config.cjs (#579)
 
 ## 2.0.0-next.39
 
 ### Patch Changes
 
-- ac3669e: Move Vite config into svelte.config.cjs
+- ac3669e: Move Vite config into svelte.config.cjs (#569)
 
 ## 2.0.0-next.38
 
 ### Patch Changes
 
-- c04887c: create-svelte: Include globals.d.ts in tsconfig
+- c04887c: create-svelte: Include globals.d.ts in tsconfig (#549)
 
 ## 2.0.0-next.37
 
 ### Patch Changes
 
-- c76c9bf: Upgrade Vite
-- ab28c0a: create-svelte: Remove duplicate types
+- c76c9bf: Upgrade Vite (#544)
+- ab28c0a: create-svelte: Remove duplicate types (#538)
 
 ## 2.0.0-next.36
 
 ### Patch Changes
 
-- 0da62eb: create-svelte: Include missing ts-template
+- 0da62eb: create-svelte: Include missing ts-template (#535)
 
 ## 2.0.0-next.35
 
 ### Patch Changes
 
-- bb01514: Actually fix $component => $lib transition
+- bb01514: Actually fix $component => $lib transition (#529)
 
 ## 2.0.0-next.34
 
 ### Patch Changes
 
-- 848687c: Fix location of example `Counter.svelte` component
+- 848687c: Fix location of example `Counter.svelte` component (#522)
 
 ## 2.0.0-next.33
 
 ### Patch Changes
 
 - f7dc6ad: Fix typo in template app
-- 5554acc: Add \$lib alias
-- c0ed7a8: create-svelte: globals.d.ts TSDoc fixes, add vite/client types to js/tsconfig
+- 5554acc: Add \$lib alias (#511)
+- c0ed7a8: create-svelte: globals.d.ts TSDoc fixes, add vite/client types to js/tsconfig (#517)
 
 ## 2.0.0-next.32
 
 ### Patch Changes
 
-- 97b7ea4: jsconfig for js projects
+- 97b7ea4: jsconfig for js projects (#510)
 
 ## 2.0.0-next.31
 
 ### Patch Changes
 
-- c3cf3f3: Bump deps
-- 625747d: create-svelte: bundle production dependencies for SSR
+- c3cf3f3: Bump deps (#492)
+- 625747d: create-svelte: bundle production dependencies for SSR (#486)
 
 ## 2.0.0-next.30
 
 ### Patch Changes
 
-- b800049: Include type declarations
+- b800049: Include type declarations (#442)
 
 ## 2.0.0-next.29
 
 ### Patch Changes
 
-- 15dd6d6: Fix setup to include vite
+- 15dd6d6: Fix setup to include vite (#415)
 
 ## 2.0.0-next.28
 
@@ -337,7 +337,7 @@
 
 ### Patch Changes
 
-- 00cbaf6: Rename _.config.js to _.config.cjs
+- 00cbaf6: Rename _.config.js to _.config.cjs (#356)
 
 ## 2.0.0-next.25
 
@@ -349,7 +349,7 @@
 
 ### Patch Changes
 
-- 0e45255: Move options behind kit namespace, change paths -> kit.files
+- 0e45255: Move options behind kit namespace, change paths -> kit.files (#236)
 
 ## 2.0.0-next.23
 
@@ -380,7 +380,7 @@
 ### Patch Changes
 
 - rename CLI to svelte-kit
-- 0904e22: rename svelte CLI to svelte-kit
+- 0904e22: rename svelte CLI to svelte-kit (#186)
 
 ## 2.0.0-alpha.16
 

--- a/packages/kit/CHANGELOG.md
+++ b/packages/kit/CHANGELOG.md
@@ -10,25 +10,25 @@
 
 ### Patch Changes
 
-- 8c0ffb8f: [fix] provide explicit JS entry point for Vite dev mode
-- c3c25ee0: [fix] take into account page-level options on error pages
+- 8c0ffb8f: [fix] provide explicit JS entry point for Vite dev mode (#2134)
+- c3c25ee0: [fix] take into account page-level options on error pages (#2117)
 
 ## 1.0.0-next.142
 
 ### Patch Changes
 
-- aed1bd07: [fix] fully initialize router before rendering
-- 970bb04c: restore reverted config changes
+- aed1bd07: [fix] fully initialize router before rendering (#2089)
+- 970bb04c: restore reverted config changes (#2093)
 
 ## 1.0.0-next.141
 
 ### Patch Changes
 
-- d109a394: [fix] successfully load nested error pages
-- fab67c94: [fix] successfully handle client errors
-- 943f5288: [fix] solve regression parsing unicode URLs
-- 4435a659: [fix] allow endpoint shadowing to work
-- ee73a265: [fix] correctly do fallthrough in simple case
+- d109a394: [fix] successfully load nested error pages (#2076)
+- fab67c94: [fix] successfully handle client errors (#2077)
+- 943f5288: [fix] solve regression parsing unicode URLs (#2078)
+- 4435a659: [fix] allow endpoint shadowing to work (#2074)
+- ee73a265: [fix] correctly do fallthrough in simple case (#2072)
 
 ## 1.0.0-next.140
 
@@ -36,161 +36,161 @@
 
 - e55bc44a: [fix] revert change to rendering options (#2008)
 - d81de603: revert adapters automatically updating .gitignore (#1924)
-- 5911b1c7: [fix] consider protocol-relative URLs as external
+- 5911b1c7: [fix] consider protocol-relative URLs as external (#2062)
 
 ## 1.0.0-next.139
 
 ### Patch Changes
 
-- 883d4b85: Add public API to let adapters update .gitignore
-- 8cbe3b05: Change `force` to `onError` in prerender config options
-- 1b18a844: Don't check external links on prerender
-- 7645399a: [fix] correctly pass Vite options in preview mode
+- 883d4b85: Add public API to let adapters update .gitignore (#1924)
+- 8cbe3b05: Change `force` to `onError` in prerender config options (#2030)
+- 1b18a844: Don't check external links on prerender (#1679)
+- 7645399a: [fix] correctly pass Vite options in preview mode (#2036)
 
 ## 1.0.0-next.138
 
 ### Patch Changes
 
-- d6563169: [chore] prefer interfaces to types
-- b18a45c1: explicitly set compilerOptions.hydratable to config.kit.hydrate
-- 538de3eb: [feat] More powerful and configurable rendering options
-- 20dad18a: Remove the `prerender.force` option in favor of `prerender.onError`
+- d6563169: [chore] prefer interfaces to types (#2010)
+- b18a45c1: explicitly set compilerOptions.hydratable to config.kit.hydrate (#2024)
+- 538de3eb: [feat] More powerful and configurable rendering options (#2008)
+- 20dad18a: Remove the `prerender.force` option in favor of `prerender.onError` (#2007)
 
 ## 1.0.0-next.137
 
 ### Patch Changes
 
-- bce1d76a: [chore] improved typing for runtime and tests
-- 2a1e9795: [chore] enable TypeScript strict mode
+- bce1d76a: [chore] improved typing for runtime and tests (#1995)
+- 2a1e9795: [chore] enable TypeScript strict mode (#1998)
 
 ## 1.0.0-next.136
 
 ### Patch Changes
 
-- 69b92ec1: [chore] improved typing on core library
+- 69b92ec1: [chore] improved typing on core library (#1993)
 
 ## 1.0.0-next.135
 
 ### Patch Changes
 
-- 3b293f2a: update svelte to 3.40 and vite-plugin-svelte to 1.0.0-next.14
-- 34b923d1: [chore] stricter TypeScript checking
+- 3b293f2a: update svelte to 3.40 and vite-plugin-svelte to 1.0.0-next.14 (#1992)
+- 34b923d1: [chore] stricter TypeScript checking (#1989)
 
 ## 1.0.0-next.134
 
 ### Patch Changes
 
-- e1e5920a: [fix] correctly find links during prerendering
-- c7db715e: Handle errors with incorrect type
+- e1e5920a: [fix] correctly find links during prerendering (#1984)
+- c7db715e: Handle errors with incorrect type (#1983)
 
 ## 1.0.0-next.133
 
 ### Patch Changes
 
-- 68190496: chore: Vite to ^2.4.3, vite-plugin-svelte to ^1.0.0-next.13
-- 0cbcd7c3: [fix] correctly detect external fetches
-- 51ec789f: Scrolling to an anchor via a hash now supports `scroll-*` CSS properties
+- 68190496: chore: Vite to ^2.4.3, vite-plugin-svelte to ^1.0.0-next.13 (#1969)
+- 0cbcd7c3: [fix] correctly detect external fetches (#1980)
+- 51ec789f: Scrolling to an anchor via a hash now supports `scroll-*` CSS properties (#1972)
 
 ## 1.0.0-next.132
 
 ### Patch Changes
 
-- 7b440b2b: Fix URL resolution for server-side fetch
+- 7b440b2b: Fix URL resolution for server-side fetch (#1953)
 
 ## 1.0.0-next.131
 
 ### Patch Changes
 
-- 0bc1b309: Minor optimization in parse_body
+- 0bc1b309: Minor optimization in parse_body (#1916)
 
 ## 1.0.0-next.130
 
 ### Patch Changes
 
-- 53e9285d: feat(config): Friendlier error messages for common errors
-- 41da1ebe: Handle 4xx and 5xx statuses without requiring `Error` instance
-- 073fc3b5: feat(cli): respect NODE_ENV when set by user
+- 53e9285d: feat(config): Friendlier error messages for common errors (#1910)
+- 41da1ebe: Handle 4xx and 5xx statuses without requiring `Error` instance (#1811)
+- 073fc3b5: feat(cli): respect NODE_ENV when set by user (#1915)
 
 ## 1.0.0-next.129
 
 ### Patch Changes
 
-- e246455: Passthrough server-side fetch cookies for most same-origin scenarios
+- e246455: Passthrough server-side fetch cookies for most same-origin scenarios (#1847)
 
 ## 1.0.0-next.128
 
 ### Patch Changes
 
-- 27e9067: Better error messages when something goes wrong while emitting types
-- 277029d: Change index.js exports to directory exports when packaging
+- 27e9067: Better error messages when something goes wrong while emitting types (#1903)
+- 277029d: Change index.js exports to directory exports when packaging (#1905)
 
 ## 1.0.0-next.127
 
 ### Patch Changes
 
-- bb3ae21: Fix endpoint validation to allow returning string for all content types
+- bb3ae21: Fix endpoint validation to allow returning string for all content types (#1900)
 
 ## 1.0.0-next.126
 
 ### Patch Changes
 
-- 4720b67: Default body parsing to binary
-- 6da07b8: fix returning null from endpoints
+- 4720b67: Default body parsing to binary (#1890)
+- 6da07b8: fix returning null from endpoints (#1886)
 
 ## 1.0.0-next.125
 
 ### Patch Changes
 
-- 7faf52f: Update and consolidate checks for binary body types
-- f854b89: Replace return type of Buffer with Uint8Array
-- f854b89: Remove Incoming from public types
+- 7faf52f: Update and consolidate checks for binary body types (#1687)
+- f854b89: Replace return type of Buffer with Uint8Array (#1876)
+- f854b89: Remove Incoming from public types (#1876)
 
 ## 1.0.0-next.124
 
 ### Patch Changes
 
-- 34d2049: handle undefined body on endpoint output
-- c826016: add config.kit.package.emitTypes
-- 8854e2f: Bump vite-plugin-svelte to 1.0.0-next.12
-- af1aa54: copy essential root files on `svelte-kit package`
-- 872840a: Pass along custom properties added to Error
-- 868f97a: Preserve README casing and package.json contents on svelte-kit package
+- 34d2049: handle undefined body on endpoint output (#1808)
+- c826016: add config.kit.package.emitTypes (#1852)
+- 8854e2f: Bump vite-plugin-svelte to 1.0.0-next.12 (#1869)
+- af1aa54: copy essential root files on `svelte-kit package` (#1747)
+- 872840a: Pass along custom properties added to Error (#1821)
+- 868f97a: Preserve README casing and package.json contents on svelte-kit package (#1735)
 
 ## 1.0.0-next.123
 
 ### Patch Changes
 
-- 4b25615: Fix ReadOnlyFormData keys and values method implementation
-- 64f749d: ServiceWorker files exclusion support available through svelte.config.js
-- 4d2fec5: Enable Vite's server.fs.strict by default
-- 1ec368a: Expose Vite.js mode from \$app/env
+- 4b25615: Fix ReadOnlyFormData keys and values method implementation (#1837)
+- 64f749d: ServiceWorker files exclusion support available through svelte.config.js (#1645)
+- 4d2fec5: Enable Vite's server.fs.strict by default (#1842)
+- 1ec368a: Expose Vite.js mode from \$app/env (#1789)
 
 ## 1.0.0-next.122
 
 ### Patch Changes
 
-- d09a4e1: Surface Svelte compiler errors
-- 79b4fe2: Update Vite to ^2.4.1
-- 2ac5781: Use esbuild inject API to insert shims
+- d09a4e1: Surface Svelte compiler errors (#1827)
+- 79b4fe2: Update Vite to ^2.4.1 (#1834)
+- 2ac5781: Use esbuild inject API to insert shims (#1822)
 
 ## 1.0.0-next.121
 
 ### Patch Changes
 
-- 939188e: Use UTF-8 encoding for JSON endpoint responses by default
-- 5b3e1e6: Add types generation to svelte-kit package command
-- 8affef2: Fix type errors inside ReadOnlyFormData that didn't allow it to be used inside for..of loops
+- 939188e: Use UTF-8 encoding for JSON endpoint responses by default (#1669)
+- 5b3e1e6: Add types generation to svelte-kit package command (#1646)
+- 8affef2: Fix type errors inside ReadOnlyFormData that didn't allow it to be used inside for..of loops (#1830)
 
 ## 1.0.0-next.120
 
 ### Patch Changes
 
-- 9fbaeda: fix attribute validation in generated script tag
-- 9f0c54a: Externalize app initialization to adapters
-- 0d69e55: Add generic type for session
-- 325c223: Improve RequestHandler and EndpointOutput type declarations.
-- 6ef148d: Generate service worker registration code even with `router` and `hydration` disabled
-- ae3ef19: Fail if config.kit.appDir starts or ends with a slash
+- 9fbaeda: fix attribute validation in generated script tag (#1768)
+- 9f0c54a: Externalize app initialization to adapters (#1804)
+- 0d69e55: Add generic type for session (#1791)
+- 325c223: Improve RequestHandler and EndpointOutput type declarations. (#1778)
+- 6ef148d: Generate service worker registration code even with `router` and `hydration` disabled (#1724)
+- ae3ef19: Fail if config.kit.appDir starts or ends with a slash (#1695)
 
 ## 1.0.0-next.119
 
@@ -203,192 +203,192 @@
 
 ### Patch Changes
 
-- 5418254: Fix regex for getting links to crawl during prerendering
+- 5418254: Fix regex for getting links to crawl during prerendering (#1743)
 
 ## 1.0.0-next.117
 
 ### Patch Changes
 
-- 828732c: Specify actual Svelte version requirement
+- 828732c: Specify actual Svelte version requirement (#1751)
 
 ## 1.0.0-next.116
 
 ### Patch Changes
 
-- ea8cd54: chore(kit): correct `engines` constraint
-- aedec24: Ensure router is initialized before parsing location
-- c7d5ce4: update vite to 2.3.8 and unpin
-- d259bca: Stricter regex for getting element attributes during prerendering
+- ea8cd54: chore(kit): correct `engines` constraint (#1696)
+- aedec24: Ensure router is initialized before parsing location (#1691)
+- c7d5ce4: update vite to 2.3.8 and unpin (#1715)
+- d259bca: Stricter regex for getting element attributes during prerendering (#1700)
 
 ## 1.0.0-next.115
 
 ### Patch Changes
 
-- 523c3e2: Allow vite.alias to be an array
-- 6fd46d1: \* update vite-plugin-svelte to 1.0.0-next.11 and use its named export
+- 523c3e2: Allow vite.alias to be an array (#1640)
+- 6fd46d1: \* update vite-plugin-svelte to 1.0.0-next.11 and use its named export (#1673)
   - update vite to 2.3.7
-- dc56d3c: Fix navigation when `base` path is set and validate that option's value
+- dc56d3c: Fix navigation when `base` path is set and validate that option's value (#1666)
 
 ## 1.0.0-next.114
 
 ### Patch Changes
 
-- 5aa64ab: fix: SSL for HMR websockets #844
-- fae75f1: add optional state parameter for goto function
-- fbd5f8a: package command can now transpile TypeScript files
+- 5aa64ab: fix: SSL for HMR websockets #844 (#1517)
+- fae75f1: add optional state parameter for goto function (#1643)
+- fbd5f8a: package command can now transpile TypeScript files (#1633)
 
 ## 1.0.0-next.113
 
 ### Patch Changes
 
-- 045c45c: update vite to 2.3.6
+- 045c45c: update vite to 2.3.6 (#1625)
 
 ## 1.0.0-next.112
 
 ### Patch Changes
 
-- cbe029e: Allow non-lowercase 'content-type' header in ssr fetch requests
-- 1bf1a02: Make it possible to type context, page params and props for LoadInput and LoadOutput
+- cbe029e: Allow non-lowercase 'content-type' header in ssr fetch requests (#1463)
+- 1bf1a02: Make it possible to type context, page params and props for LoadInput and LoadOutput (#1447)
 
 ## 1.0.0-next.111
 
 ### Patch Changes
 
-- eae1b1d: Rename handle's render parameter to resolve
+- eae1b1d: Rename handle's render parameter to resolve (#1566)
 
 ## 1.0.0-next.110
 
 ### Patch Changes
 
-- 6372690: Add svelte-kit package command
-- c3d36a3: ensure `content-length` limit respected; handle `getRawBody` error(s)
-- bf77940: bump `polka` and `sirv` dependency versions
-- 2172469: Upgrade to Vite 2.3.4
-- 028abd9: Pass validated svelte config to adapter adapt function
+- 6372690: Add svelte-kit package command (#1499)
+- c3d36a3: ensure `content-length` limit respected; handle `getRawBody` error(s) (#1528)
+- bf77940: bump `polka` and `sirv` dependency versions (#1548)
+- 2172469: Upgrade to Vite 2.3.4 (#1580)
+- 028abd9: Pass validated svelte config to adapter adapt function (#1559)
 
 ## 1.0.0-next.109
 
 ### Patch Changes
 
-- 261ee1c: Update compatible Node versions
-- ec156c6: let hash only changes be handled by router
-- 586785d: Allow passing HTTPS key pair in Vite section of config
+- 261ee1c: Update compatible Node versions (#1470)
+- ec156c6: let hash only changes be handled by router (#830)
+- 586785d: Allow passing HTTPS key pair in Vite section of config (#1456)
 
 ## 1.0.0-next.108
 
 ### Patch Changes
 
-- dad93fc: Fix workspace dependencies
-- 37fc04f: Ignore URLs that the app does not own
+- dad93fc: Fix workspace dependencies (#1434)
+- 37fc04f: Ignore URLs that the app does not own (#1487)
 
 ## 1.0.0-next.107
 
 ### Patch Changes
 
-- ad83d40: update vite to ^2.3.1
+- ad83d40: update vite to ^2.3.1 (#1429)
 
 ## 1.0.0-next.106
 
 ### Patch Changes
 
-- fe0531d: temporarily pin vite to version 2.2.4 until issues with 2.3.0 are resolved
+- fe0531d: temporarily pin vite to version 2.2.4 until issues with 2.3.0 are resolved (#1423)
 
 ## 1.0.0-next.105
 
 ### Patch Changes
 
-- f3c50a0: Bump Vite to 2.3.0
-- cfd6c3c: Use rendered CSS for AMP pages
-- 9a2cc0a: Add trailingSlash: 'never' | 'always' | 'ignore' option
+- f3c50a0: Bump Vite to 2.3.0 (#1413)
+- cfd6c3c: Use rendered CSS for AMP pages (#1408)
+- 9a2cc0a: Add trailingSlash: 'never' | 'always' | 'ignore' option (#1404)
 
 ## 1.0.0-next.104
 
 ### Patch Changes
 
-- 9b448a6: Rename @sveltejs/kit/http to @sveltejs/kit/node
+- 9b448a6: Rename @sveltejs/kit/http to @sveltejs/kit/node (#1391)
 
 ## 1.0.0-next.103
 
 ### Patch Changes
 
-- 11e7840: Generate ETags for binary response bodies
-- 11e7840: Update request/response body types
-- 9e20873: Allow ServerResponse to have non-static set of headers
-- 2562ca0: Account for POST bodies when serializing fetches
+- 11e7840: Generate ETags for binary response bodies (#1382)
+- 11e7840: Update request/response body types (#1382)
+- 9e20873: Allow ServerResponse to have non-static set of headers (#1375)
+- 2562ca0: Account for POST bodies when serializing fetches (#1385)
 
 ## 1.0.0-next.102
 
 ### Patch Changes
 
-- b5ff7f5: Rename \$layout to \_\_layout etc
-- d871213: Make Vite a prod dep of SvelteKit
+- b5ff7f5: Rename \$layout to \_\_layout etc (#1370)
+- d871213: Make Vite a prod dep of SvelteKit (#1374)
 
 ## 1.0.0-next.101
 
 ### Patch Changes
 
-- f5e626d: Reference Vite/Svelte types inside Kit types
+- f5e626d: Reference Vite/Svelte types inside Kit types (#1319)
 
 ## 1.0.0-next.100
 
 ### Patch Changes
 
-- 9890492: Use TypedArray.set to copy from Uint8Array when getting raw body in core/http
+- 9890492: Use TypedArray.set to copy from Uint8Array when getting raw body in core/http (#1349)
 
 ## 1.0.0-next.99
 
 ### Patch Changes
 
-- 051c026: Remove getContext in favour of request.locals
+- 051c026: Remove getContext in favour of request.locals (#1332)
 
 ## 1.0.0-next.98
 
 ### Patch Changes
 
-- d279e36: Add invalidate(url) API for re-running load functions
+- d279e36: Add invalidate(url) API for re-running load functions (#1303)
 
 ## 1.0.0-next.97
 
 ### Patch Changes
 
-- 694f5de: Fixes `navigating` store type
-- 0befffb: Rename .svelte to .svelte-kit
-- c6fde99: Switch to ESM in config files
+- 694f5de: Fixes `navigating` store type (#1322)
+- 0befffb: Rename .svelte to .svelte-kit (#1321)
+- c6fde99: Switch to ESM in config files (#1323)
 
 ## 1.0.0-next.96
 
 ### Patch Changes
 
-- 63eff1a: Add prerendering to \$app/env typings
+- 63eff1a: Add prerendering to \$app/env typings (#1316)
 
 ## 1.0.0-next.95
 
 ### Patch Changes
 
-- 16cca89: Export AdapterUtils type for use in adapters
-- f3ef93d: Not calling JSON.stringify on endpoint's body if it's a string and the content-type header denotes json
-- 5023e98: Remove 'Navigated to' text from announcer'
+- 16cca89: Export AdapterUtils type for use in adapters (#1300)
+- f3ef93d: Not calling JSON.stringify on endpoint's body if it's a string and the content-type header denotes json (#1272)
+- 5023e98: Remove 'Navigated to' text from announcer' (#1305)
 - b4d0d6c: Normalize keys of headers from server side requests
-- 08ebcb5: Add esm config support
-- 427e8e0: Validate template file on startup
+- 08ebcb5: Add esm config support (#936)
+- 427e8e0: Validate template file on startup (#1304)
 
 ## 1.0.0-next.94
 
 ### Patch Changes
 
-- 72c78a4: Handle URLs that need to be decoded
+- 72c78a4: Handle URLs that need to be decoded (#1273)
 
 ## 1.0.0-next.93
 
 ### Patch Changes
 
-- 353afa1: Disable FLoC by default
+- 353afa1: Disable FLoC by default (#1267)
 
 ## 1.0.0-next.92
 
 ### Patch Changes
 
-- 354e384: Allow FormData to be passed as RequestHandler type Body argument
+- 354e384: Allow FormData to be passed as RequestHandler type Body argument (#1256)
 - b1bfe83: Show error page on unknown initial path. Fixes #1190.
 
 ## 1.0.0-next.91
@@ -401,47 +401,47 @@
 
 ### Patch Changes
 
-- ac60208: Exit process after adapting
+- ac60208: Exit process after adapting (#1212)
 
 ## 1.0.0-next.89
 
 ### Patch Changes
 
-- 927e63c: update the error message of prerender to optionally include the parent variable
+- 927e63c: update the error message of prerender to optionally include the parent variable (#1200)
 
 ## 1.0.0-next.88
 
 ### Patch Changes
 
-- 6f2b4a6: Remove references to npm start
+- 6f2b4a6: Remove references to npm start (#1196)
 
 ## 1.0.0-next.87
 
 ### Patch Changes
 
-- 4131467: Prerender fallback page for SPAs
+- 4131467: Prerender fallback page for SPAs (#1181)
 
 ## 1.0.0-next.86
 
 ### Patch Changes
 
-- 2130087: Support multiple rel values on anchor tag
-- ba732ff: Report errors in hooks.js
+- 2130087: Support multiple rel values on anchor tag (#884)
+- ba732ff: Report errors in hooks.js (#1178)
 - a2f3f4b: Rename `start` to `preview` in the CLI and package scripts
 
 ## 1.0.0-next.85
 
 ### Patch Changes
 
-- 4645ad5: Force Vite to bundle Svelte component libraries in SSR
+- 4645ad5: Force Vite to bundle Svelte component libraries in SSR (#1148)
 - abf0248: Fix \$service-worker types
 
 ## 1.0.0-next.84
 
 ### Patch Changes
 
-- 5c2665f: Prevent ...rest parameters from swallowing earlier characters
-- 4e1c4ea: Omit modulepreload links from pages with no JS
+- 5c2665f: Prevent ...rest parameters from swallowing earlier characters (#1128)
+- 4e1c4ea: Omit modulepreload links from pages with no JS (#1131)
 - 5d864a6: Fix RequestHandler return type
 - e1313d0: Make response.body optional
 
@@ -449,143 +449,143 @@
 
 ### Patch Changes
 
-- a4a1075: Work around apparent Cloudflare Workers platform bugs
+- a4a1075: Work around apparent Cloudflare Workers platform bugs (#1123)
 
 ## 1.0.0-next.82
 
 ### Patch Changes
 
-- 4af45e1: Remove usage of node built-ins from runtime
+- 4af45e1: Remove usage of node built-ins from runtime (#1117)
 
 ## 1.0.0-next.81
 
 ### Patch Changes
 
-- 1237eb3: Expose rawBody on request, and expect rawBody from adapters
-- 1237eb3: Expose getRawBody from kit/http
+- 1237eb3: Expose rawBody on request, and expect rawBody from adapters (#1109)
+- 1237eb3: Expose getRawBody from kit/http (#1109)
 
 ## 1.0.0-next.80
 
 ### Patch Changes
 
-- 7a4b351: Expose install-fetch subpackage for adapters to use
+- 7a4b351: Expose install-fetch subpackage for adapters to use (#1091)
 
 ## 1.0.0-next.79
 
 ### Patch Changes
 
-- d3abd97: Fix Windows build output containing backward slashes
+- d3abd97: Fix Windows build output containing backward slashes (#1096)
 
 ## 1.0.0-next.78
 
 ### Patch Changes
 
-- 6e27880: Move server-side fetch to adapters instead of build step
-- 61d7fa0: Better error logging
-- 041b706: Implement layout resets
-- 148819a: Use latest vite-plugin-svelte
-- 9d54eed: Make sveltekit:prefetch a noop if <a> has no href
+- 6e27880: Move server-side fetch to adapters instead of build step (#1066)
+- 61d7fa0: Better error logging (#1062)
+- 041b706: Implement layout resets (#1061)
+- 148819a: Use latest vite-plugin-svelte (#1057)
+- 9d54eed: Make sveltekit:prefetch a noop if <a> has no href (#1060)
 
 ## 1.0.0-next.77
 
 ### Patch Changes
 
-- fee388a: Include CSS for entry point/generated component
+- fee388a: Include CSS for entry point/generated component (#1053)
 
 ## 1.0.0-next.76
 
 ### Patch Changes
 
-- f870909: Pin vite-plugin-svelte version
-- de2466f: Fix stale prerendering bug
+- f870909: Pin vite-plugin-svelte version (#1026)
+- de2466f: Fix stale prerendering bug (#1040)
 
 ## 1.0.0-next.75
 
 ### Patch Changes
 
-- 0c02dc0: Use global URLSearchParams instead of import from node url
-- 8021d6b: Fix default error page
-- 11ec751: Fix build warnings about missing exports in hooks file
+- 0c02dc0: Use global URLSearchParams instead of import from node url (#1020)
+- 8021d6b: Fix default error page (#1021)
+- 11ec751: Fix build warnings about missing exports in hooks file (#1003)
 
 ## 1.0.0-next.74
 
 ### Patch Changes
 
-- 4c45784: Add ambient types to published files
+- 4c45784: Add ambient types to published files (#980)
 
 ## 1.0.0-next.73
 
 ### Patch Changes
 
-- 1007f67: Allow non-root \$error.svelte components
-- ca108a6: Change `handle` hook from positional arguments to named arguments
+- 1007f67: Allow non-root \$error.svelte components (#901)
+- ca108a6: Change `handle` hook from positional arguments to named arguments (#959)
 
 ## 1.0.0-next.72
 
 ### Patch Changes
 
-- 1d5228c: Make --open option work with --https
-- 39b6967: Add ambient type definitions for \$app imports
-- 1d5228c: Make --open option work on WSL
-- bb2d97d: Fix argument type for RequestHandler
+- 1d5228c: Make --open option work with --https (#921)
+- 39b6967: Add ambient type definitions for \$app imports (#917)
+- 1d5228c: Make --open option work on WSL (#921)
+- bb2d97d: Fix argument type for RequestHandler (#914)
 
 ## 1.0.0-next.71
 
 ### Patch Changes
 
-- 108c26c: Always return a response from render function in handle
+- 108c26c: Always return a response from render function in handle (#847)
 
 ## 1.0.0-next.70
 
 ### Patch Changes
 
-- 6d9f7b1: Only include CSS on an SSR'd page
-- 6ecfa2c: Remove duplicate <style> element
+- 6d9f7b1: Only include CSS on an SSR'd page (#839)
+- 6ecfa2c: Remove duplicate <style> element (#845)
 
 ## 1.0.0-next.69
 
 ### Patch Changes
 
-- 4d2cd62: Add prerendering to \$app/env
-- e2eeeea: Call load when path changes if page.path is used
-- 50b5526: Pass through credentials when fetching in load
-- 6384af6: Only inline data if hydrate=true
+- 4d2cd62: Add prerendering to \$app/env (#833)
+- e2eeeea: Call load when path changes if page.path is used (#838)
+- 50b5526: Pass through credentials when fetching in load (#835)
+- 6384af6: Only inline data if hydrate=true (#837)
 
 ## 1.0.0-next.68
 
 ### Patch Changes
 
-- 24fab19: Add --https flag to dev and start
-- ba4f9b7: Check port, only expose to network with --host flag
+- 24fab19: Add --https flag to dev and start (#462)
+- ba4f9b7: Check port, only expose to network with --host flag (#819)
 
 ## 1.0.0-next.67
 
 ### Patch Changes
 
-- 679e997: Fix client-side redirect loop detection
-- 8d453c8: Specify minimum Node version number in @sveltejs/kit and add .npmrc to enforce it
+- 679e997: Fix client-side redirect loop detection (#811)
+- 8d453c8: Specify minimum Node version number in @sveltejs/kit and add .npmrc to enforce it (#787)
 - 78aec0c: Detect service worker support
-- f33a22c: Make ...rest parameters optional
+- f33a22c: Make ...rest parameters optional (#768)
 
 ## 1.0.0-next.66
 
 ### Patch Changes
 
-- d9ce2a2: Correct response type for fetch
+- d9ce2a2: Correct response type for fetch (#799)
 
 ## 1.0.0-next.65
 
 ### Patch Changes
 
-- c0b9873: Always apply layout props when hydrating
-- b8a8e53: Add type to config.kit.vite
-- 9b09bcc: Prevent XSS when serializing fetch results
+- c0b9873: Always apply layout props when hydrating (#794)
+- b8a8e53: Add type to config.kit.vite (#786)
+- 9b09bcc: Prevent XSS when serializing fetch results (#769)
 
 ## 1.0.0-next.64
 
 ### Patch Changes
 
-- 7f58512: Prevent Vite prebundling from crashing on startup
+- 7f58512: Prevent Vite prebundling from crashing on startup (#759)
 
 ## 1.0.0-next.63
 
@@ -597,7 +597,7 @@
 
 ### Patch Changes
 
-- 864c3d4: Assets imported from css and js/ts files are emitted as files instead of being inlined
+- 864c3d4: Assets imported from css and js/ts files are emitted as files instead of being inlined (#461)
 
 ## 1.0.0-next.61
 
@@ -609,114 +609,114 @@
 
 ### Patch Changes
 
-- 84e9023: Fix host property
-- 272148b: Rename \$service-worker::assets to files, per the docs
-- d5071c5: Hydrate initial page before starting router
-- 4a1c04a: More accurate MODULE_NOT_FOUND errors
-- d881b7e: Replace setup with hooks
+- 84e9023: Fix host property (#657)
+- 272148b: Rename \$service-worker::assets to files, per the docs (#658)
+- d5071c5: Hydrate initial page before starting router (#654)
+- 4a1c04a: More accurate MODULE_NOT_FOUND errors (#665)
+- d881b7e: Replace setup with hooks (#670)
 
 ## 1.0.0-next.59
 
 ### Patch Changes
 
-- 826f39e: Make prefetching work
+- 826f39e: Make prefetching work (#620)
 
 ## 1.0.0-next.58
 
 ### Patch Changes
 
-- 26893b0: Allow first argument to fetch in load to be a request
-- 924db15: Add copy function to Builder.js
+- 26893b0: Allow first argument to fetch in load to be a request (#619)
+- 924db15: Add copy function to Builder.js (#630)
 
 ## 1.0.0-next.57
 
 ### Patch Changes
 
-- 391189f: Check for options.initiator in correct place
+- 391189f: Check for options.initiator in correct place (#615)
 
 ## 1.0.0-next.56
 
 ### Patch Changes
 
-- 82cbe2b: Shrink client manifest
-- 8024178: remove @sveltejs/app-utils
+- 82cbe2b: Shrink client manifest (#593)
+- 8024178: remove @sveltejs/app-utils (#600)
 
 ## 1.0.0-next.55
 
 ### Patch Changes
 
-- d0a7019: switch to @sveltejs/vite-plugin-svelte
-- 8a88fad: Replace regex routes with fallthrough routes
+- d0a7019: switch to @sveltejs/vite-plugin-svelte (#584)
+- 8a88fad: Replace regex routes with fallthrough routes (#583)
 
 ## 1.0.0-next.54
 
 ### Patch Changes
 
-- 3037530: Create history entry for initial route
-- 04f17f5: Prevent erronous <style>undefined</style>
-- 8805c6d: Pass adapters directly to svelte.config.cjs
+- 3037530: Create history entry for initial route (#582)
+- 04f17f5: Prevent erronous <style>undefined</style> (#578)
+- 8805c6d: Pass adapters directly to svelte.config.cjs (#579)
 
 ## 1.0.0-next.53
 
 ### Patch Changes
 
-- 9cf2f21: Only require page components to export prerender
-- e860de0: Invalidate page when query changes
-- 7bb1cf0: Disable vite-plugin-svelte transform cache
+- 9cf2f21: Only require page components to export prerender (#577)
+- e860de0: Invalidate page when query changes (#575)
+- 7bb1cf0: Disable vite-plugin-svelte transform cache (#576)
 
 ## 1.0.0-next.52
 
 ### Patch Changes
 
-- ac3669e: Move Vite config into svelte.config.cjs
+- ac3669e: Move Vite config into svelte.config.cjs (#569)
 
 ## 1.0.0-next.51
 
 ### Patch Changes
 
-- 34a00f9: Bypass router on hydration
+- 34a00f9: Bypass router on hydration (#563)
 
 ## 1.0.0-next.50
 
 ### Patch Changes
 
-- 0512fd1: Remove startGlobal option
-- 9212aa5: Add options to adapter-node, and add adapter types
-- 0512fd1: Fire custom events for start, and navigation start/end
+- 0512fd1: Remove startGlobal option (#559)
+- 9212aa5: Add options to adapter-node, and add adapter types (#531)
+- 0512fd1: Fire custom events for start, and navigation start/end (#559)
 
 ## 1.0.0-next.49
 
 ### Patch Changes
 
-- ab28c0a: kit: include missing types.d.ts
-- c76c9bf: Upgrade Vite
+- ab28c0a: kit: include missing types.d.ts (#538)
+- c76c9bf: Upgrade Vite (#544)
 
 ## 1.0.0-next.48
 
 ### Patch Changes
 
-- e37a302: Make getSession future-proof
+- e37a302: Make getSession future-proof (#524)
 
 ## 1.0.0-next.47
 
 ### Patch Changes
 
-- 5554acc: Add \$lib alias
-- 5cd6f11: bump vite-plugin-svelte to 0.11.0
+- 5554acc: Add \$lib alias (#511)
+- 5cd6f11: bump vite-plugin-svelte to 0.11.0 (#513)
 
 ## 1.0.0-next.46
 
 ### Patch Changes
 
-- f35a5cd: Change adapter signature
+- f35a5cd: Change adapter signature (#505)
 
 ## 1.0.0-next.45
 
 ### Patch Changes
 
-- 925638a: Remove endpoints from the files built for the client
-- c3cf3f3: Bump deps
-- 625747d: kit: bundle @sveltejs/kit into built application
+- 925638a: Remove endpoints from the files built for the client (#490)
+- c3cf3f3: Bump deps (#492)
+- 625747d: kit: bundle @sveltejs/kit into built application (#486)
 - Updated dependencies [c3cf3f3]
   - @sveltejs/vite-plugin-svelte@1.0.0-next.3
 
@@ -724,67 +724,67 @@
 
 ### Patch Changes
 
-- e6449d2: Fix AMP styles for real
+- e6449d2: Fix AMP styles for real (#494)
 
 ## 1.0.0-next.43
 
 ### Patch Changes
 
-- 672e9be: Fix AMP styles, again
+- 672e9be: Fix AMP styles, again (#491)
 
 ## 1.0.0-next.42
 
 ### Patch Changes
 
-- 0f54ebc: Fix AMP styles
+- 0f54ebc: Fix AMP styles (#488)
 
 ## 1.0.0-next.41
 
 ### Patch Changes
 
-- 4aa5a73: Future-proof prepare argument
-- 58dc400: Call correct set_paths function
+- 4aa5a73: Future-proof prepare argument (#471)
+- 58dc400: Call correct set_paths function (#487)
 - 2322291: Update to node-fetch@3
 
 ## 1.0.0-next.40
 
 ### Patch Changes
 
-- 4c5fd3c: Include layout/error styles in SSR
+- 4c5fd3c: Include layout/error styles in SSR (#472)
 
 ## 1.0.0-next.39
 
 ### Patch Changes
 
-- b7fdb0d: Skip pre-bundling
+- b7fdb0d: Skip pre-bundling (#468)
 
 ## 1.0.0-next.38
 
 ### Patch Changes
 
-- 15402b1: Add service worker support
-- 0c630b5: Ignore dynamically imported components when constructing styles in dev mode
-- ac06af5: Fix svelte-kit adapt for Windows
+- 15402b1: Add service worker support (#463)
+- 0c630b5: Ignore dynamically imported components when constructing styles in dev mode (#443)
+- ac06af5: Fix svelte-kit adapt for Windows (#435)
 - 061fa46: Implement improved redirect API
-- b800049: Include type declarations
-- 07c6de4: Use posix paths in manifest even on Windows
-- 27ba872: Error if preload function exists
-- 0c630b5: Add default paths in case singletons module is invalidated
-- 73dd998: Allow custom extensions
+- b800049: Include type declarations (#442)
+- 07c6de4: Use posix paths in manifest even on Windows (#436)
+- 27ba872: Error if preload function exists (#455)
+- 0c630b5: Add default paths in case singletons module is invalidated (#443)
+- 73dd998: Allow custom extensions (#411)
 
 ## 1.0.0-next.37
 
 ### Patch Changes
 
-- 230c6d9: Indicate which request failed, if fetch fails inside load function
-- f1bc218: Run adapt via svelte-kit build
-- 6850ddc: Fix svelte-kit start for Windows
+- 230c6d9: Indicate which request failed, if fetch fails inside load function (#427)
+- f1bc218: Run adapt via svelte-kit build (#430)
+- 6850ddc: Fix svelte-kit start for Windows (#425)
 
 ## 1.0.0-next.36
 
 ### Patch Changes
 
-- 7b70a33: Force version bump so that Kit uses updated vite-plugin-svelte
+- 7b70a33: Force version bump so that Kit uses updated vite-plugin-svelte (#419)
 
 ## 1.0.0-next.35
 
@@ -805,7 +805,7 @@
 
 ### Patch Changes
 
-- 474070e: Better errors when modules cannot be found
+- 474070e: Better errors when modules cannot be found (#381)
 
 ## 1.0.0-next.32
 
@@ -817,26 +817,26 @@
 
 ### Patch Changes
 
-- b6c2434: app.js -> app.cjs
+- b6c2434: app.js -> app.cjs (#362)
 
 ## 1.0.0-next.30
 
 ### Patch Changes
 
-- 00cbaf6: Rename _.config.js to _.config.cjs
+- 00cbaf6: Rename _.config.js to _.config.cjs (#356)
 
 ## 1.0.0-next.29
 
 ### Patch Changes
 
-- 4c0edce: Use addEventListener instead of onload
+- 4c0edce: Use addEventListener instead of onload (#347)
 
 ## 1.0.0-next.28
 
 ### Patch Changes
 
-- 4353025: Prevent infinite loop when fetching bad URLs inside error responses
-- 2860065: Handle assets path when prerendering
+- 4353025: Prevent infinite loop when fetching bad URLs inside error responses (#340)
+- 2860065: Handle assets path when prerendering (#341)
 
 ## 1.0.0-next.27
 
@@ -861,50 +861,50 @@
 
 ### Patch Changes
 
-- 26643df: Account for config.paths when prerendering
+- 26643df: Account for config.paths when prerendering (#322)
 
 ## 1.0.0-next.23
 
 ### Patch Changes
 
-- 9b758aa: Upgrade to Snowpack 3
+- 9b758aa: Upgrade to Snowpack 3 (#321)
 
 ## 1.0.0-next.22
 
 ### Patch Changes
 
-- bb68595: use readFileSync instead of createReadStream
+- bb68595: use readFileSync instead of createReadStream (#320)
 
 ## 1.0.0-next.21
 
 ### Patch Changes
 
-- 217e4cc: Set paths to empty string before prerender
+- 217e4cc: Set paths to empty string before prerender (#317)
 
 ## 1.0.0-next.20
 
 ### Patch Changes
 
-- ccf4aa7: Implement prerender config
+- ccf4aa7: Implement prerender config (#315)
 
 ## 1.0.0-next.19
 
 ### Patch Changes
 
-- deda984: Make navigating store contain from and to properties
+- deda984: Make navigating store contain from and to properties (#313)
 
 ## 1.0.0-next.18
 
 ### Patch Changes
 
-- c29b61e: Announce page changes
-- 72da270: Reset focus properly
+- c29b61e: Announce page changes (#311)
+- 72da270: Reset focus properly (#309)
 
 ## 1.0.0-next.17
 
 ### Patch Changes
 
-- f7dea55: Set process.env.NODE_ENV when invoking via the CLI
+- f7dea55: Set process.env.NODE_ENV when invoking via the CLI (#304)
 
 ## 1.0.0-next.16
 
@@ -917,7 +917,7 @@
 
 ### Patch Changes
 
-- 6d1bb11: Fix AMP CSS
+- 6d1bb11: Fix AMP CSS (#286)
 - d8b53af: Ignore $layout and $error files when finding static paths
 - Better scroll tracking
 
@@ -931,7 +931,7 @@
 
 ### Patch Changes
 
-- 1ea4d6b: More robust CSS extraction
+- 1ea4d6b: More robust CSS extraction (#279)
 
 ## 1.0.0-next.12
 
@@ -943,42 +943,42 @@
 
 ### Patch Changes
 
-- a31f218: Fix SSR loader invalidation
+- a31f218: Fix SSR loader invalidation (#277)
 
 ## 1.0.0-next.10
 
 ### Patch Changes
 
-- 8b14d29: Omit svelte-data scripts from AMP pages
+- 8b14d29: Omit svelte-data scripts from AMP pages (#276)
 
 ## 1.0.0-next.9
 
 ### Patch Changes
 
-- f5fa223: AMP support
-- 47f2ee1: Always remove trailing slashes
+- f5fa223: AMP support (#274)
+- 47f2ee1: Always remove trailing slashes (#267)
 - 1becb94: Replace preload with load
 
 ## 1.0.0-next.8
 
 ### Patch Changes
 
-- 15dd751: Use meta http-equiv=refresh
-- be7e031: Fix handling of static files
-- ed6b8fd: Implement \$app/env
+- 15dd751: Use meta http-equiv=refresh (#256)
+- be7e031: Fix handling of static files (#258)
+- ed6b8fd: Implement \$app/env (#251)
 
 ## 1.0.0-next.7
 
 ### Patch Changes
 
-- 76705b0: make HMR work outside localhost
+- 76705b0: make HMR work outside localhost (#246)
 
 ## 1.0.0-next.6
 
 ### Patch Changes
 
-- 0e45255: Move options behind kit namespace, change paths -> kit.files
-- fa7f2b2: Implement live bindings for SSR code
+- 0e45255: Move options behind kit namespace, change paths -> kit.files (#236)
+- fa7f2b2: Implement live bindings for SSR code (#245)
 
 ## 1.0.0-next.5
 
@@ -1008,14 +1008,14 @@
 
 ### Patch Changes
 
-- a4bc090: Transform exported functions correctly
-- 00bbf98: Fix nested layouts
+- a4bc090: Transform exported functions correctly (#225)
+- 00bbf98: Fix nested layouts (#227)
 
 ## 0.0.31-next.0
 
 ### Patch Changes
 
-- ffd7bba: Fix SSR cache invalidation
+- ffd7bba: Fix SSR cache invalidation (#217)
 
 ## 0.0.30
 
@@ -1029,7 +1029,7 @@
 
 ### Patch Changes
 
-- 10872cc: Normalize request.query
+- 10872cc: Normalize request.query (#196)
 
 ## 0.0.28
 
@@ -1042,7 +1042,7 @@
 ### Patch Changes
 
 - rename CLI to svelte-kit
-- 0904e22: rename svelte CLI to svelte-kit
+- 0904e22: rename svelte CLI to svelte-kit (#186)
 - Validate route responses
 - Make paths and target configurable
 
@@ -1050,7 +1050,7 @@
 
 ### Patch Changes
 
-- b475ed4: Overhaul adapter API - fixes #166
+- b475ed4: Overhaul adapter API - fixes #166 (#180)
 - Updated dependencies [b475ed4]
   - @sveltejs/app-utils@0.0.18
 
@@ -1075,7 +1075,7 @@
 ### Patch Changes
 
 - a163000: Parse body on incoming requests
-- a346eab: Copy over latest Sapper router code
+- a346eab: Copy over latest Sapper router code (#6)
 - Updated dependencies [a163000]
   - @sveltejs/app-utils@0.0.15
 

--- a/packages/kit/CHANGELOG.md
+++ b/packages/kit/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 - d109a394: [fix] successfully load nested error pages
 - fab67c94: [fix] successfully handle client errors
-- 943f5288: [fix] solve regression parsing unicode URLs"
+- 943f5288: [fix] solve regression parsing unicode URLs
 - 4435a659: [fix] allow endpoint shadowing to work
 - ee73a265: [fix] correctly do fallthrough in simple case
 


### PR DESCRIPTION
As per discussion in #2116, I created a script to look up PR numbers in GitHub commit messages and add them to the changelog entries. This is the result.

While I was at it, I also fixed one obvious typo in a changeset and its corresponding changelog entry. I put that in a separate commit (22c1880) so that if modifying a changeset file after-the-fact will cause tooling issues, I can easily remove that commit from this PR. Just let me know if that's needed.

No changeset included in this PR since it doesn't make any code changes.

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
