### PR TITLE
remove unused reload flag on NavigationResult

### DIFF
--- a/.changeset/yellow-mangos-fry.md
+++ b/.changeset/yellow-mangos-fry.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+remove unused reload flag on NavigationResult

--- a/.changeset/yellow-mangos-fry.md
+++ b/.changeset/yellow-mangos-fry.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': patch
----
-
-remove unused reload flag on NavigationResult

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -264,9 +264,7 @@ export class Renderer {
 			}
 		}
 
-		if (navigation_result.reload) {
-			location.reload();
-		} else if (this.started) {
+		if (this.started) {
 			this.current = navigation_result.state;
 
 			this.root.$set(navigation_result.props);

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -15,7 +15,6 @@ export type NavigationCandidate = {
 };
 
 export type NavigationResult = {
-	reload?: boolean;
 	redirect?: string;
 	state: NavigationState;
 	props: Record<string, any>;


### PR DESCRIPTION
I spent a few hours this morning debugging why a `popstate` event during navigation to one of my pages would result in the target page content being displayed at the previous page url.  Turns out I have an endpoint at the same url as the target page and the client router was performing `location.reload()`.  That code path didn't correctly handle a `popstate` while reloading.    That codepath is no longer possible after #2656 because it removes the endpoint routes from the client manifest, but I noticed the `location.reload()` logic is still present.  This PR cleans that up.

-----

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
