### PR TITLE
[adapter-vercel] Use path/posix to resolve the relative path (issue#3163)

### DIFF
--- a/.changeset/fuzzy-jobs-retire.md
+++ b/.changeset/fuzzy-jobs-retire.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': minor
+---
+
+Use path.posix to resolve routes for esmodules

--- a/.changeset/fuzzy-jobs-retire.md
+++ b/.changeset/fuzzy-jobs-retire.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/adapter-vercel': minor
+'@sveltejs/adapter-vercel': patch
 ---
 
 Use path.posix to resolve routes for esmodules

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -1,5 +1,5 @@
 import { writeFileSync } from 'fs';
-import { relative } from 'path/posix';
+import { posix } from 'path';
 import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 
@@ -31,7 +31,7 @@ export default function () {
 
 			builder.log.minor('Generating serverless function...');
 
-			const relativePath = relative(tmp, builder.getServerDirectory());
+			const relativePath = posix.relative(tmp, builder.getServerDirectory());
 
 			builder.copy(files, tmp, {
 				replace: {

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -1,5 +1,5 @@
 import { writeFileSync } from 'fs';
-import { relative } from 'path';
+import { relative } from 'path/posix';
 import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 


### PR DESCRIPTION
if we use the default path implementation, on windows we get malformed output since esmodules use "/" as the seperator

(related https://github.com/sveltejs/kit/issues/3163 )

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
