### PR TITLE
[fix] exclude Host header from load fetch requests made on server

### DIFF
--- a/.changeset/giant-rice-notice.md
+++ b/.changeset/giant-rice-notice.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Prevent `Host` header from being incorrectly inherited by requests made from `load`'s `fetch` during SSR

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -96,9 +96,15 @@ export async function load_node({
 
 				// merge headers from request
 				for (const [key, value] of event.request.headers) {
-					if (opts.headers.has(key)) continue;
-					if (key === 'cookie' || key === 'authorization' || key === 'if-none-match') continue;
-					opts.headers.set(key, value);
+					if (
+						key !== 'authorization' &&
+						key !== 'cookie' &&
+						key !== 'host' &&
+						key !== 'if-none-match' &&
+						!opts.headers.has(key)
+					) {
+						opts.headers.set(key, value);
+					}
 				}
 
 				opts.headers.set('referer', event.url.href);


### PR DESCRIPTION
Having child requests made via `fetch` from `load` during SSR include the `Host` header is bad. At the very least, it causes SSL certificate issues. (I'm not sure whether it causes other issues in shared-IP / dynamic host environments - I don't know whether the value in the headers or in the URL takes precedence in `node-fetch`.)

This skips over the `Host` header as well when copying the headers into the outgoing request. I looked at the existing test added in #3631, but I wasn't sure how to extend it.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
