### PR TITLE
Support overwriting the default template loader via a handle hook

### DIFF
--- a/.changeset/metal-feet-run.md
+++ b/.changeset/metal-feet-run.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+added support for dynamic base template contents (app.html) during SSR

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -28,6 +28,11 @@ export async function respond(opts) {
 	/** @type {Array<SSRNode | undefined>} */
 	let nodes;
 
+	//allow developer to overwrite default template function during SSR (e.g. via `handle` hook)
+	if (request.locals.template) {
+		options.template = request.locals.template;
+	}
+
 	try {
 		nodes = await Promise.all(route.a.map((id) => (id ? options.load_component(id) : undefined)));
 	} catch (err) {


### PR DESCRIPTION
Ref #2762

[Here's a brief video explaining why I can't accomplish the same thing without this change](https://youtu.be/voYqm2Chu1U). (Apologies for the dog snoring in the background! 🐶 💤 )

Basically, our app is multi-tenant and we allow our customers to provide their own skins for different sections. But most importantly: **the skin content is not within our control.** All customers run on the same cluster of servers, and at runtime we inspect the hostname/url and look up the appropriate skin to wrap around the app.

As discussed in #2762, I tried to make this work with `{@html before}<slot />{@html after}` in a layout, and that works _as long as the skin doesn't have ANY tags wrapping the app content_ (must be a direct descendant of `<body>`). Since I'm splitting the skin content on a token, any wrapping tags become unclosed, and then `{@html ...}` goes haywire.

This change allows me to overwrite the default `template({ head, body})` method called during SSR by specifying a custom per-request template method in a `handle()` hook:

```js
// src/hooks.js
import loadSkin from '...';
export async function handle({ request, resolve }) {
	const skinHTML = await loadSkin(request.host, request.path);
	request.locals.template = ({ head, body }) => {
		return skinHTML
			.replace('</head>', `${head}</head>`)
			.replace('{{app}}', `<div id="svelte">${body}</div>`);
	};

	return resolve(request);
}
```

### Before submitting the PR, please make sure you do the following
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

I'm not sure how I could write a test for this functionality, but if someone wants to offer some advice, I can give it a try.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

I also am not able to get the tests to pass locally; both before and after my change they fail at the same spot:

![image](https://user-images.githubusercontent.com/46990/141193443-dd206ab7-0d1c-44f6-926c-a90fa51b5ba1.png)

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
