### PR TITLE
[feat] create-svelte: Add prompt for choosing adapter

### DIFF
--- a/.changeset/wicked-colts-march.md
+++ b/.changeset/wicked-colts-march.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Add option to select adapter

--- a/packages/create-svelte/adapters.js
+++ b/packages/create-svelte/adapters.js
@@ -1,0 +1,27 @@
+export default [
+	{
+		name: 'adapter-node',
+		npm: '@sveltejs/adapter-node',
+		url: 'https://github.com/sveltejs/kit/tree/master/packages/adapter-node'
+	},
+	{
+		name: 'adapter-static',
+		npm: '@sveltejs/adapter-static',
+		url: 'https://github.com/sveltejs/kit/tree/master/packages/adapter-static'
+	},
+	{
+		name: 'adapter-cloudflare-workers',
+		npm: '@sveltejs/adapter-cloudflare-workers',
+		url: 'https://github.com/sveltejs/kit/tree/master/packages/adapter-cloudflare-workers'
+	},
+	{
+		name: 'adapter-netlify',
+		npm: '@sveltejs/adapter-netlify',
+		url: 'https://github.com/sveltejs/kit/tree/master/packages/adapter-netlify'
+	},
+	{
+		name: 'adapter-vercel',
+		npm: '@sveltejs/adapter-vercel',
+		url: 'https://github.com/sveltejs/kit/tree/master/packages/adapter-vercel'
+	}
+];

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -232,7 +232,7 @@ function write_common_files(cwd, options, name) {
 	});
 
 	if (options.adapter) {
-		pkg.devDependencies[options.adapter.npm] = 'next';
+		pkg.devDependencies[options.adapter.npm] = '^1.0.0-next.1';
 	}
 	pkg.dependencies = sort_keys(pkg.dependencies);
 	pkg.devDependencies = sort_keys(pkg.devDependencies);

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -89,7 +89,7 @@ async function main() {
 					{
 						title: "I'll add it later or use a community-provided adapter",
 						description:
-							'Community provided adapters: https://sveltesociety.dev/components/#category-SvelteKit%20Adapters',
+							'Community provided adapters: https://sveltesociety.dev/components#adapters',
 						value: null
 					},
 					...adapters.map((adapter) => ({ title: adapter.name, value: adapter }))

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -87,7 +87,9 @@ async function main() {
 				message: 'Add an adapter',
 				choices: [
 					{
-						title: "I'll add it later or use a community-provided adapter (https://bit.ly/3kvqIRy)",
+						title: "I'll add it later or use a community-provided adapter",
+						description:
+							'Community provided adapters: https://sveltesociety.dev/components/#category-SvelteKit%20Adapters',
 						value: null
 					},
 					...adapters.map((adapter) => ({ title: adapter.name, value: adapter }))

--- a/packages/create-svelte/shared/+typescript/svelte.config.js
+++ b/packages/create-svelte/shared/+typescript/svelte.config.js
@@ -1,4 +1,5 @@
 import preprocess from 'svelte-preprocess';
+// insert:adapter-import
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -7,6 +8,7 @@ const config = {
 	preprocess: preprocess(),
 
 	kit: {
+		// insert:adapter
 		// hydrate the <div id="svelte"> element in src/app.html
 		target: '#svelte'
 	}

--- a/packages/create-svelte/shared/-typescript/svelte.config.js
+++ b/packages/create-svelte/shared/-typescript/svelte.config.js
@@ -1,6 +1,8 @@
+// insert:adapter-import
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
+		// insert:adapter
 		// hydrate the <div id="svelte"> element in src/app.html
 		target: '#svelte'
 	}

--- a/packages/create-svelte/types/internal.d.ts
+++ b/packages/create-svelte/types/internal.d.ts
@@ -3,6 +3,7 @@ export type Options = {
 	typescript: boolean;
 	prettier: boolean;
 	eslint: boolean;
+	adapter: { name: string; npm: string; url: string };
 };
 
 export type File = {


### PR DESCRIPTION
Fixes #2459 

Add a new prompt for adapter. The default option is `"I'll add it later or use a community-provided adapter"`.

Updated:
![image](https://user-images.githubusercontent.com/44284655/137541074-32e1b858-1293-4dd4-a6d2-09b2c8a670bf.png)

![image](https://user-images.githubusercontent.com/44284655/134497027-e6e0eedd-4828-4559-920e-906a3d6216dc.png)


### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
