### PR TITLE
[fix] rename `BASE` to `ORIGIN` and fix config handling

### DIFF
--- a/.changeset/perfect-socks-sparkle.md
+++ b/.changeset/perfect-socks-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+[fix] rename `BASE` to `ORIGIN` and fix config handling

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -22,8 +22,8 @@ export default {
 				port: 'PORT',
 				base: undefined,
 				headers: {
-					protocol: undefined,
-					host: 'host'
+					protocol: 'PROTOCOL_HEADER',
+					host: 'HOST_HEADER'
 				}
 			}
 		})

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -20,7 +20,7 @@ export default {
 				path: 'SOCKET_PATH',
 				host: 'HOST',
 				port: 'PORT',
-				base: undefined,
+				origin: 'ORIGIN',
 				headers: {
 					protocol: 'PROTOCOL_HEADER',
 					host: 'HOST_HEADER'
@@ -49,13 +49,13 @@ By default, the server will accept connections on `0.0.0.0` using port 3000. The
 HOST=127.0.0.1 PORT=4000 node build
 ```
 
-HTTP doesn't give SvelteKit a reliable way to know the URL that is currently being requested. The simplest way to tell SvelteKit where the app is being served is to set the `BASE` environment variable:
+HTTP doesn't give SvelteKit a reliable way to know the URL that is currently being requested. The simplest way to tell SvelteKit where the app is being served is to set the `ORIGIN` environment variable:
 
 ```
-BASE=https://my.site node build
+ORIGIN=https://my.site node build
 ```
 
-With this, a request for the `/stuff` pathname will correctly resolve to `https://my.site/stuff`. Alternatively, you can specify headers that tell SvelteKit about the request protocol and host, from which it can construct the base URL:
+With this, a request for the `/stuff` pathname will correctly resolve to `https://my.site/stuff`. Alternatively, you can specify headers that tell SvelteKit about the request protocol and host, from which it can construct the origin URL:
 
 ```
 PROTOCOL_HEADER=x-forwarded-proto HOST_HEADER=x-forwarded-host node build
@@ -69,7 +69,7 @@ All of these environment variables can be changed, if necessary, using the `env`
 env: {
 	host: 'MY_HOST_VARIABLE',
 	port: 'MY_PORT_VARIABLE',
-	base: 'MY_BASEURL',
+	origin: 'MY_ORIGINURL',
 	headers: {
 		protocol: 'MY_PROTOCOL_HEADER',
 		host: 'MY_HOST_HEADER'
@@ -80,7 +80,7 @@ env: {
 ```
 MY_HOST_VARIABLE=127.0.0.1 \
 MY_PORT_VARIABLE=4000 \
-MY_BASEURL=https://my.site \
+MY_ORIGINURL=https://my.site \
 node build
 ```
 

--- a/packages/adapter-node/index.d.ts
+++ b/packages/adapter-node/index.d.ts
@@ -7,7 +7,7 @@ interface AdapterOptions {
 		path?: string;
 		host?: string;
 		port?: string;
-		base?: string;
+		origin?: string;
 		headers?: {
 			protocol?: string;
 			host?: string;

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -21,7 +21,7 @@ export default function ({
 		headers: {
 			protocol: protocol_header_env = 'PROTOCOL_HEADER',
 			host: host_header_env = 'HOST_HEADER'
-		}
+		} = {}
 	} = {}
 } = {}) {
 	return {

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -54,7 +54,7 @@ export default function ({
 					PATH_ENV: JSON.stringify(path_env),
 					HOST_ENV: JSON.stringify(host_env),
 					PORT_ENV: JSON.stringify(port_env),
-					ORIGIN: origin_env ? `process.env[${JSON.stringify(origin_env)}]` : 'undefined',
+					ORIGIN_ENV: origin_env ? `process.env[${JSON.stringify(origin_env)}]` : 'undefined',
 					PROTOCOL_HEADER: JSON.stringify(protocol_header_env),
 					HOST_HEADER: JSON.stringify(host_header_env)
 				}

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -17,7 +17,7 @@ export default function ({
 		path: path_env = 'SOCKET_PATH',
 		host: host_env = 'HOST',
 		port: port_env = 'PORT',
-		base: base_env,
+		origin: origin_env = 'ORIGIN',
 		headers: {
 			protocol: protocol_header_env = 'PROTOCOL_HEADER',
 			host: host_header_env = 'HOST_HEADER'
@@ -54,7 +54,7 @@ export default function ({
 					PATH_ENV: JSON.stringify(path_env),
 					HOST_ENV: JSON.stringify(host_env),
 					PORT_ENV: JSON.stringify(port_env),
-					BASE: base_env ? `process.env[${JSON.stringify(base_env)}]` : 'undefined',
+					ORIGIN: origin_env ? `process.env[${JSON.stringify(origin_env)}]` : 'undefined',
 					PROTOCOL_HEADER: JSON.stringify(protocol_header_env),
 					HOST_HEADER: JSON.stringify(host_header_env)
 				}

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -7,10 +7,10 @@ import { getRequest, setResponse } from '@sveltejs/kit/node';
 import { App } from 'APP';
 import { manifest } from 'MANIFEST';
 
-/* global BASE_ENV, PROTOCOL_HEADER, HOST_HEADER */
+/* global ORIGIN_ENV, PROTOCOL_HEADER, HOST_HEADER */
 
 const app = new App(manifest);
-const base = BASE_ENV && process.env[BASE_ENV];
+const origin = ORIGIN_ENV && process.env[ORIGIN_ENV];
 const protocol_header = PROTOCOL_HEADER && process.env[PROTOCOL_HEADER];
 const host_header = (HOST_HEADER && process.env[HOST_HEADER]) || 'host';
 
@@ -39,7 +39,7 @@ const ssr = async (req, res) => {
 	let request;
 
 	try {
-		request = await getRequest(base || get_base(req.headers), req);
+		request = await getRequest(origin || get_origin(req.headers), req);
 	} catch (err) {
 		res.statusCode = err.status || 400;
 		return res.end(err.reason || 'Invalid request body');
@@ -68,7 +68,7 @@ function sequence(handlers) {
  * @param {import('http').IncomingHttpHeaders} headers
  * @returns
  */
-function get_base(headers) {
+function get_origin(headers) {
 	const protocol = (protocol_header && headers[protocol_header]) || 'https';
 	const host = headers[host_header];
 	return `${protocol}://${host}`;

--- a/packages/adapter-node/src/types.d.ts
+++ b/packages/adapter-node/src/types.d.ts
@@ -2,7 +2,7 @@ declare global {
 	const PATH_ENV: string;
 	const HOST_ENV: string;
 	const PORT_ENV: string;
-	const BASE_ENV: string;
+	const ORIGIN_ENV: string;
 
 	const PROTOCOL_HEADER: string;
 	const HOST_HEADER: string;


### PR DESCRIPTION
This should fix #3420 and fix #3424, but also makes some other changes.

The defaults listed in the readme were out of date, and they have been updated.

This also renamed `BASE` to `ORIGIN`, per a conversation I had with Rich on Discord.

It _also_ adds `'ORIGIN'` as a default value for `env.origin` (previously it was `undefined`), to align with the readme, which indicated that you should be able to just do that without any build-time configuration.

I'd _like_ for there to be fewer of these build-time defaults in the adapter config, but I understand that this might not be very popular.

Although the changes are pretty straightforward, this hasn't been properly tested yet. Because of this, and the decision I'd like to come to about the default env/header behavior, I haven't added changesets yet and I am marking this as draft.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
