### PR TITLE
[chore] add links to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
     id: bug-description
     attributes:
       label: Describe the bug
-      description: Bugs related to building may be caused by Vite. See this project's readme for more details. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      description: Please [check if bugs related to building are caused by Vite](https://github.com/sveltejs/kit#bug-reporting) and [file there](https://github.com/vitejs/vite/issues) if appropriate. If you intend to submit a PR for this issue, tell us in the description. Thanks!
       placeholder: Bug description
     validations:
       required: true


### PR DESCRIPTION
people aren't doing this. adding links will make it easier to get to that info and will make it stand out a bit more