### PR TITLE
rename `EndpointOutput` to `RequestHandlerOutput` and tidy up

### DIFF
--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -16,8 +16,8 @@ import {
 	MaybePromise,
 	PrerenderOnErrorValue,
 	RequestEvent,
-	RequestHandlerOutput,
 	ResolveOptions,
+	ResponseHeaders,
 	TrailingSlash
 } from './private';
 
@@ -136,3 +136,14 @@ export interface Navigation {
 export interface RequestHandler<Params = Record<string, string>, Output extends Body = Body> {
 	(event: RequestEvent<Params>): RequestHandlerOutput<Output>;
 }
+
+export type RequestHandlerOutput<Output extends Body = Body> = MaybePromise<
+	Either<
+		{
+			status?: number;
+			headers?: Headers | Partial<ResponseHeaders>;
+			body?: Output;
+		},
+		Fallthrough
+	>
+>;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -9,7 +9,6 @@ import {
 	Builder,
 	CspDirectives,
 	Either,
-	EndpointOutput,
 	ErrorLoadInput,
 	Fallthrough,
 	LoadInput,
@@ -17,6 +16,7 @@ import {
 	MaybePromise,
 	PrerenderOnErrorValue,
 	RequestEvent,
+	RequestHandlerOutput,
 	ResolveOptions,
 	TrailingSlash
 } from './private';
@@ -134,7 +134,5 @@ export interface Navigation {
  * JavaScript, delete handles are called `del` instead.
  */
 export interface RequestHandler<Params = Record<string, string>, Output extends Body = Body> {
-	(event: RequestEvent<Params>): MaybePromise<
-		Either<Output extends Response ? Response : EndpointOutput<Output>, Fallthrough>
-	>;
+	(event: RequestEvent<Params>): RequestHandlerOutput<Output>;
 }

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -195,12 +195,6 @@ export type CspDirectives = {
 
 export type Either<T, U> = Only<T, U> | Only<U, T>;
 
-export interface EndpointOutput<Output extends Body = Body> {
-	status?: number;
-	headers?: Headers | Partial<ResponseHeaders>;
-	body?: Output;
-}
-
 export interface ErrorLoadInput<Params = Record<string, string>> extends LoadInput<Params> {
 	status?: number;
 	error?: Error;
@@ -291,6 +285,17 @@ export interface RequestEvent<Params = Record<string, string>> {
 	locals: App.Locals;
 	platform: Readonly<App.Platform>;
 }
+
+export type RequestHandlerOutput<Output extends Body = Body> = MaybePromise<
+	Either<
+		{
+			status?: number;
+			headers?: Headers | Partial<ResponseHeaders>;
+			body?: Output;
+		},
+		Fallthrough
+	>
+>;
 
 export interface RequestOptions {
 	platform?: App.Platform;

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -286,17 +286,6 @@ export interface RequestEvent<Params = Record<string, string>> {
 	platform: Readonly<App.Platform>;
 }
 
-export type RequestHandlerOutput<Output extends Body = Body> = MaybePromise<
-	Either<
-		{
-			status?: number;
-			headers?: Headers | Partial<ResponseHeaders>;
-			body?: Output;
-		},
-		Fallthrough
-	>
->;
-
 export interface RequestOptions {
 	platform?: App.Platform;
 }

--- a/sites/kit.svelte.dev/src/lib/docs/server/index.js
+++ b/sites/kit.svelte.dev/src/lib/docs/server/index.js
@@ -99,6 +99,12 @@ export async function read_file(dir, file) {
 
 				html = renderCodeToHTML(twoslash.code, 'ts', { twoslash: true }, {}, highlighter, twoslash);
 
+				// we need to be able to inject the LSP attributes as HTML, not text, so we
+				// turn &lt; into &amp;lt;
+				html = html.replace(/<data-lsp lsp='(.+?)' *>(\w+)<\/data-lsp>/g, (match, lsp, name) => {
+					return `<data-lsp lsp='${lsp.replace(/&/g, '&amp;')}'>${name}</data-lsp>`;
+				});
+
 				// preserve blank lines in output (maybe there's a more correct way to do this?)
 				html = `<div class="code-block">${file ? `<h5>${file}</h5>` : ''}${html.replace(
 					/<div class='line'><\/div>/g,


### PR DESCRIPTION
This clarifies the terminology a bit — an _endpoint_ is a module corresponding to a route, a _request handler_ is a function exported from an endpoint. Therefore `RequestHandlerOutput` makes more sense than `EndpointOutput`.

It also neatens the type up. Before:

<img width="1397" alt="image" src="https://user-images.githubusercontent.com/1162160/155570946-a247806a-7876-4877-b396-5a22e2b62c96.png">

After:

<img width="1205" alt="image" src="https://user-images.githubusercontent.com/1162160/155571026-c3a8d3d8-87b9-4bbb-b4b3-d1e0703e3ceb.png">

Before:

<img width="202" alt="image" src="https://user-images.githubusercontent.com/1162160/155571101-73947db4-01fc-446c-b30e-1602092c7d40.png">

After:

<img width="326" alt="image" src="https://user-images.githubusercontent.com/1162160/155571144-b1d5fc6c-8a47-476b-8044-f7d5dea54464.png">

No changeset, since now that these types are private there's no breakage involved.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
