### PR TITLE
Add `disableScrollHandling` function

### DIFF
--- a/.changeset/beige-months-obey.md
+++ b/.changeset/beige-months-obey.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Add disableScrollHandling function
+Breaking: Add disableScrollHandling function (see https://kit.svelte.dev/docs#modules-$app-navigation)

--- a/.changeset/beige-months-obey.md
+++ b/.changeset/beige-months-obey.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add disableScrollHandling function

--- a/documentation/docs/05-modules.md
+++ b/documentation/docs/05-modules.md
@@ -19,9 +19,10 @@ import { amp, browser, dev, mode, prerendering } from '$app/env';
 ### $app/navigation
 
 ```js
-import { goto, invalidate, prefetch, prefetchRoutes } from '$app/navigation';
+import { disableScrollHandling, goto, invalidate, prefetch, prefetchRoutes } from '$app/navigation';
 ```
 
+- `disableScrollHandling` will, if called when the page is being updated following a navigation (in `onMount` or an action, for example), prevent SvelteKit from applying its normal scroll management. You should generally avoid this, as breaking user expectations of scroll behaviour can be disorienting.
 - `goto(href, { replaceState, noscroll, keepfocus, state })` returns a `Promise` that resolves when SvelteKit navigates (or fails to navigate, in which case the promise rejects) to the specified `href`. The second argument is optional:
   - `replaceState` (boolean, default `false`) If `true`, will replace the current `history` entry rather than creating a new one with `pushState`
   - `noscroll` (boolean, default `false`) If `true`, the browser will maintain its scroll position rather than scrolling to the top of the page after navigation

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -1,4 +1,4 @@
-import { router as router_ } from '../client/singletons.js';
+import { router as router_, renderer } from '../client/singletons.js';
 import { get_base_uri } from '../client/utils.js';
 
 const router = /** @type {import('../client/router').Router} */ (router_);
@@ -12,10 +12,20 @@ function guard(name) {
 	};
 }
 
+export const disableScrollHandling = import.meta.env.SSR
+	? guard('disableScrollHandling')
+	: disableScrollHandling_;
 export const goto = import.meta.env.SSR ? guard('goto') : goto_;
 export const invalidate = import.meta.env.SSR ? guard('invalidate') : invalidate_;
 export const prefetch = import.meta.env.SSR ? guard('prefetch') : prefetch_;
 export const prefetchRoutes = import.meta.env.SSR ? guard('prefetchRoutes') : prefetchRoutes_;
+
+/**
+ * @type {import('$app/navigation').goto}
+ */
+async function disableScrollHandling_() {
+	renderer.disable_scroll_handling();
+}
 
 /**
  * @type {import('$app/navigation').goto}

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -83,6 +83,8 @@ export class Renderer {
 		this.session_id = 1;
 		this.invalid = new Set();
 		this.invalidating = null;
+		this.autoscroll = true;
+		this.updating = false;
 
 		/** @type {import('./types').NavigationState} */
 		this.current = {
@@ -123,6 +125,16 @@ export class Renderer {
 			if (info) this.update(info, [], true);
 		});
 		ready = true;
+	}
+
+	disable_scroll_handling() {
+		if (import.meta.env.DEV && this.started && !this.updating) {
+			throw new Error('Can only disable scroll handling during navigation');
+		}
+
+		if (this.updating || !this.started) {
+			this.autoscroll = false;
+		}
 	}
 
 	/**
@@ -254,6 +266,8 @@ export class Renderer {
 			}
 		}
 
+		this.updating = true;
+
 		if (this.started) {
 			this.current = navigation_result.state;
 
@@ -272,26 +286,9 @@ export class Renderer {
 				document.body.focus();
 			}
 
-			const old_page_y_offset = Math.round(pageYOffset);
-			const old_max_page_y_offset = document.documentElement.scrollHeight - innerHeight;
-
 			await 0;
 
-			const new_page_y_offset = Math.round(pageYOffset);
-			const new_max_page_y_offset = document.documentElement.scrollHeight - innerHeight;
-
-			// After `await 0`, the `onMount()` function in the component executed.
-			// Check if no scrolling happened on mount.
-			const no_scroll_happened =
-				// In most cases, we can compare whether `pageYOffset` changed between navigation
-				new_page_y_offset === Math.min(old_page_y_offset, new_max_page_y_offset) ||
-				// But if the page is scrolled to/near the bottom, the browser would also scroll
-				// to/near the bottom of the new page on navigation. Since we can't detect when this
-				// behaviour happens, we naively compare by the y offset from the bottom of the page.
-				old_max_page_y_offset - old_page_y_offset === new_max_page_y_offset - new_page_y_offset;
-
-			// If there was no scrolling, we run on our custom scroll handling
-			if (no_scroll_happened) {
+			if (this.autoscroll) {
 				const deep_linked = hash && document.getElementById(hash.slice(1));
 				if (scroll) {
 					scrollTo(scroll.x, scroll.y);
@@ -311,6 +308,8 @@ export class Renderer {
 
 		this.loading.promise = null;
 		this.loading.id = null;
+		this.autoscroll = true;
+		this.updating = false;
 
 		if (!this.router) return;
 

--- a/packages/kit/src/runtime/client/singletons.js
+++ b/packages/kit/src/runtime/client/singletons.js
@@ -4,10 +4,12 @@ export let router;
 /** @type {import('./renderer').Renderer} */
 export let renderer;
 
