### PR TITLE
Fix commented-out test

### DIFF
--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -212,13 +212,11 @@ test.describe('Scrolling', () => {
 		await clicknav('#routing-page');
 		await back();
 		expect(page.url()).toBe(baseURL + '/anchor#last-anchor-2');
-		const scrollY = /** @type {number} */ (await page.evaluate(() => scrollY));
-		expect(scrollY).toEqual(originalScrollY);
+		expect(await page.evaluate(() => scrollY)).toEqual(originalScrollY);
 		// TODO: fix this. it is failing due to duplicate history entries
-		// https://github.com/sveltejs/kit/issues/3636
 		// await page.goBack();
 		// expect(page.url()).toBe(baseURL + '/anchor');
-		// expect(scrollY).toEqual(0);
+		// expect(await page.evaluate(() => scrollY)).toEqual(0);
 	});
 
 	test('url-supplied anchor is ignored with onMount() scrolling on direct page load', async ({


### PR DESCRIPTION
Leaving it disabled because it's still failing, but fixing a coding mistake