### PR TITLE
adapter-cloudflare: handle non-slash path separators

### DIFF
--- a/.changeset/gorgeous-oranges-tan.md
+++ b/.changeset/gorgeous-oranges-tan.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+Handle non-slash path separators

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -16,12 +16,12 @@ export default function (options = {}) {
 
 			const static_files = utils
 				.copy(config.kit.files.assets, target_dir)
-			  .map((f) => f.replace(sep, '/'))
+				.map((f) => f.replace(sep, '/'))
 				.map((f) => f.replace(`${target_dir}/`, ''));
 
 			const client_files = utils
 				.copy(`${process.cwd()}/.svelte-kit/output/client`, target_dir)
-			  .map((f) => f.replace(sep, '/'))
+				.map((f) => f.replace(sep, '/'))
 				.map((f) => f.replace(`${target_dir}/`, ''));
 
 			// returns nothing, very sad

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join, sep } from 'path';
 import { fileURLToPath } from 'url';
 import { readFileSync, writeFileSync } from 'fs';
 import * as esbuild from 'esbuild';
@@ -16,10 +16,12 @@ export default function (options = {}) {
 
 			const static_files = utils
 				.copy(config.kit.files.assets, target_dir)
+			  .map((f) => f.replace(sep, '/'))
 				.map((f) => f.replace(`${target_dir}/`, ''));
 
 			const client_files = utils
 				.copy(`${process.cwd()}/.svelte-kit/output/client`, target_dir)
+			  .map((f) => f.replace(sep, '/'))
 				.map((f) => f.replace(`${target_dir}/`, ''));
 
 			// returns nothing, very sad

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -16,13 +16,11 @@ export default function (options = {}) {
 
 			const static_files = utils
 				.copy(config.kit.files.assets, target_dir)
-				.map((f) => f.replace(sep, '/'))
-				.map((f) => f.replace(`${target_dir}/`, ''));
+				.map((f) => f.replace(`${target_dir}${sep}`, ''));
 
 			const client_files = utils
 				.copy(`${process.cwd()}/.svelte-kit/output/client`, target_dir)
-				.map((f) => f.replace(sep, '/'))
-				.map((f) => f.replace(`${target_dir}/`, ''));
+				.map((f) => f.replace(`${target_dir}${sep}`, ''));
 
 			// returns nothing, very sad
 			// TODO(future) get/save output
@@ -30,7 +28,7 @@ export default function (options = {}) {
 				dest: `${target_dir}/`
 			});
 
-			const static_assets = [...static_files, ...client_files];
+			const static_assets = [...static_files, ...client_files].map((f) => f.replaceAll(sep, '/'));
 			const assets = `const ASSETS = new Set(${JSON.stringify(static_assets)});\n`;
 
 			const worker = readFileSync(join(files, 'worker.js'), { encoding: 'utf-8' });


### PR DESCRIPTION
On Windows, the paths in `ASSETS` use backslashes instead of slashes, so they'll never match a request. This patch allows the adapter to handle platforms with separators other than `/`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
