### PR TITLE
[fix] allow any top-level keys in svelte config

### DIFF
--- a/.changeset/eight-keys-give.md
+++ b/.changeset/eight-keys-give.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+allow any top-level keys in svelte config

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -24,17 +24,21 @@ function validate(definition, option, keypath) {
 			);
 		}
 	}
-	for (const key in option) {
-		if (!(key in definition)) {
-			let message = `Unexpected option ${keypath}.${key}`;
 
-			if (keypath === 'config' && key in options.kit) {
-				message += ` (did you mean config.kit.${key}?)`;
-			} else if (keypath === 'config.kit' && key in options) {
-				message += ` (did you mean config.${key}?)`;
+	// only validate nested key paths
+	if (keypath !== 'config') {
+		for (const key in option) {
+			if (!(key in definition)) {
+				let message = `Unexpected option ${keypath}.${key}`;
+
+				if (keypath === 'config' && key in options.kit) {
+					message += ` (did you mean config.kit.${key}?)`;
+				} else if (keypath === 'config.kit' && key in options) {
+					message += ` (did you mean config.${key}?)`;
+				}
+
+				throw new Error(message);
 			}
-
-			throw new Error(message);
 		}
 	}
 

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -31,9 +31,7 @@ function validate(definition, option, keypath) {
 			if (!(key in definition)) {
 				let message = `Unexpected option ${keypath}.${key}`;
 
-				if (keypath === 'config' && key in options.kit) {
-					message += ` (did you mean config.kit.${key}?)`;
-				} else if (keypath === 'config.kit' && key in options) {
+				if (keypath === 'config.kit' && key in options) {
 					message += ` (did you mean config.${key}?)`;
 				}
 

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -90,6 +90,7 @@ test('errors on invalid nested values', () => {
 test('does not error on invalid top-level values', () => {
 	assert.not.throws(() => {
 		validate_config({
+			// @ts-expect-error
 			onwarn: () => {}
 		});
 	});

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -90,7 +90,7 @@ test('errors on invalid nested values', () => {
 test('does not error on invalid top-level values', () => {
 	assert.not.throws(() => {
 		validate_config({
-			// @ts-expect-error
+			// @ts-expect-error - valid option for others but not in our definition
 			onwarn: () => {}
 		});
 	});

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -87,6 +87,14 @@ test('errors on invalid nested values', () => {
 	}, /^Unexpected option config\.kit\.files\.potato$/);
 });
 
+test('does not error on invalid top-level values', () => {
+	assert.not.throws(() => {
+		validate_config({
+			onwarn: () => {}
+		});
+	});
+});
+
 test('errors on extension without leading .', () => {
 	assert.throws(() => {
 		validate_config({

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -80,6 +80,7 @@ export interface Config {
 		vite?: ViteConfig | (() => ViteConfig);
 	};
 	preprocess?: any;
+	[key: string]: any;
 }
 
 export type ValidatedConfig = RecursiveRequired<Config>;

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -80,7 +80,6 @@ export interface Config {
 		vite?: ViteConfig | (() => ViteConfig);
 	};
 	preprocess?: any;
-	[key: string]: any;
 }
 
 export type ValidatedConfig = RecursiveRequired<Config>;


### PR DESCRIPTION
Fixes #2253

Allow any top-level keys to be added to the svelte config, essentially skipping validation for the top-level keys only.

Unrelated side note: I'm not sure why we're not using something like [superstruct](https://github.com/ianstormtaylor/superstruct) to handle validation. And if the spec of the svelte config should live here?

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
