### PR TITLE
[chore] remove overriden CSS property

### DIFF
--- a/packages/create-svelte/templates/default/src/lib/Counter.svelte
+++ b/packages/create-svelte/templates/default/src/lib/Counter.svelte
@@ -79,13 +79,12 @@
 
 	.counter-viewport strong {
 		position: absolute;
-		display: block;
+		display: flex;
 		width: 100%;
 		height: 100%;
 		font-weight: 400;
 		color: var(--accent-color);
 		font-size: 4rem;
-		display: flex;
 		align-items: center;
 		justify-content: center;
 	}


### PR DESCRIPTION
display is defined 2 times in the ".counter-viewport strong" class
The "display: block" is extra and must be removed.