### PR TITLE
[feat] use preserveValueImports flag in create-svelte

### DIFF
--- a/.changeset/metal-ears-travel.md
+++ b/.changeset/metal-ears-travel.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+use preserveValueImports flag

--- a/packages/create-svelte/shared/+prettier/package.json
+++ b/packages/create-svelte/shared/+prettier/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"prettier": "^2.4.1",
-		"prettier-plugin-svelte": "^2.4.0"
+		"prettier": "^2.5.1",
+		"prettier-plugin-svelte": "^2.5.0"
 	}
 }

--- a/packages/create-svelte/shared/+typescript/package.json
+++ b/packages/create-svelte/shared/+typescript/package.json
@@ -4,7 +4,7 @@
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
-		"typescript": "^4.5.4",
+		"typescript": "~4.5.4",
 		"tslib": "^2.3.1",
 		"svelte-check": "^2.2.6",
 		"svelte-preprocess": "^4.10.1"

--- a/packages/create-svelte/shared/+typescript/package.json
+++ b/packages/create-svelte/shared/+typescript/package.json
@@ -4,9 +4,9 @@
 		"check:watch": "svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
-		"typescript": "^4.4.3",
+		"typescript": "^4.5.4",
 		"tslib": "^2.3.1",
 		"svelte-check": "^2.2.6",
-		"svelte-preprocess": "^4.9.4"
+		"svelte-preprocess": "^4.10.1"
 	}
 }

--- a/packages/create-svelte/shared/+typescript/tsconfig.json
+++ b/packages/create-svelte/shared/+typescript/tsconfig.json
@@ -7,14 +7,19 @@
 		/**
 			svelte-preprocess cannot figure out whether you have a value or a type, so tell TypeScript
 			to enforce using \`import type\` instead of \`import\` for Types.
-			*/
+		*/
 		"importsNotUsedAsValues": "error",
+		/**
+			TypeScript doesn't know about import usages in the template because it only sees the
+			script of a Svelte file. Therefore preserve all value imports. Requires TS 4.5 or higher.
+		*/
+		"preserveValueImports": true,
 		"isolatedModules": true,
 		"resolveJsonModule": true,
 		/**
 			To have warnings/errors of the Svelte compiler at the correct position,
 			enable source maps by default.
-			*/
+		*/
 		"sourceMap": true,
 		"esModuleInterop": true,
 		"skipLibCheck": true,


### PR DESCRIPTION
TypeScript doesn't know about import usages in the template because it only sees the script of a Svelte file. Therefore preserve all value imports. Requires TS 4.5 or higher, therefore also bump the version of TS and Prettier (the latter in order to deal with the new TS syntax).
Turning on preserveValueImports turns off the advanced but somewhat brittle import transpilation in svelte-preprocess which should give a small performance boost and more robustness.

This requires ESBuild 0.14 or higher. According to Vite's `package.json` they install a dependency of 0.13.x or higher, so new users should get the version. Pinging @bluwy / @benmccann to ensure I'm not wrong because they know more about Vite than me 😄 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
