### PR TITLE
[fix] polyfill fetch before running any app code

### DIFF
--- a/.changeset/strong-owls-jam.md
+++ b/.changeset/strong-owls-jam.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-vercel': patch
+---
+
+Polyfill fetch before running any app code

--- a/packages/adapter-netlify/rollup.config.js
+++ b/packages/adapter-netlify/rollup.config.js
@@ -5,7 +5,8 @@ import json from '@rollup/plugin-json';
 export default [
 	{
 		input: {
-			handler: 'src/handler.js'
+			handler: 'src/handler.js',
+			shims: 'src/shims.js'
 		},
 		output: [
 			{

--- a/packages/adapter-netlify/src/handler.js
+++ b/packages/adapter-netlify/src/handler.js
@@ -1,7 +1,5 @@
-import { __fetch_polyfill } from '@sveltejs/kit/install-fetch';
+import './shims';
 import { App } from './server/app.js';
-
-__fetch_polyfill();
 
 /**
  *

--- a/packages/adapter-netlify/src/shims.js
+++ b/packages/adapter-netlify/src/shims.js
@@ -1,0 +1,2 @@
+import { __fetch_polyfill } from '@sveltejs/kit/install-fetch';
+__fetch_polyfill();

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -6,7 +6,8 @@ export default [
 	{
 		input: {
 			index: 'src/index.js',
-			handler: 'src/handler.js'
+			handler: 'src/handler.js',
+			shims: 'src/shims.js'
 		},
 		output: {
 			dir: 'files',

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -1,15 +1,13 @@
+import './shims';
 import fs from 'fs';
 import path from 'path';
 import sirv from 'sirv';
 import { fileURLToPath } from 'url';
 import { getRawBody } from '@sveltejs/kit/node';
-import { __fetch_polyfill } from '@sveltejs/kit/install-fetch';
 
 // @ts-ignore
 import { App } from 'APP';
 import { manifest } from 'MANIFEST';
-
-__fetch_polyfill();
 
 const app = new App(manifest);
 

--- a/packages/adapter-node/src/shims.js
+++ b/packages/adapter-node/src/shims.js
@@ -1,0 +1,2 @@
+import { __fetch_polyfill } from '@sveltejs/kit/install-fetch';
+__fetch_polyfill();

--- a/packages/adapter-vercel/files/entry.js
+++ b/packages/adapter-vercel/files/entry.js
@@ -1,9 +1,7 @@
-import { __fetch_polyfill } from '@sveltejs/kit/install-fetch';
+import './shims';
 import { getRawBody } from '@sveltejs/kit/node';
 import { App } from 'APP';
 import { manifest } from 'MANIFEST';
-
-__fetch_polyfill();
 
 const app = new App(manifest);
 

--- a/packages/adapter-vercel/files/shims.js
+++ b/packages/adapter-vercel/files/shims.js
@@ -1,0 +1,2 @@
+import { __fetch_polyfill } from '@sveltejs/kit/install-fetch';
+__fetch_polyfill();


### PR DESCRIPTION
Fixes #3343 

Before this change, referencing `fetch` at the top level of `hooks.js` would throw `ReferenceError: fetch is not defined` on platforms without native fetch. This is because we were polyfilling `fetch` after importing the compiled app, at which point it was too late. It looks like this was introduced with the adapter overhaul, where we stopped using esbuild's `inject` option.

To fix this, I moved the call to `__fetch_polyfill` inside its own module so that it would run before importing the app. I had to give it its own Rollup entry (in the adapters that use Rollup) so that it remained separate and import order was preserved.

I tested this locally with the node adapter and it fixed the linked issue. I also locally generated bundles with the Netlify and Vercel adapter and verified that `__fetch_polyfill` is called before any app code.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
