### PR TITLE
Update $app/stores page.stuff to use App.Stuff

### DIFF
--- a/.changeset/sharp-beers-know.md
+++ b/.changeset/sharp-beers-know.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+Update $app/stores page.stuff to use App.Stuff

--- a/packages/kit/types/ambient-modules.d.ts
+++ b/packages/kit/types/ambient-modules.d.ts
@@ -125,7 +125,7 @@ declare module '$app/stores' {
 	export const page: Readable<{
 		url: URL;
 		params: Record<string, string>;
-		stuff: Record<string, any>;
+		stuff: App.Stuff;
 		status: number;
 		error: Error | null;
 	}>;


### PR DESCRIPTION
Following https://github.com/sveltejs/kit/pull/3670, `page.stuff` from `$app/stores` should use `App.Stuff` instead of the old `Record<string, any>`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
