### PR TITLE
[feat] provide the platform request object

### DIFF
--- a/.changeset/tricky-timers-boil.md
+++ b/.changeset/tricky-timers-boil.md
@@ -1,0 +1,8 @@
+---
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-vercel': patch
+'@sveltejs/kit': patch
+---
+
+[feat] provide the platform request object

--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -24,24 +24,25 @@ type ResponseHeaders = Record<string, string | string[]>;
 type RequestHeaders = Record<string, string>;
 
 export type RawBody = null | Uint8Array;
-export interface IncomingRequest {
+export interface IncomingRequest<PlatformRequest = any> {
 	method: string;
 	host: string;
 	path: string;
 	query: URLSearchParams;
 	headers: RequestHeaders;
 	rawBody: RawBody;
+	platformReq?: PlatformRequest;
 }
 
 type ParameterizedBody<Body = unknown> = Body extends FormData
 	? ReadOnlyFormData
 	: (string | RawBody | ReadOnlyFormData) & Body;
 // ServerRequest is exported as Request
-export interface ServerRequest<Locals = Record<string, any>, Body = unknown>
-	extends IncomingRequest {
+export interface ServerRequest<Locals = Record<string, any>, Body = unknown, PlatformRequest = any>
+	extends IncomingRequest<PlatformRequest> {
 	params: Record<string, string>;
 	body: ParameterizedBody<Body>;
-	locals: Locals; // populated by hooks handle
+	locals: Locals; // populated by the handle hook
 }
 
 type StrictBody = string | Uint8Array;

--- a/packages/adapter-netlify/files/entry.js
+++ b/packages/adapter-netlify/files/entry.js
@@ -16,7 +16,8 @@ export async function handler(event) {
 		headers,
 		path,
 		query,
-		rawBody
+		rawBody,
+		platformReq: event
 	});
 
 	if (rendered) {

--- a/packages/adapter-node/src/kit-middleware.js
+++ b/packages/adapter-node/src/kit-middleware.js
@@ -23,7 +23,8 @@ export function create_kit_middleware({ render }) {
 			headers: req.headers, // TODO: what about repeated headers, i.e. string[]
 			path: parsed.pathname,
 			query: parsed.searchParams,
-			rawBody: body
+			rawBody: body,
+			platformReq: req
 		});
 
 		if (rendered) {

--- a/packages/adapter-vercel/files/entry.js
+++ b/packages/adapter-vercel/files/entry.js
@@ -22,7 +22,8 @@ export default async (req, res) => {
 		headers: req.headers,
 		path: pathname,
 		query: searchParams,
-		rawBody: body
+		rawBody: body,
+		platformReq: req
 	});
 
 	if (rendered) {

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -345,7 +345,8 @@ async function create_handler(vite, config, dir, cwd, get_manifest) {
 						host,
 						path: parsed.pathname.replace(config.kit.paths.base, ''),
 						query: parsed.searchParams,
-						rawBody: body
+						rawBody: body,
+						platformReq: req
 					},
 					{
 						amp: config.kit.amp,

--- a/packages/kit/types/app.d.ts
+++ b/packages/kit/types/app.d.ts
@@ -27,11 +27,12 @@ export type ParameterizedBody<Body = unknown> = Body extends FormData
 	? ReadOnlyFormData
 	: (string | RawBody | ReadOnlyFormData) & Body;
 
-export interface IncomingRequest {
+export interface IncomingRequest<PlatformRequest = any> {
 	method: string;
 	host: string;
 	path: string;
 	query: URLSearchParams;
 	headers: RequestHeaders;
 	rawBody: RawBody;
+	platformReq?: PlatformRequest;
 }

--- a/packages/kit/types/hooks.d.ts
+++ b/packages/kit/types/hooks.d.ts
@@ -3,8 +3,8 @@ import { MaybePromise, ResponseHeaders } from './helper';
 
 export type StrictBody = string | Uint8Array;
 
-export interface ServerRequest<Locals = Record<string, any>, Body = unknown>
-	extends IncomingRequest {
+export interface ServerRequest<Locals = Record<string, any>, Body = unknown, PlatformRequest = any>
+	extends IncomingRequest<PlatformRequest> {
 	params: Record<string, string>;
 	body: ParameterizedBody<Body>;
 	locals: Locals;


### PR DESCRIPTION
There are some things that are not possible to do today that this will enable. E.g. if you [use `adapter-node`'s Kit middleware with a custom server](https://github.com/sveltejs/kit/tree/master/packages/adapter-node#middleware) and add some other middleware that populates a custom property onto the request then you have no way to access that today.