### PR TITLE
Remove empty package dirs

### DIFF
--- a/.changeset/odd-foxes-sing.md
+++ b/.changeset/odd-foxes-sing.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Don't create empty dirs when packaging

--- a/packages/kit/src/packaging/index.js
+++ b/packages/kit/src/packaging/index.js
@@ -50,7 +50,14 @@ export async function make_package(config, cwd = process.cwd()) {
 		if (!config.kit.package.files(normalized)) {
 			const dts_file = (svelte_ext ? file : file.slice(0, -ext.length)) + '.d.ts';
 			const dts_path = path.join(abs_package_dir, dts_file);
-			if (fs.existsSync(dts_path)) fs.unlinkSync(dts_path);
+			if (fs.existsSync(dts_path)) {
+				fs.unlinkSync(dts_path);
+
+				const dir = path.dirname(dts_path);
+				if (fs.readdirSync(dir).length === 0) {
+					fs.rmdirSync(dir);
+				}
+			}
 			continue;
 		}
 

--- a/packages/kit/src/utils/filesystem.js
+++ b/packages/kit/src/utils/filesystem.js
@@ -41,8 +41,11 @@ export function copy(from, to, filter = () => true) {
 	return files;
 }
 
-/** @param {string} cwd */
-export function walk(cwd) {
+/**
+ * @param {string} cwd
+ * @param {boolean} [dirs]
+ */
+export function walk(cwd, dirs = false) {
 	/** @type {string[]} */
 	const all_files = [];
 
@@ -54,6 +57,7 @@ export function walk(cwd) {
 			const joined = path.join(dir, file);
 			const stats = fs.statSync(path.join(cwd, joined));
 			if (stats.isDirectory()) {
+				if (dirs) all_files.push(joined);
 				walk_dir(joined);
 			} else {
 				all_files.push(joined);

--- a/packages/kit/src/utils/filesystem.js
+++ b/packages/kit/src/utils/filesystem.js
@@ -42,8 +42,9 @@ export function copy(from, to, filter = () => true) {
 }
 
 /**
- * @param {string} cwd
- * @param {boolean} [dirs]
+ * Get a list of all files in a directory
+ * @param {string} cwd - the directory to walk
+ * @param {boolean} [dirs] - whether to include directories in the result
  */
 export function walk(cwd, dirs = false) {
 	/** @type {string[]} */


### PR DESCRIPTION
Fixes a very minor annoyance — if the `config.kit.package.files` option is used to omit some files in `src/lib` from a package, an empty directory will still be created as a byproduct of types being emitted. This fixes that.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
