### PR TITLE
[fix] add types properly in exports in package.json

### DIFF
--- a/.changeset/beige-eyes-poke.md
+++ b/.changeset/beige-eyes-poke.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix types reference in exports in package.json

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -68,6 +68,9 @@
 	},
 	"exports": {
 		"./package.json": "./package.json",
+		".": {
+			"types": "./types/index.d.ts"
+		},
 		"./ssr": {
 			"import": "./dist/ssr.js"
 		},
@@ -79,8 +82,7 @@
 		},
 		"./install-fetch": {
 			"import": "./dist/install-fetch.js"
-		},
-		"./types": "./types/index.d.ts"
+		}
 	},
 	"types": "types/index.d.ts",
 	"engines": {


### PR DESCRIPTION
Fixes #2863
Also removes the somewhat weird types export "./types" which is redundant: you get these through the default import, too. This shouldn't be a breaking change either (at least right now), as only TypeScript would be able to deal with that import as it's type-only, and TypeScript isn't officially supporting the exports field yet. I don't know who would do `import { SomeInterface } from '@sveltejs/kit/types';` anyway if you can do `import { SomeInterface } from '@sveltejs/kit/types';`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
