### PR TITLE
[fix] service worker scope and registration

### DIFF
--- a/.changeset/fresh-jeans-shout.md
+++ b/.changeset/fresh-jeans-shout.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix service worker scope: add option to register sw scope and the option to not register the sw

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ yarn.lock
 .cloudflare
 .pnpm-debug.log
 .netlify
+.idea/

--- a/documentation/docs/06-service-workers.md
+++ b/documentation/docs/06-service-workers.md
@@ -6,12 +6,7 @@ Service workers act as proxy servers that handle network requests inside your ap
 
 In SvelteKit, if you have a `src/service-worker.js` file (or `src/service-worker.ts`, or `src/service-worker/index.js`, etc) it will be built with Vite and automatically registered.
 
-> You can change the location of your service worker in your [project configuration](#configuration-files).
-You can also provide the `scope` for the service worker, by default `/`. You **MUST** modify you `manifest.json` file
-to include also the `scope`: if you are using the default `scope` value, then you need to configure `scope: '/'`.
-**REMEMBER**: both, the option and the `manifest.json` entry must be the same.
-You can remove the service worker registration to allow register it on your logic, for example to allow `prompt for update`
-or configure periodic service worker updates.
+> You can change the location of your service worker in your [project configuration](#configuration-files). You can also provide the `scope` for the service worker, by default `/`. You **MUST** modify your `manifest.json` file to include also the `scope`: if you are using the default `scope` value, then you need to configure `scope: '/'`. **REMEMBER**: both, the option and the `manifest.json` entry must be the same. You can remove the service worker registration to allow register it on your logic, for example to allow `prompt for update`, configure periodic service worker updates or some logic that requires using the service worker registration.
 
 Inside the service worker you have access to the [`$service-worker` module](#modules-$service-worker).
 

--- a/documentation/docs/06-service-workers.md
+++ b/documentation/docs/06-service-workers.md
@@ -7,11 +7,9 @@ Service workers act as proxy servers that handle network requests inside your ap
 In SvelteKit, if you have a `src/service-worker.js` file (or `src/service-worker.ts`, or `src/service-worker/index.js`, etc) it will be built with Vite and automatically registered.
 
 > You can change the location of your service worker in your [project configuration](#configuration-files).
-<br />
 You can also provide the `scope` for the service worker, by default `/`. You **MUST** modify you `manifest.json` file
 to include also the `scope`: if you are using the default `scope` value, then you need to configure `scope: '/'`.
 **REMEMBER**: both, the option and the `manifest.json` entry must be the same.
-<br />
 You can remove the service worker registration to allow register it on your logic, for example to allow `prompt for update`
 or configure periodic service worker updates.
 

--- a/documentation/docs/06-service-workers.md
+++ b/documentation/docs/06-service-workers.md
@@ -7,6 +7,13 @@ Service workers act as proxy servers that handle network requests inside your ap
 In SvelteKit, if you have a `src/service-worker.js` file (or `src/service-worker.ts`, or `src/service-worker/index.js`, etc) it will be built with Vite and automatically registered.
 
 > You can change the location of your service worker in your [project configuration](#configuration-files).
+<br />
+You can also provide the `scope` for the service worker, by default `/`. You **MUST** modify you `manifest.json` file
+to include also the `scope`: if you are using the default `scope` value, then you need to configure `scope: '/'`.
+**REMEMBER**: both, the option and the `manifest.json` entry must be the same.
+<br />
+You can remove the service worker registration to allow register it on your logic, for example to allow `prompt for update`
+or configure periodic service worker updates.
 
 Inside the service worker you have access to the [`$service-worker` module](#modules-$service-worker).
 

--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -90,10 +90,10 @@ An object containing zero or more of the following `string` values:
 - `hooks` — the location of your hooks module (see [Hooks](#hooks))
 - `lib` — your app's internal library, accessible throughout the codebase as `$lib`
 - `routes` — the files that define the structure of your app (see [Routing](#routing))
-- `serviceWorker` —
+- `serviceWorker` — configuration for your service worker (see [Service workers](#service-workers))
   -  the service worker `scope`: by default `/`
   -  remove service worker registration: by default `false`
-  -  the location of your service worker's entry point (see [Service workers](#service-workers))
+  -  the location of your service worker's entry point
 - `template` — the location of the template for HTML responses
 
 ### floc

--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -90,10 +90,7 @@ An object containing zero or more of the following `string` values:
 - `hooks` — the location of your hooks module (see [Hooks](#hooks))
 - `lib` — your app's internal library, accessible throughout the codebase as `$lib`
 - `routes` — the files that define the structure of your app (see [Routing](#routing))
-- `serviceWorker` — configuration for your service worker (see [Service workers](#service-workers))
-  -  the service worker `scope`: by default `/`
-  -  remove service worker registration: by default `false`
-  -  the location of your service worker's entry point
+- `serviceWorker` — the location of your service worker's entry point (see [Service workers](#service-workers))
 - `template` — the location of the template for HTML responses
 
 ### floc
@@ -187,6 +184,8 @@ Enables or disables the client-side [router](#ssr-and-javascript-router) app-wid
 
 An object containing zero or more of the following values:
 
+- `scope` - the service worker `scope`: by default `/`.
+- `register` - register service worker registration: by default `true`.
 - `exclude` - an array of glob patterns relative to `files.assets` dir. Files matching any of these would not be available in `$service-worker.files` e.g. if `files.assets` has value `static` then ['og-tags-images/**/*'] would match all files under `static/og-tags-images` dir.
 
 ### ssr

--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -53,6 +53,8 @@ const config = {
 		},
 		router: true,
 		serviceWorker: {
+			register: boolean,
+			scope: string,
 			exclude: []
 		},
 		ssr: true,
@@ -88,7 +90,10 @@ An object containing zero or more of the following `string` values:
 - `hooks` — the location of your hooks module (see [Hooks](#hooks))
 - `lib` — your app's internal library, accessible throughout the codebase as `$lib`
 - `routes` — the files that define the structure of your app (see [Routing](#routing))
-- `serviceWorker` — the location of your service worker's entry point (see [Service workers](#service-workers))
+- `serviceWorker` —
+  -  the service worker `scope`: by default `/`
+  -  remove service worker registration: by default `false`
+  -  the location of your service worker's entry point (see [Service workers](#service-workers))
 - `template` — the location of the template for HTML responses
 
 ### floc

--- a/examples/hn.svelte.dev/package.json
+++ b/examples/hn.svelte.dev/package.json
@@ -11,6 +11,9 @@
 	"devDependencies": {
 		"@sveltejs/adapter-netlify": "workspace:*",
 		"@sveltejs/kit": "workspace:*",
-		"svelte": "^3.40.0"
+		"svelte": "^3.40.0",
+		"workbox-core": "^6.2.4",
+		"workbox-precaching": "^6.2.4",
+		"workbox-routing": "^6.2.4"
 	}
 }

--- a/examples/hn.svelte.dev/package.json
+++ b/examples/hn.svelte.dev/package.json
@@ -15,5 +15,8 @@
 		"workbox-core": "^6.2.4",
 		"workbox-precaching": "^6.2.4",
 		"workbox-routing": "^6.2.4"
+	},
+	"dependencies": {
+		"workbox-window": "^6.2.4"
 	}
 }

--- a/examples/hn.svelte.dev/src/lib/Nav.svelte
+++ b/examples/hn.svelte.dev/src/lib/Nav.svelte
@@ -6,11 +6,12 @@
 	<img alt="Svelte Hacker News logo" class="icon" src="/favicon.png">
 
 	<ul>
-		<li><a sveltekit:prefetch href="/top/1" class:selected={section === "top"}>top</a></li>
-		<li><a sveltekit:prefetch href="/new/1" class:selected={section === "new"}>new</a></li>
-		<li><a sveltekit:prefetch href="/show/1" class:selected={section === "show"}>show</a></li>
-		<li><a sveltekit:prefetch href="/ask/1" class:selected={section === "ask"}>ask</a></li>
-		<li><a sveltekit:prefetch href="/jobs/1" class:selected={section === "jobs"}>jobs</a></li>
+		<li><a href="/" class:selected={section === ''}>home</a></li>
+		<li><a sveltekit:prefetch href="/top/1" class:selected={section === 'top'}>top</a></li>
+		<li><a sveltekit:prefetch href="/new/1" class:selected={section === 'new'}>new</a></li>
+		<li><a sveltekit:prefetch href="/show/1" class:selected={section === 'show'}>show</a></li>
+		<li><a sveltekit:prefetch href="/ask/1" class:selected={section === 'ask'}>ask</a></li>
+		<li><a sveltekit:prefetch href="/jobs/1" class:selected={section === 'jobs'}>jobs</a></li>
 
 		<li class="about"><a sveltekit:prefetch href="/about" class:selected={section === "about"}>about</a></li>
 	</ul>

--- a/examples/hn.svelte.dev/src/lib/SWPrompt.svelte
+++ b/examples/hn.svelte.dev/src/lib/SWPrompt.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+	import { dev, browser } from '$app/env';
+	import { Workbox, messageSW } from 'workbox-window';
+
+	let wb;
+	let registration;
+
+	let offlineReady = false;
+	let needRefresh = false;
+
+	function showSkipWaitingPrompt(event) {
+		// \`event.wasWaitingBeforeRegister\` will be false if this is
+		// the first time the updated service worker is waiting.
+		// When \`event.wasWaitingBeforeRegister\` is true, a previously
+		// updated service worker is still waiting.
+		// You may want to customize the UI prompt accordingly.
+		// Assumes your app has some sort of prompt UI element
+		// that a user can either accept or reject.
+		// THIS WILL NEVER BE CALLED ON AUTO UPDATE.
+		needRefresh = true;
+	}
+
+	function updateServiceWorker() {
+		// Assuming the user accepted the update, set up a listener
+		// that will reload the page as soon as the previously waiting
+		// service worker has taken control.
+		if (wb) {
+			wb.addEventListener('controlling', (event) => {
+				if (event.isUpdate) {
+					window.location.reload();
+				}
+			});
+		}
+		if (registration && registration.waiting) {
+			// Send a message to the waiting service worker,
+			// instructing it to activate.
+			// Note: for this to work, you have to add a message
+			// listener in your service worker. See below.
+			messageSW(registration.waiting, { type: 'SKIP_WAITING' }).then(() => {
+				// console.log("NOTIFIED SKIP_WAITING");
+			}).catch(e => {
+				console.error('NOTIFIED SKIP_WAITING WITH ERROR', e);
+			});
+		}
+	}
+
+	function close() {
+		offlineReady = false;
+		needRefresh = false;
+	}
+
+	if (!dev && browser) {
+		if ('serviceWorker' in navigator) {
+			wb = new Workbox('/service-worker.js', { scope: '/' });
+			wb.addEventListener('activated', (event) => {
+				// this will only controls the offline request.
+				// event.isUpdate will be true if another version of the service
+				// worker was controlling the page when this version was registered.
+				if (!event.isUpdate) {
+					offlineReady = true;
+				}
+			});
+			// Add an event listener to detect when the registered
+			// service worker has installed but is waiting to activate.
+			wb.addEventListener('waiting', showSkipWaitingPrompt);
+			// eslint-disable-next-line
+			// @ts-ignore
+			wb.addEventListener('externalwaiting', showSkipWaitingPrompt);
+			// register the service worker
+			wb.register({ immediate: true }).then(r => registration = r).catch(e => {
+				console.error('cannot register service worker', e);
+			});
+		} else {
+			console.warn('Service workers are not supported.');
+		}
+	}
+
+  $: toast = offlineReady || needRefresh;
+</script>
+
+{#if toast}
+  <div
+    class="pwa-toast"
+    role="alert"
+  >
+    <div class="message">
+      {#if offlineReady}
+      <span>
+        App ready to work offline
+      </span>
+      {:else}
+      <span>
+        New content available, click on reload button to update.
+      </span>
+      {/if}
+    </div>
+    {#if needRefresh}
+      <button on:click={() => updateServiceWorker(true)}>
+        Reload
+      </button>
+    {/if}
+    <button on:click={close}>
+      Close
+    </button>
+  </div>
+{/if}
+
+<style>
+    .pwa-toast {
+        position: fixed;
+        right: 0;
+        bottom: 0;
+        margin: 16px;
+        padding: 12px;
+        border: 1px solid #8885;
+        border-radius: 4px;
+        z-index: 2;
+        text-align: left;
+        box-shadow: 3px 4px 5px 0 #8885;
+        background-color: white;
+    }
+    .pwa-toast .message {
+        margin-bottom: 8px;
+    }
+    .pwa-toast button {
+        border: 1px solid #8885;
+        outline: none;
+        margin-right: 5px;
+        border-radius: 2px;
+        padding: 3px 10px;
+    }
+</style>

--- a/examples/hn.svelte.dev/src/routes/__layout.svelte
+++ b/examples/hn.svelte.dev/src/routes/__layout.svelte
@@ -3,6 +3,7 @@
 	import Nav from '$lib/Nav.svelte';
 	import PreloadingIndicator from '$lib/PreloadingIndicator.svelte';
 	import ThemeToggler from '$lib/ThemeToggler.svelte';
+	import SWPrompt from '$lib/SWPrompt.svelte';
 	import '../app.css';
 
 
@@ -20,6 +21,8 @@
 </main>
 
 <ThemeToggler/>
+
+<SWPrompt />
 
 <style>
 	main {

--- a/examples/hn.svelte.dev/src/routes/index.svelte
+++ b/examples/hn.svelte.dev/src/routes/index.svelte
@@ -1,6 +1,19 @@
+<!--
 <script context="module">
 	import {dev} from '$app/env';
 	export function load() {
 		return { redirect: '/top/1', status: dev ? 302 : 301 };
 	}
 </script>
+-->
+<svelte:head>
+	<title>Home • Svelte Hacker News</title>
+</svelte:head>
+
+<h1>Home</h1>
+
+<p>This is a simple Hacker News clone, built with <a href="https://kit.svelte.dev">SvelteKit</a>, an application framework for <a href="https://svelte.dev">Svelte</a>.</p>
+
+<p>Svelte is a new kind of framework, one that compiles your component templates into fast, compact JavaScript — either client-side or server-side. You can read more about the design and philosophy in the <a href="https://svelte.dev/blog/svelte-3-rethinking-reactivity">introductory blog post</a>.</p>
+
+<p>We're using <a href="https://github.com/davideast/hnpwa-api">hnpwa-api</a> as a backend. The app is hosted on <a href="https://cloud.google.com/run/">Cloud Run</a>, using <a href="https://www.cloudflare.com/">Cloudflare</a> for the CDN. <a href="https://github.com/sveltejs/hn.svelte.dev">The source code is here</a>.</p>

--- a/examples/hn.svelte.dev/src/service-worker.js
+++ b/examples/hn.svelte.dev/src/service-worker.js
@@ -1,0 +1,42 @@
+import { build, files, timestamp } from '$service-worker';
+import { precacheAndRoute, cleanupOutdatedCaches, createHandlerBoundToURL } from 'workbox-precaching';
+import { NavigationRoute, registerRoute } from 'workbox-routing';
+import { clientsClaim } from 'workbox-core';
+
+/* LOGIC TO AUTO UPDATE */
+self.skipWaiting();
+clientsClaim();
+
+/* LOGIC FOR PROMPT FOR UPDATE
+self.addEventListener('message', (event) => {
+	if (event.data && event.data.type === 'SKIP_WAITING') {
+		self.skipWaiting();
+	}
+});
+*/
+
+
+precacheAndRoute([
+	...build.map(f => {
+		return {
+			url: f,
+			revision: `${timestamp}`
+		};
+	}),
+	...files.map(f => {
+		return {
+			url: f,
+			revision: `${timestamp}`
+		};
+	}),
+	...['/', 'about'].map((url) => {
+		return {
+			url,
+			revision: `${timestamp}`
+		};
+	})
+]);
+
+cleanupOutdatedCaches();
+
+registerRoute(new NavigationRoute(createHandlerBoundToURL('/')));

--- a/examples/hn.svelte.dev/static/manifest.json
+++ b/examples/hn.svelte.dev/static/manifest.json
@@ -3,8 +3,9 @@
 	"theme_color": "#ff6600",
 	"name": "Svelte Hacker News",
 	"short_name": "Svelte Hacker News",
-	"display": "minimal-ui",
+	"display": "standalone",
 	"start_url": "/",
+	"scope": "/",
 	"icons": [
 		{
 			"src": "logo-192.png",

--- a/examples/hn.svelte.dev/svelte.config.js
+++ b/examples/hn.svelte.dev/svelte.config.js
@@ -3,6 +3,9 @@ import netlify from '@sveltejs/adapter-netlify';
 export default {
 	kit: {
 		adapter: netlify(),
-		target: '#svelte'
+		target: '#svelte',
+		serviceWorker: {
+			register: false
+		}
 	}
 };

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -52,8 +52,8 @@ export async function build(config, { cwd = process.cwd(), runtime = '@sveltejs/
 		output_dir,
 		client_entry_file: `${SVELTE_KIT}/build/runtime/internal/start.js`,
 		service_worker_register:
-			config.kit.serviceWorker?.register === undefined ? true : config.kit.serviceWorker.register,
-		service_worker_scope: config.kit.serviceWorker?.scope || '/',
+			config.kit.serviceWorker.register === undefined ? true : config.kit.serviceWorker.register,
+		service_worker_scope: config.kit.serviceWorker.scope || '/',
 		service_worker_entry_file: resolve_entry(config.kit.files.serviceWorker),
 		svelte_packages
 	};

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -51,7 +51,8 @@ export async function build(config, { cwd = process.cwd(), runtime = '@sveltejs/
 		}),
 		output_dir,
 		client_entry_file: `${SVELTE_KIT}/build/runtime/internal/start.js`,
-		service_worker_register: config.kit.serviceWorker?.register === undefined ? true : config.kit.serviceWorker.register,
+		service_worker_register:
+			config.kit.serviceWorker?.register === undefined ? true : config.kit.serviceWorker.register,
 		service_worker_scope: config.kit.serviceWorker?.scope || '/',
 		service_worker_entry_file: resolve_entry(config.kit.files.serviceWorker),
 		svelte_packages

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -51,10 +51,10 @@ export async function build(config, { cwd = process.cwd(), runtime = '@sveltejs/
 		}),
 		output_dir,
 		client_entry_file: `${SVELTE_KIT}/build/runtime/internal/start.js`,
+		service_worker_entry_file: resolve_entry(config.kit.files.serviceWorker),
 		service_worker_register:
 			config.kit.serviceWorker.register === undefined ? true : config.kit.serviceWorker.register,
 		service_worker_scope: config.kit.serviceWorker.scope || '/',
-		service_worker_entry_file: resolve_entry(config.kit.files.serviceWorker),
 		svelte_packages
 	};
 
@@ -206,9 +206,9 @@ async function build_client({
  *   build_dir: string;
  *   output_dir: string;
  *   client_entry_file: string;
+ *   service_worker_entry_file: string | null;
  *   service_worker_register: boolean;
  *   service_worker_scope: string;
- *   service_worker_entry_file: string | null;
  *   svelte_packages: string[];
  * }} options
  * @param {ClientManifest} client_manifest
@@ -223,9 +223,9 @@ async function build_server(
 		build_dir,
 		output_dir,
 		client_entry_file,
+		service_worker_entry_file,
 		service_worker_register,
 		service_worker_scope,
-		service_worker_entry_file,
 		svelte_packages
 	},
 	client_manifest,
@@ -352,10 +352,10 @@ async function build_server(
 					prerender: ${config.kit.prerender.enabled},
 					read: settings.read,
 					root,
+					router: ${s(config.kit.router)},
+					service_worker: ${service_worker_entry_file ? "'/service-worker.js'" : 'null'},
 					service_worker_register: ${service_worker_register},
 					service_worker_scope: ${service_worker_scope ? `'${service_worker_scope}'` : '/'},
-					service_worker: ${service_worker_entry_file ? "'/service-worker.js'" : 'null'},
-					router: ${s(config.kit.router)},
 					ssr: ${s(config.kit.ssr)},
 					target: ${s(config.kit.target)},
 					template,

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -51,6 +51,8 @@ export async function build(config, { cwd = process.cwd(), runtime = '@sveltejs/
 		}),
 		output_dir,
 		client_entry_file: `${SVELTE_KIT}/build/runtime/internal/start.js`,
+		service_worker_register: config.kit.serviceWorker?.register === true || true,
+		service_worker_scope: config.kit.serviceWorker?.scope || '/',
 		service_worker_entry_file: resolve_entry(config.kit.files.serviceWorker),
 		svelte_packages
 	};
@@ -203,6 +205,8 @@ async function build_client({
  *   build_dir: string;
  *   output_dir: string;
  *   client_entry_file: string;
+ *   service_worker_register: boolean;
+ *   service_worker_scope: string;
  *   service_worker_entry_file: string | null;
  *   svelte_packages: string[];
  * }} options
@@ -218,6 +222,8 @@ async function build_server(
 		build_dir,
 		output_dir,
 		client_entry_file,
+		service_worker_register,
+		service_worker_scope,
 		service_worker_entry_file,
 		svelte_packages
 	},
@@ -345,6 +351,8 @@ async function build_server(
 					prerender: ${config.kit.prerender.enabled},
 					read: settings.read,
 					root,
+					service_worker_register: ${service_worker_register},
+					service_worker_scope: ${service_worker_scope ? `'${service_worker_scope}'` : '/'},
 					service_worker: ${service_worker_entry_file ? "'/service-worker.js'" : 'null'},
 					router: ${s(config.kit.router)},
 					ssr: ${s(config.kit.ssr)},

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -51,7 +51,7 @@ export async function build(config, { cwd = process.cwd(), runtime = '@sveltejs/
 		}),
 		output_dir,
 		client_entry_file: `${SVELTE_KIT}/build/runtime/internal/start.js`,
-		service_worker_register: config.kit.serviceWorker?.register === true || true,
+		service_worker_register: config.kit.serviceWorker?.register === undefined ? true : config.kit.serviceWorker.register,
 		service_worker_scope: config.kit.serviceWorker?.scope || '/',
 		service_worker_entry_file: resolve_entry(config.kit.files.serviceWorker),
 		svelte_packages

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -40,6 +40,8 @@ test('fills in defaults', () => {
 				emitTypes: true
 			},
 			serviceWorker: {
+				register: true,
+				scope: '/',
 				exclude: []
 			},
 			paths: {
@@ -150,6 +152,8 @@ test('fills in partial blanks', () => {
 				emitTypes: true
 			},
 			serviceWorker: {
+				register: true,
+				scope: '/',
 				exclude: []
 			},
 			paths: {

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -80,6 +80,8 @@ const options = {
 			serviceWorker: {
 				type: 'branch',
 				children: {
+					register: expect_boolean(true),
+					scope: expect_string('/', true),
 					exclude: expect_array_of_strings([])
 				}
 			},

--- a/packages/kit/src/core/config/test/index.js
+++ b/packages/kit/src/core/config/test/index.js
@@ -50,6 +50,8 @@ async function testLoadDefaultConfig(path) {
 				emitTypes: true
 			},
 			serviceWorker: {
+				register: true,
+				scope: '/',
 				exclude: []
 			},
 			paths: { base: '', assets: '' },

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -144,7 +144,7 @@ export async function render_response({
 		</script>`;
 	}
 
-	if (options.service_worker) {
+	if (options.service_worker && options.service_worker_register) {
 		init += `<script>
 			if ('serviceWorker' in navigator) {
 				navigator.serviceWorker.register('${options.service_worker}', { scope: '${options.service_worker_scope}' });

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -147,7 +147,7 @@ export async function render_response({
 	if (options.service_worker) {
 		init += `<script>
 			if ('serviceWorker' in navigator) {
-				navigator.serviceWorker.register('${options.service_worker}');
+				navigator.serviceWorker.register('${options.service_worker}', { scope: '${options.service_worker_scope}' });
 			}
 		</script>`;
 	}

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -72,6 +72,8 @@ export interface Config {
 		};
 		router?: boolean;
 		serviceWorker?: {
+			register?: boolean;
+			scope?: string;
 			exclude?: string[];
 		};
 		ssr?: boolean;

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -72,9 +72,9 @@ export interface Config {
 		};
 		router?: boolean;
 		serviceWorker?: {
+			exclude?: string[];
 			register?: boolean;
 			scope?: string;
-			exclude?: string[];
 		};
 		ssr?: boolean;
 		target?: string;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -131,9 +131,9 @@ export interface SSRRenderOptions {
 	read(file: string): Buffer;
 	root: SSRComponent['default'];
 	router: boolean;
+	service_worker?: string;
 	service_worker_register?: boolean;
 	service_worker_scope?: string;
-	service_worker?: string;
 	ssr: boolean;
 	target: string;
 	template({ head, body }: { head: string; body: string }): string;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -131,8 +131,8 @@ export interface SSRRenderOptions {
 	read(file: string): Buffer;
 	root: SSRComponent['default'];
 	router: boolean;
-	service_worker_register: boolean;
-	service_worker_scope: string;
+	service_worker_register?: boolean;
+	service_worker_scope?: string;
 	service_worker?: string;
 	ssr: boolean;
 	target: string;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -131,6 +131,8 @@ export interface SSRRenderOptions {
 	read(file: string): Buffer;
 	root: SSRComponent['default'];
 	router: boolean;
+	service_worker_register: boolean;
+	service_worker_scope: string;
 	service_worker?: string;
 	ssr: boolean;
 	target: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       workbox-core: ^6.2.4
       workbox-precaching: ^6.2.4
       workbox-routing: ^6.2.4
+      workbox-window: ^6.2.4
+    dependencies:
+      workbox-window: 6.2.4
     devDependencies:
       '@sveltejs/adapter-netlify': link:../../packages/adapter-netlify
       '@sveltejs/kit': link:../../packages/kit
@@ -993,6 +996,10 @@ packages:
       '@types/mime': 1.3.2
       '@types/node': 15.0.1
     dev: true
+
+  /@types/trusted-types/2.0.2:
+    resolution: {integrity: sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==}
+    dev: false
 
   /@types/yauzl/2.9.1:
     resolution: {integrity: sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==}
@@ -4149,7 +4156,6 @@ packages:
 
   /workbox-core/6.2.4:
     resolution: {integrity: sha512-Nu8X4R4Is3g8uzEJ6qwbW2CGVpzntW/cSf8OfsQGIKQR0nt84FAKzP2cLDaNLp3L/iV9TuhZgCTZzkMiap5/OQ==}
-    dev: true
 
   /workbox-precaching/6.2.4:
     resolution: {integrity: sha512-7POznbVc8EG/mkbXzeb94x3B1VJruPgXvXFgS0NJ3GRugkO4ULs/DpIIb+ycs7uJIKY9EzLS7VXvElr3rMSozQ==}
@@ -4170,6 +4176,13 @@ packages:
     dependencies:
       workbox-core: 6.2.4
     dev: true
+
+  /workbox-window/6.2.4:
+    resolution: {integrity: sha512-9jD6THkwGEASj1YP56ZBHYJ147733FoGpJlMamYk38k/EBFE75oc6K3Vs2tGOBx5ZGq54+mHSStnlrtFG3IiOg==}
+    dependencies:
+      '@types/trusted-types': 2.0.2
+      workbox-core: 6.2.4
+    dev: false
 
   /wrap-ansi/6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,10 +51,16 @@ importers:
       '@sveltejs/adapter-netlify': workspace:*
       '@sveltejs/kit': workspace:*
       svelte: ^3.40.0
+      workbox-core: ^6.2.4
+      workbox-precaching: ^6.2.4
+      workbox-routing: ^6.2.4
     devDependencies:
       '@sveltejs/adapter-netlify': link:../../packages/adapter-netlify
       '@sveltejs/kit': link:../../packages/kit
       svelte: 3.40.0
+      workbox-core: 6.2.4
+      workbox-precaching: 6.2.4
+      workbox-routing: 6.2.4
 
   packages/adapter-begin:
     specifiers:
@@ -4139,6 +4145,30 @@ packages:
   /word-wrap/1.2.3:
     resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /workbox-core/6.2.4:
+    resolution: {integrity: sha512-Nu8X4R4Is3g8uzEJ6qwbW2CGVpzntW/cSf8OfsQGIKQR0nt84FAKzP2cLDaNLp3L/iV9TuhZgCTZzkMiap5/OQ==}
+    dev: true
+
+  /workbox-precaching/6.2.4:
+    resolution: {integrity: sha512-7POznbVc8EG/mkbXzeb94x3B1VJruPgXvXFgS0NJ3GRugkO4ULs/DpIIb+ycs7uJIKY9EzLS7VXvElr3rMSozQ==}
+    dependencies:
+      workbox-core: 6.2.4
+      workbox-routing: 6.2.4
+      workbox-strategies: 6.2.4
+    dev: true
+
+  /workbox-routing/6.2.4:
+    resolution: {integrity: sha512-jHnOmpeH4MOWR4eXv6l608npD2y6IFv7yFJ1bT9/RbB8wq2vXHXJQ0ExTZRTWGbVltSG22wEU+MQ8VebDDwDeg==}
+    dependencies:
+      workbox-core: 6.2.4
+    dev: true
+
+  /workbox-strategies/6.2.4:
+    resolution: {integrity: sha512-DKgGC3ruceDuu2o+Ae5qmJy0p0q21mFP+RrkdqKrjyf2u8cJvvtvt1eIt4nevKc5BESiKxmhC2h+TZpOSzUDvA==}
+    dependencies:
+      workbox-core: 6.2.4
     dev: true
 
   /wrap-ansi/6.2.0:


### PR DESCRIPTION
This PR fixes the service worker `scope` when registering it on navigator:
- add option to configure the sw scope
- add option to not register the sw: this will be usefull when using prompt for update or periodic service worker updates or another logic that requires using the service worker registration
- updated the example to include a sw with auto update behavior
- added `workbox` deps to build the sw on the example
- `.gitignore`: excluded IntelliJ/Webstorm stuff

closes #922
