### PR TITLE
[fix] don't format when building

### DIFF
--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -20,7 +20,7 @@
 		"tiny-glob": "^0.2.8"
 	},
 	"scripts": {
-		"build": "npm run format && node scripts/build-templates",
+		"build": "node scripts/build-templates",
 		"check": "tsc",
 		"lint": "eslint --ignore-path .gitignore --ignore-path ../../.gitignore \"./*.js\" && npm run check-format",
 		"format": "npm run check-format -- --write",


### PR DESCRIPTION
We just had a release fail because building formatted the code and releasing can't happen with an unclean repo. It also caused lint to succeed eventhough the code wasn't properly formatted