### PR TITLE
Fix check_port() in dev command

### DIFF
--- a/.changeset/late-ties-relax.md
+++ b/.changeset/late-ties-relax.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix check_port() in dev command

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -53,6 +53,8 @@ prog
 		try {
 			if (H) throw new Error('-H is no longer supported — use --https instead');
 
+			await check_port(port);
+
 			process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 			const config = await load_config();
 


### PR DESCRIPTION
Fixes a bug where `check_port()` was not called in the `dev` command.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
