### PR TITLE
insert http-equiv cache-control tag when prerendering

### DIFF
--- a/.changeset/modern-sloths-greet.md
+++ b/.changeset/modern-sloths-greet.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Insert <meta http-equiv> cache-control header when prerendering

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -128,6 +128,12 @@ export async function render_response({
 
 	const inlined_style = Array.from(styles.values()).join('\n');
 
+	if (state.prerender) {
+		if (maxage) {
+			head += `<meta http-equiv="cache-control" content="max-age=${maxage}">`;
+		}
+	}
+
 	if (options.amp) {
 		head += `
 		<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>

--- a/packages/kit/test/prerendering/basics/src/routes/max-age.svelte
+++ b/packages/kit/test/prerendering/basics/src/routes/max-age.svelte
@@ -1,0 +1,10 @@
+<script context="module">
+	/** @type {import('@sveltejs/kit').Load} */
+	export function load() {
+		return {
+			maxage: 300
+		};
+	}
+</script>
+
+<h1>This page will be cached for 5 minutes</h1>

--- a/packages/kit/test/prerendering/basics/test/test.js
+++ b/packages/kit/test/prerendering/basics/test/test.js
@@ -37,4 +37,9 @@ test('escapes characters in redirect', () => {
 	);
 });
 
+test('inserts http-equiv tag for cache-control headers', () => {
+	const content = read('max-age/index.html');
+	assert.ok(content.includes('<meta http-equiv="cache-control" content="max-age=300">'));
+});
+
 test.run();


### PR DESCRIPTION
If a page specifies a `maxage` in its `load` result, a cache-control header is generated. Since apps don't (typically) have any control over headers with prerendered content, this is the next best thing. Mentioned briefly in https://github.com/sveltejs/kit/issues/909#issuecomment-1004128975.

This also lays the groundwork for inserting CSP headers in prerendered content.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
