### PR TITLE
Chore/update vite plugin svelte

### DIFF
--- a/.changeset/twenty-hairs-shave.md
+++ b/.changeset/twenty-hairs-shave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Enable nested dependency optimization by updating to @sveltejs/vite-plugin-svelte@1.0.0-next.20

--- a/.changeset/twenty-hairs-shave.md
+++ b/.changeset/twenty-hairs-shave.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Enable nested dependency optimization by updating to @sveltejs/vite-plugin-svelte@1.0.0-next.20
+Enable nested dependency optimization by updating to @sveltejs/vite-plugin-svelte@1.0.0-next.21

--- a/documentation/faq/00-other-resources.md
+++ b/documentation/faq/00-other-resources.md
@@ -2,4 +2,4 @@
 question: Other resources
 ---
 
-Please see [the Svelte FAQ](https://svelte.dev/faq) and [`vite-plugin-svelte`](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md) FAQ as well for the answers to questions deriving from those libraries.
+Please see [the Svelte FAQ](https://svelte.dev/faq) and [`vite-plugin-svelte` FAQ](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md) as well for the answers to questions deriving from those libraries.

--- a/documentation/faq/70-packages.md
+++ b/documentation/faq/70-packages.md
@@ -4,4 +4,6 @@ question: How do I fix the error I'm getting trying to include a package?
 
 SSR in Vite is not yet stable. Libraries work best with Vite when they distribute both CJS and ESM in their package and you may wish to work with library authors to make this happen.
 
+Svelte components must be written entirely in ESM. It is encouraged to make sure the dependencies of Svelte components provide an ESM version. However,in order to handle CJS dependencies [`vite-plugin-svelte` will look for any CJS dependencies](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#what-is-going-on-with-vite-and-pre-bundling-dependencies) and ask Vite to pre-bundle them by automatically adding them to Vite's `optimizeDeps.include` which will use `esbuild` to convert them to ESM.
+
 If you are still encountering issues we recommend checking [the list of known Vite issues most commonly affecting SvelteKit users](https://github.com/sveltejs/kit/issues/2086) and searching both [the Vite issue tracker](https://github.com/vitejs/vite/issues) and the issue tracker of the library in question. Sometimes issues can be worked around by fiddling with the [`optimizeDeps`](https://vitejs.dev/config/#dep-optimization-options) or [`ssr`](https://vitejs.dev/config/#ssr-options) config values.

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0-next.161",
 	"type": "module",
 	"dependencies": {
-		"@sveltejs/vite-plugin-svelte": "^1.0.0-next.20",
+		"@sveltejs/vite-plugin-svelte": "^1.0.0-next.21",
 		"cheap-watch": "^1.0.3",
 		"sade": "^1.7.4",
 		"vite": "^2.5.3"

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0-next.161",
 	"type": "module",
 	"dependencies": {
-		"@sveltejs/vite-plugin-svelte": "^1.0.0-next.16",
+		"@sveltejs/vite-plugin-svelte": "^1.0.0-next.20",
 		"cheap-watch": "^1.0.3",
 		"sade": "^1.7.4",
 		"vite": "^2.5.3"

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -496,15 +496,7 @@ async function build_server(
  * @param {ClientManifest} client_manifest
  */
 async function build_service_worker(
-	{
-		cwd,
-		assets_base,
-		config,
-		manifest,
-		build_dir,
-		output_dir,
-		service_worker_entry_file
-	},
+	{ cwd, assets_base, config, manifest, build_dir, output_dir, service_worker_entry_file },
 	client_manifest
 ) {
 	// TODO add any assets referenced in template .html file, e.g. favicon?

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -11,7 +11,7 @@ import { create_app } from '../../core/create_app/index.js';
 import { rimraf } from '../../utils/filesystem.js';
 import { respond } from '../../runtime/server/index.js';
 import { getRawBody } from '../node/index.js';
-import { copy_assets, get_svelte_packages, resolve_entry } from '../utils.js';
+import { copy_assets, resolve_entry } from '../utils.js';
 import { deep_merge, print_config_conflicts } from '../config/index.js';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { get_server } from '../server/index.js';
@@ -110,8 +110,6 @@ class Watcher extends EventEmitter {
 		// don't warn on overriding defaults
 		const [modified_vite_config] = deep_merge(default_config, vite_config);
 
-		const svelte_packages = get_svelte_packages(this.cwd);
-
 		/** @type {[any, string[]]} */
 		const [merged_config, conflicts] = deep_merge(modified_vite_config, {
 			configFile: false,
@@ -129,14 +127,6 @@ class Watcher extends EventEmitter {
 					input: path.resolve(`${this.dir}/runtime/internal/start.js`)
 				}
 			},
-			optimizeDeps: {
-				// exclude Svelte packages because optimizer skips .svelte files leading to half-bundled
-				// broken packages https://github.com/vitejs/vite/issues/3910
-				exclude: [
-					...((vite_config.optimizeDeps && vite_config.optimizeDeps.exclude) || []),
-					...svelte_packages
-				]
-			},
 			plugins: [
 				svelte({
 					extensions: this.config.extensions,
@@ -152,13 +142,6 @@ class Watcher extends EventEmitter {
 				hmr: {
 					...(this.https ? { server: this.server, port: this.port } : {})
 				}
-			},
-			ssr: {
-				noExternal: [
-					// @ts-expect-error - ssr is considered in alpha, so not yet exposed by Vite
-					...((vite_config.ssr && vite_config.ssr.noExternal) || []),
-					...svelte_packages
-				]
 			},
 			base: this.config.kit.paths.assets.startsWith('/') ? `${this.config.kit.paths.assets}/` : '/'
 		});

--- a/packages/kit/src/core/utils.js
+++ b/packages/kit/src/core/utils.js
@@ -74,27 +74,3 @@ export function resolve_entry(entry) {
 export function posixify(str) {
 	return str.replace(/\\/g, '/');
 }
-
-/**
- * Get a list of packages that use pkg.svelte, so they can be added
- * to ssr.noExternal. This is done on a best-effort basis to reduce
- * the frequency of 'Must use import to load ES Module' and similar
- * @param {string} cwd
- * @returns {string[]}
- */
-export function get_svelte_packages(cwd) {
-	const pkg_file = path.join(cwd, 'package.json');
-	if (!fs.existsSync(pkg_file)) return [];
-
-	const pkg = JSON.parse(fs.readFileSync(pkg_file, 'utf8'));
-
-	const deps = [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.devDependencies || {})];
-
-	return deps.filter((dep) => {
-		const dep_pkg_file = path.join(cwd, 'node_modules', dep, 'package.json');
-		if (!fs.existsSync(dep_pkg_file)) return false;
-
-		const dep_pkg = JSON.parse(fs.readFileSync(dep_pkg_file, 'utf-8'));
-		return !!dep_pkg.svelte;
-	});
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,7 +201,7 @@ importers:
   packages/kit:
     specifiers:
       '@rollup/plugin-replace': ^2.4.2
-      '@sveltejs/vite-plugin-svelte': ^1.0.0-next.16
+      '@sveltejs/vite-plugin-svelte': ^1.0.0-next.20
       '@types/amphtml-validator': ^1.0.1
       '@types/cookie': ^0.4.0
       '@types/marked': ^2.0.2
@@ -234,7 +234,7 @@ importers:
       uvu: ^0.5.1
       vite: ^2.5.3
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 1.0.0-next.16_svelte@3.42.4+vite@2.5.3
+      '@sveltejs/vite-plugin-svelte': 1.0.0-next.20_svelte@3.42.4+vite@2.5.3
       cheap-watch: 1.0.3
       sade: 1.7.4
       vite: 2.5.3
@@ -780,13 +780,13 @@ packages:
       picomatch: 2.2.3
     dev: false
 
-  /@sveltejs/vite-plugin-svelte/1.0.0-next.16_svelte@3.42.4+vite@2.5.3:
-    resolution: {integrity: sha512-Zzw5vWJ2PjeAFG04/HQrTHvTd4B+v/pz5hgod7fPMOMXu289ZuHs2DPj68xBmOGlmTq0JyrMfBl+NDGCgaSxzA==}
+  /@sveltejs/vite-plugin-svelte/1.0.0-next.20_svelte@3.42.4+vite@2.5.3:
+    resolution: {integrity: sha512-7IbHNr5okZqYVL7WGStNatL8IzpqMLbgKvLY9uobMBQrzVhlc/9qsQwvWn8uLBndZ9kB8Wr+m4/XEiUoeBLijg==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       diff-match-patch: ^1.0.5
       svelte: ^3.34.0
-      vite: ^2.3.7
+      vite: ^2.5.3
     peerDependenciesMeta:
       diff-match-patch:
         optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,7 +201,7 @@ importers:
   packages/kit:
     specifiers:
       '@rollup/plugin-replace': ^2.4.2
-      '@sveltejs/vite-plugin-svelte': ^1.0.0-next.20
+      '@sveltejs/vite-plugin-svelte': ^1.0.0-next.21
       '@types/amphtml-validator': ^1.0.1
       '@types/cookie': ^0.4.0
       '@types/marked': ^2.0.2
@@ -234,7 +234,7 @@ importers:
       uvu: ^0.5.1
       vite: ^2.5.3
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 1.0.0-next.20_svelte@3.42.4+vite@2.5.3
+      '@sveltejs/vite-plugin-svelte': 1.0.0-next.21_svelte@3.42.4+vite@2.5.3
       cheap-watch: 1.0.3
       sade: 1.7.4
       vite: 2.5.3
@@ -780,8 +780,8 @@ packages:
       picomatch: 2.2.3
     dev: false
 
-  /@sveltejs/vite-plugin-svelte/1.0.0-next.20_svelte@3.42.4+vite@2.5.3:
-    resolution: {integrity: sha512-7IbHNr5okZqYVL7WGStNatL8IzpqMLbgKvLY9uobMBQrzVhlc/9qsQwvWn8uLBndZ9kB8Wr+m4/XEiUoeBLijg==}
+  /@sveltejs/vite-plugin-svelte/1.0.0-next.21_svelte@3.42.4+vite@2.5.3:
+    resolution: {integrity: sha512-JjPnoQoI1+VXHjguE1bWyFYdZvPN6VTZ5RsFRpju45zICas1N5jAuOqKTbhQ1G+eEMCbhhB6zjZgQQRtaXPhNQ==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       diff-match-patch: ^1.0.5


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0


with kit already updated to vite-2.5.3 , users can update to vite-plugin-svelte@1.0.0-next.20 on their own but this should increase adoption-rate and visibility for a feature that should solve a lot of pain people were having with transitive cjs dependencies.

Not sure if patch or minor :man_shrugging: 
