### PR TITLE
[docs] update docs to reflect new home of HN example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,20 +17,7 @@ pnpm install
 pnpm build
 ```
 
-You should now be able to run [the example](examples/hn.svelte.dev) with:
-
-```bash
-cd examples/hn.svelte.dev
-pnpm dev
-```
-
-Run `pnpm dev` inside the `packages/kit` directory to continually rebuild `@sveltejs/kit` as you make changes to SvelteKit. Restarting the example/test apps will cause the newly built version to be used.
-
-To use the git hooks in the repo, which will save you waiting for CI to tell you that you forgot to lint, run this:
-
-```bash
-git config core.hookspath .githooks
-```
+You can now run SvelteKit by linking it into your project with [pnpm `overrides`](https://pnpm.io/package_json#pnpmoverrides) as demonstrated in the [sandbox example](https://github.com/sveltejs/kit-sandbox) or by running one of the test projects as described in [the testing section](#testing) below.
 
 ## Code structure
 
@@ -90,6 +77,12 @@ There are a few guidelines we follow:
 - Provide a single object as the argument to public APIs. This object can have multiple properties
 - Avoid creating new test projects under `packages/kit/test/apps` but reuse an existing one when possible
 - Ensure `pnpm lint` and `pnpm check` pass. You can run `pnpm format` to format the code
+
+To use the git hooks in the repo, which will save you waiting for CI to tell you that you forgot to lint, run this:
+
+```bash
+git config core.hookspath .githooks
+```
 
 ### Generating changelogs
 

--- a/documentation/docs/90-additional-resources.md
+++ b/documentation/docs/90-additional-resources.md
@@ -12,9 +12,8 @@ The [Svelte FAQ](https://svelte.dev/faq) and [`vite-plugin-svelte` FAQ](https://
 
 We've written and published a few different SvelteKit sites as examples:
 
-- [The examples directory](https://github.com/sveltejs/kit/tree/master/examples) in the GitHub repo contains a HackerNews clone
 - [`sveltejs/realworld`](https://github.com/sveltejs/realworld) contains an example blog site
-- [`sveltejs/sites`](https://github.com/sveltejs/sites) contains the code for this site and [svelte.dev](https//svelte.dev/)
+- [`sveltejs/sites`](https://github.com/sveltejs/sites) contains [the code for this site](https://github.com/sveltejs/sites/tree/master/sites/kit.svelte.dev), for [svelte.dev](https://github.com/sveltejs/sites/tree/master/sites/svelte.dev), and for a [HackerNews clone](https://github.com/sveltejs/sites/tree/master/sites/hn.svelte.dev)
 
 SvelteKit users have also published plenty of examples on GitHub, under the [#sveltekit](https://github.com/topics/sveltekit) and [#sveltekit-template](https://github.com/topics/sveltekit-template) topics, as well as on [the Svelte Society site](https://sveltesociety.dev/templates#svelte-kit). Note that these have not been vetted by the maintainers and may not be up to date.
 


### PR DESCRIPTION
HN example no longer exists in this repo. Now it's in the sites repo