### PR TITLE
use pnpm publish

### DIFF
--- a/.changeset/lovely-baboons-suffer.md
+++ b/.changeset/lovely-baboons-suffer.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Bump version

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"check": "pnpm -r check",
 		"lint": "pnpm -r lint",
 		"format": "pnpm -r format",
-		"release": "changeset publish",
+		"release": "pnpm -r publish",
 		"preview:docs": "action-deploy-docs --project=kit"
 	},
 	"repository": {


### PR DESCRIPTION
this (temporarily, probably) reverts the switch to using `changeset publish`, to try and get a bit of visibility into why the postpublish script is failing

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
