### PR TITLE
fix: <Route> received an unexpected slot "default"

### DIFF
--- a/.changeset/moody-students-report.md
+++ b/.changeset/moody-students-report.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix <Route> received an unexpected slot "default"
+fix `<Route> received an unexpected slot "default"` warning

--- a/.changeset/moody-students-report.md
+++ b/.changeset/moody-students-report.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix <Route> received an unexpected slot "default"

--- a/packages/kit/src/core/create_app/index.js
+++ b/packages/kit/src/core/create_app/index.js
@@ -130,11 +130,13 @@ function generate_app(manifest_data) {
 
 	while (l--) {
 		pyramid = `
-			<svelte:component this={components[${l}]} {...(props_${l} || {})}>
-				{#if components[${l + 1}]}
+			{#if components[${l + 1}]}
+				<svelte:component this={components[${l}]} {...(props_${l} || {})}>				
 					${pyramid.replace(/\n/g, '\n\t\t\t\t\t')}
-				{/if}
-			</svelte:component>
+				</svelte:component>
+			{:else}
+				<svelte:component this={components[${l}]} {...(props_${l} || {})} />
+			{/if}
 		`
 			.replace(/^\t\t\t/gm, '')
 			.trim();


### PR DESCRIPTION
Previously:
```svelte
<Route>
  {#if subroute}
    <Subroute />
  {/if}
</Route>
```
if the subroute is falsy an empty default slot is passed which causes the warning. https://github.com/sveltejs/kit/issues/981

This change renders:

```svelte
{#if subroute}
  <Route>
    <Subroute />
  </Route>
{:else}
  <Route />
{/if}
```

**Caveat:**. 
Svelte as has no VirtualDOM, so when a route toggles between having a subroute and not having subroute the <Route> component will be remounted and internal state is lost. This is could be a non-issue, as I was not able to produce that scenario.



