### PR TITLE
[fix] remove Vite workaround now that dev deps can be bundled

### DIFF
--- a/.changeset/small-ligers-wave.md
+++ b/.changeset/small-ligers-wave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] remove Vite workaround now that dev deps can be bundled

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -6,7 +6,7 @@
 		"@sveltejs/vite-plugin-svelte": "^1.0.0-next.16",
 		"cheap-watch": "^1.0.3",
 		"sade": "^1.7.4",
-		"vite": "^2.5.2"
+		"vite": "^2.5.3"
 	},
 	"devDependencies": {
 		"@rollup/plugin-replace": "^2.4.2",

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -489,7 +489,6 @@ async function build_server(
 		},
 		ssr: {
 			noExternal: [
-				'@sveltejs/kit', // TODO: see https://github.com/vitejs/vite/issues/3953
 				// @ts-expect-error - ssr is considered in alpha, so not yet exposed by Vite
 				...((vite_config.ssr && vite_config.ssr.noExternal) || []),
 				...svelte_packages

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -155,7 +155,6 @@ class Watcher extends EventEmitter {
 			},
 			ssr: {
 				noExternal: [
-					'@sveltejs/kit', // TODO: see https://github.com/vitejs/vite/issues/3953
 					// @ts-expect-error - ssr is considered in alpha, so not yet exposed by Vite
 					...((vite_config.ssr && vite_config.ssr.noExternal) || []),
 					...svelte_packages

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,12 +232,12 @@ importers:
       svelte2tsx: ~0.4.1
       tiny-glob: ^0.2.8
       uvu: ^0.5.1
-      vite: ^2.5.2
+      vite: ^2.5.3
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 1.0.0-next.16_svelte@3.40.0+vite@2.5.2
+      '@sveltejs/vite-plugin-svelte': 1.0.0-next.16_svelte@3.40.0+vite@2.5.3
       cheap-watch: 1.0.3
       sade: 1.7.4
-      vite: 2.5.2
+      vite: 2.5.3
     devDependencies:
       '@rollup/plugin-replace': 2.4.2_rollup@2.55.0
       '@types/amphtml-validator': 1.0.1
@@ -780,7 +780,7 @@ packages:
       picomatch: 2.2.3
     dev: false
 
-  /@sveltejs/vite-plugin-svelte/1.0.0-next.16_svelte@3.40.0+vite@2.5.2:
+  /@sveltejs/vite-plugin-svelte/1.0.0-next.16_svelte@3.40.0+vite@2.5.3:
     resolution: {integrity: sha512-Zzw5vWJ2PjeAFG04/HQrTHvTd4B+v/pz5hgod7fPMOMXu289ZuHs2DPj68xBmOGlmTq0JyrMfBl+NDGCgaSxzA==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
@@ -798,7 +798,7 @@ packages:
       require-relative: 0.8.7
       svelte: 3.40.0
       svelte-hmr: 0.14.7_svelte@3.40.0
-      vite: 2.5.2
+      vite: 2.5.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4073,8 +4073,8 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /vite/2.5.2:
-    resolution: {integrity: sha512-JK5uhiVyMqHiAJbgBa8rCvpP8bEhAE9dKDv1gCmP+EUP2FSPmEeW3WXlCXauPB3MDa8behPW+ntyNXqnGaxslg==}
+  /vite/2.5.3:
+    resolution: {integrity: sha512-1wMDnjflvtTTkMov8O/Xb5+w1/VW/Gw8oCf8f6dqgHn8lMOEqq0SaPtFEQeikFcOKCfSbiU0nEi0LDIx6DNsaQ==}
     engines: {node: '>=12.2.0'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
Allows `sequence` to be used without a built-in workaround