### PR TITLE
render error page if error happens in handle hook

### DIFF
--- a/.changeset/mean-mangos-marry.md
+++ b/.changeset/mean-mangos-marry.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Render error page if error happens in handle hook

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -130,15 +130,29 @@ export async function respond(incoming, options, state = {}) {
 				}
 			}
 		});
-	} catch (/** @type {unknown} */ err) {
-		const e = coalesce_to_error(err);
+	} catch (/** @type {unknown} */ e) {
+		const error = coalesce_to_error(e);
 
-		options.handle_error(e, request);
+		options.handle_error(error, request);
 
-		return {
-			status: 500,
-			headers: {},
-			body: options.dev ? e.stack : e.message
-		};
+		try {
+			const $session = await options.hooks.getSession(request);
+			return await respond_with_error({
+				request,
+				options,
+				state,
+				$session,
+				status: 500,
+				error
+			});
+		} catch (/** @type {unknown} */ e) {
+			const error = coalesce_to_error(e);
+
+			return {
+				status: 500,
+				headers: {},
+				body: options.dev ? error.stack : error.message
+			};
+		}
 	}
 }

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -20,53 +20,53 @@ import { coalesce_to_error } from '../../../utils/error.js';
  * }} opts
  */
 export async function respond_with_error({ request, options, state, $session, status, error }) {
-	const default_layout = await options.manifest._.nodes[0](); // 0 is always the root layout
-	const default_error = await options.manifest._.nodes[1](); // 1 is always the root error
+	try {
+		const default_layout = await options.manifest._.nodes[0](); // 0 is always the root layout
+		const default_error = await options.manifest._.nodes[1](); // 1 is always the root error
 
-	/** @type {Record<string, string>} */
-	const params = {}; // error page has no params
+		/** @type {Record<string, string>} */
+		const params = {}; // error page has no params
 
-	// error pages don't fall through, so we know it's not undefined
-	const loaded = /** @type {Loaded} */ (
-		await load_node({
-			request,
-			options,
-			state,
-			route: null,
-			url: request.url, // TODO this is redundant, no?
-			params,
-			node: default_layout,
-			$session,
-			stuff: {},
-			prerender_enabled: is_prerender_enabled(options, default_error, state),
-			is_leaf: false,
-			is_error: false
-		})
-	);
-
-	const branch = [
-		loaded,
-		/** @type {Loaded} */ (
+		// error pages don't fall through, so we know it's not undefined
+		const loaded = /** @type {Loaded} */ (
 			await load_node({
 				request,
 				options,
 				state,
 				route: null,
-				url: request.url,
+				url: request.url, // TODO this is redundant, no?
 				params,
-				node: default_error,
+				node: default_layout,
 				$session,
-				stuff: loaded ? loaded.stuff : {},
+				stuff: {},
 				prerender_enabled: is_prerender_enabled(options, default_error, state),
 				is_leaf: false,
-				is_error: true,
-				status,
-				error
+				is_error: false
 			})
-		)
-	];
+		);
 
-	try {
+		const branch = [
+			loaded,
+			/** @type {Loaded} */ (
+				await load_node({
+					request,
+					options,
+					state,
+					route: null,
+					url: request.url,
+					params,
+					node: default_error,
+					$session,
+					stuff: loaded ? loaded.stuff : {},
+					prerender_enabled: is_prerender_enabled(options, default_error, state),
+					is_leaf: false,
+					is_error: true,
+					status,
+					error
+				})
+			)
+		];
+
 		return await render_response({
 			options,
 			$session,

--- a/packages/kit/test/apps/basics/src/hooks.js
+++ b/packages/kit/test/apps/basics/src/hooks.js
@@ -31,6 +31,10 @@ export const handle = sequence(
 		return resolve(request);
 	},
 	async ({ request, resolve }) => {
+		if (request.url.pathname === '/errors/error-in-handle') {
+			throw new Error('Error in handle');
+		}
+
 		const response = await resolve(request);
 
 		return {

--- a/packages/kit/test/apps/basics/src/routes/errors/error-in-handle.svelte
+++ b/packages/kit/test/apps/basics/src/routes/errors/error-in-handle.svelte
@@ -1,0 +1,1 @@
+<!-- this will never be rendered, because hooks.js will throw an error for this path -->

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -615,6 +615,16 @@ test.describe.parallel('Errors', () => {
 			expect(await page.innerHTML('h1')).toBe('401');
 		}
 	});
+
+	test('error thrown in handle results in a rendered error page', async ({ page }) => {
+		await page.goto('/errors/error-in-handle');
+
+		expect(await page.textContent('footer')).toBe('Custom layout');
+		expect(await page.textContent('#message')).toBe(
+			'This is your custom error page saying: "Error in handle"'
+		);
+		expect(await page.innerHTML('h1')).toBe('500');
+	});
 });
 
 test.describe.parallel('ETags', () => {


### PR DESCRIPTION
fixes #2824, supersedes #3235 and #3171.

Right now, if an uncaught error happens during `handle`, the response will just be a plain error message. As of this PR, Kit will instead render the error page (unless rendering the error page itself causes an error, in which case there's not a whole lot we can do).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
