### PR TITLE
ignore mailto: links etc

### DIFF
--- a/.changeset/proud-numbers-promise.md
+++ b/.changeset/proud-numbers-promise.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Ignore mailto: and tel: links

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -1,10 +1,13 @@
 const absolute = /^([a-z]+:)?\/?\//;
+const scheme = /^[a-z]+:/;
 
 /**
  * @param {string} base
  * @param {string} path
  */
 export function resolve(base, path) {
+	if (scheme.test(path)) return path;
+
 	const base_match = absolute.exec(base);
 	const path_match = absolute.exec(path);
 

--- a/packages/kit/src/utils/url.spec.js
+++ b/packages/kit/src/utils/url.spec.js
@@ -46,4 +46,8 @@ test('resolves an absolute path', () => {
 	assert.equal(resolve('/a/b/c', 'https://example.com/foo'), 'https://example.com/foo');
 });
 
+test('handles schemes like tel: and mailto:', () => {
+	assert.equal(resolve('/a/b/c', 'mailto:hello@svelte.dev'), 'mailto:hello@svelte.dev');
+});
+
 test.run();


### PR DESCRIPTION
Ignores `mailto:` and `tel:` and `data:` etc links when prerendering. Fixes #2909 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x]  Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
