### PR TITLE
ensure %svelte.head% and %svelte.body% are replaced last

### DIFF
--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -261,9 +261,10 @@ export async function create_plugin(config, cwd) {
 								target: config.kit.target,
 								template: ({ head, body, assets }) => {
 									let rendered = load_template(cwd, config)
+										.replace(/%svelte\.assets%/g, assets)
+										// head and body must be replaced last, in case someone tries to sneak in %svelte.assets% etc
 										.replace('%svelte.head%', () => head)
-										.replace('%svelte.body%', () => body)
-										.replace(/%svelte\.assets%/g, assets);
+										.replace('%svelte.body%', () => body);
 
 									if (amp) {
 										const result = amp.validateString(rendered);


### PR DESCRIPTION
Very minor tweak pertaining to https://github.com/sveltejs/kit/issues/93#issuecomment-1018703874. It's quite safe to use `%svelte.assets%` (and in future, `%svelte.nonce%`) because no string replacement happens in production (the template is turned into a function), but in the interests of completeness it makes sense to ensure the same results in development.

No changeset necessary as this is vanishingly unlikely to affect anyone

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
