### PR TITLE
[fix] Correct type definition of `window.started`

### DIFF
--- a/packages/kit/test/ambient.d.ts
+++ b/packages/kit/test/ambient.d.ts
@@ -1,7 +1,7 @@
 declare global {
 	interface Window {
 		navigated: Promise<void>;
-		started: boolean;
+		started: Promise<void>;
 
 		// used in tests
 		oops: string;


### PR DESCRIPTION
related: https://github.com/sveltejs/kit/issues/2648

`ambient.d.ts` defines `window.started` as boolean.
But the actual type is `Promise<void>`.
So I corrected it out.

https://github.com/sveltejs/kit/blob/52c0f99e57b993e9749e05a7c4567c4c9e25ad34/packages/kit/test/test.js#L48-L58

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
