### PR TITLE
semi public types

### DIFF
--- a/.changeset/tiny-moles-joke.md
+++ b/.changeset/tiny-moles-joke.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] separate public from private-but-documented types

--- a/documentation/docs/13-configuration.md
+++ b/documentation/docs/13-configuration.md
@@ -230,18 +230,17 @@ See [Prerendering](/docs/page-options#prerender). An object containing zero or m
     ```js
     import adapter from '@sveltejs/adapter-static';
 
-    /** @type {import('@sveltejs/kit').PrerenderErrorHandler} */
-    const handleError = ({ status, path, referrer, referenceType }) => {
-    	if (path.startsWith('/blog')) throw new Error('Missing a blog page!');
-    	console.warn(`${status} ${path}${referrer ? ` (${referenceType} from ${referrer})` : ''}`);
-    };
-
     /** @type {import('@sveltejs/kit').Config} */
     const config = {
     	kit: {
     		adapter: adapter(),
     		prerender: {
-    			onError: handleError
+    			onError: ({ status, path, referrer, referenceType }) => {
+    				if (path.startsWith('/blog')) throw new Error('Missing a blog page!');
+    				console.warn(
+    					`${status} ${path}${referrer ? ` (${referenceType} from ${referrer})` : ''}`
+    				);
+    			}
     		}
     	}
     };

--- a/packages/kit/scripts/extract-types.js
+++ b/packages/kit/scripts/extract-types.js
@@ -83,6 +83,18 @@ function get_types(code, statements) {
 }
 
 {
+	const code = fs.readFileSync('types/private.d.ts', 'utf-8');
+	const node = ts.createSourceFile('private.d.ts', code, ts.ScriptTarget.Latest);
+
+	modules.push({
+		name: 'Additional types',
+		comment:
+			'The following are referenced by the public types documented above, but cannot be imported directly:',
+		...get_types(code, node.statements)
+	});
+}
+
+{
 	const code = fs.readFileSync('types/ambient.d.ts', 'utf-8');
 	const node = ts.createSourceFile('ambient.d.ts', code, ts.ScriptTarget.Latest);
 

--- a/packages/kit/src/core/utils.js
+++ b/packages/kit/src/core/utils.js
@@ -101,7 +101,7 @@ export function get_mime_lookup(manifest_data) {
 	return mime;
 }
 
-/** @param {import('@sveltejs/kit').ValidatedConfig} config */
+/** @param {import('types').ValidatedConfig} config */
 export function get_aliases(config) {
 	const alias = {
 		__GENERATED__: path.posix.resolve(`${SVELTE_KIT}/generated`),

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -4,80 +4,26 @@
 import './ambient';
 
 import { CompileOptions } from 'svelte/types/compiler/interfaces';
-import { SSRNodeLoader, SSRRoute } from './internal';
 import {
-	AdapterEntry,
 	Body,
+	Builder,
+	CspDirectives,
 	Either,
+	EndpointOutput,
+	ErrorLoadInput,
 	Fallthrough,
-	Logger,
+	LoadInput,
+	LoadOutput,
 	MaybePromise,
 	PrerenderOnErrorValue,
-	RecursiveRequired,
-	ResponseHeaders,
-	RequiredResolveOptions,
-	RouteDefinition,
+	RequestEvent,
+	ResolveOptions,
 	TrailingSlash
 } from './private';
 
 export interface Adapter {
 	name: string;
 	adapt(builder: Builder): Promise<void>;
-}
-
-export interface Builder {
-	log: Logger;
-	rimraf(dir: string): void;
-	mkdirp(dir: string): void;
-
-	appDir: string;
-	trailingSlash: TrailingSlash;
-
-	/**
-	 * Create entry points that map to individual functions
-	 * @param fn A function that groups a set of routes into an entry point
-	 */
-	createEntries(fn: (route: RouteDefinition) => AdapterEntry): void;
-
-	generateManifest: (opts: { relativePath: string; format?: 'esm' | 'cjs' }) => string;
-
-	getBuildDirectory(name: string): string;
-	getClientDirectory(): string;
-	getServerDirectory(): string;
-	getStaticDirectory(): string;
-
-	/**
-	 * @param dest the destination folder to which files should be copied
-	 * @returns an array of paths corresponding to the files that have been created by the copy
-	 */
-	writeClient(dest: string): string[];
-	/**
-	 * @param dest the destination folder to which files should be copied
-	 * @returns an array of paths corresponding to the files that have been created by the copy
-	 */
-	writeServer(dest: string): string[];
-	/**
-	 * @param dest the destination folder to which files should be copied
-	 * @returns an array of paths corresponding to the files that have been created by the copy
-	 */
-	writeStatic(dest: string): string[];
-	/**
-	 * @param from the source file or folder
-	 * @param to the destination file or folder
-	 * @param opts.filter a function to determine whether a file or folder should be copied
-	 * @param opts.replace a map of strings to replace
-	 * @returns an array of paths corresponding to the files that have been created by the copy
-	 */
-	copy(
-		from: string,
-		to: string,
-		opts?: {
-			filter?: (basename: string) => boolean;
-			replace?: Record<string, string>;
-		}
-	): string[];
-
-	prerender(options: { all?: boolean; dest: string; fallback?: string }): Promise<Prerendered>;
 }
 
 export interface Config {
@@ -141,127 +87,8 @@ export interface Config {
 	preprocess?: any;
 }
 
-// Based on https://github.com/josh-hemphill/csp-typed-directives/blob/latest/src/csp.types.ts
-//
-// MIT License
-//
-// Copyright (c) 2021-present, Joshua Hemphill
-// Copyright (c) 2021, Tecnico Corporation
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
-export namespace Csp {
-	type ActionSource = 'strict-dynamic' | 'report-sample';
-	type BaseSource = 'self' | 'unsafe-eval' | 'unsafe-hashes' | 'unsafe-inline' | 'none';
-	type CryptoSource = `${'nonce' | 'sha256' | 'sha384' | 'sha512'}-${string}`;
-	type FrameSource = HostSource | SchemeSource | 'self' | 'none';
-	type HostNameScheme = `${string}.${string}` | 'localhost';
-	type HostSource = `${HostProtocolSchemes}${HostNameScheme}${PortScheme}`;
-	type HostProtocolSchemes = `${string}://` | '';
-	type HttpDelineator = '/' | '?' | '#' | '\\';
-	type PortScheme = `:${number}` | '' | ':*';
-	type SchemeSource = 'http:' | 'https:' | 'data:' | 'mediastream:' | 'blob:' | 'filesystem:';
-	type Source = HostSource | SchemeSource | CryptoSource | BaseSource;
-	type Sources = Source[];
-	type UriPath = `${HttpDelineator}${string}`;
-}
-
-export type CspDirectives = {
-	'child-src'?: Csp.Sources;
-	'default-src'?: Array<Csp.Source | Csp.ActionSource>;
-	'frame-src'?: Csp.Sources;
-	'worker-src'?: Csp.Sources;
-	'connect-src'?: Csp.Sources;
-	'font-src'?: Csp.Sources;
-	'img-src'?: Csp.Sources;
-	'manifest-src'?: Csp.Sources;
-	'media-src'?: Csp.Sources;
-	'object-src'?: Csp.Sources;
-	'prefetch-src'?: Csp.Sources;
-	'script-src'?: Array<Csp.Source | Csp.ActionSource>;
-	'script-src-elem'?: Csp.Sources;
-	'script-src-attr'?: Csp.Sources;
-	'style-src'?: Array<Csp.Source | Csp.ActionSource>;
-	'style-src-elem'?: Csp.Sources;
-	'style-src-attr'?: Csp.Sources;
-	'base-uri'?: Array<Csp.Source | Csp.ActionSource>;
-	sandbox?: Array<
-		| 'allow-downloads-without-user-activation'
-		| 'allow-forms'
-		| 'allow-modals'
-		| 'allow-orientation-lock'
-		| 'allow-pointer-lock'
-		| 'allow-popups'
-		| 'allow-popups-to-escape-sandbox'
-		| 'allow-presentation'
-		| 'allow-same-origin'
-		| 'allow-scripts'
-		| 'allow-storage-access-by-user-activation'
-		| 'allow-top-navigation'
-		| 'allow-top-navigation-by-user-activation'
-	>;
-	'form-action'?: Array<Csp.Source | Csp.ActionSource>;
-	'frame-ancestors'?: Array<Csp.HostSource | Csp.SchemeSource | Csp.FrameSource>;
-	'navigate-to'?: Array<Csp.Source | Csp.ActionSource>;
-	'report-uri'?: Csp.UriPath[];
-	'report-to'?: string[];
-
-	'require-trusted-types-for'?: Array<'script'>;
-	'trusted-types'?: Array<'none' | 'allow-duplicates' | '*' | string>;
-	'upgrade-insecure-requests'?: boolean;
-
-	/** @deprecated */
-	'require-sri-for'?: Array<'script' | 'style' | 'script style'>;
-
-	/** @deprecated */
-	'block-all-mixed-content'?: boolean;
-
-	/** @deprecated */
-	'plugin-types'?: Array<`${string}/${string}` | 'none'>;
-
-	/** @deprecated */
-	referrer?: Array<
-		| 'no-referrer'
-		| 'no-referrer-when-downgrade'
-		| 'origin'
-		| 'origin-when-cross-origin'
-		| 'same-origin'
-		| 'strict-origin'
-		| 'strict-origin-when-cross-origin'
-		| 'unsafe-url'
-		| 'none'
-	>;
-};
-
-export interface EndpointOutput<Output extends Body = Body> {
-	status?: number;
-	headers?: Headers | Partial<ResponseHeaders>;
-	body?: Output;
-}
-
 export interface ErrorLoad<Params = Record<string, string>, Props = Record<string, any>> {
 	(input: ErrorLoadInput<Params>): MaybePromise<LoadOutput<Props>>;
-}
-
-export interface ErrorLoadInput<Params = Record<string, string>> extends LoadInput<Params> {
-	status?: number;
-	error?: Error;
 }
 
 export interface ExternalFetch {
@@ -287,29 +114,6 @@ export interface Load<Params = Record<string, string>, Props = Record<string, an
 	(input: LoadInput<Params>): MaybePromise<Either<Fallthrough, LoadOutput<Props>>>;
 }
 
