### PR TITLE
[adapter-cloudflare] Update static file logic to allow spaces in filenames

### DIFF
--- a/.changeset/twenty-turkeys-promise.md
+++ b/.changeset/twenty-turkeys-promise.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+Updated Cloudflare adapter to allow static files with spaces (eg. "Example File.pdf") to be accessed.

--- a/packages/adapter-cloudflare/files/worker.js
+++ b/packages/adapter-cloudflare/files/worker.js
@@ -7,7 +7,7 @@ export default {
 	async fetch(req, env) {
 		const url = new URL(req.url);
 		// check generated asset_set for static files
-		if (ASSETS.has(url.pathname.substring(1))) {
+		if (ASSETS.has(decodeURIComponent(url.pathname.substring(1)))) {
 			return env.ASSETS.fetch(req);
 		}
 

--- a/packages/adapter-cloudflare/files/worker.js
+++ b/packages/adapter-cloudflare/files/worker.js
@@ -6,14 +6,15 @@ init();
 export default {
 	async fetch(req, env) {
 		const url = new URL(req.url);
+
 		// check generated asset_set for static files
-    let pathname = url.pathname.substring(1);
-    try { 
-      pathname = decodeURIComponent(pathname);
-    } catch (err) { 
-      // ignore
-    }
-    
+		let pathname = url.pathname.substring(1);
+		try {
+			pathname = decodeURIComponent(pathname);
+		} catch (err) {
+			// ignore
+		}
+
 		if (ASSETS.has(pathname)) {
 			return env.ASSETS.fetch(req);
 		}

--- a/packages/adapter-cloudflare/files/worker.js
+++ b/packages/adapter-cloudflare/files/worker.js
@@ -7,7 +7,14 @@ export default {
 	async fetch(req, env) {
 		const url = new URL(req.url);
 		// check generated asset_set for static files
-		if (ASSETS.has(decodeURIComponent(url.pathname.substring(1)))) {
+    let pathname = url.pathname.substring(1);
+    try { 
+      pathname = decodeURIComponent(pathname);
+    } catch (err) { 
+      // ignore
+    }
+    
+		if (ASSETS.has(pathname)) {
 			return env.ASSETS.fetch(req);
 		}
 


### PR DESCRIPTION
**This PR makes the Worker URL-decode any received paths so that static files with spaces in the filename can be found.**

Without this change, accessing a static file that has a space in it (for example, `https://example.com/Example File.pdf`) fails. This is because:
1. The file is added to the `ASSETS` Set with a space (non-URL encoded).
2. The browser automatically URL encodes any space (` `) characters to `%20`, as it should.
3. When the request is received by the worker, it looks for a static file in the `ASSETS` Set with `%20` instead of space (` `). This fails, so the request is passed to SvelteKit which replies with a 404.

I've tested this change on my own local copy of adapter-cloudflare in production and it works.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
