### PR TITLE
[feat] allow using Vite's `strict.port` option

### DIFF
--- a/.changeset/beige-trees-confess.md
+++ b/.changeset/beige-trees-confess.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[feat] allow using Vite's `strict.port: false` option

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -102,7 +102,8 @@ class Watcher extends EventEmitter {
 			server: {
 				fs: {
 					strict: true
-				}
+				},
+				strictPort: true
 			}
 		};
 


### PR DESCRIPTION
Closes https://github.com/sveltejs/kit/issues/2467

This delegates port checking to Vite and allows you to set `strict.port: false`. I set the `strict.port` default to `true`, which is different than Vite's default value for backwards compatibility

The server startup message is printed twice, but that will be fixed when we upgrade to Vite 2.6. That upgrade will remove their startup message and leave only ours

This doesn't touch `preview` mode for now. It may be possible to use the Vite server in preview mode as well, but that would be blocked by an upgrade to Vite 2.6