### PR TITLE
[chore] export App types

### DIFF
--- a/.changeset/nice-ways-search.md
+++ b/.changeset/nice-ways-search.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[chore] export App types

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -105,7 +105,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 
 	const server_root = resolve_path(dir);
 
-	/** @type {import('types/internal').App} */
+	/** @type {import('types/app').App} */
 	const app = await import(pathToFileURL(`${server_root}/server/app.js`).href);
 
 	app.init({

--- a/packages/kit/src/core/preview/index.js
+++ b/packages/kit/src/core/preview/index.js
@@ -34,7 +34,7 @@ export async function preview({
 
 	const app_file = resolve(cwd, `${SVELTE_KIT}/output/server/app.js`);
 
-	/** @type {import('types/internal').App} */
+	/** @type {import('types/app').App} */
 	const app = await import(pathToFileURL(app_file).href);
 
 	/** @type {import('sirv').RequestHandler} */

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -8,7 +8,7 @@ import { coalesce_to_error } from '../utils.js';
 import { hash } from '../hash.js';
 
 /**
- * @param {import('types/internal').Incoming} incoming
+ * @param {import('types/app').IncomingRequest} incoming
  * @param {import('types/internal').SSRRenderOptions} options
  * @param {import('types/internal').SSRRenderState} [state]
  */

--- a/packages/kit/types/app.d.ts
+++ b/packages/kit/types/app.d.ts
@@ -1,0 +1,36 @@
+import { Headers, RawBody } from './helper';
+import { ServerResponse } from './hooks';
+
+export interface IncomingRequest {
+	method: string;
+	host: string;
+	path: string;
+	query: URLSearchParams;
+	headers: Headers;
+	rawBody: RawBody;
+}
+
+export interface App {
+	init({
+		paths,
+		prerendering,
+		read
+	}: {
+		paths: {
+			base: string;
+			assets: string;
+		};
+		prerendering: boolean;
+		read(file: string): Buffer;
+	}): void;
+	render(
+		incoming: IncomingRequest,
+		options?: {
+			prerender: {
+				fallback?: string;
+				all: boolean;
+				dependencies?: Map<string, ServerResponse>;
+			};
+		}
+	): Promise<ServerResponse>;
+}

--- a/packages/kit/types/app.d.ts
+++ b/packages/kit/types/app.d.ts
@@ -15,7 +15,7 @@ export interface App {
 		paths,
 		prerendering,
 		read
-	}: {
+	}?: {
 		paths: {
 			base: string;
 			assets: string;

--- a/packages/kit/types/helper.d.ts
+++ b/packages/kit/types/helper.d.ts
@@ -19,13 +19,6 @@ export type ParameterizedBody<Body = unknown> = Body extends FormData
 // but this can't happen until TypeScript 4.3
 export type Headers = Record<string, string>;
 
-export type Location<Params extends Record<string, string> = Record<string, string>> = {
-	host: string;
-	path: string;
-	params: Params;
-	query: URLSearchParams;
-};
-
 export type InferValue<T, Key extends keyof T, Default> = T extends Record<Key, infer Val>
 	? Val
 	: Default;

--- a/packages/kit/types/hooks.d.ts
+++ b/packages/kit/types/hooks.d.ts
@@ -1,11 +1,11 @@
-import { Headers, Location, MaybePromise, ParameterizedBody, RawBody } from './helper';
+import { IncomingRequest } from './app';
+import { Headers, MaybePromise, ParameterizedBody } from './helper';
 
 export type StrictBody = string | Uint8Array;
 
-export interface ServerRequest<Locals = Record<string, any>, Body = unknown> extends Location {
-	method: string;
-	headers: Headers;
-	rawBody: RawBody;
+export interface ServerRequest<Locals = Record<string, any>, Body = unknown>
+	extends IncomingRequest {
+	params: Record<string, string>;
 	body: ParameterizedBody<Body>;
 	locals: Locals;
 }

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3,6 +3,7 @@
 
 import './ambient-modules';
 
+export { App, IncomingRequest } from './app';
 export { Adapter, AdapterUtils, Config, PrerenderErrorHandler, ValidatedConfig } from './config';
 export { EndpointOutput, RequestHandler } from './endpoint';
 export { ErrorLoad, ErrorLoadInput, Load, LoadInput, LoadOutput, Page } from './page';

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -1,5 +1,4 @@
 import { RequestHandler } from './endpoint';
-import { Headers, Location, ParameterizedBody, RawBody } from './helper';
 import {
 	ExternalFetch,
 	GetSession,
@@ -12,13 +11,6 @@ import { Load } from './page';
 
 type PageId = string;
 
-export interface Incoming extends Omit<Location, 'params'> {
-	method: string;
-	headers: Headers;
-	rawBody: RawBody;
-	body?: ParameterizedBody;
-}
-
 export interface Logger {
 	(msg: string): void;
 	success(msg: string): void;
@@ -26,31 +18,6 @@ export interface Logger {
 	warn(msg: string): void;
 	minor(msg: string): void;
 	info(msg: string): void;
-}
-
-export interface App {
-	init({
-		paths,
-		prerendering,
-		read
-	}: {
-		paths: {
-			base: string;
-			assets: string;
-		};
-		prerendering: boolean;
-		read(file: string): Buffer;
-	}): void;
-	render(
-		incoming: Incoming,
-		options?: {
-			prerender: {
-				fallback?: string;
-				all: boolean;
-				dependencies?: Map<string, ServerResponse>;
-			};
-		}
-	): Promise<ServerResponse>;
 }
 
 export interface SSRComponent {

--- a/packages/kit/types/page.d.ts
+++ b/packages/kit/types/page.d.ts
@@ -1,4 +1,11 @@
-import { InferValue, Location as Page, MaybePromise, Rec } from './helper';
+import { InferValue, MaybePromise, Rec } from './helper';
+
+export interface Page<Params extends Record<string, string> = Record<string, string>> {
+	host: string;
+	path: string;
+	params: Params;
+	query: URLSearchParams;
+}
 
 export interface LoadInput<
 	PageParams extends Rec<string> = Rec<string>,
@@ -68,5 +75,3 @@ export interface ErrorLoad<
 		>
 	): MaybePromise<LoadOutput<InferValue<Output, 'props', Rec>, InferValue<Output, 'context', Rec>>>;
 }
-
-export { Page };


### PR DESCRIPTION
I *think* that exporting `App` will be enough to use `init` and `request`, but if not we can tweak a bit further

NOTE: If you open `adapter-node/src/server.js` in `master`, the import `@sveltejs/kit/node` cannot be resolved. I don't understand why. It'd be nice to use these new types in our own adapters, but I can't figure out why they're not available