### PR TITLE
[fix] do not set inlineDynamicImports

### DIFF
--- a/.changeset/honest-singers-guess.md
+++ b/.changeset/honest-singers-guess.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] do not set inlineDynamicImports

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -439,12 +439,7 @@ async function build_server(
 
 	const default_config = {
 		build: {
-			target: 'es2020',
-			rollupOptions: {
-				output: {
-					inlineDynamicImports: true
-				}
-			}
+			target: 'es2020'
 		},
 		server: {
 			fs: {


### PR DESCRIPTION
This would enable both https://github.com/sveltejs/kit/pull/2529 and https://github.com/sveltejs/kit/pull/2580

Rich said he set it because he thought Netlify may need it, but I deployed an app to Netlify without the setting and it worked just fine: https://eloquent-mestorf-107ac7.netlify.app/top/1. So we could possibly remove it since it doesn't really seem necessary

This is a setting people have complained about in the past (https://github.com/sveltejs/kit/issues/1571 and https://github.com/sveltejs/kit/issues/1718), so we recently changed it to allow it to be overriden. That means people have been setting it to false in production already, which should give us confidence that it works