### PR TITLE
handleResponse hook for logging/monitoring which route was matched

### DIFF
--- a/packages/kit/src/core/build/build_server.js
+++ b/packages/kit/src/core/build/build_server.js
@@ -41,6 +41,7 @@ const get_hooks = hooks => ({
 	getSession: hooks.getSession || (() => ({})),
 	handle: hooks.handle || (({ event, resolve }) => resolve(event)),
 	handleError: hooks.handleError || (({ error }) => console.error(error.stack)),
+	handleResponse: hooks.handleResponse || (() => {}),
 	externalFetch: hooks.externalFetch || fetch
 });
 

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -107,6 +107,7 @@ export async function create_plugin(config, cwd) {
 								return {
 									type: 'page',
 									pattern: route.pattern,
+									key: route.key,
 									params: get_params(route.params),
 									shadow: route.shadow
 										? async () => {
@@ -122,6 +123,7 @@ export async function create_plugin(config, cwd) {
 							return {
 								type: 'endpoint',
 								pattern: route.pattern,
+								key: route.key,
 								params: get_params(route.params),
 								load: async () => {
 									const url = path.resolve(cwd, route.file);
@@ -184,6 +186,7 @@ export async function create_plugin(config, cwd) {
 							// @ts-expect-error this picks up types that belong to the tests
 							getSession: user_hooks.getSession || (() => ({})),
 							handle: amp ? sequence(amp, handle) : handle,
+							handleResponse: user_hooks.handleResponse || (() => {}),
 							handleError:
 								user_hooks.handleError ||
 								(({ /** @type {Error & { frame?: string }} */ error }) => {

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -68,6 +68,7 @@ export function generate_manifest(
 						return `{
 							type: 'page',
 							pattern: ${route.pattern},
+							key: '${route.key}',
 							params: ${get_params(route.params)},
 							path: ${route.path ? s(route.path) : null},
 							shadow: ${route.shadow ? importer(`${relative_path}/${build_data.server.vite_manifest[route.shadow].file}`) : null},
@@ -84,6 +85,7 @@ export function generate_manifest(
 						return `{
 							type: 'endpoint',
 							pattern: ${route.pattern},
+							key: '${route.key}',
 							params: ${get_params(route.params)},
 							load: ${importer(`${relative_path}/${build_data.server.vite_manifest[route.file].file}`)}
 						}`.replace(/^\t\t/gm, '');

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -165,6 +165,7 @@ export async function respond(request, options, state = {}) {
 					}
 
 					if (response) {
+						options.hooks.handleResponse({ event, response, route });
 						// respond with 304 if etag matches
 						if (response.status === 200 && response.headers.has('etag')) {
 							let if_none_match_value = request.headers.get('if-none-match');

--- a/packages/kit/test/apps/basics/src/hooks.js
+++ b/packages/kit/test/apps/basics/src/hooks.js
@@ -45,6 +45,12 @@ export const handle = sequence(
 	}
 );
 
+export const handleResponse = ({ event, response, route }) => {
+	console.log(
+		`request to '${event.url.pathname}' gave response '${response.status}' from route '${route.key}'.`
+	);
+};
+
 /** @type {import('@sveltejs/kit').ExternalFetch} */
 export async function externalFetch(request) {
 	let newRequest = request;


### PR DESCRIPTION
This is a very speculative PR, with no tests or types yet. I'm interested what the view is from the maintainers about the use-case and the approach.

Fixes #3840 

From that issue:
> I'm keen to implement good logging and monitoring for my SvelteKit app. For monitoring, in particular, it's extremely useful to know which route, and which params, produced the final response. I use Prometheus, and with my old Express.js app I'd typically label each finished request/response with details like {method: 'GET', route: '/users/[id]/details', status: 200}. This generic route parameter means that I can aggregate all similar requests to the same route and understand how long the responses took to generate on average (or stddev, etc). At present, since I don't know which route rendered the response in handle(), the best I can do is to use url.pathname, which means I can't aggregate across similar request to the same route.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
