### PR TITLE
[docs] clarify how to prerender only some pages

### DIFF
--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -1,6 +1,6 @@
 # @sveltejs/adapter-static
 
-[Adapter](https://kit.svelte.dev/docs/adapters) for SvelteKit apps that prerenders your site as a collection of static files.
+[Adapter](https://kit.svelte.dev/docs/adapters) for SvelteKit apps that prerenders your entire site as a collection of static files. If you'd like to prerender only some pages, you will need to use a different adapter together with [the `export const prerender` option](https://kit.svelte.dev/docs/page-options#prerender).
 
 ## Usage
 

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -1,6 +1,6 @@
 # @sveltejs/adapter-static
 
-[Adapter](https://kit.svelte.dev/docs/adapters) for SvelteKit apps that prerenders your entire site as a collection of static files. If you'd like to prerender only some pages, you will need to use a different adapter together with [the `export const prerender` option](https://kit.svelte.dev/docs/page-options#prerender).
+[Adapter](https://kit.svelte.dev/docs/adapters) for SvelteKit apps that prerenders your entire site as a collection of static files. If you'd like to prerender only some pages, you will need to use a different adapter together with [the `prerender` option](https://kit.svelte.dev/docs/page-options#prerender).
 
 ## Usage
 


### PR DESCRIPTION
I just answered two questions in a row on GitHub Discussions about this. Apparently people think "prerendering = adapter-static" and are very confused about how to prerender only some pages