### PR TITLE
Fix readonly form data return

### DIFF
--- a/.changeset/rotten-tips-teach.md
+++ b/.changeset/rotten-tips-teach.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Change ReadOnlyFormData behavior to mimic the spec's FormData interface

--- a/packages/kit/src/runtime/server/parse_body/read_only_form_data.js
+++ b/packages/kit/src/runtime/server/parse_body/read_only_form_data.js
@@ -8,8 +8,9 @@ export function read_only_form_data() {
 		 * @param {string} value
 		 */
 		append(key, value) {
-			if (map.has(key)) {
-				(map.get(key) || []).push(value);
+			const existing_values = map.get(key);
+			if (existing_values) {
+				existing_values.push(value);
 			} else {
 				map.set(key, [value]);
 			}

--- a/packages/kit/src/runtime/server/parse_body/read_only_form_data.js
+++ b/packages/kit/src/runtime/server/parse_body/read_only_form_data.js
@@ -32,12 +32,15 @@ class ReadOnlyFormData {
 	/** @param {string} key */
 	get(key) {
 		const value = this.#map.get(key);
-		return value && value[0];
+		if (!value) {
+			return null;
+		}
+		return value[0];
 	}
 
 	/** @param {string} key */
 	getAll(key) {
-		return this.#map.get(key);
+		return this.#map.get(key) || [];
 	}
 
 	/** @param {string} key */

--- a/packages/kit/src/runtime/server/parse_body/read_only_form_data.spec.js
+++ b/packages/kit/src/runtime/server/parse_body/read_only_form_data.spec.js
@@ -2,6 +2,12 @@ import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { read_only_form_data } from './read_only_form_data.js';
 
+test('ro-fd get returns null and getAll an empty array for no values at given key', () => {
+	const { data } = read_only_form_data();
+	assert.is(data.get('foo'), null);
+	assert.equal(data.getAll('foo'), []);
+});
+
 const { data, append } = read_only_form_data();
 append('foo', '1'), append('foo', '2'), append('foo', '3');
 append('bar', '2'), append('bar', '1');

--- a/packages/kit/test/apps/basics/src/routes/routing/shadow/action.js
+++ b/packages/kit/test/apps/basics/src/routes/routing/shadow/action.js
@@ -2,7 +2,7 @@ let random = 0;
 
 /** @type {import('@sveltejs/kit').RequestHandler<any, FormData>} */
 export function post({ body }) {
-	random = +body.get('random');
+	random = +(body.get('random') || '0');
 	return { fallthrough: true };
 }
 

--- a/packages/kit/types/helper.d.ts
+++ b/packages/kit/types/helper.d.ts
@@ -1,5 +1,5 @@
 interface ReadOnlyFormData {
-	get(key: string): string;
+	get(key: string): string | null;
 	getAll(key: string): string[];
 	has(key: string): boolean;
 	entries(): Generator<[string, string], void>;


### PR DESCRIPTION
The typings for `ReadOnlyFormData`'s `get` and `getAll` methods are wrong, as they both return `undefined` when there is no value for the given key. This results in a loss of type-safety and misguided programmers, as at least I have thought that they return the empty string/array when there are no values.
This PR changes the behavior of these methods so they are identical to the spec's [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) ones: `get` returns `null` if no value is present, `getAll` returns an empty array. This is the way I expected, and I think everyone coming to Svelte, it should work, especially given that for endpoints we pass `FormData` as the `Input` type parameter for a `RequestHandler`. It is also a breaking change, as it results in some errors from Typescript (even in this codebase, see commit ae40649).

EDIT: I also wonder if the types for `RequestHeaders` are also incorrect, as both Node's [`IncomingHttpHeaders`](https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules__types_node_http_d_._http_.incominghttpheaders.html) and spec's [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) objects return either `undefined` or `null` when the header is not present.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
