### PR TITLE
[fix] force Vite dev mode to use HTTP/1 for TLS

### DIFF
--- a/.changeset/twelve-comics-enjoy.md
+++ b/.changeset/twelve-comics-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Force Vite to use HTTP/1 in dev mode, so `dev --https` works again

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -89,7 +89,7 @@ export async function dev({ cwd, port, host, https, config }) {
 	// however, node-fetch's Request implementation does not like the HTTP/2 headers
 	// we set a no-op proxy config to force Vite to downgrade to TLS-only
 	// see https://vitejs.dev/config/#server-https
-	if (!merged_config.server.proxy) {
+	if (merged_config.server.https && !merged_config.server.proxy) {
 		merged_config.server.proxy = {};
 	}
 

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -85,6 +85,14 @@ export async function dev({ cwd, port, host, https, config }) {
 		merged_config.server.https = https;
 	}
 
+	// by default, when enabling HTTPS in Vite, it also enables HTTP/2
+	// however, node-fetch's Request implementation does not like the HTTP/2 headers
+	// we set a no-op proxy config to force Vite to downgrade to TLS-only
+	// see https://vitejs.dev/config/#server-https
+	if (!merged_config.server.proxy) {
+		merged_config.server.proxy = {};
+	}
+
 	if (port) {
 		merged_config.server.port = port;
 	}


### PR DESCRIPTION
This fixes #3479 by adding a no-op `server.proxy` config to Vite in dev mode to force it to downgrade to TLS-only when HTTPS in enabled, rather than using HTTP/2. node-fetch's Request implementation did not like the HTTP/2 headers it was getting.

Arguably, we could only apply this `server.proxy` config when `--https` is enabled. I'd be up for making that change if someone else thinks it worthwhile.

I'm not entirely thrilled with this solution, but it seemed the best one at the moment. We may need to revisit how node-fetch deals with HTTP/2 headers at some point in the future.

I'm not sure how to test this nicely, so there isn't one, and I would appreciate someone else taking this for a spin.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
