### PR TITLE
various create-svelte improvements

### DIFF
--- a/.changeset/lemon-camels-brush.md
+++ b/.changeset/lemon-camels-brush.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Respect Ctrl-C when running create-svelte

--- a/.changeset/popular-hounds-love.md
+++ b/.changeset/popular-hounds-love.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Make project name an explicit option'

--- a/.changeset/unlucky-otters-tickle.md
+++ b/.changeset/unlucky-otters-tickle.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Prompt for directory when running create-svelte without argument

--- a/packages/create-svelte/index.js
+++ b/packages/create-svelte/index.js
@@ -11,10 +11,8 @@ import { mkdirp, copy, dist } from './utils.js';
 export async function create(cwd, options) {
 	mkdirp(cwd);
 
-	const name = path.basename(path.resolve(cwd));
-
-	write_template_files(options.template, options.typescript, name, cwd);
-	write_common_files(cwd, options, name);
+	write_template_files(options.template, options.typescript, options.name, cwd);
+	write_common_files(cwd, options, options.name);
 }
 
 /**

--- a/packages/create-svelte/scripts/update-template-repo-contents.js
+++ b/packages/create-svelte/scripts/update-template-repo-contents.js
@@ -14,6 +14,7 @@ fs.readdirSync(repo).forEach((file) => {
 });
 
 await create(repo, {
+	name: 'kit-template-default',
 	template: 'default',
 	eslint: false,
 	typescript: false,

--- a/packages/create-svelte/types/internal.d.ts
+++ b/packages/create-svelte/types/internal.d.ts
@@ -1,4 +1,5 @@
 export type Options = {
+	name: string;
 	template: 'default' | 'skeleton';
 	typescript: boolean;
 	prettier: boolean;


### PR DESCRIPTION
Three changes:

1. if you call `npm init svelte@next` without specifying a directory, it will prompt you for one, in line with other scaffolding tools. (if you hit 'enter', it will use the current directory, as currently happens)
2. if you Ctrl-C in the middle of the prompts, it will bail out, as you'd expect
3. the project name is an explicit option to `create`, rather than being inferred from the directory (i.e. the inference has been moved back to the CLI) 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
