### PR TITLE
Remove target config option from docs

### DIFF
--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -223,7 +223,6 @@ See [Prerendering](#page-options-prerender). An object containing zero or more o
     export default {
     	kit: {
     		adapter: adapter(),
-    		target: '#svelte',
     		prerender: {
     			onError: handleError
     		}

--- a/documentation/faq/80-integrations.md
+++ b/documentation/faq/80-integrations.md
@@ -26,7 +26,6 @@ const myPlugin = {
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		target: '#svelte',
 		vite: {
 			plugins: [ myPlugin ]
 		}


### PR DESCRIPTION
Removes mentions of the `target` config option from the docs