### PR TITLE
Add programmatic interface to create-svelte

### DIFF
--- a/.changeset/fifty-foxes-tan.md
+++ b/.changeset/fifty-foxes-tan.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Add a programmatic interface to create-svelte

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
 import { bold, cyan, gray, green, red } from 'kleur/colors';
 import prompts from 'prompts';
-import { mkdirp, copy } from './utils.js';
+import { create } from './index.js';
+import { dist } from './utils.js';
 
 // prettier-ignore
 const disclaimer = `
@@ -36,8 +36,6 @@ async function main() {
 				process.exit(1);
 			}
 		}
-	} else {
-		mkdirp(cwd);
 	}
 
 	const options = /** @type {import('./types/internal').Options} */ (
@@ -83,10 +81,7 @@ async function main() {
 		])
 	);
 
-	const name = path.basename(path.resolve(cwd));
-
-	write_template_files(options.template, options.typescript, name, cwd);
-	write_common_files(cwd, options, name);
+	await create(cwd, options);
 
 	console.log(bold(green('\nYour project is ready!')));
 
@@ -124,133 +119,6 @@ async function main() {
 
 	console.log(`\nTo close the dev server, hit ${bold(cyan('Ctrl-C'))}`);
 	console.log(`\nStuck? Visit us at ${cyan('https://svelte.dev/chat')}\n`);
-}
-
-/**
- * @param {string} template
- * @param {boolean} typescript
- * @param {string} name
- * @param {string} cwd
- */
-function write_template_files(template, typescript, name, cwd) {
-	const dir = dist(`templates/${template}`);
-	copy(`${dir}/assets`, cwd, (name) => name.replace('DOT-', '.'));
-	copy(`${dir}/package.json`, `${cwd}/package.json`);
-
-	const manifest = `${dir}/files.${typescript ? 'ts' : 'js'}.json`;
-	const files = /** @type {import('./types/internal').File[]} */ (
-		JSON.parse(fs.readFileSync(manifest, 'utf-8'))
-	);
-
-	files.forEach((file) => {
-		const dest = path.join(cwd, file.name);
-		mkdirp(path.dirname(dest));
-
-		fs.writeFileSync(dest, file.contents.replace(/~TODO~/g, name));
-	});
-}
-
-/**
- *
- * @param {string} cwd
- * @param {import('./types/internal').Options} options
- * @param {string} name
- */
-function write_common_files(cwd, options, name) {
-	const shared = dist('shared.json');
-	const { files } = /** @type {import('./types/internal').Common} */ (
-		JSON.parse(fs.readFileSync(shared, 'utf-8'))
-	);
-
-	const pkg_file = path.join(cwd, 'package.json');
-	const pkg = /** @type {any} */ (JSON.parse(fs.readFileSync(pkg_file, 'utf-8')));
-
-	files.forEach((file) => {
-		const include = file.include.every((condition) => matchesCondition(condition, options));
-		const exclude = file.exclude.some((condition) => matchesCondition(condition, options));
-
-		if (exclude || !include) return;
-
-		if (file.name === 'package.json') {
-			const new_pkg = JSON.parse(file.contents);
-			merge(pkg, new_pkg);
-		} else {
-			const dest = path.join(cwd, file.name);
-			mkdirp(path.dirname(dest));
-			fs.writeFileSync(dest, file.contents);
-		}
-	});
-
-	pkg.dependencies = sort_keys(pkg.dependencies);
-	pkg.devDependencies = sort_keys(pkg.devDependencies);
-	pkg.name = toValidPackageName(name);
-
-	fs.writeFileSync(pkg_file, JSON.stringify(pkg, null, '  '));
-}
-
-/**
- * @param {import('./types/internal').Condition} condition
- * @param {import('./types/internal').Options} options
- * @returns {boolean}
- */
-function matchesCondition(condition, options) {
-	return condition === 'default' || condition === 'skeleton'
-		? options.template === condition
-		: options[condition];
-}
-
-/**
- * @param {any} target
- * @param {any} source
- */
-function merge(target, source) {
-	for (const key in source) {
-		if (key in target) {
-			const target_value = target[key];
-			const source_value = source[key];
-
-			if (
-				typeof source_value !== typeof target_value ||
-				Array.isArray(source_value) !== Array.isArray(target_value)
-			) {
-				throw new Error('Mismatched values');
-			}
-
-			merge(target_value, source_value);
-		} else {
-			target[key] = source[key];
-		}
-	}
-}
-
-/** @param {Record<string, any>} obj */
-function sort_keys(obj) {
-	if (!obj) return;
-
-	/** @type {Record<string, any>} */
-	const sorted = {};
-	Object.keys(obj)
-		.sort()
-		.forEach((key) => {
-			sorted[key] = obj[key];
-		});
-
-	return sorted;
-}
-
-/** @param {string} path */
-function dist(path) {
-	return fileURLToPath(new URL(`./dist/${path}`, import.meta.url).href);
-}
-
-/** @param {string} name */
-function toValidPackageName(name) {
-	return name
-		.trim()
-		.toLowerCase()
-		.replace(/\s+/g, '-')
-		.replace(/^[._]/, '')
-		.replace(/[^a-z0-9~.-]+/g, '-');
 }
 
 main();

--- a/packages/create-svelte/index.js
+++ b/packages/create-svelte/index.js
@@ -57,8 +57,8 @@ function write_common_files(cwd, options, name) {
 	const pkg = /** @type {any} */ (JSON.parse(fs.readFileSync(pkg_file, 'utf-8')));
 
 	files.forEach((file) => {
-		const include = file.include.every((condition) => matchesCondition(condition, options));
-		const exclude = file.exclude.some((condition) => matchesCondition(condition, options));
+		const include = file.include.every((condition) => matches_condition(condition, options));
+		const exclude = file.exclude.some((condition) => matches_condition(condition, options));
 
 		if (exclude || !include) return;
 
@@ -74,7 +74,7 @@ function write_common_files(cwd, options, name) {
 
 	pkg.dependencies = sort_keys(pkg.dependencies);
 	pkg.devDependencies = sort_keys(pkg.devDependencies);
-	pkg.name = toValidPackageName(name);
+	pkg.name = to_valid_package_name(name);
 
 	fs.writeFileSync(pkg_file, JSON.stringify(pkg, null, '  '));
 }
@@ -84,7 +84,7 @@ function write_common_files(cwd, options, name) {
  * @param {import('./types/internal').Options} options
  * @returns {boolean}
  */
-function matchesCondition(condition, options) {
+function matches_condition(condition, options) {
 	return condition === 'default' || condition === 'skeleton'
 		? options.template === condition
 		: options[condition];
@@ -130,7 +130,7 @@ function sort_keys(obj) {
 }
 
 /** @param {string} name */
-function toValidPackageName(name) {
+function to_valid_package_name(name) {
 	return name
 		.trim()
 		.toLowerCase()

--- a/packages/create-svelte/index.js
+++ b/packages/create-svelte/index.js
@@ -1,0 +1,140 @@
+import fs from 'fs';
+import path from 'path';
+import { mkdirp, copy, dist } from './utils.js';
+
+/**
+ * Create a new SvelteKit project.
+ *
+ * @param {string} cwd - Path to the directory to create
+ * @param {import('./types/internal').Options} options
+ */
+export async function create(cwd, options) {
+	mkdirp(cwd);
+
+	const name = path.basename(path.resolve(cwd));
+
+	write_template_files(options.template, options.typescript, name, cwd);
+	write_common_files(cwd, options, name);
+}
+
+/**
+ * @param {string} template
+ * @param {boolean} typescript
+ * @param {string} name
+ * @param {string} cwd
+ */
+function write_template_files(template, typescript, name, cwd) {
+	const dir = dist(`templates/${template}`);
+	copy(`${dir}/assets`, cwd, (name) => name.replace('DOT-', '.'));
+	copy(`${dir}/package.json`, `${cwd}/package.json`);
+
+	const manifest = `${dir}/files.${typescript ? 'ts' : 'js'}.json`;
+	const files = /** @type {import('./types/internal').File[]} */ (
+		JSON.parse(fs.readFileSync(manifest, 'utf-8'))
+	);
+
+	files.forEach((file) => {
+		const dest = path.join(cwd, file.name);
+		mkdirp(path.dirname(dest));
+
+		fs.writeFileSync(dest, file.contents.replace(/~TODO~/g, name));
+	});
+}
+
+/**
+ *
+ * @param {string} cwd
+ * @param {import('./types/internal').Options} options
+ * @param {string} name
+ */
+function write_common_files(cwd, options, name) {
+	const shared = dist('shared.json');
+	const { files } = /** @type {import('./types/internal').Common} */ (
+		JSON.parse(fs.readFileSync(shared, 'utf-8'))
+	);
+
+	const pkg_file = path.join(cwd, 'package.json');
+	const pkg = /** @type {any} */ (JSON.parse(fs.readFileSync(pkg_file, 'utf-8')));
+
+	files.forEach((file) => {
+		const include = file.include.every((condition) => matchesCondition(condition, options));
+		const exclude = file.exclude.some((condition) => matchesCondition(condition, options));
+
+		if (exclude || !include) return;
+
+		if (file.name === 'package.json') {
+			const new_pkg = JSON.parse(file.contents);
+			merge(pkg, new_pkg);
+		} else {
+			const dest = path.join(cwd, file.name);
+			mkdirp(path.dirname(dest));
+			fs.writeFileSync(dest, file.contents);
+		}
+	});
+
+	pkg.dependencies = sort_keys(pkg.dependencies);
+	pkg.devDependencies = sort_keys(pkg.devDependencies);
+	pkg.name = toValidPackageName(name);
+
+	fs.writeFileSync(pkg_file, JSON.stringify(pkg, null, '  '));
+}
+
+/**
+ * @param {import('./types/internal').Condition} condition
+ * @param {import('./types/internal').Options} options
+ * @returns {boolean}
+ */
+function matchesCondition(condition, options) {
+	return condition === 'default' || condition === 'skeleton'
+		? options.template === condition
+		: options[condition];
+}
+
+/**
+ * @param {any} target
+ * @param {any} source
+ */
+function merge(target, source) {
+	for (const key in source) {
+		if (key in target) {
+			const target_value = target[key];
+			const source_value = source[key];
+
+			if (
+				typeof source_value !== typeof target_value ||
+				Array.isArray(source_value) !== Array.isArray(target_value)
+			) {
+				throw new Error('Mismatched values');
+			}
+
+			merge(target_value, source_value);
+		} else {
+			target[key] = source[key];
+		}
+	}
+}
+
+/** @param {Record<string, any>} obj */
+function sort_keys(obj) {
+	if (!obj) return;
+
+	/** @type {Record<string, any>} */
+	const sorted = {};
+	Object.keys(obj)
+		.sort()
+		.forEach((key) => {
+			sorted[key] = obj[key];
+		});
+
+	return sorted;
+}
+
+/** @param {string} name */
+function toValidPackageName(name) {
+	return name
+		.trim()
+		.toLowerCase()
+		.replace(/\s+/g, '-')
+		.replace(/^[._]/, '')
+		.replace(/[^a-z0-9~.-]+/g, '-');
+}

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -9,6 +9,7 @@
 	"license": "MIT",
 	"homepage": "https://kit.svelte.dev",
 	"bin": "./bin.js",
+	"main": "./index.js",
 	"dependencies": {
 		"kleur": "^4.1.4",
 		"prompts": "^2.4.2"

--- a/packages/create-svelte/tsconfig.json
+++ b/packages/create-svelte/tsconfig.json
@@ -9,5 +9,5 @@
 		"moduleResolution": "node",
 		"allowSyntheticDefaultImports": true
 	},
-	"include": ["scripts/**/*", "bin.js", "utils.js"]
+	"include": ["scripts/**/*", "index.js", "bin.js", "utils.js"]
 }

--- a/packages/create-svelte/utils.js
+++ b/packages/create-svelte/utils.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 /** @param {string} dir */
 export function mkdirp(dir) {
@@ -42,4 +43,9 @@ export function copy(from, to, rename = identity) {
 		mkdirp(path.dirname(to));
 		fs.copyFileSync(from, to);
 	}
+}
+
+/** @param {string} path */
+export function dist(path) {
+	return fileURLToPath(new URL(`./dist/${path}`, import.meta.url).href);
 }


### PR DESCRIPTION
This pr adds a programmatic interface to `create-svelte` so it can be called using a single function call.

Closes #3421 

Not sure if the package should be bundled, since it is now exporting an entry point. Let me know if it needs to.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
