### PR TITLE
move createIndexFiles option to adapter-static

### DIFF
--- a/.changeset/flat-stingrays-talk.md
+++ b/.changeset/flat-stingrays-talk.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/adapter-static': patch
+'@sveltejs/kit': patch
+---
+
+Move createIndexFiles option from kit to adapter-static

--- a/packages/adapter-static/index.d.ts
+++ b/packages/adapter-static/index.d.ts
@@ -5,6 +5,7 @@ interface AdapterOptions {
 	assets?: string;
 	fallback?: string;
 	precompress?: boolean;
+	createIndexFiles?: boolean;
 }
 
 declare function plugin(options?: AdapterOptions): Adapter;

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -7,7 +7,13 @@ import zlib from 'zlib';
 const pipe = promisify(pipeline);
 
 /** @type {import('.')} */
-export default function ({ pages = 'build', assets = pages, fallback, precompress = false } = {}) {
+export default function ({
+	pages = 'build',
+	assets = pages,
+	fallback,
+	precompress = false,
+	createIndexFiles = true
+} = {}) {
 	return {
 		name: '@sveltejs/adapter-static',
 
@@ -21,7 +27,8 @@ export default function ({ pages = 'build', assets = pages, fallback, precompres
 			await builder.prerender({
 				fallback,
 				all: !fallback,
-				dest: pages
+				dest: pages,
+				createIndexFiles
 			});
 
 			if (precompress) {

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -145,7 +145,7 @@ export function create_builder({ cwd, config, build_data, log }) {
 			return copy(config.kit.files.assets, dest);
 		},
 
-		async prerender({ all = false, dest, fallback }) {
+		async prerender({ all = false, dest, fallback, createIndexFiles = true }) {
 			if (generated_manifest) {
 				throw new Error(
 					'Adapters must call prerender(...) before createEntries(...) or generateManifest(...)'
@@ -159,6 +159,7 @@ export function create_builder({ cwd, config, build_data, log }) {
 				config,
 				build_data,
 				fallback,
+				index: createIndexFiles,
 				log
 			});
 

--- a/packages/kit/src/core/adapt/prerender/prerender.js
+++ b/packages/kit/src/core/adapt/prerender/prerender.js
@@ -47,11 +47,12 @@ const REDIRECT = 3;
  *   config: import('types/config').ValidatedConfig;
  *   build_data: import('types/internal').BuildData;
  *   fallback?: string;
+ *   index: boolean;
  *   all: boolean; // disregard `export const prerender = true`
  * }} opts
  * @returns {Promise<{ paths: string[] }>} returns a promise that resolves to an array of paths corresponding to the files that have been prerendered.
  */
-export async function prerender({ cwd, out, log, config, build_data, fallback, all }) {
+export async function prerender({ cwd, out, log, config, build_data, fallback, all, index }) {
 	if (!config.kit.prerender.enabled && !fallback) {
 		return { paths: [] };
 	}
@@ -121,7 +122,7 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 		}
 		const parts = path.split('/');
 		if (is_html && parts[parts.length - 1] !== 'index.html') {
-			if (config.kit.prerender.createIndexFiles) {
+			if (index) {
 				parts.push('index.html');
 			} else {
 				parts[parts.length - 1] += '.html';

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -85,7 +85,7 @@ const get_defaults = (prefix = '') => ({
 		prerender: {
 			concurrency: 1,
 			crawl: true,
-			createIndexFiles: true,
+			createIndexFiles: undefined,
 			enabled: true,
 			entries: ['*'],
 			force: undefined,

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -186,7 +186,9 @@ const options = object(
 			prerender: object({
 				concurrency: number(1),
 				crawl: boolean(true),
-				createIndexFiles: boolean(true),
+				createIndexFiles: error(
+					(keypath) => `${keypath} has been removed — configure it via your adapter instead`
+				),
 				enabled: boolean(true),
 				entries: validate(['*'], (input, keypath) => {
 					if (!Array.isArray(input) || !input.every((page) => typeof page === 'string')) {

--- a/packages/kit/test/prerendering/options/svelte.config.js
+++ b/packages/kit/test/prerendering/options/svelte.config.js
@@ -4,7 +4,9 @@ import adapter from '../../../../adapter-static/index.js';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter(),
+		adapter: adapter({
+			createIndexFiles: false
+		}),
 
 		csp: {
 			directives: {
@@ -15,10 +17,6 @@ const config = {
 		paths: {
 			base: '/path-base',
 			assets: 'https://cdn.example.com/stuff'
-		},
-
-		prerender: {
-			createIndexFiles: false
 		},
 
 		vite: {

--- a/packages/kit/test/prerendering/options/test/test.js
+++ b/packages/kit/test/prerendering/options/test/test.js
@@ -15,7 +15,7 @@ test('prerenders /path-base', () => {
 });
 
 test('prerenders nested /path-base', () => {
-	const content = read('/nested.html');
+	const content = read('nested.html');
 	assert.ok(content.includes('<h1>nested hello</h1>'));
 	assert.ok(content.includes('http://sveltekit-prerender/path-base/nested'));
 });

--- a/packages/kit/types/config.d.ts
+++ b/packages/kit/types/config.d.ts
@@ -86,7 +86,12 @@ export interface Builder {
 		}
 	): string[];
 
-	prerender(options: { all?: boolean; dest: string; fallback?: string }): Promise<{
+	prerender(options: {
+		all?: boolean;
+		dest: string;
+		fallback?: string;
+		createIndexFiles?: boolean;
+	}): Promise<{
 		paths: string[];
 	}>;
 }
@@ -153,7 +158,6 @@ export interface Config {
 		prerender?: {
 			concurrency?: number;
 			crawl?: boolean;
-			createIndexFiles?: boolean;
 			enabled?: boolean;
 			entries?: string[];
 			onError?: PrerenderOnErrorValue;


### PR DESCRIPTION
Fixes #3799. 

One thing I've noticed about this option is that people (including myself) get confused talking about it because the default is `true`, and it feels unusual to have to explicitly set an option to `false`. Two possible solutions:

1. we come up with a better name for it that means the opposite, allowing a default of `false`
2. we change the default to `false`, and make `about/index.html` instead of `about.html` opt-in

Might be worth doing a quick survey of popular static file hosts and seeing if `about.html` will work as expected in the majority of cases.

Also, it might make sense to vary the default based on the value of `trailingSlash`.

* [ ] update docs

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
