### PR TITLE
extension is needed when importing

### DIFF
--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -25,7 +25,7 @@ export async function create_plugin(config, cwd) {
 
 	if (config.kit.amp) {
 		process.env.VITE_SVELTEKIT_AMP = 'true';
-		amp = (await import('./amp_hook')).handle;
+		amp = (await import('./amp_hook.js')).handle;
 	}
 
 	return {


### PR DESCRIPTION
The `amp_hook` changed passed CI because Rollup doesn't mind if extensions are missing (our original sin), but Node does, which means tests fail locally (where we're using the unbuilt source)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
