### PR TITLE
[chore] move `RawBody` as helper type

### DIFF
--- a/packages/kit/src/core/node/index.js
+++ b/packages/kit/src/core/node/index.js
@@ -1,6 +1,6 @@
 /**
  * @param {import('http').IncomingMessage} req
- * @returns {Promise<import('types/hooks').RawBody>}
+ * @returns {Promise<import('types/helper').RawBody>}
  */
 export function getRawBody(req) {
 	return new Promise((fulfil, reject) => {

--- a/packages/kit/src/runtime/server/parse_body/index.js
+++ b/packages/kit/src/runtime/server/parse_body/index.js
@@ -1,7 +1,7 @@
 import { read_only_form_data } from './read_only_form_data.js';
 
 /**
- * @param {import('types/hooks.js').RawBody} raw
+ * @param {import('types/helper').RawBody} raw
  * @param {import('types/helper').Headers} headers
  */
 export function parse_body(raw, headers) {

--- a/packages/kit/types/helper.d.ts
+++ b/packages/kit/types/helper.d.ts
@@ -1,5 +1,3 @@
-import { RawBody } from './hooks';
-
 interface ReadOnlyFormData {
 	get(key: string): string;
 	getAll(key: string): string[];
@@ -10,10 +8,10 @@ interface ReadOnlyFormData {
 	[Symbol.iterator](): Generator<[string, string], void>;
 }
 
-type BaseBody = string | RawBody | ReadOnlyFormData;
+export type RawBody = null | Uint8Array;
 export type ParameterizedBody<Body = unknown> = Body extends FormData
 	? ReadOnlyFormData
-	: BaseBody & Body;
+	: (string | RawBody | ReadOnlyFormData) & Body;
 
 // TODO we want to differentiate between request headers, which
 // always follow this type, and response headers, in which

--- a/packages/kit/types/hooks.d.ts
+++ b/packages/kit/types/hooks.d.ts
@@ -1,8 +1,6 @@
-import { Headers, Location, MaybePromise, ParameterizedBody } from './helper';
+import { Headers, Location, MaybePromise, ParameterizedBody, RawBody } from './helper';
 
 export type StrictBody = string | Uint8Array;
-
-export type RawBody = null | Uint8Array;
 
 export interface ServerRequest<Locals = Record<string, any>, Body = unknown> extends Location {
 	method: string;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -1,10 +1,9 @@
 import { RequestHandler } from './endpoint';
-import { Headers, Location, ParameterizedBody } from './helper';
+import { Headers, Location, ParameterizedBody, RawBody } from './helper';
 import {
 	GetSession,
 	Handle,
 	HandleError,
-	RawBody,
 	ServerFetch,
 	ServerRequest,
 	ServerResponse


### PR DESCRIPTION
Helper file was implicitly designed to be self-contained and should not import or reference any type outside of itself.