### PR TITLE
[fix] refactor `import.meta.env` to be in one place for easier mocking

### DIFF
--- a/.changeset/cold-tables-shake.md
+++ b/.changeset/cold-tables-shake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+refactor `import.meta.env` usage in `$app/stores.js` to use `$app/env.js` to DRY code and make mocking easier

--- a/packages/kit/src/runtime/app/stores.js
+++ b/packages/kit/src/runtime/app/stores.js
@@ -1,6 +1,7 @@
 import { getContext } from 'svelte';
+import { browser } from './env.js';
 
-const ssr = import.meta.env.SSR;
+const ssr = !browser;
 
 // TODO remove this (for 1.0? after 1.0?)
 let warned = false;


### PR DESCRIPTION
This PR is a small refactor to ease mocking while testing Sveltekit apps, DRYing the code by only needing to deal with `import.meta.env` in the `env.js` file instead of multiple places, and to address a regression from a previous commit that broke some users unit tests.

This way you can just mock `$app/env.js` for SSR or client side testing by setting `browser` to `true` or `false`:

```js
jest.mock('$app/env.js', () => ({
  amp: false,
  browser: true,
  dev: true,
  mode: 'test'
}))
```

or 

```js
jest.mock('$app/env.js', () => ({
  amp: false,
  browser: false,
  dev: true,
  mode: 'test'
}))
```

More discussion here: https://github.com/sveltejs/kit/pull/2210/files#r691627049

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

> Ideally, include a test that fails without this PR but passes with it.

Just a small refactor - existing tests still passing is the goal.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0