### PR TITLE
update adapter docs

### DIFF
--- a/documentation/docs/10-adapters.md
+++ b/documentation/docs/10-adapters.md
@@ -12,7 +12,7 @@ By default, projects are configured to use `@sveltejs/adapter-auto`, which detec
 
 SvelteKit offers a number of officially-supported adapters.
 
-The following platforms require no additional configuration:
+You can deploy to the following platforms with the default adapter, `adapter-auto`:
 
 - [Cloudflare Pages](https://developers.cloudflare.com/pages/) via [`adapter-cloudflare`](https://github.com/sveltejs/kit/tree/master/packages/adapter-cloudflare)
 - [Netlify](https://netlify.com) via [`adapter-netlify`](https://github.com/sveltejs/kit/tree/master/packages/adapter-netlify)
@@ -20,7 +20,7 @@ The following platforms require no additional configuration:
 
 #### Node.js
 
-To create a simple Node server, install the `@sveltejs/adapter-node@next` package and update your `svelte.config.js`:
+To create a simple Node server, install the [`@sveltejs/adapter-node@next`](https://github.com/sveltejs/kit/tree/master/packages/adapter-node) package and update your `svelte.config.js`:
 
 ```diff
 // svelte.config.js
@@ -44,7 +44,7 @@ export default {
 
 #### Static sites
 
-Most adapters will generate static HTML for any [prerenderable](/docs/page-options#prerender) pages of your site. In some cases, your entire app might be prerenderable, in which case you can use `@sveltejs/adapter-static@next` to generate static HTML for _all_ your pages. A fully static site can be hosted on a wide variety of platforms, including static hosts like [GitHub Pages](https://pages.github.com/).
+Most adapters will generate static HTML for any [prerenderable](/docs/page-options#prerender) pages of your site. In some cases, your entire app might be prerenderable, in which case you can use [`@sveltejs/adapter-static@next`](https://github.com/sveltejs/kit/tree/master/packages/adapter-static) to generate static HTML for _all_ your pages. A fully static site can be hosted on a wide variety of platforms, including static hosts like [GitHub Pages](https://pages.github.com/).
 
 ```diff
 // svelte.config.js


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/3872

added links to adapter-node and adapter-static readmes

the "no additional configuration" phrase was slightly confusing because it implied that the other adapters required options to be passed to them and that you might not be able to pass options to this list of adapters