### PR TITLE
fix missed links to new multi-page docs

### DIFF
--- a/.changeset/clever-shrimps-whisper.md
+++ b/.changeset/clever-shrimps-whisper.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/adapter-auto': patch
+'create-svelte': patch
+'@sveltejs/kit': patch
+---
+
+fix links pointing to multi-page docs

--- a/documentation/docs/80-migrating.md
+++ b/documentation/docs/80-migrating.md
@@ -4,7 +4,7 @@ title: Migrating from Sapper
 
 SvelteKit is the successor to Sapper and shares many elements of its design.
 
-If you have an existing Sapper app that you plan to migrate to SvelteKit, there are a number of changes you will need to make. You may find it helpful to view [some examples](https://kit.svelte.dev/docs#additional-resources-examples) while migrating.
+If you have an existing Sapper app that you plan to migrate to SvelteKit, there are a number of changes you will need to make. You may find it helpful to view [some examples](https://kit.svelte.dev/docs/additional-resources#examples) while migrating.
 
 ### package.json
 

--- a/packages/adapter-auto/index.js
+++ b/packages/adapter-auto/index.js
@@ -33,7 +33,7 @@ export default function () {
 			}
 
 			builder.log.warn(
-				'Could not detect a supported production environment. See https://kit.svelte.dev/docs#adapters to learn how to configure your app to run on the platform of your choosing'
+				'Could not detect a supported production environment. See https://kit.svelte.dev/docs/adapters to learn how to configure your app to run on the platform of your choosing'
 			);
 		}
 	};

--- a/packages/adapter-cloudflare/README.md
+++ b/packages/adapter-cloudflare/README.md
@@ -1,6 +1,6 @@
 # adapter-cloudflare
 
