### PR TITLE
[feat] adapter module

### DIFF
--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -45,7 +45,7 @@ export default function ({
 			const files = fileURLToPath(new URL('./files', import.meta.url));
 			utils.copy(files, '.svelte-kit/node');
 			writeFileSync(
-				'.svelte-kit/node/env.js',
+				'.svelte-kit/node/env.js', // types pointed in src/env.d.ts
 				`export const path = process.env[${JSON.stringify(
 					path_env
 				)}] || false;\nexport const host = process.env[${JSON.stringify(

--- a/packages/adapter-node/src/env.d.ts
+++ b/packages/adapter-node/src/env.d.ts
@@ -1,0 +1,3 @@
+export const host: string;
+export const path: string;
+export const port: number;

--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -1,8 +1,5 @@
-// TODO hardcoding the relative location makes this brittle
-// @ts-ignore
-import { init, render } from '../output/server/app.js';
-// @ts-ignore
-import { path, host, port } from './env.js';
+import { init, render } from '@sveltejs/kit/adapter';
+import { host, path, port } from './env.js';
 import { createServer } from './server';
 
 init();

--- a/packages/adapter-node/src/server.js
+++ b/packages/adapter-node/src/server.js
@@ -16,8 +16,7 @@ const paths = {
 	prerendered: join(__dirname, '/prerendered')
 };
 
-// TODO: type render function from @sveltejs/kit/adapter
-// @ts-ignore
+/** @param {{ render: import('@sveltejs/kit').App['render'] }} app */
 export function createServer({ render }) {
 	const prerendered_handler = fs.existsSync(paths.prerendered)
 		? sirv(paths.prerendered, {

--- a/packages/kit/rollup.config.js
+++ b/packages/kit/rollup.config.js
@@ -46,6 +46,7 @@ export default [
 	{
 		input: {
 			cli: 'src/cli.js',
+			adapter: 'src/core/adapt/proxy.js',
 			ssr: 'src/runtime/server/index.js',
 			node: 'src/core/node/index.js',
 			hooks: 'src/runtime/hooks.js',

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -3,7 +3,7 @@ import { dirname, join, resolve as resolve_path } from 'path';
 import { pathToFileURL, resolve, URL } from 'url';
 import { mkdirp } from '../../utils/filesystem.js';
 import { __fetch_polyfill } from '../../install-fetch.js';
-import { SVELTE_KIT } from '../constants.js';
+import { SERVER_OUTPUT } from '../constants.js';
 
 /**
  * @typedef {import('types/config').PrerenderErrorHandler} PrerenderErrorHandler
@@ -99,14 +99,12 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 
 	__fetch_polyfill();
 
-	const dir = resolve_path(cwd, `${SVELTE_KIT}/output`);
-
 	const seen = new Set();
 
-	const server_root = resolve_path(dir);
+	const server_root = resolve_path(cwd, SERVER_OUTPUT);
 
 	/** @type {import('types/app').App} */
-	const app = await import(pathToFileURL(`${server_root}/server/app.js`).href);
+	const app = await import(pathToFileURL(`${server_root}/app.js`).href);
 
 	app.init({
 		paths: config.kit.paths,

--- a/packages/kit/src/core/adapt/proxy.js
+++ b/packages/kit/src/core/adapt/proxy.js
@@ -1,0 +1,10 @@
+import { resolve } from 'path';
+import { SERVER_OUTPUT } from '../constants';
+
+const cwd = resolve(process.cwd(), `${SERVER_OUTPUT}/app.js`);
+
+export const init = async () => (await import(cwd)).init;
+
+export const render = async () => (await import(cwd)).render;
+
+export default { init, render };

--- a/packages/kit/src/core/adapt/test/index.js
+++ b/packages/kit/src/core/adapt/test/index.js
@@ -5,7 +5,7 @@ import rimraf from 'rimraf';
 import glob from 'tiny-glob/sync.js';
 import { get_utils } from '../utils.js';
 import { fileURLToPath } from 'url';
-import { SVELTE_KIT } from '../../constants.js';
+import { CLIENT_OUTPUT, SERVER_OUTPUT } from '../../constants.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = join(__filename, '..');
@@ -63,18 +63,12 @@ suite('copy files', () => {
 	rimraf.sync(dest);
 	utils.copy_client_files(dest);
 
-	assert.equal(
-		glob('**', { cwd: `${cwd}/${SVELTE_KIT}/output/client` }),
-		glob('**', { cwd: dest })
-	);
+	assert.equal(glob('**', { cwd: `${cwd}/${CLIENT_OUTPUT}` }), glob('**', { cwd: dest }));
 
 	rimraf.sync(dest);
 	utils.copy_server_files(dest);
 
-	assert.equal(
-		glob('**', { cwd: `${cwd}/${SVELTE_KIT}/output/server` }),
-		glob('**', { cwd: dest })
-	);
+	assert.equal(glob('**', { cwd: `${cwd}/${SERVER_OUTPUT}` }), glob('**', { cwd: dest }));
 });
 
 suite('prerender', async () => {

--- a/packages/kit/src/core/adapt/utils.js
+++ b/packages/kit/src/core/adapt/utils.js
@@ -1,4 +1,4 @@
-import { SVELTE_KIT } from '../constants.js';
+import { CLIENT_OUTPUT, SERVER_OUTPUT } from '../constants.js';
 import { copy, rimraf, mkdirp } from '../../utils/filesystem.js';
 import { prerender } from './prerender.js';
 
@@ -19,11 +19,11 @@ export function get_utils({ cwd, config, build_data, log }) {
 		copy,
 
 		copy_client_files(dest) {
-			copy(`${cwd}/${SVELTE_KIT}/output/client`, dest, (file) => file[0] !== '.');
+			copy(`${cwd}/${CLIENT_OUTPUT}`, dest, (file) => file[0] !== '.');
 		},
 
 		copy_server_files(dest) {
-			copy(`${cwd}/${SVELTE_KIT}/output/server`, dest, (file) => file[0] !== '.');
+			copy(`${cwd}/${SERVER_OUTPUT}`, dest, (file) => file[0] !== '.');
 		},
 
 		copy_static_files(dest) {

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -8,7 +8,7 @@ import { create_app } from '../../core/create_app/index.js';
 import vite from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import glob from 'tiny-glob/sync.js';
-import { SVELTE_KIT } from '../constants.js';
+import { CLIENT_OUTPUT, SERVER_OUTPUT, SVELTE_KIT } from '../constants.js';
 
 /** @param {any} value */
 const s = (value) => JSON.stringify(value);
@@ -66,8 +66,8 @@ export async function build(config, { cwd = process.cwd(), runtime = '@sveltejs/
 		await build_service_worker(options, client_manifest);
 	}
 
-	const client = glob('**', { cwd: `${output_dir}/client`, filesOnly: true }).map(posixify);
-	const server = glob('**', { cwd: `${output_dir}/server`, filesOnly: true }).map(posixify);
+	const client = glob('**', { cwd: CLIENT_OUTPUT, filesOnly: true }).map(posixify);
+	const server = glob('**', { cwd: SERVER_OUTPUT, filesOnly: true }).map(posixify);
 
 	return {
 		client,
@@ -88,7 +88,6 @@ export async function build(config, { cwd = process.cwd(), runtime = '@sveltejs/
  *   build_dir: string;
  *   output_dir: string;
  *   client_entry_file: string;
- *   service_worker_entry_file: string | null;
  * }} options
  */
 async function build_client({
@@ -98,8 +97,7 @@ async function build_client({
 	manifest,
 	build_dir,
 	output_dir,
-	client_entry_file,
-	service_worker_entry_file
+	client_entry_file
 }) {
 	create_app({
 		manifest_data: manifest,
@@ -111,7 +109,7 @@ async function build_client({
 
 	process.env.VITE_SVELTEKIT_AMP = config.kit.amp ? 'true' : '';
 
-	const client_out_dir = `${output_dir}/client/${config.kit.appDir}`;
+	const client_out_dir = `${CLIENT_OUTPUT}/${config.kit.appDir}`;
 	const client_manifest_file = `${client_out_dir}/manifest.json`;
 
 	/** @type {Record<string, string>} */

--- a/packages/kit/src/core/constants.js
+++ b/packages/kit/src/core/constants.js
@@ -4,3 +4,6 @@ export const SVELTE_KIT = '.svelte-kit';
 // asset path so that we can serve local assets while still
 // verifying that requests are correctly prefixed
 export const SVELTE_KIT_ASSETS = '/_svelte_kit_assets';
+
+export const CLIENT_OUTPUT = `${SVELTE_KIT}/output/client`;
+export const SERVER_OUTPUT = `${SVELTE_KIT}/output/server`;

--- a/packages/kit/src/core/preview/index.js
+++ b/packages/kit/src/core/preview/index.js
@@ -5,7 +5,7 @@ import { getRawBody } from '../node/index.js';
 import { join, resolve } from 'path';
 import { get_server } from '../server/index.js';
 import { __fetch_polyfill } from '../../install-fetch.js';
-import { SVELTE_KIT, SVELTE_KIT_ASSETS } from '../constants.js';
+import { CLIENT_OUTPUT, SERVER_OUTPUT, SVELTE_KIT_ASSETS } from '../constants.js';
 
 /** @param {string} dir */
 const mutable = (dir) =>
@@ -32,7 +32,7 @@ export async function preview({
 }) {
 	__fetch_polyfill();
 
-	const app_file = resolve(cwd, `${SVELTE_KIT}/output/server/app.js`);
+	const app_file = resolve(cwd, `${SERVER_OUTPUT}/app.js`);
 
 	/** @type {import('types/app').App} */
 	const app = await import(pathToFileURL(app_file).href);
@@ -45,7 +45,7 @@ export async function preview({
 				return next();
 		  };
 
-	const assets_handler = sirv(resolve(cwd, `${SVELTE_KIT}/output/client`), {
+	const assets_handler = sirv(resolve(cwd, CLIENT_OUTPUT), {
 		maxAge: 31536000,
 		immutable: true
 	});

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -132,6 +132,15 @@ declare module '$service-worker' {
 	export const timestamp: number;
 }
 
+declare module '@sveltejs/kit/adapter' {
+	import { App } from '@sveltejs/kit';
+
+	export const init: App['init'];
+	export const render: App['render'];
+	const app: App;
+	export default app;
+}
+
 declare module '@sveltejs/kit/hooks' {
 	import { Handle } from '@sveltejs/kit';
 


### PR DESCRIPTION
Fixes #625
Resolves #2249

One caveat from this is that `app.init` and `app.render` would be loaded asynchronously, not sure how it would impact adapters directly, but hey they're now available to import from `@sveltejs/kit/adapter` instead