### PR TITLE
[fix] make demo app work without JS

### DIFF
--- a/.changeset/calm-spiders-turn.md
+++ b/.changeset/calm-spiders-turn.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+make demo app work without JS

--- a/packages/create-svelte/templates/default/src/routes/todos/index.ts
+++ b/packages/create-svelte/templates/default/src/routes/todos/index.ts
@@ -2,8 +2,13 @@ import { api } from './_api';
 import type { RequestHandler } from '@sveltejs/kit';
 
 export const get: RequestHandler = async ({ request, locals }) => {
+	// the API needs a request instance where the method is GET.
+	// when this endpoint is called to render a page after a POST,
+	// the original request method is POST, not GET.
+	const api_request = new Request(request.url);
+
 	// locals.userid comes from src/hooks.js
-	const response = await api(request, `todos/${locals.userid}`);
+	const response = await api(api_request, `todos/${locals.userid}`);
 
 	if (response.status === 404) {
 		// user hasn't created a todo list.
@@ -31,22 +36,37 @@ export const get: RequestHandler = async ({ request, locals }) => {
 export const post: RequestHandler = async ({ request, locals }) => {
 	const form = await request.formData();
 
-	return api(request, `todos/${locals.userid}`, {
+	const response = await api(request, `todos/${locals.userid}`, {
 		text: form.get('text')
 	});
+
+	return {
+		status: response.status,
+		body: await response.json()
+	};
 };
 
 export const patch: RequestHandler = async ({ request, locals }) => {
 	const form = await request.formData();
 
-	return api(request, `todos/${locals.userid}/${form.get('uid')}`, {
+	const response = await api(request, `todos/${locals.userid}/${form.get('uid')}`, {
 		text: form.has('text') ? form.get('text') : undefined,
 		done: form.has('done') ? !!form.get('done') : undefined
 	});
+
+	return {
+		status: response.status,
+		body: await response.json()
+	};
 };
 
 export const del: RequestHandler = async ({ request, locals }) => {
 	const form = await request.formData();
 
-	return api(request, `todos/${locals.userid}/${form.get('uid')}`);
+	const response = await api(request, `todos/${locals.userid}/${form.get('uid')}`);
+
+	return {
+		status: response.status,
+		body: await response.json()
+	};
 };


### PR DESCRIPTION
Fixes #3952

After the introduction of shadow endpoints, the demo app would throw a "Body returned from shadow endpoint request handler must be a plain object" error when adding a todo with JS disabled. This was because we were returning a Response, not a POJO.

After fixing that issue, I also had to modify the request passed to the api in the `get` handler. When rendering a page in response to a POST, the `get` handler is called with a POST request. Since we passed the original request to the `api` method, we were sometimes making a POST request when we needed a GET. By making a new request, we make sure the method is GET in all cases. I added an explanatory comment to the code since it's a little weird.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
