### PR TITLE
Don't overwrite custom etag

### DIFF
--- a/.changeset/clever-readers-turn.md
+++ b/.changeset/clever-readers-turn.md
@@ -2,6 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Don't overwrite ETAG header.
-
-Now user can provide a custom ETAG header, which should be manually checked against the 'if-none-match' header.
+Preserve explicit ETag header

--- a/.changeset/clever-readers-turn.md
+++ b/.changeset/clever-readers-turn.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/kit': patch
+---
+
+Don't overwrite ETAG header.
+
+Now user can provide a custom ETAG header, which should be manually checked against the 'if-none-match' header.

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -122,8 +122,9 @@ export async function respond(incoming, options, state = {}) {
 							: await render_page(request, route, match, options, state, ssr);
 
 					if (response) {
-						// inject ETags for 200 responses
-						if (response.status === 200) {
+						// inject ETags for 200 responses, if the endpoint
+						// doesn't have its own ETag handling
+						if (response.status === 200 && !response.headers.etag) {
 							const cache_control = get_single_valued_header(response.headers, 'cache-control');
 							if (!cache_control || !/(no-store|immutable)/.test(cache_control)) {
 								let if_none_match_value = request.headers['if-none-match'];
@@ -157,9 +158,7 @@ export async function respond(incoming, options, state = {}) {
 									};
 								}
 
-								if (!response.headers['etag']) {
-									response.headers['etag'] = etag;
-								}
+								response.headers['etag'] = etag;
 							}
 						}
 

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -152,7 +152,7 @@ export async function respond(incoming, options, state = {}) {
 									};
 								}
 
-								response.headers['etag'] = etag;
+								if (!response.headers['etag']) response.headers['etag'] = etag;
 							}
 						}
 

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -152,7 +152,9 @@ export async function respond(incoming, options, state = {}) {
 									};
 								}
 
-								if (!response.headers['etag']) response.headers['etag'] = etag;
+								if (!response.headers['etag']) {
+									response.headers['etag'] = etag;
+								}
 							}
 						}
 

--- a/packages/kit/test/apps/basics/src/routes/etag/custom.js
+++ b/packages/kit/test/apps/basics/src/routes/etag/custom.js
@@ -1,0 +1,10 @@
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export function get({ headers }) {
+	if (headers['if-none-match'] === '@1234@') return { status: 304 };
+	return {
+		body: `${Math.random()}`,
+		headers: {
+			etag: '@1234@'
+		}
+	};
+}

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -732,6 +732,20 @@ test.describe.parallel('ETags', () => {
 
 		expect(r2.status()).toBe(304);
 	});
+
+	test('custom etag', async ({ request }) => {
+		const r1 = await request.get('/etag/custom');
+		const etag = r1.headers()['etag'];
+		expect(etag).toBe('@1234@');
+
+		const r2 = await request.get('/etag/custom', {
+			headers: {
+				'if-none-match': '@1234@'
+			}
+		});
+
+		expect(r2.status()).toBe(304);
+	});
 });
 
 test.describe.parallel('Headers', () => {


### PR DESCRIPTION
Kit should not overwrite custom etag value.

Sometimes it's useful to provide a custom etag value which should not be overwritten by sveltekit.
For example, in my particular use case, when proxying an image from S3 it's possible to retrieve the ETAG with the metadata, without downloading it.
This is also useful when the etag is based on api requests, making it possible to skip rendering the page.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
