### PR TITLE
Revert vercel adapter to v1 filesystem API

### DIFF
--- a/.changeset/quiet-terms-fail.md
+++ b/.changeset/quiet-terms-fail.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+Revert to v1 filesystem API


### PR DESCRIPTION
v2 isn't ready yet, shouldn't have released `next.33`. see #3142 and #3143 (not yet sure if it fixes both)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
