### PR TITLE
[Fix]: Adding compatibility for the search shortcut to other keyboard layouts

### DIFF
--- a/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
+++ b/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
@@ -106,7 +106,7 @@
 
 <svelte:window
 	on:keydown={(e) => {
-		if (e.code === 'KeyK' && (navigator.platform === 'MacIntel' ? e.metaKey : e.ctrlKey)) {
+		if (e.key === 'k' && (navigator.platform === 'MacIntel' ? e.metaKey : e.ctrlKey)) {
 			e.preventDefault();
 			$query = '';
 			$searching = !$searching;


### PR DESCRIPTION
If you're using a keyboard layout different to QWERTY  like Dvorak or Colemak the shortcut of CMD+K will not work since the k is in another position, but if we change from event.code to event.key it will work. The other possibility
 is with event.keyCode that returns on all the layouts 75 but is not so clear what we are checking then.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
