### PR TITLE
[breaking] update prerender options for providing list of pages

### DIFF
--- a/.changeset/gorgeous-cougars-beg.md
+++ b/.changeset/gorgeous-cougars-beg.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] update prerender options for providing list of pages

--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -46,10 +46,10 @@ const config = {
 			base: ''
 		},
 		prerender: {
-			crawl: true,
+			crawl: ['*'],
 			enabled: true,
 			onError: 'fail',
-			pages: ['*']
+			pages: []
 		},
 		router: true,
 		serviceWorker: {
@@ -146,7 +146,7 @@ An object containing zero or more of the following `string` values:
 
 See [Prerendering](#ssr-and-javascript-prerender). An object containing zero or more of the following:
 
-- `crawl` — determines whether SvelteKit should find pages to prerender by following links from the seed page(s)
+- `crawl` — a list of seed page(s) to prerender and follow links from to discover additional pages for prerendering. The `*` string includes all non-dynamic routes (i.e. pages with no `[parameters]` )
 - `enabled` — set to `false` to disable prerendering altogether
 - `onError`
 
@@ -172,7 +172,7 @@ See [Prerendering](#ssr-and-javascript-prerender). An object containing zero or 
     };
     ```
 
-- `pages` — an array of pages to prerender, or start crawling from (if `crawl: true`). The `*` string includes all non-dynamic routes (i.e. pages with no `[parameters]` )
+- `pages` — an array of pages to prerender. The `*` string includes all non-dynamic routes (i.e. pages with no `[parameters]` )
 
 ### router
 

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -46,7 +46,7 @@ test('fills in defaults', () => {
 				assets: ''
 			},
 			prerender: {
-				crawl: true,
+				crawl: ['*'],
 				enabled: true,
 				// TODO: remove this for the 1.0 release
 				force: undefined,
@@ -154,7 +154,7 @@ test('fills in partial blanks', () => {
 				assets: ''
 			},
 			prerender: {
-				crawl: true,
+				crawl: ['*'],
 				enabled: true,
 				// TODO: remove this for the 1.0 release
 				force: undefined,

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -123,7 +123,28 @@ const options = object(
 			}),
 
 			prerender: object({
-				crawl: boolean(true),
+				crawl: validate(['*'], (input, keypath) => {
+					if (
+						input !== false &&
+						(!Array.isArray(input) || !input.every((page) => typeof page === 'string'))
+					) {
+						throw new Error(`${keypath} must be either an array of strings or false`);
+					}
+
+					if (input === false) return input;
+
+					input.forEach(
+						/** @param {string} page */ (page) => {
+							if (page !== '*' && page[0] !== '/') {
+								throw new Error(
+									`Each member of ${keypath} must be either '*' or an absolute path beginning with '/' — saw '${page}'`
+								);
+							}
+						}
+					);
+
+					return input;
+				}),
 				enabled: boolean(true),
 				// TODO: remove this for the 1.0 release
 				force: validate(undefined, (input, keypath) => {

--- a/packages/kit/src/core/config/test/index.js
+++ b/packages/kit/src/core/config/test/index.js
@@ -52,7 +52,7 @@ async function testLoadDefaultConfig(path) {
 				exclude: []
 			},
 			paths: { base: '', assets: '' },
-			prerender: { crawl: true, enabled: true, force: undefined, onError: 'fail', pages: ['*'] },
+			prerender: { crawl: ['*'], enabled: true, force: undefined, onError: 'fail', pages: ['*'] },
 			router: true,
 			ssr: true,
 			target: null,

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -65,7 +65,7 @@ export interface Config {
 			base?: string;
 		};
 		prerender?: {
-			crawl?: boolean;
+			crawl?: string[] | false;
 			enabled?: boolean;
 			onError?: PrerenderOnErrorValue;
 			pages?: string[];


### PR DESCRIPTION
Closes https://github.com/sveltejs/kit/issues/2185

The main reason for this is to clarify the options. It was confusing to people that `pages` wasn't just a list of pages to prerender and that the option behaved differently depending on whether `crawl` was `true` or `false`

This also happens to be more powerful because you can specify some pages to crawl and some pages to pre-render without crawling, which you could not do before

For users that had set `pages` with `crawl: true` they will need to move that option value to `crawl`