### PR TITLE
Improve JSON payload handling

### DIFF
--- a/.changeset/fuzzy-donkeys-warn.md
+++ b/.changeset/fuzzy-donkeys-warn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix XSS vulnerability on SSR pages with fetched data on `load()`

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -96,9 +96,9 @@ function create_updated_store() {
  * @param {RequestInit} [opts]
  */
 function initial_fetch(resource, opts) {
-	const url = escape_html_attr(typeof resource === 'string' ? resource : resource.url);
+	const url = typeof resource === 'string' ? resource : resource.url;
 
-	let selector = `script[sveltekit\\:data-type="data"][sveltekit\\:data-url=${url}]`;
+	let selector = `script[sveltekit\\:data-type="data"][sveltekit\\:data-url=${JSON.stringify(url)}]`;
 
 	if (opts && typeof opts.body === 'string') {
 		selector += `[sveltekit\\:data-body="${hash(opts.body)}"]`;

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -1,7 +1,6 @@
 import { tick } from 'svelte';
 import { writable } from 'svelte/store';
 import { coalesce_to_error } from '../../utils/error.js';
-import { escape_html_attr } from '../../utils/escape.js';
 import { hash } from '../hash.js';
 import { normalize } from '../load.js';
 import { base } from '../paths.js';
@@ -96,9 +95,9 @@ function create_updated_store() {
  * @param {RequestInit} [opts]
  */
 function initial_fetch(resource, opts) {
-	const url = typeof resource === 'string' ? resource : resource.url;
+	const url = JSON.stringify(typeof resource === 'string' ? resource : resource.url);
 
-	let selector = `script[sveltekit\\:data-type="data"][sveltekit\\:data-url=${JSON.stringify(url)}]`;
+	let selector = `script[sveltekit\\:data-type="data"][sveltekit\\:data-url=${url}]`;
 
 	if (opts && typeof opts.body === 'string') {
 		selector += `[sveltekit\\:data-body="${hash(opts.body)}"]`;

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -1,6 +1,7 @@
 import { tick } from 'svelte';
 import { writable } from 'svelte/store';
 import { coalesce_to_error } from '../../utils/error.js';
+import { escape_html_attr } from '../../utils/escape.js';
 import { hash } from '../hash.js';
 import { normalize } from '../load.js';
 import { base } from '../paths.js';
@@ -95,12 +96,12 @@ function create_updated_store() {
  * @param {RequestInit} [opts]
  */
 function initial_fetch(resource, opts) {
-	const url = typeof resource === 'string' ? resource : resource.url;
+	const url = escape_html_attr(typeof resource === 'string' ? resource : resource.url);
 
-	let selector = `script[data-type="svelte-data"][data-url=${JSON.stringify(url)}]`;
+	let selector = `script[sveltekit\\:data-type="data"][sveltekit\\:data-url=${url}]`;
 
 	if (opts && typeof opts.body === 'string') {
-		selector += `[data-body="${hash(opts.body)}"]`;
+		selector += `[sveltekit\\:data-body="${hash(opts.body)}"]`;
 	}
 
 	const script = document.querySelector(selector);
@@ -219,7 +220,7 @@ export class Renderer {
 				let props;
 
 				if (is_leaf) {
-					const serialized = document.querySelector('[data-type="svelte-props"]');
+					const serialized = document.querySelector('script[sveltekit\\:data-type="props"]');
 					if (serialized) {
 						props = JSON.parse(/** @type {string} */ (serialized.textContent));
 					}

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -42,13 +42,7 @@ export async function load_node({
 
 	let uses_credentials = false;
 
-	/**
-	 * @type {Array<{
-	 *   url: string;
-	 *   body: string;
-	 *   json: import('types').JSONValue;
-	 * }>}
-	 */
+	/** @type {Array<import('./types').Fetched>} */
 	const fetched = [];
 
 	/**
@@ -248,8 +242,6 @@ export async function load_node({
 							}
 
 							if (!opts.body || typeof opts.body === 'string') {
-								// the json constructed below is later added to the dom in a script tag
-								// make sure the used values are safe
 								const status_number = Number(response.status);
 								if (isNaN(status_number)) {
 									throw new Error(
@@ -258,11 +250,11 @@ export async function load_node({
 										}" type: ${typeof response.status}`
 									);
 								}
-								// prettier-ignore
+
 								fetched.push({
 									url: requested,
-									body: /** @type {string} */ (opts.body),
-									json: {
+									body: opts.body,
+									response: {
 										status: status_number,
 										statusText: response.statusText,
 										headers,

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -1,7 +1,5 @@
 import { normalize } from '../../load.js';
 import { respond } from '../index.js';
-import { s } from '../../../utils/misc.js';
-import { escape_json_in_html } from '../../../utils/escape.js';
 import { is_root_relative, resolve } from '../../../utils/url.js';
 import { create_prerendering_url_proxy } from './utils.js';
 import { is_pojo, lowercase_keys, normalize_request_method } from '../utils.js';
@@ -48,7 +46,7 @@ export async function load_node({
 	 * @type {Array<{
 	 *   url: string;
 	 *   body: string;
-	 *   json: string;
+	 *   json: import('types').JSONValue;
 	 * }>}
 	 */
 	const fetched = [];
@@ -264,7 +262,12 @@ export async function load_node({
 								fetched.push({
 									url: requested,
 									body: /** @type {string} */ (opts.body),
-									json: `{"status":${status_number},"statusText":${s(response.statusText)},"headers":${s(headers)},"body":${escape_json_in_html(body)}}`
+									json: {
+										status: status_number,
+										statusText: response.statusText,
+										headers,
+										body
+									}
 								});
 							}
 

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -2,7 +2,7 @@ import devalue from 'devalue';
 import { readable, writable } from 'svelte/store';
 import { coalesce_to_error } from '../../../utils/error.js';
 import { hash } from '../../hash.js';
-import { escape_html_attr, escape_json_in_html } from '../../../utils/escape.js';
+import { render_json_payload_script } from '../../../utils/escape.js';
 import { s } from '../../../utils/misc.js';
 import { create_prerendering_url_proxy } from './utils.js';
 import { Csp, csp_ready } from './csp.js';
@@ -57,7 +57,7 @@ export async function render_response({
 	/** @type {Map<string, string>} */
 	const styles = new Map();
 
-	/** @type {Array<{ url: string, body: string, json: string }>} */
+	/** @type {Array<{ url: string, body: string, json: import('types').JSONValue }>} */
 	const serialized_data = [];
 
 	let shadow_props;
@@ -253,19 +253,17 @@ export async function render_response({
 
 			body += `\n\t\t<script ${attributes.join(' ')}>${init_app}</script>`;
 
-			// prettier-ignore
 			body += serialized_data
-				.map(({ url, body, json }) => {
-					let attributes = `type="application/json" data-type="svelte-data" data-url=${escape_html_attr(url)}`;
-					if (body) attributes += ` data-body="${hash(body)}"`;
-
-					return `<script ${attributes}>${json}</script>`;
-				})
+				.map(({ url, body, json }) =>
+					render_json_payload_script(
+						{ type: 'data', url, body: body !== undefined ? hash(body) : undefined },
+						json
+					)
+				)
 				.join('\n\t');
 
 			if (shadow_props) {
-				// prettier-ignore
-				body += `<script type="application/json" data-type="svelte-props">${escape_json_in_html(shadow_props)}</script>`;
+				body += render_json_payload_script({ type: 'props' }, shadow_props);
 			}
 		}
 

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -57,7 +57,7 @@ export async function render_response({
 	/** @type {Map<string, string>} */
 	const styles = new Map();
 
-	/** @type {Array<{ url: string, body: string, json: import('types').JSONValue }>} */
+	/** @type {Array<import('./types').Fetched>} */
 	const serialized_data = [];
 
 	let shadow_props;
@@ -254,10 +254,10 @@ export async function render_response({
 			body += `\n\t\t<script ${attributes.join(' ')}>${init_app}</script>`;
 
 			body += serialized_data
-				.map(({ url, body, json }) =>
+				.map(({ url, body, response }) =>
 					render_json_payload_script(
-						{ type: 'data', url, body: body !== undefined ? hash(body) : undefined },
-						json
+						{ type: 'data', url, body: typeof body === 'string' ? hash(body) : undefined },
+						response
 					)
 				)
 				.join('\n\t');

--- a/packages/kit/src/runtime/server/page/types.d.ts
+++ b/packages/kit/src/runtime/server/page/types.d.ts
@@ -5,7 +5,7 @@ export type Loaded = {
 	props: JSONValue | undefined;
 	loaded: NormalizedLoadOutput;
 	stuff: Record<string, any>;
-	fetched: Array<{ url: string; body: string; json: string }>;
+	fetched: Array<{ url: string; body: string; json: JSONValue }>;
 	set_cookie_headers: string[];
 	uses_credentials: boolean;
 };

--- a/packages/kit/src/runtime/server/page/types.d.ts
+++ b/packages/kit/src/runtime/server/page/types.d.ts
@@ -1,11 +1,22 @@
-import { JSONValue, NormalizedLoadOutput, SSRNode } from 'types';
+import { JSONValue, NormalizedLoadOutput, ResponseHeaders, SSRNode } from 'types';
+
+export type Fetched = {
+	url: string;
+	body?: string | null;
+	response: {
+		status: number;
+		statusText: string;
+		headers: ResponseHeaders;
+		body: string;
+	};
+};
 
 export type Loaded = {
 	node: SSRNode;
 	props: JSONValue | undefined;
 	loaded: NormalizedLoadOutput;
 	stuff: Record<string, any>;
-	fetched: Array<{ url: string; body: string; json: JSONValue }>;
+	fetched: Fetched[];
 	set_cookie_headers: string[];
 	uses_credentials: boolean;
 };

--- a/packages/kit/src/utils/escape.js
+++ b/packages/kit/src/utils/escape.js
@@ -1,27 +1,42 @@
-// dict from https://github.com/yahoo/serialize-javascript/blob/183c18a776e4635a379fdc620f81771f219832bb/index.js#L25
-/** @type {Record<string, string>} */
-const escape_json_in_html_dict = {
-	'<': '\\u003C',
-	'>': '\\u003E',
-	'/': '\\u002F',
-	'\u2028': '\\u2028',
-	'\u2029': '\\u2029'
-};
-
-const escape_json_in_html_regex = new RegExp(
-	`[${Object.keys(escape_json_in_html_dict).join('')}]`,
-	'g'
-);
-
 /**
- * Escape a JSONValue that's going to be embedded in a `<script>` tag
- * @param {import('types').JSONValue} val
+ * Generates a raw HTML string containing a safe script element carrying JSON data and associated attributes.
+ *
+ * It escapes all the special characters needed to guarantee the element is unbroken, but care must
+ * be taken to ensure it is inserted in the document at an acceptable position for a script element,
+ * and that the resulting string isn't further modified.
+ *
+ * Attribute names must be type-checked so we don't need to escape them.
+ *
+ * **INTERPOLATING THIS STRING INTO AN UNRELATED SCRIPT ELEMENT IS NOT SAFE.**
+ *
+ * @param {import('types').PayloadScriptAttributes} attrs A list of attributes to be added to the element.
+ * @param {import('types').JSONValue} payload The data to be carried by the element. Must be serializable to JSON.
+ * @returns {string} The raw HTML of a script element carrying the JSON payload.
+ * @example const html = render_json_payload_script({ type: 'data', url: '/data.json' }, { foo: 'bar' });
  */
-export function escape_json_in_html(val) {
-	return JSON.stringify(val).replace(
-		escape_json_in_html_regex,
-		(match) => escape_json_in_html_dict[match]
-	);
+export function render_json_payload_script(attrs, payload) {
+	/**
+	 * Inside a script element, only `</script` and `<!--` hold special meaning to the HTML parser.
+	 *
+	 * The first closes the script element, so everything after is treated as raw HTML.
+	 * The second disables further parsing until `-->`, so the script element might be unexpectedly
+	 * kept open until until an unrelated HTML comment in the page.
+	 *
+	 * @see tests for unsafe parsing examples.
+	 * @see https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+	 * @see https://html.spec.whatwg.org/multipage/syntax.html#cdata-rcdata-restrictions
+	 * @see https://html.spec.whatwg.org/multipage/parsing.html#script-data-state
+	 * @see https://html.spec.whatwg.org/multipage/parsing.html#script-data-double-escaped-state
+	 */
+	const safe_payload = JSON.stringify(payload).replace(/</g, '\\u003C');
+
+	let safe_attrs = '';
+	for (const [key, value] of Object.entries(attrs)) {
+		if (value === undefined) continue;
+		safe_attrs += ` sveltekit:data-${key}=${escape_html_attr(value)}`;
+	}
+
+	return `<script type="application/json"${safe_attrs}>${safe_payload}</script>`;
 }
 
 /**

--- a/packages/kit/src/utils/escape.js
+++ b/packages/kit/src/utils/escape.js
@@ -36,8 +36,6 @@ const render_json_payload_script_regex = new RegExp(
  *
  * Attribute names must be type-checked so we don't need to escape them.
  *
- * **INTERPOLATING THIS STRING INTO AN UNRELATED SCRIPT ELEMENT IS NOT SAFE.**
- *
  * @param {import('types').PayloadScriptAttributes} attrs A list of attributes to be added to the element.
  * @param {import('types').JSONValue} payload The data to be carried by the element. Must be serializable to JSON.
  * @returns {string} The raw HTML of a script element carrying the JSON payload.

--- a/packages/kit/src/utils/escape.spec.js
+++ b/packages/kit/src/utils/escape.spec.js
@@ -1,6 +1,35 @@
 import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
-import { escape_html_attr } from './escape.js';
+import { render_json_payload_script, escape_html_attr } from './escape.js';
+
+const json = suite('render_json_payload_script');
+
+json('escapes slashes', () => {
+	assert.equal(
+		render_json_payload_script({ type: 'props' }, { unsafe: '</script><script>alert("xss")' }),
+		'<script type="application/json" sveltekit:data-type="props">' +
+			'{"unsafe":"\\u003C/script>\\u003Cscript>alert(\\"xss\\")"}' +
+			'</script>'
+	);
+});
+
+json('escapes exclamation marks', () => {
+	assert.equal(
+		render_json_payload_script({ type: 'props' }, { '<!--</script>...-->alert("xss")': 'unsafe' }),
+		'<script type="application/json" sveltekit:data-type="props">' +
+			'{"\\u003C!--\\u003C/script>...-->alert(\\"xss\\")":"unsafe"}' +
+			'</script>'
+	);
+});
+
+json('escapes the attribute values', () => {
+	const raw = 'an "attr" & a \ud800';
+	const escaped = 'an &quot;attr&quot; &amp; a &#55296;';
+	assert.equal(
+		render_json_payload_script({ type: 'data', url: raw }, {}),
+		`<script type="application/json" sveltekit:data-type="data" sveltekit:data-url="${escaped}">{}</script>`
+	);
+});
 
 const attr = suite('escape_html_attr');
 
@@ -21,4 +50,5 @@ attr('escapes invalid surrogates', () => {
 	assert.equal(escape_html_attr('\ud800\ud800\udc00\udc00'), '"&#55296;\ud800\udc00&#56320;"');
 });
 
+json.run();
 attr.run();

--- a/packages/kit/test/apps/amp/test/test.js
+++ b/packages/kit/test/apps/amp/test/test.js
@@ -12,7 +12,7 @@ test('amp is true', async ({ page, baseURL }) => {
 	await expect(page.locator('p')).toHaveText('amp is true');
 
 	// should not include serialized data
-	expect(await page.$('script[data-type="svelte-data"]')).toBeNull();
+	expect(await page.$('script[sveltekit\\:data-type="data"]')).toBeNull();
 });
 
 test('styles are applied', async ({ page, baseURL }) => {

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1068,7 +1068,7 @@ test.describe.parallel('Load', () => {
 
 		if (!javaScriptEnabled) {
 			// by the time JS has run, hydration will have nuked these scripts
-			const script_contents = await page.innerHTML('script[data-type="svelte-data"]');
+			const script_contents = await page.innerHTML('script[sveltekit\\:data-type="data"]');
 
 			const payload =
 				'{"status":200,"statusText":"","headers":{"content-type":"application/json; charset=utf-8"},"body":"{\\"answer\\":42}"}';
@@ -1098,11 +1098,11 @@ test.describe.parallel('Load', () => {
 		if (!javaScriptEnabled) {
 			// by the time JS has run, hydration will have nuked these scripts
 			const script_contents_a = await page.innerHTML(
-				'script[data-type="svelte-data"][data-url="/load/serialization-post.json"][data-body="3t25"]'
+				'script[sveltekit\\:data-type="data"][sveltekit\\:data-url="/load/serialization-post.json"][sveltekit\\:data-body="3t25"]'
 			);
 
 			const script_contents_b = await page.innerHTML(
-				'script[data-type="svelte-data"][data-url="/load/serialization-post.json"][data-body="3t24"]'
+				'script[sveltekit\\:data-type="data"][sveltekit\\:data-url="/load/serialization-post.json"][sveltekit\\:data-body="3t24"]'
 			);
 
 			expect(script_contents_a).toBe(payload_a);
@@ -1431,7 +1431,7 @@ test.describe.parallel('Page options', () => {
 			// ensure data wasn't inlined
 			expect(
 				await page.evaluate(
-					() => document.querySelectorAll('script[data-type="svelte-data"]').length
+					() => document.querySelectorAll('script[sveltekit\\:data-type="data"]').length
 				)
 			).toBe(0);
 		}

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -241,6 +241,12 @@ export type MaybePromise<T> = T | Promise<T>;
 
 export type Only<T, U> = { [P in keyof T]: T[P] } & { [P in Exclude<keyof U, keyof T>]?: never };
 
+export type PayloadScriptAttributes = PayloadScriptAttributesData | PayloadScriptAttributesProps;
+
+type PayloadScriptAttributesData = { type: 'data'; url: string; body?: string };
+
+type PayloadScriptAttributesProps = { type: 'props' };
+
 export interface Prerendered {
 	pages: Map<
 		string,


### PR DESCRIPTION
This fixes security issues related to script elements carrying JSON payloads, while refactoring the internal API so it's less likely to be used incorrectly.

## Changes to the internal API

Since `escape_json_in_html` worked in chunks of data, it was easy to mistake it for a safe method regardless of context. However, the transformed payload wouldn't be useable everywhere in a document. The only place it could safely be placed is inside a `<script>` tag.

Therefore, instead of escaping values ad-hoc and later interpolating strings to assemble the final script tag, payloads are now kept as objects until the time to render them to HTML. At that point, calling `render_json_payload_script` will render the whole script element to html, at once.

This change is intended to minimize the risk that escaped values are accidentally mishandled. As a matter of fact, we previously forgot to escape `statusText` and `headers`, current attack vectors.

It also uses `sveltekit:data-{property}` as attribute names for the payload's associated key-value data. While this is not final and is open to bikeshed, it avoids conflicts with user attributes as was previously the case.

## Changes to escaped characters

These changes are not strictly required, but since we're now ensuring the payload is in a script tag, it is possible to reduce the amount of escaped characters. Some information:

 - Escaping `<` and `>` is not strictly necessary. These have no meaning to HTML parsers inside script elements, with the exception of the literal sequence `</script`, which could be handled by escaping any of those characters. [1]

 - `\u2028` and `\u2029` are blips of history. They used to cause issues because they weren't valid characters inside JS strings. However, not only were they always valid in non-js script elements, they are also valid in JS string since the "Subsume JSON" proposal was standardized in ES2019. [2]

 - Care must be taken about HTML comments. Even though `<script>` is famously a raw text element that will parse `"</script>"` as a valid closing tag, this is not true inside HTML comments. A rogue `<!--` can deactivate parsing until the next `-->`, after which text will continue to be consumed by the script element. [3]

With this in mind, we can limit the escaped characters to `<`, but `\u2028` and `\u2029` are escaped for the sake of older browsers.

[1] https://html.spec.whatwg.org/multipage/syntax.html#cdata-rcdata-restrictions
[2] https://github.com/tc39/proposal-json-superset
[3] https://html.spec.whatwg.org/multipage/parsing.html#script-data-double-escaped-state

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
