### PR TITLE
[feat] ignore `.env` in starter templates

### DIFF
--- a/.changeset/mean-pumpkins-compete.md
+++ b/.changeset/mean-pumpkins-compete.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+feat: added .env to gitignore for skeleton and default starters

--- a/packages/create-svelte/templates/default/.gitignore
+++ b/packages/create-svelte/templates/default/.gitignore
@@ -3,3 +3,4 @@ node_modules
 /build
 /.svelte-kit
 /package
+.env

--- a/packages/create-svelte/templates/skeleton/.gitignore
+++ b/packages/create-svelte/templates/skeleton/.gitignore
@@ -3,3 +3,4 @@ node_modules
 /build
 /.svelte-kit
 /package
+.env


### PR DESCRIPTION
`.env` is added to `.gitignore` in skeleton and default starters

Closes #2718 

