### PR TITLE
improve project scaffolding language

### DIFF
--- a/.changeset/stale-glasses-brake.md
+++ b/.changeset/stale-glasses-brake.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Improve project scaffolding language

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -2,7 +2,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { bold, cyan, gray, green, red } from 'kleur/colors';
+import { bold, cyan, gray, green, red, magenta } from 'kleur/colors';
 import prompts from 'prompts';
 import { mkdirp, copy } from './utils.js';
 
@@ -12,7 +12,7 @@ ${bold(cyan('Welcome to SvelteKit!'))}
 
 ${bold(red('This is beta software; expect bugs and missing features.'))}
 
-If you encounter a problem, open an issue on ${cyan('https://github.com/sveltejs/kit/issues')} if none exists already.
+Problems? Open an issue on ${cyan('https://github.com/sveltejs/kit/issues')} if none exists already.
 `;
 
 const { version } = JSON.parse(fs.readFileSync(new URL('package.json', import.meta.url), 'utf-8'));
@@ -88,47 +88,26 @@ async function main() {
 	write_template_files(options.template, options.typescript, name, cwd);
 	write_common_files(cwd, options, name);
 
-	console.log(bold(green('✔ Copied project files')));
+	console.log(bold(green('\nYour project is ready!')));
 
 	if (options.typescript) {
-		console.log(
-			bold(
-				green(
-					'✔ Added TypeScript support. ' +
-						'To use it inside Svelte components, add lang="ts" to the attributes of a script tag.'
-				)
-			)
-		);
+		console.log(bold('✔ typescript'));
+		console.log('  Inside Svelte components, use <script lang="ts">');
 	}
 
 	if (options.eslint) {
-		console.log(
-			bold(
-				green(
-					'✔ Added ESLint.\n' +
-						'Readme for ESLint and Svelte: https://github.com/sveltejs/eslint-plugin-svelte3'
-				)
-			)
-		);
+		console.log(bold('✔ eslint'));
+		console.log(cyan('  https://github.com/sveltejs/eslint-plugin-svelte3'));
 	}
 
 	if (options.prettier) {
-		console.log(
-			bold(
-				green(
-					'✔ Added Prettier.\n' +
-						'General formatting options: https://prettier.io/docs/en/options.html\n' +
-						'Svelte-specific formatting options: https://github.com/sveltejs/prettier-plugin-svelte#options'
-				)
-			)
-		);
+		console.log(bold('✔ prettier'));
+		console.log(cyan('  https://prettier.io/docs/en/options.html'));
+		console.log(cyan('  https://github.com/sveltejs/prettier-plugin-svelte#options'));
 	}
 
-	console.log(
-		'\nWant to add other parts to your code base? ' +
-			'Visit https://github.com/svelte-add/svelte-adders, a community project of commands ' +
-			'to add particular functionality to Svelte projects\n'
-	);
+	console.log('\nInstall community-maintained integrations:');
+	console.log(cyan('  https://github.com/svelte-add/svelte-adders'));
 
 	console.log('\nNext steps:');
 	let i = 1;
@@ -140,11 +119,11 @@ async function main() {
 
 	console.log(`  ${i++}: ${bold(cyan('npm install'))} (or pnpm install, etc)`);
 	// prettier-ignore
-	console.log(`  ${i++}: ${bold(cyan('git init && git add -A && git commit -m "Initial commit"'))} (optional step)`);
+	console.log(`  ${i++}: ${bold(cyan('git init && git add -A && git commit -m "Initial commit"'))} (optional)`);
 	console.log(`  ${i++}: ${bold(cyan('npm run dev -- --open'))}`);
 
 	console.log(`\nTo close the dev server, hit ${bold(cyan('Ctrl-C'))}`);
-	console.log('\nStuck? Visit us at https://svelte.dev/chat\n');
+	console.log(`\nStuck? Visit us at ${cyan('https://svelte.dev/chat')}\n`);
 }
 
 /**

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -2,7 +2,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { bold, cyan, gray, green, red, magenta } from 'kleur/colors';
+import { bold, cyan, gray, green, red } from 'kleur/colors';
 import prompts from 'prompts';
 import { mkdirp, copy } from './utils.js';
 

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -91,17 +91,17 @@ async function main() {
 	console.log(bold(green('\nYour project is ready!')));
 
 	if (options.typescript) {
-		console.log(bold('✔ typescript'));
+		console.log(bold('✔ Typescript'));
 		console.log('  Inside Svelte components, use <script lang="ts">');
 	}
 
 	if (options.eslint) {
-		console.log(bold('✔ eslint'));
+		console.log(bold('✔ ESLint'));
 		console.log(cyan('  https://github.com/sveltejs/eslint-plugin-svelte3'));
 	}
 
 	if (options.prettier) {
-		console.log(bold('✔ prettier'));
+		console.log(bold('✔ Prettier'));
 		console.log(cyan('  https://prettier.io/docs/en/options.html'));
 		console.log(cyan('  https://github.com/sveltejs/prettier-plugin-svelte#options'));
 	}


### PR DESCRIPTION
The language you get when you `npm init svelte@next` is a bit chaotic. We can tidy it up

### before

<img width="948" alt="Screen Shot 2021-11-24 at 10 33 16 AM" src="https://user-images.githubusercontent.com/1162160/143274230-afaa0b2c-bef0-4184-83b7-4c4f96ac6b1c.png">

### after

<img width="634" alt="Screen Shot 2021-11-24 at 11 12 08 AM" src="https://user-images.githubusercontent.com/1162160/143274532-f5d493b3-37cb-45a5-b606-2dbd97891f29.png">

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
