### PR TITLE
[chore] explicit `tick()`

### DIFF
--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -1,3 +1,4 @@
+import { tick } from 'svelte';
 import { writable } from 'svelte/store';
 import { coalesce_to_error } from '../../utils/error.js';
 import { hash } from '../hash.js';
@@ -277,7 +278,7 @@ export class Renderer {
 			this._init(navigation_result);
 		}
 
-		// opts must be passed if we're navigating...
+		// opts must be passed if we're navigating
 		if (opts) {
 			const { hash, scroll, keepfocus } = opts;
 
@@ -286,7 +287,8 @@ export class Renderer {
 				document.body.focus();
 			}
 
-			await 0;
+			// need to render the DOM before we can scroll to the rendered elements
+			await tick();
 
 			if (this.autoscroll) {
 				const deep_linked = hash && document.getElementById(hash.slice(1));
@@ -302,8 +304,8 @@ export class Renderer {
 				}
 			}
 		} else {
-			// ...they will not be supplied if we're simply invalidating
-			await 0;
+			// in this case we're simply invalidating
+			await tick();
 		}
 
 		this.loading.promise = null;

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -3,9 +3,8 @@ import path from 'path';
 import http from 'http';
 import * as ports from 'port-authority';
 import { expect } from '@playwright/test';
-import { test } from '../../../utils.js';
 import { fileURLToPath } from 'url';
-import { start_server } from '../../../utils.js';
+import { start_server, test } from '../../../utils.js';
 
 /** @typedef {import('@playwright/test').Response} Response */
 


### PR DESCRIPTION
I think `await 0` would return to the event loop and I'm not entirely sure it's going to happen in order (I think it should, but there seem to be [exceptions](https://stackoverflow.com/questions/2734025/is-javascript-guaranteed-to-be-single-threaded/2734311#2734311)). If we call `tick()` then hopefully we explicitly know the DOM will be rendered. At the very least, I think this makes the code clearer

Hmmm. This doesn't seem to have helped the flake. Maybe it's still a good idea though?