### PR TITLE
[fix] Import fallback components when they are actually required

### DIFF
--- a/packages/kit/src/core/create_app/index.js
+++ b/packages/kit/src/core/create_app/index.js
@@ -102,7 +102,7 @@ function generate_client_manifest(manifest_data, base) {
 
 		export const routes = ${routes};
 
-		export const fallback = [c[0](), c[1]()];
+		export const fallback = [c[0], c[1]];
 	`);
 }
 

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -60,7 +60,7 @@ function initial_fetch(resource, opts) {
 export class Renderer {
 	/** @param {{
 	 *   Root: CSRComponent;
-	 *   fallback: [CSRComponent, CSRComponent];
+	 *   fallback: [() => CSRComponent, () => CSRComponent];
 	 *   target: Node;
 	 *   session: any;
 	 *   host: string;
@@ -708,7 +708,7 @@ export class Renderer {
 		};
 
 		const node = await this._load_node({
-			module: await this.fallback[0],
+			module: await this.fallback[0](),
 			page,
 			context: {}
 		});
@@ -718,7 +718,7 @@ export class Renderer {
 			await this._load_node({
 				status,
 				error,
-				module: await this.fallback[1],
+				module: await this.fallback[1](),
 				page,
 				context: (node && node.loaded && node.loaded.context) || {}
 			})

--- a/packages/kit/test/apps/basics/src/routes/__layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/__layout.svelte
@@ -13,10 +13,13 @@
 	}
 
 	if (browser) {
-		let h3 = document.createElement('h3');
-		let text = document.createTextNode('You cannot reset me');
+		const h3 = document.createElement('h3');
+		const text = document.createTextNode('I should not be rendered');
 		h3.appendChild(text);
-		document.getElementById('nested-layout-reset-test')?.appendChild(h3);
+		const parentDiv = document.getElementById('nested-layout-reset-test');
+		if (parentDiv) {
+			parentDiv.appendChild(h3);
+		}
 	}
 </script>
 
@@ -31,7 +34,7 @@
 	export let foo;
 </script>
 
-<slot></slot>
+<slot />
 
 <footer>{foo.bar}</footer>
 

--- a/packages/kit/test/apps/basics/src/routes/__layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/__layout.svelte
@@ -1,4 +1,6 @@
 <script context="module">
+	import { browser } from '$app/env';
+
 	/** @type {import('@sveltejs/kit').Load} */
 	export async function load() {
 		return {
@@ -8,6 +10,13 @@
 				}
 			}
 		};
+	}
+
+	if (browser) {
+		let h3 = document.createElement('h3');
+		let text = document.createTextNode('You cannot reset me');
+		h3.appendChild(text);
+		document.getElementById('nested-layout-reset-test')?.appendChild(h3);
 	}
 </script>
 

--- a/packages/kit/test/apps/basics/src/routes/nested-layout/reset/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/nested-layout/reset/_tests.js
@@ -8,4 +8,8 @@ export default function (test) {
 		assert.equal(await page.textContent('h1'), 'Layout reset');
 		assert.equal(await page.textContent('h2'), 'Hello');
 	});
+
+	test('context script reset', '/nested-layout/reset', async ({ page }) => {
+		assert.ok(await page.evaluate(() => !document.querySelector('h3')));
+	});
 }

--- a/packages/kit/test/apps/basics/src/routes/nested-layout/reset/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/nested-layout/reset/index.svelte
@@ -1,1 +1,2 @@
 <h2>Hello</h2>
+<div id="nested-layout-reset-test" />


### PR DESCRIPTION
Fixes #2154 and fixes #2130

The root cause for the above two issues is in the manifest file which exports the routes and the fallback. The fallback components (`__layout.svelte` and `error.svelte`) are always imported because of the way they are exported from the manifest. Always importing the components causes module-context code to run even when the layout is reset.
```js
const c = [
	() => import("..\\..\\..\\src\\routes\\__layout.svelte"),
	() => import("..\\components\\error.svelte"),
	() => import("..\\..\\..\\src\\routes\\index.svelte"),
	() => import("..\\..\\..\\src\\routes\\login\\__layout.reset.svelte"),
	() => import("..\\..\\..\\src\\routes\\login\\index.svelte")
];

const d = decodeURIComponent;

export const routes = [
	// src/routes/index.svelte
	[/^\/$/, [c[0], c[2]], [c[1]]],

	// src/routes/login/index.svelte
	[/^\/login\/?$/, [c[3], c[4]], []]
];

export const fallback = [c[0](), c[1]()];
```
## Proposed Changes
This PR changes the way the fallback components are exported and utilized in the Renderer. The fallback array now is of type `[() => CSRComponent, () => CSRComponent]` which was previously `[CSRComponent, CSRComponent]`. And the function to import these components are called only when required.

Now the generated manifest file would look something like below.
```js
const c = [
	() => import("..\\..\\..\\src\\routes\\__layout.svelte"),
	() => import("..\\components\\error.svelte"),
	() => import("..\\..\\..\\src\\routes\\index.svelte"),
	() => import("..\\..\\..\\src\\routes\\login\\__layout.reset.svelte"),
	() => import("..\\..\\..\\src\\routes\\login\\index.svelte")
];

const d = decodeURIComponent;

export const routes = [
	// src/routes/index.svelte
	[/^\/$/, [c[0], c[2]], [c[1]]],

	// src/routes/login/index.svelte
	[/^\/login\/?$/, [c[3], c[4]], []]
];

export const fallback = [c[0], c[1]];
```
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
