### PR TITLE
[fix] update types to match changes to Vite config handling

### DIFF
--- a/.changeset/rude-rockets-rescue.md
+++ b/.changeset/rude-rockets-rescue.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] update types to match changes to Vite config handling

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -1,7 +1,7 @@
 import { CompileOptions } from 'svelte/types/compiler/interfaces';
 import { UserConfig as ViteConfig } from 'vite';
 import { CspDirectives } from './csp';
-import { RecursiveRequired } from './helper';
+import { MaybePromise, RecursiveRequired } from './helper';
 import { HttpMethod, Logger, RouteSegment, TrailingSlash } from './internal';
 
 export interface RouteDefinition {
@@ -165,7 +165,7 @@ export interface Config {
 		};
 		target?: string;
 		trailingSlash?: TrailingSlash;
-		vite?: ViteConfig | (() => ViteConfig);
+		vite?: ViteConfig | (() => MaybePromise<ViteConfig>);
 	};
 	preprocess?: any;
 }


### PR DESCRIPTION
A recent PR added `await` wherever we're getting the call, which is now causing warnings in VS Code because the types weren't updated to match