### PR TITLE
[docs] remove mention of esbuild from Netlify docs

### DIFF
--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -66,7 +66,6 @@ During compilation, redirect rules are automatically appended to your `_redirect
 
 [functions]
   directory = "functions"
-  node_bundler = "esbuild"
 ```
 
 ## Changelog


### PR DESCRIPTION
I wasn't aware this was here. I've always advised against using `esbuild` because it adds another layer of complexity. Users are reporting their builds don't work if they use `esbuild` (https://github.com/sveltejs/kit/issues/3978#issuecomment-1046307164), so we should remove this