### PR TITLE
[fix] clicknav wait until network idle

### DIFF
--- a/packages/kit/test/test.js
+++ b/packages/kit/test/test.js
@@ -234,6 +234,7 @@ function duplicate(test_fn, config, is_build) {
 						});
 
 						await Promise.all([
+							context.pages.js.waitForNavigation({ waitUntil: 'networkidle' }),
 							context.pages.js.click(selector),
 							context.pages.js.evaluate(() => window.navigated)
 						]);


### PR DESCRIPTION
Fixes #2901

Spent a couple days on this one (https://github.com/bluwy/kit/pull/1). My findings were that for that flaky test, Windows was loading its CSS too slow before we measure `is_intersecting_viewport`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
