### PR TITLE
prevent double-fixing of stack traces

### DIFF
--- a/.changeset/angry-pugs-play.md
+++ b/.changeset/angry-pugs-play.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Prevent double-fixing of error stack traces in dev mode

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -136,6 +136,8 @@ export async function create_plugin(config, cwd) {
 
 			/** @param {Error} error */
 			function fix_stack_trace(error) {
+				// TODO https://github.com/vitejs/vite/issues/7045
+
 				// ideally vite would expose ssrRewriteStacktrace, but
 				// in lieu of that, we can implement it ourselves. we
 				// don't want to mutate the error object, because

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -259,7 +259,7 @@ export async function create_plugin(config, cwd) {
 							handle_error: (error, event) => {
 								hooks.handleError({
 									error: new Proxy(error, {
-										get: (target, property, receiver) => {
+										get: (target, property) => {
 											if (property === 'stack') {
 												return fix_stack_trace(error);
 											}

--- a/packages/kit/test/apps/basics/src/routes/errors/endpoint.json.js
+++ b/packages/kit/test/apps/basics/src/routes/errors/endpoint.json.js
@@ -1,4 +1,3 @@
-/** @type {import('@sveltejs/kit').RequestHandler} */
 export function get() {
 	throw new Error('nope');
 }

--- a/packages/kit/test/apps/basics/src/routes/errors/init-error-endpoint.js
+++ b/packages/kit/test/apps/basics/src/routes/errors/init-error-endpoint.js
@@ -1,4 +1,5 @@
-thisvariableisnotdefined;
+// @ts-expect-error
+thisvariableisnotdefined; // eslint-disable-line
 
 export function get() {
 	return {

--- a/packages/kit/test/apps/basics/src/routes/errors/init-error-endpoint.js
+++ b/packages/kit/test/apps/basics/src/routes/errors/init-error-endpoint.js
@@ -1,0 +1,9 @@
+thisvariableisnotdefined;
+
+export function get() {
+	return {
+		body: {
+			answer: 42
+		}
+	};
+}

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -915,7 +915,7 @@ test.describe.parallel('Errors', () => {
 		);
 
 		const contents = await page.textContent('#stack');
-		const location = 'endpoint-shadow.js:1:8'; // TODO this is the wrong location, but i'm not going to open the sourcemap can of worms just now
+		const location = 'endpoint-shadow.js:3:8';
 
 		if (process.env.DEV) {
 			expect(contents).toMatch(location);

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -963,7 +963,8 @@ test.describe.parallel('Errors', () => {
 		expect(await page.innerHTML('h1')).toBe('500');
 	});
 
-	test('error evaluating module', async ({ request }) => {
+	// TODO re-enable this if https://github.com/vitejs/vite/issues/7046 is implemented
+	test.skip('error evaluating module', async ({ request }) => {
 		const response = await request.get('/errors/init-error-endpoint');
 
 		expect(response.status()).toBe(500);

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -906,7 +906,7 @@ test.describe.parallel('Errors', () => {
 		expect(lines[0]).toMatch('nope');
 
 		if (process.env.DEV) {
-			expect(lines[1]).toMatch('endpoint-shadow');
+			expect(lines[1]).toMatch('endpoint-shadow.js:3:8');
 		}
 
 		expect(res && res.status()).toBe(500);
@@ -961,6 +961,13 @@ test.describe.parallel('Errors', () => {
 			'This is your custom error page saying: "Error in handle"'
 		);
 		expect(await page.innerHTML('h1')).toBe('500');
+	});
+
+	test('error evaluating module', async ({ request }) => {
+		const response = await request.get('/errors/init-error-endpoint');
+
+		expect(response.status()).toBe(500);
+		expect(await response.text()).toMatch('thisvariableisnotdefined is not defined');
 	});
 });
 


### PR DESCRIPTION
fixes #3638. The problem here was that errors were having their stack traces 'fixed' (which is not an idempotent operation) twice in some cases, resulting in invalid source mappings.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
