### PR TITLE
sort rest params alphabetically

### DIFF
--- a/.changeset/metal-rings-mix.md
+++ b/.changeset/metal-rings-mix.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Sort rest routes alphabetically

--- a/packages/kit/src/core/create_manifest_data/index.js
+++ b/packages/kit/src/core/create_manifest_data/index.js
@@ -116,7 +116,7 @@ export default function create_manifest_data({ config, output, cwd = process.cwd
 				basename,
 				ext,
 				parts,
-				file: posixify(file),
+				file,
 				is_dir,
 				is_index,
 				is_page,
@@ -288,9 +288,10 @@ function comparator(a, b) {
 		if (!a_sub_part) return 1; // b is more specific, so goes first
 		if (!b_sub_part) return -1;
 
-		// if spread && index, order later
+		// if spread, order later
 		if (a_sub_part.spread && b_sub_part.spread) {
-			return a.is_index ? 1 : -1;
+			// sort alphabetically
+			return a_sub_part.content < b_sub_part.content ? -1 : 1;
 		}
 
 		// If one is ...spread order it later

--- a/packages/kit/src/core/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/create_manifest_data/index.spec.js
@@ -176,6 +176,7 @@ test('sorts routes correctly', () => {
 			[layout, 'samples/sorting/post/[id].svelte'],
 			'samples/sorting/[endpoint].js',
 			[layout, 'samples/sorting/[wildcard].svelte'],
+			[layout, 'samples/sorting/[...anotherrest]/index.svelte'],
 			[layout, 'samples/sorting/[...rest]/deep/[...deep_rest]/xyz.svelte'],
 			[layout, 'samples/sorting/[...rest]/deep/[...deep_rest]/index.svelte'],
 			[layout, 'samples/sorting/[...rest]/deep/index.svelte'],


### PR DESCRIPTION
- `file` variable already `posixify` when declared: https://github.com/tanhauhau/kit/blob/3ccc049f197399eb7a0a955b3ad6919bc002703c/packages/kit/src/core/create_manifest_data/index.js#L67
- from what i read, since [...rest] params has to be a standalone segment, it is not possible to be `is_index: true`.
- and, it is plausible to have multiple routes with `[...rest]` params on the same level, since there's fallthrough routes. updated the comparator to sort it in alphabetical order

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
