### PR TITLE
non-hashed static assets should not be cached

### DIFF
--- a/.changeset/fast-pans-enjoy.md
+++ b/.changeset/fast-pans-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Don't cache non-hashed static assets in adapter-node

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -81,7 +81,7 @@ function sequence(handlers) {
 export const handler = sequence(
 	[
 		serve(path.join(__dirname, '/client'), 31536000),
-		serve(path.join(__dirname, '/static'), 31536000),
+		serve(path.join(__dirname, '/static'), 0),
 		serve(path.join(__dirname, '/prerendered'), 0),
 		ssr
 	].filter(Boolean)


### PR DESCRIPTION
Just realised we're treating static assets as immutable in `adapter-node` 🤦 I think this is the result of some bad copypasta on my part

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
