### PR TITLE
[docs] remove bottom overlay on phone

### DIFF
--- a/.changeset/serious-boats-deny.md
+++ b/.changeset/serious-boats-deny.md
@@ -1,0 +1,5 @@
+---
+'kit.svelte.dev': patch
+---
+
+Only show ToC sidenav bottom overlay on devices that >= than 832px.

--- a/.changeset/serious-boats-deny.md
+++ b/.changeset/serious-boats-deny.md
@@ -1,5 +1,0 @@
----
-'kit.svelte.dev': patch
----
-
-Only show ToC sidenav bottom overlay on devices that >= than 832px.

--- a/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
+++ b/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
@@ -126,22 +126,7 @@
 		color: white;
 	}
 
-	nav::after {
-		content: '';
-		position: fixed;
-		inset-inline-start: 0;
-		inset-block-end: 0;
-		inline-size: var(--sidebar-w);
-		block-size: 2em;
-		pointer-events: none;
-		block-size: var(--top-offset);
-		background: linear-gradient(
-			to bottom,
-			rgba(103, 103, 120, 0) 0%,
-			rgba(103, 103, 120, 0.7) 50%,
-			rgba(103, 103, 120, 1) 100%
-		);
-	}
+	
 
 	.sidebar {
 		padding-inline: 3.2rem 0;
@@ -221,6 +206,23 @@
 	}
 
 	@media (min-width: 832px) {
+		nav::after {
+			content: '';
+			position: fixed;
+			inset-inline-start: 0;
+			inset-block-end: 0;
+			inline-size: var(--sidebar-w);
+			block-size: 2em;
+			pointer-events: none;
+			block-size: var(--top-offset);
+			background: linear-gradient(
+				to bottom,
+				rgba(103, 103, 120, 0) 0%,
+				rgba(103, 103, 120, 0.7) 50%,
+				rgba(103, 103, 120, 1) 100%
+			);
+		}
+
 		.sidebar {
 			columns: 1;
 			padding-inline: 3.2rem 0;


### PR DESCRIPTION
Only show bottom overlay for ToC sidenav on devices that >= than 832px.

before:
<img src="https://user-images.githubusercontent.com/32354148/153344527-8ae9f94b-4739-4d18-950c-0408d3915437.png" width="375" height="812">

after:
<img src="https://user-images.githubusercontent.com/32354148/153344603-c1abfea5-a70c-462a-99eb-7ea903683d34.png" width="375" height="812">

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
