### PR TITLE
Fix html attribute escaping

### DIFF
--- a/.changeset/quiet-items-behave.md
+++ b/.changeset/quiet-items-behave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix escaped html attributes

--- a/packages/kit/src/utils/escape.js
+++ b/packages/kit/src/utils/escape.js
@@ -59,8 +59,7 @@ function escape(str, dict, unicode_encoder) {
 
 /** @type {Record<string, string>} */
 const escape_html_attr_dict = {
-	'<': '&lt;',
-	'>': '&gt;',
+	'&': '&amp;',
 	'"': '&quot;'
 };
 

--- a/packages/kit/src/utils/escape.js
+++ b/packages/kit/src/utils/escape.js
@@ -57,19 +57,25 @@ function escape(str, dict, unicode_encoder) {
 	return result;
 }
 
-/** @type {Record<string, string>} */
+/**
+ * When inside a double-quoted attribute value, only `&` and `"` hold special meaning.
+ * @see https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(double-quoted)-state
+ * @type {Record<string, string>}
+ */
 const escape_html_attr_dict = {
 	'&': '&amp;',
 	'"': '&quot;'
 };
 
 /**
- * use for escaping string values to be used html attributes on the page
- * e.g.
- * <script data-url="here">
+ * Formats a string to be used as an attribute's value in raw HTML.
+ *
+ * It escapes unpaired surrogates (which are allowed in js strings but invalid in HTML), escapes
+ * characters that are special in attributes, and surrounds the whole string in double-quotes.
  *
  * @param {string} str
- * @returns string escaped string
+ * @returns {string} Escaped string surrounded by double-quotes.
+ * @example const html = `<tag data-value=${escape_html_attr('value')}>...</tag>`;
  */
 export function escape_html_attr(str) {
 	return '"' + escape(str, escape_html_attr_dict, (code) => `&#${code};`) + '"';

--- a/packages/kit/src/utils/escape.spec.js
+++ b/packages/kit/src/utils/escape.spec.js
@@ -1,0 +1,24 @@
+import { suite } from 'uvu';
+import * as assert from 'uvu/assert';
+import { escape_html_attr } from './escape.js';
+
+const attr = suite('escape_html_attr');
+
+attr('escapes special attribute characters', () => {
+	assert.equal(
+		escape_html_attr('some "values" are &special here, <others> aren\'t.'),
+		'"some &quot;values&quot; are &amp;special here, <others> aren\'t."'
+	);
+});
+
+attr('escapes invalid surrogates', () => {
+	assert.equal(escape_html_attr('\ud800\udc00'), '"\ud800\udc00"');
+	assert.equal(escape_html_attr('\ud800'), '"&#55296;"');
+	assert.equal(escape_html_attr('\udc00'), '"&#56320;"');
+	assert.equal(escape_html_attr('\udc00\ud800'), '"&#56320;&#55296;"');
+	assert.equal(escape_html_attr('\ud800\ud800\udc00'), '"&#55296;\ud800\udc00"');
+	assert.equal(escape_html_attr('\ud800\udc00\udc00'), '"\ud800\udc00&#56320;"');
+	assert.equal(escape_html_attr('\ud800\ud800\udc00\udc00'), '"&#55296;\ud800\udc00&#56320;"');
+});
+
+attr.run();

--- a/packages/kit/test/prerendering/basics/test/test.js
+++ b/packages/kit/test/prerendering/basics/test/test.js
@@ -33,7 +33,7 @@ test('escapes characters in redirect', () => {
 	const content = read('redirect-malicious.html');
 	assert.equal(
 		content,
-		'<meta http-equiv="refresh" content="0;url=https://example.com/&lt;/script&gt;alert(&quot;pwned&quot;)">'
+		'<meta http-equiv="refresh" content="0;url=https://example.com/</script>alert(&quot;pwned&quot;)">'
 	);
 });
 


### PR DESCRIPTION
Fixes #4014.

This just adds the missing `&` and removes superfluous `<>` from the html attribute escape dictionary.

`<>` are treated as raw characters inside a double-quoted attribute value. This means they can contain `</script>` and friends inside, but if we're already in rawtext mode (meaning, inside an open `<script>` or other greedy html tags), then we're already inside an xss vector and we'd have to escape every single character, as `kill(everyone)` would be a valid value.

Try it: `<tag data-value="<script>alert('pwned')</script>">` is properly handled by browsers.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

Sorry but tests timeout at some point on this weak machine.

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
