### PR TITLE
only show gradient overlay on desktop

### DIFF
--- a/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
+++ b/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
@@ -116,31 +116,11 @@
 
 <style>
 	nav {
-		/* position: fixed; */
-		/* inline-size: var(--sidebar-w); */
-		/* block-size: 100vh; */
 		inset-block-start: 0;
 		inset-inline-start: 0;
 		overflow: hidden;
 		background-color: var(--second);
 		color: white;
-	}
-
-	nav::after {
-		content: '';
-		position: fixed;
-		inset-inline-start: 0;
-		inset-block-end: 0;
-		inline-size: var(--sidebar-w);
-		block-size: 2em;
-		pointer-events: none;
-		block-size: var(--top-offset);
-		background: linear-gradient(
-			to bottom,
-			rgba(103, 103, 120, 0) 0%,
-			rgba(103, 103, 120, 0.7) 50%,
-			rgba(103, 103, 120, 1) 100%
-		);
 	}
 
 	.sidebar {
@@ -224,6 +204,23 @@
 		.sidebar {
 			columns: 1;
 			padding-inline: 3.2rem 0;
+		}
+
+		nav::after {
+			content: '';
+			position: fixed;
+			inset-inline-start: 0;
+			inset-block-end: 0;
+			inline-size: var(--sidebar-w);
+			block-size: 2em;
+			pointer-events: none;
+			block-size: var(--top-offset);
+			background: linear-gradient(
+				to bottom,
+				rgba(103, 103, 120, 0) 0%,
+				rgba(103, 103, 120, 0.7) 50%,
+				rgba(103, 103, 120, 1) 100%
+			);
 		}
 	}
 </style>


### PR DESCRIPTION
fixes this

<img width="371" alt="image" src="https://user-images.githubusercontent.com/1162160/153624335-62d9ce7f-6ed4-4464-aaeb-b389da20412a.png">

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
