### PR TITLE
[docs] adapter-cloudflare-workers: make install instructions match other adapters

### DIFF
--- a/packages/adapter-cloudflare-workers/README.md
+++ b/packages/adapter-cloudflare-workers/README.md
@@ -4,6 +4,21 @@ SvelteKit adapter that creates a Cloudflare Workers site using a function for dy
 
 This is very experimental; the adapter API isn't at all fleshed out, and things will definitely change.
 
+## Usage
+
+Install with `npm i -D @sveltejs/adapter-cloudflare-workers@next`, then add the adapter to your `svelte.config.js`:
+
+```js
+import adapter from '@sveltejs/adapter-cloudflare-workers';
+
+export default {
+	kit: {
+		target: '#svelte',
+		adapter: adapter()
+	}
+};
+```
+
 ## Basic Configuration
 
 **You will need [Wrangler](https://developers.cloudflare.com/workers/cli-wrangler/install-update) installed on your system**
@@ -14,18 +29,6 @@ Generate this file using `wrangler` from your project directory
 
 ```sh
 wrangler init --site my-site-name
-```
-
-Add the adapter to your `svelte.config.js`:
-
-```js
-import adapter from '@sveltejs/adapter-cloudflare-workers';
-export default {
-	kit: {
-		target: '#svelte',
-		adapter: adapter()
-	}
-};
 ```
 
 Now you should get some details from Cloudflare. You should get your:


### PR DESCRIPTION
Fixes issue #2624 where I didn't know to install `@next`: this simply adds the `npm install` command (the part that was missing) and moves the configuration block up to the top (to match the instruction format in the other adapters).
