### PR TITLE
make test work offline

### DIFF
--- a/packages/kit/test/apps/basics/src/routes/routing/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/index.svelte
@@ -1,7 +1,11 @@
+<script>
+	import { page } from '$app/stores';
+</script>
+
 <h1>Great success!</h1>
 
 <a href="/routing/a">a</a>
 <a href="/routing/ambiguous/ok.json" rel="external">ok</a>
-<a href="https://www.google.com">elsewhere</a>
+<a href="http://localhost:{$page.url.searchParams.get('port')}">elsewhere</a>
 
 <div class="hydrate-test" />

--- a/packages/kit/test/utils.d.ts
+++ b/packages/kit/test/utils.d.ts
@@ -6,6 +6,7 @@ import {
 	PlaywrightWorkerOptions,
 	TestType
 } from '@playwright/test';
+import { IncomingMessage, Server, ServerResponse } from 'http';
 
 export const test: TestType<
 	PlaywrightTestArgs &
@@ -26,3 +27,11 @@ export const test: TestType<
 >;
 
 export const config: PlaywrightTestConfig;
+
+export const start_server: (
+	handler: (req: IncomingMessage, res: ServerResponse) => void,
+	start?: number
+) => {
+	server: Server;
+	port: number;
+};

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -1,4 +1,6 @@
 import fs from 'fs';
+import http from 'http';
+import * as ports from 'port-authority';
 import { test as base } from '@playwright/test';
 
 export const test = base.extend({
@@ -180,3 +182,21 @@ export const config = {
 		screenshot: 'only-on-failure'
 	}
 };
+
+/**
+ *
+ * @param {(req: http.IncomingMessage, res: http.ServerResponse) => void} handler
+ * @param {number} [start]
+ * @returns
+ */
+export async function start_server(handler, start = 4000) {
+	const port = await ports.find(start);
+
+	const server = http.createServer(handler);
+
+	await new Promise((fulfil) => {
+		server.listen(port, () => fulfil(undefined));
+	});
+
+	return { port, server };
+}


### PR DESCRIPTION
Currently on a train just south of Grantham and the test that involves clicking on a link to google.com keeps failing because of the flaky wifi. This fixes it

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
