### PR TITLE
[docs] unbreak docs deployment

### DIFF
--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -143,7 +143,7 @@ Whether to [hydrate](#page-options-hydrate) the server-rendered HTML with a clie
 
 Inline CSS inside a `<style>` block at the head of the HTML. This option is a number that specifies the maximum length of a CSS file to be inlined. All CSS files needed for the page and smaller than this value are merged and inlined in a `<style>` block.
 
-> # This results in fewer initial requests and can improve your [First Contentful Paint](https://web.dev/first-contentful-paint) score. However, it generates larger HTML output and reduces the effectiveness of browser caches. Use it advisedly.
+> This results in fewer initial requests and can improve your [First Contentful Paint](https://web.dev/first-contentful-paint) score. However, it generates larger HTML output and reduces the effectiveness of browser caches. Use it advisedly.
 
 ### methodOverride
 


### PR DESCRIPTION
the docs broke 21 hours ago complaining about a `#`, so I'm pretty sure this is the issue

See also https://github.com/sveltejs/action-deploy-docs/pull/24