### PR TITLE
[feat] Use dynamic port if specified port is already in use

### DIFF
--- a/.changeset/tiny-keys-eat.md
+++ b/.changeset/tiny-keys-eat.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Use dinamic port if specified port is already in use

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -11,6 +11,7 @@
 	"dependencies": {
 		"@sveltejs/vite-plugin-svelte": "^1.0.0-next.24",
 		"cheap-watch": "^1.0.3",
+		"portfinder": "^1.0.28",
 		"sade": "^1.7.4",
 		"vite": "^2.5.7"
 	},


### PR DESCRIPTION
This is related to https://github.com/sveltejs/kit/issues/948

## Summary of the PR

At least on Windows, when I execute `npm run dev` like the above issue's reproduction steps, I got the below error if 3000 port is already in use.
```
Error: listen EADDRINUSE: address already in use 127.0.0.1:3000
```

I think this is correct behavior.
But on the other hand, [webpack-dev-server](https://github.com/webpack/webpack-dev-server) has the feature that dev server finds free port if a default port is already in use.
https://github.com/webpack/webpack-dev-server/pull/685/files

So I implemented almost the same feature.
If a user specifies a specific port, dev server will check only the port.
But if not, dev server searches usable port from 3000.

### Questions

- Is there any issue with this PR?
- Should I add some tests? (But honestly, I don't know how to write tests for this PR...)
- Should I add/edit some documents?

Thank you!!

--- 

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
