### PR TITLE
[fix] externalize middlewares.js when not using entryPoint

### DIFF
--- a/.changeset/eight-hats-worry.md
+++ b/.changeset/eight-hats-worry.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+[fix] regression where builds not using `entryPoint` stopped having `middlewares.js` external

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -90,8 +90,11 @@ export default function ({
 						name: 'fix-middlewares-exclude',
 						setup(build) {
 							// Match an import of "middlewares.js" and mark it as external
+							const internal_middlewares_path = resolve('.svelte-kit/node/middlewares.js');
+							const build_middlewares_path = resolve(out, 'middlewares.js');
 							build.onResolve({ filter: /\/middlewares\.js$/ }, ({ path, resolveDir }) => {
-								if (resolve(resolveDir, path) === resolve(out, 'middlewares.js')) {
+								const resolved = resolve(resolveDir, path);
+								if (resolved === internal_middlewares_path || resolved === build_middlewares_path) {
 									return { path: './middlewares.js', external: true };
 								}
 							});


### PR DESCRIPTION
#2482 introduced a silly regression where normal builds _not_ using `entryPoint` (where `middlewares.js` is (internally) imported from its normal location at `.svelte-kit/node/middlewares.js`) stopped having `middlewares.js` external. We need to check both possible paths.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
