### PR TITLE
ToC updates twice on mount

### DIFF
--- a/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
+++ b/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
@@ -20,9 +20,6 @@
 		// wait for fonts to load...
 		const timeouts = [setTimeout(onresize, 1000), setTimeout(onscroll, 5000)];
 
-		update();
-		highlight();
-
 		return () => {
 			window.removeEventListener('scroll', onscroll, true);
 			window.removeEventListener('resize', onresize, true);


### PR DESCRIPTION
```js
afterNavigate(() => {
  update();
  highlight();
});
```

already calls `update();` and `highlight();` on mount. No need to do it again in `onMount`.

Not sure I get it. Does the rest of the `onMount` function accomplish anything?

```js
onMount(() => {
  // wait for fonts to load...
  const timeouts = [setTimeout(onresize, 1000), setTimeout(onscroll, 5000)];
  return () => {
    window.removeEventListener('scroll', onscroll, true);
    window.removeEventListener('resize', onresize, true);
    timeouts.forEach((timeout) => clearTimeout(timeout));
  };
});
```