### PR TITLE
[docs] adapter-netlify: remove Node 12 caveat

### DIFF
--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -8,8 +8,6 @@ This is very experimental; the adapter API isn't at all fleshed out, and things 
 
 > ⚠️ For the time being, the latest version of adapter-netlify is at the @next tag. If you get the error `config.kit.adapter should be an object with an "adapt" method.`, this is a sign that you are using the wrong version (eg `1.0.0-next.0` instead of `1.0.0-next.9`).
 
-> ⚠️ Netlify defaults to Node 12.16. SvelteKit requires Node v14.13 to build. You can pin the Node version with a `.node-version` or [`.nvmrc`](https://github.com/nvm-sh/nvm#nvmrc) file: `echo "14" > .nvmrc` or [set the `NODE_ENV` environment variable](https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-and-javascript).
-
 ```bash
 npm i -D @sveltejs/adapter-netlify@next
 ```


### PR DESCRIPTION
Netlify build images now [default to Ubuntu 20.04][1] with [Node 16][2], so the note regarding Node 12 in the readme is no longer required.

[1]: https://answers.netlify.com/t/all-new-sites-now-build-on-netlify-using-the-new-focal-build-image/42665
[2]: https://github.com/netlify/build-image/blob/focal/included_software.md#languages
