### PR TITLE
[chore] upgrade to Svelte 3.43.0

### DIFF
--- a/.changeset/itchy-days-matter.md
+++ b/.changeset/itchy-days-matter.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/adapter-static': patch
+'create-svelte': patch
+'@sveltejs/kit': patch
+---
+
+[chore] upgrade to Svelte 3.43.0"

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -28,7 +28,7 @@
 		"playwright-chromium": "^1.14.1",
 		"port-authority": "^1.1.2",
 		"sirv": "^1.0.17",
-		"svelte": "^3.42.6",
+		"svelte": "^3.43.0",
 		"uvu": "^0.5.1"
 	}
 }

--- a/packages/adapter-static/test/apps/prerendered/package.json
+++ b/packages/adapter-static/test/apps/prerendered/package.json
@@ -8,7 +8,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "next",
-		"svelte": "^3.40.0"
+		"svelte": "^3.43.0"
 	},
 	"type": "module"
 }

--- a/packages/adapter-static/test/apps/spa/package.json
+++ b/packages/adapter-static/test/apps/spa/package.json
@@ -9,7 +9,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-node": "next",
 		"@sveltejs/kit": "next",
-		"svelte": "^3.40.0"
+		"svelte": "^3.43.0"
 	},
 	"type": "module"
 }

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -21,7 +21,7 @@
 		"prettier": "^2.4.1",
 		"prettier-plugin-svelte": "^2.4.0",
 		"sucrase": "^3.20.1",
-		"svelte": "^3.42.6",
+		"svelte": "^3.43.0",
 		"svelte-preprocess": "^4.9.4",
 		"tiny-glob": "^0.2.9"
 	},

--- a/packages/create-svelte/templates/default/package.json
+++ b/packages/create-svelte/templates/default/package.json
@@ -11,7 +11,7 @@
 		"@sveltejs/adapter-netlify": "next",
 		"@sveltejs/adapter-vercel": "next",
 		"@sveltejs/kit": "next",
-		"svelte": "^3.42.6",
+		"svelte": "^3.43.0",
 		"svelte-preprocess": "^4.9.4",
 		"typescript": "^4.4.3"
 	},

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -39,14 +39,14 @@
 		"rollup": "^2.56.3",
 		"selfsigned": "^1.10.11",
 		"sirv": "^1.0.17",
-		"svelte": "^3.42.6",
+		"svelte": "^3.43.0",
 		"svelte-check": "^2.2.6",
 		"svelte2tsx": "~0.4.6",
 		"tiny-glob": "^0.2.9",
 		"uvu": "^0.5.1"
 	},
 	"peerDependencies": {
-		"svelte": "^3.39.0"
+		"svelte": "^3.43.0"
 	},
 	"bin": {
 		"svelte-kit": "svelte-kit.js"

--- a/packages/kit/test/apps/amp/package.json
+++ b/packages/kit/test/apps/amp/package.json
@@ -10,7 +10,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-node": "workspace:*",
 		"@sveltejs/kit": "workspace:*",
-		"svelte": "^3.40.0"
+		"svelte": "^3.43.0"
 	},
 	"type": "module"
 }

--- a/packages/kit/test/apps/basics/package.json
+++ b/packages/kit/test/apps/basics/package.json
@@ -10,7 +10,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-node": "workspace:*",
 		"@sveltejs/kit": "workspace:*",
-		"svelte": "^3.40.0"
+		"svelte": "^3.43.0"
 	},
 	"type": "module"
 }

--- a/packages/kit/test/apps/options/package.json
+++ b/packages/kit/test/apps/options/package.json
@@ -10,7 +10,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-node": "workspace:*",
 		"@sveltejs/kit": "workspace:*",
-		"svelte": "^3.40.0"
+		"svelte": "^3.43.0"
 	},
 	"type": "module"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,14 +123,14 @@ importers:
       playwright-chromium: ^1.14.1
       port-authority: ^1.1.2
       sirv: ^1.0.17
-      svelte: ^3.42.6
+      svelte: ^3.43.0
       uvu: ^0.5.1
     devDependencies:
       '@sveltejs/kit': link:../kit
       playwright-chromium: 1.14.1
       port-authority: 1.1.2
       sirv: 1.0.17
-      svelte: 3.42.6
+      svelte: 3.43.0
       uvu: 0.5.1
 
   packages/adapter-vercel:
