### PR TITLE
[docs] update `handle` hooks docs

### DIFF
--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -46,8 +46,7 @@ To add custom data to the request, which is passed to endpoints, populate the `e
 ```js
 /** @type {import('@sveltejs/kit').Handle} */
 export async function handle({ event, resolve }) {
-	const { locals, request } = event
-	locals.user = await getUserInformation(request.headers.get('cookie'));
+	event.locals.user = await getUserInformation(event.request.headers.get('cookie'));
 
 	const response = await resolve(event);
 	response.headers.set('x-custom-header', 'potato');

--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -46,7 +46,7 @@ To add custom data to the request, which is passed to endpoints, populate the `e
 ```js
 /** @type {import('@sveltejs/kit').Handle} */
 export async function handle({ event, resolve }) {
-	const {locals,request} = event
+	const { locals, request } = event
 	locals.user = await getUserInformation(request.headers.get('cookie'));
 
 	const response = await resolve(event);

--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -41,14 +41,15 @@ export interface Handle<Locals = Record<string, any>> {
 }
 ```
 
-To add custom data to the request, which is passed to endpoints, populate the `request.locals` object, as shown below.
+To add custom data to the request, which is passed to endpoints, populate the `event.locals` object, as shown below.
 
 ```js
 /** @type {import('@sveltejs/kit').Handle} */
-export async function handle({ request, resolve }) {
-	request.locals.user = await getUserInformation(request.headers.cookie);
+export async function handle({ event, resolve }) {
+	const {locals,request} = event
+	locals.user = await getUserInformation(request.headers.get('cookie'));
 
-	const response = await resolve(request);
+	const response = await resolve(event);
 	response.headers.set('x-custom-header', 'potato');
 
 	return response;


### PR DESCRIPTION
Updating documentation for hooks section with `@sveltejs/kit 1.0.0-next.234`. 

1. They had old examples with `{request,resolve}` instead of `{event,resolve}`.
2. Replace `request.headers.cookie` with `request.headers.get('cookie')` as `request.headers.cookie` isn't working after `@sveltejs/kit 1.0.0-next.234`.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
