### PR TITLE
fix: introduce escape utility and use it to escape html attribute 

### DIFF
--- a/.changeset/cyan-knives-mix.md
+++ b/.changeset/cyan-knives-mix.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix escaping of URLs of endpoint responses serialized into SSR response

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -47,7 +47,7 @@ function page_store(value) {
 function initial_fetch(resource, opts) {
 	const url = typeof resource === 'string' ? resource : resource.url;
 
-	let selector = `script[data-type="svelte-data"][data-url="${url}"]`;
+	let selector = `script[data-type="svelte-data"][data-url=${JSON.stringify(url)}]`;
 
 	if (opts && typeof opts.body === 'string') {
 		selector += `[data-body="${hash(opts.body)}"]`;

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -1,5 +1,6 @@
 import { normalize } from '../../load.js';
 import { respond } from '../index.js';
+import { escape_json_in_html } from '../../../utils/escape.js';
 
 const s = JSON.stringify;
 
@@ -236,7 +237,7 @@ export async function load_node({
 									fetched.push({
 										url,
 										body: /** @type {string} */ (opts.body),
-										json: `{"status":${response.status},"statusText":${s(response.statusText)},"headers":${s(headers)},"body":${escape(body)}}`
+										json: `{"status":${response.status},"statusText":${s(response.statusText)},"headers":${s(headers)},"body":"${escape_json_in_html(body)}"}`
 									});
 								}
 
@@ -298,53 +299,6 @@ export async function load_node({
 		set_cookie_headers,
 		uses_credentials
 	};
-}
-
-/** @type {Record<string, string>} */
-const escaped = {
-	'<': '\\u003C',
-	'>': '\\u003E',
-	'/': '\\u002F',
-	'\\': '\\\\',
-	'\b': '\\b',
-	'\f': '\\f',
-	'\n': '\\n',
-	'\r': '\\r',
-	'\t': '\\t',
-	'\0': '\\0',
-	'\u2028': '\\u2028',
-	'\u2029': '\\u2029'
-};
-
-/** @param {string} str */
-function escape(str) {
-	let result = '"';
-
-	for (let i = 0; i < str.length; i += 1) {
-		const char = str.charAt(i);
-		const code = char.charCodeAt(0);
-
-		if (char === '"') {
-			result += '\\"';
-		} else if (char in escaped) {
-			result += escaped[char];
-		} else if (code >= 0xd800 && code <= 0xdfff) {
-			const next = str.charCodeAt(i + 1);
-
-			// If this is the beginning of a [high, low] surrogate pair,
-			// add the next two characters, otherwise escape
-			if (code <= 0xdbff && next >= 0xdc00 && next <= 0xdfff) {
-				result += char + str[++i];
-			} else {
-				result += `\\u${code.toString(16).toUpperCase()}`;
-			}
-		} else {
-			result += char;
-		}
-	}
-
-	result += '"';
-	return result;
 }
 
 const absolute = /^([a-z]+:)?\/?\//;

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -1,6 +1,6 @@
 import { normalize } from '../../load.js';
 import { respond } from '../index.js';
-import { escape_json_in_html } from '../../../utils/escape.js';
+import { escape_json_string_in_html } from '../../../utils/escape.js';
 
 const s = JSON.stringify;
 
@@ -237,7 +237,7 @@ export async function load_node({
 									fetched.push({
 										url,
 										body: /** @type {string} */ (opts.body),
-										json: `{"status":${response.status},"statusText":${s(response.statusText)},"headers":${s(headers)},"body":"${escape_json_in_html(body)}"}`
+										json: `{"status":${response.status},"statusText":${s(response.statusText)},"headers":${s(headers)},"body":"${escape_json_string_in_html(body)}"}`
 									});
 								}
 

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -2,6 +2,7 @@ import devalue from 'devalue';
 import { writable } from 'svelte/store';
 import { coalesce_to_error } from '../../../utils/error.js';
 import { hash } from '../../hash.js';
+import { escape_html_attr, escape_json_literal_in_html } from '../../../utils/escape.js';
 
 const s = JSON.stringify;
 
@@ -168,10 +169,12 @@ export async function render_response({
 
 			${serialized_data
 				.map(({ url, body, json }) => {
-					let attributes = `type="application/json" data-type="svelte-data" data-url="${url}"`;
+					let attributes = `type="application/json" data-type="svelte-data" data-url="${escape_html_attr(
+						url
+					)}"`;
 					if (body) attributes += ` data-body="${hash(body)}"`;
 
-					return `<script ${attributes}>${json}</script>`;
+					return `<script ${attributes}>${escape_json_literal_in_html(json)}</script>`;
 				})
 				.join('\n\n\t')}
 		`;

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -169,9 +169,9 @@ export async function render_response({
 
 			${serialized_data
 				.map(({ url, body, json }) => {
-					let attributes = `type="application/json" data-type="svelte-data" data-url="${escape_html_attr(
+					let attributes = `type="application/json" data-type="svelte-data" data-url=${escape_html_attr(
 						url
-					)}"`;
+					)}`;
 					if (body) attributes += ` data-body="${hash(body)}"`;
 
 					return `<script ${attributes}>${json}</script>`;

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -2,7 +2,7 @@ import devalue from 'devalue';
 import { writable } from 'svelte/store';
 import { coalesce_to_error } from '../../../utils/error.js';
 import { hash } from '../../hash.js';
-import { escape_html_attr, escape_json_literal_in_html } from '../../../utils/escape.js';
+import { escape_html_attr } from '../../../utils/escape.js';
 
 const s = JSON.stringify;
 
@@ -174,7 +174,7 @@ export async function render_response({
 					)}"`;
 					if (body) attributes += ` data-body="${hash(body)}"`;
 
-					return `<script ${attributes}>${escape_json_literal_in_html(json)}</script>`;
+					return `<script ${attributes}>${json}</script>`;
 				})
 				.join('\n\n\t')}
 		`;

--- a/packages/kit/src/utils/escape.js
+++ b/packages/kit/src/utils/escape.js
@@ -1,0 +1,106 @@
+/** @type {Record<string, string>} */
+const escaped = {
+	'<': '\\u003C',
+	'>': '\\u003E',
+	'/': '\\u002F',
+	'\\': '\\\\',
+	'\b': '\\b',
+	'\f': '\\f',
+	'\n': '\\n',
+	'\r': '\\r',
+	'\t': '\\t',
+	'\0': '\\0',
+	'\u2028': '\\u2028',
+	'\u2029': '\\u2029'
+};
+
+/** @param {string} str */
+function escape(str) {
+	let result = '';
+
+	for (let i = 0; i < str.length; i += 1) {
+		const char = str.charAt(i);
+		const code = char.charCodeAt(0);
+
+		if (char === '"') {
+			result += '\\"';
+		} else if (char in escaped) {
+			result += escaped[char];
+		} else if (code >= 0xd800 && code <= 0xdfff) {
+			const next = str.charCodeAt(i + 1);
+
+			// If this is the beginning of a [high, low] surrogate pair,
+			// add the next two characters, otherwise escape
+			if (code <= 0xdbff && next >= 0xdc00 && next <= 0xdfff) {
+				result += char + str[++i];
+			} else {
+				result += `\\u${code.toString(16).toUpperCase()}`;
+			}
+		} else {
+			result += char;
+		}
+	}
+
+	return result;
+}
+
+/**
+ * use for escaping string values to be used in json content embedded into script tags on the page
+ * e.g.
+ * <script data-svelte>
+ *   {"somekey": "here" }
+ * </script>
+ * @param {string} str
+ * @returns string escaped string
+ */
+export function escape_json_in_html(str) {
+	return escape(str);
+}
+
+/**
+ * use for escaping ALL strings in obj to be used in json content embedded into script tags on the page
+ * e.g.
+ * <script data-svelte>
+ *   {"here": "andhere","heretoo":1 }
+ * </script>
+ * @param {string} str literal json string
+ * @returns string escaped json
+ */
+export function escape_json_literal_in_html(str) {
+	return JSON.stringify(JSON.parse(str, reviver_escape_json));
+}
+
+/**
+ *
+ * @param key {string}
+ * @param value {*}
+ * @returns {string|*}
+ */
+function reviver_escape_json(key, value) {
+	const escaped_key = escape_json_in_html(key);
+	const escaped_value = typeof value === 'string' ? escape_json_in_html(value) : value;
+	if (escaped_key === key) {
+		return escaped_value;
+	} else {
+		// @ts-ignore
+		if (Object.prototype.hasOwnProperty.call(this, escaped_key) && this[escaped_key] !== value) {
+			// @ts-ignore
+			throw new Error(
+				`encountered object with invalid key and escaped key with different value: "${key}":"${value}", "${escaped_key}":"${this[escaped_key]}"`
+			);
+		}
+		// @ts-ignore
+		this[escaped_key] = escaped_value;
+	}
+}
+
+/**
+ * use for escaping string values to be used html attributes on the page
+ * e.g.
+ * <script data-url="here">
+ * @param {string} str
+ * @returns string escaped string
+ */
+export function escape_html_attr(str) {
+	return escape(str);
+}

--- a/packages/kit/src/utils/escape.js
+++ b/packages/kit/src/utils/escape.js
@@ -1,5 +1,5 @@
 /** @type {Record<string, string>} */
-const escaped_in_json_html_string = {
+const escape_json_string_in_html_dict = {
 	'"': '\\"',
 	'<': '\\u003C',
 	'>': '\\u003E',
@@ -19,13 +19,13 @@ const escaped_in_json_html_string = {
 export function escape_json_string_in_html(str) {
 	return escape(
 		str,
-		escaped_in_json_html_string,
+		escape_json_string_in_html_dict,
 		(code) => `\\u${code.toString(16).toUpperCase()}`
 	);
 }
 
 /** @type {Record<string, string>} */
-const escaped_in_html_attr = {
+const escape_html_attr_dict = {
 	'<': '&lt;',
 	'>': '&gt;',
 	'"': '&quot;'
@@ -36,23 +36,21 @@ const escaped_in_html_attr = {
  * e.g.
  * <script data-url="here">
  *
- * only works for quoted values, do not use unqouted
- *
  * @param {string} str
  * @returns string escaped string
  */
 export function escape_html_attr(str) {
-	return escape(str, escaped_in_html_attr, (code) => `&#${code};`);
+	return '"' + escape(str, escape_html_attr_dict, (code) => `&#${code};`) + '"';
 }
 
 /**
  *
  * @param str {string} string to escape
  * @param dict {Record<string, string>} dictionary of character replacements
- * @param unicodeEncoder {function(number): string} encoder for unicode strings
+ * @param unicode_encoder {function(number): string} encoder to use for high unicode characters
  * @returns {string}
  */
-function escape(str, dict, unicodeEncoder) {
+function escape(str, dict, unicode_encoder) {
 	let result = '';
 
 	for (let i = 0; i < str.length; i += 1) {
@@ -69,7 +67,7 @@ function escape(str, dict, unicodeEncoder) {
 			if (code <= 0xdbff && next >= 0xdc00 && next <= 0xdfff) {
 				result += char + str[++i];
 			} else {
-				result += unicodeEncoder(code);
+				result += unicode_encoder(code);
 			}
 		} else {
 			result += char;

--- a/packages/kit/src/utils/escape.js
+++ b/packages/kit/src/utils/escape.js
@@ -1,5 +1,6 @@
 /** @type {Record<string, string>} */
-const escaped = {
+const escaped_in_json_html_string = {
+	'"': '\\"',
 	'<': '\\u003C',
 	'>': '\\u003E',
 	'/': '\\u002F',
@@ -15,17 +16,51 @@ const escaped = {
 };
 
 /** @param {string} str */
-function escape(str) {
+export function escape_json_string_in_html(str) {
+	return escape(
+		str,
+		escaped_in_json_html_string,
+		(code) => `\\u${code.toString(16).toUpperCase()}`
+	);
+}
+
+/** @type {Record<string, string>} */
+const escaped_in_html_attr = {
+	'<': '&lt;',
+	'>': '&gt;',
+	'"': '&quot;'
+};
+
+/**
+ * use for escaping string values to be used html attributes on the page
+ * e.g.
+ * <script data-url="here">
+ *
+ * only works for quoted values, do not use unqouted
+ *
+ * @param {string} str
+ * @returns string escaped string
+ */
+export function escape_html_attr(str) {
+	return escape(str, escaped_in_html_attr, (code) => `&#${code};`);
+}
+
+/**
+ *
+ * @param str {string} string to escape
+ * @param dict {Record<string, string>} dictionary of character replacements
+ * @param unicodeEncoder {function(number): string} encoder for unicode strings
+ * @returns {string}
+ */
+function escape(str, dict, unicodeEncoder) {
 	let result = '';
 
 	for (let i = 0; i < str.length; i += 1) {
 		const char = str.charAt(i);
 		const code = char.charCodeAt(0);
 
-		if (char === '"') {
-			result += '\\"';
-		} else if (char in escaped) {
-			result += escaped[char];
+		if (char in dict) {
+			result += dict[char];
 		} else if (code >= 0xd800 && code <= 0xdfff) {
 			const next = str.charCodeAt(i + 1);
 
@@ -34,7 +69,7 @@ function escape(str) {
 			if (code <= 0xdbff && next >= 0xdc00 && next <= 0xdfff) {
 				result += char + str[++i];
 			} else {
-				result += `\\u${code.toString(16).toUpperCase()}`;
+				result += unicodeEncoder(code);
 			}
 		} else {
 			result += char;
@@ -42,65 +77,4 @@ function escape(str) {
 	}
 
 	return result;
-}
-
-/**
- * use for escaping string values to be used in json content embedded into script tags on the page
- * e.g.
- * <script data-svelte>
- *   {"somekey": "here" }
- * </script>
- * @param {string} str
- * @returns string escaped string
- */
-export function escape_json_in_html(str) {
-	return escape(str);
-}
-
-/**
- * use for escaping ALL strings in obj to be used in json content embedded into script tags on the page
- * e.g.
- * <script data-svelte>
- *   {"here": "andhere","heretoo":1 }
- * </script>
- * @param {string} str literal json string
- * @returns string escaped json
- */
-export function escape_json_literal_in_html(str) {
-	return JSON.stringify(JSON.parse(str, reviver_escape_json));
-}
-
-/**
- *
- * @param key {string}
- * @param value {*}
- * @returns {string|*}
- */
-function reviver_escape_json(key, value) {
-	const escaped_key = escape_json_in_html(key);
-	const escaped_value = typeof value === 'string' ? escape_json_in_html(value) : value;
-	if (escaped_key === key) {
-		return escaped_value;
-	} else {
-		// @ts-ignore
-		if (Object.prototype.hasOwnProperty.call(this, escaped_key) && this[escaped_key] !== value) {
-			// @ts-ignore
-			throw new Error(
-				`encountered object with invalid key and escaped key with different value: "${key}":"${value}", "${escaped_key}":"${this[escaped_key]}"`
-			);
-		}
-		// @ts-ignore
-		this[escaped_key] = escaped_value;
-	}
-}
-
-/**
- * use for escaping string values to be used html attributes on the page
- * e.g.
- * <script data-url="here">
- * @param {string} str
- * @returns string escaped string
- */
-export function escape_html_attr(str) {
-	return escape(str);
 }


### PR DESCRIPTION
and body of injected data script block

possibly fixes #2530 

full json escape is a proto implementation and tests fail locally for me. Unfortunately i wasn't able to tell if it's just bc fixtures need updating or there's an issue with the way it's encoded.

cc @Conduitry 

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
