### PR TITLE
[chore] remove `InternalHandle`

### DIFF
--- a/.changeset/tender-buses-talk.md
+++ b/.changeset/tender-buses-talk.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[chore] remove InternalHandle

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -122,7 +122,9 @@ export async function respond(request, options, state = {}) {
 				let decoded = decodeURI(event.url.pathname);
 
 				if (options.paths.base) {
-					if (!decoded.startsWith(options.paths.base)) return;
+					if (!decoded.startsWith(options.paths.base)) {
+						return new Response(undefined, { status: 404 });
+					}
 					decoded = decoded.slice(options.paths.base.length) || '/';
 				}
 
@@ -187,6 +189,8 @@ export async function respond(request, options, state = {}) {
 						ssr
 					});
 				}
+
+				return new Response(undefined, { status: 404 });
 			},
 
 			// TODO remove for 1.0

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -190,7 +190,9 @@ export async function respond(request, options, state = {}) {
 					});
 				}
 
-				return new Response(undefined, { status: 404 });
+				// we can't load the endpoint from our own manifest,
+				// so we need to make an actual HTTP request
+				return await fetch(request);
 			},
 
 			// TODO remove for 1.0

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -195,50 +195,50 @@ export async function load_node({
 					response = await options.hooks.externalFetch.call(null, external_request);
 				}
 
-					const proxy = new Proxy(response, {
-						get(response, key, _receiver) {
-							async function text() {
-								const body = await response.text();
+				const proxy = new Proxy(response, {
+					get(response, key, _receiver) {
+						async function text() {
+							const body = await response.text();
 
-								/** @type {import('types/helper').ResponseHeaders} */
-								const headers = {};
-								for (const [key, value] of response.headers) {
-									if (key === 'set-cookie') {
-										set_cookie_headers = set_cookie_headers.concat(value);
-									} else if (key !== 'etag') {
-										headers[key] = value;
-									}
+							/** @type {import('types/helper').ResponseHeaders} */
+							const headers = {};
+							for (const [key, value] of response.headers) {
+								if (key === 'set-cookie') {
+									set_cookie_headers = set_cookie_headers.concat(value);
+								} else if (key !== 'etag') {
+									headers[key] = value;
 								}
+							}
 
-								if (!opts.body || typeof opts.body === 'string') {
-									// prettier-ignore
-									fetched.push({
+							if (!opts.body || typeof opts.body === 'string') {
+								// prettier-ignore
+								fetched.push({
 										url: requested,
 										body: /** @type {string} */ (opts.body),
 										json: `{"status":${response.status},"statusText":${s(response.statusText)},"headers":${s(headers)},"body":"${escape_json_string_in_html(body)}"}`
 									});
-								}
-
-								return body;
 							}
 
-							if (key === 'text') {
-								return text;
-							}
-
-							if (key === 'json') {
-								return async () => {
-									return JSON.parse(await text());
-								};
-							}
-
-							// TODO arrayBuffer?
-
-							return Reflect.get(response, key, response);
+							return body;
 						}
-					});
 
-					return proxy;
+						if (key === 'text') {
+							return text;
+						}
+
+						if (key === 'json') {
+							return async () => {
+								return JSON.parse(await text());
+							};
+						}
+
+						// TODO arrayBuffer?
+
+						return Reflect.get(response, key, response);
+					}
+				});
+
+				return proxy;
 			},
 			stuff: { ...stuff }
 		};

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -159,20 +159,11 @@ export async function load_node({
 						}
 					);
 
-					if (rendered) {
-						if (state.prerender) {
-							state.prerender.dependencies.set(relative, rendered);
-						}
-
-						response = rendered;
-					} else {
-						// we can't load the endpoint from our own manifest,
-						// so we need to make an actual HTTP request
-						response = await fetch(new URL(requested, event.url).href, {
-							method: opts.method || 'GET',
-							headers: opts.headers
-						});
+					if (state.prerender) {
+						state.prerender.dependencies.set(relative, rendered);
 					}
+
+					response = rendered;
 				} else {
 					// external
 					if (resolved.startsWith('//')) {
@@ -204,7 +195,6 @@ export async function load_node({
 					response = await options.hooks.externalFetch.call(null, external_request);
 				}
 
-				if (response) {
 					const proxy = new Proxy(response, {
 						get(response, key, _receiver) {
 							async function text() {
@@ -249,14 +239,6 @@ export async function load_node({
 					});
 
 					return proxy;
-				}
-
-				return (
-					response ||
-					new Response('Not found', {
-						status: 404
-					})
-				);
 			},
 			stuff: { ...stuff }
 		};

--- a/packages/kit/types/hooks.d.ts
+++ b/packages/kit/types/hooks.d.ts
@@ -24,15 +24,6 @@ export interface Handle<Locals = Record<string, any>> {
 	}): MaybePromise<Response>;
 }
 
-// internally, `resolve` could return `undefined`, so we differentiate InternalHandle
-// from the public Handle type
-export interface InternalHandle<Locals = Record<string, any>> {
-	(input: {
-		event: RequestEvent<Locals>;
-		resolve(event: RequestEvent<Locals>, opts?: ResolveOpts): MaybePromise<Response | undefined>;
-	}): MaybePromise<Response | undefined>;
-}
-
 export interface HandleError<Locals = Record<string, any>> {
 	(input: { error: Error & { frame?: string }; event: RequestEvent<Locals> }): void;
 }

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -2,7 +2,7 @@ import { OutputAsset, OutputChunk } from 'rollup';
 import { InternalApp, SSRManifest } from './app';
 import { Fallthrough, RequestHandler } from './endpoint';
 import { Either } from './helper';
-import { ExternalFetch, GetSession, HandleError, InternalHandle, RequestEvent } from './hooks';
+import { ExternalFetch, GetSession, Handle, HandleError, RequestEvent } from './hooks';
 import { Load } from './page';
 
 export interface PrerenderOptions {
@@ -97,7 +97,7 @@ export type SSRNodeLoader = () => Promise<SSRNode>;
 export interface Hooks {
 	externalFetch: ExternalFetch;
 	getSession: GetSession;
-	handle: InternalHandle;
+	handle: Handle;
 	handleError: HandleError;
 }
 

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -228,7 +228,5 @@ export interface MethodOverride {
 }
 
 export interface Respond {
-	(request: Request, options: SSRRenderOptions, state?: SSRRenderState): Promise<
-		Response | undefined
-	>;
+	(request: Request, options: SSRRenderOptions, state?: SSRRenderState): Promise<Response>;
 }


### PR DESCRIPTION
We were setting the type of the user-provided `handle` function as `InternalHandle`, which is not correct and was making it ward to work with