### PR TITLE
bump adapter-node and adapter-netlify

### DIFF
--- a/.changeset/good-keys-argue.md
+++ b/.changeset/good-keys-argue.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-netlify': patch
 ---
 
 Bump version to trigger rebuild with set-cookie support

--- a/.changeset/loud-fishes-drum.md
+++ b/.changeset/loud-fishes-drum.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Bump adapter-node version to rebuild with fixed set-cookie support


### PR DESCRIPTION
#3502 should have included changesets to bump adapter-node/netlify, since they need to be rebuilt with the `set-cookie` support. my bad

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
