### PR TITLE
fix: normalize the usage of headers

### DIFF
--- a/.changeset/smooth-cars-build.md
+++ b/.changeset/smooth-cars-build.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Headers from a `Headers()` class are now correctly handled by the server to avoid losing headers

--- a/.changeset/smooth-cars-build.md
+++ b/.changeset/smooth-cars-build.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Headers from a `Headers()` class are now correctly handled by the server to avoid losing headers
+Handle `Headers` instance in server-side `fetch`

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -1,5 +1,3 @@
-import { Headers } from 'node-fetch';
-
 import { normalize } from '../../load.js';
 import { respond } from '../index.js';
 import { escape_json_string_in_html } from '../../../utils/escape.js';

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -210,12 +210,7 @@ export async function load_node({
 							opts.credentials !== 'omit'
 						) {
 							uses_credentials = true;
-
-							if (opts.headers === undefined) {
-								opts.headers = new Headers({ cookie: request.headers.cookie });
-							} else {
-								/** @type {Headers} */ (opts.headers).set('cookie', request.headers.cookie);
-							}
+							opts.headers.set('cookie', request.headers.cookie);
 						}
 					}
 

--- a/packages/kit/src/utils/http.js
+++ b/packages/kit/src/utils/http.js
@@ -1,3 +1,5 @@
+import { Headers } from 'node-fetch';
+
 /**
  * @param {Record<string, string | string[]>} headers
  * @param {string} key
@@ -18,4 +20,52 @@ export function get_single_valued_header(headers, key) {
 		return value[0];
 	}
 	return value;
+}
+
+/**
+ * Ensure that the headers are represented as an instance of the Headers class,
+ * not an object or an array.
+ *
+ * @param {HeadersInit} headers
+ * @returns {Headers}
+ */
+export function ensure_headers_class(headers) {
+	if ('has' in headers && typeof headers.has === 'function') {
+		// `headers` is probably a WHATWG-compliant implementation of headers
+		return /** @type {Headers} */ (headers);
+	} else {
+		return new Headers(headers);
+	}
+}
+
+/**
+ * Ensure that the headers are represented as a plain object,
+ * not a `Headers` instance or an array.
+ *
+ * @param {HeadersInit} headers
+ * @returns {Record<string, string>}
+ */
+export function ensure_headers_plain_object(headers) {
+	if ('has' in headers && typeof headers.has === 'function') {
+		// `headers` is probably a WHATWG-compliant implementation of headers
+		return Object.fromEntries([.../** @type {Headers} */ (headers)]);
+	} else if (Array.isArray(headers)) {
+		return Object.fromEntries(headers);
+	} else {
+		return /** @type {Record<string, string>} */ (headers);
+	}
+}
+
+/**
+ * Clone a WHATWG-compliant implementation of headers.
+ *
+ * @param {Headers} headers
+ * @returns {Headers}
+ */
+export function clone_headers(headers) {
+	const headersClone = new Headers();
+	for (const [header, value] of headers) {
+		headersClone.append(header, value);
+	}
+	return headersClone;
 }

--- a/packages/kit/src/utils/http.js
+++ b/packages/kit/src/utils/http.js
@@ -1,5 +1,3 @@
-import { Headers } from 'node-fetch';
-
 /**
  * @param {Record<string, string | string[]>} headers
  * @param {string} key
@@ -20,52 +18,4 @@ export function get_single_valued_header(headers, key) {
 		return value[0];
 	}
 	return value;
-}
-
-/**
- * Ensure that the headers are represented as an instance of the Headers class,
- * not an object or an array.
- *
- * @param {HeadersInit} headers
- * @returns {Headers}
- */
-export function ensure_headers_class(headers) {
-	if ('has' in headers && typeof headers.has === 'function') {
-		// `headers` is probably a WHATWG-compliant implementation of headers
-		return /** @type {Headers} */ (headers);
-	} else {
-		return new Headers(headers);
-	}
-}
-
-/**
- * Ensure that the headers are represented as a plain object,
- * not a `Headers` instance or an array.
- *
- * @param {HeadersInit} headers
- * @returns {Record<string, string>}
- */
-export function ensure_headers_plain_object(headers) {
-	if ('has' in headers && typeof headers.has === 'function') {
-		// `headers` is probably a WHATWG-compliant implementation of headers
-		return Object.fromEntries([.../** @type {Headers} */ (headers)]);
-	} else if (Array.isArray(headers)) {
-		return Object.fromEntries(headers);
-	} else {
-		return /** @type {Record<string, string>} */ (headers);
-	}
-}
-
-/**
- * Clone a WHATWG-compliant implementation of headers.
- *
- * @param {Headers} headers
- * @returns {Headers}
- */
-export function clone_headers(headers) {
-	const headersClone = new Headers();
-	for (const [header, value] of headers) {
-		headersClone.append(header, value);
-	}
-	return headersClone;
 }

