### PR TITLE
Precompress wasm files

### DIFF
--- a/.changeset/purple-dragons-work.md
+++ b/.changeset/purple-dragons-work.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-static': patch
+---
+
+`precompress` option also compress wasm files

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -78,7 +78,7 @@ async function compress(directory) {
 		return;
 	}
 
-	const files = await glob('**/*.{html,js,json,css,svg,xml}', {
+	const files = await glob('**/*.{html,js,json,css,svg,xml,wasm}', {
 		cwd: directory,
 		dot: true,
 		absolute: true,

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -50,7 +50,7 @@ export default function ({ pages = 'build', assets = pages, fallback, precompres
  * @param {string} directory
  */
 async function compress(directory) {
-	const files = await glob('**/*.{html,js,json,css,svg,xml}', {
+	const files = await glob('**/*.{html,js,json,css,svg,xml,wasm}', {
 		cwd: directory,
 		dot: true,
 		absolute: true,


### PR DESCRIPTION
When enabling the `precompress` option, WebAssembly files currently aren't compressed.
In my case however, compression brings me down from 4 MB to 1.5 MB, which seems to be in line with [what can be observed in the wild](https://almanac.httparchive.org/en/2021/webassembly#can-we-improve-compression).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs<br />_just a small change_
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`<br />_Test failing is independent of this change._

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
