### PR TITLE
Support for Vercel beta filesystem API

### DIFF
--- a/packages/adapter-vercel/files/entry.js
+++ b/packages/adapter-vercel/files/entry.js
@@ -10,33 +10,34 @@ const getResult = (body, options) => ({
 	response: new Response(body, options)
 });
 
-_ENTRIES = typeof _ENTRIES === 'undefined' ? {} : _ENTRIES;
+// eslint-disable-next-line
+_ENTRIES = {
+	middleware_kit: {
+		async default({ request }) {
+			if (request.method === 'GET') {
+				const { pathname, searchParams } = new URL(request.url);
 
-_ENTRIES['middleware_kit'] = {
-	async default({ request }) {
-		if (request.method === 'GET') {
-			const { pathname, searchParams } = new URL(request.url);
+				if (!assets.has(pathname.slice(1))) {
+					const rendered = await render({
+						method: request.method,
+						headers: request.headers,
+						path: pathname,
+						query: searchParams,
+						rawBody: new Uint8Array() // TODO
+					});
 
-			if (!assets.has(pathname.slice(1))) {
-				const rendered = await render({
-					method: request.method,
-					headers: request.headers,
-					path: pathname,
-					query: searchParams,
-					rawBody: new Uint8Array() // TODO
-				});
-
-				if (rendered) {
-					const { status, headers, body } = rendered;
-					return getResult(body, { status, headers });
+					if (rendered) {
+						const { status, headers, body } = rendered;
+						return getResult(body, { status, headers });
+					}
 				}
 			}
-		}
 
-		return getResult(null, {
-			headers: {
-				'x-middleware-next': '1'
-			}
-		});
+			return getResult(null, {
+				headers: {
+					'x-middleware-next': '1'
+				}
+			});
+		}
 	}
 };

--- a/packages/adapter-vercel/files/functions-manifest.json
+++ b/packages/adapter-vercel/files/functions-manifest.json
@@ -1,0 +1,14 @@
+{
+	"version": 1,
+	"pages": {
+		"_middleware.js": {
+			"runtime": "web",
+			"env": [],
+			"files": ["server/pages/_middleware.js"],
+			"name": "kit",
+			"page": "/",
+			"regexp": "^/.*$",
+			"sortingIndex": 1
+		}
+	}
+}

--- a/packages/adapter-vercel/files/routes.json
+++ b/packages/adapter-vercel/files/routes.json
@@ -1,9 +1,0 @@
-[
-	{
-		"handle": "filesystem"
-	},
-	{
-		"src": "/.*",
-		"dest": ".vercel/functions/render"
-	}
-]

--- a/packages/adapter-vercel/files/shims.js
+++ b/packages/adapter-vercel/files/shims.js
@@ -1,1 +1,0 @@
-export { fetch, Response, Request, Headers } from '@sveltejs/kit/install-fetch';

--- a/packages/create-svelte/templates/default/.gitignore
+++ b/packages/create-svelte/templates/default/.gitignore
@@ -4,3 +4,6 @@ node_modules
 /.svelte-kit
 /package
 .env
+
+.vercel
+.output

--- a/packages/create-svelte/templates/default/package.json
+++ b/packages/create-svelte/templates/default/package.json
@@ -4,7 +4,8 @@
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build --verbose",
-		"start": "svelte-kit start"
+		"start": "svelte-kit start",
+		"deploy": "ADAPTER=@sveltejs/adapter-vercel npm run build && vercel deploy --prebuilt"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-cloudflare-workers": "next",

--- a/packages/kit/src/core/adapt/utils.js
+++ b/packages/kit/src/core/adapt/utils.js
@@ -18,6 +18,8 @@ export function get_utils({ cwd, config, build_data, log }) {
 		mkdirp,
 		copy,
 
+		build_data,
+
 		copy_client_files(dest) {
 			return copy(`${cwd}/${SVELTE_KIT}/output/client`, dest, (file) => file[0] !== '.');
 		},

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -1,6 +1,6 @@
 import { UserConfig as ViteConfig } from 'vite';
 import { RecursiveRequired } from './helper';
-import { Logger, TrailingSlash } from './internal';
+import { Logger, TrailingSlash, BuildData } from './internal';
 
 export interface AdapterUtils {
 	log: Logger;
@@ -28,6 +28,7 @@ export interface AdapterUtils {
 	 */
 	copy(from: string, to: string, filter?: (basename: string) => boolean): string[];
 	prerender(options: { all?: boolean; dest: string; fallback?: string }): Promise<void>;
+	build_data: BuildData;
 }
 
 export interface Adapter {


### PR DESCRIPTION
Vercel now has [edge functions](https://vercel.com/features/edge-functions), which allow us to render pages at the edge instead of inside serverless functions (which suffer from cold boots and higher latency).

This is a first pass at updating the Vercel adapter to take advantage of them, via the (not currently publicly documented) beta filesystem API.

Currently, to deploy an app with the adapter in this PR, you would need to

1. `vc deploy --prebuilt` rather than building on Vercel (which would use the currently published packages)
2. add a `ENABLE_FILE_SYSTEM_API=1` environment variable to the project via the Vercel web UI

Deployed example here: https://fs-api-kit-test-rich-harris.vercel.app/

There's some major outstanding todos:

* [ ] Vercel edge functions don't receive request bodies. Because of that, they're impractical for `POST`/`PUT` requests to endpoints. (Notice in the deployed example above you can't add a new TODO.) In these cases, the middleware will need to fall back to a serverless function, but this means that we essentially need to build two copies of the app (edge functions _and_ serverless functions) and configure the routing manifest accordingly
* [ ] Because edge functions run as 'middleware' before anything else happens, the app needs to know that it should disregard requests for static assets. This means that we need to pass an asset manifest to the adapter. In this PR I've done that by passing `build_data` through unchanged, but this probably warrants a closer look (and in fact the adapter API more generally could use a tidy up and some documentation)
* [ ] For larger apps, having a single edge function respond to every single request probably isn't ideal; ideally we would intelligently route people towards functions that handled a subtree of the app (or a single page/endpoint in the best case). This isn't specific to the Vercel adapter, and is something that needs to be supported by Kit (and the adapter API) itself, but it's arguably more acute in the case of edge functions/cloudflare workers because code needs to be evaluated before each and every request. The existence of [fallthrough routes](https://kit.svelte.dev/docs#routing-advanced-fallthrough-routes) probably makes this all a bit more complicated than it otherwise would be, I haven't looked at it in detail yet
* [ ] The API is still in beta, so things might well change

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
