### PR TITLE
Fall back to full page reload if link href doesn't match anything

### DIFF
--- a/.changeset/four-news-turn.md
+++ b/.changeset/four-news-turn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fall back to full page reload if link href does not match route manifest

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -45,8 +45,8 @@ async function invalidate_(resource) {
 /**
  * @type {import('$app/navigation').prefetch}
  */
-function prefetch_(href) {
-	return router.prefetch(new URL(href, get_base_uri(document)));
+async function prefetch_(href) {
+	await router.prefetch(new URL(href, get_base_uri(document)));
 }
 
 /**

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -149,7 +149,7 @@ export class Renderer {
 		/** @type {Map<string, import('./types').NavigationResult>} */
 		this.cache = new Map();
 
-		/** @type {{id: string | null, promise: Promise<import('./types').NavigationResult> | null}} */
+		/** @type {{id: string | null, promise: Promise<import('./types').NavigationResult | undefined> | null}} */
 		this.loading = {
 			id: null,
 			promise: null
@@ -316,6 +316,11 @@ export class Renderer {
 		const token = (this.token = {});
 		let navigation_result = await this._get_navigation_result(info, no_cache);
 
+		if (!navigation_result) {
+			location.href = info.url.href;
+			return;
+		}
+
 		// abort if user navigated during update
 		if (token !== this.token) return;
 
@@ -407,7 +412,7 @@ export class Renderer {
 
 	/**
 	 * @param {import('./types').NavigationInfo} info
-	 * @returns {Promise<import('./types').NavigationResult>}
+	 * @returns {Promise<import('./types').NavigationResult | undefined>}
 	 */
 	load(info) {
 		this.loading.promise = this._get_navigation_result(info, false);
@@ -459,7 +464,7 @@ export class Renderer {
 	/**
 	 * @param {import('./types').NavigationInfo} info
 	 * @param {boolean} no_cache
-	 * @returns {Promise<import('./types').NavigationResult>}
+	 * @returns {Promise<import('./types').NavigationResult | undefined>}
 	 */
 	async _get_navigation_result(info, no_cache) {
 		if (this.loading.id === info.id && this.loading.promise) {
@@ -491,12 +496,6 @@ export class Renderer {
 			);
 			if (result) return result;
 		}
-
-		return await this._load_error({
-			status: 404,
-			error: new Error(`Not found: ${info.url.pathname}`),
-			url: info.url
-		});
 	}
 
 	/**

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -496,6 +496,14 @@ export class Renderer {
 			);
 			if (result) return result;
 		}
+
+		if (info.initial) {
+			return await this._load_error({
+				status: 404,
+				error: new Error(`Not found: ${info.url.pathname}`),
+				url: info.url
+			});
+		}
 	}
 
 	/**

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -51,6 +51,7 @@ export class Router {
 		renderer.router = this;
 
 		this.enabled = true;
+		this.initialized = false;
 
 		// make it possible to reset focus
 		document.body.setAttribute('tabindex', '-1');
@@ -252,6 +253,8 @@ export class Router {
 				);
 			}
 		});
+
+		this.initialized = true;
 	}
 
 	/**
@@ -274,7 +277,8 @@ export class Router {
 				id: url.pathname + url.search,
 				routes: this.routes.filter(([pattern]) => pattern.test(path)),
 				url,
-				path
+				path,
+				initial: !this.initialized
 			};
 		}
 	}

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -324,7 +324,7 @@ export class Router {
 
 	/**
 	 * @param {URL} url
-	 * @returns {Promise<import('./types').NavigationResult>}
+	 * @returns {Promise<import('./types').NavigationResult | undefined>}
 	 */
 	async prefetch(url) {
 		const info = this.parse(url);

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -5,6 +5,7 @@ export type NavigationInfo = {
 	routes: CSRRoute[];
 	url: URL;
 	path: string;
+	initial: boolean;
 };
 
 export type NavigationCandidate = {

--- a/packages/kit/test/apps/basics/src/routes/routing/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/index.svelte
@@ -7,5 +7,6 @@
 <a href="/routing/a">a</a>
 <a href="/routing/ambiguous/ok.json" rel="external">ok</a>
 <a href="http://localhost:{$page.url.searchParams.get('port')}">elsewhere</a>
+<a href="/static.json">static.json</a>
 
 <div class="hydrate-test" />

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -2099,6 +2099,15 @@ test.describe.parallel('Routing', () => {
 		await page.goto('/routing/rest/complex/prefix-one/two/three');
 		expect(await page.textContent('h1')).toBe('parts: one/two/three');
 	});
+
+	test('links to unmatched routes result in a full page navigation, not a 404', async ({
+		page,
+		clicknav
+	}) => {
+		await page.goto('/routing');
+		await clicknav('[href="/static.json"]');
+		expect(await page.textContent('body')).toBe('"static file"\n');
+	});
 });
 
 test.describe.parallel('Session', () => {


### PR DESCRIPTION
Currently, clicking a link like `<a href="/foo">` will fail if `/foo` doesn't 'belong' to the app — it will result in the error page being rendered with a synthetic 404. In cases where `/foo` is a real resource (handled by a separate app on the same domain, or a file in `static`, etc) we need to add `rel="external"` to trick the router into ignoring it in order to avoid that unwanted behaviour.

With this PR, if a link doesn't match a route in the manifest, we fall back to a full page navigation instead, allowing the browser to access the resource. In the case where the link doesn't go anywhere, Kit will still respond with a 404, it'll just be from the server instead of the client-side router.

Closes #3935.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
