### PR TITLE
Only show sidebar nav bottom gradient on larger screens

### DIFF
--- a/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
+++ b/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
@@ -126,23 +126,6 @@
 		color: white;
 	}
 
-	nav::after {
-		content: '';
-		position: fixed;
-		inset-inline-start: 0;
-		inset-block-end: 0;
-		inline-size: var(--sidebar-w);
-		block-size: 2em;
-		pointer-events: none;
-		block-size: var(--top-offset);
-		background: linear-gradient(
-			to bottom,
-			rgba(103, 103, 120, 0) 0%,
-			rgba(103, 103, 120, 0.7) 50%,
-			rgba(103, 103, 120, 1) 100%
-		);
-	}
-
 	.sidebar {
 		padding-inline: 3.2rem 0;
 		padding-block: var(--top-offset) 6.4rem;
@@ -224,6 +207,23 @@
 		.sidebar {
 			columns: 1;
 			padding-inline: 3.2rem 0;
+		}
+		
+		nav::after {
+			content: '';
+			position: fixed;
+			inset-inline-start: 0;
+			inset-block-end: 0;
+			inline-size: var(--sidebar-w);
+			block-size: 2em;
+			pointer-events: none;
+			block-size: var(--top-offset);
+			background: linear-gradient(
+				to bottom,
+				rgba(103, 103, 120, 0) 0%,
+				rgba(103, 103, 120, 0.7) 50%,
+				rgba(103, 103, 120, 1) 100%
+			);
 		}
 	}
 </style>


### PR DESCRIPTION
Fixes #3830

Ensure the bottom gradient in the nav bar at https://kit.svelte.dev/docs only shows on screens wider than 832px, where the nav is pinned to the left.

**Before**
<img width="394" alt="2022:02:10-21 35 43" src="https://user-images.githubusercontent.com/84737/153500675-360084d2-6356-4961-ae76-0c540abe84a9.png">

**After**
<img width="384" alt="2022:02:10-21 35 58" src="https://user-images.githubusercontent.com/84737/153500681-e0e06031-97ec-46b6-a850-aededba5b06c.png">


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
