### PR TITLE
[docs] clarify adapter-node env option

### DIFF
--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -16,6 +16,7 @@ export default {
 			// default options are shown
 			out: 'build',
 			precompress: false,
+			// Name of the environment variables from which host and port are read
 			env: {
 				host: 'HOST',
 				port: 'PORT'


### PR DESCRIPTION
Just to clear up the confusion that you are not passing the actual port number.

This is a minor documentation update.