### PR TITLE
Refactor navigation

### DIFF
--- a/.changeset/sharp-starfishes-thank.md
+++ b/.changeset/sharp-starfishes-thank.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Wait until navigation ends before updating history

--- a/.changeset/sharp-starfishes-thank.md
+++ b/.changeset/sharp-starfishes-thank.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': patch
----
-
-Wait until navigation ends before updating history

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -255,10 +255,11 @@ export class Renderer {
 				});
 			} else {
 				if (this.router) {
-					this.router.goto(navigation_result.redirect, { replaceState: true }, [
-						...chain,
-						info.url.pathname
-					]);
+					this.router.goto(
+						new URL(navigation_result.redirect, info.url).href,
+						{ replaceState: true },
+						[...chain, info.url.pathname]
+					);
 				} else {
 					location.href = new URL(navigation_result.redirect, location.href).href;
 				}

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -270,8 +270,6 @@ export class Router {
 			throw new Error('Attempted to navigate to a URL that does not belong to this app');
 		}
 
-		if (method) history[method](state, '', info.url);
-
 		if (!this.navigating) {
 			dispatchEvent(new CustomEvent('sveltekit:navigation-start'));
 		}
@@ -287,6 +285,7 @@ export class Router {
 		}
 
 		info.url = new URL(url.origin + pathname + url.search + url.hash);
+		if (method) history[method](state, '', info.url);
 
 		await this.renderer.handle_navigation(info, chain, false, { hash, scroll, keepfocus });
 

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -270,6 +270,8 @@ export class Router {
 			throw new Error('Attempted to navigate to a URL that does not belong to this app');
 		}
 
+		if (method) history[method](state, '', info.url);
+
 		if (!this.navigating) {
 			dispatchEvent(new CustomEvent('sveltekit:navigation-start'));
 		}
@@ -291,7 +293,6 @@ export class Router {
 		this.navigating--;
 		if (!this.navigating) {
 			dispatchEvent(new CustomEvent('sveltekit:navigation-end'));
-			if (method) history[method](state, '', info.url);
 		}
 	}
 }

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -165,17 +165,15 @@ export class Router {
 				return;
 			}
 
-			history.pushState({}, '', url.href);
-
 			const noscroll = a.hasAttribute('sveltekit:noscroll');
-			this._navigate(url, noscroll ? scroll_state() : null, false, [], url.hash);
+			this._navigate(url, noscroll ? scroll_state() : null, false, [], url.hash, {}, 'pushState');
 			event.preventDefault();
 		});
 
 		addEventListener('popstate', (event) => {
 			if (event.state && this.enabled) {
 				const url = new URL(location.href);
-				this._navigate(url, event.state['sveltekit:scroll'], false, []);
+				this._navigate(url, event.state['sveltekit:scroll'], false, [], url.hash, null, null);
 			}
 		});
 	}
@@ -217,8 +215,15 @@ export class Router {
 		const url = new URL(href, get_base_uri(document));
 
 		if (this.enabled && this.owns(url)) {
-			history[replaceState ? 'replaceState' : 'pushState'](state, '', href);
-			return this._navigate(url, noscroll ? scroll_state() : null, keepfocus, chain, url.hash);
+			return this._navigate(
+				url,
+				noscroll ? scroll_state() : null,
+				keepfocus,
+				chain,
+				url.hash,
+				state,
+				replaceState ? 'replaceState' : 'pushState'
+			);
 		}
 
 		location.href = url.href;
@@ -254,9 +259,11 @@ export class Router {
 	 * @param {{ x: number, y: number }?} scroll
 	 * @param {boolean} keepfocus
 	 * @param {string[]} chain
-	 * @param {string} [hash]
+	 * @param {string} hash
+	 * @param {any} state
+	 * @param {'pushState' | 'replaceState' | null} method
 	 */
-	async _navigate(url, scroll, keepfocus, chain, hash) {
+	async _navigate(url, scroll, keepfocus, chain, hash, state, method) {
 		const info = this.parse(url);
 
 		if (!info) {
@@ -278,13 +285,13 @@ export class Router {
 		}
 
 		info.url = new URL(url.origin + pathname + url.search + url.hash);
-		history.replaceState({}, '', info.url);
 
 		await this.renderer.handle_navigation(info, chain, false, { hash, scroll, keepfocus });
 
 		this.navigating--;
 		if (!this.navigating) {
 			dispatchEvent(new CustomEvent('sveltekit:navigation-end'));
+			if (method) history[method](state, '', info.url);
 		}
 	}
 }


### PR DESCRIPTION
This is #3241 but without the changed functionality — we refactor so that `history` is updated inside `_navigate`, but still change the URL at the beginning of the navigation rather than at the end.

I'm doing this because I have a hunch that these changes will make #3293 a bit easier.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
