### PR TITLE
Stops package from breaking when given absolute path

### DIFF
--- a/.changeset/gold-colts-train.md
+++ b/.changeset/gold-colts-train.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-doesn't break if abs is given to package
+Allow absolute file paths given to package.dir

--- a/.changeset/gold-colts-train.md
+++ b/.changeset/gold-colts-train.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+doesn't break if abs is given to package

--- a/packages/kit/src/packaging/index.js
+++ b/packages/kit/src/packaging/index.js
@@ -12,7 +12,8 @@ const essential_files = ['README', 'LICENSE', 'CHANGELOG', '.gitignore', '.npmig
  * @param {string} cwd
  */
 export async function make_package(config, cwd = process.cwd()) {
-	const abs_package_dir = path.join(cwd, config.kit.package.dir);
+	const package_dir = config.kit.package.dir;
+	const abs_package_dir = path.isAbsolute(package_dir) ? package_dir : path.join(cwd, package_dir);
 	rimraf(abs_package_dir);
 
 	if (config.kit.package.emitTypes) {


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

I was trying to figure out what's going on here: #3001 and discovered that absolute paths break.

> Important: due to a different path issue with `svelte2tsx` (going to make a pr to fix this) the issue I linked above isn't fixed, if testing this pr disable dts emitting in package options so that the dts generation issue doesn't get in the way