### PR TITLE
[fix] refactor navigation singletons to avoid storing undefined reference

### DIFF
--- a/.changeset/brown-mangos-tie.md
+++ b/.changeset/brown-mangos-tie.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] #3269 refactor navigation/singletons

--- a/.changeset/brown-mangos-tie.md
+++ b/.changeset/brown-mangos-tie.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-[fix] refactor navigation singletons
+[fix] refactor navigation singletons to avoid storing undefined reference

--- a/.changeset/brown-mangos-tie.md
+++ b/.changeset/brown-mangos-tie.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-[fix] #3269 refactor navigation/singletons
+[fix] refactor navigation singletons

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -1,7 +1,5 @@
-import { router as router_, renderer } from '../client/singletons.js';
+import { router, renderer } from '../client/singletons.js';
 import { get_base_uri } from '../client/utils.js';
-
-const router = /** @type {import('../client/router').Router} */ (router_);
 
 /**
  * @param {string} name

--- a/packages/kit/src/runtime/client/singletons.js
+++ b/packages/kit/src/runtime/client/singletons.js
@@ -1,4 +1,7 @@
-/** @type {import('./router').Router} */
+/**
+ * The router is nullable, but not typed that way for ease-of-use
+ * @type {import('./router').Router}
+ */
 export let router;
 
 /** @type {import('./renderer').Renderer} */

--- a/packages/kit/src/runtime/client/singletons.js
+++ b/packages/kit/src/runtime/client/singletons.js
@@ -1,4 +1,4 @@
-/** @type {import('./router').Router?} */
+/** @type {import('./router').Router} */
 export let router;
 
 /** @type {import('./renderer').Renderer} */
@@ -11,6 +11,6 @@ export let renderer;
  * }} opts
  */
 export function init(opts) {
-	router = opts.router;
+	router = /** @type {import('../client/router').Router} */ (opts.router);
 	renderer = opts.renderer;
 }


### PR DESCRIPTION
This PR fixes #3269, once you import $app/navigation on multiple places inside your app and it's included inside chunks/vendor.js the router would be set before the init function is called and would always be undefined.

Current Bundle:
``` js
/// vendor-c70aba79.js
let router$1;
function init(opts) {
  router$1 = opts.router;
}
/// ....
const router = router$1; // Router is undefined and doesnt change on init call
const goto = goto_;
const invalidate = invalidate_;
async function goto_(href, opts) {
  return router.goto(href, opts, []);
}
```

New Bundle: 

``` js
let router;
function init(opts) {
  router = opts.router;
}
const goto = goto_;
const invalidate = invalidate_;
async function goto_(href, opts) {
  return router.goto(href, opts, []);
}
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
