### PR TITLE
Address playwright race conditions and environment timeouts

### DIFF
--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -60,7 +60,7 @@ export const test = base.extend({
 			if (javaScriptEnabled) {
 				await page.evaluate(() => {
 					window.navigated = new Promise((fulfil, reject) => {
-						const timeout = setTimeout(() => reject(new Error('Timed out')), 2000);
+						const timeout = setTimeout(() => reject(new Error('Timed out')), 5000);
 						addEventListener(
 							'sveltekit:navigation-end',
 							() => {
@@ -86,7 +86,7 @@ export const test = base.extend({
 			if (javaScriptEnabled) {
 				await page.evaluate(() => {
 					window.navigated = new Promise((fulfil, reject) => {
-						const timeout = setTimeout(() => reject(new Error('Timed out')), 2000);
+						const timeout = setTimeout(() => reject(new Error('Timed out')), 5000);
 						addEventListener(
 							'sveltekit:navigation-end',
 							() => {
@@ -111,20 +111,25 @@ export const test = base.extend({
 	in_view: async ({ page }, use) => {
 		/** @param {string} selector */
 		async function in_view(selector) {
-			// @ts-expect-error
-			return page.$eval(selector, async (element) => {
-				const { top, bottom } = element.getBoundingClientRect();
+			const isVisible = await page.isVisible(selector);
+			if (!isVisible) {
+				// @ts-expect-error
+				return page.$eval(selector, async (element) => {
+					const { top, bottom } = element.getBoundingClientRect();
 
-				if (top > window.innerHeight || bottom < 0) {
-					// slightly more useful feedback than true/false
-					return {
-						top,
-						bottom
-					};
-				}
+					if (top > window.innerHeight || bottom < 0) {
+						// slightly more useful feedback than true/false
+						return {
+							top,
+							bottom
+						};
+					}
 
-				return true;
-			});
+					return true;
+				});
+			}
+
+			return isVisible;
 		}
 
 		use(in_view);
@@ -181,7 +186,13 @@ export const test = base.extend({
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 export const config = {
 	// generous timeouts on CI, especially on windows
-	timeout: process.env.CI ? (process.platform === 'win32' ? 45000 : 30000) : 10000,
+	timeout: process.env.CI
+		? process.platform === 'win32'
+			? 45000
+			: 30000
+		: process.platform === 'win32'
+		? 15000
+		: 10000,
 	webServer: {
 		command: process.env.DEV ? 'npm run dev' : 'npm run build && npm run preview',
 		port: 3000


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0



Attempting to resolve #3552

First, the obligatory "it works on my machine"...

In attempting to address this issue, I encountered the following underlying difficulties:
 1) Addressing "prefetches programmatically" test race by waiting for playwright network event
 2) Handling environment dependent network requests issued by "prefetches programmatically" test
 3) Addressing visibility issues by using playwright's page.isVisible method
 4) Random test timeouts on my local machine, and apparently also in other environments according to [discord](https://discord.com/channels/457912077277855764/750401468569354431/939343653434982451). These were addressed by bumping the window.setTimeout threshold from 2s to 5s AND the test harness from 10s to 15s in utils.js, both of which were required.

Further info on changes for "prefetches programmatically" test, the following debug output
```
console.log(`waiting for ${baseURL}/routing/prefetched.json`);
requests.forEach((req) => {
  console.log(`req was: ${req}`);
});
```
Resulted in
```
waiting for http://localhost:3000/routing/prefetched.json
req was: http://localhost:3000/src/routes/routing/prefetched/index.svelte
req was: http://localhost:3000/@fs/C:/kit/packages/kit/src/runtime/env.js
req was: http://localhost:3000/routing/prefetched.json

waiting for http://localhost:3000/routing/prefetched.json
req was: http://localhost:3000/src/routes/routing/prefetched/index.svelte
req was: http://localhost:3000/routing/prefetched.json

waiting for http://localhost:3000/routing/prefetched.json
req was: http://localhost:3000/_app/pages/routing/prefetched/index.svelte-b0244d07.js
req was: http://localhost:3000/routing/prefetched.json
```
Note depending upon the vite mode, sometimes a third "fs" path would be fetched.

Possible improvements:
  1) Unfortunately, the sets_paths and trailingSlash tests still fail on windows, seemingly reliably at least. Should I open a separate for this?
  2) Should the integration timeout values just be changed to the following, in order to account for additional failures mentioned in the [discord discussion](https://discord.com/channels/457912077277855764/750401468569354431/939343653434982451):
     timeout: process.env.CI ? 45000 : 15000,


All feedback welcome!

Last but not least thank you so much for your efforts on this project, SvelteKit and Svelte are wonderful!