### PR TITLE
fix: dont register service worker if none created

### DIFF
--- a/.changeset/empty-worms-appear.md
+++ b/.changeset/empty-worms-appear.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Don't register service worker if there is none

--- a/packages/kit/src/core/build/build_server.js
+++ b/packages/kit/src/core/build/build_server.js
@@ -13,11 +13,12 @@ import { s } from '../../utils/misc.js';
  * @param {{
  *   runtime: string,
  *   hooks: string,
- *   config: import('types/config').ValidatedConfig
+ *   config: import('types/config').ValidatedConfig,
+ *   service_worker: string | null
  * }} opts
  * @returns
  */
-const template = ({ config, hooks, runtime }) => `
+const template = ({ config, hooks, runtime, service_worker }) => `
 import { respond } from '${runtime}';
 import root from './generated/root.svelte';
 import { set_paths, assets, base } from './runtime/paths.js';
@@ -73,11 +74,7 @@ export class App {
 			prerender: ${config.kit.prerender.enabled},
 			read,
 			root,
-			service_worker: ${
-				config.kit.files.serviceWorker && config.kit.serviceWorker.register
-					? "'/service-worker.js'"
-					: 'null'
-			},
+			service_worker: ${JSON.stringify(service_worker)},
 			router: ${s(config.kit.router)},
 			ssr: ${s(config.kit.ssr)},
 			target: ${s(config.kit.target)},
@@ -120,12 +117,23 @@ export class App {
  *   manifest_data: import('types/internal').ManifestData
  *   build_dir: string;
  *   output_dir: string;
+ *   service_worker_entry_file: string | null;
+ *   service_worker_register: boolean;
  * }} options
  * @param {string} runtime
  * @param {{ vite_manifest: import('vite').Manifest, assets: import('rollup').OutputAsset[] }} client
  */
 export async function build_server(
-	{ cwd, assets_base, config, manifest_data, build_dir, output_dir },
+	{
+		cwd,
+		assets_base,
+		config,
+		manifest_data,
+		build_dir,
+		output_dir,
+		service_worker_entry_file,
+		service_worker_register
+	},
 	runtime,
 	client
 ) {
@@ -173,7 +181,8 @@ export async function build_server(
 		template({
 			config,
 			hooks: app_relative(hooks_file),
-			runtime
+			runtime,
+			service_worker: service_worker_register ? service_worker_entry_file : null
 		})
 	);
 

--- a/packages/kit/src/core/build/build_server.js
+++ b/packages/kit/src/core/build/build_server.js
@@ -14,11 +14,11 @@ import { s } from '../../utils/misc.js';
  *   runtime: string,
  *   hooks: string,
  *   config: import('types/config').ValidatedConfig,
- *   service_worker: string | null
+ *   has_service_worker: boolean
  * }} opts
  * @returns
  */
-const template = ({ config, hooks, runtime, service_worker }) => `
+const template = ({ config, hooks, runtime, has_service_worker }) => `
 import { respond } from '${runtime}';
 import root from './generated/root.svelte';
 import { set_paths, assets, base } from './runtime/paths.js';
@@ -74,7 +74,7 @@ export class App {
 			prerender: ${config.kit.prerender.enabled},
 			read,
 			root,
-			service_worker: ${JSON.stringify(service_worker)},
+			service_worker: ${has_service_worker ? "'/service-worker.js'" : 'null'},
 			router: ${s(config.kit.router)},
 			ssr: ${s(config.kit.ssr)},
 			target: ${s(config.kit.target)},
@@ -182,7 +182,7 @@ export async function build_server(
 			config,
 			hooks: app_relative(hooks_file),
 			runtime,
-			service_worker: service_worker_register ? service_worker_entry_file : null
+			has_service_worker: service_worker_register && !!service_worker_entry_file
 		})
 	);
 

--- a/packages/kit/test/apps/options/source/pages/_tests.js
+++ b/packages/kit/test/apps/options/source/pages/_tests.js
@@ -10,4 +10,13 @@ export default function (test, is_dev) {
 			`Hello from the ${js ? 'client' : 'server'} in ${is_dev ? 'dev' : 'prod'} mode!`
 		);
 	});
+
+	test(
+		'does not register service worker if none created',
+		'/path-base/',
+		async ({ page }) => {
+			assert.not.match(await page.content(), /navigator\.serviceWorker/);
+		},
+		{ dev: false, js: false }
+	);
 }

--- a/packages/kit/test/apps/options/svelte.config.js
+++ b/packages/kit/test/apps/options/svelte.config.js
@@ -6,7 +6,9 @@ const config = {
 			assets: 'public',
 			lib: 'source/components',
 			routes: 'source/pages',
-			template: 'source/template.html'
+			template: 'source/template.html',
+			// while we specify a path for the service worker, we expect it to not exist in the test
+			serviceWorker: 'source/service-worker'
 		},
 		appDir: '_wheee',
 		floc: true,

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -141,7 +141,7 @@ export interface SSRRenderOptions {
 	read(file: string): Buffer;
 	root: SSRComponent['default'];
 	router: boolean;
-	service_worker?: string;
+	service_worker: string | null;
 	ssr: boolean;
 	target: string;
 	template({ head, body }: { head: string; body: string }): string;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -141,7 +141,7 @@ export interface SSRRenderOptions {
 	read(file: string): Buffer;
 	root: SSRComponent['default'];
 	router: boolean;
-	service_worker: string | null;
+	service_worker?: string;
 	ssr: boolean;
 	target: string;
 	template({ head, body }: { head: string; body: string }): string;


### PR DESCRIPTION
Fixes #3159

In #2931, the refactoring of the `build/index.js` file [changed](https://github.com/sveltejs/kit/pull/2931/files#diff-09b70580810ae66bf783d467b3ea4f54cd1ac4cb57532b38b788145e27cc0983L339) a check for the service worker registration condition. I've applied back the same logic in this PR.

<img width="686" alt="image" src="https://user-images.githubusercontent.com/34116392/147852141-40330cb8-d1c5-4fc9-bb29-ff384c21c56e.png">



### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
