### PR TITLE
Unit Tests for Netlify Adapter split_headers function

### DIFF
--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -24,6 +24,7 @@
 	"scripts": {
 		"dev": "rimraf files && rollup -cw",
 		"build": "rimraf files && rollup -c",
+		"test": "uvu src \"(spec\\.js|test[\\\\/]index\\.js)\"",
 		"lint": "eslint --ignore-path .gitignore \"**/*.{ts,js,svelte}\" && npm run check-format",
 		"format": "npm run check-format -- --write",
 		"check-format": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
@@ -41,6 +42,7 @@
 		"@rollup/plugin-node-resolve": "^13.0.5",
 		"@sveltejs/kit": "workspace:*",
 		"rimraf": "^3.0.2",
-		"rollup": "^2.58.0"
+		"rollup": "^2.58.0",
+		"uvu": "^0.5.2"
 	}
 }

--- a/packages/adapter-netlify/src/handler.js
+++ b/packages/adapter-netlify/src/handler.js
@@ -1,5 +1,6 @@
 import './shims';
 import { Server } from '0SERVER';
+import { split_headers } from './headers';
 
 /**
  * @param {import('@sveltejs/kit').SSRManifest} manifest
@@ -54,34 +55,4 @@ function to_request(event) {
 	}
 
 	return new Request(rawUrl, init);
-}
-
-/**
- * Splits headers into two categories: single value and multi value
- * @param {Headers} headers
- * @returns {{
- *   headers: Record<string, string>,
- *   multiValueHeaders: Record<string, string[]>
- * }}
- */
-function split_headers(headers) {
-	/** @type {Record<string, string>} */
-	const h = {};
-
-	/** @type {Record<string, string[]>} */
-	const m = {};
-
-	headers.forEach((value, key) => {
-		if (key === 'set-cookie') {
-			// @ts-expect-error (headers.raw() is non-standard)
-			m[key] = headers.raw()[key];
-		} else {
-			h[key] = value;
-		}
-	});
-
-	return {
-		headers: h,
-		multiValueHeaders: m
-	};
 }

--- a/packages/adapter-netlify/src/headers.js
+++ b/packages/adapter-netlify/src/headers.js
@@ -1,0 +1,29 @@
+/**
+ * Splits headers into two categories: single value and multi value
+ * @param {Headers} headers
+ * @returns {{
+ *   headers: Record<string, string>,
+ *   multiValueHeaders: Record<string, string[]>
+ * }}
+ */
+export function split_headers(headers) {
+	/** @type {Record<string, string>} */
+	const h = {};
+
+	/** @type {Record<string, string[]>} */
+	const m = {};
+
+	headers.forEach((value, key) => {
+		if (key === 'set-cookie') {
+			// @ts-expect-error (headers.raw() is non-standard)
+			m[key] = headers.raw()[key];
+		} else {
+			h[key] = value;
+		}
+	});
+
+	return {
+		headers: h,
+		multiValueHeaders: m
+	};
+}

--- a/packages/adapter-netlify/src/headers.spec.js
+++ b/packages/adapter-netlify/src/headers.spec.js
@@ -1,0 +1,56 @@
+import '../src/shims.js';
+import { suite } from 'uvu';
+import * as assert from 'uvu/assert';
+import { split_headers } from '../src/headers.js';
+
+const split_headers_test = suite('split_headers');
+
+split_headers_test('empty headers', () => {
+	const headers = new Headers();
+
+	const result = split_headers(headers);
+
+	assert.equal(result, {
+		headers: {},
+		multiValueHeaders: {}
+	});
+});
+
+split_headers_test('single-value headers', () => {
+	const headers = new Headers();
+	headers.append('Location', '/apple');
+	headers.append('Content-Type', 'application/json');
+
+	const result = split_headers(headers);
+
+	assert.equal(result, {
+		headers: {
+			// Note: becomes lowercase even if specified as uppercase
+			location: '/apple',
+			'content-type': 'application/json'
+		},
+		multiValueHeaders: {}
+	});
+});
+
+split_headers_test('multi-value headers', () => {
+	// https://httpwg.org/specs/rfc7231.html#http.date
+	const wednesday = 'Wed, 23 Feb 2022 21:01:48 GMT';
+	const thursday = 'Thu, 24 Feb 2022 21:01:48 GMT';
+
+	const headers = new Headers();
+	headers.append('Set-Cookie', `flavor=sugar; Expires=${wednesday}`);
+	headers.append('Set-Cookie', `diameter=6cm; Expires=${thursday}`);
+
+	const result = split_headers(headers);
+
+	// it splits at actual cookie boundaries, not the commas in the dates
+	assert.equal(result, {
+		headers: {},
+		multiValueHeaders: {
+			'set-cookie': [`flavor=sugar; Expires=${wednesday}`, `diameter=6cm; Expires=${thursday}`]
+		}
+	});
+});
+
+split_headers_test.run();

--- a/packages/adapter-netlify/src/headers.spec.js
+++ b/packages/adapter-netlify/src/headers.spec.js
@@ -1,11 +1,9 @@
 import '../src/shims.js';
-import { suite } from 'uvu';
+import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { split_headers } from '../src/headers.js';
 
-const split_headers_test = suite('split_headers');
-
-split_headers_test('empty headers', () => {
+test('empty headers', () => {
 	const headers = new Headers();
 
 	const result = split_headers(headers);
@@ -16,7 +14,7 @@ split_headers_test('empty headers', () => {
 	});
 });
 
-split_headers_test('single-value headers', () => {
+test('single-value headers', () => {
 	const headers = new Headers();
 	headers.append('Location', '/apple');
 	headers.append('Content-Type', 'application/json');
@@ -33,7 +31,7 @@ split_headers_test('single-value headers', () => {
 	});
 });
 
-split_headers_test('multi-value headers', () => {
+test('multi-value headers', () => {
 	// https://httpwg.org/specs/rfc7231.html#http.date
 	const wednesday = 'Wed, 23 Feb 2022 21:01:48 GMT';
 	const thursday = 'Thu, 24 Feb 2022 21:01:48 GMT';
@@ -53,4 +51,4 @@ split_headers_test('multi-value headers', () => {
 	});
 });
 
-split_headers_test.run();
+test.run();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,7 @@ importers:
       rimraf: ^3.0.2
       rollup: ^2.58.0
       tiny-glob: ^0.2.9
+      uvu: ^0.5.2
     dependencies:
       '@iarna/toml': 2.2.5
       esbuild: 0.14.21
@@ -110,6 +111,7 @@ importers:
       '@sveltejs/kit': link:../kit
       rimraf: 3.0.2
       rollup: 2.60.2
+      uvu: 0.5.2
 
   packages/adapter-node:
     specifiers:


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

## Description

This PR adds unit tests for the `split_headers` function which address #4087 with a fix already applied by #4096.