### PR TITLE
[fix] export CJS files for Netlify

### DIFF
--- a/.changeset/dirty-walls-battle.md
+++ b/.changeset/dirty-walls-battle.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] export CJS files for Netlify

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -79,13 +79,16 @@
 			"types": "./types/index.d.ts"
 		},
 		"./node": {
-			"import": "./dist/node.js"
+			"import": "./dist/node.js",
+			"require": "./dist/node.cjs"
 		},
 		"./hooks": {
-			"import": "./dist/hooks.js"
+			"import": "./dist/hooks.js",
+			"require": "./dist/hooks.cjs"
 		},
 		"./install-fetch": {
-			"import": "./dist/install-fetch.js"
+			"import": "./dist/install-fetch.js",
+			"require": "./dist/install-fetch.cjs"
 		}
 	},
 	"types": "types/index.d.ts",

--- a/packages/kit/rollup.config.js
+++ b/packages/kit/rollup.config.js
@@ -81,5 +81,37 @@ export default [
 			commonjs()
 		],
 		preserveEntrySignatures: true
+	},
+
+	{
+		input: {
+			cli: 'src/cli.js',
+			node: 'src/node.js',
+			hooks: 'src/hooks.js',
+			'install-fetch': 'src/install-fetch.js'
+		},
+		output: {
+			dir: 'dist',
+			format: 'cjs',
+			entryFileNames: '[name].cjs',
+			chunkFileNames: 'chunks/[name].cjs'
+		},
+		external: (id) => {
+			return id.startsWith('node:') || external.includes(id);
+		},
+		plugins: [
+			replace({
+				preventAssignment: true,
+				values: {
+					__VERSION__: pkg.version,
+					'process.env.BUNDLED': 'true'
+				}
+			}),
+			resolve({
+				extensions: ['.mjs', '.js', '.ts']
+			}),
+			commonjs()
+		],
+		preserveEntrySignatures: true
 	}
 ];


### PR DESCRIPTION
Hopefully fixes https://github.com/sveltejs/kit/issues/3189. I'm not really sure how to test this. And my app works on Netlify anyway somehow. It should get us closer at least though. The thing I'm unsure of is if the `assets` directory also needs to be bundled as CJS

Hopefully we won't need this forever, but it seems like Netlify is still a ways off from supporting CJS. Work is in progress in https://github.com/netlify/cli/issues/3514, but there's more work that needs to be done after that