### PR TITLE
[chore] use actions/setup-node@v2 for caching, add pnpm/action-setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6
+      - uses: actions/setup-node@v2
         with:
           node-version: '14.x'
-      - name: Cache ~/.pnpm-store
-        uses: actions/cache@main
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}
-      - run: npm install -g pnpm
+          cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build --filter ./packages --filter !./packages/create-svelte/templates
       - run: pnpm lint
@@ -43,27 +39,22 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: pnpm
       - name: Get paths for OS
         uses: ./.github/actions/env
         id: paths
-      - name: Cache ~/.pnpm-store
-        id: cache
-        uses: actions/cache@main
-        with:
-          path: ${{ steps.paths.outputs.pnpm_cache_path }}
-          key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}
       - name: Cache browsers
         id: browser_cache
         uses: actions/cache@main
         with:
           path: ${{ steps.paths.outputs.browser_cache_path }}
           key: chromium-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-      - run: npm install -g pnpm
       - run: pnpm install --frozen-lockfile
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: ${{ steps.browser_cache.outputs.cache-hit == 'true' }}
@@ -82,19 +73,15 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: pnpm
       - name: Get paths for OS
         uses: ./.github/actions/env
         id: paths
-      - name: Cache ~/.pnpm-store
-        uses: actions/cache@main
-        with:
-          path: ${{ steps.paths.outputs.pnpm_cache_path }}
-          key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node-version }}
-      - run: npm install -g pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build && pnpm build --filter="hn.svelte.dev"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
-
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6
       - name: Setup Node.js 12.x
-        uses: actions/setup-node@master
+        uses: actions/setup-node@v2
         with:
           node-version: 12.x
+          cache: pnpm
 
-      - run: npm install -g pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
 


### PR DESCRIPTION
In some ways a continuation of #1946, only now the `setup-node` action has added support for caching `pnpm`, and `pnpm` has their own action to install it. Vite uses a very similar setup (see vitejs/vite#5060).

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
