### PR TITLE
chore: add missing changeset for accidental master push

### DIFF
--- a/.changeset/seven-colts-build.md
+++ b/.changeset/seven-colts-build.md
@@ -1,0 +1,10 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-static': patch
+'@sveltejs/adapter-vercel': patch
+'@sveltejs/kit': patch
+---
+
+update dependencies


### PR DESCRIPTION
Add missing changeset for https://github.com/sveltejs/kit/commit/f2d5f4966dfdc6d17f656cf78c9bce90ea541140

notable updates are esbuild 0.13.4, vite 2.6.5 and vite-plugin-svelte 1.0.0-next.27 which prepares for an upcoming change to vites ssr api.

I also remember @benmccann talking about marked, which is updated to 3.0.7 now.

Adapters are added to the changeset because of the changed esbuild version

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
