### PR TITLE
[chore] export `HandleError` type

### DIFF
--- a/.changeset/large-carrots-visit.md
+++ b/.changeset/large-carrots-visit.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+export `HandleError` type

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -9,6 +9,7 @@ export { ErrorLoad, ErrorLoadInput, Load, LoadInput, LoadOutput, Page } from './
 export {
 	GetSession,
 	Handle,
+	HandleError,
 	ServerFetch,
 	ServerRequest as Request,
 	ServerResponse as Response

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -4,10 +4,10 @@ import {
 	GetSession,
 	Handle,
 	HandleError,
-	ServerResponse,
 	ServerFetch,
-	StrictBody,
-	ServerRequest
+	ServerRequest,
+	ServerResponse,
+	StrictBody
 } from './hooks';
 import { Load } from './page';
 


### PR DESCRIPTION
Newly added `HandleError` type from #2193 isn't exported from the main types yet