### PR TITLE
Adds context to platform in SvelteKit endpoints

### DIFF
--- a/.changeset/sharp-moles-confess.md
+++ b/.changeset/sharp-moles-confess.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+Allows access of the context variable on platform inside endpoints. Closes #2807.

--- a/.changeset/sharp-moles-confess.md
+++ b/.changeset/sharp-moles-confess.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-cloudflare': patch
 ---
 
-Allows access of the context variable on platform inside endpoints. Closes #2807.
+Add `context` to `event.platform` object

--- a/packages/adapter-cloudflare/README.md
+++ b/packages/adapter-cloudflare/README.md
@@ -53,7 +53,7 @@ When configuring your project settings, you must use the following settings:
 
 ## Environment variables
 
-The [`env`](https://developers.cloudflare.com/workers/runtime-apis/fetch-event#parameters) object, containing KV namespaces etc, is passed to SvelteKit via the `platform` property, meaning you can access it in hooks and endpoints:
+The [`env`](https://developers.cloudflare.com/workers/runtime-apis/fetch-event#parameters) object, containing KV namespaces etc, is passed to SvelteKit via the `platform` property along with `context`, meaning you can access it in hooks and endpoints:
 
 ```diff
 // src/app.d.ts
@@ -64,6 +64,9 @@ declare namespace App {
 +		env: {
 +			COUNTER: DurableObjectNamespace;
 +		};
++		context: {
++			waitUntil(promise: Promise<any>): void;
++		}
 +	}
 
 	interface Session {}

--- a/packages/adapter-cloudflare/files/worker.js
+++ b/packages/adapter-cloudflare/files/worker.js
@@ -9,8 +9,9 @@ export default {
 	/**
 	 * @param {Request} req
 	 * @param {any} env
+	 * @param {any} context
 	 */
-	async fetch(req, env) {
+	async fetch(req, env, context) {
 		const url = new URL(req.url);
 
 		// static assets
@@ -49,7 +50,7 @@ export default {
 
 		// dynamically-generated pages
 		try {
-			return await app.render(req, { platform: { env } });
+			return await app.render(req, { platform: { env, context } });
 		} catch (e) {
 			return new Response('Error rendering route: ' + (e.message || e.toString()), { status: 500 });
 		}


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Changes
- Adds the `context` variable, which Pages Functions provides, into `platform` in endpoints and hooks.
- This is important because `context` contains `waitUntil`, which quite a few error-reporting platforms and other packages make use of (such as Sentry via [Toucan.js](https://github.com/robertcepa/toucan-js)).
- Closes #2807.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
