### PR TITLE
Increase CI test timeout to 20 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - run: pnpm check
   Tests:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
As discussed in https://github.com/sveltejs/kit/issues/4123#issuecomment-1051415703, the Windows test runs have been slow recently, and several have failed by going over the 15 minute timeout. Others have succeeded but been very close to being timed out, e.g. [this run](https://github.com/sveltejs/kit/runs/5325965183?check_suite_focus=true) that took 14m54s on Windows (and 12m11s on macOS, but only 6m19s on Ubuntu — apparently the Ubuntu containers are significantly faster than the other two for some reason).

I propose increasing the timeout to 20 minutes rather than 15, to help mitigate the problem of false-positive test failures. It's still low enough that it feels like a reasonable amount of time to wait if a test run has somehow gotten itself into an infinite loop and will never complete, but it should allow the Windows test runners enough time to complete all the tests. As more features are added to Svelte-Kit, or more bugs are fixed and regression tests added, the length of the test runs is only going to go up, so I expect more false-positive test failures in the future unless the timeout is increased.

No changeset since this is just a change to the build process which shouldn't show up in changelogs.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
