### PR TITLE
[chore] expose Body generic to hook functions

### DIFF
--- a/.changeset/two-buttons-eat.md
+++ b/.changeset/two-buttons-eat.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add Body generic to hooks

--- a/.changeset/two-buttons-eat.md
+++ b/.changeset/two-buttons-eat.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Add Body generic to hooks
+Add a generic argument to allow typing Body from hooks

--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -55,8 +55,8 @@ export interface ServerResponse {
 export interface Handle<Locals = Record<string, any>, Body = unknown> {
 	(input: {
 		request: ServerRequest<Locals, Body>;
-		resolve(request: ServerRequest<Locals, Body>): MaybePromise<ServerResponse>;
-	}): MaybePromise<ServerResponse>;
+		resolve(request: ServerRequest<Locals, Body>): ServerResponse | Promise<ServerResponse>;
+	}): ServerResponse | Promise<ServerResponse>;
 }
 ```
 
@@ -117,7 +117,7 @@ If unimplemented, session is `{}`.
 // Declaration types for getSession hook
 
 export interface GetSession<Locals = Record<string, any>, Body = unknown, Session = any> {
-	(request: ServerRequest<Locals, Body>): MaybePromise<Session>;
+	(request: ServerRequest<Locals, Body>): Session | Promise<Session>;
 }
 ```
 

--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -52,11 +52,11 @@ export interface ServerResponse {
 	body?: StrictBody;
 }
 
-export interface Handle<Locals = Record<string, any>> {
+export interface Handle<Locals = Record<string, any>, Body = unknown> {
 	(input: {
-		request: ServerRequest<Locals>;
-		resolve(request: ServerRequest<Locals>): ServerResponse | Promise<ServerResponse>;
-	}): ServerResponse | Promise<ServerResponse>;
+		request: ServerRequest<Locals, Body>;
+		resolve(request: ServerRequest<Locals, Body>): MaybePromise<ServerResponse>;
+	}): MaybePromise<ServerResponse>;
 }
 ```
 
@@ -92,8 +92,8 @@ If unimplemented, SvelteKit will log the error with default formatting.
 ```ts
 // Declaration types for handleError hook
 
-export interface HandleError<Locals = Record<string, any>> {
-	(input: { error: Error & { frame?: string }; request: ServerRequest<Locals> }): void;
+export interface HandleError<Locals = Record<string, any>, Body = unknown> {
+	(input: { error: Error & { frame?: string }; request: ServerRequest<Locals, Body> }): void;
 }
 ```
 
@@ -116,8 +116,8 @@ If unimplemented, session is `{}`.
 ```ts
 // Declaration types for getSession hook
 
-export interface GetSession<Locals = Record<string, any>, Session = any> {
-	(request: ServerRequest<Locals>): Session | Promise<Session>;
+export interface GetSession<Locals = Record<string, any>, Body = unknown, Session = any> {
+	(request: ServerRequest<Locals, Body>): MaybePromise<Session>;
 }
 ```
 

--- a/packages/kit/types/hooks.d.ts
+++ b/packages/kit/types/hooks.d.ts
@@ -16,19 +16,19 @@ export interface ServerResponse {
 	body?: StrictBody;
 }
 
-export interface GetSession<Locals = Record<string, any>, Session = any> {
-	(request: ServerRequest<Locals>): MaybePromise<Session>;
+export interface GetSession<Locals = Record<string, any>, Body = unknown, Session = any> {
+	(request: ServerRequest<Locals, Body>): MaybePromise<Session>;
 }
 
-export interface Handle<Locals = Record<string, any>> {
+export interface Handle<Locals = Record<string, any>, Body = unknown> {
 	(input: {
-		request: ServerRequest<Locals>;
-		resolve(request: ServerRequest<Locals>): MaybePromise<ServerResponse>;
+		request: ServerRequest<Locals, Body>;
+		resolve(request: ServerRequest<Locals, Body>): MaybePromise<ServerResponse>;
 	}): MaybePromise<ServerResponse>;
 }
 
-export interface HandleError<Locals = Record<string, any>> {
-	(input: { error: Error & { frame?: string }; request: ServerRequest<Locals> }): void;
+export interface HandleError<Locals = Record<string, any>, Body = unknown> {
+	(input: { error: Error & { frame?: string }; request: ServerRequest<Locals, Body> }): void;
 }
 
 export interface ExternalFetch {


### PR DESCRIPTION
Closes #1215

[PR #1256](https://github.com/sveltejs/kit/pull/1256) allows us to avoid importing internal type `ReadOnlyFormData` for RequestHandler, since it has the `Body` generic. However, the hook functions don't expose the `Body` generic so we currently still need to import `ReadOnlyFormData` type if we want to process form data for post requests in our handle hooks.

This will enable users to pass in `FormData` for `Body` generic in GetSession, Handle, and HandleError.

<img width="1319" alt="image" src="https://user-images.githubusercontent.com/21700768/133001077-34d705dd-bcb2-47d2-8c51-35f5595f310d.png">