### PR TITLE
[fix] error components render with correct layout client-side as well as server-side

### DIFF
--- a/.changeset/blue-teachers-allow.md
+++ b/.changeset/blue-teachers-allow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] error components render with correct layout client-side as well as server-side

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -566,7 +566,7 @@ export class Renderer {
 		const page = { host: this.host, path, query, params };
 
 		/** @type {Array<import('./types').BranchNode | undefined>} */
-		const branch = [];
+		let branch = [];
 
 		/** @type {Record<string, any>} */
 		let context = {};
@@ -665,7 +665,7 @@ export class Renderer {
 								continue;
 							}
 
-							branch.push(error_loaded);
+							branch = branch.slice(0, j + 1).concat(error_loaded);
 							break load;
 						} catch (e) {
 							continue;

--- a/packages/kit/test/apps/basics/src/routes/nested-layout/__layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/nested-layout/__layout.svelte
@@ -1,2 +1,2 @@
 <slot></slot>
-<p>This is a nested layout component</p>
+<p id="nested">This is a nested layout component</p>

--- a/packages/kit/test/apps/basics/src/routes/nested-layout/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/nested-layout/_tests.js
@@ -7,4 +7,29 @@ export default function (test) {
 		assert.equal(await page.textContent('p'), 'This is a nested layout component');
 		assert.equal(await page.textContent('h1'), 'Hello from inside the nested layout component');
 	});
+
+	test('renders errors in the right layout', '/nested-layout/error', async ({ page }) => {
+		assert.equal(await page.textContent('footer'), 'Custom layout');
+		assert.ok(await page.evaluate(() => !document.querySelector('p#nested')));
+		assert.equal(
+			await page.textContent('#message'),
+			'This is your custom error page saying: "Error"'
+		);
+		assert.equal(await page.textContent('h1'), '500');
+	});
+
+	test(
+		'renders errors in the right layout after client navigation',
+		'/nested-layout/',
+		async ({ page, clicknav }) => {
+			await clicknav('[href="/nested-layout/error"]');
+			assert.equal(await page.textContent('footer'), 'Custom layout');
+			assert.ok(await page.evaluate(() => !document.querySelector('p#nested')));
+			assert.equal(
+				await page.textContent('#message'),
+				'This is your custom error page saying: "Error"'
+			);
+			assert.equal(await page.textContent('h1'), '500');
+		}
+	);
 }

--- a/packages/kit/test/apps/basics/src/routes/nested-layout/error.svelte
+++ b/packages/kit/test/apps/basics/src/routes/nested-layout/error.svelte
@@ -1,0 +1,7 @@
+<script context="module">
+	export function load() {
+		return { status: 500, error: 'Error' };
+	}
+</script>
+
+<h1>Not shown</h1>

--- a/packages/kit/test/apps/basics/src/routes/nested-layout/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/nested-layout/index.svelte
@@ -1,1 +1,5 @@
 <h1>Hello from inside the nested layout component</h1>
+
+<div>
+	<a href="/nested-layout/error">error</a>
+</div>


### PR DESCRIPTION
Fixes #2372.

If a deeply-nested page produced an error in its `load()` function, and that page had multiple layout components but only a top-level error component, the error component rendered differently in server-side and client-side rendering. Server-side rendering correctly chose the top-level layout component to render a top-level error component, but client-side rendering was incorrectly choosing the layout of the deeply-nested page that caused the error, instead of the layout of the folder the error component belonged to.

With this PR, client-side rendering now uses the same approach as server-side rendering to choose layouts for error components.

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
