### PR TITLE
[fix] strip `paths.base` before resolving assets in preview server.

### DIFF
--- a/.changeset/good-monkeys-reflect.md
+++ b/.changeset/good-monkeys-reflect.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix preview when `kit.paths.base` is set.

--- a/packages/kit/src/core/preview/index.js
+++ b/packages/kit/src/core/preview/index.js
@@ -86,18 +86,16 @@ export async function preview({
 
 			const parsed = new URL(initial_url, 'http://localhost/');
 
-			const rendered =
-				parsed.pathname.startsWith(config.kit.paths.base) &&
-				(await app.render({
-					host: /** @type {string} */ (
-						config.kit.host || req.headers[config.kit.hostHeader || 'host']
-					),
-					method: req.method,
-					headers: /** @type {import('types/helper').RequestHeaders} */ (req.headers),
-					path: parsed.pathname.replace(config.kit.paths.base, ''),
-					query: parsed.searchParams,
-					rawBody: body
-				}));
+			const rendered = await app.render({
+				host: /** @type {string} */ (
+					config.kit.host || req.headers[config.kit.hostHeader || 'host']
+				),
+				method: req.method,
+				headers: /** @type {import('types/helper').RequestHeaders} */ (req.headers),
+				path: parsed.pathname.replace(config.kit.paths.base, ''),
+				query: parsed.searchParams,
+				rawBody: body
+			});
 
 			if (rendered) {
 				res.writeHead(rendered.status, rendered.headers);
@@ -120,6 +118,9 @@ export async function preview({
 				render_handler();
 			}
 		} else {
+			if (initial_url.startsWith(config.kit.paths.base)) {
+				req.url = initial_url.slice(config.kit.paths.base.length);
+			}
 			assets_handler(req, res, () => {
 				static_handler(req, res, render_handler);
 			});

--- a/packages/kit/src/core/preview/index.js
+++ b/packages/kit/src/core/preview/index.js
@@ -86,16 +86,18 @@ export async function preview({
 
 			const parsed = new URL(initial_url, 'http://localhost/');
 
-			const rendered = await app.render({
-				host: /** @type {string} */ (
-					config.kit.host || req.headers[config.kit.hostHeader || 'host']
-				),
-				method: req.method,
-				headers: /** @type {import('types/helper').RequestHeaders} */ (req.headers),
-				path: parsed.pathname.replace(config.kit.paths.base, ''),
-				query: parsed.searchParams,
-				rawBody: body
-			});
+			const rendered =
+				parsed.pathname.startsWith(config.kit.paths.base) &&
+				(await app.render({
+					host: /** @type {string} */ (
+						config.kit.host || req.headers[config.kit.hostHeader || 'host']
+					),
+					method: req.method,
+					headers: /** @type {import('types/helper').RequestHeaders} */ (req.headers),
+					path: parsed.pathname.replace(config.kit.paths.base, ''),
+					query: parsed.searchParams,
+					rawBody: body
+				}));
 
 			if (rendered) {
 				res.writeHead(rendered.status, rendered.headers);


### PR DESCRIPTION
The preview server was implicitly assuming that asset URLs would never start with the base path. In fact, they _always_ do.

Vaguely related to #2230 (but this was a new issue I discovered and diagnosed while working on #2407).

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
