### PR TITLE
reinstate `EndpointOutput` generic

### DIFF
--- a/.changeset/swift-peaches-enjoy.md
+++ b/.changeset/swift-peaches-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+reinstate `EndpointOutput` generic

--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -59,18 +59,20 @@ export interface RequestEvent<Locals = Record<string, any>> {
 }
 
 type Body = JSONString | Uint8Array | ReadableStream | stream.Readable;
-export interface EndpointOutput {
+export interface EndpointOutput<Output extends Body = Body> {
 	status?: number;
-	headers?: HeadersInit;
-	body?: Body;
+	headers?: Headers | Partial<ResponseHeaders>;
+	body?: Output;
 }
 
 type MaybePromise<T> = T | Promise<T>;
 interface Fallthrough {
 	fallthrough: true;
 }
-export interface RequestHandler<Locals = Record<string, any>> {
-	(event: RequestEvent<Locals>): MaybePromise<Either<Response | EndpointOutput, Fallthrough>>;
+export interface RequestHandler<Locals = Record<string, any>, Output extends Body = Body> {
+	(event: RequestEvent<Locals>): MaybePromise<
+		Either<Response | EndpointOutput<Output>, Fallthrough>
+	>;
 }
 ```
 

--- a/packages/kit/types/endpoint.d.ts
+++ b/packages/kit/types/endpoint.d.ts
@@ -3,16 +3,18 @@ import { Either, JSONString, MaybePromise, ResponseHeaders } from './helper';
 
 type Body = JSONString | Uint8Array | ReadableStream | import('stream').Readable;
 
-export interface EndpointOutput {
+export interface EndpointOutput<Output extends Body = Body> {
 	status?: number;
 	headers?: Headers | Partial<ResponseHeaders>;
-	body?: Body;
+	body?: Output;
 }
 
 export interface Fallthrough {
 	fallthrough: true;
 }
 
-export interface RequestHandler<Locals = Record<string, any>> {
-	(event: RequestEvent<Locals>): MaybePromise<Either<Response | EndpointOutput, Fallthrough>>;
+export interface RequestHandler<Locals = Record<string, any>, Output extends Body = Body> {
+	(event: RequestEvent<Locals>): MaybePromise<
+		Either<Response | EndpointOutput<Output>, Fallthrough>
+	>;
 }


### PR DESCRIPTION
We really need that typings test (I'm working towards it)

Closes #3512 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
