### PR TITLE
[fix] Allow numeric as value of header

### DIFF
--- a/.changeset/sharp-mugs-melt.md
+++ b/.changeset/sharp-mugs-melt.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Handle numeric headers

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -4,7 +4,7 @@ import { s } from '../../../utils/misc.js';
 import { escape_json_string_in_html } from '../../../utils/escape.js';
 import { is_root_relative, resolve } from '../../../utils/url.js';
 import { create_prerendering_url_proxy } from './utils.js';
-import { is_pojo } from '../utils.js';
+import { is_pojo, lowercase_keys } from '../utils.js';
 import { coalesce_to_error } from '../../../utils/error.js';
 
 /**
@@ -397,13 +397,8 @@ async function load_shadow_data(route, event, prerender) {
 
 			if (result.fallthrough) return result;
 
-			const { status = 200, headers = {}, body = {} } = result;
-
-			validate_shadow_output(headers, body);
-
-			if (headers['set-cookie']) {
-				/** @type {string[]} */ (data.cookies).push(...headers['set-cookie']);
-			}
+			const { status, headers, body } = validate_shadow_output(result);
+			add_cookies(/** @type {string[]} */ (data.cookies), headers);
 
 			// Redirects are respected...
 			if (status >= 300 && status < 400) {
@@ -427,13 +422,8 @@ async function load_shadow_data(route, event, prerender) {
 
 			if (result.fallthrough) return result;
 
-			const { status = 200, headers = {}, body = {} } = result;
-
-			validate_shadow_output(headers, body);
-
-			if (headers['set-cookie']) {
-				/** @type {string[]} */ (data.cookies).push(...headers['set-cookie']);
-			}
+			const { status, headers, body } = validate_shadow_output(result);
+			add_cookies(/** @type {string[]} */ (data.cookies), headers);
 
 			if (status >= 400) {
 				return {
@@ -464,17 +454,40 @@ async function load_shadow_data(route, event, prerender) {
 }
 
 /**
- * @param {Headers | Partial<import('types/helper').ResponseHeaders>} headers
- * @param {import('types/helper').JSONValue} body
+ * @param {string[]} target
+ * @param {Partial<import('types/helper').ResponseHeaders>} headers
  */
-function validate_shadow_output(headers, body) {
-	if (headers instanceof Headers && headers.has('set-cookie')) {
-		throw new Error(
-			'Shadow endpoint request handler cannot use Headers interface with Set-Cookie headers'
-		);
+function add_cookies(target, headers) {
+	const cookies = headers['set-cookie'];
+	if (cookies) {
+		if (Array.isArray(cookies)) {
+			target.push(...cookies);
+		} else {
+			target.push(/** @type {string} */ (cookies));
+		}
+	}
+}
+
+/**
+ * @param {import('types/endpoint').ShadowEndpointOutput} result
+ */
+function validate_shadow_output(result) {
+	const { status = 200, body = {} } = result;
+	let headers = result.headers || {};
+
+	if (headers instanceof Headers) {
+		if (headers.has('set-cookie')) {
+			throw new Error(
+				'Shadow endpoint request handler cannot use Headers interface with Set-Cookie headers'
+			);
+		}
+	} else {
+		headers = lowercase_keys(/** @type {Record<string, string>} */ (headers));
 	}
 
 	if (!is_pojo(body)) {
 		throw new Error('Body returned from shadow endpoint request handler must be a plain object');
 	}
+
+	return { status, headers, body };
 }

--- a/packages/kit/src/utils/http.js
+++ b/packages/kit/src/utils/http.js
@@ -7,12 +7,12 @@ export function to_headers(object) {
 			const value = object[key];
 			if (!value) continue;
 
-			if (typeof value === 'string' || typeof value === 'number') {
-				headers.set(key, value);
-			} else {
+			if (Array.isArray(value)) {
 				value.forEach((value) => {
-					headers.append(key, value);
+					headers.append(key, /** @type {string} */ (value));
 				});
+			} else {
+				headers.set(key, /** @type {string} */ (value));
 			}
 		}
 	}

--- a/packages/kit/src/utils/http.js
+++ b/packages/kit/src/utils/http.js
@@ -7,7 +7,7 @@ export function to_headers(object) {
 			const value = object[key];
 			if (!value) continue;
 
-			if (typeof value === 'string') {
+			if (typeof value === 'string' || typeof value === 'number') {
 				headers.set(key, value);
 			} else {
 				value.forEach((value) => {

--- a/packages/kit/src/utils/http.spec.js
+++ b/packages/kit/src/utils/http.spec.js
@@ -1,0 +1,36 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { to_headers } from './http.js';
+import { Headers } from 'node-fetch';
+globalThis.Headers = Headers;
+
+function assert_headers_equal(actual, expected) {
+	assert.equal(Array.from(actual.entries()), Array.from(expected.entries()));
+}
+
+test('handle header string value', () => {
+	const headers = new Headers();
+	headers.set('name', 'value');
+	assert_headers_equal(to_headers({ name: 'value' }), headers);
+});
+
+test('handle header array values', () => {
+	const headers = new Headers();
+	headers.append('name', 'value1');
+	headers.append('name', 'value2');
+	assert_headers_equal(to_headers({ name: ['value1', 'value2'] }), headers);
+});
+
+test('handle header int value', () => {
+	const headers = new Headers();
+	headers.set('name', 123);
+	assert_headers_equal(to_headers({ name: 123 }), headers);
+});
+
+test('handle header decimal value', () => {
+	const headers = new Headers();
+	headers.set('name', 123.456);
+	assert_headers_equal(to_headers({ name: 123.456 }), headers);
+});
+
+test.run();

--- a/packages/kit/src/utils/http.spec.js
+++ b/packages/kit/src/utils/http.spec.js
@@ -4,33 +4,24 @@ import { to_headers } from './http.js';
 import { Headers } from 'node-fetch';
 globalThis.Headers = Headers;
 
-function assert_headers_equal(actual, expected) {
-	assert.equal(Array.from(actual.entries()), Array.from(expected.entries()));
-}
-
 test('handle header string value', () => {
-	const headers = new Headers();
-	headers.set('name', 'value');
-	assert_headers_equal(to_headers({ name: 'value' }), headers);
+	const headers = to_headers({ name: 'value' });
+	assert.equal(headers.get('name'), 'value');
 });
 
 test('handle header array values', () => {
-	const headers = new Headers();
-	headers.append('name', 'value1');
-	headers.append('name', 'value2');
-	assert_headers_equal(to_headers({ name: ['value1', 'value2'] }), headers);
+	const headers = to_headers({ name: ['value1', 'value2'] });
+	assert.equal(headers.get('name'), 'value1, value2');
 });
 
 test('handle header int value', () => {
-	const headers = new Headers();
-	headers.set('name', 123);
-	assert_headers_equal(to_headers({ name: 123 }), headers);
+	const headers = to_headers({ name: 123 });
+	assert.equal(headers.get('name'), '123');
 });
 
 test('handle header decimal value', () => {
-	const headers = new Headers();
-	headers.set('name', 123.456);
-	assert_headers_equal(to_headers({ name: 123.456 }), headers);
+	const headers = to_headers({ name: 123.456 });
+	assert.equal(headers.get('name'), '123.456');
 });
 
 test.run();

--- a/packages/kit/types/helper.d.ts
+++ b/packages/kit/types/helper.d.ts
@@ -4,7 +4,7 @@ export type JSONObject = { [key: string]: JSONValue };
 export type JSONValue = string | number | boolean | null | ToJSON | JSONValue[] | JSONObject;
 
 /** `string[]` is only for set-cookie, everything else must be type of `string` */
-export type ResponseHeaders = Record<string, string | string[]>;
+export type ResponseHeaders = Record<string, string | number | string[]>;
 
 // <-- Utility Types -->
 type Only<T, U> = { [P in keyof T]: T[P] } & { [P in Exclude<keyof U, keyof T>]?: never };


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

----

In the current version of SvelteKit, if an endpoint return an header with a numeric value, an error is raise:
> `TypeError: value.forEach is not a function`

The test on the value only assume that value can be either a `string` or an Array (the assumption is on the array).
https://github.com/sveltejs/kit/blob/89a97551f9e771e0e00064646a5196b943480ab1/packages/kit/src/utils/http.js#L10-L12

Per definition, a header value can only be a text (there is no typing in the HTTP protocol).
The type definition also define string and an array of string as only possibility
https://github.com/sveltejs/kit/blob/89a97551f9e771e0e00064646a5196b943480ab1/packages/kit/types/helper.d.ts#L7

But nothing prevent a number (integer or decimal) to be defined (if not typing check is done) and there are not, per say, wrong (for example `content-length` header is a numerical value)

----

Another approach can be to ignore all values that are not a `string` or an **array of `string`**
```js
if (typeof value === 'string') { // Allow string value
	headers.set(key, value);
} else if (Array.isArray(value)) { // Allow array
	value
		.filter((value) => typeof value === 'string') // Ignore every value that are not string
		.forEach((value) => {
			headers.append(key, value);
		});
} // values that are not a string or an array are ignored
```

----

The fact that user should set correctly headers can also be a way to handle this case.
Then feel free to close the PR :wink: 