### PR TITLE
don't pass URL from server

### DIFF
--- a/.changeset/clean-countries-push.md
+++ b/.changeset/clean-countries-push.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Set \$page.url to current URL in browser

--- a/.changeset/clean-countries-push.md
+++ b/.changeset/clean-countries-push.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Set \$page.url to current URL in browser
+Set `$page.url` to current URL in browser

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -29,6 +29,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:*",
+		"devalue": "^2.0.1",
 		"playwright-chromium": "^1.17.0",
 		"port-authority": "^1.1.2",
 		"sirv": "^2.0.0",

--- a/packages/adapter-static/test/utils.js
+++ b/packages/adapter-static/test/utils.js
@@ -29,7 +29,8 @@ export function run(app, callback) {
 	suite.before(async (context) => {
 		try {
 			const cwd = fileURLToPath(new URL(`apps/${app}`, import.meta.url));
-			const cli_path = fileURLToPath(new URL('../../kit/dist/cli.js', import.meta.url));
+			const mode = process.env.CI ? 'dist' : 'src';
+			const cli_path = fileURLToPath(new URL(`../../kit/${mode}/cli.js`, import.meta.url));
 
 			rimraf(`${cwd}/build`);
 

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -195,11 +195,12 @@ export class Renderer {
 	 *   status: number;
 	 *   error: Error;
 	 *   nodes: Array<Promise<CSRComponent>>;
-	 *   url: URL;
 	 *   params: Record<string, string>;
 	 * }} selected
 	 */
-	async start({ status, error, nodes, url, params }) {
+	async start({ status, error, nodes, params }) {
+		const url = new URL(location.href);
+
 		/** @type {Array<import('./types').BranchNode | undefined>} */
 		const branch = [];
 
@@ -210,9 +211,6 @@ export class Renderer {
 		let result;
 
 		let error_args;
-
-		// url.hash is empty when coming from the server
-		url.hash = window.location.hash;
 
 		try {
 			for (let i = 0; i < nodes.length; i += 1) {

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -21,7 +21,6 @@ import { set_paths } from '../paths.js';
  *     status: number;
  *     error: Error;
  *     nodes: Array<Promise<import('types/internal').CSRComponent>>;
- *     url: URL;
  *     params: Record<string, string>;
  *   };
  * }} opts

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -177,7 +177,6 @@ export async function render_response({
 					.map(({ node }) => `import(${s(options.prefix + node.entry)})`)
 					.join(',\n\t\t\t\t\t\t')}
 				],
-				url: new URL(${s(url.href)}),
 				params: ${devalue(params)}
 			}` : 'null'}
 		});

--- a/packages/kit/test/prerendering/options/test/test.js
+++ b/packages/kit/test/prerendering/options/test/test.js
@@ -11,13 +11,11 @@ const read = (file) => fs.readFileSync(`${build}/${file}`, 'utf-8');
 test('prerenders /path-base', () => {
 	const content = read('index.html');
 	assert.ok(content.includes('<h1>hello</h1>'));
-	assert.ok(content.includes('http://sveltekit-prerender/path-base'));
 });
 
 test('prerenders nested /path-base', () => {
 	const content = read('nested/index.html');
 	assert.ok(content.includes('<h1>nested hello</h1>'));
-	assert.ok(content.includes('http://sveltekit-prerender/path-base/nested'));
 });
 
 test('adds CSP headers via meta tag', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,7 @@ importers:
   packages/adapter-static:
     specifiers:
       '@sveltejs/kit': workspace:*
+      devalue: ^2.0.1
       playwright-chromium: ^1.17.0
       port-authority: ^1.1.2
       sirv: ^2.0.0
@@ -153,6 +154,7 @@ importers:
       tiny-glob: 0.2.9
     devDependencies:
       '@sveltejs/kit': link:../kit
+      devalue: 2.0.1
       playwright-chromium: 1.17.0
       port-authority: 1.1.2
       sirv: 2.0.0


### PR DESCRIPTION
The reasons for the previous way of doing things are somewhat cloudy — something to do with ensuring that we use the same route in the client as we do on the server, and with the same `params`, even if the page is prerendered and deployed somewhere that it doesn't expect to be.

But since those things are passed along separately, I think it's preferable to set the URL based on `window.location` — this means client-side access to `search` and `hash` (without weird hacks), and is arguably more correct, even if there is a risk of inconsistency in edge cases. 

This will allow us to close #3650 and #3680.

No tests because it's a bit of an awkward thing to test for.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
