### PR TITLE
[fix] use defaults when no opts passed to router

### DIFF
--- a/.changeset/fast-poems-notice.md
+++ b/.changeset/fast-poems-notice.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+"[fix] use defaults when no opts passed to router"

--- a/.changeset/fast-poems-notice.md
+++ b/.changeset/fast-poems-notice.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-"[fix] use defaults when no opts passed to router"
+[fix] use defaults when no opts passed to router

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -277,46 +277,42 @@ export class Renderer {
 
 		getSelection()?.removeAllRanges();
 
-		if (!opts) {
-			await 0;
-		} else {
-			const { hash, scroll, keepfocus } = opts;
+		const { hash, scroll, keepfocus } = opts || {};
 
-			if (!keepfocus) {
-				document.body.focus();
-			}
+		if (!keepfocus) {
+			document.body.focus();
+		}
 
-			const old_page_y_offset = Math.round(pageYOffset);
-			const old_max_page_y_offset = document.documentElement.scrollHeight - innerHeight;
+		const old_page_y_offset = Math.round(pageYOffset);
+		const old_max_page_y_offset = document.documentElement.scrollHeight - innerHeight;
 
-			await 0;
+		await 0;
 
-			const new_page_y_offset = Math.round(pageYOffset);
-			const new_max_page_y_offset = document.documentElement.scrollHeight - innerHeight;
+		const new_page_y_offset = Math.round(pageYOffset);
+		const new_max_page_y_offset = document.documentElement.scrollHeight - innerHeight;
 
-			// After `await 0`, the `onMount()` function in the component executed.
-			// Check if no scrolling happened on mount.
-			const no_scroll_happened =
-				// In most cases, we can compare whether `pageYOffset` changed between navigation
-				new_page_y_offset === Math.min(old_page_y_offset, new_max_page_y_offset) ||
-				// But if the page is scrolled to/near the bottom, the browser would also scroll
-				// to/near the bottom of the new page on navigation. Since we can't detect when this
-				// behaviour happens, we naively compare by the y offset from the bottom of the page.
-				old_max_page_y_offset - old_page_y_offset === new_max_page_y_offset - new_page_y_offset;
+		// After `await 0`, the `onMount()` function in the component executed.
+		// Check if no scrolling happened on mount.
+		const no_scroll_happened =
+			// In most cases, we can compare whether `pageYOffset` changed between navigation
+			new_page_y_offset === Math.min(old_page_y_offset, new_max_page_y_offset) ||
+			// But if the page is scrolled to/near the bottom, the browser would also scroll
+			// to/near the bottom of the new page on navigation. Since we can't detect when this
+			// behaviour happens, we naively compare by the y offset from the bottom of the page.
+			old_max_page_y_offset - old_page_y_offset === new_max_page_y_offset - new_page_y_offset;
 
-			// If there was no scrolling, we run on our custom scroll handling
-			if (no_scroll_happened) {
-				const deep_linked = hash && document.getElementById(hash.slice(1));
-				if (scroll) {
-					scrollTo(scroll.x, scroll.y);
-				} else if (deep_linked) {
-					// Here we use `scrollIntoView` on the element instead of `scrollTo`
-					// because it natively supports the `scroll-margin` and `scroll-behavior`
-					// CSS properties.
-					deep_linked.scrollIntoView();
-				} else {
-					scrollTo(0, 0);
-				}
+		// If there was no scrolling, we run on our custom scroll handling
+		if (no_scroll_happened) {
+			const deep_linked = hash && document.getElementById(hash.slice(1));
+			if (scroll) {
+				scrollTo(scroll.x, scroll.y);
+			} else if (deep_linked) {
+				// Here we use `scrollIntoView` on the element instead of `scrollTo`
+				// because it natively supports the `scroll-margin` and `scroll-behavior`
+				// CSS properties.
+				deep_linked.scrollIntoView();
+			} else {
+				scrollTo(0, 0);
 			}
 		}
 


### PR DESCRIPTION
I noticed this in another code review

There are somethings we don't do when `!opts`. E.g. we don't do the `document.body.focus();`. I have no idea why this would be and it seems wrong