### PR TITLE
[fix] discover new routes in dev server

### DIFF
--- a/.changeset/tall-jeans-hear.md
+++ b/.changeset/tall-jeans-hear.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/kit': minor
+'@sveltejs/kit': patch
 ---
 
 fix new route discovery in dev server

--- a/.changeset/tall-jeans-hear.md
+++ b/.changeset/tall-jeans-hear.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+fix new route discovery in dev server

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -177,7 +177,7 @@ class Watcher extends EventEmitter {
 
 		this.vite = await vite.createServer(merged_config);
 
-		const getManifest = () => {
+		const get_manifest = () => {
 			if (!this.manifest) {
 				throw new Error("Shouldn't clear manifest after server initialized");
 			}
@@ -185,7 +185,7 @@ class Watcher extends EventEmitter {
 			return this.manifest;
 		};
 
-		handler = await create_handler(this.vite, this.config, this.dir, this.cwd, getManifest);
+		handler = await create_handler(this.vite, this.config, this.dir, this.cwd, get_manifest);
 
 		this.server.listen(this.port, this.host || '0.0.0.0');
 	}
@@ -275,9 +275,9 @@ function get_params(array) {
  * @param {import('types/config').ValidatedConfig} config
  * @param {string} dir
  * @param {string} cwd
- * @param {() => import('types/internal').SSRManifest} getManifest
+ * @param {() => import('types/internal').SSRManifest} get_manifest
  */
-async function create_handler(vite, config, dir, cwd, getManifest) {
+async function create_handler(vite, config, dir, cwd, get_manifest) {
 	/**
 	 * @type {amp_validator.Validator?}
 	 */
@@ -437,7 +437,7 @@ async function create_handler(vite, config, dir, cwd, getManifest) {
 								styles: Array.from(styles)
 							};
 						},
-						manifest: getManifest(),
+						manifest: get_manifest(),
 						prerender: config.kit.prerender.enabled,
 						read: (file) => fs.readFileSync(path.join(config.kit.files.assets, file)),
 						root,

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -177,7 +177,15 @@ class Watcher extends EventEmitter {
 
 		this.vite = await vite.createServer(merged_config);
 
-		handler = await create_handler(this.vite, this.config, this.dir, this.cwd, this.manifest);
+		const getManifest = () => {
+			if (!this.manifest) {
+				throw new Error("Shouldn't clear manifest after server initialized");
+			}
+
+			return this.manifest;
+		};
+
+		handler = await create_handler(this.vite, this.config, this.dir, this.cwd, getManifest);
 
 		this.server.listen(this.port, this.host || '0.0.0.0');
 	}
@@ -267,9 +275,9 @@ function get_params(array) {
  * @param {import('types/config').ValidatedConfig} config
  * @param {string} dir
  * @param {string} cwd
- * @param {import('types/internal').SSRManifest} manifest
+ * @param {() => import('types/internal').SSRManifest} getManifest
  */
-async function create_handler(vite, config, dir, cwd, manifest) {
+async function create_handler(vite, config, dir, cwd, getManifest) {
 	/**
 	 * @type {amp_validator.Validator?}
 	 */
@@ -429,7 +437,7 @@ async function create_handler(vite, config, dir, cwd, manifest) {
 								styles: Array.from(styles)
 							};
 						},
-						manifest,
+						manifest: getManifest(),
 						prerender: config.kit.prerender.enabled,
 						read: (file) => fs.readFileSync(path.join(config.kit.files.assets, file)),
 						root,

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -179,7 +179,7 @@ class Watcher extends EventEmitter {
 
 		const get_manifest = () => {
 			if (!this.manifest) {
-				throw new Error("Shouldn't clear manifest after server initialized");
+				throw new Error('Manifest is not available');
 			}
 
 			return this.manifest;

--- a/packages/kit/test/apps/basics/src/routes/routing/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/_tests.js
@@ -242,13 +242,13 @@ export default function (test, is_dev) {
 		}
 	);
 
-	test('watch new route in dev', '/routing', async ({ page, base, js }) => {
+	test('watch new route in dev', '/routing', async ({ page, base, js, watcher }) => {
 		if (!is_dev || js) {
 			return;
 		}
 
 		// hash the filename so that it won't conflict with
-		// future test file that it has the same name
+		// future test file that has the same name
 		const route = 'bar' + new Date().valueOf();
 		const content = 'Hello new route';
 		const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -256,7 +256,7 @@ export default function (test, is_dev) {
 
 		try {
 			fs.writeFileSync(filePath, `<h1>${content}</h1>`);
-			await Promise.resolve();
+			watcher.update();
 			await page.goto(`${base}/routing/${route}`);
 
 			assert.equal(await page.textContent('h1'), content);

--- a/packages/kit/test/apps/basics/src/routes/routing/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/_tests.js
@@ -1,7 +1,10 @@
 import * as assert from 'uvu/assert';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 /** @type {import('test').TestMaker} */
-export default function (test) {
+export default function (test, is_dev) {
 	test(
 		'redirects from /routing/ to /routing',
 		'/routing/slashes',
@@ -238,4 +241,26 @@ export default function (test) {
 			assert.equal(await page.url(), 'https://www.google.com/');
 		}
 	);
+
+	test('watch new route in dev', '/routing', async ({ page, base, js }) => {
+		if (!is_dev || js) {
+			return;
+		}
+
+		// hash the filename so that it won't conflict with
+		// future test file that it has the same name
+		const route = 'bar' + new Date().valueOf();
+		const content = 'Hello new route';
+		const __dirname = path.dirname(fileURLToPath(import.meta.url));
+		const filePath = path.join(__dirname, `${route}.svelte`);
+
+		try {
+			fs.writeFileSync(filePath, `<h1>${content}</h1>`);
+			await page.goto(`${base}/routing/${route}`);
+
+			assert.equal(await page.textContent('h1'), content);
+		} finally {
+			fs.unlinkSync(filePath);
+		}
+	});
 }

--- a/packages/kit/test/apps/basics/src/routes/routing/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/_tests.js
@@ -256,6 +256,7 @@ export default function (test, is_dev) {
 
 		try {
 			fs.writeFileSync(filePath, `<h1>${content}</h1>`);
+			await Promise.resolve();
 			await page.goto(`${base}/routing/${route}`);
 
 			assert.equal(await page.textContent('h1'), content);


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

Fixes #2046. The manifest data passed into the server handler it's the initial manifest.  And the manifest won't be mutated by reference but resigned. This PR changes to pass a get function to the handler so it'll get the up-to-date manifest. 
