### PR TITLE
fix: Revert utils to builder change in adapter-static 🐛

### DIFF
--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -11,14 +11,14 @@ export default function ({ pages = 'build', assets = pages, fallback, precompres
 	return {
 		name: '@sveltejs/adapter-static',
 
-		async adapt(builder) {
-			builder.rimraf(assets);
-			builder.rimraf(pages);
+		async adapt({ utils }) {
+			utils.rimraf(assets);
+			utils.rimraf(pages);
 
-			builder.writeStatic(assets);
-			builder.writeClient(assets);
+			utils.writeStatic(assets);
+			utils.writeClient(assets);
 
-			await builder.prerender({
+			await utils.prerender({
 				fallback,
 				all: !fallback,
 				dest: pages
@@ -26,13 +26,13 @@ export default function ({ pages = 'build', assets = pages, fallback, precompres
 
 			if (precompress) {
 				if (pages === assets) {
-					builder.log.minor('Compressing assets and pages');
+					utils.log.minor('Compressing assets and pages');
 					await compress(assets);
 				} else {
-					builder.log.minor('Compressing assets');
+					utils.log.minor('Compressing assets');
 					await compress(assets);
 
-					builder.log.minor('Compressing pages');
+					utils.log.minor('Compressing pages');
 					await compress(pages);
 				}
 			}


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

Fixes #3135 

Here's the output of `console.log(builder)`. You can see that the `utils` attribute is what we want to use in this function.

```
> Using @sveltejs/adapter-static
{
  utils: {
    log: [Function: log] {
      success: [Function (anonymous)],
      error: [Function (anonymous)],
      warn: [Function (anonymous)],
      minor: [Function: noop],
      info: [Function: noop]
    },
    rimraf: [Function: rimraf],
    mkdirp: [Function: mkdirp],
    copy: [Function: copy],
    copy_client_files: [Function: copy_client_files],
    copy_server_files: [Function: copy_server_files],
    copy_static_files: [Function: copy_static_files],
    prerender: [AsyncFunction: prerender]
  },
  config: {
    preprocess: {
      defaultLanguages: [Object],
      markup: [AsyncFunction: markup],
      script: [AsyncFunction: script],
      style: [AsyncFunction: style]
    },
    extensions: [ '.svelte' ],
    kit: {
      adapter: [Object],
      amp: false,
      appDir: '_app',
      files: [Object],
      floc: false,
      host: null,
      hostHeader: null,
      hydrate: true,
      package: [Object],
      paths: [Object],
      prerender: [Object],
      router: true,
      serviceWorker: [Object],
      ssr: true,
      target: '#svelte',
      trailingSlash: 'never',
      vite: [Function: input]
    }
  }
}
> builder.rimraf is not a function
TypeError: builder.rimraf is not a function
    at adapt (file:///Users/USER/gitrepos/project/node_modules/@sveltejs/adapter-static/index.js:15:12)
    at adapt (file:///Users/USER/gitrepos/project/node_modules/@sveltejs/kit/dist/chunks/index4.js:485:8)
    at file:///Users/USER/gitrepos/project/node_modules/@sveltejs/kit/dist/cli.js:910:11
```

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

I'm not able to run the tests though, I don't have `uvu` installed? I did run `pnpm install` but that doesn't seem to do it. I'm a little new to node, so I might be doing this wrong.

```
$ pnpm test                                                                                                           

> kit@0.0.1 test /Users/USER/gitrepos/sveltekit
> pnpm -r test --workspace-concurrency=1

Scope: all 14 workspace projects

> @sveltejs/kit@1.0.0-next.208 test /Users/USER/gitrepos/sveltekit/packages/kit
> npm run test:unit && npm run test:packaging && npm run test:integration


> @sveltejs/kit@1.0.0-next.208 test:unit
> uvu src "(spec\.js|test[\\/]index\.js)" -i packaging

sh: uvu: command not found
/Users/USER/gitrepos/sveltekit/packages/kit:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @sveltejs/kit@1.0.0-next.208 test: `npm run test:unit && npm run test:packaging && npm run test:integration`
spawn ENOENT
 ELIFECYCLE  Test failed. See above for more details.
```


### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
