### PR TITLE
[docs] fix syntax highlighting on FAQ page

### DIFF
--- a/sites/kit.svelte.dev/src/routes/faq/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/faq/index.svelte
@@ -52,7 +52,6 @@
 		margin: 0;
 		inset-block-start: 0;
 		background: transparent;
-		color: white;
 	}
 
 	.faqs :global(pre) {
@@ -62,7 +61,6 @@
 		max-inline-size: var(--linemax);
 		padding-inline: 2.5rem;
 		padding-block: 1.5rem;
-		background: #333;
 		border-radius: 0.5rem;
 		font-size: 0.8rem;
 	}


### PR DESCRIPTION
Fixes #3764
Fixes https://github.com/sveltejs/sites/issues/295

This seemed to happen because we copied styles from svelte.dev's FAQ page, which is white text on black without syntax highlighting.

Before:
![image](https://user-images.githubusercontent.com/4992896/153245415-809d5d2a-5e7c-48fb-9217-ec83f922e192.png)

After:
![image](https://user-images.githubusercontent.com/4992896/153245519-552d0cb3-6d61-4860-89dc-1961582906fc.png)


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
