### PR TITLE
[docs] update vite-plugin-svelte issue status

### DIFF
--- a/documentation/faq/45-assets.md
+++ b/documentation/faq/45-assets.md
@@ -12,4 +12,8 @@ You can have Vite process your assets by importing them as shown below:
 <img src="{imageSrc}" />
 ```
 
-There is an [open request in `vite-plugin-svelte` to help do this automatically](https://github.com/sveltejs/vite-plugin-svelte/issues/114).
+If you prefer to directly import in the markup, try [svelte-preprocess-import-assets](https://github.com/bluwy/svelte-preprocess-import-assets) and you can write this instead:
+
+```html
+<img src="$lib/assets/image.png" />
+```


### PR DESCRIPTION
Based on https://github.com/sveltejs/vite-plugin-svelte/issues/114, it was closed because I think we should rely on an external svelte preprocessor to handle the asset hashes in the template, as there aren't any advantage having it built into `vite-plugin-svelte`. Plus the preprocessor can be used for other bundlers as well.

_ps: the preprocessor linked is shamelessly the one i built_

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
