### PR TITLE
[fix] properly scroll if body has margin

### DIFF
--- a/.changeset/tender-pans-explode.md
+++ b/.changeset/tender-pans-explode.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] properly scroll if body has margin

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -286,7 +286,7 @@ export class Renderer {
 
 			const oldPageYOffset = pageYOffset;
 			await 0;
-			const maxPageYOffset = document.body.scrollHeight - innerHeight;
+			const maxPageYOffset = document.documentElement.scrollHeight - innerHeight;
 
 			// After `await 0`, the `onMount()` function in the component executed.
 			// If there was no scrolling happening (checked via `pageYOffset`),

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -284,14 +284,26 @@ export class Renderer {
 				document.body.focus();
 			}
 
-			const oldPageYOffset = pageYOffset;
+			const old_page_y_offset = Math.round(pageYOffset);
+			const old_max_page_y_offset = document.documentElement.scrollHeight - innerHeight;
+
 			await 0;
-			const maxPageYOffset = document.documentElement.scrollHeight - innerHeight;
+
+			const new_page_y_offset = Math.round(pageYOffset);
+			const new_max_page_y_offset = document.documentElement.scrollHeight - innerHeight;
 
 			// After `await 0`, the `onMount()` function in the component executed.
-			// If there was no scrolling happening (checked via `pageYOffset`),
-			// continue on our custom scroll handling
-			if (pageYOffset === Math.min(oldPageYOffset, maxPageYOffset)) {
+			// Check if no scrolling happened on mount.
+			const no_scroll_happened =
+				// In most cases, we can compare whether `pageYOffset` changed between navigation
+				new_page_y_offset === Math.min(old_page_y_offset, new_max_page_y_offset) ||
+				// But if the page is scrolled to/near the bottom, the browser would also scroll
+				// to/near the bottom of the new page on navigation. Since we can't detect when this
+				// behaviour happens, we naively compare by the y offset from the bottom of the page.
+				old_max_page_y_offset - old_page_y_offset === new_max_page_y_offset - new_page_y_offset;
+
+			// If there was no scrolling, we run on our custom scroll handling
+			if (no_scroll_happened) {
 				const deep_linked = hash && document.getElementById(hash.slice(1));
 				if (scroll) {
 					scrollTo(scroll.x, scroll.y);

--- a/packages/kit/test/apps/basics/src/routes/anchor-with-manual-scroll/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/anchor-with-manual-scroll/_tests.js
@@ -11,7 +11,7 @@ export default function (test) {
 		'/anchor-with-manual-scroll/anchor#go-to-element',
 		async ({ is_intersecting_viewport, js }) => {
 			if (js) {
-				assert.ok(is_intersecting_viewport('#abcde'));
+				assert.ok(await is_intersecting_viewport('#abcde'));
 			}
 		}
 	);
@@ -22,7 +22,7 @@ export default function (test) {
 		async ({ clicknav, is_intersecting_viewport, js }) => {
 			await clicknav('[href="/anchor-with-manual-scroll/anchor#go-to-element"]');
 			if (js) {
-				assert.ok(is_intersecting_viewport('#abcde'));
+				assert.ok(await is_intersecting_viewport('#abcde'));
 			}
 		}
 	);

--- a/packages/kit/test/apps/basics/src/routes/anchor-with-manual-scroll/anchor.svelte
+++ b/packages/kit/test/apps/basics/src/routes/anchor-with-manual-scroll/anchor.svelte
@@ -11,6 +11,7 @@
 	<p id="go-to-element">The browser scrolls to me</p>
 </div>
 <p id="abcde">I take precedence</p>
+<div />
 
 <style>
 	div {

--- a/packages/kit/test/apps/basics/src/routes/anchor/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/anchor/_tests.js
@@ -11,7 +11,7 @@ export default function (test) {
 		'/anchor/anchor#go-to-element',
 		async ({ is_intersecting_viewport, js }) => {
 			if (js) {
-				assert.ok(is_intersecting_viewport('#go-to-element'));
+				assert.ok(await is_intersecting_viewport('#go-to-element'));
 			}
 		}
 	);
@@ -22,7 +22,7 @@ export default function (test) {
 		async ({ clicknav, is_intersecting_viewport, js }) => {
 			await clicknav('#first-anchor');
 			if (js) {
-				assert.ok(is_intersecting_viewport('#go-to-element'));
+				assert.ok(await is_intersecting_viewport('#go-to-element'));
 			}
 		}
 	);
@@ -33,7 +33,40 @@ export default function (test) {
 		async ({ clicknav, is_intersecting_viewport, js }) => {
 			await clicknav('#second-anchor');
 			if (js) {
-				assert.ok(is_intersecting_viewport('#go-to-element'));
+				assert.ok(await is_intersecting_viewport('#go-to-element'));
+			}
+		}
+	);
+
+	test(
+		'no-anchor url will scroll to top when navigated from scrolled page',
+		'/anchor',
+		async ({ clicknav, page, js }) => {
+			await clicknav('#third-anchor');
+			if (js) {
+				assert.ok(await page.evaluate(() => pageYOffset === 0));
+			}
+		}
+	);
+
+	test(
+		'url-supplied anchor works when navigated from bottom of page',
+		'/anchor',
+		async ({ clicknav, is_intersecting_viewport, js }) => {
+			await clicknav('#last-anchor');
+			if (js) {
+				assert.ok(await is_intersecting_viewport('#go-to-element'));
+			}
+		}
+	);
+
+	test(
+		'no-anchor url will scroll to top when navigated from bottom of page',
+		'/anchor',
+		async ({ clicknav, page, js }) => {
+			await clicknav('#last-anchor-2');
+			if (js) {
+				assert.ok(await page.evaluate(() => pageYOffset === 0));
 			}
 		}
 	);

--- a/packages/kit/test/apps/basics/src/routes/anchor/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/anchor/index.svelte
@@ -1,7 +1,12 @@
 <h1>Welcome to a test project</h1>
-<a id="first-anchor" href="/anchor/anchor#go-to-element">Anchor demo</a>
+<a id="first-anchor" href="/anchor/anchor#go-to-element">Anchor demo (first)</a>
 <div>Spacing</div>
-<a id="second-anchor" href="/anchor/anchor#go-to-element">Anchor demo below</a>
+<a id="second-anchor" href="/anchor/anchor#go-to-element">Anchor demo (second)</a>
+<div>Spacing</div>
+<a id="third-anchor" href="/anchor/anchor">Anchor demo (third)</a>
+<div>Spacing</div>
+<a id="last-anchor" href="/anchor/anchor#go-to-element">Anchor demo (last)</a>
+<a id="last-anchor-2" href="/anchor/anchor">Anchor demo (last 2)</a>
 
 <style>
 	:global(body) {


### PR DESCRIPTION
Fixes #2760


### Changes

- Fixed my dumb tests update mistake from my last PR (tests were actually failing)
- Use `document.documentElement` instead of `document.body` when checking for max scroll y
- Also fixes another sizable bug I found: When scrolling to/near the end of a page, the new page after navigation would also be scrolled to/near the end of the page by the browser regardless of the new page scroll height. Added extra checks for that.

Note: We may need to find a robust way to check for scrolling before the page `onMount()` runs. The `pageYOffset` trick is starting to bite us.

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
