### PR TITLE
fix: add entry for vite prebundling scanner

### DIFF
--- a/.changeset/quick-pets-turn.md
+++ b/.changeset/quick-pets-turn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix dev prebundling scanner

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -61,6 +61,13 @@ export async function dev({ cwd, port, host, https, config }) {
 				$lib: config.kit.files.lib
 			}
 		},
+		build: {
+			rollupOptions: {
+				// Vite dependency crawler needs an explicit JS entry point
+				// eventhough server otherwise works without it
+				input: path.resolve(`${output}/runtime/internal/start.js`)
+			}
+		},
 		plugins: [
 			svelte({
 				extensions: config.extensions,


### PR DESCRIPTION
#3138 [removed](https://github.com/sveltejs/kit/pull/3138/files#diff-ed48923f0655f935bee505cdcbf40212129ff49a89c2c9d752bd63aa1e6282c4L145-L151) the `build.rollupOptions.input` Vite config that was needed for prebundling scanner to crawl for imports, resulting in deps only prebundling later on, which slows down the initial page startup time.

e.g.

```bash
20:11:17 [vite] new dependencies found: svelte-i18n, updating...
20:11:17 [vite] ✨ dependencies updated, reloading page...
```

Also briefly reported at https://github.com/sveltejs/kit/issues/3158#issuecomment-1003428588


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
