### PR TITLE
lint types with typedoc

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -42,6 +42,7 @@
 		"svelte-preprocess": "^4.9.8",
 		"svelte2tsx": "~0.5.0",
 		"tiny-glob": "^0.2.9",
+		"typedoc": "^0.22.12",
 		"uvu": "^0.5.2"
 	},
 	"peerDependencies": {
@@ -59,7 +60,8 @@
 	"scripts": {
 		"build": "rollup -c && node scripts/cp.js src/runtime/components assets/components",
 		"dev": "rollup -cw",
-		"lint": "eslint --ignore-path .gitignore --ignore-pattern \"src/packaging/test/**\" \"{src,test}/**/*.{ts,mjs,js,svelte}\" && npm run check-format",
+		"lint": "eslint --ignore-path .gitignore --ignore-pattern \"src/packaging/test/**\" \"{src,test}/**/*.{ts,mjs,js,svelte}\" && npm run check-format && npm run lint-types",
+		"lint-types": "typedoc && rm typedoc-output.json",
 		"check": "tsc && svelte-check --ignore test/prerendering,src/packaging/test",
 		"format": "npm run check-format -- --write",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",

--- a/packages/kit/typedoc.json
+++ b/packages/kit/typedoc.json
@@ -1,0 +1,9 @@
+{
+	"name": "SvelteKit",
+	"entryPoints": ["types/index.d.ts"],
+	"githubPages": false,
+	"readme": "none",
+	"includeVersion": true,
+	"json": "typedoc-output.json",
+	"treatWarningsAsErrors": true
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,7 @@ importers:
       svelte-preprocess: ^4.9.8
       svelte2tsx: ~0.5.0
       tiny-glob: ^0.2.9
+      typedoc: ^0.22.12
       uvu: ^0.5.2
       vite: ^2.8.0
     dependencies:
@@ -287,6 +288,7 @@ importers:
       svelte-preprocess: 4.9.8_svelte@3.44.2+typescript@4.5.5
       svelte2tsx: 0.5.0_svelte@3.44.2+typescript@4.5.5
       tiny-glob: 0.2.9
+      typedoc: 0.22.12_typescript@4.5.5
       uvu: 0.5.2
 
   packages/kit/test/prerendering/basics:
@@ -3916,6 +3918,10 @@ packages:
       yallist: 4.0.0
     dev: true
 
+  /lunr/2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+    dev: true
+
   /lz-string/1.4.4:
     resolution: {integrity: sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=}
     hasBin: true
@@ -3947,6 +3953,12 @@ packages:
     resolution: {integrity: sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==}
     dependencies:
       repeat-string: 1.6.1
+    dev: true
+
+  /marked/4.0.12:
+    resolution: {integrity: sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==}
+    engines: {node: '>= 12'}
+    hasBin: true
     dev: true
 
   /marked/4.0.5:
@@ -5092,6 +5104,14 @@ packages:
       - supports-color
     dev: true
 
+  /shiki/0.10.1:
+    resolution: {integrity: sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==}
+    dependencies:
+      jsonc-parser: 3.0.0
+      vscode-oniguruma: 1.6.1
+      vscode-textmate: 5.2.0
+    dev: true
+
   /shiki/0.9.11:
     resolution: {integrity: sha512-tjruNTLFhU0hruCPoJP0y+B9LKOmcqUhTpxn7pcJB3fa+04gFChuEmxmrUfOJ7ZO6Jd+HwMnDHgY3lv3Tqonuw==}
     dependencies:
@@ -5736,6 +5756,21 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /typedoc/0.22.12_typescript@4.5.5:
+    resolution: {integrity: sha512-FcyC+YuaOpr3rB9QwA1IHOi9KnU2m50sPJW5vcNRPCIdecp+3bFkh7Rq5hBU1Fyn29UR2h4h/H7twZHWDhL0sw==}
+    engines: {node: '>= 12.10.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: 4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x
+    dependencies:
+      glob: 7.2.0
+      lunr: 2.3.9
+      marked: 4.0.12
+      minimatch: 3.0.4
+      shiki: 0.10.1
+      typescript: 4.5.5
+    dev: true
+
   /typescript/4.5.2:
     resolution: {integrity: sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==}
     engines: {node: '>=4.2.0'}
@@ -5855,6 +5890,10 @@ packages:
       rollup: 2.60.2
     optionalDependencies:
       fsevents: 2.3.2
+
+  /vscode-oniguruma/1.6.1:
+    resolution: {integrity: sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==}
+    dev: true
 
   /vscode-textmate/5.2.0:
     resolution: {integrity: sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==}


### PR DESCRIPTION
we reference tons of internal types in the public types. this will catch that and cause `lint` to fail