### PR TITLE
[fix] Modulepreload generated html head link tags aren't closed and …

### DIFF
--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -101,8 +101,8 @@ export async function render_response({
 			? `<style amp-custom>${Array.from(styles).concat(rendered.css.code).join('\n')}</style>`
 			: ''
 		: [
-				...Array.from(js).map((dep) => `<link rel="modulepreload" href="${dep}">`),
-				...Array.from(css).map((dep) => `<link rel="stylesheet" href="${dep}">`)
+				...Array.from(js).map((dep) => `<link rel="modulepreload" href="${dep}" />`),
+				...Array.from(css).map((dep) => `<link rel="stylesheet" href="${dep}" />`)
 		  ].join('\n\t\t');
 
 	/** @type {string} */


### PR DESCRIPTION
… as such trip XHTML validator end tag omitted errors #3107

- This very simple change to the kit renderer will now result in the `modulepreload` link tags to be closed and as such no longer cause `end tag omitted` XHTML 1.0 strict validation errors
- Changes are compatible with HTML5 Doctype
- pnpm test / lint / check / format are all still passing after this change.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
