### PR TITLE
[feat] customizable output file names for prerendering

### DIFF
--- a/.changeset/chatty-geckos-draw.md
+++ b/.changeset/chatty-geckos-draw.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+add output_file_name option to prerender

--- a/.changeset/spicy-pears-dress.md
+++ b/.changeset/spicy-pears-dress.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-static': patch
+---
+
+add outputFileName option

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -42,19 +42,29 @@ Specify a fallback page for SPA mode, e.g. `index.html` or `200.html` or `404.ht
 
 A optional function that is called per entry to return the destination to write to.
 
-Default value:
+By default, prerendered html pages are output as index.html files in the directory matching the URL path.
+
+| URL       | output file          |
+| --------- | -------------------- |
+| /         | /index.html          |
+| /foo      | /foo/index.html      |
+| /bar.html | /bar.html/index.html |
+| /foo/bar  | /foo/bar/index.html  |
+
+For example, you may prefer `/foo.html` to `/foo/index.html`:
 
 ```javascript
-/** @type {(opts: {path: string, is_html: boolean}) => string} */
-function default_output_file_name({ path, is_html }) {
+import { format, parse } from 'path';
+
+outputFileName: ({ path, is_html }) => {
 	if (!is_html) return path;
 
-	const parts = path.split('/');
-	if (parts[parts.length - 1] === 'index.html') return path;
+	let { root, dir, name, ext } = parse(path);
 
-	parts.push('index.html');
-	return parts.join('/');
-}
+	if (!ext) ext = '.html';
+
+	return format({ root, dir, name, ext });
+};
 ```
 
 ## SPA mode

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -38,6 +38,25 @@ The directory to write static assets (the contents of `static`, plus client-side
 
 Specify a fallback page for SPA mode, e.g. `index.html` or `200.html` or `404.html`.
 
+### outputFileName
+
+A optional function that is called per entry to return the destination to write to.
+
+Default value:
+
+```javascript
+/** @type {(opts: {path: string, is_html: boolean}) => string} */
+function default_output_file_name({ path, is_html }) {
+	if (!is_html) return path;
+
+	const parts = path.split('/');
+	if (parts[parts.length - 1] === 'index.html') return path;
+
+	parts.push('index.html');
+	return parts.join('/');
+}
+```
+
 ## SPA mode
 
 You can use `adapter-static` to create a single-page app or SPA by specifying a **fallback page**.

--- a/packages/adapter-static/index.d.ts
+++ b/packages/adapter-static/index.d.ts
@@ -4,7 +4,7 @@ interface AdapterOptions {
 	pages?: string;
 	assets?: string;
 	fallback?: string;
-	outputFileName?: (opts: { path: string, is_html: boolean }) => string;
+	outputFileName?: (opts: { path: string; is_html: boolean }) => string;
 }
 
 declare function plugin(options?: AdapterOptions): Adapter;

--- a/packages/adapter-static/index.d.ts
+++ b/packages/adapter-static/index.d.ts
@@ -4,6 +4,7 @@ interface AdapterOptions {
 	pages?: string;
 	assets?: string;
 	fallback?: string;
+	outputFileName?: (opts: { path: string, is_html: boolean }) => string;
 }
 
 declare function plugin(options?: AdapterOptions): Adapter;

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -1,8 +1,17 @@
-/** @type {import('.')} */
-export default function ({ pages = 'build', assets = pages, fallback } = {}) {
+/**
+ * @param {{
+ *   pages?: string;
+ *   assets?: string;
+ *   fallback?: string;
+ *   outputFileName?: (opts: {path: string, is_html: boolean}) => string;
+ * }} [opts]
+ */
+export default function({ pages = 'build', assets = pages, fallback, outputFileName } = {}) {
+	/** @type {import('@sveltejs/kit').Adapter} */
 	return {
 		name: '@sveltejs/adapter-static',
 
+		/** @type {import('@sveltejs/kit').Adapter['adapt']} */
 		async adapt({ utils }) {
 			utils.rimraf(assets);
 			utils.rimraf(pages);
@@ -13,7 +22,8 @@ export default function ({ pages = 'build', assets = pages, fallback } = {}) {
 			await utils.prerender({
 				fallback,
 				all: !fallback,
-				dest: pages
+				dest: pages,
+				output_file_name: outputFileName
 			});
 		}
 	};

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -1,5 +1,5 @@
 /** @type {import('.')} */
-export default function({ pages = 'build', assets = pages, fallback, outputFileName } = {}) {
+export default function ({ pages = 'build', assets = pages, fallback, outputFileName } = {}) {
 	return {
 		name: '@sveltejs/adapter-static',
 

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -1,17 +1,8 @@
-/**
- * @param {{
- *   pages?: string;
- *   assets?: string;
- *   fallback?: string;
- *   outputFileName?: (opts: {path: string, is_html: boolean}) => string;
- * }} [opts]
- */
+/** @type {import('.')} */
 export default function({ pages = 'build', assets = pages, fallback, outputFileName } = {}) {
-	/** @type {import('@sveltejs/kit').Adapter} */
 	return {
 		name: '@sveltejs/adapter-static',
 
-		/** @type {import('@sveltejs/kit').Adapter['adapt']} */
 		async adapt({ utils }) {
 			utils.rimraf(assets);
 			utils.rimraf(pages);

--- a/packages/adapter-static/test/apps/spa-entry-name/.gitignore
+++ b/packages/adapter-static/test/apps/spa-entry-name/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+node_modules
+/.svelte-kit
+/build
+/functions

--- a/packages/adapter-static/test/apps/spa-entry-name/.npmrc
+++ b/packages/adapter-static/test/apps/spa-entry-name/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/packages/adapter-static/test/apps/spa-entry-name/README.md
+++ b/packages/adapter-static/test/apps/spa-entry-name/README.md
@@ -1,0 +1,38 @@
+# create-svelte
+
+Everything you need to build a Svelte project, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte);
+
+## Creating a project
+
+If you're seeing this, you've probably already done this step. Congrats!
+
+```bash
+# create a new project in the current directory
+npm init svelte@next
+
+# create a new project in my-app
+npm init svelte@next my-app
+```
+
+> Note: the `@next` is temporary
+
+## Developing
+
+Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+
+```bash
+npm run dev
+
+# or start the server and open the app in a new browser tab
+npm run dev -- --open
+```
+
+## Building
+
+Before creating a production version of your app, install an [adapter](https://kit.svelte.dev/docs#adapters) for your target environment. Then:
+
+```bash
+npm run build
+```
+
+> You can preview the built app with `npm run preview`, regardless of whether you installed an adapter. This should _not_ be used to serve your app in production.

--- a/packages/adapter-static/test/apps/spa-entry-name/jsconfig.json
+++ b/packages/adapter-static/test/apps/spa-entry-name/jsconfig.json
@@ -1,0 +1,9 @@
+{
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"$lib/*": ["src/lib/*"]
+		}
+	},
+	"include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte"]
+}

--- a/packages/adapter-static/test/apps/spa-entry-name/package.json
+++ b/packages/adapter-static/test/apps/spa-entry-name/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "~TODO~",
+	"version": "0.0.1",
+	"scripts": {
+		"dev": "../../../../kit/svelte-kit.js dev",
+		"build": "../../../../kit/svelte-kit.js build",
+		"start": "../../../../kit/svelte-kit.js start"
+	},
+	"devDependencies": {
+		"@sveltejs/adapter-node": "next",
+		"@sveltejs/kit": "workspace:*",
+		"svelte": "^3.40.0"
+	},
+	"type": "module"
+}

--- a/packages/adapter-static/test/apps/spa-entry-name/src/app.html
+++ b/packages/adapter-static/test/apps/spa-entry-name/src/app.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%svelte.head%
+	</head>
+	<body>
+		<div id="svelte">%svelte.body%</div>
+	</body>
+</html>

--- a/packages/adapter-static/test/apps/spa-entry-name/src/global.d.ts
+++ b/packages/adapter-static/test/apps/spa-entry-name/src/global.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@sveltejs/kit" />

--- a/packages/adapter-static/test/apps/spa-entry-name/src/routes/__layout.svelte
+++ b/packages/adapter-static/test/apps/spa-entry-name/src/routes/__layout.svelte
@@ -1,0 +1,7 @@
+<nav>
+	<a href="/">home</a>
+	<a href="/page">page</a>
+	<a href="/about.html">about</a>
+</nav>
+
+<slot></slot>

--- a/packages/adapter-static/test/apps/spa-entry-name/src/routes/about.html.svelte
+++ b/packages/adapter-static/test/apps/spa-entry-name/src/routes/about.html.svelte
@@ -1,0 +1,7 @@
+<script context="module">
+	export const prerender = true;
+</script>
+
+<h1>This page was prerendered</h1>
+
+<h2>about</h2>

--- a/packages/adapter-static/test/apps/spa-entry-name/src/routes/index.svelte
+++ b/packages/adapter-static/test/apps/spa-entry-name/src/routes/index.svelte
@@ -1,0 +1,1 @@
+<h1>This page was not prerendered</h1>

--- a/packages/adapter-static/test/apps/spa-entry-name/src/routes/page.svelte
+++ b/packages/adapter-static/test/apps/spa-entry-name/src/routes/page.svelte
@@ -1,0 +1,7 @@
+<script context="module">
+	export const prerender = true;
+</script>
+
+<h1>This page was prerendered</h1>
+
+<h2>page</h2>

--- a/packages/adapter-static/test/apps/spa-entry-name/svelte.config.js
+++ b/packages/adapter-static/test/apps/spa-entry-name/svelte.config.js
@@ -1,0 +1,23 @@
+import { format, parse } from 'path';
+import adapter from '../../../index.js';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	kit: {
+		adapter: adapter({
+			fallback: '200.html',
+			outputFileName: ({ path, is_html }) => {
+				if (!is_html) return path;
+
+				let { root, dir, name, ext } = parse(path);
+
+				if (!ext) ext = '.html';
+
+				return format({ root, dir, name, ext });
+			}
+		}),
+		target: '#svelte'
+	}
+};
+
+export default config;

--- a/packages/adapter-static/test/test.js
+++ b/packages/adapter-static/test/test.js
@@ -36,3 +36,28 @@ run('spa', (test) => {
 		assert.equal(await page.textContent('h1'), '404');
 	});
 });
+
+run('spa-entry-name', (test) => {
+	test('generates a fallback page', ({ cwd }) => {
+		assert.ok(fs.existsSync(`${cwd}/build/200.html`));
+	});
+
+	test('does not prerender pages without prerender=true', ({ cwd }) => {
+		assert.ok(!fs.existsSync(`${cwd}/build/index.html`));
+	});
+
+	test('prerenders page with prerender=true', ({ cwd }) => {
+		assert.ok(fs.existsSync(`${cwd}/build/about.html`));
+		assert.ok(fs.existsSync(`${cwd}/build/page.html`));
+	});
+
+	test('renders content in fallback page when JS runs', async ({ base, page }) => {
+		await page.goto(base);
+		assert.equal(await page.textContent('h1'), 'This page was not prerendered');
+	});
+
+	test('renders error page for missing page', async ({ base, page }) => {
+		await page.goto(`${base}/nosuchpage`);
+		assert.equal(await page.textContent('h1'), '404');
+	});
+});

--- a/packages/kit/src/core/adapt/utils.js
+++ b/packages/kit/src/core/adapt/utils.js
@@ -30,7 +30,7 @@ export function get_utils({ cwd, config, build_data, log }) {
 			copy(config.kit.files.assets, dest);
 		},
 
-		async prerender({ all = false, dest, fallback }) {
+		async prerender({ all = false, dest, fallback, output_file_name }) {
 			await prerender({
 				out: dest,
 				all,
@@ -38,7 +38,8 @@ export function get_utils({ cwd, config, build_data, log }) {
 				config,
 				build_data,
 				fallback,
-				log
+				log,
+				output_file_name
 			});
 		}
 	};

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -10,7 +10,12 @@ export interface AdapterUtils {
 	copy_server_files(dest: string): void;
 	copy_static_files(dest: string): void;
 	copy(from: string, to: string, filter?: (basename: string) => boolean): void;
-	prerender(options: { all?: boolean; dest: string; fallback?: string }): Promise<void>;
+	prerender(options: {
+		all?: boolean;
+		dest: string;
+		fallback?: string;
+		output_file_name?: (opts: { path: string, is_html: boolean }) => string;
+	}): Promise<void>;
 }
 
 export interface Adapter {

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -14,7 +14,7 @@ export interface AdapterUtils {
 		all?: boolean;
 		dest: string;
 		fallback?: string;
-		output_file_name?: (opts: { path: string, is_html: boolean }) => string;
+		output_file_name?: (opts: { path: string; is_html: boolean }) => string;
 	}): Promise<void>;
 }
 


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0


Fixes #1443 

This PR provide an optional callback to custom entry names for adapter-static.

Example:

- `blog/hello-world.html.svelte` => `blog/hello-world.html`
- `about.svelte` => `about.html`

```javascript
// svelte.config.js
import adapter from '@sveltejs/adapter-static';
import { format, parse } from 'path';

/** @type {import('@sveltejs/kit').Config} */
const config = {
	kit: {
		adapter: adapter({
			fallback: '200.html',
			outputFileName: ({ path, is_html }) => {
				if (!is_html) return path;

				let { root, dir, name, ext } = parse(path);

				if (!ext) ext = '.html';

				return format({ root, dir, name, ext });
			}
		}),
		target: '#svelte'
	}
};

export default config;
```