### PR TITLE
[fix] invalid amp-install-serviceworker

### DIFF
--- a/.changeset/spotty-parents-love.md
+++ b/.changeset/spotty-parents-love.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix invalid amp-install-serviceworker

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -170,26 +170,23 @@ export async function render_response({
 		init
 	].join('\n\n\t\t');
 
-	const body = options.amp
-		? `${rendered.html}
-			${
-				options.service_worker
-					? `<amp-install-serviceworker src="${options.service_worker}" layout="nodisplay"></amp-install-serviceworker>`
-					: ''
-			}`
-		: `${rendered.html}
+	let body = rendered.html;
+	if (options.amp) {
+		if (options.service_worker) {
+			body += `<amp-install-serviceworker src="${options.service_worker}" layout="nodisplay"></amp-install-serviceworker>`;
+		}
+	} else {
+		body += `${serialized_data
+			.map(({ url, body, json }) => {
+				let attributes = `type="application/json" data-type="svelte-data" data-url=${escape_html_attr(
+					url
+				)}`;
+				if (body) attributes += ` data-body="${hash(body)}"`;
 
-			${serialized_data
-				.map(({ url, body, json }) => {
-					let attributes = `type="application/json" data-type="svelte-data" data-url=${escape_html_attr(
-						url
-					)}`;
-					if (body) attributes += ` data-body="${hash(body)}"`;
-
-					return `<script ${attributes}>${json}</script>`;
-				})
-				.join('\n\n\t')}
-		`;
+				return `<script ${attributes}>${json}</script>`;
+			})
+			.join('\n\n\t')}`;
+	}
 
 	/** @type {import('types/helper').ResponseHeaders} */
 	const headers = {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -176,7 +176,7 @@ export async function render_response({
 			body += `<amp-install-serviceworker src="${options.service_worker}" layout="nodisplay"></amp-install-serviceworker>`;
 		}
 	} else {
-		body += `${serialized_data
+		body += serialized_data
 			.map(({ url, body, json }) => {
 				let attributes = `type="application/json" data-type="svelte-data" data-url=${escape_html_attr(
 					url
@@ -185,7 +185,7 @@ export async function render_response({
 
 				return `<script ${attributes}>${json}</script>`;
 			})
-			.join('\n\n\t')}`;
+			.join('\n\n\t');
 	}
 
 	/** @type {import('types/helper').ResponseHeaders} */

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -171,7 +171,8 @@ export async function render_response({
 	].join('\n\n\t\t');
 
 	const body = options.amp
-		? rendered.html + `<amp-install-serviceworker src="${options.service_worker}" layout="nodisplay"></amp-install-serviceworker>`
+		? `${rendered.html}
+			<amp-install-serviceworker src="${options.service_worker}" layout="nodisplay"></amp-install-serviceworker>`
 		: `${rendered.html}
 
 			${serialized_data

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -172,7 +172,11 @@ export async function render_response({
 
 	const body = options.amp
 		? `${rendered.html}
-			<amp-install-serviceworker src="${options.service_worker}" layout="nodisplay"></amp-install-serviceworker>`
+			${
+				options.service_worker
+					? `<amp-install-serviceworker src="${options.service_worker}" layout="nodisplay"></amp-install-serviceworker>`
+					: ''
+			}`
 		: `${rendered.html}
 
 			${serialized_data

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -153,10 +153,8 @@ export async function render_response({
 		</script>`;
 	}
 
-	if (options.service_worker) {
-		init += options.amp
-			? `<amp-install-serviceworker src="${options.service_worker}" layout="nodisplay"></amp-install-serviceworker>`
-			: `<script>
+	if (options.service_worker && !options.amp) {
+		init += `<script>
 			if ('serviceWorker' in navigator) {
 				navigator.serviceWorker.register('${options.service_worker}');
 			}
@@ -173,7 +171,7 @@ export async function render_response({
 	].join('\n\n\t\t');
 
 	const body = options.amp
-		? rendered.html
+		? rendered.html + `<amp-install-serviceworker src="${options.service_worker}" layout="nodisplay"></amp-install-serviceworker>`
 		: `${rendered.html}
 
 			${serialized_data


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/issues/3074 by injecting `<amp-install-serviceworker>` inside `<body>` instead of `<head>`. But user won't be able to customize the component.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
