### PR TITLE
Update template automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          UPDATE_TEMPLATE_SSH_KEY: ${{ secrets.UPDATE_TEMPLATE_SSH_KEY }}
 
       # TODO alert discord
       # - name: Send a Slack notification if a publish happens

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -34,7 +34,7 @@
 		"format": "npm run check-format -- --write",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path ../../.gitignore --ignore-path .gitignore --plugin prettier-plugin-svelte --plugin-search-dir=.",
 		"prepublishOnly": "npm run build",
-		"postpublish": "./scripts/update-template-repo.sh"
+		"postpublish": "bash ./scripts/update-template-repo.sh"
 	},
 	"files": [
 		"dist",

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -33,7 +33,8 @@
 		"lint": "eslint --ignore-path .gitignore --ignore-path ../../.gitignore \"./*.js\" && npm run check-format",
 		"format": "npm run check-format -- --write",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path ../../.gitignore --ignore-path .gitignore --plugin prettier-plugin-svelte --plugin-search-dir=.",
-		"prepublishOnly": "npm run build"
+		"prepublishOnly": "npm run build",
+		"postpublish": "./scripts/update-template-repo.sh"
 	},
 	"files": [
 		"dist",

--- a/packages/create-svelte/scripts/update-template-repo-contents.js
+++ b/packages/create-svelte/scripts/update-template-repo-contents.js
@@ -1,0 +1,1 @@
+console.log('wheee!!!');

--- a/packages/create-svelte/scripts/update-template-repo-contents.js
+++ b/packages/create-svelte/scripts/update-template-repo-contents.js
@@ -1,1 +1,22 @@
-console.log('wheee!!!');
+import fs from 'fs';
+import path from 'path';
+import { create } from '../index.js';
+
+const tmp = process.argv[2];
+const repo = path.join(tmp, 'kit-template-default');
+
+fs.readdirSync(repo).forEach((file) => {
+	if (file !== '.git') {
+		fs.rmSync(path.join(repo, file), {
+			recursive: true,
+			force: true
+		});
+	}
+});
+
+await create(repo, {
+	template: 'default',
+	eslint: false,
+	typescript: false,
+	prettier: true
+});

--- a/packages/create-svelte/scripts/update-template-repo.sh
+++ b/packages/create-svelte/scripts/update-template-repo.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+DIR=$PWD
+TMP="$DIR/../node_modules/.tmp"
+
+echo "dir: $DIR"
+echo "tmp: $TMP"
+
+mkdir -p $TMP
+cd $TMP
+
+if [ "$CI" ]; then
+	(umask 0077; echo "$SSH_KEY" > ~/ssh_key;)
+	git config user.email 'noreply@svelte.dev'
+	git config user.name '[bot]'
+fi
+
+export GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=accept-new -i ~/ssh_key'
+
+rm -rf $DIR/kit-template-default
+git clone --depth 1 --single-branch --branch main git@github.com:sveltejs/kit-template-default.git
+node $DIR/update-template-repo-contents.js
+# git push git@github.com:sveltejs/kit-template-default.git main -f

--- a/packages/create-svelte/scripts/update-template-repo.sh
+++ b/packages/create-svelte/scripts/update-template-repo.sh
@@ -8,9 +8,6 @@ get_abs_filename() {
 DIR=$(get_abs_filename $(dirname "$0"))
 TMP=$(get_abs_filename "$DIR/../node_modules/.tmp")
 
-echo "dir: $DIR"
-echo "tmp: $TMP"
-
 mkdir -p $TMP
 cd $TMP
 

--- a/packages/create-svelte/scripts/update-template-repo.sh
+++ b/packages/create-svelte/scripts/update-template-repo.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
-cd "$(dirname "$0")"
-DIR=$PWD
-TMP="$DIR/../node_modules/.tmp"
+
+get_abs_filename() {
+  # $1 : relative filename
+  echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+}
+
+DIR=$(get_abs_filename $(dirname "$0"))
+TMP=$(get_abs_filename "$DIR/../node_modules/.tmp")
 
 echo "dir: $DIR"
 echo "tmp: $TMP"
@@ -13,11 +18,20 @@ if [ "$CI" ]; then
 	(umask 0077; echo "$SSH_KEY" > ~/ssh_key;)
 	git config user.email 'noreply@svelte.dev'
 	git config user.name '[bot]'
+
+	export GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=accept-new -i ~/ssh_key'
 fi
 
-export GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=accept-new -i ~/ssh_key'
-
-rm -rf $DIR/kit-template-default
+# clone the template repo
+rm -rf kit-template-default
 git clone --depth 1 --single-branch --branch main git@github.com:sveltejs/kit-template-default.git
-node $DIR/update-template-repo-contents.js
-# git push git@github.com:sveltejs/kit-template-default.git main -f
+
+# empty out the repo
+cd kit-template-default
+node $DIR/update-template-repo-contents.js $TMP
+
+# commit the new files
+git add -A
+git commit -m "version $npm_package_version"
+
+git push git@github.com:sveltejs/kit-template-default.git main -f

--- a/packages/create-svelte/scripts/update-template-repo.sh
+++ b/packages/create-svelte/scripts/update-template-repo.sh
@@ -15,7 +15,7 @@ mkdir -p $TMP
 cd $TMP
 
 if [ "$CI" ]; then
-	(umask 0077; echo "$SSH_KEY" > ~/ssh_key;)
+	(umask 0077; echo "$UPDATE_TEMPLATE_SSH_KEY" > ~/ssh_key;)
 	git config user.email 'noreply@svelte.dev'
 	git config user.name '[bot]'
 

--- a/packages/create-svelte/tsconfig.json
+++ b/packages/create-svelte/tsconfig.json
@@ -4,8 +4,8 @@
 		"checkJs": true,
 		"noEmit": true,
 		"noImplicitAny": true,
-		"target": "es2020",
-		"module": "es2020",
+		"target": "esnext",
+		"module": "esnext",
 		"moduleResolution": "node",
 		"allowSyntheticDefaultImports": true
 	},


### PR DESCRIPTION
In theory, this will update https://github.com/sveltejs/kit-template-default every time a new version of `create-svelte` is released. This will allow us to use that repo as the base for things like https://node.new/sveltekit.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
