### PR TITLE
Fix race condition in clicknav test utility func

### DIFF
--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1422,8 +1422,8 @@ test.describe.parallel('Page options', () => {
 		expect(await page.textContent('button')).toBe('clicks: 0');
 
 		if (javaScriptEnabled) {
-			await Promise.all([page.click('[href="/no-hydrate/other"]'), page.waitForNavigation()]);
-			await Promise.all([page.click('[href="/no-hydrate"]'), page.waitForNavigation()]);
+			await Promise.all([page.waitForNavigation(), page.click('[href="/no-hydrate/other"]')]);
+			await Promise.all([page.waitForNavigation(), page.click('[href="/no-hydrate"]')]);
 
 			await page.click('button');
 			expect(await page.textContent('button')).toBe('clicks: 1');
@@ -1457,7 +1457,7 @@ test.describe.parallel('Page options', () => {
 			await page.click('button');
 			expect(await page.textContent('button')).toBe('clicks: 1');
 
-			await Promise.all([page.click('[href="/no-router/b"]'), page.waitForNavigation()]);
+			await Promise.all([page.waitForNavigation(), page.click('[href="/no-router/b"]')]);
 			expect(await page.textContent('button')).toBe('clicks: 0');
 
 			await page.click('button');
@@ -1466,7 +1466,7 @@ test.describe.parallel('Page options', () => {
 			await clicknav('[href="/no-router/a"]');
 			expect(await page.textContent('button')).toBe('clicks: 1');
 
-			await Promise.all([page.click('[href="/no-router/b"]'), page.waitForNavigation()]);
+			await Promise.all([page.waitForNavigation(), page.click('[href="/no-router/b"]')]);
 			expect(await page.textContent('button')).toBe('clicks: 0');
 		}
 	});

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -73,7 +73,7 @@ export const test = base.extend({
 		 */
 		async function clicknav(selector, options) {
 			if (javaScriptEnabled) {
-				await Promise.all([page.click(selector), page.waitForNavigation(options)]);
+				await Promise.all([page.waitForNavigation(options), page.click(selector)]);
 			} else {
 				await page.click(selector);
 			}


### PR DESCRIPTION
[The Playwright docs](https://playwright.dev/docs/navigations#asynchronous-navigation) mention that when using `page.waitForNavigation()`, it's important to use `Promise.all` and await the navigation first, before triggering the event (such as a link click) that will begin navigation. Otherwise there could be a race condition where the navigation happens too fast, before the `waitForNavigation()` can get set up, resulting in `waitForNavigation()` timing out and the test failing.

It's very unlikely to happen in practice, but "very unlikely" isn't the same as "impossible", so we might as well do it the way the Playwright docs recommend, with waitForNavigation coming first.

**NOTE:** I ran the tests (for the entire repo) both before and after making this change. They passed both before and after, but there was one test that was flaky after making the change. It failed twice, then passed on the third try with no code changes. That test was the 'prevents navigation triggered by back button' test [here](https://github.com/sveltejs/kit/blob/06ceef5ef052861951eabfb525430fad43dafb89/packages/kit/test/apps/basics/test/test.js#L126). Since it doesn't use the `clicknav` fixture at all, and the only change this PR makes is to the `clicknav` fixture, I don't believe the failure is related.

No changeset included as I don't believe this is something that should be mentioned in the changelog.

Fixes #4121.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
