### PR TITLE
use old-style padding

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,7 +311,7 @@ importers:
     specifiers:
       '@sveltejs/adapter-auto': workspace:*
       '@sveltejs/kit': workspace:*
-      '@sveltejs/site-kit': ^2.0.2
+      '@sveltejs/site-kit': ^2.0.3
       '@types/node': ^16.6.1
       flexsearch: ^0.7.21
       marked: ^4.0.5
@@ -323,7 +323,7 @@ importers:
     devDependencies:
       '@sveltejs/adapter-auto': link:../../packages/adapter-auto
       '@sveltejs/kit': link:../../packages/kit
-      '@sveltejs/site-kit': 2.0.2
+      '@sveltejs/site-kit': 2.0.3
       '@types/node': 16.11.11
       flexsearch: 0.7.21
       marked: 4.0.5
@@ -1432,8 +1432,8 @@ packages:
       picomatch: 2.3.0
     dev: true
 
-  /@sveltejs/site-kit/2.0.2:
-    resolution: {integrity: sha512-YdA4YDz0As/G1yypUAs2gxF/unt6eo/itfwl67GHmfam6c7gJDYyLC0CZNZKdjPY4GfmvvYNqB/Ta4I4xHxGXQ==}
+  /@sveltejs/site-kit/2.0.3:
+    resolution: {integrity: sha512-l5fst4LmQOpvnqkpOagTE6yHqj5cm3xHnlFKLCYLMuvDENHUKhhYTX71oeRZhyboMZ2DO3gGhzlj3R6iP+TdLA==}
     dependencies:
       golden-fleece: 1.0.9
     dev: true

--- a/sites/kit.svelte.dev/package.json
+++ b/sites/kit.svelte.dev/package.json
@@ -10,7 +10,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "workspace:*",
 		"@sveltejs/kit": "workspace:*",
-		"@sveltejs/site-kit": "^2.0.2",
+		"@sveltejs/site-kit": "^2.0.3",
 		"@types/node": "^16.6.1",
 		"flexsearch": "^0.7.21",
 		"marked": "^4.0.5",

--- a/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
+++ b/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
@@ -140,7 +140,7 @@
 	a {
 		position: relative;
 		transition: color 0.2s;
-		border-block-end: none;
+		border-bottom: none;
 		padding: 0;
 		color: var(--sidebar-text);
 		user-select: none;
@@ -148,7 +148,7 @@
 
 	.section {
 		display: block;
-		padding-block-end: 0.8rem;
+		padding-bottom: 0.8rem;
 		font-size: var(--h6);
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
@@ -159,7 +159,7 @@
 		display: block;
 		font-size: 1.6rem;
 		font-family: var(--font);
-		padding-block-end: 0.6em;
+		padding-bottom: 0.6em;
 	}
 
 	.active::after {
@@ -170,7 +170,7 @@
 		width: 0;
 		height: 0;
 		border: 6px solid transparent;
-		border-inline-end-color: white;
+		border-right-color: white;
 	}
 
 	.nested {

--- a/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
+++ b/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
@@ -121,13 +121,12 @@
 	}
 
 	.sidebar {
-		padding-inline: 3.2rem 0;
-		padding-block: var(--top-offset) 6.4rem;
+		padding: var(--top-offset) 0 6.4rem 3.2rem;
 		font-family: var(--font);
 		overflow-y: auto;
-		block-size: 100%;
+		height: 100%;
 		bottom: auto;
-		inline-size: 100%;
+		width: 100%;
 		columns: 2;
 	}
 
@@ -135,7 +134,7 @@
 		display: block;
 		line-height: 1.2;
 		margin: 0;
-		margin-block-end: 4rem;
+		margin-bottom: 4rem;
 	}
 
 	a {
@@ -168,14 +167,14 @@
 		position: absolute;
 		right: 0;
 		top: 2px;
-		inline-size: 0;
-		block-size: 0;
+		width: 0;
+		height: 0;
 		border: 6px solid transparent;
 		border-inline-end-color: white;
 	}
 
 	.nested {
-		padding-inline-start: 1.2rem;
+		padding-left: 1.2rem;
 	}
 
 	ul ul,
