### PR TITLE
[fix] reset scroll when navigated from scrolled page

### DIFF
--- a/.changeset/wet-papayas-live.md
+++ b/.changeset/wet-papayas-live.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] reset scroll when navigated from scrolled page

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -275,33 +275,34 @@ export class Renderer {
 			this._init(navigation_result);
 		}
 
-		if (opts) {
-			if (!opts.keepfocus) {
+		if (!opts) {
+			await 0;
+		} else {
+			const { hash, scroll, keepfocus } = opts;
+
+			if (!keepfocus) {
 				document.body.focus();
 			}
 
-			// Scroll to top so we can compare the `pageYOffset` below. We cannot
-			// compare by recording the `pageYOffset` here as there is a possibility
-			// it will change, e.g. different page heights
-			scrollTo(0, 0);
-		}
+			const oldPageYOffset = pageYOffset;
+			await 0;
+			const maxPageYOffset = document.body.scrollHeight - innerHeight;
 
-		await 0;
-
-		// After `await 0`, the `onMount()` function in the component executed.
-		// If there was no scrolling happening (checked via `pageYOffset`),
-		// continue on our custom scroll handling
-		if (pageYOffset === 0 && opts) {
-			const { hash, scroll } = opts;
-
-			const deep_linked = hash && document.getElementById(hash.slice(1));
-			if (scroll) {
-				scrollTo(scroll.x, scroll.y);
-			} else if (deep_linked) {
-				// Here we use `scrollIntoView` on the element instead of `scrollTo`
-				// because it natively supports the `scroll-margin` and `scroll-behavior`
-				// CSS properties.
-				deep_linked.scrollIntoView();
+			// After `await 0`, the `onMount()` function in the component executed.
+			// If there was no scrolling happening (checked via `pageYOffset`),
+			// continue on our custom scroll handling
+			if (pageYOffset === Math.min(oldPageYOffset, maxPageYOffset)) {
+				const deep_linked = hash && document.getElementById(hash.slice(1));
+				if (scroll) {
+					scrollTo(scroll.x, scroll.y);
+				} else if (deep_linked) {
+					// Here we use `scrollIntoView` on the element instead of `scrollTo`
+					// because it natively supports the `scroll-margin` and `scroll-behavior`
+					// CSS properties.
+					deep_linked.scrollIntoView();
+				} else {
+					scrollTo(0, 0);
+				}
 			}
 		}
 

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -281,7 +281,7 @@ export class Renderer {
 			}
 
 			// Scroll to top so we can compare the `pageYOffset` below. We cannot
-			// compare by recording the `pageYOffset` here as there is a possiblity
+			// compare by recording the `pageYOffset` here as there is a possibility
 			// it will change, e.g. different page heights
 			scrollTo(0, 0);
 		}

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -280,16 +280,16 @@ export class Renderer {
 				document.body.focus();
 			}
 
-			// Scroll to top so we can compare the pageYOffset below. We cannot
-			// compare by recording the pageYOffset here as there is a possiblity
-			// it will change, e.g. different scroll heights
+			// Scroll to top so we can compare the `pageYOffset` below. We cannot
+			// compare by recording the `pageYOffset` here as there is a possiblity
+			// it will change, e.g. different page heights
 			scrollTo(0, 0);
 		}
 
 		await 0;
 
-		// After `await 0`, the onMount() function in the component executed.
-		// If there was no scrolling happening (checked via pageYOffset),
+		// After `await 0`, the `onMount()` function in the component executed.
+		// If there was no scrolling happening (checked via `pageYOffset`),
 		// continue on our custom scroll handling
 		if (pageYOffset === 0 && opts) {
 			const { hash, scroll } = opts;

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -275,8 +275,15 @@ export class Renderer {
 			this._init(navigation_result);
 		}
 
-		if (!opts?.keepfocus) {
-			document.body.focus();
+		if (opts) {
+			if (!opts.keepfocus) {
+				document.body.focus();
+			}
+
+			// Scroll to top so we can compare the pageYOffset below. We cannot
+			// compare by recording the pageYOffset here as there is a possiblity
+			// it will change, e.g. different scroll heights
+			scrollTo(0, 0);
 		}
 
 		await 0;
@@ -295,8 +302,6 @@ export class Renderer {
 				// because it natively supports the `scroll-margin` and `scroll-behavior`
 				// CSS properties.
 				deep_linked.scrollIntoView();
-			} else {
-				scrollTo(0, 0);
 			}
 		}
 

--- a/packages/kit/test/apps/basics/src/routes/anchor-with-manual-scroll/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/anchor-with-manual-scroll/_tests.js
@@ -9,10 +9,9 @@ export default function (test) {
 	test(
 		'url-supplied anchor is ignored with onMount() scrolling on direct page load',
 		'/anchor-with-manual-scroll/anchor#go-to-element',
-		async ({ page, js }) => {
+		async ({ is_intersecting_viewport, js }) => {
 			if (js) {
-				const p = await page.$('#abcde');
-				assert.ok(p && (await p.isVisible()));
+				assert.ok(is_intersecting_viewport('#abcde'));
 			}
 		}
 	);
@@ -20,11 +19,10 @@ export default function (test) {
 	test(
 		'url-supplied anchor is ignored with onMount() scrolling on navigation to page',
 		'/anchor-with-manual-scroll',
-		async ({ page, clicknav, js }) => {
+		async ({ clicknav, is_intersecting_viewport, js }) => {
 			await clicknav('[href="/anchor-with-manual-scroll/anchor#go-to-element"]');
 			if (js) {
-				const p = await page.$('#abcde');
-				assert.ok(p && (await p.isVisible()));
+				assert.ok(is_intersecting_viewport('#abcde'));
 			}
 		}
 	);

--- a/packages/kit/test/apps/basics/src/routes/anchor/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/anchor/_tests.js
@@ -21,7 +21,19 @@ export default function (test) {
 		'url-supplied anchor works on navigation to page',
 		'/anchor',
 		async ({ page, clicknav, js }) => {
-			await clicknav('[href="/anchor/anchor#go-to-element"]');
+			await clicknav('#first-anchor');
+			if (js) {
+				const p = await page.$('#go-to-element');
+				assert.ok(p && (await p.isVisible()));
+			}
+		}
+	);
+
+	test(
+		'url-supplied anchor works when navigated from scrolled page',
+		'/anchor',
+		async ({ page, clicknav, js }) => {
+			await clicknav('#second-anchor');
 			if (js) {
 				const p = await page.$('#go-to-element');
 				assert.ok(p && (await p.isVisible()));

--- a/packages/kit/test/apps/basics/src/routes/anchor/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/anchor/_tests.js
@@ -9,10 +9,9 @@ export default function (test) {
 	test(
 		'url-supplied anchor works on direct page load',
 		'/anchor/anchor#go-to-element',
-		async ({ page, js }) => {
+		async ({ is_intersecting_viewport, js }) => {
 			if (js) {
-				const p = await page.$('#go-to-element');
-				assert.ok(p && (await p.isVisible()));
+				assert.ok(is_intersecting_viewport('#go-to-element'));
 			}
 		}
 	);
@@ -20,11 +19,10 @@ export default function (test) {
 	test(
 		'url-supplied anchor works on navigation to page',
 		'/anchor',
-		async ({ page, clicknav, js }) => {
+		async ({ clicknav, is_intersecting_viewport, js }) => {
 			await clicknav('#first-anchor');
 			if (js) {
-				const p = await page.$('#go-to-element');
-				assert.ok(p && (await p.isVisible()));
+				assert.ok(is_intersecting_viewport('#go-to-element'));
 			}
 		}
 	);
@@ -32,11 +30,10 @@ export default function (test) {
 	test(
 		'url-supplied anchor works when navigated from scrolled page',
 		'/anchor',
-		async ({ page, clicknav, js }) => {
+		async ({ clicknav, is_intersecting_viewport, js }) => {
 			await clicknav('#second-anchor');
 			if (js) {
-				const p = await page.$('#go-to-element');
-				assert.ok(p && (await p.isVisible()));
+				assert.ok(is_intersecting_viewport('#go-to-element'));
 			}
 		}
 	);

--- a/packages/kit/test/apps/basics/src/routes/anchor/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/anchor/index.svelte
@@ -1,5 +1,7 @@
 <h1>Welcome to a test project</h1>
-<a href="/anchor/anchor#go-to-element">Anchor demo</a>
+<a id="first-anchor" href="/anchor/anchor#go-to-element">Anchor demo</a>
+<div>Spacing</div>
+<a id="second-anchor" href="/anchor/anchor#go-to-element">Anchor demo below</a>
 
 <style>
 	:global(body) {
@@ -11,5 +13,10 @@
 	a {
 		display: block;
 		margin: 20px;
+	}
+
+	div {
+		background-color: hotpink;
+		height: 180vh;
 	}
 </style>

--- a/packages/kit/test/apps/basics/src/routes/use-action/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/use-action/_tests.js
@@ -9,10 +9,9 @@ export default function (test) {
 	test(
 		'app-supplied scroll and focus work on direct page load',
 		'/use-action/focus-and-scroll',
-		async ({ page, js }) => {
+		async ({ page, is_intersecting_viewport, js }) => {
 			if (js) {
-				const input = await page.$('#input');
-				assert.ok(input && (await input.isVisible()));
+				assert.ok(await is_intersecting_viewport('#input'));
 				assert.ok(await page.$eval('#input', (el) => el === document.activeElement));
 			}
 		}
@@ -21,11 +20,10 @@ export default function (test) {
 	test(
 		'app-supplied scroll and focus work on navigation to page',
 		'/use-action',
-		async ({ page, clicknav, js }) => {
+		async ({ page, clicknav, is_intersecting_viewport, js }) => {
 			await clicknav('[href="/use-action/focus-and-scroll"]');
 			if (js) {
-				const input = await page.$('#input');
-				assert.ok(input && (await input.isVisible()));
+				assert.ok(await is_intersecting_viewport('#input'));
 				assert.ok(await page.$eval('#input', (el) => el === document.activeElement));
 			}
 		}

--- a/packages/kit/test/types.d.ts
+++ b/packages/kit/test/types.d.ts
@@ -17,6 +17,10 @@ export interface TestContext {
 	response: PlaywrightResponse;
 	clicknav(selector: string): Promise<void>;
 	back(): Promise<void>;
+	/**
+	 * Only supported in js mode
+	 */
+	is_intersecting_viewport(selector: string): Promise<boolean>;
 	fetch(url: RequestInfo, opts?: RequestInit): Promise<NodeFetchResponse>;
 	capture_requests(fn: () => Promise<void>): Promise<string[]>;
 	errors(): string;


### PR DESCRIPTION
Fixes #2733 and maybe #2664

Move the scroll to top logic before the new route mounts so that we can properly compare the `pageYOffset === 0`. This works because scroll position is preserved between route changes by default.

I also updated our `isVisble()` tests to `is_intersecting_viewport()`, since `isVisble` checks for visibility anywhere in the document. `is_intersecting_viewport` makes sure they are in the viewport.

Nonetheless, @mquandalle and @mikenikles I'd appreciate if y'all can try to see if this branch fixes your issue as well.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
