### PR TITLE
Re-evaluate even when transitioning between pages of the same component

### DIFF
--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -354,6 +354,11 @@ export class Renderer {
 
 		if (this.started) {
 			this.current = navigation_result.state;
+			
+			this.root.$set({
+				components: [],
+			});
+			await tick();
 
 			this.root.$set(navigation_result.props);
 			this.stores.navigating.set(null);

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -354,9 +354,9 @@ export class Renderer {
 
 		if (this.started) {
 			this.current = navigation_result.state;
-			
+
 			this.root.$set({
-				components: [],
+				components: []
 			});
 			await tick();
 


### PR DESCRIPTION
It seems that the processing in the script tag is not re-evaluated because the same component in routes is reused even if the params are different.

```html:routes/posts/[id].svelte
<script>
  // not called after the second time
  console.log('Hello, svelte!');
</script>

<div>
  <a href='/posts/1'>post 1</a>
</div>
<div>
  <a href='/posts/2'>post 2</a>
</div>
```

I tried resetting the component once so that it would be evaluated again.

Please merge it if you like.

----

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
