### PR TITLE
docs(routing): Accessing slug values

### DIFF
--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -43,6 +43,15 @@ Dynamic parameters are encoded using `[brackets]`. For example, a blog post migh
 
 A file or directory can have multiple dynamic parts, like `[id]-[category].svelte`. (Parameters are 'non-greedy'; in an ambiguous case like `x-y-z`, `id` would be `x` and `category` would be `y-z`.)
 
+The slug values can be accessed via the `params` object of the page store:
+```html
+<!-- src/routes/blog/[postId].svelte -->
+<script>
+	import { page } from '$app/stores';
+</script>
+{$page.params.postId}
+```
+
 ### Endpoints
 
 Endpoints are modules written in `.js` (or `.ts`) files that export functions corresponding to HTTP methods. Their job is to allow pages to read and write data that is only available on the server (for example in a database, or on the filesystem).


### PR DESCRIPTION
Add an example of how to access the value of a slug to the documentation. (Previously, documentation only showed how to create a route with a slug, but provided no example of how to use the slug value.)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
  - Not a new feature, just documenting an existing one.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
  - Not a code change, just documenting existing feature

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
  - N/A, only documentation