### PR TITLE
[feat] pass `render` function to `handle`

### DIFF
--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -42,6 +42,24 @@ export async function respond(incoming, options, state = {}) {
 
 	try {
 		return await options.hooks.handle({
+			render: async (path) => {
+				const decoded = decodeURI(path);
+				for (const route of options.manifest.routes) {
+					const match = route.pattern.exec(decoded);
+					if (!match) continue;
+
+					const response =
+						route.type === 'endpoint'
+							? undefined
+							: await render_page(request, route, match, options, state);
+
+					if(!response) continue;
+
+					const {status, body} = response;
+
+					if(status === 200) return body;
+				}
+			},
 			request,
 			resolve: async (request) => {
 				if (state.prerender && state.prerender.fallback) {

--- a/packages/kit/types/hooks.d.ts
+++ b/packages/kit/types/hooks.d.ts
@@ -22,6 +22,7 @@ export interface GetSession<Locals = Record<string, any>, Body = unknown, Sessio
 
 export interface Handle<Locals = Record<string, any>, Body = unknown> {
 	(input: {
+		render(path: string): Promise<StrictBody | undefined>;
 		request: ServerRequest<Locals, Body>;
 		resolve(request: ServerRequest<Locals, Body>): MaybePromise<ServerResponse>;
 	}): MaybePromise<ServerResponse>;


### PR DESCRIPTION
This is needed if you want to render some page from handle hook.

One potential use case would allowing render custom error page if you catch an error in handle function.