### PR TITLE
comment out empty interfaces

### DIFF
--- a/.changeset/great-seahorses-fry.md
+++ b/.changeset/great-seahorses-fry.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+fix `@typescript-eslint/no-empty-interface` lint error when starting a new app with eslint

--- a/packages/create-svelte/templates/default/src/app.d.ts
+++ b/packages/create-svelte/templates/default/src/app.d.ts
@@ -7,9 +7,9 @@ declare namespace App {
 		userid: string;
 	}
 
-	interface Platform {}
+	// interface Platform {}
 
-	interface Session {}
+	// interface Session {}
 
-	interface Stuff {}
+	// interface Stuff {}
 }

--- a/packages/create-svelte/templates/skeleton/src/app.d.ts
+++ b/packages/create-svelte/templates/skeleton/src/app.d.ts
@@ -4,10 +4,10 @@
 // for information about these interfaces
 declare namespace App {
 	// interface Locals {}
-	//
+
 	// interface Platform {}
-	//
+
 	// interface Session {}
-	//
+
 	// interface Stuff {}
 }

--- a/packages/create-svelte/templates/skeleton/src/app.d.ts
+++ b/packages/create-svelte/templates/skeleton/src/app.d.ts
@@ -3,11 +3,11 @@
 // See https://kit.svelte.dev/docs/types#the-app-namespace
 // for information about these interfaces
 declare namespace App {
-	interface Locals {}
-
-	interface Platform {}
-
-	interface Session {}
-
-	interface Stuff {}
+	// interface Locals {}
+	//
+	// interface Platform {}
+	//
+	// interface Session {}
+	//
+	// interface Stuff {}
 }


### PR DESCRIPTION
Following TS approach when generating a `tsconfig.json`, it starts out with all the options commented out with some brief description besides and above it. Since this is just an interface, having a link that points to the docs that explains everything should be enough. Having some brief descriptions would be redundant with the docs and may lead to out-of-sync details later on.

Fixes #3839 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
