### PR TITLE
fix: Check if directory exists, before compressing

### DIFF
--- a/.changeset/tiny-horses-rush.md
+++ b/.changeset/tiny-horses-rush.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Check if directory exists, before compressing

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -1,4 +1,4 @@
-import { createReadStream, createWriteStream, statSync, writeFileSync } from 'fs';
+import { createReadStream, createWriteStream, existsSync, statSync, writeFileSync } from 'fs';
 import { pipeline } from 'stream';
 import glob from 'tiny-glob';
 import { fileURLToPath } from 'url';
@@ -62,6 +62,10 @@ export default function ({
  * @param {string} directory
  */
 async function compress(directory) {
+	if (!existsSync(directory)) {
+		return;
+	}
+
 	const files = await glob('**/*.{html,js,json,css,svg,xml}', {
 		cwd: directory,
 		dot: true,


### PR DESCRIPTION
`adapter-node` crashes if `precompress` is true, but folder doesn't exist.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
