### PR TITLE
[chore] export package.json from adapters

### DIFF
--- a/.changeset/swift-dingos-glow.md
+++ b/.changeset/swift-dingos-glow.md
@@ -1,0 +1,10 @@
+---
+'@sveltejs/adapter-begin': patch
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-static': patch
+'@sveltejs/adapter-vercel': patch
+---
+
+[chore] export package.json from adapters

--- a/packages/adapter-begin/package.json
+++ b/packages/adapter-begin/package.json
@@ -21,7 +21,10 @@
 		"sirv": "^1.0.12"
 	},
 	"exports": {
-		"import": "./index.js",
-		"require": "./index.cjs"
+		".": {
+			"import": "./index.js",
+			"require": "./index.cjs"
+		},
+		"./package.json": "./package.json"
 	}
 }

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -3,7 +3,10 @@
 	"version": "1.0.0-next.20",
 	"type": "module",
 	"exports": {
-		"import": "./index.js"
+		".": {
+			"import": "./index.js"
+		},
+		"./package.json": "./package.json"
 	},
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -3,7 +3,10 @@
 	"version": "1.0.0-next.29",
 	"type": "module",
 	"exports": {
-		"import": "./index.js"
+		".": {
+			"import": "./index.js"
+		},
+		"./package.json": "./package.json"
 	},
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -3,7 +3,10 @@
 	"version": "1.0.0-next.44",
 	"type": "module",
 	"exports": {
-		"import": "./index.js"
+		".": {
+			"import": "./index.js"
+		},
+		"./package.json": "./package.json"
 	},
 	"main": "index.js",
 	"types": "index.d.ts",

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -4,7 +4,10 @@
 	"type": "module",
 	"main": "index.js",
 	"exports": {
-		"import": "./index.js"
+		".": {
+			"import": "./index.js"
+		},
+		"./package.json": "./package.json"
 	},
 	"types": "index.d.ts",
 	"scripts": {

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -3,7 +3,10 @@
 	"version": "1.0.0-next.27",
 	"type": "module",
 	"exports": {
-		"import": "./index.js"
+		".": {
+			"import": "./index.js"
+		},
+		"./package.json": "./package.json"
 	},
 	"main": "index.js",
 	"types": "index.d.ts",


### PR DESCRIPTION
We always tell people they should export `package.json`, so we should probably follow our own advice :smile: 