### PR TITLE
Fix svelte-kit dev/preview when config.kit.paths.base is set

### DIFF
--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -179,7 +179,7 @@ export async function create_plugin(config, output, cwd) {
 
 						paths.set_paths({
 							base: config.kit.paths.base,
-							assets: config.kit.paths.assets ? SVELTE_KIT_ASSETS : config.kit.paths.base
+							assets: config.kit.paths.assets ? SVELTE_KIT_ASSETS : ''
 						});
 
 						let body;
@@ -218,7 +218,7 @@ export async function create_plugin(config, output, cwd) {
 								method_override: config.kit.methodOverride,
 								paths: {
 									base: config.kit.paths.base,
-									assets: config.kit.paths.assets ? SVELTE_KIT_ASSETS : config.kit.paths.base
+									assets: config.kit.paths.assets ? SVELTE_KIT_ASSETS : ''
 								},
 								prefix: '',
 								prerender: config.kit.prerender.enabled,

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -105,7 +105,7 @@ export async function respond(incoming, options, state = {}) {
 					});
 				}
 
-				const decoded = decodeURI(request.url.pathname).replace(options.paths.base, '');
+				const decoded = decodeURI(request.url.pathname).replace(options.paths.base, '') || '/';
 
 				for (const route of options.manifest._.routes) {
 					const match = route.pattern.exec(decoded);


### PR DESCRIPTION
This fixes a few small issues I had when using `svelte-kit dev` and `svelte-kit preview` when `config.kit.paths.base` is set:

- The base-prefixed root path would be resolved to an empty-string path (instead of "/"), causing it not to be found; looks like #2838 is related
- Vite always serves the static files from the server's root directory, so update the `path.assets` of the build to look there (not sure if there is an issue for this)

After these changes, `svelte-kit dev` and `svelte-kit preview` seem to be working for my (small) app together with `paths.base`.

-------

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0