### PR TITLE
[chore] fix indention in tsconfig.json

### DIFF
--- a/sites/kit.svelte.dev/tsconfig.json
+++ b/sites/kit.svelte.dev/tsconfig.json
@@ -5,16 +5,12 @@
 		"moduleResolution": "node",
 		"module": "es2022",
 		"target": "esnext",
-		/**
-			svelte-preprocess cannot figure out whether you have a value or a type, so tell TypeScript
-			to enforce using `import type` instead of `import` for Types.
-			*/
+		// svelte-preprocess cannot figure out whether you have a value or a type, so tell
+		// TypeScript to enforce using `import type` instead of `import` for Types.
 		"importsNotUsedAsValues": "error",
 		"isolatedModules": true,
-		/**
-			To have warnings/errors of the Svelte compiler at the correct position,
-			enable source maps by default.
-			*/
+		// To have warnings/errors of the Svelte compiler at the correct position,
+		// enable source maps by default.
 		"sourceMap": true,
 		"esModuleInterop": true,
 		"skipLibCheck": true,


### PR DESCRIPTION
the indentation doesn't look bad on github, but there's two tabs on the first and last lines and three in between and it looks really bad in VS Code