### PR TITLE
[fix] support etag W/ prefix

### DIFF
--- a/.changeset/giant-ghosts-give.md
+++ b/.changeset/giant-ghosts-give.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] support etag W/ prefix

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -71,7 +71,7 @@ export async function respond(incoming, options, state = {}) {
 							if (!cache_control || !/(no-store|immutable)/.test(cache_control)) {
 								let if_none_match_value = request.headers['if-none-match'];
 								// ignore W/ prefix https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match#directives
-								if (if_none_match_value?.startsWith('W/')) {
+								if (if_none_match_value?.indexOf('W/"') === 0) {
 									if_none_match_value = if_none_match_value.substring(2);
 								}
 

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -71,7 +71,7 @@ export async function respond(incoming, options, state = {}) {
 							if (!cache_control || !/(no-store|immutable)/.test(cache_control)) {
 								let if_none_match_value = request.headers['if-none-match'];
 								// ignore W/ prefix https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match#directives
-								if (if_none_match_value?.indexOf('W/"') === 0) {
+								if (if_none_match_value?.startsWith('W/"')) {
 									if_none_match_value = if_none_match_value.substring(2);
 								}
 

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -69,9 +69,15 @@ export async function respond(incoming, options, state = {}) {
 						if (response.status === 200) {
 							const cache_control = get_single_valued_header(response.headers, 'cache-control');
 							if (!cache_control || !/(no-store|immutable)/.test(cache_control)) {
+								let if_none_match_value = request.headers['if-none-match'];
+								// ignore W/ prefix https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match#directives
+								if (if_none_match_value?.startsWith('W/')) {
+									if_none_match_value = if_none_match_value.substring(2);
+								}
+
 								const etag = `"${hash(response.body || '')}"`;
 
-								if (request.headers['if-none-match'] === etag) {
+								if (if_none_match_value === etag) {
 									return {
 										status: 304,
 										headers: {},

--- a/packages/kit/test/apps/basics/src/routes/etag/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/etag/_tests.js
@@ -47,4 +47,27 @@ export default function (test) {
 			js: false
 		}
 	);
+
+	test(
+		'support W/ etag prefix',
+		null,
+		async ({ fetch }) => {
+			const r1 = await fetch('/etag/text');
+			const etag = r1.headers.get('etag');
+			assert.ok(!!etag);
+
+			const r2 = await fetch('/etag/text', {
+				headers: etag
+					? {
+							'if-none-match': `W/${etag}`
+					  }
+					: {}
+			});
+
+			assert.equal(r2.status, 304);
+		},
+		{
+			js: false
+		}
+	);
 }


### PR DESCRIPTION
Remove [W/ prefix](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match#directives) from if-none-match header value before comparing with body hash.

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