@@ -193,14 +192,16 @@
 	@media (min-width: 600px) {
 		.sidebar {
 			columns: 2;
-			padding-inline: var(--side-nav);
+			padding-left: var(--side-nav);
+			padding-right: var(--side-nav);
 		}
 	}
 
 	@media (min-width: 832px) {
 		.sidebar {
 			columns: 1;
-			padding-inline: 3.2rem 0;
+			padding-left: 3.2rem;
+			padding-right: 0;
 		}
 
 		nav::after {
@@ -208,10 +209,10 @@
 			position: fixed;
 			left: 0;
 			bottom: 0;
-			inline-size: var(--sidebar-w);
-			block-size: 2em;
+			width: var(--sidebar-w);
+			height: 2em;
 			pointer-events: none;
-			block-size: var(--top-offset);
+			height: var(--top-offset);
 			background: linear-gradient(
 				to bottom,
 				rgba(103, 103, 120, 0) 0%,

--- a/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
+++ b/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
@@ -113,8 +113,8 @@
 
 <style>
 	nav {
-		inset-block-start: 0;
-		inset-inline-start: 0;
+		top: 0;
+		left: 0;
 		overflow: hidden;
 		background-color: var(--second);
 		color: white;
@@ -126,7 +126,7 @@
 		font-family: var(--font);
 		overflow-y: auto;
 		block-size: 100%;
-		inset-block-end: auto;
+		bottom: auto;
 		inline-size: 100%;
 		columns: 2;
 	}
@@ -166,8 +166,8 @@
 	.active::after {
 		content: '';
 		position: absolute;
-		inset-inline-end: 0;
-		inset-block-start: 2px;
+		right: 0;
+		top: 2px;
 		inline-size: 0;
 		block-size: 0;
 		border: 6px solid transparent;
@@ -206,8 +206,8 @@
 		nav::after {
 			content: '';
 			position: fixed;
-			inset-inline-start: 0;
-			inset-block-end: 0;
+			left: 0;
+			bottom: 0;
 			inline-size: var(--sidebar-w);
 			block-size: 2em;
 			pointer-events: none;

--- a/sites/kit.svelte.dev/src/routes/__error.svelte
+++ b/sites/kit.svelte.dev/src/routes/__error.svelte
@@ -14,47 +14,8 @@
 
 	// we don't want to use <svelte:window bind:online> here, because we only care about the online
 	// state when the page first loads
-	let online = typeof navigator !== 'undefined'
-		? navigator.onLine
-		: true;
+	let online = typeof navigator !== 'undefined' ? navigator.onLine : true;
 </script>
-
-<style>
-	.container {
-		padding-inline: var(--side-nav);
-		padding-block: var(--top-offset) 6rem;
-	}
-
-	h1, p {
-		margin-inline: auto;
-		margin-block: 0;
-	}
-
-	h1 {
-		font-size: 2.8em;
-		font-weight: 300;
-		margin: 0;
-		margin-block-end: 0.5em;
-	}
-
-	p {
-		margin-inline: auto;
-		margin-block: 1em;
-	}
-
-	.error {
-		background-color: #da106e;
-		color: white;
-		padding-inline: 16px;
-		padding-block: 12px;
-		font: 600 16px/1.7 var(--font);
-		border-radius: 2px;
-	}
-
-	/* @media (min-width: 480px) {
-		h1 { font-size: 4em }
-	} */
-</style>
 
 <svelte:head>
 	<title>{status}</title>
@@ -77,7 +38,11 @@
 				<p>Please try reloading the page.</p>
 			{/if}
 
-			<p>If the error persists, please drop by <a href="https://svelte.dev/chat">Discord chatroom</a> and let us know, or raise an issue on <a href="https://github.com/sveltejs/svelte">GitHub</a>. Thanks!</p>
+			<p>
+				If the error persists, please drop by <a href="https://svelte.dev/chat">Discord chatroom</a>
+				and let us know, or raise an issue on
+				<a href="https://github.com/sveltejs/svelte">GitHub</a>. Thanks!
+			</p>
 		{/if}
 	{:else}
 		<h1>It looks like you're offline</h1>
@@ -85,3 +50,37 @@
 		<p>Reload the page once you've found the internet.</p>
 	{/if}
 </div>
+
+<style>
+	.container {
+		padding: var(--top-offset) var(--side-nav) 6rem var(--side-nav);
+	}
+
+	h1,
+	p {
+		margin: 0 auto;
+	}
+
+	h1 {
+		font-size: 2.8em;
+		font-weight: 300;
+		margin: 0;
+		margin-bottom: 0.5em;
+	}
+
+	p {
+		margin: 1em auto;
+	}
+
+	.error {
+		background-color: #da106e;
+		color: white;
+		padding: 12px 16px;
+		font: 600 16px/1.7 var(--font);
+		border-radius: 2px;
+	}
+
+	/* @media (min-width: 480px) {
+		h1 { font-size: 4em }
+	} */
+</style>

--- a/sites/kit.svelte.dev/src/routes/__layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/__layout.svelte
@@ -55,8 +55,7 @@
 <style>
 	main {
 		position: relative;
-		margin-inline: auto;
-		margin-block: 0;
+		margin: 0 auto;
 		padding-block-start: var(--nav-h);
 		overflow-x: hidden;
 	}
@@ -108,12 +107,12 @@
 	/* this is an unfortunate hack, but necessary to temporarily avoid
 	   breaking changes to site-kit */
 	:global(ul.external) {
-		inline-size: 40rem !important;
+		width: 40rem !important;
 	}
 
 	@media (min-width: 960px) {
 		:global(ul.external) {
-			inline-size: 30rem !important;
+			width: 30rem !important;
 		}
 	}
 </style>

--- a/sites/kit.svelte.dev/src/routes/__layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/__layout.svelte
@@ -56,7 +56,7 @@
 	main {
 		position: relative;
 		margin: 0 auto;
-		padding-block-start: var(--nav-h);
+		padding-top: var(--nav-h);
 		overflow-x: hidden;
 	}
 

--- a/sites/kit.svelte.dev/src/routes/docs/[slug].svelte
+++ b/sites/kit.svelte.dev/src/routes/docs/[slug].svelte
@@ -75,9 +75,9 @@
 		position: relative;
 		top: -0.1rem;
 		left: 0.3rem;
-		inline-size: 1.4rem;
-		block-size: 1.4rem;
-		margin-inline-end: 0.5rem;
+		width: 1.4rem;
+		height: 1.4rem;
+		margin-right: 0.5rem;
 	}
 
 	.controls {

--- a/sites/kit.svelte.dev/src/routes/docs/_/docs.css
+++ b/sites/kit.svelte.dev/src/routes/docs/_/docs.css
@@ -1,8 +1,7 @@
 .content {
 	inline-size: 100%;
 	margin: 0;
-	padding-inline: var(--side-nav);
-	padding-block: var(--top-offset);
+	padding: var(--top-offset) var(--side-nav);
 	tab-size: 2;
 	-moz-tab-size: 2;
 }

--- a/sites/kit.svelte.dev/src/routes/docs/_/docs.css
+++ b/sites/kit.svelte.dev/src/routes/docs/_/docs.css
@@ -1,5 +1,5 @@
 .content {
-	inline-size: 100%;
+	width: 100%;
 	margin: 0;
 	padding: var(--top-offset) var(--side-nav);
 	tab-size: 2;
@@ -9,7 +9,7 @@
 @media (min-width: 832px) {
 	/* can't use vars in @media :( */
 	.content {
-		padding-inline-start: calc(var(--sidebar-w) + var(--side-nav));
+		padding-left: calc(var(--sidebar-w) + var(--side-nav));
 	}
 }
 
@@ -19,9 +19,8 @@
 }
 
 .content h2 {
-	margin-block-start: 8rem;
-	padding-inline: 0.2rem 1.6rem;
-	padding-block: 2rem 4rem;
+	margin-top: 8rem;
+	padding: 2rem 1.6rem 4rem 0.2rem;
 	border-block-start: 2px solid #ddd;
 	line-height: 1;
 	font-size: var(--h3);
@@ -30,7 +29,7 @@
 }
 
 .content section:first-of-type > h2 {
-	margin-block-start: 0;
+	margin-top: 0;
 }
 
 .content h4 {
@@ -41,8 +40,8 @@
 	position: relative;
 	display: block;
 	top: calc(-1 * var(--top-offset));
-	inline-size: 0;
-	block-size: 0;
+	width: 0;
+	height: 0;
 }
 
 .content .anchor {
@@ -50,8 +49,8 @@
 	display: block;
 	background: url(@sveltejs/site-kit/icons/link.svg) 0 50% no-repeat;
 	background-size: 1em 1em;
-	inline-size: 1.4em;
-	block-size: 1em;
+	width: 1.4em;
+	height: 1em;
 	left: -1.3em;
 	bottom: 0.3rem;
 	opacity: 0;
@@ -89,11 +88,10 @@
 
 .content h3,
 .content h3 > code {
-	margin-inline: 0;
-	margin-block: 6.4rem 1rem;
+	margin: 6.4rem 0 1rem 0;
 	padding-block-end: 1rem;
 	color: var(--text);
-	max-inline-size: var(--linemax);
+	max-width: var(--linemax);
 	border-block-end: 1px solid #ddd;
 	background: transparent;
 	line-height: 1;
@@ -117,9 +115,8 @@
 	font-weight: 600;
 	font-size: 2.4rem;
 	color: var(--second);
-	margin-inline: 0;
-	margin-block: 6.4rem 1.6rem;
-	padding-inline-start: 0;
+	margin: 6.4rem 0 1.6rem 0;
+	padding-left: 0;
 	background: transparent;
 	line-height: 1;
 	padding-block-start: 0;
@@ -129,8 +126,8 @@
 .content h4::before {
 	display: block;
 	content: ' ';
-	block-size: var(--nav-h);
-	margin-block-start: calc(-1 * var(--nav-h));
+	height: var(--nav-h);
+	margin-top: calc(-1 * var(--nav-h));
 }
 
 .content h4 > em {
@@ -144,8 +141,7 @@
 
 .content code {
 	padding: 0.4rem;
-	margin-inline: 0.2rem;
-	margin-block: 0;
+	margin: 0 0.2rem;
 	top: -0.1rem;
 	background: var(--back-api);
 }
@@ -159,20 +155,20 @@
 
 .content pre {
 	margin: 0;
-	margin-block-end: 2rem;
-	inline-size: 100%;
-	max-inline-size: var(--linemax);
+	margin-bottom: 2rem;
+	width: 100%;
+	max-width: var(--linemax);
 	padding: 1rem;
 	box-shadow: inset 1px 1px 6px hsla(205.7, 63.6%, 30.8%, 0.06);
 }
 
 .content table {
 	margin: 0;
-	margin-block-end: 2em;
+	margin-bottom: 2em;
 }
 
 .content section p {
-	max-inline-size: var(--linemax);
+	max-width: var(--linemax);
 	margin-block: 1em;
 }
 
@@ -192,11 +188,11 @@
 }
 
 .content blockquote :first-child {
-	margin-block-start: 0;
+	margin-top: 0;
 }
 
 .content blockquote :last-child {
-	margin-block-end: 0;
+	margin-bottom: 0;
 }
 
 .content blockquote code {
@@ -217,16 +213,16 @@
 .content h2[id],
 .content h3[id] {
 	padding-block-start: 10rem;
-	margin-block-start: -2rem;
+	margin-top: -2rem;
 	border-block-start: none;
 }
 
 .content h2[id]::after {
 	content: '';
 	position: absolute;
-	inline-size: 100%;
+	width: 100%;
 	left: 0;
 	top: 8rem;
-	block-size: 2px;
+	height: 2px;
 	background: #ddd;
 }

--- a/sites/kit.svelte.dev/src/routes/docs/_/docs.css
+++ b/sites/kit.svelte.dev/src/routes/docs/_/docs.css
@@ -40,7 +40,7 @@
 .content .offset-anchor {
 	position: relative;
 	display: block;
-	inset-block-start: calc(-1 * var(--top-offset));
+	top: calc(-1 * var(--top-offset));
 	inline-size: 0;
 	block-size: 0;
 }
@@ -52,18 +52,18 @@
 	background-size: 1em 1em;
 	inline-size: 1.4em;
 	block-size: 1em;
-	inset-inline-start: -1.3em;
-	inset-block-end: 0.3rem;
+	left: -1.3em;
+	bottom: 0.3rem;
 	opacity: 0;
 	transition: opacity 0.2s;
 }
 
 .content h2 .anchor {
-	inset-block-end: 4rem;
+	bottom: 4rem;
 }
 
 .content h3 .anchor {
-	inset-block-end: 1rem;
+	bottom: 1rem;
 }
 
 @media (min-width: 400px) {
@@ -123,7 +123,7 @@
 	background: transparent;
 	line-height: 1;
 	padding-block-start: 0;
-	inset-block-start: 0;
+	top: 0;
 }
 
 .content h4::before {
@@ -146,14 +146,14 @@
 	padding: 0.4rem;
 	margin-inline: 0.2rem;
 	margin-block: 0;
-	inset-block-start: -0.1rem;
+	top: -0.1rem;
 	background: var(--back-api);
 }
 
 .content pre code {
 	padding: 0;
 	margin: 0;
-	inset-block-start: 0;
+	top: 0;
 	background: transparent;
 }
 
@@ -225,8 +225,8 @@
 	content: '';
 	position: absolute;
 	inline-size: 100%;
-	inset-inline-start: 0;
-	inset-block-start: 8rem;
+	left: 0;
+	top: 8rem;
 	block-size: 2px;
 	background: #ddd;
 }

--- a/sites/kit.svelte.dev/src/routes/docs/_/docs.css
+++ b/sites/kit.svelte.dev/src/routes/docs/_/docs.css
@@ -21,7 +21,7 @@
 .content h2 {
 	margin-top: 8rem;
 	padding: 2rem 1.6rem 4rem 0.2rem;
-	border-block-start: 2px solid #ddd;
+	border-top: 2px solid #ddd;
 	line-height: 1;
 	font-size: var(--h3);
 	letter-spacing: 0.05em;
@@ -33,7 +33,7 @@
 }
 
 .content h4 {
-	margin-block: 2em 1em;
+	margin: 2em 0 1em 0;
 }
 
 .content .offset-anchor {
@@ -89,10 +89,10 @@
 .content h3,
 .content h3 > code {
 	margin: 6.4rem 0 1rem 0;
-	padding-block-end: 1rem;
+	padding-bottom: 1rem;
 	color: var(--text);
 	max-width: var(--linemax);
-	border-block-end: 1px solid #ddd;
+	border-bottom: 1px solid #ddd;
 	background: transparent;
 	line-height: 1;
 }
@@ -119,7 +119,7 @@
 	padding-left: 0;
 	background: transparent;
 	line-height: 1;
-	padding-block-start: 0;
+	padding-top: 0;
 	top: 0;
 }
 
@@ -136,7 +136,7 @@
 
 .content h5 {
 	font-size: 2.4rem;
-	margin-block: 2em 0.5em;
+	margin: 2em 0 0.5em 0;
 }
 
 .content code {
@@ -169,12 +169,12 @@
 
 .content section p {
 	max-width: var(--linemax);
-	margin-block: 1em;
+	margin: 1em 0;
 }
 
 .content small {
 	font-size: var(--h5);
-	float: inline-end;
+	float: right;
 	pointer-events: all;
 	color: var(--prime);
 	cursor: pointer;
@@ -183,7 +183,7 @@
 .content blockquote {
 	color: rgba(0, 0, 0, 0.7);
 	background-color: rgba(255, 62, 0, 0.1);
-	border-inline-start: 4px solid #ff3e00;
+	border-left: 4px solid #ff3e00;
 	padding: 1rem;
 }
 
@@ -212,9 +212,9 @@
    once https://github.com/sveltejs/action-deploy-docs/issues/1 is closed */
 .content h2[id],
 .content h3[id] {
-	padding-block-start: 10rem;
+	padding-top: 10rem;
 	margin-top: -2rem;
-	border-block-start: none;
+	border-top: none;
 }
 
 .content h2[id]::after {

--- a/sites/kit.svelte.dev/src/routes/docs/__layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/docs/__layout.svelte
@@ -53,8 +53,8 @@
 			height: 100vh;
 			overflow: auto;
 			position: fixed;
-			inset-inline-start: 0;
-			inset-block-start: 0;
+			left: 0;
+			top: 0;
 		}
 	}
 </style>

--- a/sites/kit.svelte.dev/src/routes/faq/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/faq/index.svelte
@@ -37,12 +37,10 @@
 	.faqs {
 		grid-template-columns: 1fr 1fr;
 		grid-gap: 1em;
-		min-block-size: calc(100vh - var(--nav-h));
-		padding-inline: var(--side-nav);
-		padding-block: var(--top-offset) 6rem;
-		max-inline-size: var(--main-width);
-		margin-inline: auto;
-		margin-block: 0;
+		min-height: calc(100vh - var(--nav-h));
+		padding: var(--top-offset) var(--side-nav) 6rem var(--side-nav);
+		max-width: var(--main-width);
+		margin: 0 auto;
 		tab-size: 2;
 	}
 
@@ -55,11 +53,10 @@
 
 	.faqs :global(pre) {
 		margin: 0;
-		margin-block-end: 2rem;
-		inline-size: 100%;
-		max-inline-size: var(--linemax);
-		padding-inline: 2.5rem;
-		padding-block: 1.5rem;
+		margin-bottom: 2rem;
+		width: 100%;
+		max-width: var(--linemax);
+		padding: 1.5rem 2.5rem;
 		border-radius: 0.5rem;
 		font-size: 0.8rem;
 	}
@@ -69,8 +66,8 @@
 		display: block;
 		background: url(@sveltejs/site-kit/icons/link.svg) 0 50% no-repeat;
 		background-size: 1em 1em;
-		inline-size: 1.4em;
-		block-size: 1em;
+		width: 1.4em;
+		height: 1em;
 		left: -1.3em;
 		opacity: 0;
 		transition: opacity 0.2s;
@@ -102,7 +99,7 @@
 		padding-block-start: 10rem;
 		padding-block-end: 0.2rem;
 		color: var(--text);
-		/* max-inline-size: 24em; */
+		/* max-width: 24em; */
 		font-size: var(--h3);
 		font-weight: 400;
 		border-block-end: 1px solid #ddd;
@@ -114,7 +111,7 @@
 		font-size: 2rem;
 		color: var(--second);
 		margin-block: 2rem 1.6rem;
-		padding-inline-start: 0;
+		padding-left: 0;
 		background: transparent;
 		line-height: 1.3;
 		padding: 0;
@@ -144,7 +141,7 @@
 	}
 
 	:global(.faqs .faq ul) {
-		margin-inline-start: 3.2rem;
+		margin-left: 3.2rem;
 	}
 
 	@media (max-width: 768px) {

--- a/sites/kit.svelte.dev/src/routes/faq/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/faq/index.svelte
@@ -49,7 +49,7 @@
 	.faqs :global(pre) :global(code) {
 		padding: 0;
 		margin: 0;
-		inset-block-start: 0;
+		top: 0;
 		background: transparent;
 	}
 
@@ -71,14 +71,14 @@
 		background-size: 1em 1em;
 		inline-size: 1.4em;
 		block-size: 1em;
-		inset-inline-start: -1.3em;
+		left: -1.3em;
 		opacity: 0;
 		transition: opacity 0.2s;
 	}
 
 	.faqs :global(h2 > .anchor),
 	.faqs :global(h3 > .anchor) {
-		inset-block-end: 0.3em;
+		bottom: 0.3em;
 	}
 
 	@media (min-width: 768px) {
@@ -93,7 +93,7 @@
 
 		.faqs :global(h5) :global(.anchor),
 		.faqs :global(h6) :global(.anchor) {
-			inset-block-end: 0.25em;
+			bottom: 0.25em;
 		}
 	}
 
@@ -118,7 +118,7 @@
 		background: transparent;
 		line-height: 1.3;
 		padding: 0;
-		inset-block-start: 0;
+		top: 0;
 	}
 
 	.faqs :global(a) {
@@ -151,7 +151,7 @@
 		.faqs :global(.anchor) {
 			transform: scale(0.6);
 			opacity: 1;
-			inset-inline-start: -1em;
+			left: -1em;
 		}
 	}
 </style>

--- a/sites/kit.svelte.dev/src/routes/faq/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/faq/index.svelte
@@ -95,14 +95,14 @@
 	}
 
 	h2 {
-		margin-block: -4rem 1rem;
-		padding-block-start: 10rem;
-		padding-block-end: 0.2rem;
+		margin: -4rem 0 1rem 0;
+		padding-top: 10rem;
+		padding-bottom: 0.2rem;
 		color: var(--text);
 		/* max-width: 24em; */
 		font-size: var(--h3);
 		font-weight: 400;
-		border-block-end: 1px solid #ddd;
+		border-bottom: 1px solid #ddd;
 	}
 
 	.faqs :global(h3) {
@@ -110,7 +110,7 @@
 		font-weight: 600;
 		font-size: 2rem;
 		color: var(--second);
-		margin-block: 2rem 1.6rem;
+		margin: 2rem 0 1.6rem 0;
 		padding-left: 0;
 		background: transparent;
 		line-height: 1.3;
@@ -129,10 +129,9 @@
 	}
 
 	.faq:first-child {
-		margin: 0;
-		margin-block: 2rem;
-		padding-block-end: 4rem;
-		border-block-end: var(--border-w) solid #6767785b; /* based on --second */
+		margin: 2rem 0;
+		padding-bottom: 4rem;
+		border-bottom: var(--border-w) solid #6767785b; /* based on --second */
 	}
 	.faq:first-child h2 {
 		font-size: 4rem;

--- a/sites/kit.svelte.dev/src/routes/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/index.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <script>
-	import Machine from '$img/svelte-kit-machine.webp?w=1440;800&format=avif;webp;png&meta'
+	import Machine from '$img/svelte-kit-machine.webp?w=1440;800&format=avif;webp;png&meta';
 	import { Hero, Blurb } from '@sveltejs/site-kit';
 </script>
 
@@ -95,11 +95,11 @@ npm run dev -- --open
 
 <style>
 	:global(.hero-container:dir(rtl)) {
-		max-inline-size: 116rem;
+		max-width: 116rem;
 	}
 
 	pre {
-		block-size: 100%;
+		height: 100%;
 		display: flex;
 		flex-direction: column;
 		color: var(--second-text);
@@ -110,12 +110,12 @@ npm run dev -- --open
 	}
 
 	.blurb-shifter {
-		margin-block-start: calc(-10rem + var(--side-nav));
+		margin-top: calc(-10rem + var(--side-nav));
 	}
 
 	@media (min-width: 900px) {
 		.blurb-shifter {
-			margin-block-start: -12em;
+			margin-top: -12em;
 		}
 	}
 </style>


### PR DESCRIPTION
kit.svelte.dev looks terrible on some iphones because Safari only recently began supporting logical properties, and it's not an evergreen browser. ~~I have a hunch that `padding-inline` and `padding-block` are to blame — this is a small PR to test out that theory. If it holds, we should probably remove all those declarations until such time as we need to support languages that need them.~~

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
