### PR TITLE
follow redirects when prerendering

### DIFF
--- a/.changeset/angry-tigers-prove.md
+++ b/.changeset/angry-tigers-prove.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Follow redirects when prerendering

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -1,10 +1,11 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { dirname, join, resolve as resolve_path } from 'path';
-import { pathToFileURL, resolve, URL } from 'url';
+import { pathToFileURL, URL } from 'url';
 import { mkdirp } from '../../utils/filesystem.js';
 import { __fetch_polyfill } from '../../install-fetch.js';
 import { SVELTE_KIT } from '../constants.js';
 import { get_single_valued_header } from '../../utils/http.js';
+import { resolve } from '../../utils/url.js';
 
 /**
  * @typedef {import('types/config').PrerenderErrorHandler} PrerenderErrorHandler
@@ -191,6 +192,11 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 					log.warn(`${rendered.status} ${decoded_path} -> ${location}`);
 					writeFileSync(file, `<meta http-equiv="refresh" content="0;url=${encodeURI(location)}">`);
 					written_files.push(file);
+
+					const resolved = resolve(path, location);
+					if (resolved.startsWith('/')) {
+						await visit(resolved, path);
+					}
 				} else {
 					log.warn(`location header missing on redirect received from ${decoded_path}`);
 				}

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -5,7 +5,7 @@ import { mkdirp } from '../../utils/filesystem.js';
 import { __fetch_polyfill } from '../../install-fetch.js';
 import { SVELTE_KIT } from '../constants.js';
 import { get_single_valued_header } from '../../utils/http.js';
-import { resolve } from '../../utils/url.js';
+import { is_root_relative, resolve } from '../../utils/url.js';
 
 /**
  * @typedef {import('types/config').PrerenderErrorHandler} PrerenderErrorHandler
@@ -194,7 +194,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 					written_files.push(file);
 
 					const resolved = resolve(path, location);
-					if (resolved.startsWith('/')) {
+					if (is_root_relative(resolved)) {
 						await visit(resolved, path);
 					}
 				} else {
@@ -270,7 +270,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 					if (!href) continue;
 
 					const resolved = resolve(path, href);
-					if (!resolved.startsWith('/') || resolved.startsWith('//')) continue;
+					if (!is_root_relative(resolved)) continue;
 
 					const parsed = new URL(resolved, 'http://localhost');
 					const pathname = decodeURI(parsed.pathname).replace(config.kit.paths.base, '');

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -1,6 +1,7 @@
 import { normalize } from '../../load.js';
 import { respond } from '../index.js';
 import { escape_json_string_in_html } from '../../../utils/escape.js';
+import { resolve } from '../../../utils/url.js';
 
 const s = JSON.stringify;
 
@@ -302,35 +303,4 @@ export async function load_node({
 		set_cookie_headers,
 		uses_credentials
 	};
-}
-
-const absolute = /^([a-z]+:)?\/?\//;
-
-/**
- * @param {string} base
- * @param {string} path
- */
-export function resolve(base, path) {
-	const base_match = absolute.exec(base);
-	const path_match = absolute.exec(path);
-
-	if (!base_match) {
-		throw new Error(`bad base path: "${base}"`);
-	}
-
-	const baseparts = path_match ? [] : base.slice(base_match[0].length).split('/');
-	const pathparts = path_match ? path.slice(path_match[0].length).split('/') : path.split('/');
-
-	baseparts.pop();
-
-	for (let i = 0; i < pathparts.length; i += 1) {
-		const part = pathparts[i];
-		if (part === '.') continue;
-		else if (part === '..') baseparts.pop();
-		else baseparts.push(part);
-	}
-
-	const prefix = (path_match && path_match[0]) || (base_match && base_match[0]) || '';
-
-	return `${prefix}${baseparts.join('/')}`;
 }

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -1,7 +1,7 @@
 import { normalize } from '../../load.js';
 import { respond } from '../index.js';
 import { escape_json_string_in_html } from '../../../utils/escape.js';
-import { resolve } from '../../../utils/url.js';
+import { is_root_relative, resolve } from '../../../utils/url.js';
 
 const s = JSON.stringify;
 
@@ -127,7 +127,7 @@ export async function load_node({
 								`http://${page.host}/${asset.file}`,
 								/** @type {RequestInit} */ (opts)
 						  );
-				} else if (resolved.startsWith('/') && !resolved.startsWith('//')) {
+				} else if (is_root_relative(resolved)) {
 					const relative = resolved;
 
 					const headers = /** @type {import('types/helper').RequestHeaders} */ ({

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -1,0 +1,30 @@
+const absolute = /^([a-z]+:)?\/?\//;
+
+/**
+ * @param {string} base
+ * @param {string} path
+ */
+export function resolve(base, path) {
+	const base_match = absolute.exec(base);
+	const path_match = absolute.exec(path);
+
+	if (!base_match) {
+		throw new Error(`bad base path: "${base}"`);
+	}
+
+	const baseparts = path_match ? [] : base.slice(base_match[0].length).split('/');
+	const pathparts = path_match ? path.slice(path_match[0].length).split('/') : path.split('/');
+
+	baseparts.pop();
+
+	for (let i = 0; i < pathparts.length; i += 1) {
+		const part = pathparts[i];
+		if (part === '.') continue;
+		else if (part === '..') baseparts.pop();
+		else baseparts.push(part);
+	}
+
+	const prefix = (path_match && path_match[0]) || (base_match && base_match[0]) || '';
+
+	return `${prefix}${baseparts.join('/')}`;
+}

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -28,3 +28,8 @@ export function resolve(base, path) {
 
 	return `${prefix}${baseparts.join('/')}`;
 }
+
+/** @param {string} path */
+export function is_root_relative(path) {
+	return path[0] === '/' && path[1] !== '/';
+}

--- a/packages/kit/src/utils/url.spec.js
+++ b/packages/kit/src/utils/url.spec.js
@@ -1,6 +1,6 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import { resolve } from './load_node.js';
+import { resolve } from './url.js';
 
 test('resolves a root-relative path', () => {
 	assert.equal(resolve('/a/b/c', '/x/y/z'), '/x/y/z');


### PR DESCRIPTION
When prerendering, if a page or endpoint redirects to another location, the redirect is logged but not followed. In a case I encountered just now, a `/docs` link in the nav bar was followed, but the page consisted of this...

```svelte
<script context="module">
  /** @type {import('@sveltejs/kit').Load} */
  export function load() {
    return {
      status: 308,
      redirect: '/docs/getting-started'
    };
  }
</script>
```

...and `/docs/getting-started` was never crawled. Easily fixed by ensuring that there's a link to the correct URL, but I would expect Kit to do the right thing here regardless.

Haven't added a test yet as I'm under the cosh

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
