### PR TITLE
[chore] run pnpm with --frozen-lockfile in pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,6 +2,6 @@
 
 set -e
 
-pnpm i
+pnpm install --frozen-lockfile
 pnpm lint
 pnpm check


### PR DESCRIPTION
This makes the call to `pnpm install` in the `pre-push` hook use `--frozen-lockfile`. This has two goals:

1. Make pushes fail if someone updated a `package.json` but didn't re-install dependencies and update `pnpm-lock.yaml`. We don't want people submitting a PR like this.
2. Prevent `git push` from confusingly updating `pnpm-lock.yaml` when, say, the `action-deploy-docs#main` has received an update. This is what happened to me just now when I was pushing another branch.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
