### PR TITLE
Alternative fix for #3952

### DIFF
--- a/.changeset/calm-spiders-turn.md
+++ b/.changeset/calm-spiders-turn.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+make demo app work without JS

--- a/packages/create-svelte/templates/default/src/routes/todos/_api.ts
+++ b/packages/create-svelte/templates/default/src/routes/todos/_api.ts
@@ -1,5 +1,5 @@
 /*
-	This module is used by the /todos endpoint to 
+	This module is used by the /todos endpoint to
 	make calls to api.svelte.dev, which stores todos
 	for each user. The leading underscore indicates that this is
 	a private module, _not_ an endpoint — visiting /todos/_api
@@ -11,12 +11,18 @@
 
 const base = 'https://api.svelte.dev';
 
-export async function api(request: Request, resource: string, data?: Record<string, unknown>) {
-	return fetch(`${base}/${resource}`, {
-		method: request.method,
+export async function api(method: string, resource: string, data?: Record<string, unknown>) {
+	const res = await fetch(`${base}/${resource}`, {
+		method,
 		headers: {
 			'content-type': 'application/json'
 		},
 		body: data && JSON.stringify(data)
 	});
+
+	return {
+		status: res.status,
+		headers: res.headers,
+		body: await res.json()
+	};
 }

--- a/packages/create-svelte/templates/default/src/routes/todos/index.ts
+++ b/packages/create-svelte/templates/default/src/routes/todos/index.ts
@@ -2,8 +2,13 @@ import { api } from './_api';
 import type { RequestHandler } from '@sveltejs/kit';
 
 export const get: RequestHandler = async ({ request, locals }) => {
+	// the API needs a request instance where the method is GET.
+	// when this endpoint is called to render a page after a POST,
+	// the original request method is POST, not GET.
+	const api_request = new Request(request.url);
+
 	// locals.userid comes from src/hooks.js
-	const response = await api(request, `todos/${locals.userid}`);
+	const response = await api(api_request, `todos/${locals.userid}`);
 
 	if (response.status === 404) {
 		// user hasn't created a todo list.
@@ -31,22 +36,37 @@ export const get: RequestHandler = async ({ request, locals }) => {
 export const post: RequestHandler = async ({ request, locals }) => {
 	const form = await request.formData();
 
-	return api(request, `todos/${locals.userid}`, {
+	const response = await api(request, `todos/${locals.userid}`, {
 		text: form.get('text')
 	});
+
+	return {
+		status: response.status,
+		body: await response.json()
+	};
 };
 
 export const patch: RequestHandler = async ({ request, locals }) => {
 	const form = await request.formData();
 
-	return api(request, `todos/${locals.userid}/${form.get('uid')}`, {
+	const response = await api(request, `todos/${locals.userid}/${form.get('uid')}`, {
 		text: form.has('text') ? form.get('text') : undefined,
 		done: form.has('done') ? !!form.get('done') : undefined
 	});
+
+	return {
+		status: response.status,
+		body: await response.json()
+	};
 };
 
 export const del: RequestHandler = async ({ request, locals }) => {
 	const form = await request.formData();
 
-	return api(request, `todos/${locals.userid}/${form.get('uid')}`);
+	const response = await api(request, `todos/${locals.userid}/${form.get('uid')}`);
+
+	return {
+		status: response.status,
+		body: await response.json()
+	};
 };

--- a/packages/create-svelte/templates/default/src/routes/todos/index.ts
+++ b/packages/create-svelte/templates/default/src/routes/todos/index.ts
@@ -2,13 +2,8 @@ import { api } from './_api';
 import type { RequestHandler } from '@sveltejs/kit';
 
 export const get: RequestHandler = async ({ request, locals }) => {
-	// the API needs a request instance where the method is GET.
-	// when this endpoint is called to render a page after a POST,
-	// the original request method is POST, not GET.
-	const api_request = new Request(request.url);
-
 	// locals.userid comes from src/hooks.js
-	const response = await api(api_request, `todos/${locals.userid}`);
+	const response = await api('get', `todos/${locals.userid}`);
 
 	if (response.status === 404) {
 		// user hasn't created a todo list.
@@ -20,10 +15,10 @@ export const get: RequestHandler = async ({ request, locals }) => {
 		};
 	}
 
-	if (response.ok) {
+	if (response.status === 200) {
 		return {
 			body: {
-				todos: await response.json()
+				todos: response.body
 			}
 		};
 	}
@@ -33,40 +28,38 @@ export const get: RequestHandler = async ({ request, locals }) => {
 	};
 };
 
+const redirect = {
+	status: 303,
+	headers: {
+		location: '/todos'
+	}
+};
+
 export const post: RequestHandler = async ({ request, locals }) => {
 	const form = await request.formData();
 
-	const response = await api(request, `todos/${locals.userid}`, {
+	await api('post', `todos/${locals.userid}`, {
 		text: form.get('text')
 	});
 
-	return {
-		status: response.status,
-		body: await response.json()
-	};
+	return redirect;
 };
 
 export const patch: RequestHandler = async ({ request, locals }) => {
 	const form = await request.formData();
 
-	const response = await api(request, `todos/${locals.userid}/${form.get('uid')}`, {
+	await api('patch', `todos/${locals.userid}/${form.get('uid')}`, {
 		text: form.has('text') ? form.get('text') : undefined,
 		done: form.has('done') ? !!form.get('done') : undefined
 	});
 
-	return {
-		status: response.status,
-		body: await response.json()
-	};
+	return redirect;
 };
 
 export const del: RequestHandler = async ({ request, locals }) => {
 	const form = await request.formData();
 
-	const response = await api(request, `todos/${locals.userid}/${form.get('uid')}`);
+	await api('delete', `todos/${locals.userid}/${form.get('uid')}`);
 
-	return {
-		status: response.status,
-		body: await response.json()
-	};
+	return redirect;
 };


### PR DESCRIPTION
This is an alternative to #3965 — was easier to do as a separate PR than to make commit suggestions. Rather than each handler needing to `await response.json()`, we can just change the return value from the `api` helper to make it a valid shadow endpoint response.

I found one other issue with the current version of the app. If you patch or delete a todo with JS disabled, the URL will update to `/todos?_method=PATCH`. This is no good — reloading the page will cause an error, because method overrides can't be used with GET requests. To fix that, I changed the handlers so that they're redirecting back to `/todos` instead (which we can do, because we're not using the return values for anything — we're relying on invalidation instead).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
