### PR TITLE
[fix] deeply-nested error components render with correct layout

### DIFF
--- a/.changeset/empty-poets-check.md
+++ b/.changeset/empty-poets-check.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] deeply-nested error components render with correct layout

--- a/packages/kit/src/core/create_manifest_data/index.js
+++ b/packages/kit/src/core/create_manifest_data/index.js
@@ -220,23 +220,24 @@ export default function create_manifest_data({ config, output, cwd = process.cwd
 				components.push(item.file);
 
 				const concatenated = layout_stack.concat(item.file);
+				const errors = error_stack.slice();
 
 				const pattern = get_pattern(segments, true);
 
 				let i = concatenated.length;
 				while (i--) {
-					if (!error_stack[i] && !concatenated[i]) {
-						error_stack.splice(i, 1);
+					if (!errors[i] && !concatenated[i]) {
+						errors.splice(i, 1);
 						concatenated.splice(i, 1);
 					}
 				}
 
-				i = error_stack.length;
+				i = errors.length;
 				while (i--) {
-					if (error_stack[i]) break;
+					if (errors[i]) break;
 				}
 
-				error_stack.splice(i + 1);
+				errors.splice(i + 1);
 
 				const path = segments.every((segment) => segment.length === 1 && !segment[0].dynamic)
 					? `/${segments.map((segment) => segment[0].content).join('/')}`
@@ -248,7 +249,7 @@ export default function create_manifest_data({ config, output, cwd = process.cwd
 					params,
 					path,
 					a: /** @type {string[]} */ (concatenated),
-					b: /** @type {string[]} */ (error_stack)
+					b: /** @type {string[]} */ (errors)
 				});
 			} else {
 				const pattern = get_pattern(segments, !item.route_suffix);

--- a/packages/kit/test/apps/basics/src/routes/nested-layout/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/nested-layout/_tests.js
@@ -32,4 +32,16 @@ export default function (test) {
 			assert.equal(await page.textContent('h1'), '500');
 		}
 	);
+
+	test(
+		'renders deeply-nested errors in the right layout',
+		'/nested-layout/foo/bar/nope',
+		async ({ page }) => {
+			assert.equal(await page.textContent('footer'), 'Custom layout');
+			assert.ok(await page.evaluate(() => document.querySelector('p#nested')));
+			assert.ok(await page.evaluate(() => document.querySelector('p#nested-foo')));
+			assert.ok(await page.evaluate(() => document.querySelector('p#nested-bar')));
+			assert.equal(await page.textContent('#nested-error-message'), 'error.message: nope');
+		}
+	);
 }

--- a/packages/kit/test/apps/basics/src/routes/nested-layout/foo/__layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/nested-layout/foo/__layout.svelte
@@ -1,0 +1,2 @@
+<slot></slot>
+<p id="nested-foo">Nested layout foo</p>

--- a/packages/kit/test/apps/basics/src/routes/nested-layout/foo/bar/__error.svelte
+++ b/packages/kit/test/apps/basics/src/routes/nested-layout/foo/bar/__error.svelte
@@ -1,0 +1,34 @@
+<script context="module">
+	/** @type {import('@sveltejs/kit').ErrorLoad} */
+	export async function load({ status, error }) {
+		return {
+			props: {
+				answer: 42,
+				status,
+				error
+			}
+		};
+	}
+</script>
+
+<script>
+	/** @type {number} */
+	export let status;
+
+	/** @type {Error} */
+	export let error;
+
+	/** @type {number} */
+	export let answer;
+</script>
+
+<h1>Nested error page</h1>
+<p id="nested-error-status">status: {status}</p>
+<p id="nested-error-message">error.message: {error && error.message}</p>
+<p id="nested-error-loaded">answer: {answer}</p>
+
+<style>
+	h1 {
+		color: blue;
+	}
+</style>

--- a/packages/kit/test/apps/basics/src/routes/nested-layout/foo/bar/__layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/nested-layout/foo/bar/__layout.svelte
@@ -1,0 +1,2 @@
+<slot></slot>
+<p id="nested-bar">Nested layout bar</p>

--- a/packages/kit/test/apps/basics/src/routes/nested-layout/foo/bar/nope.svelte
+++ b/packages/kit/test/apps/basics/src/routes/nested-layout/foo/bar/nope.svelte
@@ -1,0 +1,7 @@
+<script context="module">
+	export async function load() {
+		throw new Error('nope');
+	}
+</script>
+
+<h1>should not see this</h1>

--- a/packages/kit/test/apps/basics/src/routes/nested-layout/foo/baz.svelte
+++ b/packages/kit/test/apps/basics/src/routes/nested-layout/foo/baz.svelte
@@ -1,0 +1,1 @@
+<p id="baz">baz</p>


### PR DESCRIPTION
Under some circumstances, a deeply-nested error component could render with a layout from a parent folder instead of the layout from the error component's own folder. This commit fixes that bug, so that error components are correctly matched up with layout components in the same folder even when deeply nested.

Fixes #2383.

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
