### PR TITLE
restore `tabindex` after navigation

### DIFF
--- a/.changeset/honest-islands-flash.md
+++ b/.changeset/honest-islands-flash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] `tabindex="-1"` is no longer added to `<body>`; `<html>` only briefly receives it during navigation

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -369,6 +369,11 @@ export class Renderer {
 			const { scroll, keepfocus } = opts;
 
 			if (!keepfocus) {
+				// reset page selection and focus
+				// we try to mimick browsers' behaviour as closely as possible by targetting the
+				// viewport, but unfortunately it's not a perfect match—eg. shift-tabbing won't
+				// immediately cycle from the end of the page
+				// see https://html.spec.whatwg.org/multipage/interaction.html#get-the-focusable-area
 				const root = document.documentElement;
 				const tabindex = root.getAttribute('tabindex');
 
@@ -376,6 +381,7 @@ export class Renderer {
 				root.tabIndex = -1;
 				root.focus();
 
+				// restore `tabindex` as to prevent the document from stealing input from elements
 				if (tabindex !== null) {
 					root.setAttribute('tabindex', tabindex);
 				} else {

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -369,8 +369,18 @@ export class Renderer {
 			const { scroll, keepfocus } = opts;
 
 			if (!keepfocus) {
+				const root = document.documentElement;
+				const tabindex = root.getAttribute('tabindex');
+
 				getSelection()?.removeAllRanges();
-				document.body.focus();
+				root.tabIndex = -1;
+				root.focus();
+
+				if (tabindex !== null) {
+					root.setAttribute('tabindex', tabindex);
+				} else {
+					root.removeAttribute('tabindex');
+				}
 			}
 
 			// need to render the DOM before we can scroll to the rendered elements

--- a/packages/kit/src/runtime/client/renderer.js
+++ b/packages/kit/src/runtime/client/renderer.js
@@ -369,11 +369,11 @@ export class Renderer {
 			const { scroll, keepfocus } = opts;
 
 			if (!keepfocus) {
-				// reset page selection and focus
-				// we try to mimick browsers' behaviour as closely as possible by targetting the
-				// viewport, but unfortunately it's not a perfect match—eg. shift-tabbing won't
+				// Reset page selection and focus
+				// We try to mimick browsers' behaviour as closely as possible by targeting the
+				// viewport, but unfortunately it's not a perfect match — e.g. shift-tabbing won't
 				// immediately cycle from the end of the page
-				// see https://html.spec.whatwg.org/multipage/interaction.html#get-the-focusable-area
+				// See https://html.spec.whatwg.org/multipage/interaction.html#get-the-focusable-area
 				const root = document.documentElement;
 				const tabindex = root.getAttribute('tabindex');
 

--- a/packages/kit/src/runtime/client/router.js
+++ b/packages/kit/src/runtime/client/router.js
@@ -73,9 +73,6 @@ export class Router {
 		this.enabled = true;
 		this.initialized = false;
 
-		// make it possible to reset focus
-		document.body.setAttribute('tabindex', '-1');
-
 		// keeping track of the history index in order to prevent popstate navigation events if needed
 		this.current_history_index = history.state?.['sveltekit:index'] ?? 0;
 

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -25,6 +25,8 @@ test.describe.parallel('a11y', () => {
 		await page.keyboard.press('Tab');
 		expect(await page.evaluate(() => (document.activeElement || {}).nodeName)).toBe('A');
 		expect(await page.evaluate(() => (document.activeElement || {}).textContent)).toBe('a');
+
+		expect(await page.evaluate(() => document.documentElement.getAttribute('tabindex'))).toBe(null);
 	});
 
 	test('announces client-side navigation', async ({ page, clicknav, javaScriptEnabled }) => {

--- a/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
+++ b/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
@@ -57,7 +57,9 @@
 			const scroll = -parseInt(document.body.style.top || '0');
 			document.body.style.position = '';
 			document.body.style.top = '';
+			document.body.tabIndex = -1;
 			document.body.focus();
+			document.body.removeAttribute('tabindex');
 			window.scrollTo(0, scroll);
 		}
 	}


### PR DESCRIPTION
Fixes #3501.

As noted in the issue, adding `tabindex="-1"` to `<body>` causes a few focus management problems with body "stealing" input from other elements (eg. scrolling overflown children).

Since it's only needed to reset the page's focus during navigation, we can safely [?] remove it afterwards.

[?]: I'm not able to test this on Apple devices.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
