### PR TITLE
[fix] prevent text unselection for keepfocus

### DIFF
--- a/.changeset/empty-grapes-own.md
+++ b/.changeset/empty-grapes-own.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] prevent text unselection for keepfocus

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -275,11 +275,10 @@ export class Renderer {
 			this._init(navigation_result);
 		}
 
-		getSelection()?.removeAllRanges();
-
 		const { hash, scroll, keepfocus } = opts || {};
 
 		if (!keepfocus) {
+			getSelection()?.removeAllRanges();
 			document.body.focus();
 		}
 

--- a/packages/kit/test/apps/basics/src/routes/keepfocus/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/keepfocus/_tests.js
@@ -1,0 +1,12 @@
+import * as assert from 'uvu/assert';
+
+/** @type {import('test').TestMaker} */
+export default function (test) {
+	test('keepfocus works', '/keepfocus', async ({ page, js }) => {
+		if (js) {
+			await page.type('#input', 'bar');
+			assert.ok(page.url().includes('?foo=bar'));
+			assert.ok(await page.$eval('#input', (el) => el === document.activeElement));
+		}
+	});
+}

--- a/packages/kit/test/apps/basics/src/routes/keepfocus/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/keepfocus/index.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
+</script>
+
+<input
+	id="input"
+	type="text"
+	value={$page.query.get('foo')}
+	on:input={(e) => {
+		goto('?foo=' + e.currentTarget?.value, { keepfocus: true });
+	}}
+/>


### PR DESCRIPTION
Fixes #2853

Text unselection also messes with focus, so have that logic honor `keepfocus` too.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
