### PR TITLE
error if handle returns non-Response

### DIFF
--- a/.changeset/green-mayflies-shave.md
+++ b/.changeset/green-mayflies-shave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Error if handle hook returns something other than a Response

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -196,7 +196,7 @@ export async function respond(request, options, state = {}) {
 			}
 		});
 
-		// TODO remove for 1.0
+		// TODO for 1.0, change the error message to point to docs rather than PR
 		if (response && !(response instanceof Response)) {
 			throw new Error('handle must return a Response object' + details);
 		}

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -99,7 +99,7 @@ export async function respond(request, options, state = {}) {
 	let ssr = true;
 
 	try {
-		return await options.hooks.handle({
+		const response = await options.hooks.handle({
 			event,
 			resolve: async (event, opts) => {
 				if (opts && 'ssr' in opts) ssr = /** @type {boolean} */ (opts.ssr);
@@ -195,6 +195,13 @@ export async function respond(request, options, state = {}) {
 				throw new Error('request in handle has been replaced with event' + details);
 			}
 		});
+
+		// TODO remove for 1.0
+		if (response && !(response instanceof Response)) {
+			throw new Error('handle must return a Response object' + details);
+		}
+
+		return response;
 	} catch (/** @type {unknown} */ e) {
 		const error = coalesce_to_error(e);
 


### PR DESCRIPTION
this would have prevented #3491 — if you return anything other than a `Response` from `handle`, this will let you know about it

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
