### PR TITLE
[fix] prerendering not working with `kit.paths.base` set.

### DIFF
--- a/.changeset/unlucky-dodos-greet.md
+++ b/.changeset/unlucky-dodos-greet.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix prerendering/adapter-static failing when `kit.paths.base` was set.

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -262,7 +262,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 					const parsed = new URL(resolved, 'http://localhost');
 					const pathname = decodeURI(parsed.pathname);
 
-					const file = pathname.replace(config.kit.paths.assets, '').slice(1);
+					const file = pathname.replace(config.kit.paths.base, '').slice(1);
 					if (files.has(file)) continue;
 
 					if (parsed.search) {

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -260,16 +260,16 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 					if (!resolved.startsWith('/') || resolved.startsWith('//')) continue;
 
 					const parsed = new URL(resolved, 'http://localhost');
-					const pathname = decodeURI(parsed.pathname);
+					const pathname = decodeURI(parsed.pathname).replace(config.kit.paths.base, '');
 
-					const file = pathname.replace(config.kit.paths.base, '').slice(1);
+					const file = pathname.slice(1);
 					if (files.has(file)) continue;
 
 					if (parsed.search) {
 						// TODO warn that query strings have no effect on statically-exported pages
 					}
 
-					await visit(pathname.replace(config.kit.paths.base, ''), path);
+					await visit(pathname, path);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #2230 

Local assets were not being excluded from being `visit`ed during prerendering because they were not being detected as being one of the local files.

Specifically, this used to work until the semantics of `kit.paths.assets` was changed in #2189 to only be either empty or an absolute (external) path, and assets were instead prefixed with `paths.base` if `paths.assets` was not an absolute path. This line should have been updated then.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
