### PR TITLE
Skip trailingSlash for paths with extension

### DIFF
--- a/packages/kit/src/core/adapt/prerender/prerender.js
+++ b/packages/kit/src/core/adapt/prerender/prerender.js
@@ -106,8 +106,8 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 		// has_ext('rss.xml') === true
 		// has_ext('robots.txt') === true
 		// has_ext('manifest.webmanifest') === true
-		const fname = path.split('/').pop()
-		return fname.slice((Math.max(0, fname.lastIndexOf(".")) || Infinity) + 1).length > 0;
+		const fname = path.split('/').pop();
+		return fname.slice((Math.max(0, fname.lastIndexOf('.')) || Infinity) + 1).length > 0;
 	}
 
 	/**

--- a/packages/kit/src/core/adapt/prerender/prerender.js
+++ b/packages/kit/src/core/adapt/prerender/prerender.js
@@ -97,11 +97,25 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 	});
 
 	/**
+	 * Checks if path has extension
+	 * @param {string} path
+	 */
+	function has_ext(path) {
+		// has_ext('.htcaccess') === false
+		// has_ext('path/to/.htcaccess') === false
+		// has_ext('rss.xml') === true
+		// has_ext('robots.txt') === true
+		// has_ext('manifest.webmanifest') === true
+		const fname = path.split('/').pop()
+		return fname.slice((Math.max(0, fname.lastIndexOf(".")) || Infinity) + 1).length > 0;
+	}
+
+	/**
 	 * @param {string} path
 	 */
 	function normalize(path) {
 		if (config.kit.trailingSlash === 'always') {
-			return path.endsWith('/') ? path : `${path}/`;
+			return path.endsWith('/') || has_ext(path) ? path : `${path}/`;
 		} else if (config.kit.trailingSlash === 'never') {
 			return !path.endsWith('/') || path === '/' ? path : path.slice(0, -1);
 		}

--- a/packages/kit/src/core/adapt/prerender/prerender.js
+++ b/packages/kit/src/core/adapt/prerender/prerender.js
@@ -101,8 +101,8 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 	 * @param {string} path
 	 */
 	function has_ext(path) {
-		// has_ext('.htcaccess') === false
-		// has_ext('path/to/.htcaccess') === false
+		// has_ext('.htaccess') === false
+		// has_ext('path/to/.htaccess') === false
 		// has_ext('rss.xml') === true
 		// has_ext('robots.txt') === true
 		// has_ext('manifest.webmanifest') === true

--- a/packages/kit/src/core/adapt/prerender/prerender.js
+++ b/packages/kit/src/core/adapt/prerender/prerender.js
@@ -107,7 +107,9 @@ export async function prerender({ cwd, out, log, config, build_data, fallback, a
 		// has_ext('robots.txt') === true
 		// has_ext('manifest.webmanifest') === true
 		const fname = path.split('/').pop();
-		return fname.slice((Math.max(0, fname.lastIndexOf('.')) || Infinity) + 1).length > 0;
+		return fname !== undefined
+			? fname.slice((Math.max(0, fname.lastIndexOf('.')) || Infinity) + 1).length > 0
+			: false;
 	}
 
 	/**

--- a/packages/kit/test/prerendering/options/src/routes/index.svelte
+++ b/packages/kit/test/prerendering/options/src/routes/index.svelte
@@ -3,4 +3,4 @@
 </script>
 
 <h1>hello</h1>
-<a href=".{base}/rss.xml">Link</a>
+<a href='.{base}/rss.xml'>Link</a>

--- a/packages/kit/test/prerendering/options/src/routes/index.svelte
+++ b/packages/kit/test/prerendering/options/src/routes/index.svelte
@@ -1,6 +1,6 @@
 <script context="module">
-  import { base } from '$app/paths';
+	import { base } from '$app/paths';
 </script>
 
 <h1>hello</h1>
-<a href='.{base}/rss.xml'>Link</a>
+<a href=".{base}/rss.xml">Link</a>

--- a/packages/kit/test/prerendering/options/src/routes/index.svelte
+++ b/packages/kit/test/prerendering/options/src/routes/index.svelte
@@ -1,1 +1,6 @@
+<script context="module">
+  import { base } from '$app/paths'
+</script>
+
 <h1>hello</h1>
+<a href=".{base}/rss.xml">Link</a>

--- a/packages/kit/test/prerendering/options/src/routes/index.svelte
+++ b/packages/kit/test/prerendering/options/src/routes/index.svelte
@@ -1,5 +1,5 @@
 <script context="module">
-  import { base } from '$app/paths'
+  import { base } from '$app/paths';
 </script>
 
 <h1>hello</h1>

--- a/packages/kit/test/prerendering/options/src/routes/rss.xml.js
+++ b/packages/kit/test/prerendering/options/src/routes/rss.xml.js
@@ -1,0 +1,30 @@
+export async function get() {
+  const body = `<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" media="screen" href="/rss.xsl"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Blog</title>
+    <description>Description for blog</description>
+    <link>https://website.com/</link>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+    <pubDate>${new Date().toUTCString()}</pubDate>
+    <language>en-us</language>
+    <copyright>Copyright 2022, Author</copyright>
+    <generator>sveltekit</generator>
+    <item>
+      <title>Title</title>
+      <link>https://website.com/first-blog</link>
+      <guid isPermaLink="true">https://website.com/first-blog</guid>
+      <atom:link href="https://website.com/first-blog" rel="self"></atom:link>
+    </item>
+  </channel>
+</rss>`;
+  const headers = {
+    'cache-control': 'max-age=0, s-maxage=3600',
+    'content-type': 'application/xml'
+  };
+  return {
+    headers,
+    body
+  };
+}

--- a/packages/kit/test/prerendering/options/src/routes/rss.xml.js
+++ b/packages/kit/test/prerendering/options/src/routes/rss.xml.js
@@ -1,5 +1,5 @@
 export async function get() {
-  const body = `<?xml version="1.0"?>
+	const body = `<?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" media="screen" href="/rss.xsl"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
@@ -19,12 +19,12 @@ export async function get() {
     </item>
   </channel>
 </rss>`;
-  const headers = {
-    'cache-control': 'max-age=0, s-maxage=3600',
-    'content-type': 'application/xml'
-  };
-  return {
-    headers,
-    body
-  };
+	const headers = {
+		'cache-control': 'max-age=0, s-maxage=3600',
+		'content-type': 'application/xml'
+	};
+	return {
+		headers,
+		body
+	};
 }

--- a/packages/kit/test/prerendering/options/test/test.js
+++ b/packages/kit/test/prerendering/options/test/test.js
@@ -14,6 +14,11 @@ test('prerenders /path-base', () => {
 	assert.ok(content.includes('http://sveltekit-prerender/path-base'));
 });
 
+test('prerenders /rss.xml', () => {
+	const content = read('rss.xml');
+	assert.ok(content.includes('<title>Blog</title>'));
+});
+
 test('prerenders nested /path-base', () => {
 	const content = read('nested/index.html');
 	assert.ok(content.includes('<h1>nested hello</h1>'));


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/issues/2390

Currently, when using `trailingSlash: 'always'` in sveltekit's `svelte.config.js`, the `normalize` function adds a trailing slash to _all_ paths that don't contain a trailing slash. This causes issues when you want to use `trailingSlash: 'always'` _and_ also want to host some dynamic content on an endpoint, for example when using `rss.xml` as a endpoint.

This PR changes the behavior of `normalize` to not add a trailing slash when the filename in the path contains an extension.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
