### PR TITLE
Ensure handleError hook is called for shadow endpoint errors

### DIFF
--- a/.changeset/selfish-walls-grow.md
+++ b/.changeset/selfish-walls-grow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Ensure handleError hook is called for shadow endpoint errors

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -66,6 +66,7 @@ export async function load_node({
 		? await load_shadow_data(
 				/** @type {import('types/internal').SSRPage} */ (route),
 				event,
+				options,
 				!!state.prerender
 		  )
 		: {};
@@ -360,10 +361,11 @@ export async function load_node({
  *
  * @param {import('types/internal').SSRPage} route
  * @param {import('types/hooks').RequestEvent} event
+ * @param {import('types/internal').SSROptions} options
  * @param {boolean} prerender
  * @returns {Promise<import('types/endpoint').ShadowData>}
  */
-async function load_shadow_data(route, event, prerender) {
+async function load_shadow_data(route, event, options, prerender) {
 	if (!route.shadow) return {};
 
 	try {
@@ -440,9 +442,12 @@ async function load_shadow_data(route, event, prerender) {
 
 		return data;
 	} catch (e) {
+		const error = coalesce_to_error(e);
+		options.handle_error(error, event);
+
 		return {
 			status: 500,
-			error: coalesce_to_error(e)
+			error
 		};
 	}
 }

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -125,6 +125,8 @@ export async function respond(opts) {
 
 					if (loaded.loaded.error) {
 						({ status, error } = loaded.loaded);
+						const e = coalesce_to_error(error);
+						options.handle_error(e, event);
 					}
 				} catch (err) {
 					const e = coalesce_to_error(err);

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -125,8 +125,6 @@ export async function respond(opts) {
 
 					if (loaded.loaded.error) {
 						({ status, error } = loaded.loaded);
-						const e = coalesce_to_error(error);
-						options.handle_error(e, event);
 					}
 				} catch (err) {
 					const e = coalesce_to_error(err);

--- a/packages/kit/test/apps/basics/src/routes/errors/endpoint-not-ok.json.js
+++ b/packages/kit/test/apps/basics/src/routes/errors/endpoint-not-ok.json.js
@@ -1,4 +1,6 @@
 /** @type {import('@sveltejs/kit').RequestHandler} */
 export function get() {
-	throw new Error('nope');
+	return {
+		status: 555
+	};
 }

--- a/packages/kit/test/apps/basics/src/routes/errors/endpoint-not-ok.svelte
+++ b/packages/kit/test/apps/basics/src/routes/errors/endpoint-not-ok.svelte
@@ -1,0 +1,18 @@
+<script context="module">
+	/** @type {import('@sveltejs/kit').Load} */
+	export async function load({ fetch }) {
+		const res = await fetch('/errors/endpoint-not-ok.json');
+		if (res.ok) {
+			return {
+				props: await res.json()
+			};
+		} else {
+			return {
+				status: res.status,
+				error: new Error(res.statusText)
+			};
+		}
+	}
+</script>
+
+<h1>this text should not appear</h1>

--- a/packages/kit/test/apps/basics/src/routes/errors/endpoint-shadow-not-ok.js
+++ b/packages/kit/test/apps/basics/src/routes/errors/endpoint-shadow-not-ok.js
@@ -1,4 +1,6 @@
 /** @type {import('@sveltejs/kit').RequestHandler} */
 export function get() {
-	throw new Error('nope');
+	return {
+		status: 555
+	};
 }

--- a/packages/kit/test/apps/basics/src/routes/errors/endpoint-shadow-not-ok.svelte
+++ b/packages/kit/test/apps/basics/src/routes/errors/endpoint-shadow-not-ok.svelte
@@ -1,0 +1,2 @@
+
+<h1>this text should not appear</h1>

--- a/packages/kit/test/apps/basics/src/routes/errors/endpoint-shadow.js
+++ b/packages/kit/test/apps/basics/src/routes/errors/endpoint-shadow.js
@@ -1,0 +1,4 @@
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export function get() {
+	throw new Error('nope shadow');
+}

--- a/packages/kit/test/apps/basics/src/routes/errors/endpoint-shadow.svelte
+++ b/packages/kit/test/apps/basics/src/routes/errors/endpoint-shadow.svelte
@@ -1,0 +1,2 @@
+
+<h1>this text should not appear</h1>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -764,6 +764,30 @@ test.describe.parallel('Errors', () => {
 		}
 	});
 
+	test('error in shadow endpoint', async ({ page, read_errors }) => {
+		const res = await page.goto('/errors/endpoint-shadow');
+
+		// should include stack trace
+		const lines = read_errors('/errors/endpoint-shadow').split('\n');
+		expect(lines[0]).toMatch('nope');
+
+		if (process.env.DEV) {
+			expect(lines[1]).toMatch('endpoint-shadow');
+		}
+
+		expect(res && res.status()).toBe(500);
+		expect(await page.textContent('#message')).toBe('This is your custom error page saying: ""');
+
+		const contents = await page.textContent('#stack');
+		const location = 'endpoint.svelte:12:15';
+
+		if (process.env.DEV) {
+			expect(contents).toMatch(location);
+		} else {
+			expect(contents).not.toMatch(location);
+		}
+	});
+
 	test('server-side 4xx status without error from load()', async ({ page }) => {
 		const response = await page.goto('/errors/load-status-without-error-server');
 


### PR DESCRIPTION
Fixes #3807 

I'm honestly not sure this is the right place, or the right treatment for errors thrown in shadow endpoints, but it seems wrong that they weren't being passed to the `handleError` hook. I added a failing test, and tracked down a possible fix location. The test still fails as the assertion for `page.textContent('#message')` is getting the error message, but expecting an empty string. I don't know what's desired here (I just copied the `'error in endpoint'` test above), so the failure might indicate the fix is more complex than I thought. Anyway, it's a start!

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
