### PR TITLE
chore: remove usage of pageXOffset

### DIFF
--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -2,8 +2,8 @@ import { get_base_uri } from './utils';
 
 function scroll_state() {
 	return {
-		x: pageXOffset,
-		y: pageYOffset
+		x: scrollX,
+		y: scrollX
 	};
 }
 


### PR DESCRIPTION
Super tiny change : replace `pageXOffset` by `scrollX`. 
`pageXOffset` is marked as a deprecated API, which make VSCode render it as crossed :

![image](https://user-images.githubusercontent.com/1730702/142779322-df9048cc-cb9a-4b6f-a7f7-d48464f3ec04.png)

`pageXOffset` is an alias for `scrollX` so this doesn't change anything except on IE8- 
https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollX


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
