### PR TITLE
[fix] persist scroll position without scroll event (#365)

### DIFF
--- a/.changeset/shaggy-ants-smell.md
+++ b/.changeset/shaggy-ants-smell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Persist scroll position without scroll event

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -282,9 +282,7 @@ export class Renderer {
 		await 0;
 
 		// After `await 0`, the onMount() function in the component executed.
-		// If there was no scrolling happening (checked via pageYOffset),
-		// continue on our custom scroll handling
-		if (pageYOffset === 0 && opts) {
+		if (opts) {
 			const { hash, scroll } = opts;
 
 			const deep_linked = hash && document.getElementById(hash.slice(1));


### PR DESCRIPTION
## Solution

A faster approach to persisting scroll position without using 'scroll' events. When a `popstate` event is fired, which happens **after** a user navigates backwards (or forwards), we navigate in reverse to store the scroll position in the history's state of the previous page, and subsequently navigate in reverse again to arrive at the intended page.

This should also fix Sentry API abuse complaints regarding history.replaceState described in #365.

## Problem

A debounced 'scroll' event is used to store scroll events, which harms scrolling performance. Unfortunately browsers don't provide an event like 'popstate' that fires **before** a user navigates backwards (or forwards), however my trick should do it for the browsers I've tested it on.

### Before submitting the PR, please make sure you do the following
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
