### PR TITLE
Simplify hash change click handler

### DIFF
--- a/.changeset/sharp-olives-sparkle.md
+++ b/.changeset/sharp-olives-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Update page store without rerunning load when hash changes

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -395,6 +395,10 @@ export class Renderer {
 		this.autoscroll = true;
 		this.updating = false;
 
+		if (navigation_result.props.page) {
+			this.page = navigation_result.props.page;
+		}
+
 		if (!this.router) return;
 
 		const leaf_node = navigation_result.state.branch[navigation_result.state.branch.length - 1];
@@ -432,12 +436,20 @@ export class Renderer {
 		return this.invalidating;
 	}
 
+	/** @param {URL} url */
+	update_page_store(url) {
+		this.stores.page.set({ ...this.page, url });
+		this.stores.page.notify();
+	}
+
 	/** @param {import('./types').NavigationResult} result */
 	_init(result) {
 		this.current = result.state;
 
 		const style = document.querySelector('style[data-svelte]');
 		if (style) style.remove();
+
+		this.page = result.props.page;
 
 		this.root = new this.Root({
 			target: this.target,

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -205,10 +205,6 @@ export class Router {
 
 				this.#update_scroll_positions();
 
-				/** @ŧype {Record<string, any>} */
-				const page = get(this.renderer.stores.page);
-				this.renderer.stores.page.set({ ...page, url: new URL(url.href) });
-
 				return;
 			}
 
@@ -259,6 +255,10 @@ export class Router {
 					'',
 					location.href
 				);
+
+				/** @ŧype {Record<string, any>} */
+				const page = get(this.renderer.stores.page);
+				this.renderer.stores.page.set({ ...page, url: new URL(location.href) });
 			}
 		});
 	}

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -1,4 +1,5 @@
 import { onMount } from 'svelte';
+import { get } from 'svelte/store';
 import { normalize_path } from '../../utils/url';
 import { get_base_uri } from './utils';
 
@@ -204,9 +205,10 @@ export class Router {
 
 				this.#update_scroll_positions();
 
-				this.renderer.stores.page.subscribe((page) => {
-					this.renderer.stores.page.set({ ...page, url: new URL(url.href) });
-				})();
+				/** @ŧype {Record<string, any>} */
+				const page = get(this.renderer.stores.page);
+				this.renderer.stores.page.set({ ...page, url: new URL(url.href) });
+
 				return;
 			}
 

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -205,6 +205,11 @@ export class Router {
 
 				this.#update_scroll_positions();
 
+				/** @ŧype {Record<string, any>} */
+				const page = get(this.renderer.stores.page);
+				this.renderer.stores.page.set({ ...page, url: new URL(url.href) });
+				this.renderer.stores.page.notify();
+
 				return;
 			}
 
@@ -255,10 +260,6 @@ export class Router {
 					'',
 					location.href
 				);
-
-				/** @ŧype {Record<string, any>} */
-				const page = get(this.renderer.stores.page);
-				this.renderer.stores.page.set({ ...page, url: new URL(location.href) });
 			}
 		});
 	}

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -1,5 +1,4 @@
 import { onMount } from 'svelte';
-import { get } from 'svelte/store';
 import { normalize_path } from '../../utils/url';
 import { get_base_uri } from './utils';
 
@@ -204,11 +203,7 @@ export class Router {
 				this.hash_navigating = true;
 
 				this.#update_scroll_positions();
-
-				/** @ŧype {Record<string, any>} */
-				const page = get(this.renderer.stores.page);
-				this.renderer.stores.page.set({ ...page, url: new URL(url.href) });
-				this.renderer.stores.page.notify();
+				this.renderer.update_page_store(new URL(url.href));
 
 				return;
 			}

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -204,10 +204,9 @@ export class Router {
 
 				this.#update_scroll_positions();
 
-				const info = this.parse(url);
-				if (info) {
-					return this.renderer.update(info, [], false);
-				}
+				this.renderer.stores.page.subscribe((page) => {
+					this.renderer.stores.page.set({ ...page, url: new URL(url.href) });
+				})();
 				return;
 			}
 


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0


Simplifies hash handling initiated by click. as @benmccann pointed out in https://github.com/sveltejs/kit/pull/3873#discussion_r805219310 we don't really need to call renderer.update when the only thing needed update is page store, so that's what we are doing here, this is close to the browser default behavior, and since 
@Rich-Harris merged pulls #3931 and #3938 we can now do that.