### PR TITLE
[fix] adapter-netlify: handle undefined body

### DIFF
--- a/.changeset/afraid-eels-tease.md
+++ b/.changeset/afraid-eels-tease.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+[fix] adapter-netlify: handle undefined body

--- a/packages/adapter-netlify/files/entry.js
+++ b/packages/adapter-netlify/files/entry.js
@@ -31,20 +31,20 @@ export async function handler(event) {
 		...split_headers(rendered.headers)
 	};
 
-	if (typeof rendered.body === 'string') {
+	if (rendered.body instanceof Uint8Array) {
+		// Function responses should always be strings, and responses with binary
+		// content should be base64 encoded and set isBase64Encoded to true.
+		// https://github.com/netlify/functions/blob/main/src/function/response.d.ts
 		return {
 			...partial_response,
-			body: rendered.body
+			isBase64Encoded: true,
+			body: Buffer.from(rendered.body).toString('base64')
 		};
 	}
 
-	// Function responses should always be strings, and responses with binary
-	// content should be base64 encoded and set isBase64Encoded to true.
-	// https://github.com/netlify/functions/blob/main/src/function/response.d.ts
 	return {
 		...partial_response,
-		isBase64Encoded: true,
-		body: Buffer.from(rendered.body).toString('base64')
+		body: rendered.body
 	};
 }
 


### PR DESCRIPTION
Swap the condition so that when body is `undefined`, `null`, etc. we don't try to pass it into `Buffer.from`. Also, the old check wasn't quite correct in checking if the type was a string because you really should do `typeof myVar === 'string' || myVar instanceof String`

@Xenonym @Egnus do you want to check if this fix works for you?