### PR TITLE
[feat] Add nonce placeholders in rendered pages.

### DIFF
--- a/.changeset/lovely-rats-cheer.md
+++ b/.changeset/lovely-rats-cheer.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add option to place CSP nonce placeholders in rendered pages.

--- a/documentation/docs/15-content-security-policy.md
+++ b/documentation/docs/15-content-security-policy.md
@@ -1,0 +1,49 @@
+---
+title: Content Security Policy
+---
+
+At the moment, SvelteKit supports adding Content Security Policy via hooks. In environments with a runtime, HTTP headers can be added to the response object.
+
+However, SvelteKit also requires some small pieces of inline JavaScript in order for hydration to work. To avoid using `'unsafe-inline'` (which, as the name suggests, should be avoided), SvelteKit can be configured to inject place-holders for CSP Nonces into the html it generates.
+
+These placeholders take the form `%svelte.CSPNonce%`, and can be replaced with a nonce inside the hook. A basic CSP handler hook might then look like this:
+```javascript
+export async function handle ({ request, resolve }) => {
+  const directives = {
+    'default-src': ["'self'", rootDomain, `ws://${rootDomain}`],
+    'script-src': ["'strict-dynamic'"],
+    'style-src': ["'self'"]
+  };
+
+  const response = await resolve(request);
+
+  const nonce = randomBytes(32).toString('base64');
+
+  if (response.headers['content-type'] === 'text/html') {
+    response.body = (response.body as string).replace(/%svelte.CSPNonce%/g, `nonce="${nonce}"`);
+  }
+  directives['script-src'].push(`'nonce-${nonce}'`);
+  directives['style-src'].push(`'nonce-${nonce}'`);
+  
+  if (process.env.NODE_ENV === 'development') {
+    directives['style-src'].push('unsafe-inline')
+  }
+  
+  const csp = Object.entries(directives)
+    .map(([key, arr]) => key + ' ' + arr.join(' '))
+    .join('; ');
+    
+  return {
+    ...response,
+    headers: {
+      ...response.headers,
+      'Content-Security-Policy': csp
+    }
+  };
+};
+```
+Because of the way Vite performs hot reloads of stylesheets, `'unsafe-inline'` is required in dev mode.
+
+Be warned: some other features of Svelte (in particular CSS transitions and animations) might run afoul of this Content Security Policy and require either rewriting to JS-based transitions or enabling `style-src: 'unsafe-inline'`.
+
+The nonce placeholders can be toggled with the `kit.noncePlaceholders` configuration option.

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -349,7 +349,8 @@ async function build_server(
 					ssr: ${s(config.kit.ssr)},
 					target: ${s(config.kit.target)},
 					template,
-					trailing_slash: ${s(config.kit.trailingSlash)}
+					trailing_slash: ${s(config.kit.trailingSlash)},
+					noncePlaceholders: ${s(config.kit.noncePlaceholders)}
 				};
 			}
 

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -56,7 +56,8 @@ test('fills in defaults', () => {
 			router: true,
 			ssr: true,
 			target: null,
-			trailingSlash: 'never'
+			trailingSlash: 'never',
+			noncePlaceholders: false
 		}
 	});
 });
@@ -164,7 +165,8 @@ test('fills in partial blanks', () => {
 			router: true,
 			ssr: true,
 			target: null,
-			trailingSlash: 'never'
+			trailingSlash: 'never',
+			noncePlaceholders: false
 		}
 	});
 });

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -192,7 +192,9 @@ const options = object(
 
 					return input;
 				}
-			)
+			),
+
+			noncePlaceholders: boolean(false)
 		})
 	},
 	true

--- a/packages/kit/src/core/config/test/index.js
+++ b/packages/kit/src/core/config/test/index.js
@@ -63,7 +63,8 @@ async function testLoadDefaultConfig(path) {
 			router: true,
 			ssr: true,
 			target: null,
-			trailingSlash: 'never'
+			trailingSlash: 'never',
+			noncePlaceholders: false
 		}
 	});
 }

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -474,7 +474,8 @@ async function create_handler(vite, config, dir, cwd, get_manifest) {
 
 							return rendered;
 						},
-						trailing_slash: config.kit.trailingSlash
+						trailing_slash: config.kit.trailingSlash,
+						noncePlaceholders: config.kit.noncePlaceholders
 					}
 				);
 

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -78,6 +78,7 @@ export interface Config {
 		target?: string;
 		trailingSlash?: TrailingSlash;
 		vite?: ViteConfig | (() => ViteConfig);
+		noncePlaceholders?: boolean;
 	};
 	preprocess?: any;
 }

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -136,6 +136,7 @@ export interface SSRRenderOptions {
 	target: string;
 	template({ head, body }: { head: string; body: string }): string;
 	trailing_slash: TrailingSlash;
+	noncePlaceholders: boolean;
 }
 
 export interface SSRRenderState {


### PR DESCRIPTION
Related to #93 

Adds a CSP nonce placeholder to all script and style tags if `config.kit.noncePlaceholders` is true. This allows a hook to easily replace them with a nonce alongside where they are likely already inserting the CSP headers themselves.

As currently configured this supports `'strict-dynamic'` (that's why the nonce is added to all scripts, not just the inline init script).

Note that this only works on dynamic hosts. Nonces can't be used in a static environment.

This will need documentation somewhere; I'm open to doing that if someone points me to where to place it :) Particularly an example of a CSP hook would be good.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
