### PR TITLE
Adapter-native Request and Response (enables full Cloudflare Worker functionality)

### DIFF
--- a/examples/hn.svelte.dev/src/routes/__error.svelte
+++ b/examples/hn.svelte.dev/src/routes/__error.svelte
@@ -1,4 +1,5 @@
 <script context="module">
+	/** @type {import('@sveltejs/kit').ErrorLoad} */
 	export function load({ error, status }) {
 		return {
 			props: { error, status }

--- a/examples/hn.svelte.dev/src/routes/index.svelte
+++ b/examples/hn.svelte.dev/src/routes/index.svelte
@@ -1,4 +1,5 @@
 <script context="module">
+	/** @type {import('@sveltejs/kit').Load} */
 	export function load({ page }) {
 		let host = page.host;
 		const i = host.indexOf(':');

--- a/examples/hn.svelte.dev/src/routes/rss.js
+++ b/examples/hn.svelte.dev/src/routes/rss.js
@@ -1,6 +1,7 @@
-import {dev} from '$app/env';
+import { dev } from '$app/env';
+
 /**
- * @type {import('@sveltejs/kit').RequestHandler}
+ * @type {import('@sveltejs/adapter-netlify').AdapterRequestHandler}
  */
 export function get() {
 	return {

--- a/examples/hn.svelte.dev/src/routes/rss.js
+++ b/examples/hn.svelte.dev/src/routes/rss.js
@@ -1,7 +1,7 @@
 import { dev } from '$app/env';
 
 /**
- * @type {import('@sveltejs/adapter-netlify').AdapterRequestHandler}
+ * @type {import('@sveltejs/kit').RequestHandler}
  */
 export function get() {
 	return {

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -35,10 +35,15 @@ async function handle(event) {
 			query: request_url.searchParams,
 			rawBody: await read(request),
 			headers: Object.fromEntries(request.headers),
-			method: request.method
+			method: request.method,
+			adapter: { event }
 		});
 
 		if (rendered) {
+			if (rendered.adapter) {
+				return rendered.adapter.response;
+			}
+
 			return new Response(rendered.body, {
 				status: rendered.status,
 				headers: makeHeaders(rendered.headers)

--- a/packages/adapter-cloudflare-workers/index.d.ts
+++ b/packages/adapter-cloudflare-workers/index.d.ts
@@ -1,9 +1,25 @@
-import { Adapter } from '@sveltejs/kit';
+/// <reference types="@cloudflare/workers-types" />
+
+import { Adapter, RequestHandler } from '@sveltejs/kit';
+import { DefaultBody } from '@sveltejs/kit/types/endpoint';
 import { BuildOptions } from 'esbuild';
 
 interface AdapterOptions {
 	esbuild?: (options: BuildOptions) => Promise<BuildOptions> | BuildOptions;
 }
 
-declare function plugin(options?: AdapterOptions): Adapter;
-export = plugin;
+export default function (options?: AdapterOptions): Adapter;
+
+export type AdapterRequest = {
+	event: FetchEvent;
+};
+
+export interface AdapterResponse {
+	response: Parameters<FetchEvent['respondWith']>[0];
+}
+
+export type AdapterRequestHandler<
+	Locals = Record<string, any>,
+	Input = unknown,
+	Output extends DefaultBody = DefaultBody
+> = RequestHandler<Locals, Input, Output, AdapterRequest, AdapterResponse>;

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -30,6 +30,7 @@
 		"esbuild": "^0.13.4"
 	},
 	"devDependencies": {
+		"@cloudflare/workers-types": "^3.2.0",
 		"@sveltejs/kit": "workspace:*"
 	}
 }

--- a/packages/adapter-cloudflare/index.d.ts
+++ b/packages/adapter-cloudflare/index.d.ts
@@ -1,4 +1,27 @@
-import { Adapter } from '@sveltejs/kit';
+/// <reference types="@cloudflare/workers-types" />
+
+import { Adapter, RequestHandler } from '@sveltejs/kit';
 import { BuildOptions } from 'esbuild';
+import { DefaultBody } from '@sveltejs/kit/types/endpoint';
 
 export default function (options?: BuildOptions): Adapter;
+
+// TODO: Does not work (is the normal Request)
+type CfRequest = Parameters<ExportedHandlerFetchHandler>[0];
+
+export type AdapterRequest<Env = unknown> = {
+	request: CfRequest;
+	env: Env;
+	ctx: ExecutionContext;
+};
+
+export interface AdapterResponse {
+	response: ReturnType<ExportedHandlerFetchHandler>;
+}
+
+export type AdapterRequestHandler<
+	Locals = Record<string, any>,
+	Input = unknown,
+	Output extends DefaultBody = DefaultBody,
+	Env = unknown
+> = RequestHandler<Locals, Input, Output, AdapterRequest<Env>, AdapterResponse>;

--- a/packages/adapter-cloudflare/index.d.ts
+++ b/packages/adapter-cloudflare/index.d.ts
@@ -6,11 +6,21 @@ import { DefaultBody } from '@sveltejs/kit/types/endpoint';
 
 export default function (options?: BuildOptions): Adapter;
 
-// TODO: Does not work (is the normal Request)
-type CfRequest = Parameters<ExportedHandlerFetchHandler>[0];
+// TODO: Why do I have to copy paste that and cannot use the one direclty from @cloudflare/workers-types
+declare class Request extends Body {
+	constructor(input: Request | string, init?: RequestInit | Request);
+	clone(): Request;
+	readonly method: string;
+	readonly url: string;
+	readonly headers: Headers;
+	readonly redirect: string;
+	readonly fetcher: Fetcher | null;
+	readonly signal: AbortSignal;
+	readonly cf?: IncomingRequestCfProperties;
+}
 
 export type AdapterRequest<Env = unknown> = {
-	request: CfRequest;
+	request: Request;
 	env: Env;
 	ctx: ExecutionContext;
 };

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -30,6 +30,7 @@
 		"esbuild": "^0.13.4"
 	},
 	"devDependencies": {
+		"@cloudflare/workers-types": "^3.2.0",
 		"@sveltejs/kit": "workspace:*"
 	},
 	"publishConfig": {

--- a/packages/adapter-netlify/files/entry.js
+++ b/packages/adapter-netlify/files/entry.js
@@ -3,7 +3,7 @@ import { init, render } from '../output/server/app.js';
 
 init();
 
-export async function handler(event) {
+export async function handler(event, context) {
 	const { path, httpMethod, headers, rawQuery, body, isBase64Encoded } = event;
 
 	const query = new URLSearchParams(rawQuery);
@@ -16,7 +16,8 @@ export async function handler(event) {
 		headers,
 		path,
 		query,
-		rawBody
+		rawBody,
+		adapter: { event, context }
 	});
 
 	if (!rendered) {
@@ -24,6 +25,10 @@ export async function handler(event) {
 			statusCode: 404,
 			body: 'Not found'
 		};
+	}
+
+	if (rendered.adapter) {
+		return rendered.adapter.response;
 	}
 
 	const partial_response = {

--- a/packages/adapter-netlify/index.d.ts
+++ b/packages/adapter-netlify/index.d.ts
@@ -1,9 +1,25 @@
-import { Adapter } from '@sveltejs/kit';
+import { Adapter, RequestHandler } from '@sveltejs/kit';
 import { BuildOptions } from 'esbuild';
+import { HandlerEvent, HandlerContext, Handler } from '@netlify/functions';
+import { DefaultBody } from '@sveltejs/kit/types/endpoint';
 
 interface AdapterOptions {
 	esbuild?: (options: BuildOptions) => Promise<BuildOptions> | BuildOptions;
 }
 
-declare function plugin(options?: AdapterOptions): Adapter;
-export = plugin;
+export default function (options?: AdapterOptions): Adapter;
+
+export interface AdapterRequest<Context extends HandlerContext = HandlerContext> {
+	event: HandlerEvent;
+	context: Context;
+}
+
+export interface AdapterResponse {
+	response: ReturnType<Handler>;
+}
+
+export type AdapterRequestHandler<
+	Locals = Record<string, any>,
+	Input = unknown,
+	Output extends DefaultBody = DefaultBody
+> = RequestHandler<Locals, Input, Output, AdapterRequest, AdapterResponse>;

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -30,6 +30,7 @@
 		"esbuild": "^0.13.4"
 	},
 	"devDependencies": {
+		"@netlify/functions": "^0.9.0",
 		"@sveltejs/kit": "workspace:*"
 	}
 }

--- a/packages/adapter-node/src/kit-middleware.js
+++ b/packages/adapter-node/src/kit-middleware.js
@@ -33,6 +33,12 @@ export function create_kit_middleware({ render }) {
 		});
 
 		if (rendered) {
+			if ('adapter' in rendered) {
+				throw new Error(
+					'Adapter-native request was not defined, returning a adapter-native response is not supported'
+				);
+			}
+
 			res.writeHead(rendered.status, rendered.headers);
 			if (rendered.body) {
 				res.write(rendered.body);

--- a/packages/adapter-vercel/files/entry.js
+++ b/packages/adapter-vercel/files/entry.js
@@ -26,6 +26,11 @@ export default async (req, res) => {
 	});
 
 	if (rendered) {
+		if ('adapter' in rendered) {
+			throw new Error(
+				'Adapter-native request was not defined, returning a adapter-native response is not supported'
+			);
+		}
 		const { status, headers, body } = rendered;
 		return res.writeHead(status, headers).end(body);
 	}

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -150,7 +150,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 		if (seen.has(path)) return;
 		seen.add(path);
 
-		/** @type {Map<string, import('types/hooks').ServerResponse>} */
+		/** @type {Map<string, import('types/hooks').ServerResponseNormal>} */
 		const dependencies = new Map();
 
 		const rendered = await app.render(
@@ -171,6 +171,12 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 		);
 
 		if (rendered) {
+			if ('adapter' in rendered) {
+				throw new Error(
+					'Adapter-native request was not defined, returning a adapter-native response is not supported'
+				);
+			}
+
 			const response_type = Math.floor(rendered.status / 100);
 			const headers = rendered.headers;
 			const type = headers && headers['content-type'];

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -515,6 +515,11 @@ async function create_plugin(config, dir, cwd, get_manifest) {
 				);
 
 				if (rendered) {
+					if ('adapter' in rendered) {
+						throw new Error(
+							'Adapter-native request was not defined, returning a adapter-native response is not supported'
+						);
+					}
 					res.writeHead(rendered.status, rendered.headers);
 					if (rendered.body) res.write(rendered.body);
 					res.end();

--- a/packages/kit/src/core/preview/index.js
+++ b/packages/kit/src/core/preview/index.js
@@ -100,6 +100,11 @@ export async function preview({
 				}));
 
 			if (rendered) {
+				if ('adapter' in rendered) {
+					throw new Error(
+						'Adapter-native request was not defined, returning a adapter-native response is not supported'
+					);
+				}
 				res.writeHead(rendered.status, rendered.headers);
 				if (rendered.body) res.write(rendered.body);
 				res.end();

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -60,6 +60,10 @@ export async function render_endpoint(request, route, match) {
 		return error(`${preface}: expected an object, got ${typeof response}`);
 	}
 
+	if ('adapter' in response) {
+		return { adapter: response.adapter };
+	}
+
 	let { status = 200, body, headers = {} } = response;
 
 	headers = lowercase_keys(headers);

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -65,6 +65,10 @@ export async function respond(incoming, options, state = {}) {
 							: await render_page(request, route, match, options, state);
 
 					if (response) {
+						if ('adapter' in response) {
+							return response;
+						}
+
 						// inject ETags for 200 responses
 						if (response.status === 200) {
 							const cache_control = get_single_valued_header(response.headers, 'cache-control');

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -161,7 +161,8 @@ export async function load_node({
 							headers,
 							path: relative,
 							rawBody: opts.body == null ? null : new TextEncoder().encode(opts.body),
-							query: new URLSearchParams(search)
+							query: new URLSearchParams(search),
+							adapter: request.adapter
 						},
 						options,
 						{
@@ -171,6 +172,12 @@ export async function load_node({
 					);
 
 					if (rendered) {
+						if ('adapter' in rendered) {
+							throw new Error(
+								`Cannot use adapter-native response for URL (${url}) in internal server-side fetch`
+							);
+						}
+
 						if (state.prerender) {
 							state.prerender.dependencies.set(relative, rendered);
 						}

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -5,7 +5,7 @@ import { coalesce_to_error } from '../../../utils/error.js';
 
 /**
  * @typedef {import('./types.js').Loaded} Loaded
- * @typedef {import('types/hooks').ServerResponse} ServerResponse
+ * @typedef {import('types/hooks').ServerResponseNormal} ServerResponseNormal
  * @typedef {import('types/internal').SSRNode} SSRNode
  * @typedef {import('types/internal').SSRRenderOptions} SSRRenderOptions
  * @typedef {import('types/internal').SSRRenderState} SSRRenderState
@@ -20,7 +20,7 @@ import { coalesce_to_error } from '../../../utils/error.js';
  *   route: import('types/internal').SSRPage;
  *   page: import('types/page').Page;
  * }} opts
- * @returns {Promise<ServerResponse | undefined>}
+ * @returns {Promise<ServerResponseNormal | undefined>}
  */
 export async function respond(opts) {
 	const { request, options, state, $session, route } = opts;
@@ -233,7 +233,7 @@ function get_page_config(leaf, options) {
 }
 
 /**
- * @param {ServerResponse} response
+ * @param {ServerResponseNormal} response
  * @param {string[]} set_cookie_headers
  */
 function with_cookies(response, set_cookie_headers) {

--- a/packages/kit/test/apps/basics/src/hooks.js
+++ b/packages/kit/test/apps/basics/src/hooks.js
@@ -19,6 +19,11 @@ export const handle = sequence(
 	async ({ request, resolve }) => {
 		const response = await resolve(request);
 
+		// In this example this will not happen
+		if ('adapter' in response) {
+			return { adapter: response.adapter };
+		}
+
 		return {
 			...response,
 			headers: {

--- a/packages/kit/types/app.d.ts
+++ b/packages/kit/types/app.d.ts
@@ -3,7 +3,9 @@ import { ServerResponse } from './hooks';
 
 export interface App {
 	init(): void;
-	render(incoming: IncomingRequest): Promise<ServerResponse>;
+	render<AdapterRequest = unknown, AdapterResponse = unknown>(
+		incoming: IncomingRequest<AdapterRequest>
+	): Promise<ServerResponse<AdapterResponse>>;
 }
 
 export type RawBody = null | Uint8Array;
@@ -11,11 +13,12 @@ export type ParameterizedBody<Body = unknown> = Body extends FormData
 	? ReadOnlyFormData
 	: (string | RawBody | ReadOnlyFormData) & Body;
 
-export interface IncomingRequest {
+export interface IncomingRequest<AdapterRequest = unknown> {
 	method: string;
 	host: string;
 	path: string;
 	query: URLSearchParams;
 	headers: RequestHeaders;
 	rawBody: RawBody;
+	adapter?: AdapterRequest;
 }

--- a/packages/kit/types/endpoint.d.ts
+++ b/packages/kit/types/endpoint.d.ts
@@ -1,18 +1,32 @@
 import { ServerRequest } from './hooks';
-import { JSONString, MaybePromise, ResponseHeaders } from './helper';
+import { Either, JSONString, MaybePromise, ResponseHeaders } from './helper';
 
 type DefaultBody = JSONString | Uint8Array;
 
-export interface EndpointOutput<Body extends DefaultBody = DefaultBody> {
+export type EndpointOutputNormal<Body extends DefaultBody = DefaultBody> = {
 	status?: number;
 	headers?: ResponseHeaders;
 	body?: Body;
-}
+};
+
+export type EndpointOutputAdapterResponse<AdapterResponse = unknown> = {
+	adapter: AdapterResponse;
+};
+
+export type EndpointOutput<
+	Body extends DefaultBody = DefaultBody,
+	AdapterResponse = unknown
+> = Either<EndpointOutputNormal<Body>, EndpointOutputAdapterResponse<AdapterResponse>>;
 
 export interface RequestHandler<
 	Locals = Record<string, any>,
 	Input = unknown,
-	Output extends DefaultBody = DefaultBody
+	Output extends DefaultBody = DefaultBody,
+	AdapterRequest = unknown,
+	AdapterResponse = unknown
 > {
-	(request: ServerRequest<Locals, Input>): MaybePromise<void | EndpointOutput<Output>>;
+	(request: ServerRequest<Locals, Input, AdapterRequest>): MaybePromise<void | EndpointOutput<
+		Output,
+		AdapterResponse
+	>>;
 }

--- a/packages/kit/types/helper.d.ts
+++ b/packages/kit/types/helper.d.ts
@@ -39,3 +39,11 @@ export type RecursiveRequired<T> = {
 		? Extract<T[K], Function> // only take the Function type.
 		: T[K]; // Use the exact type for everything else
 };
+
+export type Only<T, U> = {
+	[P in keyof T]: T[P];
+} & {
+	[P in keyof U]?: never;
+};
+
+export type Either<T, U> = Only<T, U> | Only<U, T>;

--- a/packages/kit/types/helper.d.ts
+++ b/packages/kit/types/helper.d.ts
@@ -43,7 +43,7 @@ export type RecursiveRequired<T> = {
 export type Only<T, U> = {
 	[P in keyof T]: T[P];
 } & {
-	[P in keyof U]?: never;
+	[P in keyof U]?: undefined;
 };
 
 export type Either<T, U> = Only<T, U> | Only<U, T>;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -28,12 +28,12 @@ export interface App extends PublicApp {
 		read(file: string): Buffer;
 	}): void;
 
-	render(
-		incoming: IncomingRequest,
+	render<AdapterRequest = unknown, AdapterResponse = unknown>(
+		incoming: IncomingRequest<AdapterRequest>,
 		options?: {
 			prerender: PrerenderOptions;
 		}
-	): Promise<ServerResponse>;
+	): Promise<ServerResponse<AdapterResponse>>;
 }
 
 export interface Logger {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,15 +68,18 @@ importers:
 
   packages/adapter-cloudflare:
     specifiers:
+      '@cloudflare/workers-types': ^3.2.0
       '@sveltejs/kit': workspace:*
       esbuild: ^0.13.4
     dependencies:
       esbuild: 0.13.12
     devDependencies:
+      '@cloudflare/workers-types': 3.2.0
       '@sveltejs/kit': link:../kit
 
   packages/adapter-cloudflare-workers:
     specifiers:
+      '@cloudflare/workers-types': ^3.2.0
       '@iarna/toml': ^2.2.5
       '@sveltejs/kit': workspace:*
       esbuild: ^0.13.4
@@ -84,17 +87,20 @@ importers:
       '@iarna/toml': 2.2.5
       esbuild: 0.13.12
     devDependencies:
+      '@cloudflare/workers-types': 3.2.0
       '@sveltejs/kit': link:../kit
 
   packages/adapter-netlify:
     specifiers:
       '@iarna/toml': ^2.2.5
+      '@netlify/functions': ^0.9.0
       '@sveltejs/kit': workspace:*
       esbuild: ^0.13.4
     dependencies:
       '@iarna/toml': 2.2.5
       esbuild: 0.13.12
     devDependencies:
+      '@netlify/functions': 0.9.0
       '@sveltejs/kit': link:../kit
 
   packages/adapter-node:
@@ -508,6 +514,10 @@ packages:
       prettier: 1.19.1
     dev: true
 
+  /@cloudflare/workers-types/3.2.0:
+    resolution: {integrity: sha512-y0+f7QeB5/fMMdU0wSwvBB18yE9kAD2s7Wben8a4uI4f/EJyE+eJrai5QO52Pq8EmWP0vRpKqZh0qU857WhY2A==}
+    dev: true
+
   /@eslint/eslintrc/0.4.3:
     resolution: {integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -583,6 +593,13 @@ packages:
       fs-extra: 8.1.0
       globby: 11.0.4
       read-yaml-file: 1.1.0
+    dev: true
+
+  /@netlify/functions/0.9.0:
+    resolution: {integrity: sha512-CQ2L2MEA/hfcZrVl7yJrNCqTGjXDIrdcgF4NX/OwzU5QAmSQmjQWI890nMHf98Q7++K8ljTFyICpq26HDLKbDg==}
+    engines: {node: '>=8.3.0'}
+    dependencies:
+      is-promise: 4.0.0
     dev: true
 
   /@nodelib/fs.scandir/2.1.5:
@@ -2571,6 +2588,10 @@ packages:
   /is-plain-object/5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /is-promise/4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
     dev: true
 
   /is-reference/1.2.1:


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

---

Hi, this is my weekend project that allows to directly interact with the Request and Response objects (and more) used by the adapter (if implemented).
This makes most sense for the two Cloudflare adapters, as it exposes the full CF Worker functionality:
- Env vars
- KV Namespaces
- waitUntil
- the Request.cf and Response.cf property
- The ability to proxy requests through without buffering
- *basically anything a normal worker has access to*

Here is a example that tests some of the Cloudflare specific functionality exposed by the adapter:
```ts
import type { AdapterRequestHandler } from '@sveltejs/adapter-cloudflare';

export const get: AdapterRequestHandler = async (request) => {
  if (request.adapter) {
    const colo = request.adapter.request.cf?.colo;

    request.adapter.ctx.waitUntil(
      (async () => {
        // Do stuff here
        return;
      })()
    );

    return {
      adapter: {
        // No buffering in memory happens here! Its passed straight through.
        response: fetch(
          `https://fakeimg.pl/440x230/282828/eae0d0/?retina=1&text=${encodeURIComponent(
            `proxied by CF in ${colo}`
          )}`,
          { cf: { cacheEverything: true } }
        )
      }
    };
  }
  return {
    status: 302,
    headers: {
      location: `https://fakeimg.pl/440x230/282828/eae0d0/?retina=1&text=${encodeURIComponent(
        'fallback to redirect'
      )}`
    }
  };
};
```

To test it, I build a example project https://github.com/skirsten/kit/tree/master, deployed here https://svelte-kit-cf-adapter-demo.pages.dev/.

It should be 100% backwards compatible and there is no need to use this new feature in your project.
This closes a number of issues:
- https://github.com/sveltejs/kit/issues/2844
- https://github.com/sveltejs/kit/issues/2807
- https://github.com/sveltejs/kit/issues/2606
- *and probably more*

Unfortunately I don't have the time to finish this, so this is a draft. If the approach taken here is okay with the maintainers, I would be glad if somebody can take this over and finish it.

### Missing
- [ ] Mismatch between Cloudflare Worker types and other types (Request, fetch, etc.). I am stuck here, I have no idea how to force it to use the Cloudflare Worker types...
- [ ] Only tested `adapter-cloudflare` not the `adapter-cloudflare-workers` and not `adapter-netlify` (was only a proof of concept to keep it generic)
- [ ] Update docs
- [ ] Test (automated?) all the edge-case interactions e.g. pre-rendered, handle hook, etc.
- [ ] Fix one failing CI. Seems unrelated.