### PR TITLE
fix(typings): remove esbuild and entryPoint properties per recent change

### DIFF
--- a/.changeset/tame-needles-march.md
+++ b/.changeset/tame-needles-march.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Fix types

--- a/packages/adapter-node/index.d.ts
+++ b/packages/adapter-node/index.d.ts
@@ -1,8 +1,6 @@
 import { Adapter } from '@sveltejs/kit';
-import { BuildOptions } from 'esbuild';
 
 interface AdapterOptions {
-	entryPoint?: string;
 	out?: string;
 	precompress?: boolean;
 	env?: {
@@ -10,7 +8,6 @@ interface AdapterOptions {
 		host?: string;
 		port?: string;
 	};
-	esbuild?: (options: BuildOptions) => Promise<BuildOptions> | BuildOptions;
 }
 
 declare function plugin(options?: AdapterOptions): Adapter;


### PR DESCRIPTION
https://github.com/sveltejs/kit/pull/2931

Addresses issue https://github.com/sveltejs/kit/issues/3175 - entryPoint and esbuild properties removed from AdapterOptions via https://github.com/sveltejs/kit/pull/2931.
