### PR TITLE
Implementation: Handling of static assets with `paths.base`

### DIFF
--- a/.changeset/tender-actors-tease.md
+++ b/.changeset/tender-actors-tease.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Handle static assets with /basepath in svelte-kit dev

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -75,7 +75,6 @@ export async function dev({ cwd, port, host, https, config }) {
 			}),
 			await create_plugin(config, output, cwd)
 		],
-		publicDir: config.kit.files.assets,
 		base: '/'
 	});
 

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { URL } from 'url';
 import colors from 'kleur';
+import sirv from 'sirv';
 import { respond } from '../../runtime/server/index.js';
 import { __fetch_polyfill } from '../../install-fetch.js';
 import { create_app } from '../create_app/index.js';
@@ -127,6 +128,14 @@ export async function create_plugin(config, output, cwd) {
 			vite.watcher.on('add', update_manifest);
 			vite.watcher.on('remove', update_manifest);
 
+			const assets_path = config.kit.paths.assets ? SVELTE_KIT_ASSETS : config.kit.paths.base;
+			const asset_server = sirv(config.kit.files.assets, {
+				dev: true,
+				etag: true,
+				maxAge: 0,
+				extensions: []
+			});
+
 			return () => {
 				remove_html_middlewares(vite.middlewares);
 
@@ -135,8 +144,20 @@ export async function create_plugin(config, output, cwd) {
 						if (!req.url || !req.method) throw new Error('Incomplete request');
 						if (req.url === '/favicon.ico') return not_found(res);
 
-						const parsed = new URL(req.url, 'http://localhost/');
-						if (!parsed.pathname.startsWith(config.kit.paths.base)) return not_found(res);
+						const decoded = decodeURI(new URL(req.url, 'http://localhost').pathname);
+						if (decoded.startsWith(assets_path)) {
+							const initial_url = req.url;
+							/* Static asset server doesn't care about query or hash - no need to pass them on */
+							req.url = encodeURI(decoded.slice(assets_path.length));
+							await new Promise((/** @type {(val: void) => void} */ resolve, reject) =>
+								asset_server(req, res, (/** @type {unknown} */ err) =>
+									err ? reject(err) : resolve()
+								)
+							);
+							req.url = initial_url;
+						}
+
+						if (!decoded.startsWith(config.kit.paths.base)) return not_found(res);
 
 						/** @type {Partial<import('types/internal').Hooks>} */
 						const user_hooks = resolve_entry(config.kit.files.hooks)
@@ -179,7 +200,7 @@ export async function create_plugin(config, output, cwd) {
 
 						paths.set_paths({
 							base: config.kit.paths.base,
-							assets: config.kit.paths.assets ? SVELTE_KIT_ASSETS : config.kit.paths.base
+							assets: assets_path
 						});
 
 						let body;
@@ -218,7 +239,7 @@ export async function create_plugin(config, output, cwd) {
 								method_override: config.kit.methodOverride,
 								paths: {
 									base: config.kit.paths.base,
-									assets: config.kit.paths.assets ? SVELTE_KIT_ASSETS : config.kit.paths.base
+									assets: assets_path
 								},
 								prefix: '',
 								prerender: config.kit.prerender.enabled,


### PR DESCRIPTION
With this PR, `svelte-kit dev` now serves static assets from the appropriate place: `/_svelte_kit_assets` if `paths.assets` is set ([as documented](https://kit.svelte.dev/docs#modules-$app-paths)), otherwise `paths.base`. It accomplishes this by serving static assets with its own `sirv` instance instead of relying on Vite. This neatly bypasses the problems discussed in #3346, with minimal additional complexity. These changes build off the failing test added in #3346 (which now passes).

I based the options for the sirv instance off what was already being used in `svelte-kit preview` and what Vite's `servePublicMiddleware` (which, prior to this change, was serving the static assets).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
