### PR TITLE
[fix] externalize middlewares.js when using adapter-node's entryPoint

### DIFF
--- a/.changeset/mighty-ears-divide.md
+++ b/.changeset/mighty-ears-divide.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+[fix] Correctly treat `middlewares.js` as external when using `entryPoint` option

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -7,7 +7,7 @@ import {
 	statSync,
 	writeFileSync
 } from 'fs';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { pipeline } from 'stream';
 import glob from 'tiny-glob';
 import { fileURLToPath } from 'url';
@@ -81,7 +81,6 @@ export default function ({
 				entryPoints: [entryPoint],
 				outfile: join(out, 'index.js'),
 				bundle: true,
-				external: ['./middlewares.js'], // does not work, eslint does not exclude middlewares from target
 				format: 'esm',
 				platform: 'node',
 				target: 'node12',
@@ -90,8 +89,12 @@ export default function ({
 					{
 						name: 'fix-middlewares-exclude',
 						setup(build) {
-							// Match an import called "./middlewares.js" and mark it as external
-							build.onResolve({ filter: /^\.\/middlewares\.js$/ }, () => ({ external: true }));
+							// Match an import of "middlewares.js" and mark it as external
+							build.onResolve({ filter: /\/middlewares\.js$/ }, ({ path, resolveDir }) => {
+								if (resolve(resolveDir, path) === resolve(out, 'middlewares.js')) {
+									return { path: './middlewares.js', external: true };
+								}
+							});
 						}
 					}
 				]


### PR DESCRIPTION
Fixes #2481, hopefully without breaking anything else. This is almost the same as my suggested solution in my comment on that issue - except it also includes an override for the path in the `onResolve` hook to avoid having `import { assetsMiddleware, prerenderedMiddleware, kitMiddleware } from "../build/middlewares.js";` in the final file.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