@@ -154,7 +154,7 @@ importers:
       prettier-plugin-svelte: ^2.4.0
       prompts: ^2.4.1
       sucrase: ^3.20.1
-      svelte: ^3.42.6
+      svelte: ^3.43.0
       svelte-preprocess: ^4.9.4
       tiny-glob: ^0.2.9
     dependencies:
@@ -167,10 +167,10 @@ importers:
       '@types/prompts': 2.0.14
       gitignore-parser: 0.0.2
       prettier: 2.4.1
-      prettier-plugin-svelte: 2.4.0_prettier@2.4.1+svelte@3.42.6
+      prettier-plugin-svelte: 2.4.0_prettier@2.4.1+svelte@3.43.0
       sucrase: 3.20.1
-      svelte: 3.42.6
-      svelte-preprocess: 4.9.4_svelte@3.42.6+typescript@4.4.3
+      svelte: 3.43.0
+      svelte-preprocess: 4.9.4_svelte@3.43.0+typescript@4.4.3
       tiny-glob: 0.2.9
 
   packages/create-svelte/templates/default:
@@ -182,7 +182,7 @@ importers:
       '@sveltejs/adapter-vercel': next
       '@sveltejs/kit': next
       cookie: ^0.4.1
-      svelte: ^3.42.6
+      svelte: ^3.43.0
       svelte-preprocess: ^4.9.4
       typescript: ^4.4.3
     dependencies:
@@ -194,8 +194,8 @@ importers:
       '@sveltejs/adapter-netlify': link:../../../adapter-netlify
       '@sveltejs/adapter-vercel': link:../../../adapter-vercel
       '@sveltejs/kit': link:../../../kit
-      svelte: 3.42.6
-      svelte-preprocess: 4.9.4_svelte@3.42.6+typescript@4.4.3
+      svelte: 3.43.0
+      svelte-preprocess: 4.9.4_svelte@3.43.0+typescript@4.4.3
       typescript: 4.4.3
 
   packages/kit:
@@ -227,14 +227,14 @@ importers:
       sade: ^1.7.4
       selfsigned: ^1.10.11
       sirv: ^1.0.17
-      svelte: ^3.42.6
+      svelte: ^3.43.0
       svelte-check: ^2.2.6
       svelte2tsx: ~0.4.6
       tiny-glob: ^0.2.9
       uvu: ^0.5.1
       vite: ^2.5.7
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 1.0.0-next.24_svelte@3.42.6+vite@2.5.7
+      '@sveltejs/vite-plugin-svelte': 1.0.0-next.24_svelte@3.43.0+vite@2.5.7
       cheap-watch: 1.0.4
       sade: 1.7.4
       vite: 2.5.7
@@ -263,9 +263,9 @@ importers:
       rollup: 2.56.3
       selfsigned: 1.10.11
       sirv: 1.0.17
-      svelte: 3.42.6
-      svelte-check: 2.2.6_svelte@3.42.6
-      svelte2tsx: 0.4.6_svelte@3.42.6+typescript@4.4.3
+      svelte: 3.43.0
+      svelte-check: 2.2.6_svelte@3.43.0
+      svelte2tsx: 0.4.6_svelte@3.43.0+typescript@4.4.3
       tiny-glob: 0.2.9
       uvu: 0.5.1
 
@@ -763,7 +763,7 @@ packages:
       picomatch: 2.3.0
     dev: false
 
