### PR TITLE
fix focused placeholder colour

### DIFF
--- a/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
+++ b/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
@@ -243,6 +243,10 @@
 		outline: none;
 	}
 
+	input:focus-visible::placeholder {
+		color: rgba(255, 255, 255, 0.5);
+	}
+
 	button[aria-label='Close'] {
 		--size: 2rem;
 		position: absolute;


### PR DESCRIPTION
Supersedes #3944. In Chrome, changes this...

<img width="514" alt="image" src="https://user-images.githubusercontent.com/1162160/154525943-2298974e-ab5d-484b-96d8-1652fe6216e9.png">

...to this:

<img width="515" alt="image" src="https://user-images.githubusercontent.com/1162160/154525993-2d31630f-c55e-4c77-849a-cc20b7fe14d5.png">
