### PR TITLE
solves #3305 - When there is not title in the page(inside svelte:head in svelte page component in the src/routes folder) the browser shows title for the last page that had it

### DIFF
--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -279,7 +279,7 @@ export class Renderer {
 		}
 
 		this.updating = true;
-
+		document.title = '';
 		if (this.started) {
 			this.current = navigation_result.state;
 


### PR DESCRIPTION
solves #3305 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
