### PR TITLE
remove unnecessary units

### DIFF
--- a/.changeset/late-bats-rule.md
+++ b/.changeset/late-bats-rule.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+remove unnecessary CSS units

--- a/packages/create-svelte/templates/default/src/routes/todos/index.svelte
+++ b/packages/create-svelte/templates/default/src/routes/todos/index.svelte
@@ -124,7 +124,7 @@
 	.done {
 		transform: none;
 		opacity: 0.4;
-		filter: drop-shadow(0px 0px 1px rgba(0, 0, 0, 0.1));
+		filter: drop-shadow(0 0 1px rgba(0, 0, 0, 0.1));
 	}
 
 	form.text {


### PR DESCRIPTION
This is extremely minor so I haven't filled in most of the checklist

Changes `0px 0px` to `0 0`

Using units after 0 causes a lint warning in vscode, `css(zeroUnits)`, and also it's consistent with the omission in `margin: 0 0 0.5rem 0`

There are some cases in `calc` where units are required, but this doesn't apply since the change is in [`drop-shadow`](https://developer.mozilla.org/en-US/docs/Web/CSS/filter-function/drop-shadow())

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
