### PR TITLE
Include remote_addr of client in request header

### DIFF
--- a/packages/kit/src/node.js
+++ b/packages/kit/src/node.js
@@ -53,6 +53,7 @@ function get_raw_body(req) {
 /** @type {import('@sveltejs/kit/node').GetRequest} */
 export async function getRequest(base, req) {
 	let headers = /** @type {Record<string, string>} */ (req.headers);
+	headers['remote_addr'] = req.socket.remoteAddress;
 	if (req.httpVersionMajor === 2) {
 		// we need to strip out the HTTP/2 pseudo-headers because node-fetch's
 		// Request implementation doesn't like them


### PR DESCRIPTION
Currently the IP address (remote_addr) of clients that send a request is not available in endpoints or handle because the header object of the raw request is simply copied. However the remote_addr lies within the socket object of the raw request. The IP address of the requesting client is an important env needed for various use cases, like security and logging tasks. Hence, it is useful to include this env into the request object available for endpoints. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
