### PR TITLE
fix mismatched ambient types

### DIFF
--- a/.changeset/slimy-cougars-double.md
+++ b/.changeset/slimy-cougars-double.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+remove nonexistent `url` store from `$app/stores` ambient types

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -107,13 +107,8 @@ declare module '$app/stores' {
 	 * Most of the time, you won't need to use it.
 	 */
 	export function getStores<Session = any>(): {
-		navigating: Readable<Navigating | null>;
-		page: Readable<{
-			url: URL;
-			params: Record<string, string>;
-			status: number;
-			error: Error | null;
-		}>;
+		navigating: typeof navigating;
+		page: typeof page;
 		session: Writable<Session>;
 	};
 	/**

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -116,7 +116,6 @@ declare module '$app/stores' {
 		}>;
 		session: Writable<Session>;
 	};
-	export const url: Readable<URL>;
 	/**
 	 * A readable store whose value contains page data.
 	 */


### PR DESCRIPTION
According to the docs and 3a104faa33b74ac84e5bed668a4c06dfd05c0b8e, `url` shouldn't exist in `$app/stores`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
