### PR TITLE
[fix] match regex against route only once

### DIFF
--- a/.changeset/serious-dolphins-approve.md
+++ b/.changeset/serious-dolphins-approve.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] match regex against route only once

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -18,9 +18,10 @@ function is_string(s) {
 /**
  * @param {import('types/hooks').ServerRequest} request
  * @param {import('types/internal').SSREndpoint} route
+ * @param {RegExpExecArray} match
  * @returns {Promise<import('types/hooks').ServerResponse | undefined>}
  */
-export async function render_endpoint(request, route) {
+export async function render_endpoint(request, route, match) {
 	const mod = await route.load();
 
 	/** @type {import('types/endpoint').RequestHandler} */
@@ -28,11 +29,6 @@ export async function render_endpoint(request, route) {
 
 	if (!handler) {
 		return;
-	}
-
-	const match = route.pattern.exec(request.path);
-	if (!match) {
-		return error('could not parse parameters from request path');
 	}
 
 	const params = route.params(match);

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -59,12 +59,13 @@ export async function respond(incoming, options, state = {}) {
 
 				const decoded = decodeURI(request.path);
 				for (const route of options.manifest.routes) {
-					if (!route.pattern.test(decoded)) continue;
+					const match = route.pattern.exec(decoded);
+					if (!match) continue;
 
 					const response =
 						route.type === 'endpoint'
-							? await render_endpoint(request, route)
-							: await render_page(request, route, options, state);
+							? await render_endpoint(request, route, match)
+							: await render_page(request, route, match, options, state);
 
 					if (response) {
 						// inject ETags for 200 responses

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -3,11 +3,12 @@ import { respond } from './respond.js';
 /**
  * @param {import('types/hooks').ServerRequest} request
  * @param {import('types/internal').SSRPage} route
+ * @param {RegExpExecArray} match
  * @param {import('types/internal').SSRRenderOptions} options
  * @param {import('types/internal').SSRRenderState} state
  * @returns {Promise<import('types/hooks').ServerResponse | undefined>}
  */
-export async function render_page(request, route, options, state) {
+export async function render_page(request, route, match, options, state) {
 	if (state.initiator === route) {
 		// infinite request cycle detected
 		return {
@@ -17,8 +18,6 @@ export async function render_page(request, route, options, state) {
 		};
 	}
 
-	const match = route.pattern.exec(request.path);
-	// @ts-expect-error we already know there's a match
 	const params = route.params(match);
 
 	const page = {


### PR DESCRIPTION
- is more efficient
- removes the need for a `@ts-expect-error`
- fixes the server side of https://github.com/sveltejs/kit/issues/2201