### PR TITLE
Add package command

### DIFF
--- a/.changeset/sour-taxis-laugh.md
+++ b/.changeset/sour-taxis-laugh.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Add an npm run package command to templates

--- a/packages/create-svelte/templates/default/package.template.json
+++ b/packages/create-svelte/templates/default/package.template.json
@@ -4,6 +4,7 @@
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",
+		"package": "svelte-kit package",
 		"preview": "svelte-kit preview"
 	},
 	"devDependencies": {

--- a/packages/create-svelte/templates/skeleton/package.template.json
+++ b/packages/create-svelte/templates/skeleton/package.template.json
@@ -4,6 +4,7 @@
 	"scripts": {
 		"dev": "svelte-kit dev",
 		"build": "svelte-kit build",
+		"package": "svelte-kit package",
 		"preview": "svelte-kit preview"
 	},
 	"devDependencies": {

--- a/packages/kit/src/packaging/index.js
+++ b/packages/kit/src/packaging/index.js
@@ -1,9 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { createRequire } from 'module';
-
+import colors from 'kleur';
 import { preprocess } from 'svelte/compiler';
-
 import { mkdirp, rimraf, walk } from '../utils/filesystem.js';
 
 const essential_files = ['README', 'LICENSE', 'CHANGELOG', '.gitignore', '.npmignore'];
@@ -132,14 +131,14 @@ export async function make_package(config, cwd = process.cwd()) {
 				console.warn(
 					'Cannot generate a "svelte" entry point because ' +
 						'the "." entry in "exports" is not a string. ' +
-						'If you set it by hand, please also set one of the options as a "svelte" entry point'
+						'If you set it by hand, please also set one of the options as a "svelte" entry point\n'
 				);
 			}
 		} else {
 			console.warn(
 				'Cannot generate a "svelte" entry point because ' +
 					'the "." entry in "exports" is missing. ' +
-					'Please specify one or set a "svelte" entry point yourself'
+					'Please specify one or set a "svelte" entry point yourself\n'
 			);
 		}
 	}
@@ -157,13 +156,20 @@ export async function make_package(config, cwd = process.cwd()) {
 		const package_path = path.join(abs_package_dir, pathname);
 		if (!fs.existsSync(package_path)) fs.copyFileSync(full_path, package_path);
 	}
+
+	const from = path.relative(cwd, config.kit.files.lib);
+	const to = path.relative(cwd, config.kit.package.dir);
+	console.log(colors.bold().green(`${from} -> ${to}`));
+	console.log(`Successfully built '${pkg.name}' package. To publish it to npm:`);
+	console.log(colors.bold().cyan(`  cd ${to}`));
+	console.log(colors.bold().cyan('  npm publish\n'));
 }
 
 /**
  * Resolves the `$lib` alias.
  *
  * TODO: make this more generic to also handle other aliases the user could have defined
- * via `kit.vite.resolve.alias`. Also investage how to do this in a more robust way
+ * via `kit.vite.resolve.alias`. Also investigate how to do this in a more robust way
  * (right now regex string replacement is used).
  * For more discussion see https://github.com/sveltejs/kit/pull/2453
  *


### PR DESCRIPTION
If component libraries are to be a first-class use case for Kit, it stands to reason that `npm run package` should be available in new projects alongside `npm run build`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
