### PR TITLE
first stab at shiki-twoslash integration

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,6 +319,7 @@ importers:
       marked: ^4.0.5
       prism-svelte: ^0.4.7
       prismjs: ^1.26.0
+      shiki-twoslash: ^3.0.2
       svelte: ^3.43.0
       typescript: ~4.5.5
       vite-imagetools: ^4.0.3
@@ -331,6 +332,7 @@ importers:
       marked: 4.0.5
       prism-svelte: 0.4.7
       prismjs: 1.26.0
+      shiki-twoslash: 3.0.2
       svelte: 3.44.2
       typescript: 4.5.5
       vite-imagetools: 4.0.3
@@ -1768,6 +1770,32 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.5.0
       eslint-visitor-keys: 3.1.0
+    dev: true
+
+  /@typescript/twoslash/3.1.0:
+    resolution: {integrity: sha512-kTwMUQ8xtAZaC4wb2XuLkPqFVBj2dNBueMQ89NWEuw87k2nLBbuafeG5cob/QEr6YduxIdTVUjix0MtC7mPlmg==}
+    dependencies:
+      '@typescript/vfs': 1.3.5
+      debug: 4.3.3
+      lz-string: 1.4.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript/vfs/1.3.4:
+    resolution: {integrity: sha512-RbyJiaAGQPIcAGWFa3jAXSuAexU4BFiDRF1g3hy7LmRqfNpYlTQWGXjcrOaVZjJ8YkkpuwG0FcsYvtWQpd9igQ==}
+    dependencies:
+      debug: 4.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript/vfs/1.3.5:
+    resolution: {integrity: sha512-pI8Saqjupf9MfLw7w2+og+fmb0fZS0J6vsKXXrp4/PDXEFvntgzXmChCXC/KefZZS0YGS6AT8e0hGAJcTsdJlg==}
+    dependencies:
+      debug: 4.3.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /accepts/1.3.7:
@@ -3795,6 +3823,10 @@ packages:
       minimist: 1.2.5
     dev: true
 
+  /jsonc-parser/3.0.0:
+    resolution: {integrity: sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==}
+    dev: true
+
   /jsonfile/4.0.0:
     resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=}
     optionalDependencies:
@@ -3888,11 +3920,22 @@ packages:
       yallist: 2.1.2
     dev: true
 
+  /lru-cache/5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+    dependencies:
+      yallist: 3.1.1
+    dev: true
+
   /lru-cache/6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+    dev: true
+
+  /lz-string/1.4.4:
+    resolution: {integrity: sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=}
+    hasBin: true
     dev: true
 
   /magic-string/0.25.7:
@@ -4327,6 +4370,12 @@ packages:
     resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
     dependencies:
       wrappy: 1.0.2
+    dev: true
+
+  /onigasm/2.2.5:
+    resolution: {integrity: sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==}
+    dependencies:
+      lru-cache: 5.1.1
     dev: true
 
   /open/8.4.0:
@@ -5050,6 +5099,25 @@ packages:
   /shebang-regex/3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+    dev: true
+
+  /shiki-twoslash/3.0.2:
+    resolution: {integrity: sha512-2VxUykJ0ETWxageixkfKcMjK5mpMYxJU3uhAoscTZnfX/iq+bWnEpLZnsrcErMJrD85orxABMw5w/GoO4nUiqg==}
+    dependencies:
+      '@typescript/twoslash': 3.1.0
+      '@typescript/vfs': 1.3.4
+      shiki: 0.9.11
+      typescript: 4.5.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /shiki/0.9.11:
+    resolution: {integrity: sha512-tjruNTLFhU0hruCPoJP0y+B9LKOmcqUhTpxn7pcJB3fa+04gFChuEmxmrUfOJ7ZO6Jd+HwMnDHgY3lv3Tqonuw==}
+    dependencies:
+      jsonc-parser: 3.0.0
+      onigasm: 2.2.5
+      vscode-textmate: 5.2.0
     dev: true
 
   /side-channel/1.0.4:
@@ -5811,6 +5879,10 @@ packages:
       fsevents: 2.3.2
     dev: false
 
+  /vscode-textmate/5.2.0:
+    resolution: {integrity: sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==}
+    dev: true
+
   /wcwidth/1.0.1:
     resolution: {integrity: sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=}
     dependencies:
@@ -5934,6 +6006,10 @@ packages:
 
   /yallist/2.1.2:
     resolution: {integrity: sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=}
+    dev: true
+
+  /yallist/3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
     dev: true
 
   /yallist/4.0.0:

--- a/sites/kit.svelte.dev/package.json
+++ b/sites/kit.svelte.dev/package.json
@@ -16,6 +16,7 @@
 		"marked": "^4.0.5",
 		"prism-svelte": "^0.4.7",
 		"prismjs": "^1.26.0",
+		"shiki-twoslash": "^3.0.2",
 		"svelte": "^3.43.0",
 		"typescript": "~4.5.5",
 		"vite-imagetools": "^4.0.3"

--- a/sites/kit.svelte.dev/src/routes/docs/index.json.js
+++ b/sites/kit.svelte.dev/src/routes/docs/index.json.js
@@ -1,7 +1,7 @@
-import { read_all } from '$lib/docs';
+import { read_headings } from '$lib/docs';
 
 export function get() {
 	return {
-		body: read_all('docs').map(({ slug, title, sections }) => ({ slug, title, sections }))
+		body: read_headings('docs').map(({ slug, title, sections }) => ({ slug, title, sections }))
 	};
 }

--- a/sites/kit.svelte.dev/tsconfig.json
+++ b/sites/kit.svelte.dev/tsconfig.json
@@ -3,7 +3,8 @@
 		"allowJs": true,
 		"checkJs": true,
 		"moduleResolution": "node",
-		"target": "es2017",
+		"module": "es2022",
+		"target": "esnext",
 		/**
 			svelte-preprocess cannot figure out whether you have a value or a type, so tell TypeScript
 			to enforce using `import type` instead of `import` for Types.


### PR DESCRIPTION
#3324. This is very WIP. If anyone can help me figure out how to do the hovers, I'd be grateful — the [docs](https://shikijs.github.io/twoslash/) have inline `<data-lsp>` elements which aren't being generated in this setup, and I'm not sure why (nor am I sure where the client-side JS is supposed to come from).

* [ ] Hovers
* [ ] Update all the docs
* [ ] Improve styles (match colour scheme, give empty lines a height)
* [ ] Would be cool if we could show the filename outside the code block, if one is specified
* [ ] Stretch goal: make it work with `.svelte` blocks (this could be a follow-up PR)
* [ ] We should have a reference of all the available types on https://kit.svelte.dev/docs/typescript (and maybe occurences to them in code blocks could link to the references?)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
