### PR TITLE
fix broken docs url for App namespace interfaces

### DIFF
--- a/.changeset/curvy-rivers-share.md
+++ b/.changeset/curvy-rivers-share.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+[fix] update docs URL for App namespace interfaces

--- a/packages/create-svelte/templates/default/src/app.d.ts
+++ b/packages/create-svelte/templates/default/src/app.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="@sveltejs/kit" />
 
-// See https://kit.svelte.dev/docs/typescript
+// See https://kit.svelte.dev/docs/types#the-app-namespace
 // for information about these interfaces
 declare namespace App {
 	interface Locals {

--- a/packages/create-svelte/templates/skeleton/src/app.d.ts
+++ b/packages/create-svelte/templates/skeleton/src/app.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="@sveltejs/kit" />
 
-// See https://kit.svelte.dev/docs/typescript
+// See https://kit.svelte.dev/docs/types#the-app-namespace
 // for information about these interfaces
 declare namespace App {
 	interface Locals {}


### PR DESCRIPTION
The docs url [https://kit.svelte.dev/docs/typescript](https://kit.svelte.dev/docs/typescript) in the generated `app.d.ts` templates is broken:
<img width="1215" alt="image" src="https://user-images.githubusercontent.com/25834218/155062009-958aa755-60ed-462e-a2d7-349b86d74a98.png">

From looking around in the docs, I believe the correct url should be [https://kit.svelte.dev/docs/types#the-app-namespace](https://kit.svelte.dev/docs/types#the-app-namespace)

This PR replaces the broken url with `https://kit.svelte.dev/docs/types#the-app-namespace`.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