--- a/packages/kit/test/apps/basics/src/routes/headers/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/headers/_tests.js
@@ -11,7 +11,7 @@ export default function (test) {
 		'allows headers to be sent as a Headers class instead of a POJO',
 		'/headers/class',
 		async ({ page }) => {
-			assert.equal(await page.innerHTML('pre'), JSON.stringify({ foo: 'bar' }));
+			assert.equal(await page.innerHTML('p'), 'bar');
 		}
 	);
 }

--- a/packages/kit/test/apps/basics/src/routes/headers/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/headers/_tests.js
@@ -6,4 +6,12 @@ export default function (test) {
 		const headers = response.headers();
 		assert.equal(headers['permissions-policy'], 'interest-cohort=()');
 	});
+
+	test(
+		'allows headers to be sent as a Headers class instead of a POJO',
+		'/headers/class',
+		async ({ page }) => {
+			assert.equal(await page.innerHTML('pre'), JSON.stringify({ foo: 'bar' }));
+		}
+	);
 }

--- a/packages/kit/test/apps/basics/src/routes/headers/class.svelte
+++ b/packages/kit/test/apps/basics/src/routes/headers/class.svelte
@@ -5,17 +5,19 @@
 			headers: new Headers({ foo: 'bar' })
 		});
 
+		const { foo } = await res.json();
+
 		return {
 			props: {
-				headers: await res.json()
+				foo
 			}
 		};
 	}
 </script>
 
 <script>
-	/** @type {Record<string, string>} */
-	export let headers;
+	/** @type {string} */
+	export let foo;
 </script>
 
-<pre>{JSON.stringify(headers)}</pre>
+<p>{foo}</p>

--- a/packages/kit/test/apps/basics/src/routes/headers/class.svelte
+++ b/packages/kit/test/apps/basics/src/routes/headers/class.svelte
@@ -1,0 +1,21 @@
+<script context="module">
+	/** @type {import('@sveltejs/kit').Load} */
+	export async function load({ fetch }) {
+		const res = await fetch('/headers/echo', {
+			headers: new Headers({ foo: 'bar' })
+		});
+
+		return {
+			props: {
+				headers: await res.json()
+			}
+		};
+	}
+</script>
+
+<script>
+	/** @type {Record<string, string>} */
+	export let headers;
+</script>
+
+<pre>{JSON.stringify(headers)}</pre>

--- a/packages/kit/test/apps/basics/src/routes/headers/echo.js
+++ b/packages/kit/test/apps/basics/src/routes/headers/echo.js
@@ -1,5 +1,7 @@
 /** @type {import('@sveltejs/kit').RequestHandler} */
 export function get({ headers }) {
+	delete headers.cookie;
+
 	return {
 		body: headers
 	};

--- a/packages/kit/test/apps/basics/src/routes/headers/echo.js
+++ b/packages/kit/test/apps/basics/src/routes/headers/echo.js
@@ -1,0 +1,6 @@
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export function get({ headers }) {
+	return {
+		body: headers
+	};
+}


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

This will normalize the usage of headers across the server-side `fetch` to ensure that `Record<string, string>`, `string[][]` and `Headers` are all treated correctly. Previosly, as described in https://github.com/sveltejs/kit/issues/3009, whenever headers in the form of `Headers` would come to the server-side fetch, the would be lost under a certain condition.

This only fixes one of the problems in #3009, the other one about the hostnames not being compared correctly still persists.