### PR TITLE
only set cache-control: immutable when appropriate

### DIFF
--- a/.changeset/wild-eyes-walk.md
+++ b/.changeset/wild-eyes-walk.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Only set cache-control: immutable when appropriate

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -18,14 +18,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 /**
  * @param {string} path
  * @param {number} max_age
+ * @param {boolean} immutable
  */
-function serve(path, max_age) {
+function serve(path, max_age, immutable = false) {
 	return (
 		fs.existsSync(path) &&
 		sirv(path, {
 			etag: true,
 			maxAge: max_age,
-			immutable: true,
+			immutable,
 			gzip: true,
 			brotli: true
 		})
@@ -80,7 +81,7 @@ function sequence(handlers) {
 
 export const handler = sequence(
 	[
-		serve(path.join(__dirname, '/client'), 31536000),
+		serve(path.join(__dirname, '/client'), 31536000, true),
 		serve(path.join(__dirname, '/static'), 0),
 		serve(path.join(__dirname, '/prerendered'), 0),
 		ssr


### PR DESCRIPTION
follow-up to #3193 — `immutable` probably doesn't do anything when `max-age` is `0`, but there's still no reason to set it

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
