### PR TITLE
update kit peerDependency on svelte to ^3.39.0

### DIFF
--- a/.changeset/brave-falcons-approve.md
+++ b/.changeset/brave-falcons-approve.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+update svelte peerDependency to 3.39.0

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -40,7 +40,7 @@
 		"uvu": "^0.5.1"
 	},
 	"peerDependencies": {
-		"svelte": "^3.34.0"
+		"svelte": "^3.39.0"
 	},
 	"bin": {
 		"svelte-kit": "svelte-kit.js"


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

svelte 3.39.0 introduced a new export `svelte/ssr` with a noop for onMount
https://github.com/sveltejs/svelte/issues/6372
which is supported by vite-plugin-svelte https://github.com/sveltejs/vite-plugin-svelte/issues/74

To make sure users do profit from this improvement, raise the peer dependency version. 
Example of a user with older svelte version: https://github.com/sveltejs/kit/issues/2181
