### PR TITLE
add configuration for mixed JS/TS codebase

### DIFF
--- a/packages/create-svelte/shared/+eslint+prettier+typescript/.eslintrc.cjs
+++ b/packages/create-svelte/shared/+eslint+prettier+typescript/.eslintrc.cjs
@@ -4,7 +4,15 @@ module.exports = {
 	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
 	plugins: ['svelte3', '@typescript-eslint'],
 	ignorePatterns: ['*.cjs'],
-	overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],
+	overrides: [
+		{ files: ['*.svelte'], processor: 'svelte3/svelte3' },
+		{
+			files: ['*.ts'],
+			rules: {
+				'@typescript-eslint/explicit-module-boundary-types': ['warn']
+			}
+		}
+	],
 	settings: {
 		'svelte3/typescript': () => require('typescript')
 	},
@@ -16,5 +24,8 @@ module.exports = {
 		browser: true,
 		es2017: true,
 		node: true
+	},
+	rules: {
+		'@typescript-eslint/explicit-module-boundary-types': 'off'
 	}
 };

--- a/packages/create-svelte/shared/+eslint+typescript/.eslintrc.cjs
+++ b/packages/create-svelte/shared/+eslint+typescript/.eslintrc.cjs
@@ -4,7 +4,15 @@ module.exports = {
 	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
 	plugins: ['svelte3', '@typescript-eslint'],
 	ignorePatterns: ['*.cjs'],
-	overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],
+	overrides: [
+		{ files: ['*.svelte'], processor: 'svelte3/svelte3' },
+		{
+			files: ['*.ts'],
+			rules: {
+				'@typescript-eslint/explicit-module-boundary-types': ['warn']
+			}
+		}
+	],
 	settings: {
 		'svelte3/typescript': () => require('typescript')
 	},
@@ -16,5 +24,8 @@ module.exports = {
 		browser: true,
 		es2017: true,
 		node: true
+	},
+	rules: {
+		'@typescript-eslint/explicit-module-boundary-types': 'off'
 	}
 };


### PR DESCRIPTION
TS ESLint is [weird](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md#configuring-in-a-mixed-jsts-codebase)

Resolves #3514

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
