### PR TITLE
Fix truncated basepath

### DIFF
--- a/.changeset/curly-pets-vanish.md
+++ b/.changeset/curly-pets-vanish.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Handle requests for /basepath

--- a/packages/kit/src/core/adapt/prerender/prerender.js
+++ b/packages/kit/src/core/adapt/prerender/prerender.js
@@ -230,8 +230,12 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 
 					const parsed = new URL(resolved, 'http://localhost');
 
-					if (!parsed.pathname.startsWith(config.kit.paths.base)) continue;
-					const pathname = decodeURI(parsed.pathname).slice(config.kit.paths.base.length) || '/';
+					let pathname = decodeURI(parsed.pathname);
+
+					if (config.kit.paths.base) {
+						if (!pathname.startsWith(config.kit.paths.base)) continue;
+						pathname = pathname.slice(config.kit.paths.base.length) || '/';
+					}
 
 					const file = pathname.slice(1);
 					if (files.has(file)) continue;

--- a/packages/kit/src/core/adapt/prerender/prerender.js
+++ b/packages/kit/src/core/adapt/prerender/prerender.js
@@ -229,7 +229,9 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 					if (!is_root_relative(resolved)) continue;
 
 					const parsed = new URL(resolved, 'http://localhost');
-					const pathname = decodeURI(parsed.pathname).replace(config.kit.paths.base, '');
+
+					if (!parsed.pathname.startsWith(config.kit.paths.base)) continue;
+					const pathname = decodeURI(parsed.pathname).slice(config.kit.paths.base.length) || '/';
 
 					const file = pathname.slice(1);
 					if (files.has(file)) continue;

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -179,7 +179,7 @@ export async function create_plugin(config, output, cwd) {
 
 						paths.set_paths({
 							base: config.kit.paths.base,
-							assets: config.kit.paths.assets ? SVELTE_KIT_ASSETS : ''
+							assets: config.kit.paths.assets ? SVELTE_KIT_ASSETS : config.kit.paths.base
 						});
 
 						let body;
@@ -218,7 +218,7 @@ export async function create_plugin(config, output, cwd) {
 								method_override: config.kit.methodOverride,
 								paths: {
 									base: config.kit.paths.base,
-									assets: config.kit.paths.assets ? SVELTE_KIT_ASSETS : ''
+									assets: config.kit.paths.assets ? SVELTE_KIT_ASSETS : config.kit.paths.base
 								},
 								prefix: '',
 								prerender: config.kit.prerender.enabled,

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -179,7 +179,7 @@ export async function create_plugin(config, output, cwd) {
 
 						paths.set_paths({
 							base: config.kit.paths.base,
-							assets: config.kit.paths.assets ? SVELTE_KIT_ASSETS : config.kit.paths.base
+							assets: config.kit.paths.assets ? SVELTE_KIT_ASSETS : ''
 						});
 
 						let body;
@@ -218,7 +218,7 @@ export async function create_plugin(config, output, cwd) {
 								method_override: config.kit.methodOverride,
 								paths: {
 									base: config.kit.paths.base,
-									assets: config.kit.paths.assets ? SVELTE_KIT_ASSETS : config.kit.paths.base
+									assets: config.kit.paths.assets ? SVELTE_KIT_ASSETS : ''
 								},
 								prefix: '',
 								prerender: config.kit.prerender.enabled,

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -105,7 +105,7 @@ export async function respond(incoming, options, state = {}) {
 					});
 				}
 
-				const decoded = decodeURI(request.url.pathname).replace(options.paths.base, '');
+				const decoded = decodeURI(request.url.pathname).replace(options.paths.base, '') || '/';
 
 				for (const route of options.manifest._.routes) {
 					const match = route.pattern.exec(decoded);

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -90,6 +90,8 @@ export async function respond(incoming, options, state = {}) {
 			resolve: async (request, opts) => {
 				if (opts && 'ssr' in opts) ssr = /** @type {boolean} */ (opts.ssr);
 
+				if (!request.url.pathname.startsWith(options.paths.base)) return;
+
 				if (state.prerender && state.prerender.fallback) {
 					return await render_response({
 						url: request.url,
@@ -105,7 +107,7 @@ export async function respond(incoming, options, state = {}) {
 					});
 				}
 
-				const decoded = decodeURI(request.url.pathname).replace(options.paths.base, '') || '/';
+				const decoded = decodeURI(request.url.pathname).slice(options.paths.base.length) || '/';
 
 				for (const route of options.manifest._.routes) {
 					const match = route.pattern.exec(decoded);

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -105,8 +105,12 @@ export async function respond(incoming, options, state = {}) {
 					});
 				}
 
-				if (!request.url.pathname.startsWith(options.paths.base)) return;
-				const decoded = decodeURI(request.url.pathname).slice(options.paths.base.length) || '/';
+				let decoded = decodeURI(request.url.pathname);
+
+				if (options.paths.base) {
+					if (!decoded.startsWith(options.paths.base)) return;
+					decoded = decoded.slice(options.paths.base.length) || '/';
+				}
 
 				for (const route of options.manifest._.routes) {
 					const match = route.pattern.exec(decoded);

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -90,8 +90,6 @@ export async function respond(incoming, options, state = {}) {
 			resolve: async (request, opts) => {
 				if (opts && 'ssr' in opts) ssr = /** @type {boolean} */ (opts.ssr);
 
-				if (!request.url.pathname.startsWith(options.paths.base)) return;
-
 				if (state.prerender && state.prerender.fallback) {
 					return await render_response({
 						url: request.url,
@@ -107,6 +105,7 @@ export async function respond(incoming, options, state = {}) {
 					});
 				}
 
+				if (!request.url.pathname.startsWith(options.paths.base)) return;
 				const decoded = decodeURI(request.url.pathname).slice(options.paths.base.length) || '/';
 
 				for (const route of options.manifest._.routes) {

--- a/packages/kit/test/apps/options-2/svelte.config.js
+++ b/packages/kit/test/apps/options-2/svelte.config.js
@@ -1,6 +1,9 @@
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
+		paths: {
+			base: '/basepath'
+		},
 		serviceWorker: {
 			register: false
 		}

--- a/packages/kit/test/apps/options-2/test/test.js
+++ b/packages/kit/test/apps/options-2/test/test.js
@@ -3,22 +3,24 @@ import { test } from '../../../utils.js';
 
 /** @typedef {import('@playwright/test').Response} Response */
 
-test.describe.parallel('Service worker', () => {
-	test('serves /', async ({ page }) => {
-		await page.goto('/');
+test.describe.parallel('paths.base', () => {
+	test('serves /basepath', async ({ page }) => {
+		await page.goto('/basepath');
 		expect(await page.textContent('h1')).toBe('Hello');
 	});
+});
 
+test.describe.parallel('Service worker', () => {
 	if (!process.env.DEV) {
-		test('build /service-worker.js', async ({ request }) => {
-			const response = await request.get('/service-worker.js');
+		test('build /basepath/service-worker.js', async ({ request }) => {
+			const response = await request.get('/basepath/service-worker.js');
 			const content = await response.text();
 
 			expect(content).toMatch(/\/_app\/start-[a-z0-9]+\.js/);
 		});
 
-		test('does not register /service-worker.js', async ({ page }) => {
-			await page.goto('/');
+		test('does not register /basepath/service-worker.js', async ({ page }) => {
+			await page.goto('/basepath');
 			expect(await page.content()).not.toMatch(/navigator\.serviceWorker/);
 		});
 	}

--- a/packages/kit/test/apps/options/source/pages/origin/index.svelte
+++ b/packages/kit/test/apps/options/source/pages/origin/index.svelte
@@ -1,7 +1,9 @@
 <script context="module">
+	import { base } from '$app/paths';
+
 	/** @type {import('@sveltejs/kit').Load} */
 	export async function load({ url, fetch }) {
-		const res = await fetch('/origin.json');
+		const res = await fetch(`${base}/origin.json`);
 		const data = await res.json();
 
 		return {


### PR DESCRIPTION
Supersedes #3337. Ensures that requests for `/basepath` (where `paths.base === '/basepath`) resolve correctly (the existing tests didn't catch this because of `trailingSlash: 'always'`).

This _doesn't_ fix static asset handling, which is a bit finicky — will open a separate PR for that.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
