### PR TITLE
[fix] add svelte field when packaging

### DIFF
--- a/.changeset/friendly-chefs-draw.md
+++ b/.changeset/friendly-chefs-draw.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add "svelte" field to package.json when running package command

--- a/packages/kit/src/packaging/index.js
+++ b/packages/kit/src/packaging/index.js
@@ -112,19 +112,24 @@ export async function make_package(config, cwd = process.cwd()) {
 		// rely on the "svelte" property. Vite/Rollup/Webpack plugin can all deal with it.
 		// See https://github.com/sveltejs/kit/issues/1959 for more info and related threads.
 		if (pkg.exports['.']) {
-			const svelte_export = typeof pkg.exports['.'] === 'string' ? pkg.exports['.'] : undefined;
+			const svelte_export =
+				typeof pkg.exports['.'] === 'string'
+					? pkg.exports['.']
+					: pkg.exports['.'].import || pkg.exports['.'].default;
 			if (svelte_export) {
 				pkg.svelte = svelte_export;
 			} else {
 				console.warn(
-					'The "." entry in "exports" is not a string. ' +
+					'Cannot generate a "svelte" entry point because ' +
+						'the "." entry in "exports" is not a string. ' +
 						'If you set it by hand, please also set one of the options as a "svelte" entry point'
 				);
 			}
 		} else {
 			console.warn(
-				'The "." entry in "exports" is not a string. ' +
-					'If you set it by hand, please also set one of the options as a "svelte" entry point'
+				'Cannot generate a "svelte" entry point because ' +
+					'the "." entry in "exports" is missing. ' +
+					'Please specify one or set a "svelte" entry point yourself'
 			);
 		}
 	}

--- a/packages/kit/src/packaging/index.js
+++ b/packages/kit/src/packaging/index.js
@@ -104,6 +104,27 @@ export async function make_package(config, cwd = process.cwd()) {
 	}
 
 	pkg.exports = { ...generated, ...pkg.exports };
