### PR TITLE
[fix] restore functioning of --host CLI flag with no arg

### DIFF
--- a/.changeset/swift-jokes-compete.md
+++ b/.changeset/swift-jokes-compete.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] restore functioning of --host CLI flag with no arg

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -79,10 +79,10 @@ const prog = sade('svelte-kit').version('__VERSION__');
 prog
 	.command('dev')
 	.describe('Start a development server')
-	.option('-p, --port', 'Port', 3000)
-	.option('-h, --host', 'Host (only use this on trusted networks)', 'localhost')
-	.option('-H, --https', 'Use self-signed HTTPS certificate', false)
-	.option('-o, --open', 'Open a browser tab', false)
+	.option('-p, --port', 'Port')
+	.option('-h, --host', 'Host (only use this on trusted networks)')
+	.option('-H, --https', 'Use self-signed HTTPS certificate')
+	.option('-o, --open', 'Open a browser tab')
 	.action(async ({ port, host, https, open }) => {
 		process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 		const config = await get_config();
@@ -226,7 +226,7 @@ function welcome({ port, host, https, open }) {
 	console.log(colors.bold().cyan(`\n  SvelteKit v${'__VERSION__'}\n`));
 
 	const protocol = https ? 'https:' : 'http:';
-	const exposed = host !== 'localhost' && host !== '127.0.0.1';
+	const exposed = typeof host !== 'undefined' && host !== 'localhost' && host !== '127.0.0.1';
 
 	Object.values(networkInterfaces()).forEach((interfaces) => {
 		if (!interfaces) return;

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -153,17 +153,13 @@ class Watcher extends EventEmitter {
 
 		// optional config from command-line flags
 		// these should take precedence, but not print conflict warnings
-		const cli_opts = {};
-		if (this.host || this.https) {
-			cli_opts.server = {};
-		}
-		if (this.host) {
-			cli_opts.server.host = this.host;
-		}
-		if (this.https) {
-			cli_opts.server.https = this.https;
-		}
-		[merged_config] = deep_merge(merged_config, cli_opts);
+		[merged_config] = deep_merge(merged_config, {
+			server: {
+				host: this.host,
+				https: this.https,
+				port: this.port
+			}
+		});
 
 		this.vite = await vite.createServer(merged_config);
 		remove_html_middlewares(this.vite.middlewares);


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/issues/2521. Also lets you specify these values in `svelte.config.js`, which wasn't working either