### PR TITLE
[docs] clarify sequence usage

### DIFF
--- a/documentation/docs/05-modules.md
+++ b/documentation/docs/05-modules.md
@@ -95,13 +95,23 @@ This module provides a helper function to sequence multiple `handle` calls.
 import { sequence } from '@sveltejs/kit/hooks';
 
 async function first({ event, resolve }) {
-	console.log('first');
-	return await resolve(event);
+	console.log('first pre-processing');
+	const result = await resolve(event);
+	console.log('first post-processing');
+	return result;
 }
 async function second({ event, resolve }) {
-	console.log('second');
-	return await resolve(event);
+	console.log('second pre-processing');
+	const result = await resolve(event);
+	console.log('second post-processing');
+	return result;
 }
 
 export const handle = sequence(first, second);
 ```
+
+The example above would print:
+>first pre-processing
+>second pre-processing
+>second post-processing
+>first post-processing


### PR DESCRIPTION
The current example is a bit unclear. Most usages of `handle` I've seen focus on post-processing and if you only have post-processors then they are applied in the reverse order that you specify them, which wasn't super obvious to me from the example. Even after Rich explained it (https://github.com/sveltejs/kit/pull/3554#discussion_r793124699), I still had to stare at it for a good while before figuring it out.