### PR TITLE
Add Netlify Functions Context to Netlify Adapter

### DIFF
--- a/.changeset/many-pigs-deliver.md
+++ b/.changeset/many-pigs-deliver.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/adapter-netlify': minor
+'@sveltejs/adapter-netlify': patch
 ---
 
 Add Netlify Functions Context to Netlify Adapter

--- a/.changeset/many-pigs-deliver.md
+++ b/.changeset/many-pigs-deliver.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-netlify': patch
 ---
 
-Add Netlify Functions Context to Netlify Adapter
+Add Netlify Functions context as `event.platform.context`

--- a/.changeset/many-pigs-deliver.md
+++ b/.changeset/many-pigs-deliver.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': minor
+---
+
+Add Netlify Functions Context to Netlify Adapter

--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -57,7 +57,9 @@ During compilation, redirect rules are automatically appended to your `_redirect
 
 ### Using Netlify Functions
 
-[Netlify Functions](https://docs.netlify.com/functions/overview/) can be used alongside your SvelteKit routes. If you would like to add them to your site, you should create a directory for them and add the configuration to your `netlify.toml` file. For example:
+With this adapter, SvelteKit Endpoints are automatically hosted as [Netlify Functions](https://docs.netlify.com/functions/overview/). Netlify Function handlers have additional context passed to them by Netlify, including Netlify Identity information.  You can access this context via the `event.platform.context` field inside of your `hooks` and Endpoint handlers.
+
+Additionally, Netlify Functions can be used alongside your SvelteKit routes. If you would like to add them to your site separately from your Endpoints, you should create a directory for them and add the configuration to your `netlify.toml` file. For example:
 
 ```toml
 [build]

--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -57,7 +57,7 @@ During compilation, redirect rules are automatically appended to your `_redirect
 
 ### Using Netlify Functions
 
-With this adapter, SvelteKit Endpoints are automatically hosted as [Netlify Functions](https://docs.netlify.com/functions/overview/). Netlify Function handlers have additional context passed to them by Netlify, including Netlify Identity information.  You can access this context via the `event.platform.context` field inside of your `hooks` and Endpoint handlers.
+With this adapter, SvelteKit Endpoints are automatically hosted as [Netlify Functions](https://docs.netlify.com/functions/overview/). Netlify Function handlers have additional context passed to them by Netlify, including Netlify Identity information. You can access this context via the `event.platform.context` field inside of your `hooks` and Endpoint handlers.
 
 Additionally, Netlify Functions can be used alongside your SvelteKit routes. If you would like to add them to your site separately from your Endpoints, you should create a directory for them and add the configuration to your `netlify.toml` file. For example:
 

--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -57,9 +57,9 @@ During compilation, redirect rules are automatically appended to your `_redirect
 
 ### Using Netlify Functions
 
-With this adapter, SvelteKit Endpoints are automatically hosted as [Netlify Functions](https://docs.netlify.com/functions/overview/). Netlify Function handlers have additional context passed to them by Netlify, including Netlify Identity information. You can access this context via the `event.platform.context` field inside of your `hooks` and Endpoint handlers.
+With this adapter, SvelteKit endpoints are hosted as [Netlify Functions](https://docs.netlify.com/functions/overview/). Netlify function handlers have additional context, including [Netlify Identity](https://docs.netlify.com/visitor-access/identity/) information. You can access this context via the `event.platform.context` field inside your hooks and endpoints.
 
-Additionally, Netlify Functions can be used alongside your SvelteKit routes. If you would like to add them to your site separately from your Endpoints, you should create a directory for them and add the configuration to your `netlify.toml` file. For example:
+Additionally, you can add your own Netlify functions by creating a directory for them and adding the configuration to your `netlify.toml` file. For example:
 
 ```toml
 [build]

--- a/packages/adapter-netlify/src/handler.js
+++ b/packages/adapter-netlify/src/handler.js
@@ -9,8 +9,8 @@ import { split_headers } from './headers';
 export function init(manifest) {
 	const server = new Server(manifest);
 
-	return async (event) => {
-		const rendered = await server.respond(to_request(event));
+	return async (event, context) => {
+		const rendered = await server.respond(to_request(event), { platform: { context } });
 
 		const partial_response = {
 			statusCode: rendered.status,


### PR DESCRIPTION
Netlify Functions' Handler type[1] has a `context` argument that the adapter currently drops.  The context contains useful information that Endpoints may want to have access to, namely auth information[2].  This PR passes that context down to Endpoints via app. Doing this has been discussed previously in https://github.com/sveltejs/kit/issues/1249, including one person patching something roughly equivalent to this change into their local repo.

[1] https://github.com/netlify/functions/blob/efcf21eb6c969c73d165e01b00f33b53f3e150b5/src/function/handler.ts#L11

[2] https://docs.netlify.com/functions/functions-and-identity/


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
