### PR TITLE
remove backspace hack from search box

### DIFF
--- a/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
+++ b/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
@@ -150,28 +150,6 @@
 							modal.querySelector('a').click();
 						}
 					}
-
-					// ideally, opening the modal would create a history entry that we
-					// could use with browser back/forward buttons — this would be the
-					// best way to allow people to close the modal on mobile, for
-					// example. That's a little tricky to do right now — need to add
-					// new APIs to SvelteKit — but in the meantime we can close the
-					// modal when the backspace key is pressed. we _don't_ want that
-					// to happen when the backspace keydown fires repeatedly, so we
-					// track whether it was already pressed or not. (Sadly this
-					// doesn't work on mobile, longpress will close the modal)
-					if (e.key === 'Backspace') {
-						if ($query === '' && !backspace_pressed) {
-							close();
-						}
-
-						backspace_pressed = true;
-					}
-				}}
-				on:keyup={(e) => {
-					if (e.key === 'Backspace') {
-						backspace_pressed = false;
-					}
 				}}
 				on:input={(e) => {
 					$query = e.target.value;


### PR DESCRIPTION
when building the search box for kit.svelte.dev, there wasn't a close button at first, so in lieu of a proper history-based solution to the modal, hitting backspace when the input was empty would close it. i should have removed it when we added the close button, but i forgot

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
