### PR TITLE
[feat] Allow `transformPage` to return a promise

### DIFF
--- a/.changeset/forty-seahorses-rest.md
+++ b/.changeset/forty-seahorses-rest.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Allow the `transformPage` resolve option to return a promise

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -299,7 +299,7 @@ export async function render_response({
 	const assets =
 		options.paths.assets || (segments.length > 0 ? segments.map(() => '..').join('/') : '.');
 
-	const html = resolve_opts.transformPage({
+	const html = await resolve_opts.transformPage({
 		html: options.template({ head, body, assets, nonce: /** @type {string} */ (csp.nonce) })
 	});
 

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -206,7 +206,7 @@ export type RecursiveRequired<T> = {
 
 export interface RequiredResolveOptions {
 	ssr: boolean;
-	transformPage: ({ html }: { html: string }) => string;
+	transformPage: ({ html }: { html: string }) => MaybePromise<string>;
 }
 
 export interface Respond {


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

Closes #3967 by allowing the `transformPage` resolve option to return a promise.
