### PR TITLE
updated prerender docs to correct static adapter

### DIFF
--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -170,8 +170,8 @@ See [Prerendering](#ssr-and-javascript-prerender). An object containing zero or 
   - `function` — custom error handler allowing you to log, `throw` and fail the build, or take other action of your choosing based on the details of the crawl
 
     ```ts
-    /** @type {import('@sveltejs/kit').PrerenderErrorHandler} */
     import adapter from '@sveltejs/adapter-static';
+    /** @type {import('@sveltejs/kit').PrerenderErrorHandler} */
     const handleError = ({ status, path, referrer, referenceType }) => {
     	if (path.startsWith('/blog')) throw new Error('Missing a blog page!');
     	console.warn(`${status} ${path}${referrer ? ` (${referenceType} from ${referrer})` : ''}`);


### PR DESCRIPTION
There is no issue regarding this, but noticed the discrepancy when someone was struggling in the Svelte discord with this since static is a reserved word in JS and was causing errors. I have updated the docs to avoid confusion and use correct verbiage.

The change on line 144 was done by prettier, but should also be correct. Running `pnpm -r lint` returned no errors.