-/** @param {{
+/**
+ * @param {{
  *   router: import('./router').Router?;
  *   renderer: import('./renderer').Renderer;
- * }} opts */
+ * }} opts
+ */
 export function init(opts) {
 	router = opts.router;
 	renderer = opts.renderer;

--- a/packages/kit/src/runtime/client/singletons.js
+++ b/packages/kit/src/runtime/client/singletons.js
@@ -1,7 +1,14 @@
 /** @type {import('./router').Router?} */
 export let router;
 
-/** @param {import('./router').Router?} _ */
-export function init(_) {
-	router = _;
+/** @type {import('./renderer').Renderer} */
+export let renderer;
+
+/** @param {{
+ *   router: import('./router').Router?;
+ *   renderer: import('./renderer').Renderer;
+ * }} opts */
+export function init(opts) {
+	router = opts.router;
+	renderer = opts.renderer;
 }

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -48,7 +48,7 @@ export async function start({ paths, target, session, route, spa, trailing_slash
 		  })
 		: null;
 
-	init(router);
+	init({ router, renderer });
 	set_paths(paths);
 
 	if (hydrate) await renderer.start(hydrate);

--- a/packages/kit/test/apps/basics/src/routes/anchor-with-manual-scroll/anchor.svelte
+++ b/packages/kit/test/apps/basics/src/routes/anchor-with-manual-scroll/anchor.svelte
@@ -1,7 +1,9 @@
 <script>
 	import { onMount } from 'svelte';
+	import { disableScrollHandling } from '$app/navigation';
 
 	onMount(() => {
+		disableScrollHandling();
 		document.getElementById('abcde')?.scrollIntoView();
 	});
 </script>

--- a/packages/kit/test/apps/basics/src/routes/use-action/focus-and-scroll.svelte
+++ b/packages/kit/test/apps/basics/src/routes/use-action/focus-and-scroll.svelte
@@ -1,5 +1,9 @@
 <script>
+	import { disableScrollHandling } from '$app/navigation';
+
 	const focusAndScroll = /** @param {HTMLInputElement} node */ (node) => {
+		disableScrollHandling();
+
 		node.focus();
 		node.scrollIntoView();
 	};

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -27,6 +27,11 @@ declare module '$app/env' {
 
 declare module '$app/navigation' {
 	/**
+	 * Disable SvelteKit's built-in scroll handling for the current navigation, in case you need to manually control the scroll position.
+	 * This is generally discouraged, since it breaks user expectations.
+	 */
+	export function disableScrollHandling(): void;
+	/**
 	 * Returns a Promise that resolves when SvelteKit navigates (or fails to navigate, in which case the promise rejects) to the specified href.
 	 *
 	 * @param href Where to navigate to


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/issues/2794 by adding a new `disableScrollHandling` function. Calling it in `onMount` or inside an action will, if a navigation is currently happening, prevent Kit from applying its normal scroll handling. (Calling it when navigation is not currently happening will cause an error to be thrown.)

See https://github.com/sveltejs/kit/pull/2986#issuecomment-1002302203 for previous discussion.

I prefer the imperative `disableScrollHandling` to a declarative `export const autoscroll = false` for various reasons:

1. This _should_ feel a bit awkward. Disabling default scroll behaviour will, in general, disorient your users. It should be a last resort. Adding an `autoscroll` page option feels like we're _blessing_ that behaviour rather than simply _tolerating_ it.
2. The implementation is more straightforward
3. If provides more flexibility — it's easier to use it inside an action (etc). Any page that could use `autoscroll` could also use `disableScrollHandling`, but the reverse isn't true

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
