### PR TITLE
[docs] Clarify usage of `page.query`

### DIFF
--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -92,7 +92,7 @@ The `load` function receives an object containing four fields — `page`, `fetch
 
 #### page
 
-`page` is a `{ host, path, params, query }` object where `host` is the URL's host, `path` is its pathname, `params` is derived from `path` and the route filename, and `query` is an instance of [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams). Mutating `page` does not update the current URL; you should instead navigate using [`goto`](#modules-$app-navigation).
+`page` is a `{ host, path, params, query }` object where `host` is the URL's host, `path` is its pathname, `params` is derived from `path` and the route filename, and `query` is an instance of [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams). Using `query` on the server makes the current page not [prerenderable](#ssr-and-javascript-prerender). Mutating `page` does not update the current URL; you should instead navigate using [`goto`](#modules-$app-navigation).
 
 So if the example above was `src/routes/blog/[slug].svelte` and the URL was `https://example.com/blog/some-post?foo=bar&baz&bizz=a&bizz=b`, the following would be true:
 

--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -92,7 +92,7 @@ The `load` function receives an object containing four fields — `page`, `fetch
 
 #### page
 
-`page` is a `{ host, path, params, query }` object where `host` is the URL's host, `path` is its pathname, `params` is derived from `path` and the route filename, and `query` is an instance of [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams). Using `query` on the server makes the current page not [prerenderable](#ssr-and-javascript-prerender). Mutating `page` does not update the current URL; you should instead navigate using [`goto`](#modules-$app-navigation).
+`page` is a `{ host, path, params, query }` object where `host` is the URL's host, `path` is its pathname, `params` is derived from `path` and the route filename, and `query` is an instance of [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams). Mutating `page` does not update the current URL; you should instead navigate using [`goto`](#modules-$app-navigation).
 
 So if the example above was `src/routes/blog/[slug].svelte` and the URL was `https://example.com/blog/some-post?foo=bar&baz&bizz=a&bizz=b`, the following would be true:
 

--- a/documentation/docs/11-ssr-and-javascript.md
+++ b/documentation/docs/11-ssr-and-javascript.md
@@ -72,6 +72,8 @@ The basic rule is this: for a page to be prerenderable, any two users hitting it
 
 Note that you can still prerender pages that load data based on the page's parameters, like our `src/routes/blog/[slug].svelte` example from earlier. The prerenderer will intercept requests made inside `load`, so the data served from `src/routes/blog/[slug].json.js` will also be captured.
 
+> Using [`page.query`](#loading-input-page) on a server context will cause the current page to not be prerenderable. If you want to use `page.query` and keep the page prerenderable, you should only use it in a [client context](#modules-$app-env)
+
 #### Route conflicts
 
 Because prerendering writes to the filesystem, it isn't possible to have two endpoints that would cause a directory and a file to have the same name. For example, `src/routes/foo/index.js` and `src/routes/foo/bar.js` would try to create `foo` and `foo/bar`, which is impossible.

--- a/documentation/docs/11-ssr-and-javascript.md
+++ b/documentation/docs/11-ssr-and-javascript.md
@@ -72,7 +72,7 @@ The basic rule is this: for a page to be prerenderable, any two users hitting it
 
 Note that you can still prerender pages that load data based on the page's parameters, like our `src/routes/blog/[slug].svelte` example from earlier. The prerenderer will intercept requests made inside `load`, so the data served from `src/routes/blog/[slug].json.js` will also be captured.
 
-> Using [`page.query`](#loading-input-page) on a server context will cause the current page to not be prerenderable. If you want to use `page.query` and keep the page prerenderable, you should only use it in a [client context](#modules-$app-env)
+Accessing [`page.query`](#loading-input-page) during prerendering is forbidden. If you need to use it, ensure you are only doing so in the browser (for example in `onMount`).
 
 #### Route conflicts
 


### PR DESCRIPTION
This PR clarifies the usage of `page.query`. Currently if you use it in a prerendered page it throws an error unless you use it in a browser/client context only. These behavior is undocumented and people have asked related questions before #2262 #669 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
