### PR TITLE
[feat] pass `ComponentLoader` to `handle`

### DIFF
--- a/.changeset/three-steaks-ring.md
+++ b/.changeset/three-steaks-ring.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[feat] experimental: pass ComponentLoader to handle

--- a/packages/kit/src/runtime/hooks.js
+++ b/packages/kit/src/runtime/hooks.js
@@ -6,7 +6,7 @@ export function sequence(...handlers) {
 	const length = handlers.length;
 	if (!length) return ({ request, resolve }) => resolve(request);
 
-	return ({ request, resolve }) => {
+	return ({ request, loader, resolve }) => {
 		return apply_handle(0, request);
 
 		/**
@@ -19,6 +19,7 @@ export function sequence(...handlers) {
 
 			return handle({
 				request,
+				loader,
 				resolve: i < length - 1 ? (request) => apply_handle(i + 1, request) : resolve
 			});
 		}

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -4,11 +4,12 @@ import { respond } from './respond.js';
  * @param {import('types/hooks').ServerRequest} request
  * @param {import('types/internal').SSRPage} route
  * @param {RegExpExecArray} match
+ * @param {import('types/internal').ComponentLoader} loader
  * @param {import('types/internal').SSRRenderOptions} options
  * @param {import('types/internal').SSRRenderState} state
  * @returns {Promise<import('types/hooks').ServerResponse | undefined>}
  */
-export async function render_page(request, route, match, options, state) {
+export async function render_page(request, route, match, loader, options, state) {
 	if (state.initiator === route) {
 		// infinite request cycle detected
 		return {
@@ -31,6 +32,7 @@ export async function render_page(request, route, match, options, state) {
 
 	const response = await respond({
 		request,
+		loader,
 		options,
 		state,
 		$session,

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -7,6 +7,7 @@ const s = JSON.stringify;
 /**
  * @param {{
  *   request: import('types/hooks').ServerRequest;
+ *   loader: import('types/internal').ComponentLoader;
  *   options: import('types/internal').SSRRenderOptions;
  *   state: import('types/internal').SSRRenderState;
  *   route: import('types/internal').SSRPage | null;
@@ -24,6 +25,7 @@ const s = JSON.stringify;
  */
 export async function load_node({
 	request,
+	loader,
 	options,
 	state,
 	route,
@@ -37,7 +39,7 @@ export async function load_node({
 	status,
 	error
 }) {
-	const { module } = node;
+	const module = /** @type import('types/internal').SSRComponent */ (node.module);
 
 	let uses_credentials = false;
 
@@ -163,6 +165,7 @@ export async function load_node({
 							rawBody: opts.body == null ? null : new TextEncoder().encode(opts.body),
 							query: new URLSearchParams(search)
 						},
+						loader,
 						options,
 						{
 							fetched: url,

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -11,6 +11,7 @@ const s = JSON.stringify;
 /**
  * @param {{
  *   branch: Array<import('./types').Loaded>;
+ *   loader: import('types/internal').ComponentLoader;
  *   options: import('types/internal').SSRRenderOptions;
  *   $session: any;
  *   page_config: { hydrate: boolean, router: boolean, ssr: boolean };
@@ -21,6 +22,7 @@ const s = JSON.stringify;
  */
 export async function render_response({
 	branch,
+	loader,
 	options,
 	$session,
 	page_config,
@@ -41,7 +43,7 @@ export async function render_response({
 	let maxage;
 
 	if (error) {
-		error.stack = options.get_stack(error);
+		loader.fixStackTrace({ error });
 	}
 
 	if (page_config.ssr) {

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -157,11 +157,12 @@ declare module '@sveltejs/kit/node' {
 declare module '@sveltejs/kit/ssr' {
 	import { IncomingRequest, Response } from '@sveltejs/kit';
 	// TODO import from public types, right now its heavily coupled with internal
+	type Loader = import('@sveltejs/kit/types/internal').ComponentLoader;
 	type Options = import('@sveltejs/kit/types/internal').SSRRenderOptions;
 	type State = import('@sveltejs/kit/types/internal').SSRRenderState;
 
 	export interface Respond {
-		(incoming: IncomingRequest, options: Options, state?: State): Promise<Response>;
+		(incoming: IncomingRequest, loader: Loader, options: Options, state?: State): Promise<Response>;
 	}
 	export const respond: Respond;
 }

--- a/packages/kit/types/hooks.d.ts
+++ b/packages/kit/types/hooks.d.ts
@@ -1,5 +1,6 @@
 import { IncomingRequest, ParameterizedBody } from './app';
 import { MaybePromise, ResponseHeaders } from './helper';
+import { ComponentLoader } from './internal';
 
 export type StrictBody = string | Uint8Array;
 
@@ -23,6 +24,7 @@ export interface GetSession<Locals = Record<string, any>, Body = unknown, Sessio
 export interface Handle<Locals = Record<string, any>, Body = unknown> {
 	(input: {
 		request: ServerRequest<Locals, Body>;
+		loader: ComponentLoader;
 		resolve(request: ServerRequest<Locals, Body>): MaybePromise<ServerResponse>;
 	}): MaybePromise<ServerResponse>;
 }

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -45,13 +45,26 @@ export interface Logger {
 	info(msg: string): void;
 }
 
-export interface SSRComponent {
+export interface SSRComponent extends GenericSSRComponent {
 	ssr?: boolean;
 	router?: boolean;
 	hydrate?: boolean;
 	prerender?: boolean;
 	preload?: any; // TODO remove for 1.0
 	load: Load;
+	default: {
+		render(props: Record<string, any>): {
+			html: string;
+			head: string;
+			css: {
+				code: string;
+				map: any; // TODO
+			};
+		};
+	};
+}
+
+export interface GenericSSRComponent {
 	default: {
 		render(props: Record<string, any>): {
 			html: string;
@@ -120,7 +133,7 @@ export interface Hooks {
 }
 
 export interface SSRNode {
-	module: SSRComponent;
+	module: GenericSSRComponent;
 	/** client-side module URL for this component */
 	entry: string;
 	/** external CSS files */
@@ -129,6 +142,12 @@ export interface SSRNode {
 	js: string[];
 	/** inlined styles */
 	styles: string[];
+}
+
+// TODO: expose this after experimental period
+export interface ComponentLoader {
+	fixStackTrace: ({ error }: { error: Error }) => void;
+	loadComponent({ id }: { id: PageId }): Promise<SSRNode>;
 }
 
 export interface SSRRenderOptions {
@@ -140,11 +159,9 @@ export interface SSRRenderOptions {
 		js: string[];
 	};
 	floc: boolean;
-	get_stack: (error: Error) => string | undefined;
 	handle_error(error: Error & { frame?: string }, request: ServerRequest<any>): void;
 	hooks: Hooks;
 	hydrate: boolean;
-	load_component(id: PageId): Promise<SSRNode>;
 	manifest: SSRManifest;
 	paths: {
 		base: string;


### PR DESCRIPTION
This is needed if you want to load any `.svelte` file from `handle`

One potential usecase would be allowing you to use any other router with SvelteKit allowing you to leverage SvelteKit adapters, HMR, etc. without using our router. I'm sure there'd be other use cases as well.

I tried using this with Routify and it basically worked except that Routify doesn't seem to support SSR.

Even if we don't expose this yet, separating out `ComponentLoader` from the routing options might be a nice change.

I have purposefully not documented this as I consider it an experimental API still. We can add it to the docs after we flesh it out.