### PR TITLE
Docker and Kubernetes support during npm init

### DIFF
--- a/.changeset/yellow-terms-lay.md
+++ b/.changeset/yellow-terms-lay.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': minor
+---
+
+Add Docker and Kubernetes support during npm init

--- a/packages/create-svelte/templates/default/.dockerignore
+++ b/packages/create-svelte/templates/default/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/create-svelte/templates/default/Dockerfile
+++ b/packages/create-svelte/templates/default/Dockerfile
@@ -1,0 +1,11 @@
+FROM docker.io/node:14 as build
+
+WORKDIR /app
+
+COPY package*.json .
+RUN npm install
+
+COPY . .
+
+# Pass --host flag to expose the server from container to host
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/packages/create-svelte/templates/default/k8s.yaml
+++ b/packages/create-svelte/templates/default/k8s.yaml
@@ -1,0 +1,31 @@
+# prettier-ignore
+apiVersion: v1
+kind: Service
+metadata:
+  name: ~TODO~-service
+spec:
+  selector:
+    app: ~TODO~-deployment
+  ports:
+    - port: 80
+      targetPort: 3000
+      protocol: TCP
+---
+# prettier-ignore
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ~TODO~-deployment
+spec:
+  selector:
+    matchLabels:
+      app: ~TODO~-deployment
+  template:
+    spec:
+      containers:
+        - name: ~TODO~-container
+          image: "~TODO~"
+          ports:
+            - containerPort: 3000
+              hostPort: 3000

--- a/packages/create-svelte/templates/skeleton/.dockerignore
+++ b/packages/create-svelte/templates/skeleton/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/create-svelte/templates/skeleton/Dockerfile
+++ b/packages/create-svelte/templates/skeleton/Dockerfile
@@ -1,0 +1,11 @@
+FROM docker.io/node:14 as build
+
+WORKDIR /app
+
+COPY package*.json .
+RUN npm install
+
+COPY . .
+
+# Pass --host flag to expose the server from container to host
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/packages/create-svelte/templates/skeleton/k8s.yaml
+++ b/packages/create-svelte/templates/skeleton/k8s.yaml
@@ -1,0 +1,31 @@
+# prettier-ignore
+apiVersion: v1
+kind: Service
+metadata:
+  name: ~TODO~-service
+spec:
+  selector:
+    app: ~TODO~-deployment
+  ports:
+    - port: 80
+      targetPort: 3000
+      protocol: TCP
+---
+# prettier-ignore
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ~TODO~-deployment
+spec:
+  selector:
+    matchLabels:
+      app: ~TODO~-deployment
+  template:
+    spec:
+      containers:
+        - name: ~TODO~-container
+          image: "~TODO~"
+          ports:
+            - containerPort: 3000
+              hostPort: 3000

--- a/packages/create-svelte/types/internal.d.ts
+++ b/packages/create-svelte/types/internal.d.ts
@@ -3,6 +3,8 @@ export type Options = {
 	typescript: boolean;
 	prettier: boolean;
 	eslint: boolean;
+	docker: boolean;
+	kubernetes: boolean;
 };
 
 export type File = {


### PR DESCRIPTION
This commit adds support for adding Docker and Kubernetes support during
project creation using npm init. The following files are additionally
created
* Dockerfile and .dockerignore (when Docker support is enabled)
* k8s.yaml with Deployment and Service (when Kubernetes support is
enabled)

Signed-off-by: Chaitanya Munukutla <chaitanya.m61292@gmail.com>

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
