### PR TITLE
Rebase the service worker to the app's base path

### DIFF
--- a/.changeset/grumpy-poets-try.md
+++ b/.changeset/grumpy-poets-try.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+The path to a service worker is now rebased to the app's base path

--- a/packages/kit/src/core/build/build_server.js
+++ b/packages/kit/src/core/build/build_server.js
@@ -77,7 +77,7 @@ export class App {
 			prerender: ${config.kit.prerender.enabled},
 			read,
 			root,
-			service_worker: ${has_service_worker ? "'/service-worker.js'" : 'null'},
+			service_worker: ${has_service_worker ? "base + '/service-worker.js'" : 'null'},
 			router: ${s(config.kit.router)},
 			target: ${s(config.kit.target)},
 			template,


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

Closes #3290 
This will make the service worker registration respect the app's base path to prevent requests to `/service-worker.js` when the app is expected to be served on `/non-root/`.