### PR TITLE
[fix] handle incoming requests from HTTP/2

### DIFF
--- a/.changeset/eight-readers-thank.md
+++ b/.changeset/eight-readers-thank.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix handling an incoming request from HTTP/2

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -85,14 +85,6 @@ export async function dev({ cwd, port, host, https, config }) {
 		merged_config.server.https = https;
 	}
 
-	// by default, when enabling HTTPS in Vite, it also enables HTTP/2
-	// however, node-fetch's Request implementation does not like the HTTP/2 headers
-	// we set a no-op proxy config to force Vite to downgrade to TLS-only
-	// see https://vitejs.dev/config/#server-https
-	if (merged_config.server.https && !merged_config.server.proxy) {
-		merged_config.server.proxy = {};
-	}
-
 	if (port) {
 		merged_config.server.port = port;
 	}

--- a/packages/kit/src/node.js
+++ b/packages/kit/src/node.js
@@ -52,9 +52,19 @@ function get_raw_body(req) {
 
 /** @type {import('@sveltejs/kit/node').GetRequest} */
 export async function getRequest(base, req) {
+	let headers = /** @type {Record<string, string>} */ (req.headers);
+	if (req.httpVersionMajor === 2) {
+		// we need to strip out the HTTP/2 pseudo-headers because node-fetch's
+		// Request implementation doesn't like them
+		headers = Object.assign({}, headers);
+		delete headers[':method'];
+		delete headers[':path'];
+		delete headers[':authority'];
+		delete headers[':scheme'];
+	}
 	return new Request(base + req.url, {
 		method: req.method,
-		headers: /** @type {Record<string, string>} */ (req.headers),
+		headers,
 		body: await get_raw_body(req) // TODO stream rather than buffer
 	});
 }


### PR DESCRIPTION
This fixes #3566 by making it `getRequest`'s responsibility to filter out HTTP/2 pseudo-headers before passing them to node-fetch's `Request` implementation. It also removes the workaround in #3553 which is no longer necessary.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
