### PR TITLE
[feat] allow returning strings from shadow endpoints

### DIFF
--- a/.changeset/nasty-poems-fix.md
+++ b/.changeset/nasty-poems-fix.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[feat] allow returning strings from shadow endpoints

--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -265,7 +265,7 @@ export default config;
 
 ### Standalone endpoints
 
-Most commonly, endpoints exist to provide data to the page with which they're paired. They can, however, exist separately from pages. Standalone endpoints have slightly more flexibility over the returned `body` type — in addition to objects, they can return a string or a `Uint8Array`.
+Most commonly, endpoints exist to provide data to the page with which they're paired. They can, however, exist separately from pages. Standalone endpoints have slightly more flexibility over the returned `body` type — in addition to objects, they can return a `Uint8Array`.
 
 > Support for streaming request and response bodies is [coming soon](https://github.com/sveltejs/kit/issues/3419).
 

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -1,17 +1,12 @@
 import { to_headers } from '../../utils/http.js';
 import { hash } from '../hash.js';
-import { is_pojo, normalize_request_method } from './utils.js';
+import { is_pojo, is_string, normalize_request_method } from './utils.js';
 
 /** @param {string} body */
 function error(body) {
 	return new Response(body, {
 		status: 500
 	});
-}
-
-/** @param {unknown} s */
-function is_string(s) {
-	return typeof s === 'string' || s instanceof String;
 }
 
 const text_types = new Set([

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -4,7 +4,7 @@ import { s } from '../../../utils/misc.js';
 import { escape_json_in_html } from '../../../utils/escape.js';
 import { is_root_relative, resolve } from '../../../utils/url.js';
 import { create_prerendering_url_proxy } from './utils.js';
-import { is_pojo, lowercase_keys, normalize_request_method } from '../utils.js';
+import { is_pojo, is_string, lowercase_keys, normalize_request_method } from '../utils.js';
 import { coalesce_to_error } from '../../../utils/error.js';
 
 /**
@@ -496,9 +496,10 @@ function validate_shadow_output(result) {
 		headers = lowercase_keys(/** @type {Record<string, string>} */ (headers));
 	}
 
-	if (!is_pojo(body)) {
-		throw new Error('Body returned from endpoint request handler must be a plain object');
+	const parsed = is_string(body) ? JSON.parse(body) : body || {};
+	if (!is_pojo(parsed)) {
+		throw new Error('Body returned from endpoint request handler must be a string or plain object');
 	}
 
-	return { status, headers, body };
+	return { status, headers, body: parsed };
 }

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -32,6 +32,14 @@ export function decode_params(params) {
 	return params;
 }
 
+/**
+ * @param {unknown} s
+ * @return {s is string}
+ */
+export function is_string(s) {
+	return typeof s === 'string' || s instanceof String;
+}
+
 /** @param {any} body */
 export function is_pojo(body) {
 	if (typeof body !== 'object') return false;

--- a/packages/kit/test/apps/basics/src/routes/shadowed/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shadowed/index.svelte
@@ -1,4 +1,5 @@
 <a href="/shadowed/simple">simple</a>
+<a href="/shadowed/string">string</a>
 <a href="/shadowed/redirect-get">redirect-get</a>
 <a href="/shadowed/redirect-get-with-cookie">redirect-get-with-cookie</a>
 <a href="/shadowed/error-get">error-get</a>

--- a/packages/kit/test/apps/basics/src/routes/shadowed/string.js
+++ b/packages/kit/test/apps/basics/src/routes/shadowed/string.js
@@ -1,0 +1,6 @@
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export function get({ locals }) {
+	return {
+		body: `{ "answer": ${locals.answer} }`
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/shadowed/string.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shadowed/string.svelte
@@ -1,0 +1,6 @@
+<script>
+	/** @type {number} */
+	export let answer;
+</script>
+
+<h1>The answer is {answer}</h1>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -385,6 +385,12 @@ test.describe.parallel('Shadowed pages', () => {
 		expect(await page.textContent('h1')).toBe('The answer is 42');
 	});
 
+	test('Loads props from an endpoint returning a string', async ({ page, clicknav }) => {
+		await page.goto('/shadowed');
+		await clicknav('[href="/shadowed/string"]');
+		expect(await page.textContent('h1')).toBe('The answer is 42');
+	});
+
 	test('Handles GET redirects', async ({ page, clicknav }) => {
 		await page.goto('/shadowed');
 		await clicknav('[href="/shadowed/redirect-get"]');


### PR DESCRIPTION
I had some JSON serialized to disk that I was trying to return from a shadow endpoint and was surprised that I couldn't. The restriction was only documented under the "standalone endpoints" section, so I also didn't see it there for a few days until I happened across it later. Removing the unnecessary restriction should hopefully be more intuitive