### PR TITLE
[fix] Disable meta http-equiv in static amp

### DIFF
--- a/.changeset/eight-chicken-sin.md
+++ b/.changeset/eight-chicken-sin.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Disable meta http-equiv tags for static amp configuration

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -278,7 +278,7 @@ export async function render_response({
 		}
 	}
 
-	if (state.prerender) {
+	if (state.prerender && !options.amp) {
 		const http_equiv = [];
 
 		const csp_headers = csp.get_meta();


### PR DESCRIPTION
Fixes invalid `meta http-equiv` tags in static amp docs: https://github.com/sveltejs/kit/issues/4074

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/kit/issues/4074
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
