### PR TITLE
[chore] refactor AMP validation

### DIFF
--- a/.changeset/poor-lizards-punch.md
+++ b/.changeset/poor-lizards-punch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[chore] refactor AMP validation

--- a/packages/kit/src/core/dev/amp_hook.js
+++ b/packages/kit/src/core/dev/amp_hook.js
@@ -1,0 +1,54 @@
+/** @type {import('amphtml-validator').Validator} */
+const amp = await (await import('amphtml-validator')).getInstance();
+
+/** @type {import('types/hooks').Handle} */
+export async function handle({ event, resolve }) {
+	const response = await resolve(event);
+	if (response.headers.get('content-type') !== 'text/html') {
+		return response;
+	}
+
+	let rendered = await response.text();
+	const result = amp.validateString(rendered);
+
+	if (result.status !== 'PASS') {
+		const lines = rendered.split('\n');
+
+		/** @param {string} str */
+		const escape = (str) => str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+		rendered = `<!doctype html>
+		<head>
+			<meta charset="utf-8" />
+			<meta name="viewport" content="width=device-width, initial-scale=1" />
+			<style>
+				body {
+					font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+					color: #333;
+				}
+
+				pre {
+					background: #f4f4f4;
+					padding: 1em;
+					overflow-x: auto;
+				}
+			</style>
+		</head>
+		<h1>AMP validation failed</h1>
+
+		${result.errors
+			.map(
+				(error) => `
+			<h2>${error.severity}</h2>
+			<p>Line ${error.line}, column ${error.col}: ${error.message} (<a href="${error.specUrl}">${
+					error.code
+				}</a>)</p>
+			<pre>${escape(lines[error.line - 1])}</pre>
+		`
+			)
+			.join('\n\n')}
+	`;
+	}
+
+	return new Response(rendered, { status: response.status, headers: response.headers });
+}

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -12,6 +12,7 @@ import { SVELTE_KIT, SVELTE_KIT_ASSETS } from '../constants.js';
 import { get_mime_lookup, resolve_entry, runtime } from '../utils.js';
 import { coalesce_to_error } from '../../utils/error.js';
 import { load_template } from '../config/index.js';
+import { sequence } from '../../hooks.js';
 
 /**
  * @param {import('types/config').ValidatedConfig} config
@@ -19,12 +20,12 @@ import { load_template } from '../config/index.js';
  * @returns {Promise<import('vite').Plugin>}
  */
 export async function create_plugin(config, cwd) {
-	/** @type {import('amphtml-validator').Validator} */
+	/** @type {import('types/hooks').Handle} */
 	let amp;
 
 	if (config.kit.amp) {
 		process.env.VITE_SVELTEKIT_AMP = 'true';
-		amp = await (await import('amphtml-validator')).getInstance();
+		amp = (await import('./amp_hook')).handle;
 	}
 
 	return {
@@ -166,10 +167,12 @@ export async function create_plugin(config, cwd) {
 							? await vite.ssrLoadModule(`/${config.kit.files.hooks}`)
 							: {};
 
+						const handle = user_hooks.handle || (({ event, resolve }) => resolve(event));
+
 						/** @type {import('types/internal').Hooks} */
 						const hooks = {
 							getSession: user_hooks.getSession || (() => ({})),
-							handle: user_hooks.handle || (({ event, resolve }) => resolve(event)),
+							handle: amp ? sequence(amp, handle) : handle,
 							handleError:
 								user_hooks.handleError ||
 								(({ /** @type {Error & { frame?: string }} */ error }) => {
@@ -256,58 +259,14 @@ export async function create_plugin(config, cwd) {
 							router: config.kit.router,
 							target: config.kit.target,
 							template: ({ head, body, assets, nonce }) => {
-								let rendered = template
-									.replace(/%svelte\.assets%/g, assets)
-									.replace(/%svelte\.nonce%/g, nonce)
-									// head and body must be replaced last, in case someone tries to sneak in %svelte.assets% etc
-									.replace('%svelte.head%', () => head)
-									.replace('%svelte.body%', () => body);
-
-								if (amp) {
-									const result = amp.validateString(rendered);
-
-									if (result.status !== 'PASS') {
-										const lines = rendered.split('\n');
-
-										/** @param {string} str */
-										const escape = (str) =>
-											str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-
-										rendered = `<!doctype html>
-										<head>
-											<meta charset="utf-8" />
-											<meta name="viewport" content="width=device-width, initial-scale=1" />
-											<style>
-												body {
-													font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-													color: #333;
-												}
-
-												pre {
-													background: #f4f4f4;
-													padding: 1em;
-													overflow-x: auto;
-												}
-											</style>
-										</head>
-										<h1>AMP validation failed</h1>
-
-										${result.errors
-											.map(
-												(error) => `
-											<h2>${error.severity}</h2>
-											<p>Line ${error.line}, column ${error.col}: ${error.message} (<a href="${error.specUrl}">${
-													error.code
-												}</a>)</p>
-											<pre>${escape(lines[error.line - 1])}</pre>
-										`
-											)
-											.join('\n\n')}
-									`;
-									}
-								}
-
-								return rendered;
+								return (
+									template
+										.replace(/%svelte\.assets%/g, assets)
+										.replace(/%svelte\.nonce%/g, nonce)
+										// head and body must be replaced last, in case someone tries to sneak in %svelte.assets% etc
+										.replace('%svelte.head%', () => head)
+										.replace('%svelte.body%', () => body)
+								);
 							},
 							template_contains_nonce: template.includes('%svelte.nonce%'),
 							trailing_slash: config.kit.trailingSlash


### PR DESCRIPTION
Make the AMP validation happen in a `handle` hook. This should fix https://github.com/sveltejs/kit/issues/3330 (it won't allow disabling it, but it will make it so that it's correct) and be a step towards https://github.com/sveltejs/kit/issues/2603. It wouldn't be hard to move this to an external package for users to call. However, the actual AMP HTML generation is pretty tied into SvelteKit and I'm not sure how we'd change that