### PR TITLE
Fix Todo delete button not disabling while waiting for API response

### DIFF
--- a/.changeset/wicked-humans-taste.md
+++ b/.changeset/wicked-humans-taste.md
@@ -1,6 +1,5 @@
 ---
-"create-svelte": patch
-"~TODO~": patch
+'create-svelte': patch
 ---
 
 Disable delete button while waiting for API response

--- a/.changeset/wicked-humans-taste.md
+++ b/.changeset/wicked-humans-taste.md
@@ -1,0 +1,6 @@
+---
+"create-svelte": patch
+"~TODO~": patch
+---
+
+Disable delete button while waiting for API response

--- a/packages/create-svelte/templates/default/src/routes/todos/index.svelte
+++ b/packages/create-svelte/templates/default/src/routes/todos/index.svelte
@@ -59,7 +59,6 @@
 		use:enhance={{
 			result: async (res, form) => {
 				const created = await res.json();
-				created.pending_delete = false;
 				todos = [...todos, created];
 
 				form.reset();
@@ -112,7 +111,7 @@
 					}
 				}}
 			>
-				<button class="delete" aria-label="Delete todo" disabled={todo.pending_delete} />
+				<button class="delete" aria-label="Delete todo" disabled={!!todo.pending_delete} />
 			</form>
 		</div>
 	{/each}

--- a/packages/create-svelte/templates/default/src/routes/todos/index.svelte
+++ b/packages/create-svelte/templates/default/src/routes/todos/index.svelte
@@ -59,6 +59,7 @@
 		use:enhance={{
 			result: async (res, form) => {
 				const created = await res.json();
+				created.pending_delete = false;
 				todos = [...todos, created];
 
 				form.reset();
@@ -105,12 +106,13 @@
 				action="/todos/{todo.uid}.json?_method=delete"
 				method="post"
 				use:enhance={{
+					pending: () => todo.pending_delete = true,
 					result: () => {
 						todos = todos.filter((t) => t.uid !== todo.uid);
 					}
 				}}
 			>
-				<button class="delete" aria-label="Delete todo" />
+				<button class="delete" aria-label="Delete todo" disabled={todo.pending_delete} />
 			</form>
 		</div>
 	{/each}

--- a/packages/create-svelte/templates/default/src/routes/todos/index.svelte
+++ b/packages/create-svelte/templates/default/src/routes/todos/index.svelte
@@ -31,6 +31,7 @@
 		created_at: Date;
 		text: string;
 		done: boolean;
+		pending_delete: boolean;
 	};
 
 	export let todos: Todo[];
@@ -111,7 +112,7 @@
 					}
 				}}
 			>
-				<button class="delete" aria-label="Delete todo" disabled={!!todo.pending_delete} />
+				<button class="delete" aria-label="Delete todo" disabled={todo.pending_delete} />
 			</form>
 		</div>
 	{/each}

--- a/packages/create-svelte/templates/default/src/routes/todos/index.svelte
+++ b/packages/create-svelte/templates/default/src/routes/todos/index.svelte
@@ -105,7 +105,7 @@
 				action="/todos/{todo.uid}.json?_method=delete"
 				method="post"
 				use:enhance={{
-					pending: () => todo.pending_delete = true,
+					pending: () => (todo.pending_delete = true),
 					result: () => {
 						todos = todos.filter((t) => t.uid !== todo.uid);
 					}


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/issues/1564, currently the todo's in the demo app suffer from a bug where you can click delete on a todo while the first delete is still pending. 

This allows multiple delete requests to be sent, HTTP 500 errors to be received (https://github.com/sveltejs/api.svelte.dev/blob/master/src/routes/todos.ts#L46) and the todo to never visually disappear.

![image](https://user-images.githubusercontent.com/8846579/129121794-4d2338cd-b103-4c89-9226-be96b1190a7a.png)