-[Adapter](https://kit.svelte.dev/docs#adapters) for building SvelteKit applications on [Cloudflare Pages](https://developers.cloudflare.com/pages/) with [Workers integration](https://developers.cloudflare.com/pages/platform/functions).
+[Adapter](https://kit.svelte.dev/docs/adapters) for building SvelteKit applications on [Cloudflare Pages](https://developers.cloudflare.com/pages/) with [Workers integration](https://developers.cloudflare.com/pages/platform/functions).
 
 If you're using [adapter-auto](../adapter-auto), you don't need to install this — it's already included.
 

--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -52,7 +52,7 @@ During compilation, redirect rules are automatically appended to your `_redirect
 ### Using Netlify Forms
 
 1. Create your Netlify HTML form as described [here](https://docs.netlify.com/forms/setup/#html-forms), e.g. as `/routes/contact.svelte`. (Don't forget to add the hidden `form-name` input element!)
-2. Netlify's build bot parses your HTML files at deploy time, which means your form must be [prerendered](https://kit.svelte.dev/docs#page-options-prerender) as HTML. You can either add `export const prerender = true` to your `contact.svelte` to prerender just that page or set the `kit.prerender.force: true` option to prerender all pages.
+2. Netlify's build bot parses your HTML files at deploy time, which means your form must be [prerendered](https://kit.svelte.dev/docs/page-options#prerender) as HTML. You can either add `export const prerender = true` to your `contact.svelte` to prerender just that page or set the `kit.prerender.force: true` option to prerender all pages.
 3. If your Netlify form has a [custom success message](https://docs.netlify.com/forms/setup/#success-messages) like `<form netlify ... action="/success">` then ensure the corresponding `/routes/success.svelte` exists and is prerendered.
 
 ### Using Netlify Functions

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -1,6 +1,6 @@
 # @sveltejs/adapter-node
 
-[Adapter](https://kit.svelte.dev/docs#adapters) for SvelteKit apps that generates a standalone Node server.
+[Adapter](https://kit.svelte.dev/docs/adapters) for SvelteKit apps that generates a standalone Node server.
 
 ## Usage
 

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -1,6 +1,6 @@
 # @sveltejs/adapter-static
 
-[Adapter](https://kit.svelte.dev/docs#adapters) for SvelteKit apps that prerenders your site as a collection of static files.
+[Adapter](https://kit.svelte.dev/docs/adapters) for SvelteKit apps that prerenders your site as a collection of static files.
 
 ## Usage
 
@@ -23,7 +23,7 @@ export default {
 };
 ```
 
-Unless you're in [SPA mode](#spa-mode), the adapter will attempt to prerender every page of your app, regardless of whether the [`prerender`](https://kit.svelte.dev/docs#page-options-prerender) option is set.
+Unless you're in [SPA mode](#spa-mode), the adapter will attempt to prerender every page of your app, regardless of whether the [`prerender`](https://kit.svelte.dev/docs/page-options#prerender) option is set.
 
 ## Options
 
@@ -64,11 +64,11 @@ export default {
 };
 ```
 
-When operating in SPA mode, only pages that have the [`prerender`](https://kit.svelte.dev/docs#page-options-prerender) option set will be prerendered.
+When operating in SPA mode, only pages that have the [`prerender`](https://kit.svelte.dev/docs/page-options#prerender) option set will be prerendered.
 
 ## GitHub Pages
 
-When building for GitHub Pages, make sure to update [`paths.base`](https://kit.svelte.dev/docs#configuration-paths) to match your repo name, since the site will be served from https://your-username.github.io/your-repo-name rather than from the root.
+When building for GitHub Pages, make sure to update [`paths.base`](https://kit.svelte.dev/docs/configuration#paths) to match your repo name, since the site will be served from <https://your-username.github.io/your-repo-name> rather than from the root.
 
 You will have to prevent GitHub's provided Jekyll from managing your site by putting an empty `.nojekyll` file in your static folder. If you do not want to disable Jekyll, change the kit's `appDir` configuration option to `'app_'` or anything not starting with an underscore. For more information, see GitHub's [Jekyll documentation](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#configuring-jekyll-in-your-github-pages-site).
 

--- a/packages/create-svelte/shared/README.md
+++ b/packages/create-svelte/shared/README.md
@@ -37,4 +37,4 @@ npm run build
 
 You can preview the production build with `npm run preview`.
 
-> To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs#adapters) for your target environment.
+> To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.

--- a/packages/create-svelte/templates/default/src/app.d.ts
+++ b/packages/create-svelte/templates/default/src/app.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="@sveltejs/kit" />
 
-// See https://kit.svelte.dev/docs#typescript
+// See https://kit.svelte.dev/docs/typescript
 // for information about these interfaces
 declare namespace App {
 	interface Locals {

--- a/packages/create-svelte/templates/skeleton/src/app.d.ts
+++ b/packages/create-svelte/templates/skeleton/src/app.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="@sveltejs/kit" />
 
-// See https://kit.svelte.dev/docs#typescript
+// See https://kit.svelte.dev/docs/typescript
 // for information about these interfaces
 declare namespace App {
 	interface Locals {}

--- a/packages/kit/CHANGELOG.md
+++ b/packages/kit/CHANGELOG.md
@@ -218,9 +218,9 @@
 
 ### Patch Changes
 
-- Allow endpoints to return a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response), or an object with [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) ([docs](https://kit.svelte.dev/docs#routing-endpoints), [#3384](https://github.com/sveltejs/kit/pull/3384))
+- Allow endpoints to return a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response), or an object with [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) ([docs](https://kit.svelte.dev/docs/routing#endpoints), [#3384](https://github.com/sveltejs/kit/pull/3384))
 
-* [breaking] Expose standard [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object to endpoints and hooks. `method`, `headers`, and `body` now accessed through `request` field ([docs](https://kit.svelte.dev/docs#routing-endpoints), [#3384](https://github.com/sveltejs/kit/pull/3384))
+* [breaking] Expose standard [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) object to endpoints and hooks. `method`, `headers`, and `body` now accessed through `request` field ([docs](https://kit.svelte.dev/docs/routing#endpoints), [#3384](https://github.com/sveltejs/kit/pull/3384))
 
 - [breaking] change `app.render` signature to (request: Request) => Promise<Response> ([#3384](https://github.com/sveltejs/kit/pull/3384))
 
@@ -370,7 +370,7 @@
 
 ### Patch Changes
 
-- [breaking] Add `disableScrollHandling` function (see https://kit.svelte.dev/docs#modules-$app-navigation) ([#3182](https://github.com/sveltejs/kit/pull/3182))
+- [breaking] Add `disableScrollHandling` function (see https://kit.svelte.dev/docs/modules#$app-navigation) ([#3182](https://github.com/sveltejs/kit/pull/3182))
 
 ## 1.0.0-next.213
 

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -110,7 +110,7 @@ prog
 
 			// prettier-ignore
 			console.log(
-				`See ${colors.bold().cyan('https://kit.svelte.dev/docs#adapters')} to learn how to configure your app to run on the platform of your choosing`
+				`See ${colors.bold().cyan('https://kit.svelte.dev/docs/adapters')} to learn how to configure your app to run on the platform of your choosing`
 			);
 		} catch (error) {
 			handle_error(error);

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -32,7 +32,7 @@ export async function load_config({ cwd = process.cwd() } = {}) {
 
 	if (!fs.existsSync(config_file)) {
 		throw new Error(
-			'You need to create a svelte.config.js file. See https://kit.svelte.dev/docs#configuration'
+			'You need to create a svelte.config.js file. See https://kit.svelte.dev/docs/configuration'
 		);
 	}
 
@@ -57,7 +57,7 @@ export async function load_config({ cwd = process.cwd() } = {}) {
 export function validate_config(config) {
 	if (typeof config !== 'object') {
 		throw new Error(
-			'svelte.config.js must have a configuration object as its default export. See https://kit.svelte.dev/docs#configuration'
+			'svelte.config.js must have a configuration object as its default export. See https://kit.svelte.dev/docs/configuration'
 		);
 	}
 

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -204,7 +204,7 @@ test('fails if kit.appDir is only slash', () => {
 				appDir: '/'
 			}
 		});
-	}, /^config\.kit\.appDir cannot start or end with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration$/);
+	}, /^config\.kit\.appDir cannot start or end with '\/'. See https:\/\/kit\.svelte\.dev\/docs\/configuration$/);
 });
 
 test('fails if kit.appDir starts with slash', () => {
@@ -214,7 +214,7 @@ test('fails if kit.appDir starts with slash', () => {
 				appDir: '/_app'
 			}
 		});
-	}, /^config\.kit\.appDir cannot start or end with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration$/);
+	}, /^config\.kit\.appDir cannot start or end with '\/'. See https:\/\/kit\.svelte\.dev\/docs\/configuration$/);
 });
 
 test('fails if kit.appDir ends with slash', () => {
@@ -224,7 +224,7 @@ test('fails if kit.appDir ends with slash', () => {
 				appDir: '_app/'
 			}
 		});
-	}, /^config\.kit\.appDir cannot start or end with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration$/);
+	}, /^config\.kit\.appDir cannot start or end with '\/'. See https:\/\/kit\.svelte\.dev\/docs\/configuration$/);
 });
 
 test('fails if paths.base is not root-relative', () => {
@@ -236,7 +236,7 @@ test('fails if paths.base is not root-relative', () => {
 				}
 			}
 		});
-	}, /^config\.kit\.paths\.base option must be a root-relative path that starts but doesn't end with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
+	}, /^config\.kit\.paths\.base option must be a root-relative path that starts but doesn't end with '\/'. See https:\/\/kit\.svelte\.dev\/docs\/configuration#paths$/);
 });
 
 test("fails if paths.base ends with '/'", () => {
@@ -248,7 +248,7 @@ test("fails if paths.base ends with '/'", () => {
 				}
 			}
 		});
-	}, /^config\.kit\.paths\.base option must be a root-relative path that starts but doesn't end with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
+	}, /^config\.kit\.paths\.base option must be a root-relative path that starts but doesn't end with '\/'. See https:\/\/kit\.svelte\.dev\/docs\/configuration#paths$/);
 });
 
 test('fails if paths.assets is relative', () => {
@@ -260,7 +260,7 @@ test('fails if paths.assets is relative', () => {
 				}
 			}
 		});
-	}, /^config\.kit\.paths\.assets option must be an absolute path, if specified. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
+	}, /^config\.kit\.paths\.assets option must be an absolute path, if specified. See https:\/\/kit\.svelte\.dev\/docs\/configuration#paths$/);
 });
 
 test('fails if paths.assets has trailing slash', () => {
@@ -272,7 +272,7 @@ test('fails if paths.assets has trailing slash', () => {
 				}
 			}
 		});
-	}, /^config\.kit\.paths\.assets option must not end with '\/'. See https:\/\/kit\.svelte\.dev\/docs#configuration-paths$/);
+	}, /^config\.kit\.paths\.assets option must not end with '\/'. See https:\/\/kit\.svelte\.dev\/docs\/configuration#paths$/);
 });
 
 test('fails if prerender.entries are invalid', () => {
@@ -363,7 +363,7 @@ test('errors on loading config with incorrect default export', async () => {
 
 	assert.equal(
 		message,
-		'svelte.config.js must have a configuration object as its default export. See https://kit.svelte.dev/docs#configuration'
+		'svelte.config.js must have a configuration object as its default export. See https://kit.svelte.dev/docs/configuration'
 	);
 });
 

--- a/packages/kit/src/packaging/index.js
+++ b/packages/kit/src/packaging/index.js
@@ -331,7 +331,7 @@ async function try_load_svelte2tsx() {
 			return await import('svelte2tsx');
 		} catch (e) {
 			throw new Error(
-				'You need svelte2tsx and typescript if you want to generate type definitions. Install it through your package manager, or disable generation which is highly discouraged. See https://kit.svelte.dev/docs#packaging'
+				'You need svelte2tsx and typescript if you want to generate type definitions. Install it through your package manager, or disable generation which is highly discouraged. See https://kit.svelte.dev/docs/packaging'
 			);
 		}
 	}

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -27,10 +27,6 @@ import { set_paths } from '../paths.js';
  * }} opts
  */
 export async function start({ paths, target, session, route, spa, trailing_slash, hydrate }) {
-	if (import.meta.env.DEV && !target) {
-		throw new Error('Missing target element. See https://kit.svelte.dev/docs#configuration-target');
-	}
-
 	const renderer = new Renderer({
 		Root,
 		fallback,

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -47,7 +47,7 @@ export async function respond(request, options, state = {}) {
 				});
 			} else {
 				const verb = allowed.length === 0 ? 'enabled' : 'allowed';
-				const body = `${parameter}=${method_override} is not ${verb}. See https://kit.svelte.dev/docs#configuration-methodoverride`;
+				const body = `${parameter}=${method_override} is not ${verb}. See https://kit.svelte.dev/docs/configuration#methodoverride`;
 
 				return new Response(body, {
 					status: 400

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -247,7 +247,7 @@ function get_page_config(leaf, options) {
 	// TODO remove for 1.0
 	if ('ssr' in leaf) {
 		throw new Error(
-			'`export const ssr` has been removed — use the handle hook instead: https://kit.svelte.dev/docs#hooks-handle'
+			'`export const ssr` has been removed — use the handle hook instead: https://kit.svelte.dev/docs/hooks#handle'
 		);
 	}
 


### PR DESCRIPTION
Site were recently upgraded to have multi-page docs and we missed some warning and error links that were not updated. Added changeset to have warning and error links be updated as well on newer versions.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
