### PR TITLE
fix in_view function

### DIFF
--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -112,7 +112,8 @@ export const test = base.extend({
 		/** @param {string} selector */
 		async function in_view(selector) {
 			const box = await page.locator(selector).boundingBox();
-			return !!box;
+			const view = await page.viewportSize();
+			return box && view && box.y < view.height && box.y + box.height > 0;
 		}
 
 		use(in_view);


### PR DESCRIPTION
@PH4NTOMiki's https://github.com/sveltejs/kit/pull/3873#issuecomment-1037486329 reminded me of https://github.com/sveltejs/kit/pull/3741#discussion_r802313189. The `in_view` function now isn't correct and reports `true` if the element is anywhere on the page, not stricly in the viewport as expected.

With this PR, `in_view` only returns true if the element is actually in the viewport.

## Notes

According to [playwright's docs](https://playwright.dev/docs/api/class-locator#locator-bounding-box):

> This method returns the bounding box of the element, or null if the element is not visible

Playwright's term for "is not visible" is [confusing](https://playwright.dev/docs/actionability#visible):

> Element is considered visible when it has non-empty bounding box and does not have visibility:hidden computed style. Note that elements of zero size or with display:none are not considered visible.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
