### PR TITLE
[fix] ignore hash links during prerendering (again)

### DIFF
--- a/.changeset/grumpy-panthers-mate.md
+++ b/.changeset/grumpy-panthers-mate.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] ignore hash links during prerendering (again)

--- a/packages/kit/src/core/adapt/prerender/prerender.js
+++ b/packages/kit/src/core/adapt/prerender/prerender.js
@@ -223,7 +223,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 
 			if (is_html && config.kit.prerender.crawl) {
 				for (const href of crawl(/** @type {string} */ (rendered.body))) {
-					if (href.startsWith('data:')) continue;
+					if (href.startsWith('data:') || href.startsWith('#')) continue;
 
 					const resolved = resolve(path, href);
 					if (!is_root_relative(resolved)) continue;


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/3228

this was fixed the other day in https://github.com/sveltejs/kit/pull/3251, but has broken again