### PR TITLE
[fix] avoid infinite loop if no routes found

### DIFF
--- a/.changeset/serious-bears-listen.md
+++ b/.changeset/serious-bears-listen.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-[fix] avoid infinite loop and log warning if no routes found
+[fix] avoid infinite loop if no routes found

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -92,10 +92,6 @@ prog
 		try {
 			const watcher = await dev({ port, host, https, config });
 
-			if (!watcher.manifest || !watcher.manifest.routes.length) {
-				console.log(colors.bold().yellow('No route components found'));
-			}
-
 			watcher.on('stdout', (data) => {
 				process.stdout.write(data);
 			});
@@ -129,10 +125,6 @@ prog
 		try {
 			const { build } = await import('./core/build/index.js');
 			const build_data = await build(config);
-
-			if (!build_data.entries.length) {
-				console.log(colors.bold().yellow('No route components found'));
-			}
 
 			console.log(
 				`\nRun ${colors.bold().cyan('npm run preview')} to preview your production build locally.`

--- a/packages/kit/src/core/create_app/index.js
+++ b/packages/kit/src/core/create_app/index.js
@@ -118,7 +118,7 @@ function generate_app(manifest_data) {
 		...manifest_data.routes.map((route) =>
 			route.type === 'page' ? route.a.filter(Boolean).length : 0
 		),
-		0
+		1
 	);
 
 	const levels = [];


### PR DESCRIPTION
fix: https://github.com/sveltejs/kit/issues/2602

Please refer [My Comment](https://github.com/sveltejs/kit/pull/2614#issuecomment-945034814) for details.
~~I handled only `src/routes/index.svelte` because if another file is not found, we can notice it on browser.~~
~~(We can see a 404 message on browser.)~~

~~(Is it correct that always `src/routes/index.svelte` exists?🤔)~~
-> According to the comment, may not have `src/routes/index.svelte`.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
