### PR TITLE
fix: change url protocol for prerender

### DIFF
--- a/.changeset/gentle-rules-camp.md
+++ b/.changeset/gentle-rules-camp.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix url pathname for prerenders

--- a/packages/kit/src/core/adapt/prerender.js
+++ b/packages/kit/src/core/adapt/prerender.js
@@ -180,7 +180,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 
 		const rendered = await app.render(
 			{
-				url: `${config.kit.protocol || 'sveltekit'}://${config.kit.host || 'prerender'}${path}`,
+				url: `${config.kit.protocol || 'http'}://${config.kit.host || 'prerender'}${path}`,
 				method: 'GET',
 				headers: {},
 				rawBody: null
@@ -329,7 +329,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 	if (fallback) {
 		const rendered = await app.render(
 			{
-				url: `${config.kit.host || 'sveltekit'}://${config.kit.host || 'prerender'}/[fallback]`,
+				url: `${config.kit.protocol || 'http'}://${config.kit.host || 'prerender'}/[fallback]`,
 				method: 'GET',
 				headers: {},
 				rawBody: null


### PR DESCRIPTION
Fixes #3164

Fore prerenders, change fallback `sveltekit` protocol to `http`. (Thoughts?)

In Node and Safari, the `sveltekit` protocol is recognized and properly parsed. Firefox and Chrome however don't and incorrectly parses it. e.g. `new URL('sveltekit://prerender/')`, Firefox and Chrome reported `//prerender/` as the `pathname`.

Looking at the [spec](https://url.spec.whatwg.org/#url-representation) (the scheme table), I think Node and Safari are correct, since _presumably_ we're not using a domain or ipv4 address as the host.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
