### PR TITLE
Prod mode page errors

### DIFF
--- a/.changeset/ten-hairs-perform.md
+++ b/.changeset/ten-hairs-perform.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add path/query error getters in prod mode

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -445,24 +445,22 @@ export class Renderer {
 		if (!this.current.url || url.href !== this.current.url.href) {
 			result.props.page = { url, params };
 
-			if (import.meta.env.DEV) {
-				// TODO remove this for 1.0
-				/**
-				 * @param {string} property
-				 * @param {string} replacement
-				 */
-				const print_error = (property, replacement) => {
-					Object.defineProperty(result.props.page, property, {
-						get: () => {
-							throw new Error(`$page.${property} has been replaced by $page.url.${replacement}`);
-						}
-					});
-				};
+			// TODO remove this for 1.0
+			/**
+			 * @param {string} property
+			 * @param {string} replacement
+			 */
+			const print_error = (property, replacement) => {
+				Object.defineProperty(result.props.page, property, {
+					get: () => {
+						throw new Error(`$page.${property} has been replaced by $page.url.${replacement}`);
+					}
+				});
+			};
 
-				print_error('origin', 'origin');
-				print_error('path', 'pathname');
-				print_error('query', 'searchParams');
-			}
+			print_error('origin', 'origin');
+			print_error('path', 'pathname');
+			print_error('query', 'searchParams');
 		}
 
 		const leaf = filtered[filtered.length - 1];

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -43,24 +43,22 @@ export async function respond(incoming, options, state = {}) {
 		locals: {}
 	};
 
-	if (options.dev) {
-		// TODO remove this for 1.0
-		/**
-		 * @param {string} property
-		 * @param {string} replacement
-		 */
-		const print_error = (property, replacement) => {
-			Object.defineProperty(request, property, {
-				get: () => {
-					throw new Error(`request.${property} has been replaced by request.url.${replacement}`);
-				}
-			});
-		};
+	// TODO remove this for 1.0
+	/**
+	 * @param {string} property
+	 * @param {string} replacement
+	 */
+	const print_error = (property, replacement) => {
+		Object.defineProperty(request, property, {
+			get: () => {
+				throw new Error(`request.${property} has been replaced by request.url.${replacement}`);
+			}
+		});
+	};
 
-		print_error('origin', 'origin');
-		print_error('path', 'pathname');
-		print_error('query', 'searchParams');
-	}
+	print_error('origin', 'origin');
+	print_error('path', 'pathname');
+	print_error('query', 'searchParams');
 
 	try {
 		return await options.hooks.handle({

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -72,24 +72,22 @@ export async function render_response({
 			components: branch.map(({ node }) => node.module.default)
 		};
 
-		if (options.dev) {
-			// TODO remove this for 1.0
-			/**
-			 * @param {string} property
-			 * @param {string} replacement
-			 */
-			const print_error = (property, replacement) => {
-				Object.defineProperty(props.page, property, {
-					get: () => {
-						throw new Error(`$page.${property} has been replaced by $page.url.${replacement}`);
-					}
-				});
-			};
+		// TODO remove this for 1.0
+		/**
+		 * @param {string} property
+		 * @param {string} replacement
+		 */
+		const print_error = (property, replacement) => {
+			Object.defineProperty(props.page, property, {
+				get: () => {
+					throw new Error(`$page.${property} has been replaced by $page.url.${replacement}`);
+				}
+			});
+		};
 
-			print_error('origin', 'origin');
-			print_error('path', 'pathname');
-			print_error('query', 'searchParams');
-		}
+		print_error('origin', 'origin');
+		print_error('path', 'pathname');
+		print_error('query', 'searchParams');
 
 		// props_n (instead of props[n]) makes it easy to avoid
 		// unnecessary updates for layout components


### PR DESCRIPTION
#3143. Turns out a lot of people's first exposure to new versions isn't when they upgrade locally, it's when the newer version gets automatically installed in CI. Because of that, errors helping people identify removed features need to exist in prod mode as well as dev mode.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
