### PR TITLE
revert change to Cloudflare ES target version

### DIFF
--- a/.changeset/five-oranges-melt.md
+++ b/.changeset/five-oranges-melt.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+---
+
+revert change to Cloudflare ES target version

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -55,7 +55,7 @@ export default function () {
 				entryPoints: [`${tmp}/entry.js`],
 				outfile: `${entrypoint}/index.js`,
 				bundle: true,
-				target: 'es2019',
+				target: 'es2020',
 				platform: 'browser'
 			});
 


### PR DESCRIPTION
reverts https://github.com/sveltejs/kit/pull/3827 per the last comment on that thread