### PR TITLE
[docs] use Netlify's esbuild node_bundler command

### DIFF
--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -33,6 +33,9 @@ Then, make sure you have a [netlify.toml](https://docs.netlify.com/configure-bui
 [build]
   command = "npm run build"
   publish = "build"
+	
+[functions]
+  node_bundler = "esbuild"
 ```
 
 If the `netlify.toml` file or the `build.publish` value is missing, a default value of `"build"` will be used. Note that if you have set the publish directory in the Netlify UI to something else then you will need to set it in `netlify.toml` too, or use the default value of `"build"`.


### PR DESCRIPTION
Netlify is trying out a new node_bundler system and you can enable it through the flag 'esbuild'. Without this flag, users may have to install additional packages into their package.json file that don't relate to their project. Using the new node_bundler, you don't need to do this anymore.

### Related to this issue:
#1859 
