### PR TITLE
[chore] cleanup `Router` and `Renderer`

### DIFF
--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -31,7 +31,7 @@ async function disableScrollHandling_() {
  * @type {import('$app/navigation').goto}
  */
 async function goto_(href, opts) {
-	return router.goto(href, opts, []);
+	return router.goto(href, opts);
 }
 
 /**
@@ -39,14 +39,14 @@ async function goto_(href, opts) {
  */
 async function invalidate_(resource) {
 	const { href } = new URL(resource, location.href);
-	return router.renderer.invalidate(href);
+	return renderer.invalidate(href);
 }
 
 /**
  * @type {import('$app/navigation').prefetch}
  */
 async function prefetch_(href) {
-	await router.prefetch(new URL(href, get_base_uri(document)));
+	await renderer.prefetch(new URL(href, get_base_uri(document)));
 }
 
 /**

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -49,7 +49,6 @@ export class Router {
 		this.navigation_handler = navigation_handler;
 
 		this.enabled = true;
-		this.initialized = false;
 
 		// make it possible to reset focus
 		document.body.setAttribute('tabindex', '-1');
@@ -217,8 +216,6 @@ export class Router {
 				);
 			}
 		});
-
-		this.initialized = true;
 	}
 
 	/**
@@ -238,8 +235,7 @@ export class Router {
 				id: url.pathname + url.search,
 				routes: this.routes.filter(([pattern]) => pattern.test(path)),
 				url,
-				path,
-				initial: !this.initialized
+				path
 			};
 		}
 	}

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -227,12 +227,11 @@ export class Router {
 	}
 
 	/** @param {URL} url */
-	parse(url) {
+	get_navigation_candidates(url) {
 		if (this.owns(url)) {
 			const path = decodeURI(url.pathname.slice(this.base.length) || '/');
 
 			return {
-				id: url.pathname + url.search,
 				routes: this.routes.filter(([pattern]) => pattern.test(path)),
 				url,
 				path

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -46,7 +46,7 @@ export async function start({ paths, target, session, route, spa, trailing_slash
 	init({ router, renderer });
 	set_paths(paths);
 
-	if (hydrate) await renderer.start(hydrate);
+	if (hydrate) await renderer.hydrate(hydrate);
 	if (router) {
 		if (spa) router.goto(location.href, { replaceState: true });
 		router.init_listeners();

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -38,18 +38,20 @@ export async function start({ paths, target, session, route, spa, trailing_slash
 				base: paths.base,
 				routes,
 				trailing_slash,
-				renderer
+				navigation_handler: renderer.handle_navigation.bind(renderer)
 		  })
 		: null;
+	renderer.router = router;
 
 	init({ router, renderer });
 	set_paths(paths);
 
 	if (hydrate) await renderer.start(hydrate);
 	if (router) {
-		if (spa) router.goto(location.href, { replaceState: true }, []);
+		if (spa) router.goto(location.href, { replaceState: true });
 		router.init_listeners();
 	}
+	renderer.init_listeners();
 
 	dispatchEvent(new CustomEvent('sveltekit:start'));
 }

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -9,7 +9,6 @@ export interface NavigationHandler {
 }
 
 export interface NavigationInfo {
-	id: string;
 	routes: CSRRoute[];
 	url: URL;
 	path: string;

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -1,25 +1,34 @@
 import { CSRComponent, CSRRoute, NormalizedLoadOutput } from 'types';
 
-export type NavigationInfo = {
+export interface NavigationHandler {
+	(
+		url: URL,
+		opts: { hash?: string; scroll: { x: number; y: number } | null; keepfocus: boolean },
+		redirect_chain: string[],
+		no_cache?: boolean
+	): Promise<void>;
+}
+
+export interface NavigationInfo {
 	id: string;
 	routes: CSRRoute[];
 	url: URL;
 	path: string;
 	initial: boolean;
-};
+}
 
-export type NavigationCandidate = {
+export interface NavigationCandidate {
 	route: CSRRoute;
 	info: NavigationInfo;
-};
+}
 
-export type NavigationResult = {
+export interface NavigationResult {
 	redirect?: string;
 	state: NavigationState;
 	props: Record<string, any>;
-};
+}
 
-export type BranchNode = {
+export interface BranchNode {
 	module: CSRComponent;
 	loaded: NormalizedLoadOutput | null;
 	uses: {
@@ -30,11 +39,11 @@ export type BranchNode = {
 		dependencies: Set<string>;
 	};
 	stuff: Record<string, any>;
-};
+}
 
-export type NavigationState = {
+export interface NavigationState {
 	url: URL;
 	params: Record<string, string>;
 	branch: Array<BranchNode | undefined>;
 	session_id: number;
-};
+}

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -4,8 +4,7 @@ export interface NavigationHandler {
 	(
 		url: URL,
 		opts: { hash?: string; scroll: { x: number; y: number } | null; keepfocus: boolean },
-		redirect_chain: string[],
-		no_cache?: boolean
+		redirect_chain: string[]
 	): Promise<void>;
 }
 
@@ -14,7 +13,6 @@ export interface NavigationInfo {
 	routes: CSRRoute[];
 	url: URL;
 	path: string;
-	initial: boolean;
 }
 
 export interface NavigationCandidate {
@@ -22,7 +20,7 @@ export interface NavigationCandidate {
 	info: NavigationInfo;
 }
 
-export interface NavigationResult {
+export interface LoadResult {
 	redirect?: string;
 	state: NavigationState;
 	props: Record<string, any>;

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -9,3 +9,18 @@ export function get_base_uri(doc) {
 
 	return baseURI;
 }
+
+/** @param {Event} event */
+export function find_anchor(event) {
+	const node = event
+		.composedPath()
+		.find((e) => e instanceof Node && e.nodeName.toUpperCase() === 'A'); // SVG <a> elements have a lowercase name
+	return /** @type {HTMLAnchorElement | SVGAElement | undefined} */ (node);
+}
+
+/** @param {HTMLAnchorElement | SVGAElement} node */
+export function get_href(node) {
+	return node instanceof SVGAElement
+		? new URL(node.href.baseVal, document.baseURI)
+		: new URL(node.href);
+}


### PR DESCRIPTION
I know there's been some talk of combining `Router` and `Renderer` into a single class, but I think the original idea of having separate `Router` and `Renderer` implementation came from a good place and we just never implemented it very well

The benefits of having a separate `Router` and `Renderer` include being able to hydrate without loading the `Router` code
 and more possibilities for improved `Router` testing.

This removes `renderer` as a field from `Router`. By removing cycles between the two classes, it's far easier to understand what's happening and what should happen where. One of the main things needed to accomplish this is to move prefetching to the `Renderer`. It makes more sense in `Renderer` than `Router` since it almost renders the page by calling `load`, etc. whereas the `Router` is meant to be just related to navigation

Things this PR  cleans up the API quite a bit. The set of public methods on the two classes is much saner now.