### PR TITLE
prevent accidentally merging test.only

### DIFF
--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -169,7 +169,7 @@ export const test = base.extend({
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 export const config = {
-  forbidOnly: !!process.env.CI,
+	forbidOnly: !!process.env.CI,
 	// generous timeouts on CI
 	timeout: process.env.CI ? 45000 : 15000,
 	webServer: {

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -167,6 +167,17 @@ export const test = base.extend({
 	}
 });
 
+// If there's a more elegant/declarative way to do this, let me know
+if (process.env.CI) {
+	test.only =
+		test.describe.only =
+		test.describe.serial.only =
+		test.describe.parallel.only =
+			() => {
+				throw new Error('You must remove .only from tests before merging');
+			};
+}
+
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 export const config = {
 	// generous timeouts on CI

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -180,6 +180,7 @@ if (process.env.CI) {
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 export const config = {
+  forbidOnly: !!process.env.CI,
 	// generous timeouts on CI
 	timeout: process.env.CI ? 45000 : 15000,
 	webServer: {

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -167,17 +167,6 @@ export const test = base.extend({
 	}
 });
 
-// If there's a more elegant/declarative way to do this, let me know
-if (process.env.CI) {
-	test.only =
-		test.describe.only =
-		test.describe.serial.only =
-		test.describe.parallel.only =
-			() => {
-				throw new Error('You must remove .only from tests before merging');
-			};
-}
-
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 export const config = {
   forbidOnly: !!process.env.CI,


### PR DESCRIPTION
There might be a neater way to do this, I couldn't find one. It prevents us accidentally merging `test.only(...)` (https://github.com/sveltejs/kit/pull/3816/files#r806298858)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
