### PR TITLE
Update example node adapter config with correct defaults

### DIFF
--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -17,8 +17,8 @@ export default {
 			out: 'build',
 			precompress: false,
 			env: {
-				host: 'HOST',
-				port: 'PORT'
+				host: '0.0.0.0',
+				port: '3000'
 			}
 		})
 	}


### PR DESCRIPTION
The `svelte.config.js` example in the README included `host: 'HOST'` and `port: 'PORT'` properties and a comment that says `// default options are shown`. This implies that `HOST` or `PORT` environment variables must be specified or the service will not know which host and port to bind to.

But then below it says

```
By default, the server will accept connections on `0.0.0.0` using port 3000.
```

I think it's more accurate to show the default host and port the service will bind to if not specified anywhere else. And then keep the language saying that host and port can be overridden with the `HOST` and `PORT` environment variables.

----------------------

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] ~~Ideally, include a test that fails without this PR but passes with it.~~ (not applicable)

### Tests
- [ ] ~~Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`~~ (not applicable)

### Changesets
- [ ] ~~If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0~~ (not necessary for this change)
