### PR TITLE
ci: remove '.' from archive tar hierachy and omit empty results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: archive test results
         if: failure()
         shell: bash
-        run: find . -type d -name test-results | tar -czf test-results.tar.gz --exclude='*-retry*' --files-from=-
+        run: find packages -type d -name test-results -not -empty | tar -czf test-results.tar.gz --exclude='*-retry*' --files-from=-
       - name: Upload failed tests screenshots
         if: failure()
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
getting screenshots from the downloaded archive is a bit of a hassle. you get a tar.gz inside a .zip and then there's a lot of nested directories inside the tar.

This PR removes the root '.' directory inside the tar and also omits empty `test-results` directories to avoid confusion.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
