### PR TITLE
[fix] correctly serialize response headers

### DIFF
--- a/.changeset/bright-pens-joke.md
+++ b/.changeset/bright-pens-joke.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] correctly serialize response headers

--- a/packages/kit/src/node.js
+++ b/packages/kit/src/node.js
@@ -61,7 +61,7 @@ export async function getRequest(base, req) {
 
 /** @type {import('@sveltejs/kit/node').SetResponse} */
 export async function setResponse(res, response) {
-	res.writeHead(response.status, Object.fromEntries(response.headers));
+	res.writeHead(response.status, Object.fromEntries(response.headers.entries()));
 
 	if (response.body instanceof Readable) {
 		response.body.pipe(res);


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/3491. Note thought that I haven't tested this

I'm surprised that TypeScript didn't catch this. I guess that the tests don't because this is only used by adapters which are largely untested?