### PR TITLE
Add a scroll restoration test

### DIFF
--- a/packages/kit/test/apps/basics/src/routes/anchor/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/anchor/index.svelte
@@ -1,4 +1,5 @@
 <h1>Welcome to a test project</h1>
+<a id="scroll-anchor" href="#last-anchor-2">Bottom of this page</a>
 <a id="first-anchor" href="/anchor/anchor#go-to-element">Anchor demo (first)</a>
 <div>Spacing</div>
 <a id="second-anchor" href="/anchor/anchor#go-to-element">Anchor demo (second)</a>
@@ -7,6 +8,7 @@
 <div>Spacing</div>
 <a id="last-anchor" href="/anchor/anchor#go-to-element">Anchor demo (last)</a>
 <a id="last-anchor-2" href="/anchor/anchor">Anchor demo (last 2)</a>
+<a id="routing-page" href="/routing/hashes/target">Different page</a>
 
 <style>
 	:global(body) {

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -197,17 +197,28 @@ test.describe('Scrolling', () => {
 	}) => {
 		await page.goto('/anchor');
 		await clicknav('#last-anchor-2');
-		expect(await page.evaluate(() => scrollY === 0)).toBeTruthy;
+		expect(await page.evaluate(() => scrollY === 0)).toBeTruthy();
 	});
 
-	test('scroll is restored after hitting the back button', async ({ back, clicknav, page }) => {
+	test('scroll is restored after hitting the back button', async ({
+		back,
+		baseURL,
+		clicknav,
+		page
+	}) => {
 		await page.goto('/anchor');
 		await page.click('#scroll-anchor');
 		const originalScrollY = /** @type {number} */ (await page.evaluate(() => scrollY));
 		await clicknav('#routing-page');
 		await back();
+		expect(page.url()).toBe(baseURL + '/anchor#last-anchor-2');
 		const scrollY = /** @type {number} */ (await page.evaluate(() => scrollY));
 		expect(scrollY).toEqual(originalScrollY);
+		// TODO: fix this. it is failing due to duplicate history entries
+		// https://github.com/sveltejs/kit/issues/3636
+		// await page.goBack();
+		// expect(page.url()).toBe(baseURL + '/anchor');
+		// expect(scrollY).toEqual(0);
 	});
 
 	test('url-supplied anchor is ignored with onMount() scrolling on direct page load', async ({

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -178,7 +178,7 @@ test.describe('Scrolling', () => {
 	}) => {
 		await page.goto('/anchor');
 		await clicknav('#third-anchor');
-		expect(await page.evaluate(() => pageYOffset === 0)).toBeTruthy();
+		expect(await page.evaluate(() => scrollY === 0)).toBeTruthy();
 	});
 
 	test('url-supplied anchor works when navigated from bottom of page', async ({
@@ -197,7 +197,17 @@ test.describe('Scrolling', () => {
 	}) => {
 		await page.goto('/anchor');
 		await clicknav('#last-anchor-2');
-		expect(await page.evaluate(() => pageYOffset === 0)).toBeTruthy;
+		expect(await page.evaluate(() => scrollY === 0)).toBeTruthy;
+	});
+
+	test('scroll is restored after hitting the back button', async ({ back, clicknav, page }) => {
+		await page.goto('/anchor');
+		await page.click('#scroll-anchor');
+		const originalScrollY = /** @type {number} */ (await page.evaluate(() => scrollY));
+		await clicknav('#routing-page');
+		await back();
+		const scrollY = /** @type {number} */ (await page.evaluate(() => scrollY));
+		expect(scrollY).toEqual(originalScrollY);
 	});
 
 	test('url-supplied anchor is ignored with onMount() scrolling on direct page load', async ({


### PR DESCRIPTION
This test passes on `master`, but fails with https://github.com/sveltejs/kit/pull/3835, which hopefully should help us a bit in preventing regressions in this area.

One thing that's very strange is that it didn't fail on https://github.com/sveltejs/kit/pull/3835 if I navigated to `/anchor/anchor`, but it did if I navigated to `/routing/hashes/target`. I have no explanation for why that would be. It took me a long time to actually figure out how to make the test fail :stuck_out_tongue_closed_eyes: 