### PR TITLE
[fix] remove scroll handling code

### DIFF
--- a/.changeset/cyan-dodos-clap.md
+++ b/.changeset/cyan-dodos-clap.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] remove manual scroll handling code

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -294,7 +294,7 @@ export class Renderer {
 	 * @param {import('./types').NavigationInfo} info
 	 * @param {string[]} chain
 	 * @param {boolean} no_cache
-	 * @param {{hash?: string, scroll: { x: number, y: number } | null, keepfocus: boolean}} [opts]
+	 * @param {{hash?: string, from_history: boolean, keepfocus: boolean}} [opts]
 	 */
 	async handle_navigation(info, chain, no_cache, opts) {
 		if (this.started) {
@@ -311,7 +311,7 @@ export class Renderer {
 	 * @param {import('./types').NavigationInfo} info
 	 * @param {string[]} chain
 	 * @param {boolean} no_cache
-	 * @param {{hash?: string, scroll: { x: number, y: number } | null, keepfocus: boolean}} [opts]
+	 * @param {{hash?: string, from_history: boolean, keepfocus: boolean}} [opts]
 	 */
 	async update(info, chain, no_cache, opts) {
 		const token = (this.token = {});
@@ -363,9 +363,7 @@ export class Renderer {
 
 		// opts must be passed if we're navigating
 		if (opts) {
-			const { scroll, keepfocus } = opts;
-
-			if (!keepfocus) {
+			if (!opts.keepfocus) {
 				getSelection()?.removeAllRanges();
 				document.body.focus();
 			}
@@ -373,14 +371,9 @@ export class Renderer {
 			// need to render the DOM before we can scroll to the rendered elements
 			await tick();
 
-			if (this.autoscroll) {
+			if (this.autoscroll && !opts.from_history) {
 				const deep_linked = info.url.hash && document.getElementById(info.url.hash.slice(1));
-				if (scroll) {
-					scrollTo(scroll.x, scroll.y);
-				} else if (deep_linked) {
-					// Here we use `scrollIntoView` on the element instead of `scrollTo`
-					// because it natively supports the `scroll-margin` and `scroll-behavior`
-					// CSS properties.
+				if (deep_linked) {
 					deep_linked.scrollIntoView();
 				} else {
 					scrollTo(0, 0);


### PR DESCRIPTION
I started wondering why we need some of the scroll handling stuff and dug into what React Router does. It looks like they have zero scroll handling and rely on the browser to handle it. SvelteKit's scroll handling was originally inspired by Nuxt. I think that older browsers at some point before 2017 didn't have built-in scroll handling with `pushState`, but have since added it and so there's no longer a reason to include this code

Fixes https://github.com/sveltejs/kit/issues/3636
Fixes https://github.com/sveltejs/kit/issues/3621

With this PR, the forward button seems to only scroll to the correct location for every other page. Though given that it fixes two more serious issues, that's probably something we can live with for now

I left `disableScrollHandling` for now as it wasn't clear to me that we can get rid of it. React Router does not handle deep links by default and you have to include [another package](https://github.com/rafgraph/react-router-hash-link) for it, but I think it's better that we include it by default