-export interface LoadInput<Params = Record<string, string>> {
-	url: URL;
-	params: Params;
-	props: Record<string, any>;
-	fetch(info: RequestInfo, init?: RequestInit): Promise<Response>;
-	session: App.Session;
-	stuff: Partial<App.Stuff>;
-}
-
-export interface LoadOutput<Props = Record<string, any>> {
-	status?: number;
-	error?: string | Error;
-	redirect?: string;
-	props?: Props;
-	stuff?: Partial<App.Stuff>;
-	maxage?: number;
-}
-
-export interface Navigation {
-	from: URL;
-	to: URL;
-}
-
 export interface Page<Params extends Record<string, string> = Record<string, string>> {
 	url: URL;
 	params: Params;
@@ -318,47 +122,9 @@ export interface Page<Params extends Record<string, string> = Record<string, str
 	error: Error | null;
 }
 
-export interface Prerendered {
-	pages: Map<
-		string,
-		{
-			/** The location of the .html file relative to the output directory */
-			file: string;
-		}
-	>;
-	assets: Map<
-		string,
-		{
-			/** The MIME type of the asset */
-			type: string;
-		}
-	>;
-	redirects: Map<
-		string,
-		{
-			status: number;
-			location: string;
-		}
-	>;
-	/** An array of prerendered paths (without trailing slashes, regardless of the trailingSlash config) */
-	paths: string[];
-}
-
-export interface PrerenderErrorHandler {
-	(details: {
-		status: number;
-		path: string;
-		referrer: string | null;
-		referenceType: 'linked' | 'fetched';
-	}): void;
-}
-
-export interface RequestEvent<Params = Record<string, string>> {
-	request: Request;
-	url: URL;
-	params: Params;
-	locals: App.Locals;
-	platform: Readonly<App.Platform>;
+export interface Navigation {
+	from: URL;
+	to: URL;
 }
 
 /**
@@ -372,33 +138,3 @@ export interface RequestHandler<Params = Record<string, string>, Output extends 
 		Either<Output extends Response ? Response : EndpointOutput<Output>, Fallthrough>
 	>;
 }
-
-export interface RequestOptions {
-	platform?: App.Platform;
-}
-
-export type ResolveOptions = Partial<RequiredResolveOptions>;
-
-export class Server {
-	constructor(manifest: SSRManifest);
-	respond(request: Request, options?: RequestOptions): Promise<Response>;
-}
-
-export interface SSRManifest {
-	appDir: string;
-	assets: Set<string>;
-	/** private fields */
-	_: {
-		mime: Record<string, string>;
-		entry: {
-			file: string;
-			js: string[];
-			css: string[];
-		};
-		nodes: SSRNodeLoader[];
-		routes: SSRRoute[];
-	};
-}
-
-// TODO should this be public?
-export type ValidatedConfig = RecursiveRequired<Config>;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -5,7 +5,6 @@ import './ambient';
 
 import { CompileOptions } from 'svelte/types/compiler/interfaces';
 import {
-	AdapterEntry,
 	Body,
 	Either,
 	Fallthrough,
@@ -20,6 +19,7 @@ import {
 	SSRRoute,
 	TrailingSlash
 } from './internal';
+import { AdapterEntry } from './private';
 
 export interface Adapter {
 	name: string;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -4,7 +4,9 @@
 import './ambient';
 
 import { CompileOptions } from 'svelte/types/compiler/interfaces';
+import { SSRNodeLoader, SSRRoute } from './internal';
 import {
+	AdapterEntry,
 	Body,
 	Either,
 	Fallthrough,
@@ -12,14 +14,11 @@ import {
 	MaybePromise,
 	PrerenderOnErrorValue,
 	RecursiveRequired,
-	RequiredResolveOptions,
 	ResponseHeaders,
+	RequiredResolveOptions,
 	RouteDefinition,
-	SSRNodeLoader,
-	SSRRoute,
 	TrailingSlash
-} from './internal';
-import { AdapterEntry } from './private';
+} from './private';
 
 export interface Adapter {
 	name: string;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -303,7 +303,6 @@ export interface SSRState {
 
 export type StrictBody = string | Uint8Array;
 
-// TODO should this be public?
 export type ValidatedConfig = RecursiveRequired<Config>;
 
 export * from './index';

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -1,16 +1,12 @@
 import { OutputAsset, OutputChunk } from 'rollup';
 import {
-	SSRManifest,
-	ValidatedConfig,
 	RequestHandler,
 	Load,
 	ExternalFetch,
 	GetSession,
 	Handle,
 	HandleError,
-	RequestEvent,
-	RequestOptions,
-	Server
+	Config
 } from './index';
 import {
 	Either,
@@ -18,8 +14,13 @@ import {
 	HttpMethod,
 	JSONObject,
 	MaybePromise,
+	RequestEvent,
+	RequestOptions,
+	ResolveOptions,
 	ResponseHeaders,
 	RouteSegment,
+	Server,
+	SSRManifest,
 	TrailingSlash
 } from './private';
 
@@ -148,6 +149,19 @@ export interface PrerenderOptions {
 	all: boolean;
 	dependencies: Map<string, PrerenderDependency>;
 }
+
+export type RecursiveRequired<T> = {
+	// Recursive implementation of TypeScript's Required utility type.
+	// Will recursively continue until it reaches primitive or union
+	// with a Function in it, except those commented below
+	[K in keyof T]-?: Extract<T[K], Function> extends never // If it does not have a Function type
+		? RecursiveRequired<T[K]> // recursively continue through.
+		: K extends 'vite' // If it reaches the 'vite' key
+		? Extract<T[K], Function> // only take the Function type.
+		: T[K]; // Use the exact type for everything else
+};
+
+export type RequiredResolveOptions = Required<ResolveOptions>;
 
 export interface Respond {
 	(request: Request, options: SSROptions, state?: SSRState): Promise<Response>;
@@ -288,6 +302,9 @@ export interface SSRState {
 }
 
 export type StrictBody = string | Uint8Array;
+
+// TODO should this be public?
+export type ValidatedConfig = RecursiveRequired<Config>;
 
 export * from './index';
 export * from './private';

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -14,30 +14,6 @@ import {
 	Server
 } from './index';
 
-export interface AdapterEntry {
-	/**
-	 * A string that uniquely identifies an HTTP service (e.g. serverless function) and is used for deduplication.
-	 * For example, `/foo/a-[b]` and `/foo/[c]` are different routes, but would both
-	 * be represented in a Netlify _redirects file as `/foo/:param`, so they share an ID
-	 */
-	id: string;
-
-	/**
-	 * A function that compares the candidate route with the current route to determine
-	 * if it should be treated as a fallback for the current route. For example, `/foo/[c]`
-	 * is a fallback for `/foo/a-[b]`, and `/[...catchall]` is a fallback for all routes
-	 */
-	filter: (route: RouteDefinition) => boolean;
-
-	/**
-	 * A function that is invoked once the entry has been created. This is where you
-	 * should write the function to the filesystem and generate redirect manifests.
-	 */
-	complete: (entry: {
-		generateManifest: (opts: { relativePath: string; format?: 'esm' | 'cjs' }) => string;
-	}) => void;
-}
-
 export interface ServerModule {
 	Server: typeof InternalServer;
 

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -10,9 +10,18 @@ import {
 	HandleError,
 	RequestEvent,
 	RequestOptions,
-	PrerenderErrorHandler,
 	Server
 } from './index';
+import {
+	Either,
+	Fallthrough,
+	HttpMethod,
+	JSONObject,
+	MaybePromise,
+	ResponseHeaders,
+	RouteSegment,
+	TrailingSlash
+} from './private';
 
 export interface ServerModule {
 	Server: typeof InternalServer;
@@ -33,8 +42,6 @@ export interface Asset {
 	size: number;
 	type: string | null;
 }
-
-export type Body = JSONValue | Uint8Array | ReadableStream | import('stream').Readable;
 
 export interface BuildData {
 	app_dir: string;
@@ -65,8 +72,6 @@ export type CSRComponentLoader = () => Promise<CSRComponent>;
 
 export type CSRRoute = [RegExp, CSRComponentLoader[], CSRComponentLoader[], GetParams?, HasShadow?];
 
-export type Either<T, U> = Only<T, U> | Only<U, T>;
-
 export interface EndpointData {
 	type: 'endpoint';
 	key: string;
@@ -74,10 +79,6 @@ export interface EndpointData {
 	pattern: RegExp;
 	params: string[];
 	file: string;
-}
-
-export interface Fallthrough {
-	fallthrough: true;
 }
 
 export type GetParams = (match: RegExpExecArray) => Record<string, string>;
@@ -91,8 +92,6 @@ export interface Hooks {
 	handleError: HandleError;
 }
 
-export type HttpMethod = 'get' | 'head' | 'post' | 'put' | 'delete' | 'patch';
-
 export class InternalServer extends Server {
 	respond(
 		request: Request,
@@ -102,19 +101,6 @@ export class InternalServer extends Server {
 	): Promise<Response>;
 }
 
-export type JSONObject = { [key: string]: JSONValue };
-
-export type JSONValue = string | number | boolean | null | ToJSON | JSONValue[] | JSONObject;
-
-export interface Logger {
-	(msg: string): void;
-	success(msg: string): void;
-	error(msg: string): void;
-	warn(msg: string): void;
-	minor(msg: string): void;
-	info(msg: string): void;
-}
-
 export interface ManifestData {
 	assets: Asset[];
 	layout: string;
@@ -122,8 +108,6 @@ export interface ManifestData {
 	components: string[];
 	routes: RouteData[];
 }
-
-export type MaybePromise<T> = T | Promise<T>;
 
 export interface MethodOverride {
 	parameter: string;
@@ -142,8 +126,6 @@ export type NormalizedLoadOutput = Either<
 	Fallthrough
 >;
 
-type Only<T, U> = { [P in keyof T]: T[P] } & { [P in Exclude<keyof U, keyof T>]?: never };
-
 export interface PageData {
 	type: 'page';
 	key: string;
@@ -161,51 +143,17 @@ export interface PrerenderDependency {
 	body: null | string | Uint8Array;
 }
 
-export type PrerenderOnErrorValue = 'fail' | 'continue' | PrerenderErrorHandler;
-
 export interface PrerenderOptions {
 	fallback?: string;
 	all: boolean;
 	dependencies: Map<string, PrerenderDependency>;
 }
 
-export type RecursiveRequired<T> = {
-	// Recursive implementation of TypeScript's Required utility type.
-	// Will recursively continue until it reaches primitive or union
-	// with a Function in it, except those commented below
-	[K in keyof T]-?: Extract<T[K], Function> extends never // If it does not have a Function type
-		? RecursiveRequired<T[K]> // recursively continue through.
-		: K extends 'vite' // If it reaches the 'vite' key
-		? Extract<T[K], Function> // only take the Function type.
-		: T[K]; // Use the exact type for everything else
-};
-
-export interface RequiredResolveOptions {
-	ssr: boolean;
-	transformPage: ({ html }: { html: string }) => MaybePromise<string>;
-}
-
 export interface Respond {
 	(request: Request, options: SSROptions, state?: SSRState): Promise<Response>;
 }
 
-/** `string[]` is only for set-cookie, everything else must be type of `string` */
-export type ResponseHeaders = Record<string, string | number | string[]>;
-
 export type RouteData = PageData | EndpointData;
-
-export interface RouteDefinition {
-	type: 'page' | 'endpoint';
-	pattern: RegExp;
-	segments: RouteSegment[];
-	methods: HttpMethod[];
-}
-
-export interface RouteSegment {
-	content: string;
-	dynamic: boolean;
-	rest: boolean;
-}
 
 export interface ShadowEndpointOutput<Output extends JSONObject = JSONObject> {
 	status?: number;
@@ -341,8 +289,5 @@ export interface SSRState {
 
 export type StrictBody = string | Uint8Array;
 
-type ToJSON = { toJSON(...args: any[]): Exclude<JSONValue, ToJSON> };
-
-export type TrailingSlash = 'never' | 'always' | 'ignore';
-
 export * from './index';
+export * from './private';

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -2,7 +2,7 @@
 // but which cannot be imported from `@sveltejs/kit`. Care should
 // be taken to avoid breaking changes when editing this file
 
-import { PrerenderErrorHandler } from './index';
+import { SSRNodeLoader, SSRRoute } from './internal';
 
 export interface AdapterEntry {
 	/**
@@ -30,7 +30,181 @@ export interface AdapterEntry {
 
 export type Body = JSONValue | Uint8Array | ReadableStream | import('stream').Readable;
 
+export interface Builder {
+	log: Logger;
+	rimraf(dir: string): void;
+	mkdirp(dir: string): void;
+
+	appDir: string;
+	trailingSlash: TrailingSlash;
+
+	/**
+	 * Create entry points that map to individual functions
+	 * @param fn A function that groups a set of routes into an entry point
+	 */
+	createEntries(fn: (route: RouteDefinition) => AdapterEntry): void;
+
+	generateManifest: (opts: { relativePath: string; format?: 'esm' | 'cjs' }) => string;
+
+	getBuildDirectory(name: string): string;
+	getClientDirectory(): string;
+	getServerDirectory(): string;
+	getStaticDirectory(): string;
+
+	/**
+	 * @param dest the destination folder to which files should be copied
+	 * @returns an array of paths corresponding to the files that have been created by the copy
+	 */
+	writeClient(dest: string): string[];
+	/**
+	 * @param dest the destination folder to which files should be copied
+	 * @returns an array of paths corresponding to the files that have been created by the copy
+	 */
+	writeServer(dest: string): string[];
+	/**
+	 * @param dest the destination folder to which files should be copied
+	 * @returns an array of paths corresponding to the files that have been created by the copy
+	 */
+	writeStatic(dest: string): string[];
+	/**
+	 * @param from the source file or folder
+	 * @param to the destination file or folder
+	 * @param opts.filter a function to determine whether a file or folder should be copied
+	 * @param opts.replace a map of strings to replace
+	 * @returns an array of paths corresponding to the files that have been created by the copy
+	 */
+	copy(
+		from: string,
+		to: string,
+		opts?: {
+			filter?: (basename: string) => boolean;
+			replace?: Record<string, string>;
+		}
+	): string[];
+
+	prerender(options: { all?: boolean; dest: string; fallback?: string }): Promise<Prerendered>;
+}
+
+// Based on https://github.com/josh-hemphill/csp-typed-directives/blob/latest/src/csp.types.ts
+//
+// MIT License
+//
+// Copyright (c) 2021-present, Joshua Hemphill
+// Copyright (c) 2021, Tecnico Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+export namespace Csp {
+	type ActionSource = 'strict-dynamic' | 'report-sample';
+	type BaseSource = 'self' | 'unsafe-eval' | 'unsafe-hashes' | 'unsafe-inline' | 'none';
+	type CryptoSource = `${'nonce' | 'sha256' | 'sha384' | 'sha512'}-${string}`;
+	type FrameSource = HostSource | SchemeSource | 'self' | 'none';
+	type HostNameScheme = `${string}.${string}` | 'localhost';
+	type HostSource = `${HostProtocolSchemes}${HostNameScheme}${PortScheme}`;
+	type HostProtocolSchemes = `${string}://` | '';
+	type HttpDelineator = '/' | '?' | '#' | '\\';
+	type PortScheme = `:${number}` | '' | ':*';
+	type SchemeSource = 'http:' | 'https:' | 'data:' | 'mediastream:' | 'blob:' | 'filesystem:';
+	type Source = HostSource | SchemeSource | CryptoSource | BaseSource;
+	type Sources = Source[];
+	type UriPath = `${HttpDelineator}${string}`;
+}
+
+export type CspDirectives = {
+	'child-src'?: Csp.Sources;
+	'default-src'?: Array<Csp.Source | Csp.ActionSource>;
+	'frame-src'?: Csp.Sources;
+	'worker-src'?: Csp.Sources;
+	'connect-src'?: Csp.Sources;
+	'font-src'?: Csp.Sources;
+	'img-src'?: Csp.Sources;
+	'manifest-src'?: Csp.Sources;
+	'media-src'?: Csp.Sources;
+	'object-src'?: Csp.Sources;
+	'prefetch-src'?: Csp.Sources;
+	'script-src'?: Array<Csp.Source | Csp.ActionSource>;
+	'script-src-elem'?: Csp.Sources;
+	'script-src-attr'?: Csp.Sources;
+	'style-src'?: Array<Csp.Source | Csp.ActionSource>;
+	'style-src-elem'?: Csp.Sources;
+	'style-src-attr'?: Csp.Sources;
+	'base-uri'?: Array<Csp.Source | Csp.ActionSource>;
+	sandbox?: Array<
+		| 'allow-downloads-without-user-activation'
+		| 'allow-forms'
+		| 'allow-modals'
+		| 'allow-orientation-lock'
+		| 'allow-pointer-lock'
+		| 'allow-popups'
+		| 'allow-popups-to-escape-sandbox'
+		| 'allow-presentation'
+		| 'allow-same-origin'
+		| 'allow-scripts'
+		| 'allow-storage-access-by-user-activation'
+		| 'allow-top-navigation'
+		| 'allow-top-navigation-by-user-activation'
+	>;
+	'form-action'?: Array<Csp.Source | Csp.ActionSource>;
+	'frame-ancestors'?: Array<Csp.HostSource | Csp.SchemeSource | Csp.FrameSource>;
+	'navigate-to'?: Array<Csp.Source | Csp.ActionSource>;
+	'report-uri'?: Csp.UriPath[];
+	'report-to'?: string[];
+
+	'require-trusted-types-for'?: Array<'script'>;
+	'trusted-types'?: Array<'none' | 'allow-duplicates' | '*' | string>;
+	'upgrade-insecure-requests'?: boolean;
+
+	/** @deprecated */
+	'require-sri-for'?: Array<'script' | 'style' | 'script style'>;
+
+	/** @deprecated */
+	'block-all-mixed-content'?: boolean;
+
+	/** @deprecated */
+	'plugin-types'?: Array<`${string}/${string}` | 'none'>;
+
+	/** @deprecated */
+	referrer?: Array<
+		| 'no-referrer'
+		| 'no-referrer-when-downgrade'
+		| 'origin'
+		| 'origin-when-cross-origin'
+		| 'same-origin'
+		| 'strict-origin'
+		| 'strict-origin-when-cross-origin'
+		| 'unsafe-url'
+		| 'none'
+	>;
+};
+
 export type Either<T, U> = Only<T, U> | Only<U, T>;
+
+export interface EndpointOutput<Output extends Body = Body> {
+	status?: number;
+	headers?: Headers | Partial<ResponseHeaders>;
+	body?: Output;
+}
+
+export interface ErrorLoadInput<Params = Record<string, string>> extends LoadInput<Params> {
+	status?: number;
+	error?: Error;
+}
 
 export interface Fallthrough {
 	fallthrough: true;
@@ -41,6 +215,24 @@ export type HttpMethod = 'get' | 'head' | 'post' | 'put' | 'delete' | 'patch';
 export type JSONObject = { [key: string]: JSONValue };
 
 export type JSONValue = string | number | boolean | null | ToJSON | JSONValue[] | JSONObject;
+
+export interface LoadInput<Params = Record<string, string>> {
+	url: URL;
+	params: Params;
+	props: Record<string, any>;
+	fetch(info: RequestInfo, init?: RequestInit): Promise<Response>;
+	session: App.Session;
+	stuff: Partial<App.Stuff>;
+}
+
+export interface LoadOutput<Props = Record<string, any>> {
+	status?: number;
+	error?: string | Error;
+	redirect?: string;
+	props?: Props;
+	stuff?: Partial<App.Stuff>;
+	maxage?: number;
+}
 
 export interface Logger {
 	(msg: string): void;
@@ -55,23 +247,59 @@ export type MaybePromise<T> = T | Promise<T>;
 
 export type Only<T, U> = { [P in keyof T]: T[P] } & { [P in Exclude<keyof U, keyof T>]?: never };
 
+export interface Prerendered {
+	pages: Map<
+		string,
+		{
+			/** The location of the .html file relative to the output directory */
+			file: string;
+		}
+	>;
+	assets: Map<
+		string,
+		{
+			/** The MIME type of the asset */
+			type: string;
+		}
+	>;
+	redirects: Map<
+		string,
+		{
+			status: number;
+			location: string;
+		}
+	>;
+	/** An array of prerendered paths (without trailing slashes, regardless of the trailingSlash config) */
+	paths: string[];
+}
+
+export interface PrerenderErrorHandler {
+	(details: {
+		status: number;
+		path: string;
+		referrer: string | null;
+		referenceType: 'linked' | 'fetched';
+	}): void;
+}
+
 export type PrerenderOnErrorValue = 'fail' | 'continue' | PrerenderErrorHandler;
 
-export type RecursiveRequired<T> = {
-	// Recursive implementation of TypeScript's Required utility type.
-	// Will recursively continue until it reaches primitive or union
-	// with a Function in it, except those commented below
-	[K in keyof T]-?: Extract<T[K], Function> extends never // If it does not have a Function type
-		? RecursiveRequired<T[K]> // recursively continue through.
-		: K extends 'vite' // If it reaches the 'vite' key
-		? Extract<T[K], Function> // only take the Function type.
-		: T[K]; // Use the exact type for everything else
-};
-
-export interface RequiredResolveOptions {
-	ssr: boolean;
-	transformPage: ({ html }: { html: string }) => MaybePromise<string>;
+export interface RequestEvent<Params = Record<string, string>> {
+	request: Request;
+	url: URL;
+	params: Params;
+	locals: App.Locals;
+	platform: Readonly<App.Platform>;
 }
+
+export interface RequestOptions {
+	platform?: App.Platform;
+}
+
+export type ResolveOptions = {
+	ssr?: boolean;
+	transformPage?: ({ html }: { html: string }) => MaybePromise<string>;
+};
 
 /** `string[]` is only for set-cookie, everything else must be type of `string` */
 export type ResponseHeaders = Record<string, string | number | string[]>;
@@ -87,6 +315,27 @@ export interface RouteSegment {
 	content: string;
 	dynamic: boolean;
 	rest: boolean;
+}
+
+export class Server {
+	constructor(manifest: SSRManifest);
+	respond(request: Request, options?: RequestOptions): Promise<Response>;
+}
+
+export interface SSRManifest {
+	appDir: string;
+	assets: Set<string>;
+	/** private fields */
+	_: {
+		mime: Record<string, string>;
+		entry: {
+			file: string;
+			js: string[];
+			css: string[];
+		};
+		nodes: SSRNodeLoader[];
+		routes: SSRRoute[];
+	};
 }
 
 export type ToJSON = { toJSON(...args: any[]): Exclude<JSONValue, ToJSON> };

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -1,0 +1,27 @@
+// This module contains types that are visible in the documentation,
+// but which cannot be imported from `@sveltejs/kit`. Care should
+// be taken to avoid breaking changes when editing this file
+
+export interface AdapterEntry {
+	/**
+	 * A string that uniquely identifies an HTTP service (e.g. serverless function) and is used for deduplication.
+	 * For example, `/foo/a-[b]` and `/foo/[c]` are different routes, but would both
+	 * be represented in a Netlify _redirects file as `/foo/:param`, so they share an ID
+	 */
+	id: string;
+
+	/**
+	 * A function that compares the candidate route with the current route to determine
+	 * if it should be treated as a fallback for the current route. For example, `/foo/[c]`
+	 * is a fallback for `/foo/a-[b]`, and `/[...catchall]` is a fallback for all routes
+	 */
+	filter: (route: RouteDefinition) => boolean;
+
+	/**
+	 * A function that is invoked once the entry has been created. This is where you
+	 * should write the function to the filesystem and generate redirect manifests.
+	 */
+	complete: (entry: {
+		generateManifest: (opts: { relativePath: string; format?: 'esm' | 'cjs' }) => string;
+	}) => void;
+}

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -2,6 +2,8 @@
 // but which cannot be imported from `@sveltejs/kit`. Care should
 // be taken to avoid breaking changes when editing this file
 
+import { PrerenderErrorHandler } from './index';
+
 export interface AdapterEntry {
 	/**
 	 * A string that uniquely identifies an HTTP service (e.g. serverless function) and is used for deduplication.
@@ -25,3 +27,68 @@ export interface AdapterEntry {
 		generateManifest: (opts: { relativePath: string; format?: 'esm' | 'cjs' }) => string;
 	}) => void;
 }
+
+export type Body = JSONValue | Uint8Array | ReadableStream | import('stream').Readable;
+
+export type Either<T, U> = Only<T, U> | Only<U, T>;
+
+export interface Fallthrough {
+	fallthrough: true;
+}
+
+export type HttpMethod = 'get' | 'head' | 'post' | 'put' | 'delete' | 'patch';
+
+export type JSONObject = { [key: string]: JSONValue };
+
+export type JSONValue = string | number | boolean | null | ToJSON | JSONValue[] | JSONObject;
+
+export interface Logger {
+	(msg: string): void;
+	success(msg: string): void;
+	error(msg: string): void;
+	warn(msg: string): void;
+	minor(msg: string): void;
+	info(msg: string): void;
+}
+
+export type MaybePromise<T> = T | Promise<T>;
+
+type Only<T, U> = { [P in keyof T]: T[P] } & { [P in Exclude<keyof U, keyof T>]?: never };
+
+export type PrerenderOnErrorValue = 'fail' | 'continue' | PrerenderErrorHandler;
+
+export type RecursiveRequired<T> = {
+	// Recursive implementation of TypeScript's Required utility type.
+	// Will recursively continue until it reaches primitive or union
+	// with a Function in it, except those commented below
+	[K in keyof T]-?: Extract<T[K], Function> extends never // If it does not have a Function type
+		? RecursiveRequired<T[K]> // recursively continue through.
+		: K extends 'vite' // If it reaches the 'vite' key
+		? Extract<T[K], Function> // only take the Function type.
+		: T[K]; // Use the exact type for everything else
+};
+
+export interface RequiredResolveOptions {
+	ssr: boolean;
+	transformPage: ({ html }: { html: string }) => MaybePromise<string>;
+}
+
+/** `string[]` is only for set-cookie, everything else must be type of `string` */
+export type ResponseHeaders = Record<string, string | number | string[]>;
+
+export interface RouteDefinition {
+	type: 'page' | 'endpoint';
+	pattern: RegExp;
+	segments: RouteSegment[];
+	methods: HttpMethod[];
+}
+
+export interface RouteSegment {
+	content: string;
+	dynamic: boolean;
+	rest: boolean;
+}
+
+type ToJSON = { toJSON(...args: any[]): Exclude<JSONValue, ToJSON> };
+
+export type TrailingSlash = 'never' | 'always' | 'ignore';

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -53,7 +53,7 @@ export interface Logger {
 
 export type MaybePromise<T> = T | Promise<T>;
 
-type Only<T, U> = { [P in keyof T]: T[P] } & { [P in Exclude<keyof U, keyof T>]?: never };
+export type Only<T, U> = { [P in keyof T]: T[P] } & { [P in Exclude<keyof U, keyof T>]?: never };
 
 export type PrerenderOnErrorValue = 'fail' | 'continue' | PrerenderErrorHandler;
 
@@ -89,6 +89,6 @@ export interface RouteSegment {
 	rest: boolean;
 }
 
-type ToJSON = { toJSON(...args: any[]): Exclude<JSONValue, ToJSON> };
+export type ToJSON = { toJSON(...args: any[]): Exclude<JSONValue, ToJSON> };
 
 export type TrailingSlash = 'never' | 'always' | 'ignore';

--- a/sites/kit.svelte.dev/src/lib/docs/server/index.js
+++ b/sites/kit.svelte.dev/src/lib/docs/server/index.js
@@ -25,11 +25,23 @@ const base = '../../documentation';
 
 const type_regex = new RegExp(
 	`(import\\(&apos;@sveltejs\\/kit&apos;\\)\\.)?\\b(${modules
-		.find((mod) => mod.name === '@sveltejs/kit')
-		.types.map((type) => type.name)
+		.map((module) => module.types)
+		.flat()
+		.map((type) => type.name)
 		.join('|')})\\b`,
 	'g'
 );
+
+const type_links = new Map();
+
+modules.forEach((module) => {
+	const slug = slugify(module.name);
+
+	module.types.forEach((type) => {
+		const link = `/docs/types#${slug}-${slugify(type.name)}`;
+		type_links.set(type.name, link);
+	});
+});
 
 /**
  * @param {string} dir
@@ -126,13 +138,13 @@ export async function read_file(dir, file) {
 			type_regex.lastIndex = 0;
 
 			return html
-				.replace(type_regex, (match, prefix, content) => {
-					if (content === current) {
+				.replace(type_regex, (match, prefix, name) => {
+					if (name === current) {
 						// we don't want e.g. RequestHandler to link to RequestHandler
 						return match;
 					}
 
-					const link = `<a href="/docs/types#sveltejs-kit-${slugify(content)}">${content}</a>`;
+					const link = `<a href="${type_links.get(name)}">${name}</a>`;
 					return `${prefix || ''}${link}`;
 				})
 				.replace(


### PR DESCRIPTION
Deploy preview: https://kit-svelte-dev-git-semi-public-types-svelte.vercel.app/docs/types#additional-types

---

I tried to do this in #4021 but the merge was too gnarly. Easier to start fresh.

The basic thinking here is that we have public types in `index.d.ts` and `ambient.d.ts`, and private-but-documented types in `private.d.ts`. Changes to these types should be made carefully to avoid breakage.

`internal.d.ts` is for things that aren't referenced by public types, and can be changed freely.

~~So far I haven't actually moved most of the types, I've just set up the logic for extracting/rendering/linking them.~~