### PR TITLE
adapter-node: Make remoteAddress of requesting client available

### DIFF
--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -45,7 +45,7 @@ const ssr = async (req, res) => {
 		return res.end(err.reason || 'Invalid request body');
 	}
 
-	setResponse(res, await app.render(request, { 'platform':  {'remoteAddress' : req.socket.remoteAddress}  }));
+	setResponse(res, await app.render(request, { platform:  {remoteAddress : req.socket.remoteAddress}  }));
 };
 
 /** @param {import('polka').Middleware[]} handlers */

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -45,7 +45,7 @@ const ssr = async (req, res) => {
 		return res.end(err.reason || 'Invalid request body');
 	}
 
-	setResponse(res, await app.render(request));
+	setResponse(res, await app.render(request, { 'platform':  {'remoteAddress' : req.socket.remoteAddress}  }));
 };
 
 /** @param {import('polka').Middleware[]} handlers */


### PR DESCRIPTION
This makes available to endpoints the IP address of client requesting the resource via platform object.

Improved solution to [#3972 ](https://github.com/sveltejs/kit/pull/3972)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
