### PR TITLE
Update 60-env-vars.md

### DIFF
--- a/documentation/faq/60-env-vars.md
+++ b/documentation/faq/60-env-vars.md
@@ -2,8 +2,8 @@
 title: How do I use environment variables?
 ---
 
-Vite uses [dotenv](https://github.com/motdotla/dotenv) to load environment variables from a file named `.env` or similar. Only environment variables prefixed with `VITE_` are exposed ([you can set `envPrefix` to change this](https://vitejs.dev/config/#envprefix)). Vite will use these and statically replace them at build-time.
+Vite uses [dotenv](https://github.com/motdotla/dotenv) to load environment variables from a file named `.env` or similar. Only environment variables prefixed with `VITE_` are exposed ([you can set `envPrefix` to change this](https://vitejs.dev/config/#envprefix)). You can access the variable using `import.meta.env.VITE_ENV_VAR`, and Vite will statically replace them at build-time.
 
-To use environment variables at runtime, you would need to instantiate dotenv yourself in your server-side code so that they are exposed at `import.meta.env.YOUR_ENV_VAR`. You may also use `$session` to pass them to the client if needed.
+To use environment variables at runtime, you would need to instantiate dotenv yourself in your server-side code so that they are exposed at `process.env.YOUR_ENV_VAR`. You may also use `$session` to pass them to the client if needed.
 
 Please see [the Vite documentation](https://vitejs.dev/guide/env-and-mode.html#env-files) for more info about environment variables.

--- a/documentation/faq/60-env-vars.md
+++ b/documentation/faq/60-env-vars.md
@@ -4,6 +4,6 @@ title: How do I use environment variables?
 
 Vite uses [dotenv](https://github.com/motdotla/dotenv) to load environment variables from a file named `.env` or similar. Only environment variables prefixed with `VITE_` are exposed ([you can set `envPrefix` to change this](https://vitejs.dev/config/#envprefix)). Vite will use these and statically replace them at build-time.
 
-To use environment variables at runtime, you would need to instantiate dotenv yourself in your server-side code so that they are exposed at `process.env.YOUR_ENV_VAR`. You may also use `$session` to pass them to the client if needed.
+To use environment variables at runtime, you would need to instantiate dotenv yourself in your server-side code so that they are exposed at `import.meta.env.YOUR_ENV_VAR`. You may also use `$session` to pass them to the client if needed.
 
 Please see [the Vite documentation](https://vitejs.dev/guide/env-and-mode.html#env-files) for more info about environment variables.


### PR DESCRIPTION
Vite doesn't use `process.` it's `import.meta`

Fixes `process not defined` errors when using environment variables

@bluwy edit: Explain that `import.meta.env.` is used for build time.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
