### PR TITLE
[fix] make properties overwritable (#3356)

### DIFF
--- a/.changeset/cyan-schools-kiss.md
+++ b/.changeset/cyan-schools-kiss.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Allow \_\_fetch_polyfill() to run several times

--- a/packages/kit/src/install-fetch.js
+++ b/packages/kit/src/install-fetch.js
@@ -5,18 +5,22 @@ export function __fetch_polyfill() {
 	Object.defineProperties(globalThis, {
 		fetch: {
 			enumerable: true,
+			configurable: true,
 			value: fetch
 		},
 		Response: {
 			enumerable: true,
+			configurable: true,
 			value: Response
 		},
 		Request: {
 			enumerable: true,
+			configurable: true,
 			value: Request
 		},
 		Headers: {
 			enumerable: true,
+			configurable: true,
 			value: Headers
 		}
 	});


### PR DESCRIPTION
This PR makes import side effects less aggressive by allowing __fetch_polyfill() to run several times.
See #3356 for more details.