### PR TITLE
feat: bump eslint ecmaVersion to 2020

### DIFF
--- a/.changeset/gorgeous-toys-rule.md
+++ b/.changeset/gorgeous-toys-rule.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+bump eslint ecmaVersion to 2020

--- a/packages/create-svelte/shared/+eslint+prettier+typescript/.eslintrc.cjs
+++ b/packages/create-svelte/shared/+eslint+prettier+typescript/.eslintrc.cjs
@@ -10,7 +10,7 @@ module.exports = {
 	},
 	parserOptions: {
 		sourceType: 'module',
-		ecmaVersion: 2019
+		ecmaVersion: 2020
 	},
 	env: {
 		browser: true,

--- a/packages/create-svelte/shared/+eslint+prettier-typescript/.eslintrc.cjs
+++ b/packages/create-svelte/shared/+eslint+prettier-typescript/.eslintrc.cjs
@@ -5,7 +5,7 @@ module.exports = {
 	overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],
 	parserOptions: {
 		sourceType: 'module',
-		ecmaVersion: 2019
+		ecmaVersion: 2020
 	},
 	env: {
 		browser: true,

--- a/packages/create-svelte/shared/+eslint+typescript/.eslintrc.cjs
+++ b/packages/create-svelte/shared/+eslint+typescript/.eslintrc.cjs
@@ -10,7 +10,7 @@ module.exports = {
 	},
 	parserOptions: {
 		sourceType: 'module',
-		ecmaVersion: 2019
+		ecmaVersion: 2020
 	},
 	env: {
 		browser: true,

--- a/packages/create-svelte/shared/+eslint-typescript/.eslintrc.cjs
+++ b/packages/create-svelte/shared/+eslint-typescript/.eslintrc.cjs
@@ -5,7 +5,7 @@ module.exports = {
 	overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],
 	parserOptions: {
 		sourceType: 'module',
-		ecmaVersion: 2019
+		ecmaVersion: 2020
 	},
 	env: {
 		browser: true,


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

## Description

reference #2984 

Bumps eslint `ecmaVersion` to 2020, enables usage of `import.meta.env` in JS files without error