### PR TITLE
Handle error

### DIFF
--- a/.changeset/chilled-laws-battle.md
+++ b/.changeset/chilled-laws-battle.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add hook to handle errors

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -331,13 +331,6 @@ async function build_server(
 					floc: ${config.kit.floc},
 					get_component_path: id => ${s(`${config.kit.paths.assets}/${config.kit.appDir}/`)} + entry_lookup[id],
 					get_stack: error => String(error), // for security
-					handle_error: /** @param {Error & {frame?: string}} error */ (error) => {
-						if (error.frame) {
-							console.error(error.frame);
-						}
-						console.error(error.stack);
-						error.stack = options.get_stack(error);
-					},
 					hooks: get_hooks(user_hooks),
 					hydrate: ${s(config.kit.hydrate)},
 					initiator: undefined,
@@ -397,6 +390,18 @@ async function build_server(
 			const get_hooks = hooks => ({
 				getSession: hooks.getSession || (() => ({})),
 				handle: hooks.handle || (({ request, resolve }) => resolve(request)),
+				handleError: ((opts) => {
+					const { error } = opts;
+					if (hooks.handleError) {
+						hooks.handleError(opts);
+					} else {
+						if (error.frame) {
+							console.error(error.frame);
+						}
+						console.error(error.stack);
+					}
+					error.stack = options.get_stack(error);
+				}),
 				serverFetch: hooks.serverFetch || fetch
 			});
 

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -396,7 +396,7 @@ async function build_server(
 			const get_hooks = hooks => ({
 				getSession: hooks.getSession || (() => ({})),
 				handle: hooks.handle || (({ request, resolve }) => resolve(request)),
-				handleError: hooks.handleError || (error => console.error(error.stack)),
+				handleError: hooks.handleError || (({ error }) => console.error(error.stack)),
 				serverFetch: hooks.serverFetch || fetch
 			});
 

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -396,7 +396,7 @@ async function build_server(
 			const get_hooks = hooks => ({
 				getSession: hooks.getSession || (() => ({})),
 				handle: hooks.handle || (({ request, resolve }) => resolve(request)),
-				handleError: hooks.handleError || error => console.error(error.stack),
+				handleError: hooks.handleError || (error => console.error(error.stack)),
 				serverFetch: hooks.serverFetch || fetch
 			});
 

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -347,19 +347,24 @@ async function create_handler(vite, config, dir, cwd, manifest) {
 							vite.ssrFixStacktrace(error);
 							return error.stack;
 						},
-						handle_error: /** @param {Error & {frame?: string}} error */ (error) => {
-							vite.ssrFixStacktrace(error);
-							console.error(colors.bold().red(error.message));
-							if (error.frame) {
-								console.error(colors.gray(error.frame));
-							}
-							if (error.stack) {
-								console.error(colors.gray(error.stack));
-							}
-						},
 						hooks: {
 							getSession: hooks.getSession || (() => ({})),
 							handle: hooks.handle || (({ request, resolve }) => resolve(request)),
+							handleError: (opts) => {
+								const { error } = opts;
+								vite.ssrFixStacktrace(error);
+								if (hooks.handleError) {
+									hooks.handleError(opts);
+								} else {
+									console.error(colors.bold().red(error.message));
+									if (error.frame) {
+										console.error(colors.gray(error.frame));
+									}
+									if (error.stack) {
+										console.error(colors.gray(error.stack));
+									}
+								}
+							},
 							serverFetch: hooks.serverFetch || fetch
 						},
 						hydrate: config.kit.hydrate,

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -311,7 +311,6 @@ async function create_handler(vite, config, dir, cwd, manifest) {
 					handleError:
 						user_hooks.handleError ||
 						(({ /** @type {Error & { frame?: string }} */ error, request }) => {
-							console.error(colors.bold().red(request.path));
 							console.error(colors.bold().red(error.message));
 							if (error.frame) {
 								console.error(colors.gray(error.frame));

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -300,9 +300,28 @@ async function create_handler(vite, config, dir, cwd, manifest) {
 				if (req.url === '/favicon.ico') return;
 
 				/** @type {Partial<import('types/internal').Hooks>} */
-				const hooks = resolve_entry(config.kit.files.hooks)
+				const user_hooks = resolve_entry(config.kit.files.hooks)
 					? await vite.ssrLoadModule(`/${config.kit.files.hooks}`)
 					: {};
+
+				/** @type {import('types/internal').Hooks} */
+				const hooks = {
+					getSession: user_hooks.getSession || (() => ({})),
+					handle: user_hooks.handle || (({ request, resolve }) => resolve(request)),
+					handleError:
+						user_hooks.handleError ||
+						(({ /** @type {Error & { frame?: string }} */ error, request }) => {
+							console.error(colors.bold().red(request.path));
+							console.error(colors.bold().red(error.message));
+							if (error.frame) {
+								console.error(colors.gray(error.frame));
+							}
+							if (error.stack) {
+								console.error(colors.gray(error.stack));
+							}
+						}),
+					serverFetch: user_hooks.serverFetch || fetch
+				};
 
 				if (/** @type {any} */ (hooks).getContext) {
 					// TODO remove this for 1.0
@@ -347,26 +366,11 @@ async function create_handler(vite, config, dir, cwd, manifest) {
 							vite.ssrFixStacktrace(error);
 							return error.stack;
 						},
-						hooks: {
-							getSession: hooks.getSession || (() => ({})),
-							handle: hooks.handle || (({ request, resolve }) => resolve(request)),
-							handleError: (opts) => {
-								const { error } = opts;
-								vite.ssrFixStacktrace(error);
-								if (hooks.handleError) {
-									hooks.handleError(opts);
-								} else {
-									console.error(colors.bold().red(error.message));
-									if (error.frame) {
-										console.error(colors.gray(error.frame));
-									}
-									if (error.stack) {
-										console.error(colors.gray(error.stack));
-									}
-								}
-							},
-							serverFetch: hooks.serverFetch || fetch
+						handle_error: (error, request) => {
+							vite.ssrFixStacktrace(error);
+							hooks.handleError({ error, request });
 						},
+						hooks,
 						hydrate: config.kit.hydrate,
 						paths: config.kit.paths,
 						load_component: async (id) => {

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -34,17 +34,18 @@ export async function respond(incoming, options, state = {}) {
 		}
 	}
 
-	try {
-		const headers = lowercase_keys(incoming.headers);
+	const headers = lowercase_keys(incoming.headers);
+	const request = {
+		...incoming,
+		headers,
+		body: parse_body(incoming.rawBody, headers),
+		params: {},
+		locals: {}
+	};
 
+	try {
 		return await options.hooks.handle({
-			request: {
-				...incoming,
-				headers,
-				body: parse_body(incoming.rawBody, headers),
-				params: {},
-				locals: {}
-			},
+			request,
 			resolve: async (request) => {
 				if (state.prerender && state.prerender.fallback) {
 					return await render_response({
@@ -100,7 +101,7 @@ export async function respond(incoming, options, state = {}) {
 	} catch (/** @type {unknown} */ err) {
 		const e = coalesce_to_error(err);
 
-		options.handle_error(e);
+		options.hooks.handleError({ error: e, request });
 
 		return {
 			status: 500,

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -101,7 +101,7 @@ export async function respond(incoming, options, state = {}) {
 	} catch (/** @type {unknown} */ err) {
 		const e = coalesce_to_error(err);
 
-		options.hooks.handleError({ error: e, request });
+		options.handle_error(e, request);
 
 		return {
 			status: 500,

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -105,7 +105,7 @@ export async function respond(opts) {
 				} catch (/** @type {unknown} */ err) {
 					const e = coalesce_to_error(err);
 
-					options.hooks.handleError({ error: e, request });
+					options.handle_error(e, request);
 
 					status = 500;
 					error = e;
@@ -150,7 +150,7 @@ export async function respond(opts) {
 							} catch (/** @type {unknown} */ err) {
 								const e = coalesce_to_error(err);
 
-								options.hooks.handleError({ error: e, request });
+								options.handle_error(e, request);
 
 								continue;
 							}

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -32,7 +32,7 @@ export async function respond(opts) {
 	} catch (/** @type {unknown} */ err) {
 		const error = coalesce_to_error(err);
 
-		options.hooks.handleError({ error, request });
+		options.handle_error(error, request);
 
 		return await respond_with_error({
 			request,
@@ -192,7 +192,7 @@ export async function respond(opts) {
 	} catch (/** @type {unknown} */ err) {
 		const error = coalesce_to_error(err);
 
-		options.hooks.handleError({ error, request });
+		options.handle_error(error, request);
 
 		return await respond_with_error({
 			...opts,

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -32,7 +32,7 @@ export async function respond(opts) {
 	} catch (/** @type {unknown} */ err) {
 		const error = coalesce_to_error(err);
 
-		options.handle_error(error);
+		options.hooks.handleError({ error, request });
 
 		return await respond_with_error({
 			request,
@@ -105,7 +105,7 @@ export async function respond(opts) {
 				} catch (/** @type {unknown} */ err) {
 					const e = coalesce_to_error(err);
 
-					options.handle_error(e);
+					options.hooks.handleError({ error: e, request });
 
 					status = 500;
 					error = e;
@@ -150,7 +150,7 @@ export async function respond(opts) {
 							} catch (/** @type {unknown} */ err) {
 								const e = coalesce_to_error(err);
 
-								options.handle_error(e);
+								options.hooks.handleError({ error: e, request });
 
 								continue;
 							}
@@ -192,7 +192,7 @@ export async function respond(opts) {
 	} catch (/** @type {unknown} */ err) {
 		const error = coalesce_to_error(err);
 
-		options.handle_error(error);
+		options.hooks.handleError({ error, request });
 
 		return await respond_with_error({
 			...opts,

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -81,7 +81,7 @@ export async function respond_with_error({ request, options, state, $session, st
 	} catch (/** @type {unknown} */ err) {
 		const error = coalesce_to_error(err);
 
-		options.handle_error(error);
+		options.hooks.handleError({ error, request });
 
 		return {
 			status: 500,

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -81,7 +81,7 @@ export async function respond_with_error({ request, options, state, $session, st
 	} catch (/** @type {unknown} */ err) {
 		const error = coalesce_to_error(err);
 
-		options.hooks.handleError({ error, request });
+		options.handle_error(error, request);
 
 		return {
 			status: 500,

--- a/packages/kit/types/hooks.d.ts
+++ b/packages/kit/types/hooks.d.ts
@@ -27,6 +27,10 @@ export interface Handle<Locals = Record<string, any>> {
 	}): MaybePromise<ServerResponse>;
 }
 
+export interface HandleError<Locals = Record<string, any>> {
+	(input: { error: Error & { frame?: string }; request: ServerRequest<Locals> }): void;
+}
+
 export interface ServerFetch {
 	(req: Request): Promise<Response>;
 }

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -1,6 +1,6 @@
 import { RequestHandler } from './endpoint';
 import { Headers, Location, ParameterizedBody } from './helper';
-import { GetSession, Handle, ServerResponse, ServerFetch, StrictBody } from './hooks';
+import { GetSession, Handle, HandleError, ServerResponse, ServerFetch, StrictBody } from './hooks';
 import { Load } from './page';
 
 type PageId = string;
@@ -122,6 +122,7 @@ export interface SSRManifest {
 export interface Hooks {
 	getSession: GetSession;
 	handle: Handle;
+	handleError: HandleError;
 	serverFetch: ServerFetch;
 }
 
@@ -142,8 +143,7 @@ export interface SSRRenderOptions {
 		js: string[];
 	};
 	floc: boolean;
-	get_stack(error: Error): string | undefined;
-	handle_error(error: Error): void;
+	get_stack: (error: Error) => string | undefined;
 	hooks: Hooks;
 	hydrate: boolean;
 	load_component(id: PageId): Promise<SSRNode>;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -1,6 +1,14 @@
 import { RequestHandler } from './endpoint';
 import { Headers, Location, ParameterizedBody } from './helper';
-import { GetSession, Handle, HandleError, ServerResponse, ServerFetch, StrictBody } from './hooks';
+import {
+	GetSession,
+	Handle,
+	HandleError,
+	ServerResponse,
+	ServerFetch,
+	StrictBody,
+	ServerRequest
+} from './hooks';
 import { Load } from './page';
 
 type PageId = string;
@@ -144,6 +152,7 @@ export interface SSRRenderOptions {
 	};
 	floc: boolean;
 	get_stack: (error: Error) => string | undefined;
+	handle_error(error: Error & { frame?: string }, request: ServerRequest<any>): void;
 	hooks: Hooks;
 	hydrate: boolean;
 	load_component(id: PageId): Promise<SSRNode>;


### PR DESCRIPTION
Closes https://github.com/sveltejs/kit/issues/1857

#2122 with a few tweaks — updated docs, and reinstated `handle_error`. Despite the naming similarity, they're separate things — `handleError` is the user's code, `handle_error` is what the framework does (which includes calling the user's code). It's better to avoid conflating them, even if the framework isn't doing much beyond what the user does (i.e. just manipulating `error.stack`)

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
