### PR TITLE
ci: don't run deploy docs workflow on forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   release:
+    # prevents this action from running on forks
+    if: github.repository == 'sveltejs/kit'
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Just an inconvenience, the action fails on forks because of the missing required secrect, but this spares the trouble

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
