### PR TITLE
[fix] Use headers.raw() on `split_headers`

### DIFF
--- a/.changeset/three-elephants-breathe.md
+++ b/.changeset/three-elephants-breathe.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+Fix incorrect set-cookie header handling on adapter-netlify

--- a/packages/adapter-netlify/src/handler.js
+++ b/packages/adapter-netlify/src/handler.js
@@ -73,7 +73,8 @@ function split_headers(headers) {
 
 	headers.forEach((value, key) => {
 		if (key === 'set-cookie') {
-			m[key] = value.split(', ');
+			// @ts-expect-error (headers.raw() is non-standard)
+			m[key] = headers.raw()[key];
 		} else {
 			h[key] = value;
 		}


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

Fixes #4087 by using the `headers.raw()` method from node-fetch to get the array of cookie headers.