### PR TITLE
[docs] Add more info on query params

### DIFF
--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -78,7 +78,7 @@ SvelteKit's `load` receives an implemention of `fetch`, which has the following 
 
 > Code called inside `load` blocks:
 >
-> - should use the SvelteKit-provided [`fetch`](#loading-input-fetch) wrapper rather than using the native fetch as the latter will make the request twice each during SSR and hydration
+> - should use the SvelteKit-provided [`fetch`](#loading-input-fetch) wrapper rather than using the native `fetch`
 > - should not reference `window`, `document`, or any browser-specific objects
 > - should not directly reference any API keys or secrets, which will be exposed to the client, but instead call an endpoint that uses any required secrets
 

--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -92,7 +92,7 @@ The `load` function receives an object containing four fields — `page`, `fetch
 
 #### page
 
-`page` is a `{ host, path, params, query }` object where `host` is the URL's host, `path` is its pathname, `params` is derived from `path` and the route filename, and `query` is an instance of [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams).
+`page` is a `{ host, path, params, query }` object where `host` is the URL's host, `path` is its pathname, `params` is derived from `path` and the route filename, and `query` is an instance of [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams). Mutating `page` does not update the current URL, rather, it should be done by means of navigation using `goto`.
 
 So if the example above was `src/routes/blog/[slug].svelte` and the URL was `https://example.com/blog/some-post?foo=bar&baz&bizz=a&bizz=b`, the following would be true:
 

--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -92,7 +92,7 @@ The `load` function receives an object containing four fields — `page`, `fetch
 
 #### page
 
-`page` is a `{ host, path, params, query }` object where `host` is the URL's host, `path` is its pathname, `params` is derived from `path` and the route filename, and `query` is an instance of [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams). Mutating `page` does not update the current URL, rather, it should be done by means of navigation using `goto`.
+`page` is a `{ host, path, params, query }` object where `host` is the URL's host, `path` is its pathname, `params` is derived from `path` and the route filename, and `query` is an instance of [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams). Mutating `page` does not update the current URL; you should instead navigate using [`goto`](#modules-$app-navigation).
 
 So if the example above was `src/routes/blog/[slug].svelte` and the URL was `https://example.com/blog/some-post?foo=bar&baz&bizz=a&bizz=b`, the following would be true:
 

--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -78,7 +78,7 @@ SvelteKit's `load` receives an implemention of `fetch`, which has the following 
 
 > Code called inside `load` blocks:
 >
-> - should use the SvelteKit-provided [`fetch`](#loading-input-fetch) wrapper rather than using the native `fetch`
+> - should use the SvelteKit-provided [`fetch`](#loading-input-fetch) wrapper rather than using the native `fetch`. Although, using native `fetch` will work, it will cause the API server to be called twice - during SSR and hydration
 > - should not reference `window`, `document`, or any browser-specific objects
 > - should not directly reference any API keys or secrets, which will be exposed to the client, but instead call an endpoint that uses any required secrets
 

--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -78,7 +78,7 @@ SvelteKit's `load` receives an implemention of `fetch`, which has the following 
 
 > Code called inside `load` blocks:
 >
-> - should use the SvelteKit-provided [`fetch`](#loading-input-fetch) wrapper rather than using the native `fetch`. Although, using native `fetch` will work, it will cause the API server to be called twice - during SSR and hydration
+> - should use the SvelteKit-provided [`fetch`](#loading-input-fetch) wrapper rather than using the native fetch as the latter will make the request twice each during SSR and hydration
 > - should not reference `window`, `document`, or any browser-specific objects
 > - should not directly reference any API keys or secrets, which will be exposed to the client, but instead call an endpoint that uses any required secrets
 

--- a/documentation/docs/05-modules.md
+++ b/documentation/docs/05-modules.md
@@ -22,7 +22,7 @@ import { amp, browser, dev, mode, prerendering } from '$app/env';
 import { goto, invalidate, prefetch, prefetchRoutes } from '$app/navigation';
 ```
 
-- `goto(href, { replaceState, noscroll, keepfocus, state })` returns a `Promise` that resolves when SvelteKit navigates (or fails to navigate, in which case the promise rejects) to the specified `href`. Causes the `load` function of the `href` to be called. The second argument is optional:
+- `goto(href, { replaceState, noscroll, keepfocus, state })` returns a `Promise` that resolves when SvelteKit navigates (or fails to navigate, in which case the promise rejects) to the specified `href`. The second argument is optional:
   - `replaceState` (boolean, default `false`) If `true`, will replace the current `history` entry rather than creating a new one with `pushState`
   - `noscroll` (boolean, default `false`) If `true`, the browser will maintain its scroll position rather than scrolling to the top of the page after navigation
   - `keepfocus` (boolean, default `false`) If `true`, the currently focused element will retain focus after navigation. Otherwise, focus will be reset to the body

--- a/documentation/docs/05-modules.md
+++ b/documentation/docs/05-modules.md
@@ -60,10 +60,8 @@ The stores themselves attach to the correct context at the point of subscription
 - `page` is a readable store whose value reflects the object passed to `load` functions — it contains `host`, `path`, `params` and `query`. See the [`page` section](#loading-input-page) above for more details. Updating the query params of a page can be done by means of navigation by creating a new instance of `$page.query` and using the [goto](#modules-$app-navigation). For example:
   
   ```
-  let query = new URLSearchParams($page.query.toString());
-
+  const query = new URLSearchParams($page.query.toString());
   query.set('word', word);
-      
   goto(`?${query.toString()}`);
   ```
 - `session` is a [writable store](https://svelte.dev/tutorial/writable-stores) whose initial value is whatever was returned from [`getSession`](#hooks-getsession). It can be written to, but this will _not_ cause changes to persist on the server — this is something you must implement yourself.

--- a/documentation/docs/05-modules.md
+++ b/documentation/docs/05-modules.md
@@ -22,7 +22,7 @@ import { amp, browser, dev, mode, prerendering } from '$app/env';
 import { goto, invalidate, prefetch, prefetchRoutes } from '$app/navigation';
 ```
 
-- `goto(href, { replaceState, noscroll, keepfocus, state })` returns a `Promise` that resolves when SvelteKit navigates (or fails to navigate, in which case the promise rejects) to the specified `href`. The second argument is optional:
+- `goto(href, { replaceState, noscroll, keepfocus, state })` returns a `Promise` that resolves when SvelteKit navigates (or fails to navigate, in which case the promise rejects) to the specified `href`. Causes the `load` function of the `href` to be called. The second argument is optional:
   - `replaceState` (boolean, default `false`) If `true`, will replace the current `history` entry rather than creating a new one with `pushState`
   - `noscroll` (boolean, default `false`) If `true`, the browser will maintain its scroll position rather than scrolling to the top of the page after navigation
   - `keepfocus` (boolean, default `false`) If `true`, the currently focused element will retain focus after navigation. Otherwise, focus will be reset to the body
@@ -57,7 +57,15 @@ Because of that, the stores are not free-floating objects: they must be accessed
 The stores themselves attach to the correct context at the point of subscription, which means you can import and use them directly in components without boilerplate. However, it still needs to be called synchronously on component or page initialisation when `$`-prefix isn't used. Use `getStores` to safely `.subscribe` asynchronously instead.
 
 - `navigating` is a [readable store](https://svelte.dev/tutorial/readable-stores). When navigating starts, its value is `{ from, to }`, where `from` and `to` both mirror the `page` store value. When navigating finishes, its value reverts to `null`.
-- `page` is a readable store whose value reflects the object passed to `load` functions — it contains `host`, `path`, `params` and `query`. See the [`page` section](#loading-input-page) above for more details.
+- `page` is a readable store whose value reflects the object passed to `load` functions — it contains `host`, `path`, `params` and `query`. See the [`page` section](#loading-input-page) above for more details. Updating the query params of a page can be done by means of navigation by creating a new instance of `$page.query` and using the [goto](#modules-$app-navigation). For example:
+  
+  ```
+  let query = new URLSearchParams($page.query.toString());
+
+  query.set('word', word);
+      
+  goto(`?${query.toString()}`);
+  ```
 - `session` is a [writable store](https://svelte.dev/tutorial/writable-stores) whose initial value is whatever was returned from [`getSession`](#hooks-getsession). It can be written to, but this will _not_ cause changes to persist on the server — this is something you must implement yourself.
 
 ### $lib

--- a/documentation/docs/05-modules.md
+++ b/documentation/docs/05-modules.md
@@ -57,13 +57,7 @@ Because of that, the stores are not free-floating objects: they must be accessed
 The stores themselves attach to the correct context at the point of subscription, which means you can import and use them directly in components without boilerplate. However, it still needs to be called synchronously on component or page initialisation when `$`-prefix isn't used. Use `getStores` to safely `.subscribe` asynchronously instead.
 
 - `navigating` is a [readable store](https://svelte.dev/tutorial/readable-stores). When navigating starts, its value is `{ from, to }`, where `from` and `to` both mirror the `page` store value. When navigating finishes, its value reverts to `null`.
-- `page` is a readable store whose value reflects the object passed to `load` functions — it contains `host`, `path`, `params` and `query`. See the [`page` section](#loading-input-page) above for more details. Updating the query params of a page can be done by means of navigation by creating a new instance of `$page.query` and using the [goto](#modules-$app-navigation). For example:
-  
-  ```
-  const query = new URLSearchParams($page.query.toString());
-  query.set('word', word);
-  goto(`?${query.toString()}`);
-  ```
+- `page` is a readable store whose value reflects the object passed to `load` functions — it contains `host`, `path`, `params` and `query`. See the [`page` section](#loading-input-page) above for more details. 
 - `session` is a [writable store](https://svelte.dev/tutorial/writable-stores) whose initial value is whatever was returned from [`getSession`](#hooks-getsession). It can be written to, but this will _not_ cause changes to persist on the server — this is something you must implement yourself.
 
 ### $lib

--- a/documentation/docs/05-modules.md
+++ b/documentation/docs/05-modules.md
@@ -57,7 +57,7 @@ Because of that, the stores are not free-floating objects: they must be accessed
 The stores themselves attach to the correct context at the point of subscription, which means you can import and use them directly in components without boilerplate. However, it still needs to be called synchronously on component or page initialisation when `$`-prefix isn't used. Use `getStores` to safely `.subscribe` asynchronously instead.
 
 - `navigating` is a [readable store](https://svelte.dev/tutorial/readable-stores). When navigating starts, its value is `{ from, to }`, where `from` and `to` both mirror the `page` store value. When navigating finishes, its value reverts to `null`.
-- `page` is a readable store whose value reflects the object passed to `load` functions — it contains `host`, `path`, `params` and `query`. See the [`page` section](#loading-input-page) above for more details. 
+- `page` is a readable store whose value reflects the object passed to `load` functions — it contains `host`, `path`, `params` and `query`. See the [`page` section](#loading-input-page) above for more details.
 - `session` is a [writable store](https://svelte.dev/tutorial/writable-stores) whose initial value is whatever was returned from [`getSession`](#hooks-getsession). It can be written to, but this will _not_ cause changes to persist on the server — this is something you must implement yourself.
 
 ### $lib


### PR DESCRIPTION
This PR adds more info on how to update the query params of a page, why we need to use SvelteKit's fetch and whether the load function will be called during navigation using goto. These informations are unavailable in the docs and has caused confusions as seen in [#2785 ](https://github.com/sveltejs/kit/issues/2785) and [#969](https://github.com/sveltejs/kit/issues/969)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ x] This message body should clearly illustrate what problems it solves.
- [x ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
