### PR TITLE
fix(cloudflare): allow `npm publish` to succeed

### DIFF
--- a/.changeset/itchy-beds-drop.md
+++ b/.changeset/itchy-beds-drop.md
@@ -1,0 +1,6 @@
+---
+"@sveltejs/adapter-cloudflare": patch
+---
+
+- Allow `npm publish` to succeed via `publishConfig.access` config
+- Add instructions to README for configuring a new/existing Pages project

--- a/packages/adapter-cloudflare/README.md
+++ b/packages/adapter-cloudflare/README.md
@@ -63,14 +63,13 @@ Please follow the [Get Started Guide](https://developers.cloudflare.com/pages/ge
 
 When configuring your project settings, you must use the following settings:
 
-* **Framework preset** – None
-* **Build command** – `npm run build` or `svelte-kit build`
-* **Build output directory** – `.svelte-kit/cloudflare`
-* **Environment variables**
-	* `NODE_VERSION`: `16` or `14`
+- **Framework preset** – None
+- **Build command** – `npm run build` or `svelte-kit build`
+- **Build output directory** – `.svelte-kit/cloudflare`
+- **Environment variables**
+  - `NODE_VERSION`: `16` or `14`
 
 > **Important:** You need to add a `NODE_VERSION` environment variable to both the "production" and "preview" environments. You can add this during project setup or later in the Pages project settings. SvelteKit requires Node `14.13` or later, so you should use `14` or `16` as the `NODE_VERSION` value.
-
 
 ## Changelog
 

--- a/packages/adapter-cloudflare/README.md
+++ b/packages/adapter-cloudflare/README.md
@@ -39,7 +39,7 @@ export default {
 };
 ```
 
-## Options
+### Options
 
 The adapter optionally accepts all
 [`esbuild.build`](https://esbuild.github.io/api/#build-api) configuration.
@@ -56,6 +56,21 @@ allowOverwrite: true,
 format: 'esm',
 bundle: true,
 ```
+
+## Deployment
+
+Please follow the [Get Started Guide](https://developers.cloudflare.com/pages/get-started) for Cloudflare Pages to begin.
+
+When configuring your project settings, you must use the following settings:
+
+* **Framework preset** – None
+* **Build command** – `npm run build` or `svelte-kit build`
+* **Build output directory** – `.svelte-kit/cloudflare`
+* **Environment variables**
+	* `NODE_VERSION`: `16` or `14`
+
+> **Important:** You need to add a `NODE_VERSION` environment variable to both the "production" and "preview" environments. You can add this during project setup or later in the Pages project settings. SvelteKit requires Node `14.13` or later, so you should use `14` or `16` as the `NODE_VERSION` value.
+
 
 ## Changelog
 

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -33,6 +33,6 @@
 		"@sveltejs/kit": "workspace:*"
 	},
 	"publishConfig": {
-    "access": "public"
-  }
+		"access": "public"
+	}
 }

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -31,5 +31,8 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:*"
-	}
+	},
+	"publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
The automation behind publishing packages works for existing packages, but is either missing flags for _new_ packages or new packages need to have the relevant `package.json` config added – I added that here. (See #2818 error [here](https://github.com/sveltejs/kit/runs/4254022567?check_suite_focus=true#step:7:38))

Also added instructions for getting Pages projects working with the new adapter.