### PR TITLE
[chore] remove TODO

### DIFF
--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -126,7 +126,6 @@ export async function load_node({
 				} else if (is_root_relative(resolved)) {
 					const relative = resolved;
 
-					// TODO: fix type https://github.com/node-fetch/node-fetch/issues/1113
 					if (opts.credentials !== 'omit') {
 						uses_credentials = true;
 


### PR DESCRIPTION
It looks like we're now using the browser `fetch` types instead of the `node-fetch` types so there's no longer a type checking warning. I'm not exactly sure how `install-fetch` doesn't run into an issue with the types being different or maybe it does and that's ignored elsewhere, but at least in this portion of the code there no longer seems to be an issue