### PR TITLE
Fix Cloudflare Workers adapter target

### DIFF
--- a/.changeset/wicked-terms-agree.md
+++ b/.changeset/wicked-terms-agree.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+---
+
+Fix Cloudflare adapter targets

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -55,7 +55,7 @@ export default function () {
 				entryPoints: [`${tmp}/entry.js`],
 				outfile: `${entrypoint}/index.js`,
 				bundle: true,
-				target: 'es2020',
+				target: 'es2019',
 				platform: 'browser'
 			});
 


### PR DESCRIPTION
When attempting to upload a SvelteKit app which contains modern ES
features such as optional chaining or nullish coalescing, workers is
unable to parse the built output.

```
Module parse failed: Unexpected token (13066:47)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|       if (typeof window !== "undefined") {
|         const windowAny = window;
>         const dataLayer = windowAny.dataLayer ?? [];
|         windowAny.dataLayer = dataLayer;
|         gtag = function() {
Error: webpack returned an error. You may be able to resolve this issue by running npm install
```

I could not find any official documentation of what version of ES
workers support, but ES2020 is the year that nullish coalescing was
introduced, and setting it to ES2019 appears to fix the issue.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

Unsure how to test this

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
