### PR TITLE
[fix] increase scroll debounce timeout

### DIFF
--- a/.changeset/eight-glasses-sparkle.md
+++ b/.changeset/eight-glasses-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] increase scroll debounce timeout

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -88,7 +88,7 @@ export class Router {
 					'sveltekit:scroll': scroll_state()
 				};
 				history.replaceState(new_state, document.title, window.location.href);
-				// iOS scroll event intervals happens between 30-150ms, sometimes around 200ms
+				// iOS scroll event intervals happen between 30-150ms, sometimes around 200ms
 			}, 200);
 		});
 

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -88,6 +88,7 @@ export class Router {
 					'sveltekit:scroll': scroll_state()
 				};
 				history.replaceState(new_state, document.title, window.location.href);
+			// iOS scroll event intervals happens between 30-150ms, sometimes around 200ms
 			}, 200);
 		});
 

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -88,7 +88,7 @@ export class Router {
 					'sveltekit:scroll': scroll_state()
 				};
 				history.replaceState(new_state, document.title, window.location.href);
-			// iOS scroll event intervals happens between 30-150ms, sometimes around 200ms
+				// iOS scroll event intervals happens between 30-150ms, sometimes around 200ms
 			}, 200);
 		});
 

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -88,7 +88,7 @@ export class Router {
 					'sveltekit:scroll': scroll_state()
 				};
 				history.replaceState(new_state, document.title, window.location.href);
-			}, 50);
+			}, 200);
 		});
 
 		/** @param {MouseEvent|TouchEvent} event */


### PR DESCRIPTION
Fixes #365 

iOS scroll event intervals happens between 30-150ms, sometimes around 200ms. So we set the debounce timeout to 200ms to prevent most false positives.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
