### PR TITLE
Fix a typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ npm publish --access=public
 ## Code structure
 
 Entry points to be aware of are:
-- [`packages/create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte) - code that's run when you create a new project with `npm init svelte@next`
+- [`packages/create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte) - code that runs when you create a new project with `npm init svelte@next`
 - [`packages/kit/src/packaging`](https://github.com/sveltejs/kit/tree/master/packages/kit/src/packaging) - for the `svelte-kit package` command
 - [`packages/kit/src/core/dev/index.js`](https://github.com/sveltejs/kit/blob/master/packages/kit/src/core/dev/index.js) - for the dev-mode server
 - [`packages/kit/src/core/build/index.js`](https://github.com/sveltejs/kit/blob/master/packages/kit/src/core/build/index.js) - for the production server


### PR DESCRIPTION
Edit :   code that's run   ->   code that runs