### PR TITLE
[docs] `adapter-cloudflare-workers`: describe how to skip webpack bundling

### DIFF
--- a/packages/adapter-cloudflare-workers/README.md
+++ b/packages/adapter-cloudflare-workers/README.md
@@ -38,7 +38,7 @@ Now you should get some details from Cloudflare. You should get your:
 
 Get them by visiting your Cloudflare-Dashboard and click on any domain. There, you can scroll down and on the left, you can see your details under **API**.
 
-Then configure your sites build directory, your account-details and some other options in the config file. You may optionally specify a build command which will run before publishing (For example: `npm run build`) or just leave it empty. For all the available options, take a look at the [wrangler.toml](https://developers.cloudflare.com/workers/platform/sites/configuration) documentation on Cloudflare.
+Then configure your sites build directory and your account-details in the config file:
 
 ```toml
 account_id = 'YOUR ACCOUNT_ID'

--- a/packages/adapter-cloudflare-workers/README.md
+++ b/packages/adapter-cloudflare-workers/README.md
@@ -48,6 +48,7 @@ site = {bucket = "./build", entry-point = "./workers-site"}
 type = "javascript"
 
 [build]
+# Assume it's already been built. You can make this "npm run build" to ensure a build before publishing
 command = ""
 
 [build.upload]

--- a/packages/adapter-cloudflare-workers/README.md
+++ b/packages/adapter-cloudflare-workers/README.md
@@ -46,7 +46,6 @@ zone_id    = 'YOUR ZONE_ID' # optional, if you don't specify this a workers.dev 
 site = {bucket = "./build", entry-point = "./workers-site"}
 
 type = "javascript"
-compatibility_date = "2021-10-22"
 
 [build]
 command = ""

--- a/packages/adapter-cloudflare-workers/README.md
+++ b/packages/adapter-cloudflare-workers/README.md
@@ -38,12 +38,21 @@ Now you should get some details from Cloudflare. You should get your:
 
 Get them by visiting your Cloudflare-Dashboard and click on any domain. There, you can scroll down and on the left, you can see your details under **API**.
 
-Then configure your sites build directory and your account-details in the config file:
+Then configure your sites build directory, your account-details and some other options in the config file. You may optionally specify a build command which will run before publishing (For example: `npm run build`) or just leave it empty. For all the available options, take a look at the [wrangler.toml](https://developers.cloudflare.com/workers/platform/sites/configuration) documentation on Cloudflare.
 
 ```toml
 account_id = 'YOUR ACCOUNT_ID'
 zone_id    = 'YOUR ZONE_ID' # optional, if you don't specify this a workers.dev subdomain will be used.
 site = {bucket = "./build", entry-point = "./workers-site"}
+
+type = "javascript"
+compatibility_date = "2021-10-22"
+
+[build]
+command = ""
+
+[build.upload]
+format = "service-worker"
 ```
 
 It's recommended that you add the `build` and `workers-site` folders (or whichever other folders you specify) to your `.gitignore`.


### PR DESCRIPTION
Updated information on `wrangler.toml` configuration for the cloudflare workers adapter. fixes #2679