### PR TITLE
try to get deploys working with pnpm

### DIFF
--- a/packages/create-svelte/templates/default/.ignore
+++ b/packages/create-svelte/templates/default/.ignore
@@ -5,3 +5,4 @@ wrangler.toml
 vercel.json
 .cloudflare
 .netlify
+README.md

--- a/packages/create-svelte/templates/default/README.md
+++ b/packages/create-svelte/templates/default/README.md
@@ -1,0 +1,53 @@
+# Default template
+
+This README isn't part of the template; it is ignored, and replaced with [the shared README](../../shared/README.md) when a project is created.
+
+The default template is automatically deployed to Cloudflare Pages, Netlify and Vercel on every commit. Commits to `master` will update production deployments:
+
+- https://cloudflare.demo.svelte.dev
+- https://kit-demo.netlify.app
+- https://kit-demo.vercel.app
+
+## Cloudflare Pages settings
+
+### Build command
+
+```
+npm i -g pnpm && pnpm i && pnpm build -r
+```
+
+### Build output directory
+
+```
+/packages/create-svelte/templates/default/.svelte-kit/cloudflare
+```
+
+### Environment variables
+
+```
+NPM_FLAGS=--version
+```
+
+## Netlify settings
+
+Most settings are contained in [netlify.toml](netlify.toml).
+
+### Build directory
+
+```
+packages/create-svelte/templates/default
+```
+
+## Vercel settings
+
+### Install command
+
+```
+npm install -g pnpm && pnpm install && pnpm build -r
+```
+
+### Root directory
+
+```
+packages/create-svelte/templates/default
+```

--- a/packages/create-svelte/templates/default/netlify.toml
+++ b/packages/create-svelte/templates/default/netlify.toml
@@ -1,6 +1,3 @@
 [build]
   command = "npm run build"
   publish = "build"
-
-[build.environment]
-  NPM_FLAGS="--prefix=/dev/null"

--- a/packages/create-svelte/templates/default/netlify.toml
+++ b/packages/create-svelte/templates/default/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npx pnpm install --store=node_modules/.pnpm-store && npx pnpm build"
+  command = "npx pnpm install --store=node_modules/.pnpm-store && npx pnpm build -r"
   publish = "build"
 
 [build.environment]

--- a/packages/create-svelte/templates/default/netlify.toml
+++ b/packages/create-svelte/templates/default/netlify.toml
@@ -1,3 +1,6 @@
 [build]
   command = "npm run build"
   publish = "build"
+
+[build.environment]
+  NPM_FLAGS="--prefix=/dev/null"

--- a/packages/create-svelte/templates/default/netlify.toml
+++ b/packages/create-svelte/templates/default/netlify.toml
@@ -1,3 +1,6 @@
 [build]
-  command = "npm run build"
+  command = "npx pnpm install --store=node_modules/.pnpm-store && npx pnpm build"
   publish = "build"
+
+[build.environment]
+  NPM_FLAGS = "--version"

--- a/packages/create-svelte/templates/default/netlify.toml
+++ b/packages/create-svelte/templates/default/netlify.toml
@@ -3,4 +3,4 @@
   publish = "build"
 
 [build.environment]
-  NPM_FLAGS = "--version"
+  NPM_FLAGS = "--version" # this prevents npm install from happening

--- a/packages/create-svelte/templates/default/package.json
+++ b/packages/create-svelte/templates/default/package.json
@@ -3,7 +3,6 @@
 	"version": "0.0.1",
 	"scripts": {
 		"dev": "svelte-kit dev",
-		"prebuild": "test \"$CI\" = true && npx pnpm install -r --store=node_modules/.pnpm-store || echo skipping pnpm install && npx pnpm build -r",
 		"build": "svelte-kit build --verbose",
 		"preview": "svelte-kit preview",
 		"start": "svelte-kit start"

--- a/packages/create-svelte/templates/default/package.json
+++ b/packages/create-svelte/templates/default/package.json
@@ -3,13 +3,14 @@
 	"version": "0.0.1",
 	"scripts": {
 		"dev": "svelte-kit dev",
+		"prebuild": "test \"$CI\" = true && npx pnpm install -r --store=node_modules/.pnpm-store || echo skipping pnpm install && npx pnpm build -r",
 		"build": "svelte-kit build --verbose",
 		"preview": "svelte-kit preview",
 		"start": "svelte-kit start"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "next",
-		"@sveltejs/kit": "next",
+		"@sveltejs/adapter-auto": "workspace:*",
+		"@sveltejs/kit": "workspace:*",
 		"svelte": "^3.44.0",
 		"svelte-preprocess": "^4.9.8",
 		"typescript": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,8 +217,8 @@ importers:
     specifiers:
       '@fontsource/fira-mono': ^4.5.0
       '@lukeed/uuid': ^2.0.0
-      '@sveltejs/adapter-auto': next
-      '@sveltejs/kit': next
+      '@sveltejs/adapter-auto': workspace:*
+      '@sveltejs/kit': workspace:*
       cookie: ^0.4.1
       svelte: ^3.44.0
       svelte-preprocess: ^4.9.8


### PR DESCRIPTION
At the moment, deploys of the demo app (which are useful as an end-to-end test) sometimes fail noisily because the app depends on the `next` version of Kit etc, rather than the current state of the repo. In theory if we could use pnpm instead on Netlify, Cloudflare and Vercel (the three platforms for which we currently do automated deploys) that would no longer be the case?

It might even fix the persistent build cache issues we experience with Netlify.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
