### PR TITLE
implicitly allow `Response` object instance

### DIFF
--- a/.changeset/few-rockets-sort.md
+++ b/.changeset/few-rockets-sort.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Allow Response object to be returned without properties showing up in object constructor

--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -72,7 +72,9 @@ interface Fallthrough {
 }
 
 export interface RequestHandler<Output extends Body = Body> {
-	(event: RequestEvent): MaybePromise<Either<Response | EndpointOutput<Output>, Fallthrough>>;
+	(event: RequestEvent): MaybePromise<
+		Either<Output extends Response ? Response : EndpointOutput<Output>, Fallthrough>
+	>;
 }
 ```
 

--- a/packages/kit/types/endpoint.d.ts
+++ b/packages/kit/types/endpoint.d.ts
@@ -14,5 +14,7 @@ export interface Fallthrough {
 }
 
 export interface RequestHandler<Output extends Body = Body> {
-	(event: RequestEvent): MaybePromise<Either<Response | EndpointOutput<Output>, Fallthrough>>;
+	(event: RequestEvent): MaybePromise<
+		Either<Output extends Response ? Response : EndpointOutput<Output>, Fallthrough>
+	>;
 }


### PR DESCRIPTION
This will only show our `EndpointOutput` properties, but still allow `Response` instances to be returned

|constructor|instance|
|---|---|
|![image](https://user-images.githubusercontent.com/8156777/152294193-cd3e6ca6-90ae-42c8-a8fa-e4239cbaa1ab.png)|![image](https://user-images.githubusercontent.com/8156777/152294589-0e60bf10-465e-4386-ba5e-c02220997249.png)|

Fixes #3676 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