-  /@sveltejs/vite-plugin-svelte/1.0.0-next.24_svelte@3.42.6+vite@2.5.7:
+  /@sveltejs/vite-plugin-svelte/1.0.0-next.24_svelte@3.43.0+vite@2.5.7:
     resolution: {integrity: sha512-b+n3jcLpk2j/25APQbk5ejCyd0faYTB2bOxR3gY0LX3MFGgdiL8zdf3/aawcPSxLdbL73YVlxNBIATGuvq03uQ==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
@@ -779,8 +779,8 @@ packages:
       kleur: 4.1.4
       magic-string: 0.25.7
       require-relative: 0.8.7
-      svelte: 3.42.6
-      svelte-hmr: 0.14.7_svelte@3.42.6
+      svelte: 3.43.0
+      svelte-hmr: 0.14.7_svelte@3.43.0
       vite: 2.5.7
     transitivePeerDependencies:
       - supports-color
@@ -3217,14 +3217,14 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-svelte/2.4.0_prettier@2.4.1+svelte@3.42.6:
+  /prettier-plugin-svelte/2.4.0_prettier@2.4.1+svelte@3.43.0:
     resolution: {integrity: sha512-JwJ9bOz4XHLQtiLnX4mTSSDUdhu12WH8sTwy/XTDCSyPlah6IcV7NWeYBZscPEcceu2YnW8Y9sJCP40Z2UH9GA==}
     peerDependencies:
       prettier: ^1.16.4 || ^2.0.0
       svelte: ^3.2.0
     dependencies:
       prettier: 2.4.1
-      svelte: 3.42.6
+      svelte: 3.43.0
     dev: true
 
   /prettier/1.19.1:
@@ -3743,7 +3743,7 @@ packages:
       has-flag: 4.0.0
     dev: true
 
-  /svelte-check/2.2.6_svelte@3.42.6:
+  /svelte-check/2.2.6_svelte@3.43.0:
     resolution: {integrity: sha512-oJux/afbmcZO+N+ADXB88h6XANLie8Y2rh2qBlhgfkpr2c3t/q/T0w2JWrHqagaDL8zeNwO8a8RVFBkrRox8gg==}
     hasBin: true
     peerDependencies:
@@ -3756,8 +3756,8 @@ packages:
       minimist: 1.2.5
       sade: 1.7.4
       source-map: 0.7.3
-      svelte: 3.42.6
-      svelte-preprocess: 4.9.4_svelte@3.42.6+typescript@4.4.3
+      svelte: 3.43.0
+      svelte-preprocess: 4.9.4_svelte@3.43.0+typescript@4.4.3
       typescript: 4.4.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -3772,15 +3772,15 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-hmr/0.14.7_svelte@3.42.6:
+  /svelte-hmr/0.14.7_svelte@3.43.0:
     resolution: {integrity: sha512-pDrzgcWSoMaK6AJkBWkmgIsecW0GChxYZSZieIYfCP0v2oPyx2CYU/zm7TBIcjLVUPP714WxmViE9Thht4etog==}
     peerDependencies:
       svelte: '>=3.19.0'
     dependencies:
-      svelte: 3.42.6
+      svelte: 3.43.0
     dev: false
 
-  /svelte-preprocess/4.9.4_svelte@3.42.6+typescript@4.4.3:
+  /svelte-preprocess/4.9.4_svelte@3.43.0+typescript@4.4.3:
     resolution: {integrity: sha512-Z0mUQBGtE+ZZSv/HerRSHe7ukJokxjiPeHe7iPOIXseEoRw51H3K/Vh6OMIMstetzZ11vWO9rCsXSD/uUUArmA==}
     engines: {node: '>= 9.11.2'}
     requiresBuild: true
@@ -3827,7 +3827,7 @@ packages:
       magic-string: 0.25.7
       sorcery: 0.10.0
       strip-indent: 3.0.0
-      svelte: 3.42.6
+      svelte: 3.43.0
       typescript: 4.4.3
     dev: true
 
@@ -3836,7 +3836,12 @@ packages:
     engines: {node: '>= 8'}
     dev: true
 
-  /svelte2tsx/0.4.6_svelte@3.42.6+typescript@4.4.3:
+  /svelte/3.43.0:
+    resolution: {integrity: sha512-T2pMPHrxXp+SM8pLLUXLQgkdo+JhTls7aqj9cD7z8wT2ccP+OrCAmtQS7h6pvMjitaZhXFNnCK582NxDpy8HSw==}
+    engines: {node: '>= 8'}
+    dev: true
+
+  /svelte2tsx/0.4.6_svelte@3.43.0+typescript@4.4.3:
     resolution: {integrity: sha512-flljgh/MbJDijo6Z1HhCfyzdRgn1Nd7QTuuxk9Oq5CzyBXZl/NJYh4otZZwUHnx5poy8k7Oxr2CBE3IBh89tmQ==}
     peerDependencies:
       svelte: ^3.24
@@ -3844,7 +3849,7 @@ packages:
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 3.42.6
+      svelte: 3.43.0
       typescript: 4.4.3
     dev: true
 


### PR DESCRIPTION
Svelte 3.43.0 provides an `exports` map in `package.json` to return a different version of Svelte for SSR builds