### PR TITLE
log adapter-static output directories

### DIFF
--- a/.changeset/tall-mails-burn.md
+++ b/.changeset/tall-mails-burn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-static': patch
+---
+
+Log adapter-static output directories

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -36,6 +36,12 @@ export default function ({ pages = 'build', assets = pages, fallback, precompres
 					await compress(pages);
 				}
 			}
+
+			if (pages === assets) {
+				builder.log(`Wrote site to "${pages}"`);
+			} else {
+				builder.log(`Wrote pages to "${pages}" and assets to "${assets}"`);
+			}
 		}
 	};
 }


### PR DESCRIPTION
supersedes #3264. Logs output directory/directories when using adapter-static

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
