### PR TITLE
create-svelte: set folder name as pkg.name

### DIFF
--- a/.changeset/cyan-ads-pump.md
+++ b/.changeset/cyan-ads-pump.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Use the name of folder as name in package.json

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -84,7 +84,7 @@ async function main() {
 	const name = path.basename(path.resolve(cwd));
 
 	write_template_files(options.template, options.typescript, name, cwd);
-	write_common_files(cwd, options);
+	write_common_files(cwd, options, name);
 
 	console.log(bold(green('✔ Copied project files')));
 
@@ -173,8 +173,9 @@ function write_template_files(template, typescript, name, cwd) {
  *
  * @param {string} cwd
  * @param {import('./types/internal').Options} options
+ * @param {string} name
  */
-function write_common_files(cwd, options) {
+function write_common_files(cwd, options, name) {
 	const shared = dist('shared.json');
 	const { files } = /** @type {import('./types/internal').Common} */ (JSON.parse(
 		fs.readFileSync(shared, 'utf-8')
@@ -201,6 +202,7 @@ function write_common_files(cwd, options) {
 
 	pkg.dependencies = sort_keys(pkg.dependencies);
 	pkg.devDependencies = sort_keys(pkg.devDependencies);
+	pkg.name = toValidPackageName(name);
 
 	fs.writeFileSync(pkg_file, JSON.stringify(pkg, null, '  '));
 }
@@ -258,6 +260,16 @@ function sort_keys(obj) {
 /** @param {string} path */
 function dist(path) {
 	return fileURLToPath(new URL(`./dist/${path}`, import.meta.url).href);
+}
+
+/** @param {string} name */
+function toValidPackageName(name) {
+	return name
+		.trim()
+		.toLowerCase()
+		.replace(/\s+/g, '-')
+		.replace(/^[._]/, '')
+		.replace(/[^a-z0-9~.-]+/g, '-');
 }
 
 main();


### PR DESCRIPTION
Fixes #2050 

Use name of folder as name in `package.json`. If folder name is not a valid package name, it is converted to a valid name by removing and replacing invalid characters.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
