### PR TITLE
feat: Use `composedPath` to find anchor elements

### DIFF
--- a/.changeset/unlucky-phones-promise.md
+++ b/.changeset/unlucky-phones-promise.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[feat] Use `event.composedPath` to find anchors for prefetching and routing

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -8,11 +8,11 @@ function scroll_state() {
 }
 
 /**
- * @param {Node | null} node
- * @returns {HTMLAnchorElement | SVGAElement | null}
+ * @param {Node[]} nodes
+ * @returns {HTMLAnchorElement | SVGAElement | undefined}
  */
-function find_anchor(node) {
-	while (node && node.nodeName.toUpperCase() !== 'A') node = node.parentNode; // SVG <a> elements have a lowercase name
+function find_anchor(nodes) {
+	const node = nodes.find((e) => e.nodeName.toUpperCase() === 'A'); // SVG <a> elements have a lowercase name
 	return /** @type {HTMLAnchorElement | SVGAElement} */ (node);
 }
 
@@ -94,7 +94,7 @@ export class Router {
 
 		/** @param {MouseEvent|TouchEvent} event */
 		const trigger_prefetch = (event) => {
-			const a = find_anchor(/** @type {Node} */ (event.target));
+			const a = find_anchor(/** @type {Node[]} */ (event.composedPath()));
 			if (a && a.href && a.hasAttribute('sveltekit:prefetch')) {
 				this.prefetch(get_href(a));
 			}
@@ -124,7 +124,7 @@ export class Router {
 			if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
 			if (event.defaultPrevented) return;
 
-			const a = find_anchor(/** @type {Node} */ (event.target));
+			const a = find_anchor(/** @type {Node[]} */ (event.composedPath()));
 			if (!a) return;
 
 			if (!a.href) return;

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -8,12 +8,14 @@ function scroll_state() {
 }
 
 /**
- * @param {Node[]} nodes
+ * @param {Event} event
  * @returns {HTMLAnchorElement | SVGAElement | undefined}
  */
-function find_anchor(nodes) {
-	const node = nodes.find((e) => e.nodeName.toUpperCase() === 'A'); // SVG <a> elements have a lowercase name
-	return /** @type {HTMLAnchorElement | SVGAElement} */ (node);
+function find_anchor(event) {
+	const node = event
+		.composedPath()
+		.find((e) => e instanceof Node && e.nodeName.toUpperCase() === 'A'); // SVG <a> elements have a lowercase name
+	return /** @type {HTMLAnchorElement | SVGAElement | undefined} */ (node);
 }
 
 /**
@@ -94,7 +96,7 @@ export class Router {
 
 		/** @param {MouseEvent|TouchEvent} event */
 		const trigger_prefetch = (event) => {
-			const a = find_anchor(/** @type {Node[]} */ (event.composedPath()));
+			const a = find_anchor(event);
 			if (a && a.href && a.hasAttribute('sveltekit:prefetch')) {
 				this.prefetch(get_href(a));
 			}
@@ -124,7 +126,7 @@ export class Router {
 			if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
 			if (event.defaultPrevented) return;
 
-			const a = find_anchor(/** @type {Node[]} */ (event.composedPath()));
+			const a = find_anchor(event);
 			if (!a) return;
 
 			if (!a.href) return;

--- a/packages/kit/test/apps/basics/src/routes/routing/shadow-dom/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/shadow-dom/_tests.js
@@ -1,0 +1,24 @@
+import * as assert from 'uvu/assert';
+
+/** @type {import('test').TestMaker} */
+export default function (test) {
+	test(
+		'client router captures anchors in shadow dom',
+		'/routing/shadow-dom',
+		async ({ app, capture_requests, page, clicknav, js }) => {
+			if (js) {
+				await app.prefetchRoutes(['/routing/a']).catch((e) => {
+					// from error handler tests; ignore
+					if (!e.message.includes('Crashing now')) throw e;
+				});
+
+				const requests = await capture_requests(async () => {
+					await clicknav('div[id="clickme"]');
+					assert.equal(await page.textContent('h1'), 'a');
+				});
+
+				assert.equal(requests, []);
+			}
+		}
+	);
+}

--- a/packages/kit/test/apps/basics/src/routes/routing/shadow-dom/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/shadow-dom/index.svelte
@@ -1,0 +1,18 @@
+<script>
+	import { onMount } from 'svelte';
+
+	/** @type {HTMLDivElement} */
+	let elem;
+
+	onMount(() => {
+		const shadow = elem.attachShadow({ mode: 'open' });
+		const anchor = document.createElement('a');
+		anchor.href = '/routing/a';
+		anchor.innerHTML = '<slot>';
+		shadow.appendChild(anchor);
+	});
+</script>
+
+<div bind:this={elem}>
+	<div id="clickme">Hello world</div>
+</div>


### PR DESCRIPTION
Closes #2768 

### Changes
* The client-side router registers event handlers on mouse movements and clicks that search anchor elements in an event's target's ancestors to perform prefetching or routing. The current implementation uses `parentNode` which "skips" anchor elements in shadow doms.
* This change searches instead the `event.composedPath()`, which includes nodes in open shadow trees.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
