### PR TITLE
recover scroll state on reload

### DIFF
--- a/.changeset/khaki-onions-enjoy.md
+++ b/.changeset/khaki-onions-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Recover scroll state on page reload

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -79,6 +79,8 @@ export class Router {
 			history.scrollRestoration = 'manual';
 		}
 
+		// if we reload the page, or Cmd-Shift-T back to it,
+		// recover scroll position
 		const scroll = history.state?.['sveltekit:scroll'];
 		if (scroll) {
 			scrollTo(scroll.x, scroll.y);

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -79,6 +79,11 @@ export class Router {
 			history.scrollRestoration = 'manual';
 		}
 
+		const scroll = history.state?.['sveltekit:scroll'];
+		if (scroll) {
+			scrollTo(scroll.x, scroll.y);
+		}
+
 		// Adopted from Nuxt.js
 		// Reset scrollRestoration to auto when leaving page, allowing page reload
 		// and back-navigation from other pages to use the browser to restore the


### PR DESCRIPTION
See discussion on #3873 — if you Cmd-W out of a page, then Cmd-Shift-T back into it, Kit loses scroll position. This fixes it. No tests because Playwright doesn't (AFAICT) have a way to simulate that behaviour

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
