### PR TITLE
[fix] clear node output before adapting

### DIFF
--- a/.changeset/shiny-books-try.md
+++ b/.changeset/shiny-books-try.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Clear output directory before adapting

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -31,6 +31,8 @@ export default function ({
 		name: '@sveltejs/adapter-node',
 
 		async adapt({ utils, config }) {
+			utils.rimraf(out);
+
 			utils.log.minor('Copying assets');
 			const static_directory = join(out, 'assets');
 			utils.copy_client_files(static_directory);

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -25,7 +25,7 @@ export default function ({
 	out = 'build',
 	precompress,
 	env: { path: path_env = 'SOCKET_PATH', host: host_env = 'HOST', port: port_env = 'PORT' } = {},
-	esbuild: esbuildConfig
+	esbuild: esbuild_config
 } = {}) {
 	return {
 		name: '@sveltejs/adapter-node',
@@ -71,12 +71,12 @@ export default function ({
 					APP_DIR: `"/${config.kit.appDir}/"`
 				}
 			};
-			const buildOptions = esbuildConfig ? await esbuildConfig(defaultOptions) : defaultOptions;
-			await esbuild.build(buildOptions);
+			const build_options = esbuild_config ? await esbuild_config(defaultOptions) : defaultOptions;
+			await esbuild.build(build_options);
 
 			utils.log.minor('Building SvelteKit reference server');
 			/** @type {BuildOptions} */
-			const defaultOptionsRefServer = {
+			const default_options_ref_server = {
 				entryPoints: ['.svelte-kit/node/index.js'],
 				outfile: join(out, 'index.js'),
 				bundle: true,
@@ -95,10 +95,10 @@ export default function ({
 					}
 				]
 			};
-			const buildOptionsRefServer = esbuildConfig
-				? await esbuildConfig(defaultOptionsRefServer)
-				: defaultOptionsRefServer;
-			await esbuild.build(buildOptionsRefServer);
+			const build_options_ref_server = esbuild_config
+				? await esbuild_config(default_options_ref_server)
+				: default_options_ref_server;
+			await esbuild.build(build_options_ref_server);
 
 			utils.log.minor('Prerendering static pages');
 			await utils.prerender({


### PR DESCRIPTION
Closes #2386 

Node adapter should be the last one that doesn't clear the output directory prior to building