### PR TITLE
Source documentation for `./packages/kit/src/core/create_app` - issue #3707

### DIFF
--- a/packages/kit/src/core/create_app/index.js
+++ b/packages/kit/src/core/create_app/index.js
@@ -53,8 +53,10 @@ function trim(str) {
  * @param {string} base - the base path to prepend to imports
  */
 function generate_client_manifest(manifest_data, base) {
-	/**Maps relative path of component to the component's index in `manifest_date.components`.
-	 * @type {Record<string, number>} */
+	/**
+	 * Maps relative path of component to the component's index in `manifest_date.components`.
+	 * @type {Record<string, number>}
+	 */
 	const component_indexes = {};
 
 	/**

--- a/packages/kit/src/core/create_app/index.js
+++ b/packages/kit/src/core/create_app/index.js
@@ -4,7 +4,7 @@ import { s } from '../../utils/misc.js';
 import { mkdirp } from '../../utils/filesystem.js';
 
 /**
- * Maps file contents to file path
+ * Maps file contents to file path.
  *  @type {Map<string, string>} */
 const previous_contents = new Map();
 
@@ -48,15 +48,17 @@ function trim(str) {
 }
 
 /**
- * Generates code for the `manifest.js` file which imports svelte components and exports the app's `routes`, an an array of arrays containing a pattern to match the route and two arrays of components (`[__layout, page]` and `[error]`)
+ * Generates code for the `manifest.js` file which imports svelte components and exports the app's `routes`, an an array of arrays containing a pattern to match the route and two arrays of components (`[__layout, page]` and `[error]`).
  * @param {ManifestData} manifest_data - object containing paths to the apps assets, user defined components, routes, and the app's __layout and error components.
  * @param {string} base - the base path to prepend to imports 
  */
 function generate_client_manifest(manifest_data, base) {
-	/** @type {Record<string, number>} */
+	/**Maps relative path of component to the component's index in `manifest_date.components`.
+	 * @type {Record<string, number>} */
 	const component_indexes = {};
 
-	/** @param {string} c */
+	/**Wraps `path.relative`. 
+	 * @param {string} c - component path */
 	const get_path = (c) => path.relative(base, c);
 	
 	const components = `[

--- a/packages/kit/src/core/create_app/index.js
+++ b/packages/kit/src/core/create_app/index.js
@@ -48,8 +48,8 @@ function trim(str) {
 }
 
 /**
- * Generates code which imports svelte components and exports the app's `routes`, an an array of arrays containing a pattern to match the route and an array of components ([layout, component, error])
- * @param {ManifestData} manifest_data - object containing paths to the apps assets, user defined components, routes, and __layout and error components
+ * Generates code for the `manifest.js` file which imports svelte components and exports the app's `routes`, an an array of arrays containing a pattern to match the route and two arrays of components (`[__layout, page]` and `[error]`)
+ * @param {ManifestData} manifest_data - object containing paths to the apps assets, user defined components, routes, and the app's __layout and error components.
  * @param {string} base - the base path to prepend to imports 
  */
 function generate_client_manifest(manifest_data, base) {
@@ -58,7 +58,7 @@ function generate_client_manifest(manifest_data, base) {
 
 	/** @param {string} c */
 	const get_path = (c) => path.relative(base, c);
-
+	
 	const components = `[
 		${manifest_data.components
 			.map((component, i) => {
@@ -69,7 +69,9 @@ function generate_client_manifest(manifest_data, base) {
 			.join(',\n\t\t\t\t')}
 	]`.replace(/^\t/gm, '');
 
-	/** @param {string[]} parts */
+	/** 
+	 * Matches components by path and returns an array of those components accessed within the `c`array.
+	 * @param {string[]} parts - array of component paths */
 	const get_indices = (parts) =>
 		`[${parts.map((part) => (part ? `c[${component_indexes[part]}]` : '')).join(', ')}]`;
 
@@ -116,7 +118,8 @@ function generate_client_manifest(manifest_data, base) {
 }
 
 /**
- * @param {ManifestData} manifest_data
+ * Generates the code for the `root.svelte` component.
+ * @param {ManifestData} manifest_data - object containing paths to the apps assets, user defined components, routes, and the app's __layout and error components.
  */
 function generate_app(manifest_data) {
 	// TODO remove default layout altogether

--- a/packages/kit/src/core/create_app/index.js
+++ b/packages/kit/src/core/create_app/index.js
@@ -72,7 +72,8 @@ function generate_client_manifest(manifest_data, base) {
 
 	/**
 	 * Matches components by path and returns an array of those components accessed within the `c`array.
-	 * @param {string[]} parts - array of component paths */
+	 * @param {string[]} parts - array of component paths
+	 */
 	const get_indices = (parts) =>
 		`[${parts.map((part) => (part ? `c[${component_indexes[part]}]` : '')).join(', ')}]`;
 

--- a/packages/kit/src/core/create_app/index.js
+++ b/packages/kit/src/core/create_app/index.js
@@ -5,7 +5,8 @@ import { mkdirp } from '../../utils/filesystem.js';
 
 /**
  * Maps file contents to file path.
- *  @type {Map<string, string>} */
+ * @type {Map<string, string>}
+ */
 const previous_contents = new Map();
 
 /**

--- a/packages/kit/src/core/create_app/index.js
+++ b/packages/kit/src/core/create_app/index.js
@@ -23,7 +23,6 @@ export function write_if_changed(file, code) {
 
 /** @typedef {import('types/internal').ManifestData} ManifestData */
 
-
 /**
  * Updates or creates two files - manifest.js and root.svelte - in the specified output directory.
  * @param {Object} options
@@ -41,7 +40,7 @@ export function create_app({ manifest_data, output, cwd = process.cwd() }) {
 /**
  * Returns string without leading tabs and whitespace.
  * @param {string} str
- * 
+ *
  */
 function trim(str) {
 	return str.replace(/^\t\t/gm, '').trim();
@@ -50,17 +49,17 @@ function trim(str) {
 /**
  * Generates code for the `manifest.js` file which imports svelte components and exports the app's `routes`, an an array of arrays containing a pattern to match the route and two arrays of components (`[__layout, page]` and `[error]`).
  * @param {ManifestData} manifest_data - object containing paths to the apps assets, user defined components, routes, and the app's __layout and error components.
- * @param {string} base - the base path to prepend to imports 
+ * @param {string} base - the base path to prepend to imports
  */
 function generate_client_manifest(manifest_data, base) {
 	/**Maps relative path of component to the component's index in `manifest_date.components`.
 	 * @type {Record<string, number>} */
 	const component_indexes = {};
 
-	/**Wraps `path.relative`. 
+	/**Wraps `path.relative`.
 	 * @param {string} c - component path */
 	const get_path = (c) => path.relative(base, c);
-	
+
 	const components = `[
 		${manifest_data.components
 			.map((component, i) => {
@@ -71,7 +70,7 @@ function generate_client_manifest(manifest_data, base) {
 			.join(',\n\t\t\t\t')}
 	]`.replace(/^\t/gm, '');
 
-	/** 
+	/**
 	 * Matches components by path and returns an array of those components accessed within the `c`array.
 	 * @param {string[]} parts - array of component paths */
 	const get_indices = (parts) =>

--- a/packages/kit/src/core/create_app/index.js
+++ b/packages/kit/src/core/create_app/index.js
@@ -57,8 +57,10 @@ function generate_client_manifest(manifest_data, base) {
 	 * @type {Record<string, number>} */
 	const component_indexes = {};
 
-	/**Wraps `path.relative`.
-	 * @param {string} c - component path */
+	/**
+	 * Wraps `path.relative`.
+	 * @param {string} c - component path
+	 */
 	const get_path = (c) => path.relative(base, c);
 
 	const components = `[

--- a/packages/kit/src/core/create_app/index.js
+++ b/packages/kit/src/core/create_app/index.js
@@ -3,12 +3,15 @@ import path from 'path';
 import { s } from '../../utils/misc.js';
 import { mkdirp } from '../../utils/filesystem.js';
 
-/** @type {Map<string, string>} */
+/**
+ * Maps file contents to file path
+ *  @type {Map<string, string>} */
 const previous_contents = new Map();
 
 /**
- * @param {string} file
- * @param {string} code
+ * Checks `previous_contents` map for `file` key and performs strict inequality comparison of `code` against the value, then writes `code` to `file` if there are changes.
+ * @param {string} file - the path of the file to be written
+ * @param {string} code - code to be checked against `previous_contents` and written if unequal
  */
 export function write_if_changed(file, code) {
 	if (code !== previous_contents.get(file)) {
@@ -20,12 +23,13 @@ export function write_if_changed(file, code) {
 
 /** @typedef {import('types/internal').ManifestData} ManifestData */
 
+
 /**
- * @param {{
- *   manifest_data: ManifestData;
- *   output: string;
- *   cwd: string;
- * }} options
+ * Updates or creates two files - manifest.js and root.svelte - in the specified output directory.
+ * @param {Object} options
+ * @param {ManifestData} options.manifest_data - details the apps assets, user defined components, routes, and __layout and error components
+ * @param {string} options.output - directory files will be written in
+ * @param {string} options.cwd - the current working directory. Defaults to `process.cwd()`
  */
 export function create_app({ manifest_data, output, cwd = process.cwd() }) {
 	const base = path.relative(cwd, output);
@@ -35,15 +39,18 @@ export function create_app({ manifest_data, output, cwd = process.cwd() }) {
 }
 
 /**
+ * Returns string without leading tabs and whitespace.
  * @param {string} str
+ * 
  */
 function trim(str) {
 	return str.replace(/^\t\t/gm, '').trim();
 }
 
 /**
- * @param {ManifestData} manifest_data
- * @param {string} base
+ * Generates code which imports svelte components and exports the app's `routes`, an an array of arrays containing a pattern to match the route and an array of components ([layout, component, error])
+ * @param {ManifestData} manifest_data - object containing paths to the apps assets, user defined components, routes, and __layout and error components
+ * @param {string} base - the base path to prepend to imports 
  */
 function generate_client_manifest(manifest_data, base) {
 	/** @type {Record<string, number>} */


### PR DESCRIPTION
### Documentation standards I made up
Bases on some quick checking of other libraries' documentation practices, I followed some rules that seemed pretty sensible.
- I wrote documentation for any function or object which had an existing JSDoc type declaration
- Descriptions of objects/functions were written with sentence case and ended with a period
- Parameter descriptions are separated from the parameter they describe with a dash, are not capitalized, and do not end in a period
- In cases where a parameter type is defined as an object, I re-wrote to match the [format described here](https://jsdoc.app/tags-param.html#parameters-with-properties). It should be noted that VS Code's typescript hover info doesn't include these descriptions, but this seemed like the best option since it's recommended by JSDoc

These are the only things I did that I feel should be standardized in any way (and really, this isn't super important). This seems like a good enough way to handle incrementally adding more info to source documentation - it took minimal effort to write out short descriptions while I was reading through these functions. I started with this folder since it only has one file, after this I'll be working through the other folders in `src/core`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
