### PR TITLE
[fix] remove unnecessary body

### DIFF
--- a/packages/adapter-netlify/files/entry.js
+++ b/packages/adapter-netlify/files/entry.js
@@ -32,9 +32,9 @@ export async function handler(event) {
 	};
 
 	if (rendered.body instanceof Uint8Array) {
-		// Function responses should always be strings, and responses with binary
+		// Function responses should be strings (or undefined), and responses with binary
 		// content should be base64 encoded and set isBase64Encoded to true.
-		// https://github.com/netlify/functions/blob/main/src/function/response.d.ts
+		// https://github.com/netlify/functions/blob/main/src/function/response.ts
 		return {
 			...partial_response,
 			isBase64Encoded: true,

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -74,8 +74,7 @@ export async function respond(incoming, options, state = {}) {
 								if (request.headers['if-none-match'] === etag) {
 									return {
 										status: 304,
-										headers: {},
-										body: ''
+										headers: {}
 									};
 								}
 

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -55,8 +55,7 @@ export async function respond(opts) {
 		// otherwise bail out at this point
 		return {
 			status: 204,
-			headers: {},
-			body: ''
+			headers: {}
 		};
 	}
 


### PR DESCRIPTION
Empty string on return body was introduced on this [commit](https://github.com/sveltejs/kit/commit/2a1e9795ad9773e04669a7b9d0234caa0b688ade#diff-70bbf390c5a53b49a9f23557426bbd1bee9188a247ce1ef34e5f4f217036c7f6) I think that happened because ServerResponse.body type did not support nulls.

Because of that, there are problems when using miniflare(v2) which [uses](https://github.com/cloudflare/miniflare/blob/76cfa71fee062125fafe68b24aadee8709977193/packages/core/src/standards/http.ts#L345) nodejs/undici package to create Response instance. Undici [throws](https://github.com/nodejs/undici/blob/d8b3f35b8e46d3eb471e06ddcf1727b6aa01eefa/lib/fetch/response.js#L160) [TypeError](https://fetch.spec.whatwg.org/#ref-for-null-body-status%E2%91%A0) if we pass non-null body with 304(or any other null body status from [fetch specs](https://fetch.spec.whatwg.org/#null-body-status)).

This pull request removes unnecessary body returned on 304 and 204 statuses.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
