### PR TITLE
[chore] update vite-plugin-svelte

### DIFF
--- a/.changeset/hip-nails-burn.md
+++ b/.changeset/hip-nails-burn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Update vite-plugin-svelte to 1.0.0-next.23

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -1,9 +1,9 @@
 {
 	"name": "@sveltejs/kit",
-	"version": "1.0.0-next.166",
+	"version": "1.0.0-next.165",
 	"type": "module",
 	"dependencies": {
-		"@sveltejs/vite-plugin-svelte": "^1.0.0-next.22",
+		"@sveltejs/vite-plugin-svelte": "^1.0.0-next.23",
 		"cheap-watch": "^1.0.3",
 		"sade": "^1.7.4",
 		"vite": "^2.5.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,7 +201,7 @@ importers:
   packages/kit:
     specifiers:
       '@rollup/plugin-replace': ^2.4.2
-      '@sveltejs/vite-plugin-svelte': ^1.0.0-next.22
+      '@sveltejs/vite-plugin-svelte': ^1.0.0-next.23
       '@types/amphtml-validator': ^1.0.1
       '@types/cookie': ^0.4.0
       '@types/marked': ^2.0.2
@@ -234,7 +234,7 @@ importers:
       uvu: ^0.5.1
       vite: ^2.5.6
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 1.0.0-next.22_svelte@3.42.4+vite@2.5.6
+      '@sveltejs/vite-plugin-svelte': 1.0.0-next.23_svelte@3.42.4+vite@2.5.6
       cheap-watch: 1.0.3
       sade: 1.7.4
       vite: 2.5.6
@@ -780,8 +780,8 @@ packages:
       picomatch: 2.2.3
     dev: false
 
-  /@sveltejs/vite-plugin-svelte/1.0.0-next.22_svelte@3.42.4+vite@2.5.6:
-    resolution: {integrity: sha512-B1O/GMIxpE4iJ3/FBUJ3oYGKHhJ99G9uFARsb8kVeReLDPhtZGXTM+7brLDefJuedbKkRkGEEkbGOVuEuEBo3g==}
+  /@sveltejs/vite-plugin-svelte/1.0.0-next.23_svelte@3.42.4+vite@2.5.6:
+    resolution: {integrity: sha512-zmguJ9OYYsvZUhzPA3ZeYana2qx/ORadI0LVjzDIuXEXcR7AKj9qJgGCWe5Wi2Z/xg9PsKMHTTCHgiiplphIYg==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       diff-match-patch: ^1.0.5


### PR DESCRIPTION
Fixes #2397

Had to set kit version to 165 for the lock file to generate correctly. Last release (166) failed.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
