### PR TITLE
fix: update `sveltekit:prefetch` mouse detection

### DIFF
--- a/.changeset/lazy-ways-swim.md
+++ b/.changeset/lazy-ways-swim.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+dispatch custom event to retrieve composed path

--- a/.changeset/lazy-ways-swim.md
+++ b/.changeset/lazy-ways-swim.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-dispatch custom event to retrieve composed path
+fix `sveltekit:prefetch` mouse detection

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -109,7 +109,7 @@ export class Router {
 		const handle_mousemove = (event) => {
 			clearTimeout(mousemove_timeout);
 			mousemove_timeout = setTimeout(() => {
-				event.target.dispatchEvent(new CustomEvent('trigger_prefetch', { bubbles: true }))
+				event.target.dispatchEvent(new CustomEvent('trigger_prefetch', { bubbles: true }));
 			}, 20);
 		};
 

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -109,12 +109,13 @@ export class Router {
 		const handle_mousemove = (event) => {
 			clearTimeout(mousemove_timeout);
 			mousemove_timeout = setTimeout(() => {
-				trigger_prefetch(event);
+				event.target.dispatchEvent(new CustomEvent('trigger_prefetch', { bubbles: true }))
 			}, 20);
 		};
 
 		addEventListener('touchstart', trigger_prefetch);
 		addEventListener('mousemove', handle_mousemove);
+		addEventListener('trigger_prefetch', trigger_prefetch);
 
 		/** @param {MouseEvent} event */
 		addEventListener('click', (event) => {

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -109,9 +109,8 @@ export class Router {
 		const handle_mousemove = (event) => {
 			clearTimeout(mousemove_timeout);
 			mousemove_timeout = setTimeout(() => {
-				if (!event.target) return;
 				// ensure event.composedPath() in find_anchor(event) returns an array of EventTarget objects
-				event.target.dispatchEvent(
+				event.target?.dispatchEvent(
 					new CustomEvent('sveltekit:trigger_prefetch', { bubbles: true })
 				);
 			}, 20);

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -109,7 +109,8 @@ export class Router {
 		const handle_mousemove = (event) => {
 			clearTimeout(mousemove_timeout);
 			mousemove_timeout = setTimeout(() => {
-				// ensure event.composedPath() in find_anchor(event) returns an array of EventTarget objects
+				// event.composedPath(), which is used in find_anchor, will be empty if the event is read in a timeout
+				// add a layer of indirection to address that
 				event.target?.dispatchEvent(
 					new CustomEvent('sveltekit:trigger_prefetch', { bubbles: true })
 				);

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -109,13 +109,16 @@ export class Router {
 		const handle_mousemove = (event) => {
 			clearTimeout(mousemove_timeout);
 			mousemove_timeout = setTimeout(() => {
-				event.target.dispatchEvent(new CustomEvent('trigger_prefetch', { bubbles: true }));
+				// ensure event.composedPath() in find_anchor(event) returns an array of EventTarget objects
+				event.target.dispatchEvent(
+					new CustomEvent('sveltekit:trigger_prefetch', { bubbles: true })
+				);
 			}, 20);
 		};
 
 		addEventListener('touchstart', trigger_prefetch);
 		addEventListener('mousemove', handle_mousemove);
-		addEventListener('trigger_prefetch', trigger_prefetch);
+		addEventListener('sveltekit:trigger_prefetch', trigger_prefetch);
 
 		/** @param {MouseEvent} event */
 		addEventListener('click', (event) => {

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -94,7 +94,7 @@ export class Router {
 			}, 200);
 		});
 
-		/** @param {MouseEvent|TouchEvent} event */
+		/** @param {Event} event */
 		const trigger_prefetch = (event) => {
 			const a = find_anchor(event);
 			if (a && a.href && a.hasAttribute('sveltekit:prefetch')) {
@@ -109,6 +109,7 @@ export class Router {
 		const handle_mousemove = (event) => {
 			clearTimeout(mousemove_timeout);
 			mousemove_timeout = setTimeout(() => {
+				if (!event.target) return;
 				// ensure event.composedPath() in find_anchor(event) returns an array of EventTarget objects
 				event.target.dispatchEvent(
 					new CustomEvent('sveltekit:trigger_prefetch', { bubbles: true })


### PR DESCRIPTION
dispatches a custom event so that `event.composedPath` returns an array of objects - fixes #2929

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
