### PR TITLE
[feat] added an option to make handler behave as a pure middleware 

### DIFF
--- a/.changeset/fresh-carrots-travel.md
+++ b/.changeset/fresh-carrots-travel.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Added an option to make `handler` invoke the next middleware on 404 errors.

--- a/.changeset/little-dolls-beg.md
+++ b/.changeset/little-dolls-beg.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Fixed `sequence` to handle properly the last middleware.

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -56,6 +56,24 @@ env: {
 MY_HOST_VARIABLE=127.0.0.1 MY_PORT_VARIABLE=4000 node build
 ```
 
+### handle404
+
+Note: this option is meant to be used when building for Custom Servers, see below.
+
+By default, the `handler` middleware catches HTTP errors to render [custom error pages](https://kit.svelte.dev/docs#layouts-error-pages). You can set `handle404` to `false` to turn off this behavior, and make `handler` invoke the next middleware on 404 errors.
+
+Consider the following code:
+
+```js
+import { handler } from './build/handler.js';
+
+const app = express();
+app.use(handler, otherMiddleware);
+```
+
+- When `handle404` is set to `true` (by default), `otherMiddleware` will never be called.
+- When `handle404` is set to `false`, `otherMiddleware` will be called when your SvelteKit site does not have a matching route.
+
 ## Custom server
 
 The adapter creates two files in your build directory — `index.js` and `handler.js`. Running `index.js` — e.g. `node build`, if you use the default build directory — will start a server on the configured port.

--- a/packages/adapter-node/index.d.ts
+++ b/packages/adapter-node/index.d.ts
@@ -8,6 +8,7 @@ interface AdapterOptions {
 		host?: string;
 		port?: string;
 	};
+	handle404?: boolean;
 }
 
 declare function plugin(options?: AdapterOptions): Adapter;

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -13,7 +13,8 @@ const files = fileURLToPath(new URL('./files', import.meta.url));
 export default function ({
 	out = 'build',
 	precompress,
-	env: { path: path_env = 'SOCKET_PATH', host: host_env = 'HOST', port: port_env = 'PORT' } = {}
+	env: { path: path_env = 'SOCKET_PATH', host: host_env = 'HOST', port: port_env = 'PORT' } = {},
+	handle404 = true
 } = {}) {
 	return {
 		name: '@sveltejs/adapter-node',
@@ -44,7 +45,8 @@ export default function ({
 					MANIFEST: './manifest.js',
 					PATH_ENV: JSON.stringify(path_env),
 					HOST_ENV: JSON.stringify(host_env),
-					PORT_ENV: JSON.stringify(port_env)
+					PORT_ENV: JSON.stringify(port_env),
+					HANDLE_404: JSON.stringify(handle404)
 				}
 			});
 

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -7,7 +7,10 @@ import { __fetch_polyfill } from '@sveltejs/kit/install-fetch';
 
 // @ts-ignore
 import { App } from 'APP';
+// @ts-ignore
 import { manifest } from 'MANIFEST';
+
+/* global HANDLE_404 */
 
 __fetch_polyfill();
 
@@ -34,7 +37,7 @@ function serve(path, max_age, immutable = false) {
 }
 
 /** @type {import('polka').Middleware} */
-const ssr = async (req, res) => {
+const ssr = async (req, res, next) => {
 	let body;
 
 	try {
@@ -50,6 +53,10 @@ const ssr = async (req, res) => {
 		headers: req.headers, // TODO: what about repeated headers, i.e. string[]
 		rawBody: body
 	});
+
+	if (!HANDLE_404 && (!rendered || rendered.status === 404)) {
+		return next();
+	}
 
 	if (rendered) {
 		res.writeHead(rendered.status, rendered.headers);

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -70,7 +70,7 @@ function sequence(handlers) {
 		/** @param {number} i */
 		function handle(i) {
 			handlers[i](req, res, () => {
-				if (i < handlers.length) handle(i + 1);
+				if (i + 1 < handlers.length) handle(i + 1);
 				else next();
 			});
 		}

--- a/packages/adapter-node/src/types.d.ts
+++ b/packages/adapter-node/src/types.d.ts
@@ -2,6 +2,7 @@ declare global {
 	const PATH_ENV: string;
 	const HOST_ENV: string;
 	const PORT_ENV: string;
+	const HANDLE_404: boolean;
 }
 
 export {};

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -200,5 +200,6 @@ declare module '@sveltejs/kit/ssr' {
 declare module '@sveltejs/kit/install-fetch' {
 	import fetch, { Headers, Request, Response } from 'node-fetch';
 
+	export function __fetch_polyfill(): void;
 	export { fetch, Headers, Request, Response };
 }


### PR DESCRIPTION
## Updated

I committed to the same branch because I needed the fix to work, so here is a bigger PR...

**New feature:**
Added a build option, `handle404: boolean`, that, when set to false, makes `handler` behave as a pure middleware.

Please see #3363 for context

---

## Old message

Fixed the upper bound of the loop

See also
https://github.com/sveltejs/kit/blob/a79b5bf51b38b778af85ed4ade1d26bf7584c417/packages/kit/src/hooks.js#L22