+
+	// Several heuristics in Kit/vite-plugin-svelte to tell Vite to mark Svelte packages
+	// rely on the "svelte" property. Vite/Rollup/Webpack plugin can all deal with it.
+	// See https://github.com/sveltejs/kit/issues/1959 for more info and related threads.
+	if (pkg.exports['.']) {
+		const svelte_export = typeof pkg.exports['.'] === 'string' ? pkg.exports['.'] : undefined;
+		if (svelte_export) {
+			pkg.svelte = svelte_export;
+		} else {
+			console.warn(
+				'The "." entry in "exports" is not a string. ' +
+					'If you set it by hand, please also set one of the options as a "svelte" entry point'
+			);
+		}
+	} else {
+		console.warn(
+			'The "." entry in "exports" is not a string. ' +
+				'If you set it by hand, please also set one of the options as a "svelte" entry point'
+		);
+	}
+
 	write(path.join(cwd, config.kit.package.dir, 'package.json'), JSON.stringify(pkg, null, '  '));
 
 	const whitelist = fs.readdirSync(cwd).filter((file) => {

--- a/packages/kit/src/packaging/index.js
+++ b/packages/kit/src/packaging/index.js
@@ -107,7 +107,7 @@ export async function make_package(config, cwd = process.cwd()) {
 
 	pkg.exports = { ...generated, ...pkg.exports };
 
-	if (contains_svelte_files) {
+	if (!pkg.svelte && contains_svelte_files) {
 		// Several heuristics in Kit/vite-plugin-svelte to tell Vite to mark Svelte packages
 		// rely on the "svelte" property. Vite/Rollup/Webpack plugin can all deal with it.
 		// See https://github.com/sveltejs/kit/issues/1959 for more info and related threads.

--- a/packages/kit/src/packaging/index.js
+++ b/packages/kit/src/packaging/index.js
@@ -39,6 +39,7 @@ export async function make_package(config, cwd = process.cwd()) {
 
 	/** @type {Record<string, string>} */
 	const clashes = {};
+	let contains_svelte_files = false;
 
 	for (const file of files) {
 		const ext = path.extname(file);
@@ -66,6 +67,7 @@ export async function make_package(config, cwd = process.cwd()) {
 			out_contents = config.preprocess
 				? (await preprocess(source, config.preprocess, { filename })).code
 				: source;
+			contains_svelte_files = true;
 		} else if (ext === '.ts' && file.endsWith('.d.ts')) {
 			// TypeScript's declaration emit won't copy over the d.ts files, so we do it here
 			out_file = file;
@@ -105,24 +107,26 @@ export async function make_package(config, cwd = process.cwd()) {
 
 	pkg.exports = { ...generated, ...pkg.exports };
 
-	// Several heuristics in Kit/vite-plugin-svelte to tell Vite to mark Svelte packages
-	// rely on the "svelte" property. Vite/Rollup/Webpack plugin can all deal with it.
-	// See https://github.com/sveltejs/kit/issues/1959 for more info and related threads.
-	if (pkg.exports['.']) {
-		const svelte_export = typeof pkg.exports['.'] === 'string' ? pkg.exports['.'] : undefined;
-		if (svelte_export) {
-			pkg.svelte = svelte_export;
+	if (contains_svelte_files) {
+		// Several heuristics in Kit/vite-plugin-svelte to tell Vite to mark Svelte packages
+		// rely on the "svelte" property. Vite/Rollup/Webpack plugin can all deal with it.
+		// See https://github.com/sveltejs/kit/issues/1959 for more info and related threads.
+		if (pkg.exports['.']) {
+			const svelte_export = typeof pkg.exports['.'] === 'string' ? pkg.exports['.'] : undefined;
+			if (svelte_export) {
+				pkg.svelte = svelte_export;
+			} else {
+				console.warn(
+					'The "." entry in "exports" is not a string. ' +
+						'If you set it by hand, please also set one of the options as a "svelte" entry point'
+				);
+			}
 		} else {
 			console.warn(
 				'The "." entry in "exports" is not a string. ' +
 					'If you set it by hand, please also set one of the options as a "svelte" entry point'
 			);
 		}
-	} else {
-		console.warn(
-			'The "." entry in "exports" is not a string. ' +
-				'If you set it by hand, please also set one of the options as a "svelte" entry point'
-		);
 	}
 
 	write(path.join(cwd, config.kit.package.dir, 'package.json'), JSON.stringify(pkg, null, '  '));

--- a/packages/kit/src/packaging/test/fixtures/emitTypes-false/expected/package.json
+++ b/packages/kit/src/packaging/test/fixtures/emitTypes-false/expected/package.json
@@ -8,5 +8,6 @@
 		"./Test.svelte": "./Test.svelte",
 		"./Test2.svelte": "./Test2.svelte",
 		".": "./index.js"
-	}
+	},
+	"svelte": "./index.js"
 }

--- a/packages/kit/src/packaging/test/fixtures/exports-merge/expected/package.json
+++ b/packages/kit/src/packaging/test/fixtures/exports-merge/expected/package.json
@@ -16,5 +16,6 @@
 		"./Test": "./Test.svelte",
 		"./package.json": "./package.json"
 	},
-	"type": "module"
+	"type": "module",
+	"svelte": "./index.js"
 }

--- a/packages/kit/src/packaging/test/fixtures/exports-replace/expected/package.json
+++ b/packages/kit/src/packaging/test/fixtures/exports-replace/expected/package.json
@@ -8,5 +8,6 @@
 			"import": "./index.js"
 		},
 		"./package.json": "./package.json"
-	}
+	},
+	"svelte": "./Test.svelte"
 }

--- a/packages/kit/src/packaging/test/fixtures/exports-replace/package.json
+++ b/packages/kit/src/packaging/test/fixtures/exports-replace/package.json
@@ -7,5 +7,6 @@
 		".": {
 			"import": "./index.js"
 		}
-	}
+	},
+	"svelte": "./Test.svelte"
 }

--- a/packages/kit/src/packaging/test/fixtures/files-exclude/expected/package.json
+++ b/packages/kit/src/packaging/test/fixtures/files-exclude/expected/package.json
@@ -8,5 +8,6 @@
 		"./internal": "./internal/index.js",
 		"./Test.svelte": "./Test.svelte",
 		".": "./index.js"
-	}
+	},
+	"svelte": "./index.js"
 }

--- a/packages/kit/src/packaging/test/fixtures/javascript/expected/package.json
+++ b/packages/kit/src/packaging/test/fixtures/javascript/expected/package.json
@@ -11,5 +11,6 @@
 		"./Test2.svelte": "./Test2.svelte",
 		"./utils": "./utils.js",
 		".": "./index.js"
-	}
+	},
+	"svelte": "./index.js"
 }

--- a/packages/kit/src/packaging/test/fixtures/typescript/expected/package.json
+++ b/packages/kit/src/packaging/test/fixtures/typescript/expected/package.json
@@ -9,5 +9,6 @@
 		"./Test2.svelte": "./Test2.svelte",
 		"./utils": "./utils.js",
 		".": "./index.js"
-	}
+	},
+	"svelte": "./index.js"
 }


### PR DESCRIPTION
Several heuristics in Kit/vite-plugin-svelte to tell Vite to mark Svelte packages rely on the "svelte" property. Vite/Rollup/Webpack plugin can all deal with it.

Fixes #1959

@dominikg @bluwy  I didn't quite follow through your discussion over at `vite-plugin-svelte`, but I think this change is needed for Svelte packages to properly get detected, right?

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
