### PR TITLE
[fix] pre-render crawl parse with value-less attributes

### DIFF
--- a/.changeset/proud-goats-hide.md
+++ b/.changeset/proud-goats-hide.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix parsing during pre-render crawl when there are HTML attributes without a value

--- a/packages/kit/src/core/adapt/prerender/crawl.js
+++ b/packages/kit/src/core/adapt/prerender/crawl.js
@@ -175,6 +175,8 @@ export function crawl(html) {
 									hrefs.push(src);
 								}
 							}
+						} else {
+							i -= 1;
 						}
 					}
 

--- a/packages/kit/src/core/adapt/prerender/crawl.js
+++ b/packages/kit/src/core/adapt/prerender/crawl.js
@@ -25,7 +25,7 @@ export function crawl(html) {
 			if (html[i + 1] === '!') {
 				i += 2;
 
-				if (html.substr(i, DOCTYPE.length).toUpperCase() === DOCTYPE) {
+				if (html.substring(i, DOCTYPE.length).toUpperCase() === DOCTYPE) {
 					i += DOCTYPE.length;
 					while (i < html.length) {
 						if (html[i++] === '>') {
@@ -35,10 +35,10 @@ export function crawl(html) {
 				}
 
 				// skip cdata
-				if (html.substr(i, CDATA_OPEN.length) === CDATA_OPEN) {
+				if (html.substring(i, CDATA_OPEN.length) === CDATA_OPEN) {
 					i += CDATA_OPEN.length;
 					while (i < html.length) {
-						if (html.substr(i, CDATA_CLOSE.length) === CDATA_CLOSE) {
+						if (html.substring(i, CDATA_CLOSE.length) === CDATA_CLOSE) {
 							i += CDATA_CLOSE.length;
 							continue main;
 						}
@@ -48,10 +48,10 @@ export function crawl(html) {
 				}
 
 				// skip comments
-				if (html.substr(i, COMMENT_OPEN.length) === COMMENT_OPEN) {
+				if (html.substring(i, COMMENT_OPEN.length) === COMMENT_OPEN) {
 					i += COMMENT_OPEN.length;
 					while (i < html.length) {
-						if (html.substr(i, COMMENT_CLOSE.length) === COMMENT_CLOSE) {
+						if (html.substring(i, COMMENT_CLOSE.length) === COMMENT_CLOSE) {
 							i += COMMENT_CLOSE.length;
 							continue main;
 						}
@@ -79,7 +79,7 @@ export function crawl(html) {
 						if (
 							html[i] === '<' &&
 							html[i + 1] === '/' &&
-							html.substr(i + 2, tag.length).toUpperCase() === tag
+							html.substring(i + 2, tag.length).toUpperCase() === tag
 						) {
 							continue main;
 						}

--- a/packages/kit/src/core/adapt/prerender/fixtures/basic-href/input.html
+++ b/packages/kit/src/core/adapt/prerender/fixtures/basic-href/input.html
@@ -7,5 +7,8 @@
 	<body>
 		<a href="https://external.com">https://external.com</a>
 		<a href="/wheee">/wheee</a>
+		<a sveltekit:prefetch href="/wheee2">/wheee</a>
+		<a href="/wheee3" sveltekit:prefetch>/wheee</a>
+		<a href="/wheee4">/wheee</a>
 	</body>
 </html>

--- a/packages/kit/src/core/adapt/prerender/fixtures/basic-href/output.json
+++ b/packages/kit/src/core/adapt/prerender/fixtures/basic-href/output.json
@@ -1,1 +1,1 @@
-["/styles.css", "/favicon.png", "https://external.com", "/wheee"]
+["/styles.css", "/favicon.png", "https://external.com", "/wheee", "/wheee2", "/wheee3", "/wheee4"]


### PR DESCRIPTION
Fixes #3660. When there was an attribute with no value (e.g., `sveltekit:prefetch`), the next attribute had its first character missing, so things like `href` or `src` were read as `ref` and `rc` and so weren't properly handled when crawling.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
