### PR TITLE
add a SvelteKit namespace for app-level types (#3569)

### DIFF
--- a/.changeset/ninety-suns-relax.md
+++ b/.changeset/ninety-suns-relax.md
@@ -3,4 +3,4 @@
 '@sveltejs/kit': patch
 ---
 
-Add SvelteKit namespace for app-level types
+Add App namespace for app-level types

--- a/.changeset/ninety-suns-relax.md
+++ b/.changeset/ninety-suns-relax.md
@@ -1,0 +1,6 @@
+---
+'create-svelte': patch
+'@sveltejs/kit': patch
+---
+
+Add SvelteKit namespace for app-level types

--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -51,12 +51,12 @@ Endpoints are modules written in `.js` (or `.ts`) files that export functions co
 // Declaration types for Endpoints
 // * declarations that are not exported are for internal use
 
-export interface RequestEvent<Locals = Record<string, any>, Platform = Record<string, any>> {
+export interface RequestEvent {
 	request: Request;
 	url: URL;
 	params: Record<string, string>;
-	locals: Locals;
-	platform: Platform;
+	locals: SvelteKit.Locals;
+	platform: SvelteKit.Platform;
 }
 
 type Body = JSONString | Uint8Array | ReadableStream | stream.Readable;
@@ -71,14 +71,8 @@ interface Fallthrough {
 	fallthrough: true;
 }
 
-export interface RequestHandler<
-	Locals = Record<string, any>,
-	Platform = Record<string, any>,
-	Output extends Body = Body
-> {
-	(event: RequestEvent<Locals, Platform>): MaybePromise<
-		Either<Response | EndpointOutput<Output>, Fallthrough>
-	>;
+export interface RequestHandler<Output extends Body = Body> {
+	(event: RequestEvent): MaybePromise<Either<Response | EndpointOutput<Output>, Fallthrough>>;
 }
 ```
 

--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -76,6 +76,8 @@ export interface RequestHandler<Output extends Body = Body> {
 }
 ```
 
+> See the [TypeScript](#typescript) section for information on `SvelteKit.Locals` and `SvelteKit.Platform`.
+
 For example, our hypothetical blog page, `/blog/cool-article`, might request data from `/blog/cool-article.json`, which could be represented by a `src/routes/blog/[slug].json.js` endpoint:
 
 ```js

--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -55,8 +55,8 @@ export interface RequestEvent {
 	request: Request;
 	url: URL;
 	params: Record<string, string>;
-	locals: SvelteKit.Locals;
-	platform: SvelteKit.Platform;
+	locals: App.Locals;
+	platform: App.Platform;
 }
 
 type Body = JSONString | Uint8Array | ReadableStream | stream.Readable;
@@ -76,7 +76,7 @@ export interface RequestHandler<Output extends Body = Body> {
 }
 ```
 
-> See the [TypeScript](#typescript) section for information on `SvelteKit.Locals` and `SvelteKit.Platform`.
+> See the [TypeScript](#typescript) section for information on `App.Locals` and `App.Platform`.
 
 For example, our hypothetical blog page, `/blog/cool-article`, might request data from `/blog/cool-article.json`, which could be represented by a `src/routes/blog/[slug].json.js` endpoint:
 

--- a/documentation/docs/02-layouts.md
+++ b/documentation/docs/02-layouts.md
@@ -80,11 +80,8 @@ For example, if `src/routes/settings/notifications/index.svelte` failed to load,
 // declaration type
 // * also see type for `LoadOutput` in the Loading section
 
-export interface ErrorLoadInput<
-	PageParams extends Record<string, string> = Record<string, string>,
-	Stuff extends Record<string, any> = Record<string, any>,
-	Session = any
-> extends LoadInput<PageParams, Stuff, Session> {
+export interface ErrorLoadInput<Params extends Record<string, string> = Record<string, string>>
+	extends LoadInput<Params> {
 	status?: number;
 	error?: Error;
 }

--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -12,8 +12,8 @@ export interface LoadInput<Params extends Record<string, string> = Record<string
 	url: URL;
 	params: Params;
 	fetch(info: RequestInfo, init?: RequestInit): Promise<Response>;
-	session: SvelteKit.Session;
-	stuff: Partial<SvelteKit.Stuff>;
+	session: App.Session;
+	stuff: Partial<App.Stuff>;
 }
 
 export interface LoadOutput<Props extends Record<string, any> = Record<string, any>> {
@@ -21,7 +21,7 @@ export interface LoadOutput<Props extends Record<string, any> = Record<string, a
 	error?: string | Error;
 	redirect?: string;
 	props?: Props;
-	stuff?: Partial<SvelteKit.Stuff>;
+	stuff?: Partial<App.Stuff>;
 	maxage?: number;
 }
 
@@ -35,7 +35,7 @@ export interface Load<Params = Record<string, string>, Props = Record<string, an
 }
 ```
 
-> See the [TypeScript](#typescript) section for information on `SvelteKit.Session` and `SvelteKit.Stuff`.
+> See the [TypeScript](#typescript) section for information on `App.Session` and `App.Stuff`.
 
 Our example blog page might contain a `load` function like the following:
 

--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -10,7 +10,7 @@ A component that defines a page or a layout can export a `load` function that ru
 
 export interface LoadInput<Params extends Record<string, string> = Record<string, string>> {
 	url: URL;
-	params: PageParams;
+	params: Params;
 	fetch(info: RequestInfo, init?: RequestInit): Promise<Response>;
 	session: SvelteKit.Session;
 	stuff: Partial<SvelteKit.Stuff>;
@@ -34,6 +34,8 @@ export interface Load<Params = Record<string, string>, Props = Record<string, an
 	(input: LoadInput<Params>): MaybePromise<Either<Fallthrough, LoadOutput<Props>>>;
 }
 ```
+
+> See the [TypeScript](#typescript) section for information on `SvelteKit.Session` and `SvelteKit.Stuff`.
 
 Our example blog page might contain a `load` function like the following:
 

--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -8,63 +8,30 @@ A component that defines a page or a layout can export a `load` function that ru
 // Declaration types for Loading
 // * declarations that are not exported are for internal use
 
-export interface LoadInput<
-	PageParams extends Record<string, string> = Record<string, string>,
-	Stuff extends Record<string, any> = Record<string, any>,
-	Session = any
-> {
+export interface LoadInput<Params extends Record<string, string> = Record<string, string>> {
 	url: URL;
 	params: PageParams;
 	fetch(info: RequestInfo, init?: RequestInit): Promise<Response>;
-	session: Session;
-	stuff: Stuff;
+	session: SvelteKit.Session;
+	stuff: Partial<SvelteKit.Stuff>;
 }
 
-export interface LoadOutput<
-	Props extends Record<string, any> = Record<string, any>,
-	Stuff extends Record<string, any> = Record<string, any>
-> {
+export interface LoadOutput<Props extends Record<string, any> = Record<string, any>> {
 	status?: number;
 	error?: string | Error;
 	redirect?: string;
 	props?: Props;
-	stuff?: Stuff;
+	stuff?: Partial<SvelteKit.Stuff>;
 	maxage?: number;
-}
-
-interface LoadInputExtends {
-	stuff?: Record<string, any>;
-	pageParams?: Record<string, string>;
-	session?: any;
-}
-interface LoadOutputExtends {
-	stuff?: Record<string, any>;
-	props?: Record<string, any>;
 }
 
 type MaybePromise<T> = T | Promise<T>;
 interface Fallthrough {
 	fallthrough: true;
 }
-export interface Load<
-	Input extends LoadInputExtends = Required<LoadInputExtends>,
-	Output extends LoadOutputExtends = Required<LoadOutputExtends>
-> {
-	(
-		input: LoadInput<
-			InferValue<Input, 'pageParams', Record<string, string>>,
-			InferValue<Input, 'stuff', Record<string, any>>,
-			InferValue<Input, 'session', any>
-		>
-	): MaybePromise<
-		Either<
-			Fallthrough,
-			LoadOutput<
-				InferValue<Output, 'props', Record<string, any>>,
-				InferValue<Output, 'stuff', Record<string, any>>
-			>
-		>
-	>;
+
+export interface Load<Params = Record<string, string>, Props = Record<string, any>> {
+	(input: LoadInput<Params>): MaybePromise<Either<Fallthrough, LoadOutput<Props>>>;
 }
 ```
 

--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -26,8 +26,8 @@ export interface RequestEvent {
 	request: Request;
 	url: URL;
 	params: Record<string, string>;
-	locals: SvelteKit.Locals;
-	platform: SvelteKit.Platform;
+	locals: App.Locals;
+	platform: App.Platform;
 }
 
 export interface ResolveOpts {
@@ -42,7 +42,7 @@ export interface Handle {
 }
 ```
 
-> See the [TypeScript](#typescript) section for information on `SvelteKit.Locals` and `SvelteKit.Platform`.
+> See the [TypeScript](#typescript) section for information on `App.Locals` and `App.Platform`.
 
 To add custom data to the request, which is passed to endpoints, populate the `event.locals` object, as shown below.
 
@@ -111,7 +111,7 @@ If unimplemented, session is `{}`.
 ```ts
 // Declaration types for getSession hook
 export interface GetSession {
-	(event: RequestEvent): MaybePromise<SvelteKit.Session>;
+	(event: RequestEvent): MaybePromise<App.Session>;
 }
 ```
 

--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -42,6 +42,8 @@ export interface Handle {
 }
 ```
 
+> See the [TypeScript](#typescript) section for information on `SvelteKit.Locals` and `SvelteKit.Platform`.
+
 To add custom data to the request, which is passed to endpoints, populate the `event.locals` object, as shown below.
 
 ```js

--- a/documentation/docs/04-hooks.md
+++ b/documentation/docs/04-hooks.md
@@ -22,22 +22,22 @@ If unimplemented, defaults to `({ event, resolve }) => resolve(event)`.
 // everything else must be a type of string
 type ResponseHeaders = Record<string, string | string[]>;
 
-export interface RequestEvent<Locals = Record<string, any>, Platform = Record<string, any>> {
+export interface RequestEvent {
 	request: Request;
 	url: URL;
 	params: Record<string, string>;
-	locals: Locals;
-	platform: Platform;
+	locals: SvelteKit.Locals;
+	platform: SvelteKit.Platform;
 }
 
 export interface ResolveOpts {
 	ssr?: boolean;
 }
 
-export interface Handle<Locals = Record<string, any>, Platform = Record<string, any>> {
+export interface Handle {
 	(input: {
-		event: RequestEvent<Locals, Platform>;
-		resolve(event: RequestEvent<Locals, Platform>, opts?: ResolveOpts): MaybePromise<Response>;
+		event: RequestEvent;
+		resolve(event: RequestEvent, opts?: ResolveOpts): MaybePromise<Response>;
 	}): MaybePromise<Response>;
 }
 ```
@@ -85,8 +85,8 @@ If unimplemented, SvelteKit will log the error with default formatting.
 
 ```ts
 // Declaration types for handleError hook
-export interface HandleError<Locals = Record<string, any>, Platform = Record<string, any>> {
-	(input: { error: Error & { frame?: string }; event: RequestEvent<Locals, Platform> }): void;
+export interface HandleError {
+	(input: { error: Error & { frame?: string }; event: RequestEvent }): void;
 }
 ```
 
@@ -108,12 +108,8 @@ If unimplemented, session is `{}`.
 
 ```ts
 // Declaration types for getSession hook
-export interface GetSession<
-	Locals = Record<string, any>,
-	Platform = Record<string, any>,
-	Session = any
-> {
-	(event: RequestEvent<Locals, Platform>): MaybePromise<Session>;
+export interface GetSession {
+	(event: RequestEvent): MaybePromise<SvelteKit.Session>;
 }
 ```
 
@@ -130,7 +126,7 @@ export function getSession(event) {
 					email: event.locals.user.email,
 					avatar: event.locals.user.avatar
 				}
-			}
+		  }
 		: {};
 }
 ```

--- a/documentation/docs/15-typescript.md
+++ b/documentation/docs/15-typescript.md
@@ -1,0 +1,37 @@
+---
+title: TypeScript
+---
+
+All APIs in SvelteKit are fully typed. Additionally, it's possible to tell SvelteKit how to type objects inside your app by declaring the `SvelteKit` namespace. By default, a new project will have a file called `src/app.d.ts` containing the following:
+
+```ts
+/// <reference types="@sveltejs/kit" />
+
+declare namespace SvelteKit {
+	interface Locals {}
+
+	interface Platform {}
+
+	interface Session {}
+
+	interface Stuff {}
+}
+```
+
+By populating these interfaces, you will gain type safety when using `event.locals`, `event.platform`, `session` and `stuff`:
+
+### SvelteKit.Locals
+
+The interface that defines `event.locals`, which can be accessed in [hooks](#hooks) (`handle`, `handleError` and `getSession`) and [endpoints](#endpoints).
+
+### SvelteKit.Platform
+
+If your adapter provides [platform-specific context](#adapters-supported-environments-platform-specific-context) via `event.platform`, you can specify it here.
+
+### SvelteKit.Session
+
+The interface that defines `session`, both as an argument to [`load`](#loading) functions and the value of the [session store](#modules-$app-stores).
+
+### SvelteKit.Stuff
+
+The interface that defines `stuff`, as input or output to [`load`](#loading) or as the value of the `stuff` property of the [page store](#modules-$app-stores).

--- a/documentation/docs/15-typescript.md
+++ b/documentation/docs/15-typescript.md
@@ -2,12 +2,12 @@
 title: TypeScript
 ---
 
-All APIs in SvelteKit are fully typed. Additionally, it's possible to tell SvelteKit how to type objects inside your app by declaring the `SvelteKit` namespace. By default, a new project will have a file called `src/app.d.ts` containing the following:
+All APIs in SvelteKit are fully typed. Additionally, it's possible to tell SvelteKit how to type objects inside your app by declaring the `App` namespace. By default, a new project will have a file called `src/app.d.ts` containing the following:
 
 ```ts
 /// <reference types="@sveltejs/kit" />
 
-declare namespace SvelteKit {
+declare namespace App {
 	interface Locals {}
 
 	interface Platform {}
@@ -20,18 +20,18 @@ declare namespace SvelteKit {
 
 By populating these interfaces, you will gain type safety when using `event.locals`, `event.platform`, `session` and `stuff`:
 
-### SvelteKit.Locals
+### App.Locals
 
 The interface that defines `event.locals`, which can be accessed in [hooks](#hooks) (`handle`, `handleError` and `getSession`) and [endpoints](#endpoints).
 
-### SvelteKit.Platform
+### App.Platform
 
 If your adapter provides [platform-specific context](#adapters-supported-environments-platform-specific-context) via `event.platform`, you can specify it here.
 
-### SvelteKit.Session
+### App.Session
 
 The interface that defines `session`, both as an argument to [`load`](#loading) functions and the value of the [session store](#modules-$app-stores).
 
-### SvelteKit.Stuff
+### App.Stuff
 
 The interface that defines `stuff`, as input or output to [`load`](#loading) or as the value of the `stuff` property of the [page store](#modules-$app-stores).

--- a/packages/adapter-cloudflare/README.md
+++ b/packages/adapter-cloudflare/README.md
@@ -56,16 +56,25 @@ When configuring your project settings, you must use the following settings:
 
 The [`env`](https://developers.cloudflare.com/workers/runtime-apis/fetch-event#parameters) object, containing KV namespaces etc, is passed to SvelteKit via the `platform` property, meaning you can access it in hooks and endpoints:
 
-```ts
-interface Locals {}
+```diff
+// src/app.d.ts
+declare namespace App {
+	interface Locals {}
 
-interface Platform {
-	env: {
-		COUNTER: DurableObjectNamespace;
-	};
++	interface Platform {
++		env: {
++			COUNTER: DurableObjectNamespace;
++		};
++	}
+
+	interface Session {}
+
+	interface Stuff {}
 }
+```
 
-export async function post<Locals, Platform>({ request, platform }) {
+```js
+export async function post({ request, platform }) {
 	const counter = platform.env.COUNTER.idFromName('A');
 }
 ```

--- a/packages/create-svelte/templates/default/src/app.d.ts
+++ b/packages/create-svelte/templates/default/src/app.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="@sveltejs/kit" />
+
+declare namespace SvelteKit {
+	interface Locals {
+		userid: string;
+	}
+
+	interface Platform {}
+
+	interface Session {}
+
+	interface Stuff {}
+}

--- a/packages/create-svelte/templates/default/src/app.d.ts
+++ b/packages/create-svelte/templates/default/src/app.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="@sveltejs/kit" />
 
-declare namespace SvelteKit {
+declare namespace App {
 	interface Locals {
 		userid: string;
 	}

--- a/packages/create-svelte/templates/default/src/app.d.ts
+++ b/packages/create-svelte/templates/default/src/app.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="@sveltejs/kit" />
 
+// See https://kit.svelte.dev/docs#typescript
+// for information about these interfaces
 declare namespace App {
 	interface Locals {
 		userid: string;

--- a/packages/create-svelte/templates/default/src/global.d.ts
+++ b/packages/create-svelte/templates/default/src/global.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@sveltejs/kit" />

--- a/packages/create-svelte/templates/default/src/lib/types.d.ts
+++ b/packages/create-svelte/templates/default/src/lib/types.d.ts
@@ -1,7 +1,0 @@
-/**
- * Can be made globally available by placing this
- * inside `global.d.ts` and removing `export` keyword
- */
-export interface Locals {
-	userid: string;
-}

--- a/packages/create-svelte/templates/default/src/routes/todos/[uid].json.ts
+++ b/packages/create-svelte/templates/default/src/routes/todos/[uid].json.ts
@@ -1,9 +1,8 @@
 import { api } from './_api';
 import type { RequestHandler } from '@sveltejs/kit';
-import type { Locals } from '$lib/types';
 
 // PATCH /todos/:uid.json
-export const patch: RequestHandler<Locals> = async (event) => {
+export const patch: RequestHandler = async (event) => {
 	const data = await event.request.formData();
 
 	return api(event, `todos/${event.locals.userid}/${event.params.uid}`, {
@@ -13,6 +12,6 @@ export const patch: RequestHandler<Locals> = async (event) => {
 };
 
 // DELETE /todos/:uid.json
-export const del: RequestHandler<Locals> = async (event) => {
+export const del: RequestHandler = async (event) => {
 	return api(event, `todos/${event.locals.userid}/${event.params.uid}`);
 };

--- a/packages/create-svelte/templates/default/src/routes/todos/_api.ts
+++ b/packages/create-svelte/templates/default/src/routes/todos/_api.ts
@@ -1,5 +1,4 @@
 import type { EndpointOutput, RequestEvent } from '@sveltejs/kit';
-import type { Locals } from '$lib/types';
 
 /*
 	This module is used by the /todos.json and /todos/[uid].json
@@ -15,7 +14,7 @@ import type { Locals } from '$lib/types';
 const base = 'https://api.svelte.dev';
 
 export async function api(
-	event: RequestEvent<Locals>,
+	event: RequestEvent,
 	resource: string,
 	data?: Record<string, unknown>
 ): Promise<EndpointOutput> {

--- a/packages/create-svelte/templates/default/src/routes/todos/index.json.ts
+++ b/packages/create-svelte/templates/default/src/routes/todos/index.json.ts
@@ -1,9 +1,8 @@
 import { api } from './_api';
 import type { RequestHandler } from '@sveltejs/kit';
-import type { Locals } from '$lib/types';
 
 // GET /todos.json
-export const get: RequestHandler<Locals> = async (event) => {
+export const get: RequestHandler = async (event) => {
 	// event.locals.userid comes from src/hooks.js
 	const response = await api(event, `todos/${event.locals.userid}`);
 
@@ -17,7 +16,7 @@ export const get: RequestHandler<Locals> = async (event) => {
 };
 
 // POST /todos.json
-export const post: RequestHandler<Locals> = async (event) => {
+export const post: RequestHandler = async (event) => {
 	const data = await event.request.formData();
 
 	const response = await api(event, `todos/${event.locals.userid}`, {

--- a/packages/create-svelte/templates/skeleton/src/app.d.ts
+++ b/packages/create-svelte/templates/skeleton/src/app.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="@sveltejs/kit" />
 
-declare namespace SvelteKit {
+declare namespace App {
 	interface Locals {}
 
 	interface Platform {}

--- a/packages/create-svelte/templates/skeleton/src/app.d.ts
+++ b/packages/create-svelte/templates/skeleton/src/app.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="@sveltejs/kit" />
 
+// See https://kit.svelte.dev/docs#typescript
+// for information about these interfaces
 declare namespace App {
 	interface Locals {}
 

--- a/packages/create-svelte/templates/skeleton/src/app.d.ts
+++ b/packages/create-svelte/templates/skeleton/src/app.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="@sveltejs/kit" />
+
+declare namespace SvelteKit {
+	interface Locals {}
+
+	interface Platform {}
+
+	interface Session {}
+
+	interface Stuff {}
+}

--- a/packages/create-svelte/templates/skeleton/src/global.d.ts
+++ b/packages/create-svelte/templates/skeleton/src/global.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@sveltejs/kit" />

--- a/packages/kit/.eslintrc.json
+++ b/packages/kit/.eslintrc.json
@@ -11,5 +11,8 @@
 		"prefetchRoutes": true,
 		"beforeNavigate": true,
 		"afterNavigate": true
+	},
+	"rules": {
+		"@typescript-eslint/no-empty-interface": "off"
 	}
 }

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -175,6 +175,7 @@ export async function create_plugin(config, cwd) {
 
 						/** @type {import('types/internal').Hooks} */
 						const hooks = {
+							// @ts-expect-error this picks up types that belong to the tests
 							getSession: user_hooks.getSession || (() => ({})),
 							handle: amp ? sequence(amp, handle) : handle,
 							handleError:

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -60,6 +60,7 @@ export async function respond(request, options, state = {}) {
 		request,
 		url,
 		params: {},
+		// @ts-expect-error this picks up types that belong to the tests
 		locals: {},
 		platform: state.platform
 	};

--- a/packages/kit/test/apps/basics/src/app.d.ts
+++ b/packages/kit/test/apps/basics/src/app.d.ts
@@ -1,4 +1,11 @@
 declare namespace SvelteKit {
+	interface Locals {
+		answer: number;
+		name: string;
+	}
+
+	interface Platform {}
+
 	interface Session {
 		answer: number;
 		calls: number;

--- a/packages/kit/test/apps/basics/src/app.d.ts
+++ b/packages/kit/test/apps/basics/src/app.d.ts
@@ -1,4 +1,4 @@
-declare namespace SvelteKit {
+declare namespace App {
 	interface Locals {
 		answer: number;
 		name: string;

--- a/packages/kit/test/apps/basics/src/app.d.ts
+++ b/packages/kit/test/apps/basics/src/app.d.ts
@@ -1,0 +1,15 @@
+declare namespace SvelteKit {
+	interface Session {
+		answer: number;
+		calls: number;
+	}
+
+	interface Stuff {
+		message: string;
+		error: string;
+		page: string;
+		value: number;
+		x: string;
+		y: string;
+	}
+}

--- a/packages/kit/test/apps/basics/src/hooks.js
+++ b/packages/kit/test/apps/basics/src/hooks.js
@@ -4,7 +4,10 @@ import { sequence } from '../../../../src/hooks';
 
 /** @type {import('@sveltejs/kit').GetSession} */
 export function getSession(request) {
-	return request.locals;
+	return {
+		answer: request.locals.answer,
+		calls: 0
+	};
 }
 
 /** @type {import('@sveltejs/kit').HandleError} */

--- a/packages/kit/test/apps/basics/src/routes/store/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/store/index.svelte
@@ -7,12 +7,18 @@
 	let calls = 0;
 
 	onMount(() => {
-		session.set(calls);
+		session.update(($session) => ({
+			...$session,
+			calls
+		}));
 	});
 
 	const unsubscribe = page.subscribe(() => {
 		calls++;
-		session.set(calls);
+		session.update(($session) => ({
+			...$session,
+			calls
+		}));
 	});
 
 	onDestroy(unsubscribe);

--- a/packages/kit/test/apps/basics/src/routes/store/result.svelte
+++ b/packages/kit/test/apps/basics/src/routes/store/result.svelte
@@ -8,7 +8,7 @@
 	let calls = 0;
 
 	onMount(() => {
-		calls = get(session);
+		({ calls } = get(session));
 	});
 </script>
 

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-duplicates */
 
-declare namespace SvelteKit {
+declare namespace App {
 	interface Locals {}
 	interface Platform {}
 	interface Session {}
@@ -116,7 +116,7 @@ declare module '$app/stores' {
 	export function getStores(): {
 		navigating: typeof navigating;
 		page: typeof page;
-		session: Writable<SvelteKit.Session>;
+		session: Writable<App.Session>;
 		updated: typeof updated;
 	};
 	/**
@@ -139,7 +139,7 @@ declare module '$app/stores' {
 	 * A writable store whose initial value is whatever was returned from `getSession`.
 	 * It can be written to, but this will not cause changes to persist on the server — this is something you must implement yourself.
 	 */
-	export const session: Writable<SvelteKit.Session>;
+	export const session: Writable<App.Session>;
 	/**
 	 * A writable store indicating if the site was updated since the store was created.
 	 * It can be written to when custom logic is required to detect updates.

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -1,5 +1,12 @@
 /* eslint-disable import/no-duplicates */
 
+declare namespace SvelteKit {
+	interface Locals {}
+	interface Platform {}
+	interface Session {}
+	interface Stuff {}
+}
+
 declare module '$app/env' {
 	/**
 	 * Whether or not app is in AMP mode.
@@ -106,10 +113,10 @@ declare module '$app/stores' {
 	 * A convenience function around `getContext` that returns `{ navigating, page, session }`.
 	 * Most of the time, you won't need to use it.
 	 */
-	export function getStores<Session = any>(): {
+	export function getStores(): {
 		navigating: typeof navigating;
 		page: typeof page;
-		session: Writable<Session>;
+		session: Writable<SvelteKit.Session>;
 		updated: typeof updated;
 	};
 	/**
@@ -132,7 +139,7 @@ declare module '$app/stores' {
 	 * A writable store whose initial value is whatever was returned from `getSession`.
 	 * It can be written to, but this will not cause changes to persist on the server — this is something you must implement yourself.
 	 */
-	export const session: Writable<any>;
+	export const session: Writable<SvelteKit.Session>;
 	/**
 	 * A writable store indicating if the site was updated since the store was created.
 	 * It can be written to when custom logic is required to detect updates.

--- a/packages/kit/types/endpoint.d.ts
+++ b/packages/kit/types/endpoint.d.ts
@@ -13,12 +13,6 @@ export interface Fallthrough {
 	fallthrough: true;
 }
 
-export interface RequestHandler<
-	Locals = Record<string, any>,
-	Platform = Record<string, any>,
-	Output extends Body = Body
-> {
-	(event: RequestEvent<Locals, Platform>): MaybePromise<
-		Either<Response | EndpointOutput<Output>, Fallthrough>
-	>;
+export interface RequestHandler<Output extends Body = Body> {
+	(event: RequestEvent): MaybePromise<Either<Response | EndpointOutput<Output>, Fallthrough>>;
 }

--- a/packages/kit/types/helper.d.ts
+++ b/packages/kit/types/helper.d.ts
@@ -16,9 +16,6 @@ export type ResponseHeaders = Record<string, string | string[]>;
 type Only<T, U> = { [P in keyof T]: T[P] } & { [P in Exclude<keyof U, keyof T>]?: never };
 
 export type Either<T, U> = Only<T, U> | Only<U, T>;
-export type InferValue<T, Key extends keyof T, Default> = T extends Record<Key, infer Val>
-	? Val
-	: Default;
 export type MaybePromise<T> = T | Promise<T>;
 export type RecursiveRequired<T> = {
 	// Recursive implementation of TypeScript's Required utility type.

--- a/packages/kit/types/hooks.d.ts
+++ b/packages/kit/types/hooks.d.ts
@@ -6,12 +6,12 @@ export interface RequestEvent {
 	request: Request;
 	url: URL;
 	params: Record<string, string>;
-	locals: SvelteKit.Locals;
-	platform: Readonly<SvelteKit.Platform>;
+	locals: App.Locals;
+	platform: Readonly<App.Platform>;
 }
 
 export interface GetSession {
-	(event: RequestEvent): MaybePromise<SvelteKit.Session>;
+	(event: RequestEvent): MaybePromise<App.Session>;
 }
 
 export interface ResolveOpts {

--- a/packages/kit/types/hooks.d.ts
+++ b/packages/kit/types/hooks.d.ts
@@ -2,35 +2,31 @@ import { MaybePromise } from './helper';
 
 export type StrictBody = string | Uint8Array;
 
-export interface RequestEvent<Locals = Record<string, any>, Platform = Record<string, any>> {
+export interface RequestEvent {
 	request: Request;
 	url: URL;
 	params: Record<string, string>;
-	locals: Locals;
-	platform: Readonly<Platform>;
+	locals: SvelteKit.Locals;
+	platform: Readonly<SvelteKit.Platform>;
 }
 
-export interface GetSession<
-	Locals = Record<string, any>,
-	Platform = Record<string, any>,
-	Session = any
-> {
-	(event: RequestEvent<Locals, Platform>): MaybePromise<Session>;
+export interface GetSession {
+	(event: RequestEvent): MaybePromise<SvelteKit.Session>;
 }
 
 export interface ResolveOpts {
 	ssr?: boolean;
 }
 
-export interface Handle<Locals = Record<string, any>, Platform = Record<string, any>> {
+export interface Handle {
 	(input: {
-		event: RequestEvent<Locals, Platform>;
-		resolve(event: RequestEvent<Locals, Platform>, opts?: ResolveOpts): MaybePromise<Response>;
+		event: RequestEvent;
+		resolve(event: RequestEvent, opts?: ResolveOpts): MaybePromise<Response>;
 	}): MaybePromise<Response>;
 }
 
-export interface HandleError<Locals = Record<string, any>> {
-	(input: { error: Error & { frame?: string }; event: RequestEvent<Locals> }): void;
+export interface HandleError {
+	(input: { error: Error & { frame?: string }; event: RequestEvent }): void;
 }
 
 export interface ExternalFetch {

--- a/packages/kit/types/page.d.ts
+++ b/packages/kit/types/page.d.ts
@@ -23,14 +23,6 @@ export interface LoadOutput<Props = Record<string, any>> {
 	maxage?: number;
 }
 
-interface LoadInputExtends {
-	params?: Record<string, string>;
-}
-
-interface LoadOutputExtends {
-	props?: Record<string, any>;
-}
-
 export interface Load<Params = Record<string, string>, Props = Record<string, any>> {
 	(input: LoadInput<Params>): MaybePromise<Either<Fallthrough, LoadOutput<Props>>>;
 }

--- a/packages/kit/types/page.d.ts
+++ b/packages/kit/types/page.d.ts
@@ -1,85 +1,40 @@
 import { Fallthrough } from './endpoint';
-import { Either, InferValue, MaybePromise } from './helper';
+import { Either, MaybePromise } from './helper';
 
-export interface LoadInput<
-	PageParams extends Record<string, string> = Record<string, string>,
-	Stuff extends Record<string, any> = Record<string, any>,
-	Session = any
-> {
+export interface LoadInput<Params = Record<string, string>> {
 	url: URL;
-	params: PageParams;
+	params: Params;
 	fetch(info: RequestInfo, init?: RequestInit): Promise<Response>;
-	session: Session;
-	stuff: Stuff;
+	session: SvelteKit.Session;
+	stuff: Partial<SvelteKit.Stuff>;
 }
 
-export interface ErrorLoadInput<
-	PageParams extends Record<string, string> = Record<string, string>,
-	Stuff extends Record<string, any> = Record<string, any>,
-	Session = any
-> extends LoadInput<PageParams, Stuff, Session> {
+export interface ErrorLoadInput<Params = Record<string, string>> extends LoadInput<Params> {
 	status?: number;
 	error?: Error;
 }
 
-export interface LoadOutput<
-	Props extends Record<string, any> = Record<string, any>,
-	Stuff extends Record<string, any> = Record<string, any>
-> {
+export interface LoadOutput<Props = Record<string, any>> {
 	status?: number;
 	error?: string | Error;
 	redirect?: string;
 	props?: Props;
-	stuff?: Stuff;
+	stuff?: Partial<SvelteKit.Stuff>;
 	maxage?: number;
 }
 
 interface LoadInputExtends {
-	stuff?: Record<string, any>;
-	pageParams?: Record<string, string>;
-	session?: any;
+	params?: Record<string, string>;
 }
 
 interface LoadOutputExtends {
-	stuff?: Record<string, any>;
 	props?: Record<string, any>;
 }
 
-export interface Load<
-	Input extends LoadInputExtends = Required<LoadInputExtends>,
-	Output extends LoadOutputExtends = Required<LoadOutputExtends>
-> {
-	(
-		input: LoadInput<
-			InferValue<Input, 'pageParams', Record<string, string>>,
-			InferValue<Input, 'stuff', Record<string, any>>,
-			InferValue<Input, 'session', any>
-		>
-	): MaybePromise<
-		Either<
-			Fallthrough,
-			LoadOutput<
-				InferValue<Output, 'props', Record<string, any>>,
-				InferValue<Output, 'stuff', Record<string, any>>
-			>
-		>
-	>;
+export interface Load<Params = Record<string, string>, Props = Record<string, any>> {
+	(input: LoadInput<Params>): MaybePromise<Either<Fallthrough, LoadOutput<Props>>>;
 }
 
-export interface ErrorLoad<
-	Input extends LoadInputExtends = Required<LoadInputExtends>,
-	Output extends LoadOutputExtends = Required<LoadOutputExtends>
-> {
-	(
-		input: ErrorLoadInput<
-			InferValue<Input, 'pageParams', Record<string, string>>,
-			InferValue<Input, 'stuff', Record<string, any>>,
-			InferValue<Input, 'session', any>
-		>
-	): MaybePromise<
-		LoadOutput<
-			InferValue<Output, 'props', Record<string, any>>,
-			InferValue<Output, 'stuff', Record<string, any>>
-		>
-	>;
+export interface ErrorLoad<Params = Record<string, string>, Props = Record<string, any>> {
+	(input: ErrorLoadInput<Params>): MaybePromise<LoadOutput<Props>>;
 }

--- a/packages/kit/types/page.d.ts
+++ b/packages/kit/types/page.d.ts
@@ -5,8 +5,8 @@ export interface LoadInput<Params = Record<string, string>> {
 	url: URL;
 	params: Params;
 	fetch(info: RequestInfo, init?: RequestInit): Promise<Response>;
-	session: SvelteKit.Session;
-	stuff: Partial<SvelteKit.Stuff>;
+	session: App.Session;
+	stuff: Partial<App.Stuff>;
 }
 
 export interface ErrorLoadInput<Params = Record<string, string>> extends LoadInput<Params> {
@@ -19,7 +19,7 @@ export interface LoadOutput<Props = Record<string, any>> {
 	error?: string | Error;
 	redirect?: string;
 	props?: Props;
-	stuff?: Partial<SvelteKit.Stuff>;
+	stuff?: Partial<App.Stuff>;
 	maxage?: number;
 }
 


### PR DESCRIPTION
Ref #3569.

This is a breaking change, as it affects how `Load` and `ErrorLoad` are typed if you're using generic arguments. If you're not, TypeScript will likely start yelling at you because `session` and `locals` etc are no longer typed as `any`.

By creating an app-level `namespace`, we're able to provide types for `event.locals`, `event.platform`, `page.session` and `page.stuff` throughout the app with no duplication. One caveat — it's no longer possible to specify input `stuff` and output `stuff` separately for a `load` function (unless you create your own type, I suppose) which might be a nuisance if you're ultra-pedantic. Personally I think the ergonomics are vastly better this way.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
