### PR TITLE
Check ports in a more cross-platform way.

### DIFF
--- a/.changeset/late-mugs-agree.md
+++ b/.changeset/late-mugs-agree.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Check ports usage in a more cross-platform way in dev server error logging

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -200,16 +200,21 @@ prog.parse(process.argv, { unknown: (arg) => `Unknown option: ${arg}` });
 
 /** @param {number} port */
 async function check_port(port) {
-	const n = await ports.blame(port);
-
-	if (n) {
+	if (!(await ports.check(port))) {
 		console.log(colors.bold().red(`Port ${port} is occupied`));
 
-		// prettier-ignore
-		console.log(
-			`Terminate process ${colors.bold(n)} or specify a different port with ${colors.bold('--port')}\n`
-		);
-
+		const n = await ports.blame(port); // Only works on systems with `lsof`.
+		if (n) {
+			// prettier-ignore
+			console.log(
+				`Terminate process ${colors.bold(n)} or specify a different port with ${colors.bold('--port')}\n`
+			);
+		} else {
+			// prettier-ignore
+			console.log(
+				`Terminate the process using it or specify a different port with ${colors.bold('--port')}\n`
+			);
+		}
 		process.exit(1);
 	}
 }

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -200,23 +200,23 @@ prog.parse(process.argv, { unknown: (arg) => `Unknown option: ${arg}` });
 
 /** @param {number} port */
 async function check_port(port) {
-	if (!(await ports.check(port))) {
-		console.log(colors.bold().red(`Port ${port} is occupied`));
-
-		const n = await ports.blame(port); // Only works on systems with `lsof`.
-		if (n) {
-			// prettier-ignore
-			console.log(
-				`Terminate process ${colors.bold(n)} or specify a different port with ${colors.bold('--port')}\n`
-			);
-		} else {
-			// prettier-ignore
-			console.log(
-				`Terminate the process using it or specify a different port with ${colors.bold('--port')}\n`
-			);
-		}
-		process.exit(1);
+	if (await ports.check(port)) {
+		return;
 	}
+	console.log(colors.bold().red(`Port ${port} is occupied`));
+	const n = await ports.blame(port);
+	if (n) {
+		// prettier-ignore
+		console.log(
+			`Terminate process ${colors.bold(n)} or specify a different port with ${colors.bold('--port')}\n`
+		);
+	} else {
+		// prettier-ignore
+		console.log(
+			`Terminate the process occupying the port or specify a different port with ${colors.bold('--port')}\n`
+		);
+	}
+	process.exit(1);
 }
 
 /**


### PR DESCRIPTION
related to #2020

We were using `ports.blame()` to check for port usage for the pretty error messages, but this silently fails on any system which does not have `lsof`. This PR instead uses `ports.check()`, which tries to listen to a port, as a more robust way to check if the port is in use. It still uses `ports.blame()` to find the process id using the port if possible.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0