### PR TITLE
[fix] Allow service workers to use the $lib alias

### DIFF
--- a/.changeset/fresh-adults-ring.md
+++ b/.changeset/fresh-adults-ring.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Allow service workers to access files using the $lib alias

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -606,7 +606,8 @@ async function build_service_worker(
 		},
 		resolve: {
 			alias: {
-				'$service-worker': path.resolve(`${build_dir}/runtime/service-worker`)
+				'$service-worker': path.resolve(`${build_dir}/runtime/service-worker`),
+				$lib: config.kit.files.lib
 			}
 		}
 	});


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

Fixes #2321 by adding the `$lib` alias to the build options of service workers.