### PR TITLE
give module id an invalid name to prevent invalid replacement

### DIFF
--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -51,7 +51,7 @@ export default function ({ split = false } = {}) {
 			const redirects = [];
 
 			const replace = {
-				APP: './server/app.js'
+				'0APP': './server/app.js'
 			};
 
 			if (esm) {

--- a/packages/adapter-netlify/rollup.config.js
+++ b/packages/adapter-netlify/rollup.config.js
@@ -19,6 +19,7 @@ export default [
 			}
 		],
 		plugins: [nodeResolve(), commonjs(), json()],
-		external: ['APP', ...require('module').builtinModules]
+		external: (id) => id === '0APP' || id.startsWith('node:'),
+		preserveEntrySignatures: true
 	}
 ];

--- a/packages/adapter-netlify/src/handler.d.ts
+++ b/packages/adapter-netlify/src/handler.d.ts
@@ -1,3 +1,3 @@
-declare module 'APP' {
+declare module '0APP' {
 	export { App } from '@sveltejs/kit';
 }

--- a/packages/adapter-netlify/src/handler.js
+++ b/packages/adapter-netlify/src/handler.js
@@ -1,5 +1,5 @@
 import './shims';
-import { App } from 'APP';
+import { App } from '0APP';
 
 /**
  * @param {import('@sveltejs/kit').SSRManifest} manifest


### PR DESCRIPTION
fixes #3526. #3528 was close, but still had the bug — in order to fix it we need the module ID to be something that Rollup can't (in its desire to generate readable code) turn into an identical variable name. We can't use something like `{APP}` because that seems to cause issues with string replacement (possibly word boundary related? couldn't quite be bothered to figure it out), but if we prefix the ID with a number than Rollup is forced to add another character, thus hacking around the issue.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
