### PR TITLE
[fix] Exclude keys common for T and U on Only type

### DIFF
--- a/packages/kit/types/helper.d.ts
+++ b/packages/kit/types/helper.d.ts
@@ -13,7 +13,7 @@ export type JSONString =
 export type ResponseHeaders = Record<string, string | string[]>;
 
 // <-- Utility Types -->
-type Only<T, U> = { [P in keyof T]: T[P] } & { [P in keyof U]?: never };
+type Only<T, U> = { [P in keyof T]: T[P] } & { [P in Exclude<keyof U, keyof T>]?: never };
 
 export type Either<T, U> = Only<T, U> | Only<U, T>;
 export type InferValue<T, Key extends keyof T, Default> = T extends Record<Key, infer Val>


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

This pull request fixes an issue that happened when the arguments of `Only` had a common property name, creating a key conflict and making the type resolve to `never`. The issue is fixed by excluding the keys common for T and U before iterating over them.

Here is a [reproduction](https://www.typescriptlang.org/play?#code/C4TwDgpgBA8gdgGxAHgCoBooFUB8UC8UA3gFACQA2gApQCWcUA1hCAPYBmUqAugFxfVuAbhIBfKADJi5anQbM2nLNwD8-OBABuEAE4jRIkhAAeYVjuBRQkKAFFawABa60mXAViIUGbHgA+nkjIWJioOIb0wLrsAIYAxtAAYqys0lBQMeoArgC2AEa6JOl5-ADOwDr0AOZiJJHR8dAAQjE6aVAlHSkIEDFwRVBx2fmFoiQ9luwp-PZOLsmsmC06eISk6ZlQAIzoA50ARDGlACb7teMQlnmtMw7OOsgLS62r7Z0VWRC76UPbYkA)

And [here](https://www.typescriptlang.org/play?ssl=25&ssc=2&pln=17&pc=1#code/C4TwDgpgBA8gdgGxAHgCoBooFUB8UC8UA3gFACQA2gApQCWcUA1hCAPYBmUqAugFxfVuAbhIBfKADJi5anQYBRAB4BjBAFcAJhGTM2nLJl0cuObgH5+cCADcIAJxGiRJCIrCs7wKKEhR5tYAALezRMXAJYRBQMbDwAH0ikZAMTZ3pge3YAQ2VoADFWVmkoKCzLNQBbACN7EhKq-gBnYDt6AHMxEnTMnOgAISy7YqgGkcKECCy4Oqhlcura0RIJr3ZC-n8gkILWTAG7PEJSErKoAEZ0GdGAIizGjWvO5YgvKsGNgOC7ZB29wcPhqMWmoIJcSnNzmIgA) is how the fixed version behaves