### PR TITLE
add optimizeDeps.entries when build.rollupOptions.input is unspecified

### DIFF
--- a/.changeset/smooth-kangaroos-guess.md
+++ b/.changeset/smooth-kangaroos-guess.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Set optimizeDeps.entries to [] when building service worker

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -591,6 +591,7 @@ async function build_service_worker(
 			emptyOutDir: false
 		},
 		optimizeDeps: {
+			entries: [],
 			// exclude Svelte packages because optimizer skips .svelte files leading to half-bundled
 			// broken packages https://github.com/vitejs/vite/issues/3910
 			exclude: [


### PR DESCRIPTION
#2137 removed the `optimizeDeps.entries` configuration added in #468. In most cases that's harmless, but I've experienced situations where Vite attempts to scan thousands of build artifacts in order to populate `optimizeDeps.include`, resulting in a crash. According to Vite's docs, it only does this when `rollupOptions.input` is unspecified. Since that's only true for the service worker build config, I've only re-added it there.

Aside: I do not understand why prebundling is necessary. To me it feels like Vite should be able to say 'the browser is requesting `foo` from `node_modules`, which appears to be suitable for prebundling, so lemme just run esbuild over it before responding'. I don't get why it has to happen eagerly.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
