### PR TITLE
Add license to package.json of individual packages

### DIFF
--- a/packages/adapter-auto/package.json
+++ b/packages/adapter-auto/package.json
@@ -6,6 +6,7 @@
 		"url": "https://github.com/sveltejs/kit",
 		"directory": "packages/adapter-auto"
 	},
+	"license": "MIT",
 	"homepage": "https://kit.svelte.dev",
 	"type": "module",
 	"exports": {

--- a/packages/adapter-begin/package.json
+++ b/packages/adapter-begin/package.json
@@ -6,6 +6,7 @@
 		"url": "https://github.com/sveltejs/kit",
 		"directory": "packages/adapter-begin"
 	},
+	"license": "MIT",
 	"homepage": "https://kit.svelte.dev",
 	"main": "index.cjs",
 	"types": "index.d.ts",

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -6,6 +6,7 @@
 		"url": "https://github.com/sveltejs/kit",
 		"directory": "packages/adapter-cloudflare-workers"
 	},
+	"license": "MIT",
 	"homepage": "https://kit.svelte.dev",
 	"type": "module",
 	"exports": {

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -6,6 +6,7 @@
 		"url": "https://github.com/sveltejs/kit",
 		"directory": "packages/adapter-cloudflare"
 	},
+	"license": "MIT",
 	"homepage": "https://kit.svelte.dev",
 	"type": "module",
 	"exports": {

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -6,6 +6,7 @@
 		"url": "https://github.com/sveltejs/kit",
 		"directory": "packages/adapter-netlify"
 	},
+	"license": "MIT",
 	"homepage": "https://kit.svelte.dev",
 	"type": "module",
 	"exports": {

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -6,6 +6,7 @@
 		"url": "https://github.com/sveltejs/kit",
 		"directory": "packages/adapter-node"
 	},
+	"license": "MIT",
 	"homepage": "https://kit.svelte.dev",
 	"type": "module",
 	"exports": {

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -6,6 +6,7 @@
 		"url": "https://github.com/sveltejs/kit",
 		"directory": "packages/adapter-static"
 	},
+	"license": "MIT",
 	"homepage": "https://kit.svelte.dev",
 	"type": "module",
 	"main": "index.js",

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -6,6 +6,7 @@
 		"url": "https://github.com/sveltejs/kit",
 		"directory": "packages/adapter-vercel"
 	},
+	"license": "MIT",
 	"homepage": "https://kit.svelte.dev",
 	"type": "module",
 	"exports": {

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -6,6 +6,7 @@
 		"url": "https://github.com/sveltejs/kit",
 		"directory": "packages/create-svelte"
 	},
+	"license": "MIT",
 	"homepage": "https://kit.svelte.dev",
 	"bin": "./bin.js",
 	"dependencies": {

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -6,6 +6,7 @@
 		"url": "https://github.com/sveltejs/kit",
 		"directory": "packages/kit"
 	},
+	"license": "MIT",
 	"homepage": "https://kit.svelte.dev",
 	"type": "module",
 	"dependencies": {


### PR DESCRIPTION
Everything in the repo has always been MIT-licensed. Being explicit about it in the sub-packages will help automated license reporting tools

Closes https://github.com/sveltejs/kit/issues/2893