### PR TITLE
[fix] prevent crashing when tag attributes are empty

### DIFF
--- a/.changeset/spotty-cooks-happen.md
+++ b/.changeset/spotty-cooks-happen.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix script and style tags without attributes crashing svelte-kit package

--- a/packages/kit/src/packaging/index.js
+++ b/packages/kit/src/packaging/index.js
@@ -207,6 +207,7 @@ function strip_lang_tags(content) {
 			'g'
 		);
 		content = content.replace(regexp, (tag, attributes) => {
+			if (!attributes) return tag;
 			const idx = tag.indexOf(attributes);
 			return (
 				tag.substring(0, idx) +

--- a/packages/kit/src/packaging/test/fixtures/typescript/expected/Plain.svelte
+++ b/packages/kit/src/packaging/test/fixtures/typescript/expected/Plain.svelte
@@ -1,0 +1,4 @@
+<script>
+	/** @type {import('./foo').Foo} */
+	export let foo;
+</script>

--- a/packages/kit/src/packaging/test/fixtures/typescript/expected/Plain.svelte.d.ts
+++ b/packages/kit/src/packaging/test/fixtures/typescript/expected/Plain.svelte.d.ts
@@ -1,0 +1,26 @@
+/** @typedef {typeof __propDef.props}  PlainProps */
+/** @typedef {typeof __propDef.events}  PlainEvents */
+/** @typedef {typeof __propDef.slots}  PlainSlots */
+export default class Plain extends SvelteComponentTyped<
+	{
+		foo: boolean;
+	},
+	{
+		[evt: string]: CustomEvent<any>;
+	},
+	{}
+> {}
+export type PlainProps = typeof __propDef.props;
+export type PlainEvents = typeof __propDef.events;
+export type PlainSlots = typeof __propDef.slots;
+import { SvelteComponentTyped } from 'svelte';
+declare const __propDef: {
+	props: {
+		foo: import('./foo').Foo;
+	};
+	events: {
+		[evt: string]: CustomEvent<any>;
+	};
+	slots: {};
+};
+export {};

--- a/packages/kit/src/packaging/test/fixtures/typescript/expected/package.json
+++ b/packages/kit/src/packaging/test/fixtures/typescript/expected/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"exports": {
 		"./package.json": "./package.json",
+		"./Plain.svelte": "./Plain.svelte",
 		"./Test.svelte": "./Test.svelte",
 		"./Test2.svelte": "./Test2.svelte",
 		"./utils": "./utils.js",

--- a/packages/kit/src/packaging/test/fixtures/typescript/src/lib/Plain.svelte
+++ b/packages/kit/src/packaging/test/fixtures/typescript/src/lib/Plain.svelte
@@ -1,0 +1,4 @@
+<script>
+	/** @type {import('./foo').Foo} */
+	export let foo;
+</script>


### PR DESCRIPTION
Fixes #2491 