### PR TITLE
remove -H and -h shortcuts from CLI - 

### DIFF
--- a/.changeset/serious-horses-rule.md
+++ b/.changeset/serious-horses-rule.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Breaking: remove -H and (conflicting) -h shortcuts from CLI

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -48,8 +48,11 @@ prog
 	.option('-o, --open', 'Open a browser tab')
 	.option('--host', 'Host (only use this on trusted networks)')
 	.option('--https', 'Use self-signed HTTPS certificate')
-	.action(async ({ port, host, https, open }) => {
+	.option('-H', 'no longer supported, use --https instead') // TODO remove for 1.0
+	.action(async ({ port, host, https, open, H }) => {
 		try {
+			if (H) throw new Error('-H is no longer supported — use --https instead');
+
 			process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 			const config = await load_config();
 
@@ -121,8 +124,11 @@ prog
 	.option('-o, --open', 'Open a browser tab', false)
 	.option('--host', 'Host (only use this on trusted networks)', 'localhost')
 	.option('--https', 'Use self-signed HTTPS certificate', false)
-	.action(async ({ port, host, https, open }) => {
+	.option('-H', 'no longer supported, use --https instead') // TODO remove for 1.0
+	.action(async ({ port, host, https, open, H }) => {
 		try {
+			if (H) throw new Error('-H is no longer supported — use --https instead');
+
 			await check_port(port);
 
 			process.env.NODE_ENV = process.env.NODE_ENV || 'production';

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -45,9 +45,9 @@ prog
 	.command('dev')
 	.describe('Start a development server')
 	.option('-p, --port', 'Port')
-	.option('-h, --host', 'Host (only use this on trusted networks)')
-	.option('-H, --https', 'Use self-signed HTTPS certificate')
 	.option('-o, --open', 'Open a browser tab')
+	.option('--host', 'Host (only use this on trusted networks)')
+	.option('--https', 'Use self-signed HTTPS certificate')
 	.action(async ({ port, host, https, open }) => {
 		try {
 			process.env.NODE_ENV = process.env.NODE_ENV || 'development';
@@ -118,9 +118,9 @@ prog
 	.command('preview')
 	.describe('Serve an already-built app')
 	.option('-p, --port', 'Port', 3000)
-	.option('-h, --host', 'Host (only use this on trusted networks)', 'localhost')
-	.option('-H, --https', 'Use self-signed HTTPS certificate', false)
 	.option('-o, --open', 'Open a browser tab', false)
+	.option('--host', 'Host (only use this on trusted networks)', 'localhost')
+	.option('--https', 'Use self-signed HTTPS certificate', false)
 	.action(async ({ port, host, https, open }) => {
 		try {
 			await check_port(port);


### PR DESCRIPTION
One possible way to fix #1432 — removes the `-h` shortcut (which is hardcoded to `--help`, so does nothing) and `-H`. In effect, this means people currently using `-H` will need to use `--https` instead. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
