### PR TITLE
[fix] load function should not leak props

### DIFF
--- a/.changeset/polite-elephants-care.md
+++ b/.changeset/polite-elephants-care.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] load function should not leak props to other components

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -404,7 +404,7 @@ export class Renderer {
 
 		for (let i = 0; i < filtered.length; i += 1) {
 			const loaded = filtered[i].loaded;
-			if (loaded) result.props[`props_${i}`] = await loaded.props;
+			result.props[`props_${i}`] = loaded ? await loaded.props : null;
 		}
 
 		if (

--- a/packages/kit/test/apps/basics/src/routes/load/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/load/_tests.js
@@ -231,4 +231,12 @@ export default function (test, is_dev) {
 		assert.equal(await page.innerHTML('.parsed'), '{"oddly":{"formatted":"json"}}');
 		assert.equal(await page.innerHTML('.raw'), '{ "oddly" : { "formatted" : "json" } }');
 	});
+
+	test('does not leak props to other pages', '/load/props/about', async ({ page, clicknav }) => {
+		assert.equal(await page.textContent('p'), 'Data: undefined');
+		await clicknav('[href="/load/props/"]');
+		assert.equal(await page.textContent('p'), 'Data: Hello from Index!');
+		await clicknav('[href="/load/props/about"]');
+		assert.equal(await page.textContent('p'), 'Data: undefined');
+	});
 }

--- a/packages/kit/test/apps/basics/src/routes/load/props/__layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/props/__layout.svelte
@@ -1,0 +1,10 @@
+<header>
+	<nav>
+		<a href="/load/props/">Index</a>
+		<a href="/load/props/about">About</a>
+	</nav>
+</header>
+
+<main>
+	<slot />
+</main>

--- a/packages/kit/test/apps/basics/src/routes/load/props/about.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/props/about.svelte
@@ -1,0 +1,7 @@
+<script>
+	export let data;
+</script>
+
+<h3>About</h3>
+
+<p>Data: {data}</p>

--- a/packages/kit/test/apps/basics/src/routes/load/props/about.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/props/about.svelte
@@ -1,5 +1,5 @@
 <script>
-	export let data;
+	export let data = 'undefined';
 </script>
 
 <h3>About</h3>

--- a/packages/kit/test/apps/basics/src/routes/load/props/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/props/index.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <script>
-	export let data;
+	export let data = 'undefined';
 </script>
 
 <h3>Index</h3>

--- a/packages/kit/test/apps/basics/src/routes/load/props/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/props/index.svelte
@@ -1,0 +1,14 @@
+<script context="module">
+	export async function load() {
+		const data = 'Hello from Index!';
+		return { props: { data } };
+	}
+</script>
+
+<script>
+	export let data;
+</script>
+
+<h3>Index</h3>
+
+<p>Data: {data}</p>


### PR DESCRIPTION
Fixes #2133.

When navigating from a page with a `load()` function to a page without a `load()` function, props were not being reset, so if the second page had a prop with the same name as the prop returned by the first page's `load()` function, the second page would receive the same prop that the first page did.

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
