### PR TITLE
feat: add precompress option to adapter-static

### DIFF
--- a/.changeset/healthy-pandas-pull.md
+++ b/.changeset/healthy-pandas-pull.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-static': minor
+---
+
+add precompress option to adapter-static

--- a/packages/adapter-static/index.d.ts
+++ b/packages/adapter-static/index.d.ts
@@ -4,6 +4,7 @@ interface AdapterOptions {
 	pages?: string;
 	assets?: string;
 	fallback?: string;
+	precompress?: boolean;
 }
 
 declare function plugin(options?: AdapterOptions): Adapter;

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -1,5 +1,13 @@
+import { createReadStream, createWriteStream, statSync } from 'fs';
+import { pipeline } from 'stream';
+import glob from 'tiny-glob';
+import { promisify } from 'util';
+import zlib from 'zlib';
+
+const pipe = promisify(pipeline);
+
 /** @type {import('.')} */
-export default function ({ pages = 'build', assets = pages, fallback } = {}) {
+export default function ({ pages = 'build', assets = pages, fallback, precompress = true } = {}) {
 	return {
 		name: '@sveltejs/adapter-static',
 
@@ -15,6 +23,57 @@ export default function ({ pages = 'build', assets = pages, fallback } = {}) {
 				all: !fallback,
 				dest: pages
 			});
+
+			if (precompress) {
+				if (pages === assets) {
+					utils.log.minor('Compressing assets and pages');
+					await compress(assets);
+				} else {
+					utils.log.minor('Compressing assets');
+					await compress(assets);
+
+					utils.log.minor('Compressing pages');
+					await compress(pages);
+				}
+			}
 		}
 	};
+}
+
+/**
+ * @param {string} directory
+ */
+async function compress(directory) {
+	const files = await glob('**/*.{html,js,json,css,svg,xml}', {
+		cwd: directory,
+		dot: true,
+		absolute: true,
+		filesOnly: true
+	});
+
+	await Promise.all(
+		files.map((file) => Promise.all([compress_file(file, 'gz'), compress_file(file, 'br')]))
+	);
+}
+
+/**
+ * @param {string} file
+ * @param {'gz' | 'br'} format
+ */
+async function compress_file(file, format = 'gz') {
+	const compress =
+		format == 'br'
+			? zlib.createBrotliCompress({
+					params: {
+						[zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT,
+						[zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,
+						[zlib.constants.BROTLI_PARAM_SIZE_HINT]: statSync(file).size
+					}
+			  })
+			: zlib.createGzip({ level: zlib.constants.Z_BEST_COMPRESSION });
+
+	const source = createReadStream(file);
+	const destination = createWriteStream(`${file}.${format}`);
+
+	await pipe(source, compress, destination);
 }

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -7,7 +7,7 @@ import zlib from 'zlib';
 const pipe = promisify(pipeline);
 
 /** @type {import('.')} */
-export default function ({ pages = 'build', assets = pages, fallback, precompress = true } = {}) {
+export default function ({ pages = 'build', assets = pages, fallback, precompress = false } = {}) {
 	return {
 		name: '@sveltejs/adapter-static',
 

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -24,6 +24,9 @@
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"test": "uvu test test.js"
 	},
+	"dependencies": {
+		"tiny-glob": "^0.2.9"
+	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:*",
 		"playwright-chromium": "^1.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,7 +143,10 @@ importers:
       port-authority: ^1.1.2
       sirv: ^1.0.19
       svelte: ^3.44.2
+      tiny-glob: ^0.2.9
       uvu: ^0.5.2
+    dependencies:
+      tiny-glob: 0.2.9
     devDependencies:
       '@sveltejs/kit': link:../kit
       playwright-chromium: 1.17.0


### PR DESCRIPTION
This PR adds the precompress option from adapter-node to adapter-static.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
