### PR TITLE
Loadfunction custom headers

### DIFF
--- a/.changeset/mean-cheetahs-train.md
+++ b/.changeset/mean-cheetahs-train.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Optionally return headers from load function

--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -8,6 +8,10 @@ A component that defines a page or a layout can export a `load` function that ru
 // Declaration types for Loading
 // * declarations that are not exported are for internal use
 
+// type of string[] is only for set-cookie
+// everything else must be a type of string
+type ResponseHeaders = Record<string, string | string[]>;
+
 export interface LoadInput<
 	PageParams extends Record<string, string> = Record<string, string>,
 	Stuff extends Record<string, any> = Record<string, any>,
@@ -30,6 +34,7 @@ export interface LoadOutput<
 	props?: Props;
 	stuff?: Stuff;
 	maxage?: number;
+	headers?: ResponseHeaders;
 }
 ```
 
@@ -154,3 +159,9 @@ If the `load` function returns a `props` object, the props will be passed to the
 This will be merged with any existing `stuff` and passed to the `load` functions of subsequent layout and page components.
 
 This only applies to layout components, _not_ page components.
+
+#### headers
+
+Custom headers that are added to the response when a page component is requested. `headers` are only considered when the load function runs on the server-side.
+
+This only applies to page components, _not_ layout components.

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -40,6 +40,7 @@ export async function render_response({
 
 	let is_private = false;
 	let maxage;
+	let loadHeaders;
 
 	if (error) {
 		error.stack = options.get_stack(error);
@@ -57,6 +58,7 @@ export async function render_response({
 			if (uses_credentials) is_private = true;
 
 			maxage = loaded.maxage;
+			loadHeaders = loaded.headers;
 		});
 
 		const session = writable($session);
@@ -211,6 +213,12 @@ export async function render_response({
 
 	if (!options.floc) {
 		headers['permissions-policy'] = 'interest-cohort=()';
+	}
+
+	if (loadHeaders) {
+		for (const header of Object.keys(loadHeaders)) {
+			headers[header] = loadHeaders[header];
+		}
 	}
 
 	return {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -40,7 +40,7 @@ export async function render_response({
 
 	let is_private = false;
 	let maxage;
-	let loadHeaders;
+	let load_headers;
 
 	if (error) {
 		error.stack = options.get_stack(error);
@@ -58,7 +58,7 @@ export async function render_response({
 			if (uses_credentials) is_private = true;
 
 			maxage = loaded.maxage;
-			loadHeaders = loaded.headers;
+			load_headers = loaded.headers;
 		});
 
 		const session = writable($session);
@@ -215,9 +215,9 @@ export async function render_response({
 		headers['permissions-policy'] = 'interest-cohort=()';
 	}
 
-	if (loadHeaders) {
-		for (const header of Object.keys(loadHeaders)) {
-			headers[header] = loadHeaders[header];
+	if (load_headers) {
+		for (const header of Object.keys(load_headers)) {
+			headers[header] = load_headers[header];
 		}
 	}
 

--- a/packages/kit/test/apps/basics/src/routes/load/_tests.js
+++ b/packages/kit/test/apps/basics/src/routes/load/_tests.js
@@ -239,4 +239,9 @@ export default function (test) {
 		await clicknav('[href="/load/props/about"]');
 		assert.equal(await page.textContent('p'), 'Data: undefined');
 	});
+
+	test('load returns response headers', null, async ({ fetch }) => {
+		const loadReq = await fetch('/load/headers');
+		assert.equal(loadReq.headers.get('potato'), 'potahto');
+	});
 }

--- a/packages/kit/test/apps/basics/src/routes/load/headers.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/headers.svelte
@@ -1,10 +1,8 @@
 <script context="module">
 	/** @type {import('@sveltejs/kit').Load} */
-	export async function load({ params, fetch }) {
+	export async function load() {
 		return { headers: { potato: 'potahto' } };
 	}
 </script>
 
-<div>
-  Never gonna give you up
-</div>
+<div>Never gonna give you up</div>

--- a/packages/kit/test/apps/basics/src/routes/load/headers.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/headers.svelte
@@ -1,0 +1,10 @@
+<script context="module">
+	/** @type {import('@sveltejs/kit').Load} */
+	export async function load({ params, fetch }) {
+		return { headers: { potato: 'potahto' } };
+	}
+</script>
+
+<div>
+  Never gonna give you up
+</div>

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -10,6 +10,7 @@ import {
 	ServerResponse
 } from './hooks';
 import { Load } from './page';
+import { ResponseHeaders } from './helper';
 
 type PageId = string;
 
@@ -226,6 +227,7 @@ export interface NormalizedLoadOutput {
 	props?: Record<string, any> | Promise<Record<string, any>>;
 	stuff?: Record<string, any>;
 	maxage?: number;
+	headers?: ResponseHeaders;
 }
 
 export type TrailingSlash = 'never' | 'always' | 'ignore';

--- a/packages/kit/types/page.d.ts
+++ b/packages/kit/types/page.d.ts
@@ -1,4 +1,4 @@
-import { InferValue, MaybePromise, Rec } from './helper';
+import { InferValue, MaybePromise, Rec, ResponseHeaders } from './helper';
 
 export interface LoadInput<
 	PageParams extends Rec<string> = Rec<string>,
@@ -28,6 +28,7 @@ export interface LoadOutput<Props extends Rec = Rec, Stuff extends Rec = Rec> {
 	props?: Props;
 	stuff?: Stuff;
 	maxage?: number;
+	headers?: ResponseHeaders;
 }
 
 interface LoadInputExtends {


### PR DESCRIPTION
Fixes #909. The load function can now return headers, which are passed to the response headers.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
