### PR TITLE
Parse value of srcset attribute closer to specifications

### DIFF
--- a/.changeset/curvy-zebras-tan.md
+++ b/.changeset/curvy-zebras-tan.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix srcset parsing

--- a/packages/kit/src/core/adapt/prerender/crawl.js
+++ b/packages/kit/src/core/adapt/prerender/crawl.js
@@ -171,7 +171,7 @@ export function crawl(html) {
 								}
 								candidates.push(value);
 								for (const candidate of candidates) {
-									const src = candidate.trim().split(WHITESPACE)[0];
+									const src = candidate.split(WHITESPACE)[0];
 									hrefs.push(src);
 								}
 							}

--- a/packages/kit/src/core/adapt/prerender/crawl.js
+++ b/packages/kit/src/core/adapt/prerender/crawl.js
@@ -157,15 +157,19 @@ export function crawl(html) {
 								hrefs.push(value);
 							} else if (name === 'srcset') {
 								const candidates = [];
-								// Parse the content of the srcset attribute.
-								// The regexp is modelled after the srcset specs (https://html.spec.whatwg.org/multipage/images.html#srcset-attribute)
-								// and should cover most reasonable cases.
-								const regex =
-									/\s*([^\s,]\S+[^\s,])\s*((?:\d+w)|(?:-?\d+(?:\.\d+)?(?:[eE]-?\d+)?x))?/gm;
-								let sub_matches;
-								while ((sub_matches = regex.exec(value))) {
-									candidates.push(sub_matches[1]);
+								let insideURL = true;
+								value = value.trim();
+								for (let i = 0; i < value.length; i++) {
+									if (value[i] === ',' && (!insideURL || (insideURL && value[i + 1] === ' '))) {
+										candidates.push(value.slice(0, i));
+										value = value.substring(i + 1).trim();
+										i = 0;
+										insideURL = true;
+									} else if (value[i] === ' ') {
+										insideURL = false;
+									}
 								}
+								candidates.push(value);
 								for (const candidate of candidates) {
 									const src = candidate.trim().split(WHITESPACE)[0];
 									hrefs.push(src);

--- a/packages/kit/src/core/adapt/prerender/crawl.js
+++ b/packages/kit/src/core/adapt/prerender/crawl.js
@@ -156,7 +156,16 @@ export function crawl(html) {
 							} else if (name === 'src') {
 								hrefs.push(value);
 							} else if (name === 'srcset') {
-								const candidates = value.split(',');
+								const candidates = [];
+								// Parse the content of the srcset attribute.
+								// The regexp is modelled after the srcset specs (https://html.spec.whatwg.org/multipage/images.html#srcset-attribute)
+								// and should cover most reasonable cases.
+								const regex =
+									/\s*([^\s,]\S+[^\s,])\s*((?:\d+w)|(?:-?\d+(?:\.\d+)?(?:[eE]-?\d+)?x))?/gm;
+								let sub_matches;
+								while ((sub_matches = regex.exec(value))) {
+									candidates.push(sub_matches[1]);
+								}
 								for (const candidate of candidates) {
 									const src = candidate.trim().split(WHITESPACE)[0];
 									hrefs.push(src);

--- a/packages/kit/src/core/adapt/prerender/fixtures/basic-srcset/input.html
+++ b/packages/kit/src/core/adapt/prerender/fixtures/basic-srcset/input.html
@@ -5,7 +5,7 @@
 		<img
 			alt="A header"
 			src="header.png"
-			srcset="header640.png 640w, header960.png 960w, header1024.png 1024w, header.png"
+			srcset="https://url-with-commas.com/w_200,q_100/header.png 200w, header640.png 640w, header960.png 960w, header1024.png 1024w, header.png"
 		/>
 	</body>
 </html>

--- a/packages/kit/src/core/adapt/prerender/fixtures/basic-srcset/input.html
+++ b/packages/kit/src/core/adapt/prerender/fixtures/basic-srcset/input.html
@@ -5,7 +5,7 @@
 		<img
 			alt="A header"
 			src="header.png"
-			srcset="https://url-with-commas.com/w_200,q_100/header.png 200w, header640.png 640w, header960.png 960w, header1024.png 1024w, header.png"
+			srcset="https://example.com/w_200,q_100/header.png 200w, header640.png 640w, header960.png 960w, header1024.png 1024w, header.png"
 		/>
 	</body>
 </html>

--- a/packages/kit/src/core/adapt/prerender/fixtures/basic-srcset/output.json
+++ b/packages/kit/src/core/adapt/prerender/fixtures/basic-srcset/output.json
@@ -1,6 +1,6 @@
 [
 	"header.png",
-	"https://url-with-commas.com/w_200,q_100/header.png",
+	"https://example.com/w_200,q_100/header.png",
 	"header640.png",
 	"header960.png",
 	"header1024.png",

--- a/packages/kit/src/core/adapt/prerender/fixtures/basic-srcset/output.json
+++ b/packages/kit/src/core/adapt/prerender/fixtures/basic-srcset/output.json
@@ -1,1 +1,8 @@
-["header.png", "header640.png", "header960.png", "header1024.png", "header.png"]
+[
+	"header.png",
+	"https://url-with-commas.com/w_200,q_100/header.png",
+	"header640.png",
+	"header960.png",
+	"header1024.png",
+	"header.png"
+]


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

This PR attempts to fix #3299 which was a regression introduced by #3288 .

## Problem

The problem lies with the the specifications of the srcset attribute:

> If present, its value must consist of one or more image candidate strings, each separated from the next by a U+002C COMMA character (,). If an image candidate string contains no descriptors and no ASCII whitespace after the URL, the following image candidate string, if there is one, must begin with one or more ASCII whitespace.

Simply comma separating the value of the srcset attributes doesn't work in the case that there is a "," comma in one or more of the URLs of the srcset. Since popular image hosts like cloudinary use commas to enumerate transformations, this should be addressed, as prerendering fails when the crawler tries to crawl the resulting broken links.

## Proposed Solution

Rather than just reverting back to the previous RegularExpression, I attempted to write a primitive parser to implement the specification, as Rich made the original PR to get away from hard to understand regexes.
There are problems with my parser though: 

A. It fails in the case that there is a URL ending with a comma 
B. It is significantly slower than the previous regex solution (https://jsbench.me/mxkybbu22g/1)
C. There might be other problems I'm overlooking

I also modified the fixtures to test for this behavior

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
