### PR TITLE
[docs] remove Server prefix from Request and Response types

### DIFF
--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -69,8 +69,7 @@ export interface IncomingRequest {
 type ParameterizedBody<Body = unknown> = Body extends FormData
 	? ReadOnlyFormData
 	: (string | RawBody | ReadOnlyFormData) & Body;
-// ServerRequest is exported as Request
-export interface ServerRequest<Locals = Record<string, any>, Body = unknown>
+export interface Request<Locals = Record<string, any>, Body = unknown>
 	extends IncomingRequest {
 	params: Record<string, string>;
 	body: ParameterizedBody<Body>;
@@ -89,7 +88,7 @@ export interface RequestHandler<
 	Input = unknown,
 	Output extends DefaultBody = DefaultBody
 > = (
-	request: ServerRequest<Locals, Input>
+	request: Request<Locals, Input>
 ) => void | EndpointOutput<Output> | Promise<void | EndpointOutput<Output>>;
 ```
 

--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -36,8 +36,7 @@ export interface IncomingRequest {
 type ParameterizedBody<Body = unknown> = Body extends FormData
 	? ReadOnlyFormData
 	: (string | RawBody | ReadOnlyFormData) & Body;
-// ServerRequest is exported as Request
-export interface ServerRequest<Locals = Record<string, any>, Body = unknown>
+export interface Request<Locals = Record<string, any>, Body = unknown>
 	extends IncomingRequest {
 	params: Record<string, string>;
 	body: ParameterizedBody<Body>;
@@ -45,8 +44,7 @@ export interface ServerRequest<Locals = Record<string, any>, Body = unknown>
 }
 
 type StrictBody = string | Uint8Array;
-// ServerResponse is exported as Response
-export interface ServerResponse {
+export interface Response {
 	status: number;
 	headers: ResponseHeaders;
 	body?: StrictBody;
@@ -54,9 +52,9 @@ export interface ServerResponse {
 
 export interface Handle<Locals = Record<string, any>> {
 	(input: {
-		request: ServerRequest<Locals>;
-		resolve(request: ServerRequest<Locals>): ServerResponse | Promise<ServerResponse>;
-	}): ServerResponse | Promise<ServerResponse>;
+		request: Request<Locals>;
+		resolve(request: Request<Locals>): Response | Promise<Response>;
+	}): Response | Promise<Response>;
 }
 ```
 

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -148,7 +148,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 		if (seen.has(path)) return;
 		seen.add(path);
 
-		/** @type {Map<string, import('types/hooks').ServerResponse>} */
+		/** @type {Map<string, import('types/hooks').Response>} */
 		const dependencies = new Map();
 
 		const rendered = await app.render(

--- a/packages/kit/src/runtime/hooks.js
+++ b/packages/kit/src/runtime/hooks.js
@@ -11,8 +11,8 @@ export function sequence(...handlers) {
 
 		/**
 		 * @param {number} i
-		 * @param {import('types/hooks').ServerRequest} request
-		 * @returns {import('types/helper').MaybePromise<import('types/hooks').ServerResponse>}
+		 * @param {import('types/hooks').Request} request
+		 * @returns {import('types/helper').MaybePromise<import('types/hooks').Response>}
 		 */
 		function apply_handle(i, request) {
 			const handle = handlers[i];

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -33,10 +33,10 @@ function is_content_type_textual(content_type) {
 }
 
 /**
- * @param {import('types/hooks').ServerRequest} request
+ * @param {import('types/hooks').Request} request
  * @param {import('types/internal').SSREndpoint} route
  * @param {RegExpExecArray} match
- * @returns {Promise<import('types/hooks').ServerResponse | undefined>}
+ * @returns {Promise<import('types/hooks').Response | undefined>}
  */
 export async function render_endpoint(request, route, match) {
 	const mod = await route.load();

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -1,12 +1,12 @@
 import { respond } from './respond.js';
 
 /**
- * @param {import('types/hooks').ServerRequest} request
+ * @param {import('types/hooks').Request} request
  * @param {import('types/internal').SSRPage} route
  * @param {RegExpExecArray} match
  * @param {import('types/internal').SSRRenderOptions} options
  * @param {import('types/internal').SSRRenderState} state
- * @returns {Promise<import('types/hooks').ServerResponse | undefined>}
+ * @returns {Promise<import('types/hooks').Response | undefined>}
  */
 export async function render_page(request, route, match, options, state) {
 	if (state.initiator === route) {

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -5,7 +5,7 @@ const s = JSON.stringify;
 
 /**
  * @param {{
- *   request: import('types/hooks').ServerRequest;
+ *   request: import('types/hooks').Request;
  *   options: import('types/internal').SSRRenderOptions;
  *   state: import('types/internal').SSRRenderState;
  *   route: import('types/internal').SSRPage | null;

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -12,14 +12,14 @@ import { coalesce_to_error } from '../../utils.js';
 
 /**
  * @param {{
- *   request: import('types/hooks').ServerRequest;
+ *   request: import('types/hooks').Request;
  *   options: SSRRenderOptions;
  *   state: SSRRenderState;
  *   $session: any;
  *   route: import('types/internal').SSRPage;
  *   page: import('types/page').Page;
  * }} opts
- * @returns {Promise<import('types/hooks').ServerResponse | undefined>}
+ * @returns {Promise<import('types/hooks').Response | undefined>}
  */
 export async function respond(opts) {
 	const { request, options, state, $session, route } = opts;

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -11,7 +11,7 @@ import { coalesce_to_error } from '../../utils.js';
 
 /**
  * @param {{
- *   request: import('types/hooks').ServerRequest;
+ *   request: import('types/hooks').Request;
  *   options: SSRRenderOptions;
  *   state: SSRRenderState;
  *   $session: any;

--- a/packages/kit/types/app.d.ts
+++ b/packages/kit/types/app.d.ts
@@ -1,5 +1,5 @@
 import { ReadOnlyFormData, RequestHeaders } from './helper';
-import { ServerResponse } from './hooks';
+import { Response } from './hooks';
 
 export interface App {
 	init(options?: {
@@ -16,10 +16,10 @@ export interface App {
 			prerender: {
 				fallback?: string;
 				all: boolean;
-				dependencies?: Map<string, ServerResponse>;
+				dependencies?: Map<string, Response>;
 			};
 		}
-	): Promise<ServerResponse>;
+	): Promise<Response>;
 }
 
 export type RawBody = null | Uint8Array;

--- a/packages/kit/types/endpoint.d.ts
+++ b/packages/kit/types/endpoint.d.ts
@@ -1,4 +1,4 @@
-import { ServerRequest } from './hooks';
+import { Request } from './hooks';
 import { MaybePromise, ResponseHeaders } from './helper';
 
 type ToJSON = { toJSON(...args: any[]): JSONValue };
@@ -25,5 +25,5 @@ export interface RequestHandler<
 	Input = unknown,
 	Output extends DefaultBody = DefaultBody
 > {
-	(request: ServerRequest<Locals, Input>): MaybePromise<void | EndpointOutput<Output>>;
+	(request: Request<Locals, Input>): MaybePromise<void | EndpointOutput<Output>>;
 }

--- a/packages/kit/types/hooks.d.ts
+++ b/packages/kit/types/hooks.d.ts
@@ -3,34 +3,33 @@ import { MaybePromise, ResponseHeaders } from './helper';
 
 export type StrictBody = string | Uint8Array;
 
-export interface ServerRequest<Locals = Record<string, any>, Body = unknown>
-	extends IncomingRequest {
+export interface Request<Locals = Record<string, any>, Body = unknown> extends IncomingRequest {
 	params: Record<string, string>;
 	body: ParameterizedBody<Body>;
 	locals: Locals;
 }
 
-export interface ServerResponse {
+export interface Response {
 	status: number;
 	headers: ResponseHeaders;
 	body?: StrictBody;
 }
 
 export interface GetSession<Locals = Record<string, any>, Session = any> {
-	(request: ServerRequest<Locals>): MaybePromise<Session>;
+	(request: Request<Locals>): MaybePromise<Session>;
 }
 
 export interface Handle<Locals = Record<string, any>> {
 	(input: {
-		request: ServerRequest<Locals>;
-		resolve(request: ServerRequest<Locals>): MaybePromise<ServerResponse>;
-	}): MaybePromise<ServerResponse>;
+		request: Request<Locals>;
+		resolve(request: Request<Locals>): MaybePromise<Response>;
+	}): MaybePromise<Response>;
 }
 
 export interface HandleError<Locals = Record<string, any>> {
-	(input: { error: Error & { frame?: string }; request: ServerRequest<Locals> }): void;
+	(input: { error: Error & { frame?: string }; request: Request<Locals> }): void;
 }
 
 export interface ExternalFetch {
-	(req: Request): Promise<Response>;
+	(req: globalThis.Request): Promise<globalThis.Response>;
 }

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -7,11 +7,4 @@ export { App, IncomingRequest, RawBody } from './app';
 export { Adapter, AdapterUtils, Config, PrerenderErrorHandler, ValidatedConfig } from './config';
 export { EndpointOutput, RequestHandler } from './endpoint';
 export { ErrorLoad, ErrorLoadInput, Load, LoadInput, LoadOutput, Page } from './page';
-export {
-	ExternalFetch,
-	GetSession,
-	Handle,
-	HandleError,
-	ServerRequest as Request,
-	ServerResponse as Response
-} from './hooks';
+export { ExternalFetch, GetSession, Handle, HandleError, Request, Response } from './hooks';

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -1,12 +1,5 @@
 import { RequestHandler } from './endpoint';
-import {
-	ExternalFetch,
-	GetSession,
-	Handle,
-	HandleError,
-	ServerRequest,
-	ServerResponse
-} from './hooks';
+import { ExternalFetch, GetSession, Handle, HandleError, Request, Response } from './hooks';
 import { Load } from './page';
 
 type PageId = string;
@@ -118,7 +111,7 @@ export interface SSRRenderOptions {
 	};
 	floc: boolean;
 	get_stack: (error: Error) => string | undefined;
-	handle_error(error: Error & { frame?: string }, request: ServerRequest<any>): void;
+	handle_error(error: Error & { frame?: string }, request: Request<any>): void;
 	hooks: Hooks;
 	hydrate: boolean;
 	load_component(id: PageId): Promise<SSRNode>;
@@ -144,7 +137,7 @@ export interface SSRRenderState {
 	prerender?: {
 		fallback: string;
 		all: boolean;
-		dependencies: Map<string, ServerResponse>;
+		dependencies: Map<string, Response>;
 		error: Error;
 	};
 	fallback?: string;


### PR DESCRIPTION
I think this will make the docs easier to read than saying `ServerRequest`, but oh it's really called `Request`! :smile: 