### PR TITLE
Vercel externals

### DIFF
--- a/.changeset/eight-birds-run.md
+++ b/.changeset/eight-birds-run.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+Expose external option

--- a/packages/adapter-vercel/README.md
+++ b/packages/adapter-vercel/README.md
@@ -14,10 +14,16 @@ import vercel from '@sveltejs/adapter-vercel';
 export default {
 	kit: {
 		...
-		adapter: vercel()
+		adapter: vercel(options)
 	}
 };
 ```
+
+## Options
+
+You can pass an `options` argument, if necessary, with the following:
+
+- `external` — an array of dependencies that [esbuild](https://esbuild.github.io/api/#external) should treat as external
 
 ## Changelog
 

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -1,4 +1,8 @@
 import { Adapter } from '@sveltejs/kit';
 
-declare function plugin({ external }?: { external?: string[] }): Adapter;
+type Options = {
+	external?: string[];
+};
+
+declare function plugin(options?: Options): Adapter;
 export = plugin;

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -1,4 +1,4 @@
 import { Adapter } from '@sveltejs/kit';
 
-declare function plugin(): Adapter;
+declare function plugin({ external }?: { external?: string[] }): Adapter;
 export = plugin;

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -6,7 +6,7 @@ import esbuild from 'esbuild';
 const dir = '.vercel_build_output';
 
 /** @type {import('.')} **/
-export default function () {
+export default function ({ external = [] } = {}) {
 	return {
 		name: '@sveltejs/adapter-vercel',
 
@@ -52,7 +52,8 @@ export default function () {
 				outfile: `${dirs.lambda}/index.js`,
 				target: 'node14',
 				bundle: true,
-				platform: 'node'
+				platform: 'node',
+				external
 			});
 
 			writeFileSync(`${dirs.lambda}/package.json`, JSON.stringify({ type: 'commonjs' }));


### PR DESCRIPTION
fixes #3588, by adding an `external` option that gets passed to esbuild 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
