### PR TITLE
include service-worker.js in manifest

### DIFF
--- a/.changeset/brown-impalas-travel.md
+++ b/.changeset/brown-impalas-travel.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Include service worker in manifest

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -57,6 +57,7 @@ export async function build(config) {
 	const build_data = {
 		app_dir: config.kit.appDir,
 		manifest_data: options.manifest_data,
+		service_worker: options.service_worker_entry_file ? 'service_worker.js' : null, // TODO make file configurable?
 		client,
 		server,
 		static: options.manifest_data.assets.map((asset) => posixify(asset.file)),

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -47,10 +47,15 @@ export function generate_manifest(
 			? (path) => `() => import('${path}')`
 			: (path) => `() => Promise.resolve().then(() => require('${path}'))`;
 
+	const assets = build_data.manifest_data.assets.map((asset) => asset.file);
+	if (build_data.service_worker) {
+		assets.push(build_data.service_worker);
+	}
+
 	// prettier-ignore
 	return `{
 		appDir: ${s(build_data.app_dir)},
-		assets: new Set(${s(build_data.manifest_data.assets.map(asset => asset.file))}),
+		assets: new Set(${s(assets)}),
 		_: {
 			mime: ${s(get_mime_lookup(build_data.manifest_data))},
 			entry: ${s(build_data.client.entry)},

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -209,6 +209,7 @@ export interface ManifestData {
 export interface BuildData {
 	app_dir: string;
 	manifest_data: ManifestData;
+	service_worker: string | null;
 	client: {
 		assets: OutputAsset[];
 		chunks: OutputChunk[];


### PR DESCRIPTION
fixes #3187. `service-worker.js` is an anomaly because it's a generated file, but it lives among the contents of `static`, so it was overlooked previously. No test because the effects are only really observable in certain production environments (Cloudflare specifically, because the handler itself is responsible for serving assets), depending on how they work

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
