### PR TITLE
feat(kit): type `config.compilerOptions` as `CompileOptions` instead of any

### DIFF
--- a/.changeset/young-ears-rhyme.md
+++ b/.changeset/young-ears-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Type compilerOptions as CompileOptions instead of any

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -1,3 +1,4 @@
+import { CompileOptions } from 'svelte/types/compiler/interfaces';
 import { UserConfig as ViteConfig } from 'vite';
 import { RecursiveRequired } from './helper';
 import { HttpMethod, Logger, RouteSegment, TrailingSlash } from './internal';
@@ -110,7 +111,7 @@ export interface PrerenderErrorHandler {
 export type PrerenderOnErrorValue = 'fail' | 'continue' | PrerenderErrorHandler;
 
 export interface Config {
-	compilerOptions?: any;
+	compilerOptions?: CompileOptions;
 	extensions?: string[];
 	kit?: {
 		adapter?: Adapter;


### PR DESCRIPTION
<!--
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
-->

This types `compilerOptions` using the `CompileOptions` interface for an improved developer experience. This is a nice-to-have as it would be useful to glean which options and values are valid without looking up the docs.

`vite-plugin-svelte` also [strongly types `compilerOptions`](https://github.com/sveltejs/vite-plugin-svelte/blob/e0505412daf2be60f4adde9491332784088522a9/packages/vite-plugin-svelte/src/utils/options.ts#L378).

<!--
### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
-->

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
