### PR TITLE
Support `svelte.config.ts`

### DIFF
--- a/.changeset/good-brooms-sing.md
+++ b/.changeset/good-brooms-sing.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Support `svelte.config.ts` as Typescript-based config file.

--- a/documentation/docs/13-configuration.md
+++ b/documentation/docs/13-configuration.md
@@ -84,8 +84,6 @@ const config = {
 export default config;
 ```
 
-SvelteKit also directly supports TS config files (`svelte.config.ts`).
-
 ### adapter
 
 Required when running `svelte-kit build` and determines how the output is converted for different platforms. See [Adapters](/docs/adapters).

--- a/documentation/docs/13-configuration.md
+++ b/documentation/docs/13-configuration.md
@@ -84,6 +84,8 @@ const config = {
 export default config;
 ```
 
+SvelteKit also directly supports TS config files (`svelte.config.ts`).
+
 ### adapter
 
 Required when running `svelte-kit build` and determines how the output is converted for different platforms. See [Adapters](/docs/adapters).

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -54,7 +54,7 @@ prog
 			if (H) throw new Error('-H is no longer supported — use --https instead');
 
 			process.env.NODE_ENV = process.env.NODE_ENV || 'development';
-			const config = await load_config();
+			const config = await load_config({ mode: process.env.NODE_ENV });
 
 			const { dev } = await import('./core/dev/index.js');
 
@@ -89,7 +89,7 @@ prog
 	.action(async ({ verbose }) => {
 		try {
 			process.env.NODE_ENV = process.env.NODE_ENV || 'production';
-			const config = await load_config();
+			const config = await load_config({ mode: process.env.NODE_ENV });
 
 			const { build } = await import('./core/build/index.js');
 			const build_data = await build(config);
@@ -132,7 +132,7 @@ prog
 			await check_port(port);
 
 			process.env.NODE_ENV = process.env.NODE_ENV || 'production';
-			const config = await load_config();
+			const config = await load_config({ mode: process.env.NODE_ENV });
 
 			const { preview } = await import('./core/preview/index.js');
 


### PR DESCRIPTION
This is a continuation of https://github.com/sveltejs/kit/issues/1919 and most likely https://github.com/sveltejs/kit/issues/2576, making use of Vite's `loadConfigFromFile` to handle TypeScript config file. For now this was only tested on a local SvelteKit project.

As mentionned in most threads, the remaining issue/quirk is making it work with other Svelte tools (like the VSCode plugin, which is expecting a `svelte.config.js` file).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
