### PR TITLE
[fix] HTML crawl regression

### DIFF
--- a/.changeset/tidy-pigs-peel.md
+++ b/.changeset/tidy-pigs-peel.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix regression in parsing HTML when crawling for pre-rendering

--- a/packages/kit/src/core/adapt/prerender/crawl.js
+++ b/packages/kit/src/core/adapt/prerender/crawl.js
@@ -25,7 +25,7 @@ export function crawl(html) {
 			if (html[i + 1] === '!') {
 				i += 2;
 
-				if (html.substring(i, DOCTYPE.length).toUpperCase() === DOCTYPE) {
+				if (html.substr(i, DOCTYPE.length).toUpperCase() === DOCTYPE) {
 					i += DOCTYPE.length;
 					while (i < html.length) {
 						if (html[i++] === '>') {
@@ -35,10 +35,10 @@ export function crawl(html) {
 				}
 
 				// skip cdata
-				if (html.substring(i, CDATA_OPEN.length) === CDATA_OPEN) {
+				if (html.substr(i, CDATA_OPEN.length) === CDATA_OPEN) {
 					i += CDATA_OPEN.length;
 					while (i < html.length) {
-						if (html.substring(i, CDATA_CLOSE.length) === CDATA_CLOSE) {
+						if (html.substr(i, CDATA_CLOSE.length) === CDATA_CLOSE) {
 							i += CDATA_CLOSE.length;
 							continue main;
 						}
@@ -48,10 +48,10 @@ export function crawl(html) {
 				}
 
 				// skip comments
-				if (html.substring(i, COMMENT_OPEN.length) === COMMENT_OPEN) {
+				if (html.substr(i, COMMENT_OPEN.length) === COMMENT_OPEN) {
 					i += COMMENT_OPEN.length;
 					while (i < html.length) {
-						if (html.substring(i, COMMENT_CLOSE.length) === COMMENT_CLOSE) {
+						if (html.substr(i, COMMENT_CLOSE.length) === COMMENT_CLOSE) {
 							i += COMMENT_CLOSE.length;
 							continue main;
 						}
@@ -79,7 +79,7 @@ export function crawl(html) {
 						if (
 							html[i] === '<' &&
 							html[i + 1] === '/' &&
-							html.substring(i + 2, tag.length).toUpperCase() === tag
+							html.substr(i + 2, tag.length).toUpperCase() === tag
 						) {
 							continue main;
 						}


### PR DESCRIPTION
Whoops. #3668 introduced a bunch of huge bugs because `substr` is not the same as `substring`. We could keep using `substr` even though it's deprecated, or we could rewrite this. I've opted for the former because I want to get this fixed quickly.

There are also no new tests. Ideally this dumb bug would have been caught by a test, but it wasn't, and I'm not going to write more right now, also because I want to get this fixed quickly.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
