### PR TITLE
[chore] do all middleware munging in the Vite plugin

### DIFF
--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -180,7 +180,6 @@ class Watcher extends EventEmitter {
 		}
 
 		this.vite = await vite.createServer(merged_config);
-		remove_html_middlewares(this.vite.middlewares);
 		await this.vite.listen(this.port);
 	}
 
@@ -536,6 +535,7 @@ async function create_plugin(config, dir, cwd, get_manifest) {
 		 */
 		configureServer(vite) {
 			return () => {
+				remove_html_middlewares(vite.middlewares);
 				vite.middlewares.use(create_kit_middleware(vite));
 			};
 		}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
       '@sveltejs/eslint-config': github.com/sveltejs/eslint-config/9a7d728e03ac433e5856a6e06775c17ee986d641_d9525e585486a10ae6317f3f61e9597f
       '@typescript-eslint/eslint-plugin': 5.5.0_15fb0f7dd5018b02e6608eb3a323af2f
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.4.4
-      action-deploy-docs: github.com/sveltejs/action-deploy-docs/e238bd8fcb7c96b683534eff14f3c7283d6a85c2
+      action-deploy-docs: github.com/sveltejs/action-deploy-docs/b907399e6bf74c9cc8f246ba38d2a392c77c8fc3
       dotenv: 10.0.0
       eslint: 8.3.0
       eslint-plugin-import: 2.25.3_eslint@8.3.0
@@ -4637,8 +4637,8 @@ packages:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: true
 
-  github.com/sveltejs/action-deploy-docs/e238bd8fcb7c96b683534eff14f3c7283d6a85c2:
-    resolution: {tarball: https://codeload.github.com/sveltejs/action-deploy-docs/tar.gz/e238bd8fcb7c96b683534eff14f3c7283d6a85c2}
+  github.com/sveltejs/action-deploy-docs/b907399e6bf74c9cc8f246ba38d2a392c77c8fc3:
+    resolution: {tarball: https://codeload.github.com/sveltejs/action-deploy-docs/tar.gz/b907399e6bf74c9cc8f246ba38d2a392c77c8fc3}
     name: action-deploy-docs
     version: 1.0.0
     hasBin: true


### PR DESCRIPTION
We should do less in the CLI and more in the Vite plugin. This makes it so that `init_server` now does nothing but build the Vite config and use it to start a server.

No changelog on this PR since it should not introduce any user-visible changes