### PR TITLE
[chore] Remove usages of waitForTimeout

### DIFF
--- a/.changeset/brown-bottles-refuse.md
+++ b/.changeset/brown-bottles-refuse.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': patch
----
-
-Remove usages of waitForTimeout.

--- a/.changeset/brown-bottles-refuse.md
+++ b/.changeset/brown-bottles-refuse.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Remove usages of waitForTimeout.

--- a/packages/adapter-cloudflare-workers/README.md
+++ b/packages/adapter-cloudflare-workers/README.md
@@ -59,7 +59,6 @@ $ npm run build && wrangler publish
 
 **You are done!**
 
-
 More info on configuring a cloudflare worker site can be found [here](https://developers.cloudflare.com/workers/platform/sites/start-from-existing)
 
 ## Advanced Configuration

--- a/packages/kit/test/apps/basics/src/routes/accessibility/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/accessibility/_tests.js
@@ -5,19 +5,15 @@ export default function (test) {
 	test('resets focus', '/accessibility/a', async ({ page, clicknav }) => {
 		await clicknav('[href="/accessibility/b"]');
 		assert.equal(await page.innerHTML('h1'), 'b');
-		await page.waitForTimeout(50);
 		assert.equal(await page.evaluate(() => (document.activeElement || {}).nodeName), 'BODY');
 		await page.keyboard.press('Tab');
-		await page.waitForTimeout(50);
 		assert.equal(await page.evaluate(() => (document.activeElement || {}).nodeName), 'A');
 		assert.equal(await page.evaluate(() => (document.activeElement || {}).textContent), 'a');
 
 		await clicknav('[href="/accessibility/a"]');
 		assert.equal(await page.innerHTML('h1'), 'a');
-		await page.waitForTimeout(50);
 		assert.equal(await page.evaluate(() => (document.activeElement || {}).nodeName), 'BODY');
 		await page.keyboard.press('Tab');
-		await page.waitForTimeout(50);
 		assert.equal(await page.evaluate(() => (document.activeElement || {}).nodeName), 'A');
 		assert.equal(await page.evaluate(() => (document.activeElement || {}).textContent), 'a');
 	});

--- a/packages/kit/test/apps/basics/src/routes/no-router/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/no-router/_tests.js
@@ -5,14 +5,12 @@ export default function (test, is_dev) {
 	test('disables router if router=false', '/no-router/a', async ({ page, clicknav, js }) => {
 		if (js) {
 			await page.click('button');
-			await page.waitForTimeout(50);
 			assert.equal(await page.textContent('button'), 'clicks: 1');
 
 			await Promise.all([page.click('[href="/no-router/b"]'), page.waitForNavigation()]);
 			assert.equal(await page.textContent('button'), 'clicks: 0');
 
 			await page.click('button');
-			await page.waitForTimeout(50);
 			assert.equal(await page.textContent('button'), 'clicks: 1');
 
 			await clicknav('[href="/no-router/a"]');

--- a/packages/kit/test/apps/basics/src/routes/redirect/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/redirect/_tests.js
@@ -13,7 +13,7 @@ export default function (test, is_dev) {
 		await page.click('[href="/redirect/loopy/a"]');
 
 		if (js) {
-			await page.waitForTimeout(100);
+			await page.waitForSelector('#message');
 			assert.equal(page.url(), `${base}/redirect/loopy/a`);
 			assert.equal(await page.textContent('h1'), '500');
 			assert.equal(

--- a/packages/kit/test/apps/basics/src/routes/routing/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/_tests.js
@@ -95,10 +95,6 @@ export default function (test, is_dev) {
 					if (!e.message.includes('Crashing now')) throw e;
 				});
 
-				// // weird flakiness — without this, some requests are
-				// // reported after prefetchRoutes has finished
-				// await page.waitForTimeout(500);
-
 				const requests = await capture_requests(async () => {
 					await clicknav('a[href="/routing/a"]');
 					assert.equal(await page.textContent('h1'), 'a');

--- a/packages/kit/test/apps/basics/src/routes/routing/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/_tests.js
@@ -192,11 +192,11 @@ export default function (test, is_dev) {
 	test(
 		'back button returns to previous route when previous route has been navigated to via hash anchor',
 		'/routing/hashes/a',
-		async ({ page, clicknav }) => {
+		async ({ page, clicknav, back }) => {
 			await clicknav('[href="#hash-target"]');
 			await clicknav('[href="/routing/hashes/b"]');
 
-			await page.goBack();
+			await back();
 			assert.equal(await page.textContent('h1'), 'a');
 		}
 	);

--- a/packages/kit/test/apps/basics/src/routes/session/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/session/_tests.js
@@ -8,7 +8,6 @@ export default function (test) {
 
 		if (js) {
 			await page.click('button');
-			await page.waitForTimeout(10);
 			assert.equal(await page.innerHTML('h1'), 'answer via props: 43');
 			assert.equal(await page.innerHTML('h2'), 'answer via store: 43');
 		}

--- a/packages/kit/test/apps/basics/src/routes/store/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/store/_tests.js
@@ -29,7 +29,7 @@ export default function (test) {
 					'navigating from /store/navigating/a to /store/navigating/b'
 				);
 
-				await page.waitForSelector('#no-navigating');
+				await page.waitForSelector('#not-navigating');
 				assert.equal(await page.textContent('#navigating'), 'not currently navigating');
 			}
 		}

--- a/packages/kit/test/apps/basics/src/routes/store/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/store/_tests.js
@@ -29,7 +29,7 @@ export default function (test) {
 					'navigating from /store/navigating/a to /store/navigating/b'
 				);
 
-				await page.waitForTimeout(100);
+				await page.waitForSelector('#no-navigating');
 				assert.equal(await page.textContent('#navigating'), 'not currently navigating');
 			}
 		}

--- a/packages/kit/test/apps/basics/src/routes/store/navigating/__layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/store/navigating/__layout.svelte
@@ -8,7 +8,7 @@
 	{#if $navigating}
 		<p>navigating from {$navigating.from.path} to {$navigating.to.path}</p>
 	{:else}
-		<p>not currently navigating</p>
+		<p id="no-navigating">not currently navigating</p>
 	{/if}
 </div>
 

--- a/packages/kit/test/apps/basics/src/routes/store/navigating/__layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/store/navigating/__layout.svelte
@@ -8,7 +8,7 @@
 	{#if $navigating}
 		<p>navigating from {$navigating.from.path} to {$navigating.to.path}</p>
 	{:else}
-		<p id="no-navigating">not currently navigating</p>
+		<p id="not-navigating">not currently navigating</p>
 	{/if}
 </div>
 


### PR DESCRIPTION
Closes https://github.com/sveltejs/kit/issues/2473

Most cases only needed to remove `waitForTimeout`.
Some of the cases required a waiting process, so we replaced them with `waitForSelector`.
And I removed some comments in the second commit.
Please check this is ok or not.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
