### PR TITLE
Prerender pages in parallel

### DIFF
--- a/.changeset/tough-gifts-compete.md
+++ b/.changeset/tough-gifts-compete.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Enables running prerendering of pages in parallel

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -44,6 +44,7 @@ test('fills in defaults', () => {
 			prerender: {
 				crawl: true,
 				enabled: true,
+				parallel: false,
 				entries: ['*'],
 				force: undefined,
 				onError: 'fail',
@@ -144,6 +145,7 @@ test('fills in partial blanks', () => {
 			prerender: {
 				crawl: true,
 				enabled: true,
+				parallel: false,
 				entries: ['*'],
 				force: undefined,
 				onError: 'fail',

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -116,6 +116,7 @@ const options = object(
 
 			prerender: object({
 				crawl: boolean(true),
+				parallel: boolean(false),
 				enabled: boolean(true),
 				entries: validate(['*'], (input, keypath) => {
 					if (!Array.isArray(input) || !input.every((page) => typeof page === 'string')) {

--- a/packages/kit/src/core/config/test/index.js
+++ b/packages/kit/src/core/config/test/index.js
@@ -46,6 +46,7 @@ async function testLoadDefaultConfig(path) {
 			prerender: {
 				crawl: true,
 				enabled: true,
+				parallel: false,
 				entries: ['*'],
 				force: undefined,
 				onError: 'fail',

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -77,6 +77,7 @@ export interface Config {
 		};
 		prerender?: {
 			crawl?: boolean;
+			parallel?: boolean;
 			enabled?: boolean;
 			entries?: string[];
 			onError?: PrerenderOnErrorValue;


### PR DESCRIPTION
#3065 

This PR enables prerendering pages in parallel. 
When enabling prerendering the entries are now batched and prerendered in parallel. Errors emerged when running more than 10 entries at once, thus the batch size. The batch size should maybe be configurable or not needed.
```
SyntaxError: Unexpected token < in JSON at position 0
  at JSON.parse (<anonymous>)
  at Response.json (file:///Users/felix/Projects/kit/packages/kit/dist/install-fetch.js:4868:15)
  at runMicrotasks (<anonymous>)
  at processTicksAndRejections (node:internal/process/task_queues:96:5)
  at async getAllEntities (file:///Users/felix/Projects/kit/examples/web/.svelte-kit/output/server/chunks/wordpress-cb2619c2.js:12:16)
  at async getAllProductsWithFilterParams (file:///Users/felix/Projects/kit/examples/web/.svelte-kit/output/server/chunks/woocommerce-a9f9aaa5.js:41:34)
  at async Promise.all (index 0)
  at async get (file:///Users/felix/Projects/kit/examples/web/.svelte-kit/output/server/chunks/_slug_.json-c5701545.js:10:40)
  at async render_endpoint (file:///Users/felix/Projects/kit/examples/web/.svelte-kit/output/server/chunks/app-52ab529a.js:96:20)
  at async resolve (file:///Users/felix/Projects/kit/examples/web/.svelte-kit/output/server/chunks/app-52ab529a.js:1259:56)
```

`dev:basics` tests are currently failing but to my understanding that's just for my setup and not any project specific. Tests regarding the default options are all passing.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [ ] Pass tests

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
