### PR TITLE
Copy endpoint response Headers instead of setting directly

### DIFF
--- a/.changeset/fast-coats-attack.md
+++ b/.changeset/fast-coats-attack.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Copy endpoint response Headers instead of setting directly
+[fix] avoid mutating response `Headers`

--- a/.changeset/fast-coats-attack.md
+++ b/.changeset/fast-coats-attack.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Copy endpoint response Headers instead of setting directly

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -60,7 +60,9 @@ export async function render_endpoint(event, mod) {
 
 	const { status = 200, body = {} } = response;
 	const headers =
-		response.headers instanceof Headers ? response.headers : to_headers(response.headers);
+		response.headers instanceof Headers
+			? new Headers(response.headers)
+			: to_headers(response.headers);
 
 	const type = headers.get('content-type');
 


### PR DESCRIPTION
Headers that are created as part of a Response object (e.g. directly
from `fetch` or via `Response.redirect`) are not mutable in some
environments, including the browser and Cloudflare Workers. If an
endpoint returns an instance of a Response currently, it will attempt
to mutate the headers, which throws an error. This only fails in
Cloudflare, so it's hard to catch before a deployment.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

Thought about it a bit and I'm unsure how to test this since it's environment specific. We could try to hijack the `Response` global potentially.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
