### PR TITLE
[docs] add types for error load function

### DIFF
--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -101,9 +101,7 @@ export interface RequestHandler<
 ```js
 import db from '$lib/database';
 
-/**
- * @type {import('@sveltejs/kit').RequestHandler}
- */
+/** @type {import('@sveltejs/kit').RequestHandler} */
 export async function get({ params }) {
 	// the `slug` parameter is available because this file
 	// is called [slug].json.js

--- a/documentation/docs/02-layouts.md
+++ b/documentation/docs/02-layouts.md
@@ -76,6 +76,20 @@ For example, if `src/routes/settings/notifications/index.svelte` failed to load,
 
 > SvelteKit provides a default error page in case you don't supply `src/routes/__error.svelte`, but it's recommended that you bring your own.
 
+```ts
+// declaration type
+// * also see type for `LoadOutput` in the Loading section
+
+export interface ErrorLoadInput<
+	PageParams extends Rec<string> = Rec<string>,
+	Stuff extends Rec = Rec,
+	Session = any
+> extends LoadInput<PageParams, Stuff, Session> {
+	status?: number;
+	error?: Error;
+}
+```
+
 If an error component has a [`load`](#loading) function, it will be called with `error` and `status` properties:
 
 ```html
@@ -98,17 +112,3 @@ If an error component has a [`load`](#loading) function, it will be called with 
 ```
 
 > Server-side stack traces will be removed from `error` in production, to avoid exposing privileged information to users.
-
-```ts
-// declaration type
-// * also see type for `LoadOutput` in the Loading section
-
-export interface ErrorLoadInput<
-	PageParams extends Rec<string> = Rec<string>,
-	Stuff extends Rec = Rec,
-	Session = any
-> extends LoadInput<PageParams, Stuff, Session> {
-	status?: number;
-	error?: Error;
-}
-```

--- a/documentation/docs/02-layouts.md
+++ b/documentation/docs/02-layouts.md
@@ -80,11 +80,14 @@ If an error component has a [`load`](#loading) function, it will be called with 
 
 ```html
 <script context="module">
+	/**
+	 * @type {import('@sveltejs/kit').ErrorLoad}
+	 */
 	export function load({ error, status }) {
 		return {
 			props: {
-				title: `${status}: ${error.message}`
-			}
+				title: `${status}: ${error.message}`,
+			},
 		};
 	}
 </script>
@@ -97,3 +100,17 @@ If an error component has a [`load`](#loading) function, it will be called with 
 ```
 
 > Server-side stack traces will be removed from `error` in production, to avoid exposing privileged information to users.
+
+```ts
+// declaration type
+// * also see type for `LoadOutput` in the Loading section
+
+export interface ErrorLoadInput<
+	PageParams extends Rec<string> = Rec<string>,
+	Stuff extends Rec = Rec,
+	Session = any
+> extends LoadInput<PageParams, Stuff, Session> {
+	status?: number;
+	error?: Error;
+}
+```

--- a/documentation/docs/02-layouts.md
+++ b/documentation/docs/02-layouts.md
@@ -80,14 +80,12 @@ If an error component has a [`load`](#loading) function, it will be called with 
 
 ```html
 <script context="module">
-	/**
-	 * @type {import('@sveltejs/kit').ErrorLoad}
-	 */
+	/** @type {import('@sveltejs/kit').ErrorLoad} */
 	export function load({ error, status }) {
 		return {
 			props: {
-				title: `${status}: ${error.message}`,
-			},
+				title: `${status}: ${error.message}`
+			}
 		};
 	}
 </script>

--- a/documentation/docs/02-layouts.md
+++ b/documentation/docs/02-layouts.md
@@ -81,8 +81,8 @@ For example, if `src/routes/settings/notifications/index.svelte` failed to load,
 // * also see type for `LoadOutput` in the Loading section
 
 export interface ErrorLoadInput<
-	PageParams extends Rec<string> = Rec<string>,
-	Stuff extends Rec = Rec,
+	PageParams extends Record<string, string> = Record<string, string>,
+	Stuff extends Record<string, any> = Record<string, any>,
 	Session = any
 > extends LoadInput<PageParams, Stuff, Session> {
 	status?: number;

--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -41,9 +41,7 @@ Our example blog page might contain a `load` function like the following:
 
 ```html
 <script context="module">
-	/**
-	 * @type {import('@sveltejs/kit').Load}
-	 */
+	/** @type {import('@sveltejs/kit').Load} */
 	export async function load({ page, fetch, session, stuff }) {
 		const url = `/blog/${page.params.slug}.json`;
 		const res = await fetch(url);

--- a/documentation/docs/80-adapter-api.md
+++ b/documentation/docs/80-adapter-api.md
@@ -7,9 +7,7 @@ We recommend [looking at the source for an adapter](https://github.com/sveltejs/
 Adapters packages must implement the following API, which creates an `Adapter`:
 
 ```js
-/**
- * @param {AdapterSpecificOptions} options
- */
+/** @param {AdapterSpecificOptions} options */
 export default function (options) {
 	/** @type {import('@sveltejs/kit').Adapter} */
 	return {


### PR DESCRIPTION
related to https://github.com/sveltejs/kit/issues/2712

Pure doc change.

This makes the error `load` description consistent with the description for `load`.

Seems that we're not cluttering the docs with TypeScript for now, since we don't have code tabs to make it neat.  JSDoc types are helpful though.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
