### PR TITLE
[fix] avoid downloading CSS with highest priority when `inlineStyleThreshold` is used

### DIFF
--- a/.changeset/little-candles-trade.md
+++ b/.changeset/little-candles-trade.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] add media="print" to lower priority of css that's been inlined

--- a/.changeset/little-candles-trade.md
+++ b/.changeset/little-candles-trade.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-[fix] add media="print" to lower priority of css that's been inlined
+[fix] add media="(max-width: 0)" to prevent stylesheets from downloading

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -148,8 +148,8 @@ export async function render_response({
 		}
 		// prettier-ignore
 		head += Array.from(css)
-            .map((dep) => `\n\t<link${styles.has(dep) ? ' media="print"' : ''} rel="stylesheet" href="${options.prefix + dep}">`)
-            .join('');
+			.map((dep) => `\n\t<link${styles.has(dep) ? ' disabled media="(max-width: 0)"' : ''} rel="stylesheet" href="${options.prefix + dep}">`)
+			.join('');
 
 		if (page_config.router || page_config.hydrate) {
 			head += Array.from(js)

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -148,8 +148,8 @@ export async function render_response({
 		}
 		// prettier-ignore
 		head += Array.from(css)
-				.map((dep) => `\n\t<link${styles.has(dep) ? ' disabled' : ''} rel="stylesheet" href="${options.prefix + dep}">`)
-				.join('');
+            .map((dep) => `\n\t<link${styles.has(dep) ? ' disabled media="screen and (max-width: 1px)"' : ''} rel="stylesheet" href="${options.prefix + dep}">`)
+            .join('');
 
 		if (page_config.router || page_config.hydrate) {
 			head += Array.from(js)

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -24,139 +24,139 @@ import { create_prerendering_url_proxy } from './utils.js';
  * }} opts
  */
 export async function render_response({
-	branch,
-	options,
-	state,
-	$session,
-	page_config,
-	status,
-	error,
-	url,
-	params,
-	ssr,
-	stuff
+    branch,
+    options,
+    state,
+    $session,
+    page_config,
+    status,
+    error,
+    url,
+    params,
+    ssr,
+    stuff
 }) {
-	const css = new Set(options.manifest._.entry.css);
-	const js = new Set(options.manifest._.entry.js);
-	/** @type {Map<string, string>} */
-	const styles = new Map();
+    const css = new Set(options.manifest._.entry.css);
+    const js = new Set(options.manifest._.entry.js);
+    /** @type {Map<string, string>} */
+    const styles = new Map();
 
-	/** @type {Array<{ url: string, body: string, json: string }>} */
-	const serialized_data = [];
+    /** @type {Array<{ url: string, body: string, json: string }>} */
+    const serialized_data = [];
 
-	let rendered;
+    let rendered;
 
-	let is_private = false;
-	let maxage;
+    let is_private = false;
+    let maxage;
 
-	if (error) {
-		error.stack = options.get_stack(error);
-	}
+    if (error) {
+        error.stack = options.get_stack(error);
+    }
 
-	if (ssr) {
-		branch.forEach(({ node, loaded, fetched, uses_credentials }) => {
-			if (node.css) node.css.forEach((url) => css.add(url));
-			if (node.js) node.js.forEach((url) => js.add(url));
-			if (node.styles) Object.entries(node.styles).forEach(([k, v]) => styles.set(k, v));
+    if (ssr) {
+        branch.forEach(({ node, loaded, fetched, uses_credentials }) => {
+            if (node.css) node.css.forEach((url) => css.add(url));
+            if (node.js) node.js.forEach((url) => js.add(url));
+            if (node.styles) Object.entries(node.styles).forEach(([k, v]) => styles.set(k, v));
 
-			// TODO probably better if `fetched` wasn't populated unless `hydrate`
-			if (fetched && page_config.hydrate) serialized_data.push(...fetched);
+            // TODO probably better if `fetched` wasn't populated unless `hydrate`
+            if (fetched && page_config.hydrate) serialized_data.push(...fetched);
 
-			if (uses_credentials) is_private = true;
+            if (uses_credentials) is_private = true;
 
-			maxage = loaded.maxage;
-		});
+            maxage = loaded.maxage;
+        });
 
-		const session = writable($session);
+        const session = writable($session);
 
-		/** @type {Record<string, any>} */
-		const props = {
-			stores: {
-				page: writable(null),
-				navigating: writable(null),
-				session
-			},
-			page: {
-				url: state.prerender ? create_prerendering_url_proxy(url) : url,
-				params,
-				status,
-				error,
-				stuff
-			},
-			components: branch.map(({ node }) => node.module.default)
-		};
+        /** @type {Record<string, any>} */
+        const props = {
+            stores: {
+                page: writable(null),
+                navigating: writable(null),
+                session
+            },
+            page: {
+                url: state.prerender ? create_prerendering_url_proxy(url) : url,
+                params,
+                status,
+                error,
+                stuff
+            },
+            components: branch.map(({ node }) => node.module.default)
+        };
 
-		// TODO remove this for 1.0
-		/**
-		 * @param {string} property
-		 * @param {string} replacement
-		 */
-		const print_error = (property, replacement) => {
-			Object.defineProperty(props.page, property, {
-				get: () => {
-					throw new Error(`$page.${property} has been replaced by $page.url.${replacement}`);
-				}
-			});
-		};
+        // TODO remove this for 1.0
+        /**
+         * @param {string} property
+         * @param {string} replacement
+         */
+        const print_error = (property, replacement) => {
+            Object.defineProperty(props.page, property, {
+                get: () => {
+                    throw new Error(`$page.${property} has been replaced by $page.url.${replacement}`);
+                }
+            });
+        };
 
-		print_error('origin', 'origin');
-		print_error('path', 'pathname');
-		print_error('query', 'searchParams');
+        print_error('origin', 'origin');
+        print_error('path', 'pathname');
+        print_error('query', 'searchParams');
 
-		// props_n (instead of props[n]) makes it easy to avoid
-		// unnecessary updates for layout components
-		for (let i = 0; i < branch.length; i += 1) {
-			props[`props_${i}`] = await branch[i].loaded.props;
-		}
+        // props_n (instead of props[n]) makes it easy to avoid
+        // unnecessary updates for layout components
+        for (let i = 0; i < branch.length; i += 1) {
+            props[`props_${i}`] = await branch[i].loaded.props;
+        }
 
-		let session_tracking_active = false;
-		const unsubscribe = session.subscribe(() => {
-			if (session_tracking_active) is_private = true;
-		});
-		session_tracking_active = true;
+        let session_tracking_active = false;
+        const unsubscribe = session.subscribe(() => {
+            if (session_tracking_active) is_private = true;
+        });
+        session_tracking_active = true;
 
-		try {
-			rendered = options.root.render(props);
-		} finally {
-			unsubscribe();
-		}
-	} else {
-		rendered = { head: '', html: '', css: { code: '', map: null } };
-	}
+        try {
+            rendered = options.root.render(props);
+        } finally {
+            unsubscribe();
+        }
+    } else {
+        rendered = { head: '', html: '', css: { code: '', map: null } };
+    }
 
-	let { head, html: body } = rendered;
+    let { head, html: body } = rendered;
 
-	const inlined_style = Array.from(styles.values()).join('\n');
+    const inlined_style = Array.from(styles.values()).join('\n');
 
-	if (options.amp) {
-		head += `
+    if (options.amp) {
+        head += `
 		<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>
 		<noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 		<script async src="https://cdn.ampproject.org/v0.js"></script>
 
 		<style amp-custom>${inlined_style}\n${rendered.css.code}</style>`;
 
-		if (options.service_worker) {
-			head +=
-				'<script async custom-element="amp-install-serviceworker" src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js"></script>';
+        if (options.service_worker) {
+            head +=
+                '<script async custom-element="amp-install-serviceworker" src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js"></script>';
 
-			body += `<amp-install-serviceworker src="${options.service_worker}" layout="nodisplay"></amp-install-serviceworker>`;
-		}
-	} else {
-		if (inlined_style) {
-			head += `\n\t<style${options.dev ? ' data-svelte' : ''}>${inlined_style}</style>`;
-		}
-		// prettier-ignore
-		head += Array.from(css)
-            .map((dep) => `\n\t<link${styles.has(dep) ? ' disabled media="screen and (max-width: 1px)"' : ''} rel="stylesheet" href="${options.prefix + dep}">`)
+            body += `<amp-install-serviceworker src="${options.service_worker}" layout="nodisplay"></amp-install-serviceworker>`;
+        }
+    } else {
+        if (inlined_style) {
+            head += `\n\t<style${options.dev ? ' data-svelte' : ''}>${inlined_style}</style>`;
+        }
+        // prettier-ignore
+        head += Array.from(css)
+            .map((dep) => `\n\t<link${styles.has(dep) ? ' media="print"' : ''} rel="stylesheet" href="${options.prefix + dep}">`)
             .join('');
 
-		if (page_config.router || page_config.hydrate) {
-			head += Array.from(js)
-				.map((dep) => `\n\t<link rel="modulepreload" href="${options.prefix + dep}">`)
-				.join('');
-			// prettier-ignore
-			head += `
+        if (page_config.router || page_config.hydrate) {
+            head += Array.from(js)
+                .map((dep) => `\n\t<link rel="modulepreload" href="${options.prefix + dep}">`)
+                .join('');
+            // prettier-ignore
+            head += `
 			<script type="module">
 				import { start } from ${s(options.prefix + options.manifest._.entry.file)};
 				start({

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -24,139 +24,139 @@ import { create_prerendering_url_proxy } from './utils.js';
  * }} opts
  */
 export async function render_response({
-    branch,
-    options,
-    state,
-    $session,
-    page_config,
-    status,
-    error,
-    url,
-    params,
-    ssr,
-    stuff
+	branch,
+	options,
+	state,
+	$session,
+	page_config,
+	status,
+	error,
+	url,
+	params,
+	ssr,
+	stuff
 }) {
-    const css = new Set(options.manifest._.entry.css);
-    const js = new Set(options.manifest._.entry.js);
-    /** @type {Map<string, string>} */
-    const styles = new Map();
+	const css = new Set(options.manifest._.entry.css);
+	const js = new Set(options.manifest._.entry.js);
+	/** @type {Map<string, string>} */
+	const styles = new Map();
 
-    /** @type {Array<{ url: string, body: string, json: string }>} */
-    const serialized_data = [];
+	/** @type {Array<{ url: string, body: string, json: string }>} */
+	const serialized_data = [];
 
-    let rendered;
+	let rendered;
 
-    let is_private = false;
-    let maxage;
+	let is_private = false;
+	let maxage;
 
-    if (error) {
-        error.stack = options.get_stack(error);
-    }
+	if (error) {
+		error.stack = options.get_stack(error);
+	}
 
-    if (ssr) {
-        branch.forEach(({ node, loaded, fetched, uses_credentials }) => {
-            if (node.css) node.css.forEach((url) => css.add(url));
-            if (node.js) node.js.forEach((url) => js.add(url));
-            if (node.styles) Object.entries(node.styles).forEach(([k, v]) => styles.set(k, v));
+	if (ssr) {
+		branch.forEach(({ node, loaded, fetched, uses_credentials }) => {
+			if (node.css) node.css.forEach((url) => css.add(url));
+			if (node.js) node.js.forEach((url) => js.add(url));
+			if (node.styles) Object.entries(node.styles).forEach(([k, v]) => styles.set(k, v));
 
-            // TODO probably better if `fetched` wasn't populated unless `hydrate`
-            if (fetched && page_config.hydrate) serialized_data.push(...fetched);
+			// TODO probably better if `fetched` wasn't populated unless `hydrate`
+			if (fetched && page_config.hydrate) serialized_data.push(...fetched);
 
-            if (uses_credentials) is_private = true;
+			if (uses_credentials) is_private = true;
 
-            maxage = loaded.maxage;
-        });
+			maxage = loaded.maxage;
+		});
 
-        const session = writable($session);
+		const session = writable($session);
 
-        /** @type {Record<string, any>} */
-        const props = {
-            stores: {
-                page: writable(null),
-                navigating: writable(null),
-                session
-            },
-            page: {
-                url: state.prerender ? create_prerendering_url_proxy(url) : url,
-                params,
-                status,
-                error,
-                stuff
-            },
-            components: branch.map(({ node }) => node.module.default)
-        };
+		/** @type {Record<string, any>} */
+		const props = {
+			stores: {
+				page: writable(null),
+				navigating: writable(null),
+				session
+			},
+			page: {
+				url: state.prerender ? create_prerendering_url_proxy(url) : url,
+				params,
+				status,
+				error,
+				stuff
+			},
+			components: branch.map(({ node }) => node.module.default)
+		};
 
-        // TODO remove this for 1.0
-        /**
-         * @param {string} property
-         * @param {string} replacement
-         */
-        const print_error = (property, replacement) => {
-            Object.defineProperty(props.page, property, {
-                get: () => {
-                    throw new Error(`$page.${property} has been replaced by $page.url.${replacement}`);
-                }
-            });
-        };
+		// TODO remove this for 1.0
+		/**
+		 * @param {string} property
+		 * @param {string} replacement
+		 */
+		const print_error = (property, replacement) => {
+			Object.defineProperty(props.page, property, {
+				get: () => {
+					throw new Error(`$page.${property} has been replaced by $page.url.${replacement}`);
+				}
+			});
+		};
 
-        print_error('origin', 'origin');
-        print_error('path', 'pathname');
-        print_error('query', 'searchParams');
+		print_error('origin', 'origin');
+		print_error('path', 'pathname');
+		print_error('query', 'searchParams');
 
-        // props_n (instead of props[n]) makes it easy to avoid
-        // unnecessary updates for layout components
-        for (let i = 0; i < branch.length; i += 1) {
-            props[`props_${i}`] = await branch[i].loaded.props;
-        }
+		// props_n (instead of props[n]) makes it easy to avoid
+		// unnecessary updates for layout components
+		for (let i = 0; i < branch.length; i += 1) {
+			props[`props_${i}`] = await branch[i].loaded.props;
+		}
 
-        let session_tracking_active = false;
-        const unsubscribe = session.subscribe(() => {
-            if (session_tracking_active) is_private = true;
-        });
-        session_tracking_active = true;
+		let session_tracking_active = false;
+		const unsubscribe = session.subscribe(() => {
+			if (session_tracking_active) is_private = true;
+		});
+		session_tracking_active = true;
 
-        try {
-            rendered = options.root.render(props);
-        } finally {
-            unsubscribe();
-        }
-    } else {
-        rendered = { head: '', html: '', css: { code: '', map: null } };
-    }
+		try {
+			rendered = options.root.render(props);
+		} finally {
+			unsubscribe();
+		}
+	} else {
+		rendered = { head: '', html: '', css: { code: '', map: null } };
+	}
 
-    let { head, html: body } = rendered;
+	let { head, html: body } = rendered;
 
-    const inlined_style = Array.from(styles.values()).join('\n');
+	const inlined_style = Array.from(styles.values()).join('\n');
 
-    if (options.amp) {
-        head += `
+	if (options.amp) {
+		head += `
 		<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>
 		<noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 		<script async src="https://cdn.ampproject.org/v0.js"></script>
 
 		<style amp-custom>${inlined_style}\n${rendered.css.code}</style>`;
 
-        if (options.service_worker) {
-            head +=
-                '<script async custom-element="amp-install-serviceworker" src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js"></script>';
+		if (options.service_worker) {
+			head +=
+				'<script async custom-element="amp-install-serviceworker" src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js"></script>';
 
-            body += `<amp-install-serviceworker src="${options.service_worker}" layout="nodisplay"></amp-install-serviceworker>`;
-        }
-    } else {
-        if (inlined_style) {
-            head += `\n\t<style${options.dev ? ' data-svelte' : ''}>${inlined_style}</style>`;
-        }
-        // prettier-ignore
-        head += Array.from(css)
+			body += `<amp-install-serviceworker src="${options.service_worker}" layout="nodisplay"></amp-install-serviceworker>`;
+		}
+	} else {
+		if (inlined_style) {
+			head += `\n\t<style${options.dev ? ' data-svelte' : ''}>${inlined_style}</style>`;
+		}
+		// prettier-ignore
+		head += Array.from(css)
             .map((dep) => `\n\t<link${styles.has(dep) ? ' media="print"' : ''} rel="stylesheet" href="${options.prefix + dep}">`)
             .join('');
 
-        if (page_config.router || page_config.hydrate) {
-            head += Array.from(js)
-                .map((dep) => `\n\t<link rel="modulepreload" href="${options.prefix + dep}">`)
-                .join('');
-            // prettier-ignore
-            head += `
+		if (page_config.router || page_config.hydrate) {
+			head += Array.from(js)
+				.map((dep) => `\n\t<link rel="modulepreload" href="${options.prefix + dep}">`)
+				.join('');
+			// prettier-ignore
+			head += `
 			<script type="module">
 				import { start } from ${s(options.prefix + options.manifest._.entry.file)};
 				start({

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -4,142 +4,144 @@ import { test } from '../../../utils.js';
 /** @typedef {import('@playwright/test').Response} Response */
 
 test.describe.parallel('base path', () => {
-    test('serves /', async({ page, javaScriptEnabled }) => {
-        await page.goto('/path-base/');
+	test('serves /', async ({ page, javaScriptEnabled }) => {
+		await page.goto('/path-base/');
 
-        expect(await page.textContent('h1')).toBe('I am in the template');
-        expect(await page.textContent('h2')).toBe("We're on index.svelte");
+		expect(await page.textContent('h1')).toBe('I am in the template');
+		expect(await page.textContent('h2')).toBe("We're on index.svelte");
 
-        const mode = process.env.DEV ? 'dev' : 'prod';
-        expect(await page.textContent('p')).toBe(
-            `Hello from the ${javaScriptEnabled ? 'client' : 'server'} in ${mode} mode!`
-        );
-    });
+		const mode = process.env.DEV ? 'dev' : 'prod';
+		expect(await page.textContent('p')).toBe(
+			`Hello from the ${javaScriptEnabled ? 'client' : 'server'} in ${mode} mode!`
+		);
+	});
 
-    test('sets_paths', async({ page }) => {
-        await page.goto('/path-base/base/');
-        expect(await page.textContent('[data-source="base"]')).toBe('/path-base');
-        expect(await page.textContent('[data-source="assets"]')).toBe('/_svelte_kit_assets');
-    });
+	test('sets_paths', async ({ page }) => {
+		await page.goto('/path-base/base/');
+		expect(await page.textContent('[data-source="base"]')).toBe('/path-base');
+		expect(await page.textContent('[data-source="assets"]')).toBe('/_svelte_kit_assets');
+	});
 
-    test('loads javascript', async({ page, javaScriptEnabled }) => {
-        await page.goto('/path-base/base/');
-        expect(await page.textContent('button')).toBe('clicks: 0');
+	test('loads javascript', async ({ page, javaScriptEnabled }) => {
+		await page.goto('/path-base/base/');
+		expect(await page.textContent('button')).toBe('clicks: 0');
 
-        if (javaScriptEnabled) {
-            await page.click('button');
-            expect(await page.innerHTML('h2')).toBe('button has been clicked 1 time');
-        }
-    });
+		if (javaScriptEnabled) {
+			await page.click('button');
+			expect(await page.innerHTML('h2')).toBe('button has been clicked 1 time');
+		}
+	});
 
-    test('loads CSS', async({ page }) => {
-        await page.goto('/path-base/base/');
-        expect(
-            await page.evaluate(() => {
-                const el = document.querySelector('p');
-                return el && getComputedStyle(el).color;
-            })
-        ).toBe('rgb(255, 0, 0)');
-    });
+	test('loads CSS', async ({ page }) => {
+		await page.goto('/path-base/base/');
+		expect(
+			await page.evaluate(() => {
+				const el = document.querySelector('p');
+				return el && getComputedStyle(el).color;
+			})
+		).toBe('rgb(255, 0, 0)');
+	});
 
-    test('inlines CSS', async({ page, javaScriptEnabled }) => {
-        await page.goto('/path-base/base/');
-        if (process.env.DEV) {
-            const ssr_style = await page.evaluate(() => document.querySelector('style[data-svelte]'));
+	test('inlines CSS', async ({ page, javaScriptEnabled }) => {
+		await page.goto('/path-base/base/');
+		if (process.env.DEV) {
+			const ssr_style = await page.evaluate(() => document.querySelector('style[data-svelte]'));
 
-            if (javaScriptEnabled) {
-                // <style data-svelte> is removed upon hydration
-                expect(ssr_style).toBeNull();
-            } else {
-                expect(ssr_style).not.toBeNull();
-            }
+			if (javaScriptEnabled) {
+				// <style data-svelte> is removed upon hydration
+				expect(ssr_style).toBeNull();
+			} else {
+				expect(ssr_style).not.toBeNull();
+			}
 
-            expect(
-                await page.evaluate(() => document.querySelector('link[rel="stylesheet"]'))
-            ).toBeNull();
-        } else {
-            expect(await page.evaluate(() => document.querySelector('style'))).not.toBeNull();
-            expect(
-                await page.evaluate(() => document.querySelector('link[rel="stylesheet"][media="print"]'))
-            ).not.toBeNull();
-            expect(
-                await page.evaluate(() => document.querySelector('link[rel="stylesheet"]:not([media="print"])'))
-            ).not.toBeNull();
-        }
-    });
+			expect(
+				await page.evaluate(() => document.querySelector('link[rel="stylesheet"]'))
+			).toBeNull();
+		} else {
+			expect(await page.evaluate(() => document.querySelector('style'))).not.toBeNull();
+			expect(
+				await page.evaluate(() => document.querySelector('link[rel="stylesheet"][media="print"]'))
+			).not.toBeNull();
+			expect(
+				await page.evaluate(() =>
+					document.querySelector('link[rel="stylesheet"]:not([media="print"])')
+				)
+			).not.toBeNull();
+		}
+	});
 
-    test('sets params correctly', async({ page, clicknav }) => {
-        await page.goto('/path-base/base/one');
+	test('sets params correctly', async ({ page, clicknav }) => {
+		await page.goto('/path-base/base/one');
 
-        expect(await page.textContent('h2')).toBe('one');
+		expect(await page.textContent('h2')).toBe('one');
 
-        await clicknav('[href="/path-base/base/two"]');
-        expect(await page.textContent('h2')).toBe('two');
-    });
+		await clicknav('[href="/path-base/base/two"]');
+		expect(await page.textContent('h2')).toBe('two');
+	});
 });
 
 test.describe.parallel('Custom extensions', () => {
-    test('works with arbitrary extensions', async({ page }) => {
-        await page.goto('/path-base/custom-extensions/');
-        expect(await page.textContent('h2')).toBe('Great success!');
-    });
+	test('works with arbitrary extensions', async ({ page }) => {
+		await page.goto('/path-base/custom-extensions/');
+		expect(await page.textContent('h2')).toBe('Great success!');
+	});
 
-    test('works with other arbitrary extensions', async({ page }) => {
-        await page.goto('/path-base/custom-extensions/const');
-        expect(await page.textContent('h2')).toBe('Tremendous!');
+	test('works with other arbitrary extensions', async ({ page }) => {
+		await page.goto('/path-base/custom-extensions/const');
+		expect(await page.textContent('h2')).toBe('Tremendous!');
 
-        await page.goto('/path-base/custom-extensions/a');
+		await page.goto('/path-base/custom-extensions/a');
 
-        expect(await page.textContent('h2')).toBe('a');
+		expect(await page.textContent('h2')).toBe('a');
 
-        await page.goto('/path-base/custom-extensions/test-slug');
+		await page.goto('/path-base/custom-extensions/test-slug');
 
-        expect(await page.textContent('h2')).toBe('TEST-SLUG');
+		expect(await page.textContent('h2')).toBe('TEST-SLUG');
 
-        await page.goto('/path-base/custom-extensions/unsafe-replacement');
+		await page.goto('/path-base/custom-extensions/unsafe-replacement');
 
-        expect(await page.textContent('h2')).toBe('Bazooom!');
-    });
+		expect(await page.textContent('h2')).toBe('Bazooom!');
+	});
 });
 
 test.describe.parallel('Headers', () => {
-    test('enables floc', async({ page }) => {
-        const response = await page.goto('/path-base');
-        const headers = /** @type {Response} */ (response).headers();
-        expect(headers['permissions-policy']).toBeUndefined();
-    });
+	test('enables floc', async ({ page }) => {
+		const response = await page.goto('/path-base');
+		const headers = /** @type {Response} */ (response).headers();
+		expect(headers['permissions-policy']).toBeUndefined();
+	});
 });
 
 test.describe.parallel('Origin', () => {
-    test('sets origin', async({ baseURL, page }) => {
-        await page.goto('/path-base/origin/');
+	test('sets origin', async ({ baseURL, page }) => {
+		await page.goto('/path-base/origin/');
 
-        const origin = process.env.DEV ? baseURL : 'https://example.com';
+		const origin = process.env.DEV ? baseURL : 'https://example.com';
 
-        expect(await page.textContent('[data-source="load"]')).toBe(origin);
-        expect(await page.textContent('[data-source="store"]')).toBe(origin);
-        expect(await page.textContent('[data-source="endpoint"]')).toBe(origin);
-    });
+		expect(await page.textContent('[data-source="load"]')).toBe(origin);
+		expect(await page.textContent('[data-source="store"]')).toBe(origin);
+		expect(await page.textContent('[data-source="endpoint"]')).toBe(origin);
+	});
 });
 
 test.describe.parallel('trailingSlash', () => {
-    test('adds trailing slash', async({ baseURL, page, clicknav }) => {
-        await page.goto('/path-base/slash');
+	test('adds trailing slash', async ({ baseURL, page, clicknav }) => {
+		await page.goto('/path-base/slash');
 
-        expect(page.url()).toBe(`${baseURL}/path-base/slash/`);
-        expect(await page.textContent('h2')).toBe('/slash/');
+		expect(page.url()).toBe(`${baseURL}/path-base/slash/`);
+		expect(await page.textContent('h2')).toBe('/slash/');
 
-        await clicknav('[href="/path-base/slash/child"]');
-        expect(page.url()).toBe(`${baseURL}/path-base/slash/child/`);
-        expect(await page.textContent('h2')).toBe('/slash/child/');
-    });
+		await clicknav('[href="/path-base/slash/child"]');
+		expect(page.url()).toBe(`${baseURL}/path-base/slash/child/`);
+		expect(await page.textContent('h2')).toBe('/slash/child/');
+	});
 });
 
 test.describe.parallel('serviceWorker', () => {
-    if (!process.env.DEV) {
-        test('does not register service worker if none created', async({ page }) => {
-            await page.goto('/path-base/');
-            expect(await page.content()).not.toMatch('navigator.serviceWorker');
-        });
-    }
+	if (!process.env.DEV) {
+		test('does not register service worker if none created', async ({ page }) => {
+			await page.goto('/path-base/');
+			expect(await page.content()).not.toMatch('navigator.serviceWorker');
+		});
+	}
 });

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -4,142 +4,142 @@ import { test } from '../../../utils.js';
 /** @typedef {import('@playwright/test').Response} Response */
 
 test.describe.parallel('base path', () => {
-	test('serves /', async ({ page, javaScriptEnabled }) => {
-		await page.goto('/path-base/');
+    test('serves /', async({ page, javaScriptEnabled }) => {
+        await page.goto('/path-base/');
 
-		expect(await page.textContent('h1')).toBe('I am in the template');
-		expect(await page.textContent('h2')).toBe("We're on index.svelte");
+        expect(await page.textContent('h1')).toBe('I am in the template');
+        expect(await page.textContent('h2')).toBe("We're on index.svelte");
 
-		const mode = process.env.DEV ? 'dev' : 'prod';
-		expect(await page.textContent('p')).toBe(
-			`Hello from the ${javaScriptEnabled ? 'client' : 'server'} in ${mode} mode!`
-		);
-	});
+        const mode = process.env.DEV ? 'dev' : 'prod';
+        expect(await page.textContent('p')).toBe(
+            `Hello from the ${javaScriptEnabled ? 'client' : 'server'} in ${mode} mode!`
+        );
+    });
 
-	test('sets_paths', async ({ page }) => {
-		await page.goto('/path-base/base/');
-		expect(await page.textContent('[data-source="base"]')).toBe('/path-base');
-		expect(await page.textContent('[data-source="assets"]')).toBe('/_svelte_kit_assets');
-	});
+    test('sets_paths', async({ page }) => {
+        await page.goto('/path-base/base/');
+        expect(await page.textContent('[data-source="base"]')).toBe('/path-base');
+        expect(await page.textContent('[data-source="assets"]')).toBe('/_svelte_kit_assets');
+    });
 
-	test('loads javascript', async ({ page, javaScriptEnabled }) => {
-		await page.goto('/path-base/base/');
-		expect(await page.textContent('button')).toBe('clicks: 0');
+    test('loads javascript', async({ page, javaScriptEnabled }) => {
+        await page.goto('/path-base/base/');
+        expect(await page.textContent('button')).toBe('clicks: 0');
 
-		if (javaScriptEnabled) {
-			await page.click('button');
-			expect(await page.innerHTML('h2')).toBe('button has been clicked 1 time');
-		}
-	});
+        if (javaScriptEnabled) {
+            await page.click('button');
+            expect(await page.innerHTML('h2')).toBe('button has been clicked 1 time');
+        }
+    });
 
-	test('loads CSS', async ({ page }) => {
-		await page.goto('/path-base/base/');
-		expect(
-			await page.evaluate(() => {
-				const el = document.querySelector('p');
-				return el && getComputedStyle(el).color;
-			})
-		).toBe('rgb(255, 0, 0)');
-	});
+    test('loads CSS', async({ page }) => {
+        await page.goto('/path-base/base/');
+        expect(
+            await page.evaluate(() => {
+                const el = document.querySelector('p');
+                return el && getComputedStyle(el).color;
+            })
+        ).toBe('rgb(255, 0, 0)');
+    });
 
-	test('inlines CSS', async ({ page, javaScriptEnabled }) => {
-		await page.goto('/path-base/base/');
-		if (process.env.DEV) {
-			const ssr_style = await page.evaluate(() => document.querySelector('style[data-svelte]'));
+    test('inlines CSS', async({ page, javaScriptEnabled }) => {
+        await page.goto('/path-base/base/');
+        if (process.env.DEV) {
+            const ssr_style = await page.evaluate(() => document.querySelector('style[data-svelte]'));
 
-			if (javaScriptEnabled) {
-				// <style data-svelte> is removed upon hydration
-				expect(ssr_style).toBeNull();
-			} else {
-				expect(ssr_style).not.toBeNull();
-			}
+            if (javaScriptEnabled) {
+                // <style data-svelte> is removed upon hydration
+                expect(ssr_style).toBeNull();
+            } else {
+                expect(ssr_style).not.toBeNull();
+            }
 
-			expect(
-				await page.evaluate(() => document.querySelector('link[rel="stylesheet"]'))
-			).toBeNull();
-		} else {
-			expect(await page.evaluate(() => document.querySelector('style'))).not.toBeNull();
-			expect(
-				await page.evaluate(() => document.querySelector('link[rel="stylesheet"][disabled]'))
-			).not.toBeNull();
-			expect(
-				await page.evaluate(() => document.querySelector('link[rel="stylesheet"]:not([disabled])'))
-			).not.toBeNull();
-		}
-	});
+            expect(
+                await page.evaluate(() => document.querySelector('link[rel="stylesheet"]'))
+            ).toBeNull();
+        } else {
+            expect(await page.evaluate(() => document.querySelector('style'))).not.toBeNull();
+            expect(
+                await page.evaluate(() => document.querySelector('link[rel="stylesheet"][media="print"]'))
+            ).not.toBeNull();
+            expect(
+                await page.evaluate(() => document.querySelector('link[rel="stylesheet"]:not([media="print"])'))
+            ).not.toBeNull();
+        }
+    });
 
-	test('sets params correctly', async ({ page, clicknav }) => {
-		await page.goto('/path-base/base/one');
+    test('sets params correctly', async({ page, clicknav }) => {
+        await page.goto('/path-base/base/one');
 
-		expect(await page.textContent('h2')).toBe('one');
+        expect(await page.textContent('h2')).toBe('one');
 
-		await clicknav('[href="/path-base/base/two"]');
-		expect(await page.textContent('h2')).toBe('two');
-	});
+        await clicknav('[href="/path-base/base/two"]');
+        expect(await page.textContent('h2')).toBe('two');
+    });
 });
 
 test.describe.parallel('Custom extensions', () => {
-	test('works with arbitrary extensions', async ({ page }) => {
-		await page.goto('/path-base/custom-extensions/');
-		expect(await page.textContent('h2')).toBe('Great success!');
-	});
+    test('works with arbitrary extensions', async({ page }) => {
+        await page.goto('/path-base/custom-extensions/');
+        expect(await page.textContent('h2')).toBe('Great success!');
+    });
 
-	test('works with other arbitrary extensions', async ({ page }) => {
-		await page.goto('/path-base/custom-extensions/const');
-		expect(await page.textContent('h2')).toBe('Tremendous!');
+    test('works with other arbitrary extensions', async({ page }) => {
+        await page.goto('/path-base/custom-extensions/const');
+        expect(await page.textContent('h2')).toBe('Tremendous!');
 
-		await page.goto('/path-base/custom-extensions/a');
+        await page.goto('/path-base/custom-extensions/a');
 
-		expect(await page.textContent('h2')).toBe('a');
+        expect(await page.textContent('h2')).toBe('a');
 
-		await page.goto('/path-base/custom-extensions/test-slug');
+        await page.goto('/path-base/custom-extensions/test-slug');
 
-		expect(await page.textContent('h2')).toBe('TEST-SLUG');
+        expect(await page.textContent('h2')).toBe('TEST-SLUG');
 
-		await page.goto('/path-base/custom-extensions/unsafe-replacement');
+        await page.goto('/path-base/custom-extensions/unsafe-replacement');
 
-		expect(await page.textContent('h2')).toBe('Bazooom!');
-	});
+        expect(await page.textContent('h2')).toBe('Bazooom!');
+    });
 });
 
 test.describe.parallel('Headers', () => {
-	test('enables floc', async ({ page }) => {
-		const response = await page.goto('/path-base');
-		const headers = /** @type {Response} */ (response).headers();
-		expect(headers['permissions-policy']).toBeUndefined();
-	});
+    test('enables floc', async({ page }) => {
+        const response = await page.goto('/path-base');
+        const headers = /** @type {Response} */ (response).headers();
+        expect(headers['permissions-policy']).toBeUndefined();
+    });
 });
 
 test.describe.parallel('Origin', () => {
-	test('sets origin', async ({ baseURL, page }) => {
-		await page.goto('/path-base/origin/');
+    test('sets origin', async({ baseURL, page }) => {
+        await page.goto('/path-base/origin/');
 
-		const origin = process.env.DEV ? baseURL : 'https://example.com';
+        const origin = process.env.DEV ? baseURL : 'https://example.com';
 
-		expect(await page.textContent('[data-source="load"]')).toBe(origin);
-		expect(await page.textContent('[data-source="store"]')).toBe(origin);
-		expect(await page.textContent('[data-source="endpoint"]')).toBe(origin);
-	});
+        expect(await page.textContent('[data-source="load"]')).toBe(origin);
+        expect(await page.textContent('[data-source="store"]')).toBe(origin);
+        expect(await page.textContent('[data-source="endpoint"]')).toBe(origin);
+    });
 });
 
 test.describe.parallel('trailingSlash', () => {
-	test('adds trailing slash', async ({ baseURL, page, clicknav }) => {
-		await page.goto('/path-base/slash');
+    test('adds trailing slash', async({ baseURL, page, clicknav }) => {
+        await page.goto('/path-base/slash');
 
-		expect(page.url()).toBe(`${baseURL}/path-base/slash/`);
-		expect(await page.textContent('h2')).toBe('/slash/');
+        expect(page.url()).toBe(`${baseURL}/path-base/slash/`);
+        expect(await page.textContent('h2')).toBe('/slash/');
 
-		await clicknav('[href="/path-base/slash/child"]');
-		expect(page.url()).toBe(`${baseURL}/path-base/slash/child/`);
-		expect(await page.textContent('h2')).toBe('/slash/child/');
-	});
+        await clicknav('[href="/path-base/slash/child"]');
+        expect(page.url()).toBe(`${baseURL}/path-base/slash/child/`);
+        expect(await page.textContent('h2')).toBe('/slash/child/');
+    });
 });
 
 test.describe.parallel('serviceWorker', () => {
-	if (!process.env.DEV) {
-		test('does not register service worker if none created', async ({ page }) => {
-			await page.goto('/path-base/');
-			expect(await page.content()).not.toMatch('navigator.serviceWorker');
-		});
-	}
+    if (!process.env.DEV) {
+        test('does not register service worker if none created', async({ page }) => {
+            await page.goto('/path-base/');
+            expect(await page.content()).not.toMatch('navigator.serviceWorker');
+        });
+    }
 });

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -60,12 +60,10 @@ test.describe.parallel('base path', () => {
 		} else {
 			expect(await page.evaluate(() => document.querySelector('style'))).not.toBeNull();
 			expect(
-				await page.evaluate(() => document.querySelector('link[rel="stylesheet"][media="print"]'))
+				await page.evaluate(() => document.querySelector('link[rel="stylesheet"][disabled]'))
 			).not.toBeNull();
 			expect(
-				await page.evaluate(() =>
-					document.querySelector('link[rel="stylesheet"]:not([media="print"])')
-				)
+				await page.evaluate(() => document.querySelector('link[rel="stylesheet"]:not([disabled])'))
 			).not.toBeNull();
 		}
 	});


### PR DESCRIPTION
Fixes #3307 
`<link disabled rel="stylesheet" href="...">` still causes the browser to download the file, with the highest priority, even though it's never used.

This PR adds a media query with a 1px max screen width, this prevents the browser from downloading the CSS, but leaves the link tag in place so vite functions correctly.

`<link disabled media="screen and (max-width: 1px)" rel="stylesheet" href="...">`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
