### PR TITLE
[fix] rename dotfiles to avoid template problems

### DIFF
--- a/.changeset/odd-ligers-march.md
+++ b/.changeset/odd-ligers-march.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+include missing .npmrc in templates

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -134,7 +134,7 @@ async function main() {
  */
 function write_template_files(template, typescript, name, cwd) {
 	const dir = dist(`templates/${template}`);
-	copy(`${dir}/assets`, cwd, (name) => name.replace('gitignore', '.gitignore'));
+	copy(`${dir}/assets`, cwd, (name) => name.replace('DOT-', '.'));
 	copy(`${dir}/package.json`, `${cwd}/package.json`);
 
 	const manifest = `${dir}/files.${typescript ? 'ts' : 'js'}.json`;

--- a/packages/create-svelte/scripts/build-templates.js
+++ b/packages/create-svelte/scripts/build-templates.js
@@ -56,7 +56,7 @@ async function generate_templates(shared) {
 					contents
 				});
 			} else {
-				const dest = path.join(assets, name).replace('.gitignore', 'gitignore'); // npm does wacky stuff to gitignores
+				const dest = path.join(assets, name.replace(/^\./, 'DOT-'));
 				mkdirp(path.dirname(dest));
 				fs.copyFileSync(path.join(cwd, name), dest);
 			}


### PR DESCRIPTION
Fixes #2952.

Rather than adding another special case for `.npmrc` like there already is for `.gitignore`, this simply renames all dotfiles to instead begin with `DOT-` when the `create-svelte` package is being built, and un-renames them when bootstrapping a new project with the CLI. This doesn't currently handle dotfiles other than at the top level of a particular template, but we don't have any of those. I didn't include that for simplicity, but if other folks think that would be a good idea to handle now while we're thinking of it, I'd be amenable to that.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
