### PR TITLE
[fix] adapter-node ORIGIN runtime environment variable

### DIFF
--- a/.changeset/tricky-news-smash.md
+++ b/.changeset/tricky-news-smash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+fix usage of `ORIGIN` environment variable

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -54,7 +54,7 @@ export default function ({
 					PATH_ENV: JSON.stringify(path_env),
 					HOST_ENV: JSON.stringify(host_env),
 					PORT_ENV: JSON.stringify(port_env),
-					ORIGIN_ENV: origin_env ? `process.env[${JSON.stringify(origin_env)}]` : 'undefined',
+					ORIGIN: origin_env ? `process.env[${JSON.stringify(origin_env)}]` : 'undefined',
 					PROTOCOL_HEADER: JSON.stringify(protocol_header_env),
 					HOST_HEADER: JSON.stringify(host_header_env)
 				}

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -7,10 +7,10 @@ import { getRequest, setResponse } from '@sveltejs/kit/node';
 import { App } from 'APP';
 import { manifest } from 'MANIFEST';
 
-/* global ORIGIN_ENV, PROTOCOL_HEADER, HOST_HEADER */
+/* global ORIGIN, PROTOCOL_HEADER, HOST_HEADER */
 
 const app = new App(manifest);
-const origin = ORIGIN_ENV && process.env[ORIGIN_ENV];
+const origin = ORIGIN;
 const protocol_header = PROTOCOL_HEADER && process.env[PROTOCOL_HEADER];
 const host_header = (HOST_HEADER && process.env[HOST_HEADER]) || 'host';
 

--- a/packages/adapter-node/src/types.d.ts
+++ b/packages/adapter-node/src/types.d.ts
@@ -2,7 +2,7 @@ declare global {
 	const PATH_ENV: string;
 	const HOST_ENV: string;
 	const PORT_ENV: string;
-	const ORIGIN_ENV: string;
+	const ORIGIN: string;
 
 	const PROTOCOL_HEADER: string;
 	const HOST_HEADER: string;


### PR DESCRIPTION
#3423 was an incomplete fix. The adapter was producing output like `const origin = process.env["ORIGIN"] && process.env[process.env["ORIGIN"]];` when we just wanted `const origin = process.env["ORIGIN"];`. I'd still like another set of eyes on this because I did get it wrong last time.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
