### PR TITLE
Concurrency

### DIFF
--- a/.changeset/tough-gifts-compete.md
+++ b/.changeset/tough-gifts-compete.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Enables running prerendering of pages in parallel

--- a/.changeset/tough-gifts-compete.md
+++ b/.changeset/tough-gifts-compete.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Enables running prerendering of pages in parallel
+Add `config.kit.prerender.concurrency` setting

--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -41,6 +41,7 @@ const config = {
 			base: ''
 		},
 		prerender: {
+			concurrency: 1,
 			crawl: true,
 			enabled: true,
 			entries: ['*'],
@@ -55,7 +56,7 @@ const config = {
 		trailingSlash: 'never',
 		vite: () => ({})
 	},
-	
+
 	// SvelteKit uses vite-plugin-svelte. Its options can be provided directly here.
 	// See the available options at https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/config.md
 
@@ -163,6 +164,7 @@ An object containing zero or more of the following `string` values:
 
 See [Prerendering](#ssr-and-javascript-prerender). An object containing zero or more of the following:
 
+- `concurrency` — how many pages can be prerendered simultaneously. In cases where prerendering performance is network-bound (for example loading content from a remote CMS) this can speed things up
 - `crawl` — determines whether SvelteKit should find pages to prerender by following links from the seed page(s)
 - `enabled` — set to `false` to disable prerendering altogether
 - `entries` — an array of pages to prerender, or start crawling from (if `crawl: true`). The `*` string includes all non-dynamic routes (i.e. pages with no `[parameters]` )

--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -164,7 +164,7 @@ An object containing zero or more of the following `string` values:
 
 See [Prerendering](#ssr-and-javascript-prerender). An object containing zero or more of the following:
 
-- `concurrency` — how many pages can be prerendered simultaneously. In cases where prerendering performance is network-bound (for example loading content from a remote CMS) this can speed things up
+- `concurrency` — how many pages can be prerendered simultaneously. JS is single-threaded, but in cases where prerendering performance is network-bound (for example loading content from a remote CMS) this can speed things up by processing other tasks while waiting on the network response
 - `crawl` — determines whether SvelteKit should find pages to prerender by following links from the seed page(s)
 - `enabled` — set to `false` to disable prerendering altogether
 - `entries` — an array of pages to prerender, or start crawling from (if `crawl: true`). The `*` string includes all non-dynamic routes (i.e. pages with no `[parameters]` )

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -6,6 +6,7 @@ import { __fetch_polyfill } from '../../install-fetch.js';
 import { SVELTE_KIT } from '../constants.js';
 import { get_single_valued_header } from '../../utils/http.js';
 import { is_root_relative, resolve } from '../../utils/url.js';
+import { queue } from './queue.js';
 
 /**
  * @typedef {import('types/config').PrerenderErrorHandler} PrerenderErrorHandler
@@ -141,16 +142,27 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 		return path;
 	}
 
+	const q = queue(config.kit.prerender.concurrency);
+
 	/**
 	 * @param {string} decoded_path
 	 * @param {string?} referrer
 	 */
-	async function visit(decoded_path, referrer) {
+	function enqueue(decoded_path, referrer) {
 		const path = encodeURI(normalize(decoded_path));
 
 		if (seen.has(path)) return;
 		seen.add(path);
 
+		return q.add(() => visit(path, decoded_path, referrer));
+	}
+
+	/**
+	 * @param {string} path
+	 * @param {string} decoded_path
+	 * @param {string?} referrer
+	 */
+	async function visit(path, decoded_path, referrer) {
 		/** @type {Map<string, import('types/hooks').ServerResponse>} */
 		const dependencies = new Map();
 
@@ -195,7 +207,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 
 					const resolved = resolve(path, location);
 					if (is_root_relative(resolved)) {
-						await visit(resolved, path);
+						enqueue(resolved, path);
 					}
 				} else {
 					log.warn(`location header missing on redirect received from ${decoded_path}`);
@@ -282,38 +294,24 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 						// TODO warn that query strings have no effect on statically-exported pages
 					}
 
-					await visit(pathname, path);
+					enqueue(pathname, path);
 				}
 			}
 		}
 	}
 
 	if (config.kit.prerender.enabled) {
-		const prerenderAllNonDynamicPages = config.kit.prerender.entries.some((entry) => entry === '*');
-		const entries = prerenderAllNonDynamicPages
-			? [...build_data.entries, ...config.kit.prerender.entries.filter((e) => e !== '*')]
-			: config.kit.prerender.entries;
-
-		if (config.kit.prerender.parallel) {
-			const batchSize = 10;
-			const batchEntries = (acc, _, i, arr) => {
-				if (i % batchSize === 0) {
-					return [...acc, arr.slice(i, i + batchSize)];
+		for (const entry of config.kit.prerender.entries) {
+			if (entry === '*') {
+				for (const entry of build_data.entries) {
+					enqueue(entry, null);
 				}
-				return acc;
-			};
-
-			const batches = entries.reduce(batchEntries, []);
-
-			for (const entries of batches) {
-				const visitResults = entries.map((entry) => visit(entry, null));
-				await Promise.all(visitResults);
-			}
-		} else {
-			for (const entry of entries) {
-				await visit(entry, null);
+			} else {
+				enqueue(entry, null);
 			}
 		}
+
+		await q.done();
 	}
 
 	if (fallback) {

--- a/packages/kit/src/core/adapt/queue.js
+++ b/packages/kit/src/core/adapt/queue.js
@@ -1,0 +1,78 @@
+/** @typedef {{
+ *   fn: () => Promise<any>,
+ *   fulfil: (value: any) => void,
+ *   reject: (error: Error) => void
+ * }} Task */
+
+/** @param {number} concurrency */
+export function queue(concurrency) {
+	/** @type {Task[]} */
+	const tasks = [];
+
+	let current = 0;
+
+	/** @type {(value?: any) => void} */
+	let fulfil;
+
+	/** @type {(error: Error) => void} */
+	let reject;
+
+	let closed = false;
+
+	const done = new Promise((f, r) => {
+		fulfil = f;
+		reject = r;
+	});
+
+	done.catch((e) => {
+		// this is necessary in case a catch handler is never added
+		// to the done promise by the user
+	});
+
+	function dequeue() {
+		if (current < concurrency) {
+			const task = tasks.shift();
+
+			if (task) {
+				current += 1;
+				const promise = Promise.resolve(task.fn());
+
+				promise
+					.then(task.fulfil, (err) => {
+						task.reject(err);
+						reject(err);
+					})
+					.then(() => {
+						current -= 1;
+						dequeue();
+					});
+			} else if (current === 0) {
+				closed = true;
+				fulfil();
+			}
+		}
+	}
+
+	return {
+		/** @param {() => any} fn */
+		add: (fn) => {
+			if (closed) throw new Error('Cannot add tasks to a queue that has ended');
+
+			const promise = new Promise((fulfil, reject) => {
+				tasks.push({ fn, fulfil, reject });
+			});
+
+			dequeue();
+			return promise;
+		},
+
+		done: () => {
+			if (current === 0) {
+				closed = true;
+				fulfil();
+			}
+
+			return done;
+		}
+	};
+}

--- a/packages/kit/src/core/adapt/queue.js
+++ b/packages/kit/src/core/adapt/queue.js
@@ -24,7 +24,7 @@ export function queue(concurrency) {
 		reject = r;
 	});
 
-	done.catch((e) => {
+	done.catch(() => {
 		// this is necessary in case a catch handler is never added
 		// to the done promise by the user
 	});

--- a/packages/kit/src/core/adapt/queue.spec.js
+++ b/packages/kit/src/core/adapt/queue.spec.js
@@ -2,7 +2,10 @@ import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { queue } from './queue.js';
 
-const sleep = (ms) => new Promise((f) => setTimeout(f, ms));
+/** @param {number} ms */
+function sleep(ms) {
+	return new Promise((f) => setTimeout(f, ms));
+}
 
 test('q.add resolves to the correct value', async () => {
 	const q = queue(1);
@@ -22,7 +25,7 @@ test('q.add rejects if task rejects', async () => {
 
 		assert.ok(false);
 	} catch (e) {
-		assert.equal(e.message, 'nope');
+		assert.equal(/** @type {Error} */ (e).message, 'nope');
 	}
 });
 
@@ -104,7 +107,7 @@ test('q.done() rejects if task rejects', async () => {
 		await q.done();
 		assert.ok(false);
 	} catch (e) {
-		assert.equal(e.message, 'nope');
+		assert.equal(/** @type {Error} */ (e).message, 'nope');
 	}
 });
 

--- a/packages/kit/src/core/adapt/queue.spec.js
+++ b/packages/kit/src/core/adapt/queue.spec.js
@@ -1,0 +1,111 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { queue } from './queue.js';
+
+const sleep = (ms) => new Promise((f) => setTimeout(f, ms));
+
+test('q.add resolves to the correct value', async () => {
+	const q = queue(1);
+
+	const value = await q.add(() => 42);
+	assert.equal(value, 42);
+});
+
+test('q.add rejects if task rejects', async () => {
+	const q = queue(1);
+
+	try {
+		await q.add(async () => {
+			await sleep(1);
+			throw new Error('nope');
+		});
+
+		assert.ok(false);
+	} catch (e) {
+		assert.equal(e.message, 'nope');
+	}
+});
+
+test('starts tasks in sequence', async () => {
+	const q = queue(2);
+
+	const promises = [];
+
+	/** @type {Array<(value?: any) => void>} */
+	const fulfils = [];
+
+	const started = [false, false, false, false];
+	const finished = [false, false, false, false];
+
+	for (let i = 0; i < 4; i += 1) {
+		promises[i] = q
+			.add(() => {
+				started[i] = true;
+				return new Promise((f) => {
+					fulfils.push(f);
+				});
+			})
+			.then(() => {
+				finished[i] = true;
+			});
+	}
+
+	assert.equal(started, [true, true, false, false]);
+	assert.equal(finished, [false, false, false, false]);
+
+	fulfils[0]();
+	await promises[0];
+
+	assert.equal(started, [true, true, true, false]);
+	assert.equal(finished, [true, false, false, false]);
+
+	fulfils[1]();
+	await promises[1];
+
+	assert.equal(started, [true, true, true, true]);
+	assert.equal(finished, [true, true, false, false]);
+
+	fulfils[2]();
+	fulfils[3]();
+	await q.done();
+
+	assert.equal(finished, [true, true, true, true]);
+});
+
+test('q.add fails if queue is already finished', async () => {
+	const q = queue(1);
+	q.add(() => {});
+
+	await q.done();
+	assert.throws(() => q.add(() => {}), /Cannot add tasks to a queue that has ended/);
+});
+
+test('q.done() resolves if nothing was added to the queue', async () => {
+	const q = queue(100);
+	await Promise.race([
+		q.done(),
+		sleep(1).then(() => {
+			throw new Error('Timed out');
+		})
+	]);
+});
+
+test('q.done() rejects if task rejects', async () => {
+	const q = queue(1);
+
+	q.add(async () => {
+		await sleep(1);
+		throw new Error('nope');
+	}).catch((e) => {
+		assert.equal(e.message, 'nope');
+	});
+
+	try {
+		await q.done();
+		assert.ok(false);
+	} catch (e) {
+		assert.equal(e.message, 'nope');
+	}
+});
+
+test.run();

--- a/packages/kit/src/core/adapt/test/index.js
+++ b/packages/kit/src/core/adapt/test/index.js
@@ -91,6 +91,7 @@ suite('prerender', async () => {
 			},
 			appDir: '_app',
 			prerender: {
+				concurrency: 1,
 				enabled: true,
 				entries: ['*']
 			}
@@ -115,7 +116,7 @@ suite('prerender', async () => {
 		dest
 	});
 
-	assert.equal(glob('**', { cwd: `${prerendered_files}` }), glob('**', { cwd: dest }));
+	assert.equal(glob('**', { cwd: prerendered_files }), glob('**', { cwd: dest }));
 
 	rmSync(dest, { recursive: true, force: true });
 });

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -42,9 +42,9 @@ test('fills in defaults', () => {
 				assets: ''
 			},
 			prerender: {
+				concurrency: 1,
 				crawl: true,
 				enabled: true,
-				parallel: false,
 				entries: ['*'],
 				force: undefined,
 				onError: 'fail',
@@ -143,9 +143,9 @@ test('fills in partial blanks', () => {
 				assets: ''
 			},
 			prerender: {
+				concurrency: 1,
 				crawl: true,
 				enabled: true,
-				parallel: false,
 				entries: ['*'],
 				force: undefined,
 				onError: 'fail',

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -44,6 +44,7 @@ test('fills in defaults', () => {
 			prerender: {
 				crawl: true,
 				enabled: true,
+				parallel: false,
 				entries: ['*'],
 				force: undefined,
 				onError: 'fail',
@@ -144,6 +145,7 @@ test('fills in partial blanks', () => {
 			prerender: {
 				crawl: true,
 				enabled: true,
+				parallel: false,
 				entries: ['*'],
 				force: undefined,
 				onError: 'fail',

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -116,6 +116,7 @@ const options = object(
 
 			prerender: object({
 				crawl: boolean(true),
+				parallel: boolean(false),
 				enabled: boolean(true),
 				entries: validate(['*'], (input, keypath) => {
 					if (!Array.isArray(input) || !input.every((page) => typeof page === 'string')) {

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -115,8 +115,8 @@ const options = object(
 			}),
 
 			prerender: object({
+				concurrency: number(1),
 				crawl: boolean(true),
-				parallel: boolean(false),
 				enabled: boolean(true),
 				entries: validate(['*'], (input, keypath) => {
 					if (!Array.isArray(input) || !input.every((page) => typeof page === 'string')) {
@@ -258,6 +258,19 @@ function string(fallback, allow_empty = true) {
 			throw new Error(`${keypath} cannot be empty`);
 		}
 
+		return input;
+	});
+}
+
+/**
+ * @param {number} fallback
+ * @returns {Validator}
+ */
+function number(fallback) {
+	return validate(fallback, (input, keypath) => {
+		if (typeof input !== 'number') {
+			throw new Error(`${keypath} should be a number, if specified`);
+		}
 		return input;
 	});
 }

--- a/packages/kit/src/core/config/test/index.js
+++ b/packages/kit/src/core/config/test/index.js
@@ -44,9 +44,9 @@ async function testLoadDefaultConfig(path) {
 			serviceWorker: {},
 			paths: { base: '', assets: '' },
 			prerender: {
+				concurrency: 1,
 				crawl: true,
 				enabled: true,
-				parallel: false,
 				entries: ['*'],
 				force: undefined,
 				onError: 'fail',

--- a/packages/kit/src/core/config/test/index.js
+++ b/packages/kit/src/core/config/test/index.js
@@ -46,6 +46,7 @@ async function testLoadDefaultConfig(path) {
 			prerender: {
 				crawl: true,
 				enabled: true,
+				parallel: false,
 				entries: ['*'],
 				force: undefined,
 				onError: 'fail',

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -77,6 +77,7 @@ export interface Config {
 		};
 		prerender?: {
 			crawl?: boolean;
+			parallel?: boolean;
 			enabled?: boolean;
 			entries?: string[];
 			onError?: PrerenderOnErrorValue;

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -76,8 +76,8 @@ export interface Config {
 			base?: string;
 		};
 		prerender?: {
+			concurrency?: number;
 			crawl?: boolean;
-			parallel?: boolean;
 			enabled?: boolean;
 			entries?: string[];
 			onError?: PrerenderOnErrorValue;


### PR DESCRIPTION
Supersedes #3066, closes #3065. Adds a new `config.kit.prerender.concurrency` setting, which controls how many pages can be prerendered simultaneously (default `1`). 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
