### PR TITLE
mark svelte-kit package as experimental

### DIFF
--- a/documentation/docs/11-packaging.md
+++ b/documentation/docs/11-packaging.md
@@ -2,7 +2,7 @@
 title: Packaging
 ---
 
-> `svelte-kit package` is experimental, and may undergo breaking changes.
+> `svelte-kit package` is currently experimental and is not subject to Semantic Versioning rules. Non-backward compatible changes may occur in any future release.
 
 You can use SvelteKit to build component libraries as well as apps.
 

--- a/documentation/docs/11-packaging.md
+++ b/documentation/docs/11-packaging.md
@@ -2,6 +2,8 @@
 title: Packaging
 ---
 
+> `svelte-kit package` is experimental, and may undergo breaking changes.
+
 You can use SvelteKit to build component libraries as well as apps.
 
 When you're creating an app, the contents of `src/routes` is the public-facing stuff; [`src/lib`](/docs/modules#$lib) contains your app's internal library.

--- a/documentation/docs/12-cli.md
+++ b/documentation/docs/12-cli.md
@@ -40,6 +40,6 @@ Like `svelte-kit dev`, it accepts the following options:
 
 ### svelte-kit package
 
-> `svelte-kit package` is experimental, and may undergo breaking changes.
+> `svelte-kit package` is currently experimental and is not subject to Semantic Versioning rules. Non-backward compatible changes may occur in any future release.
 
 For package authors, see [packaging](/docs/packaging).

--- a/documentation/docs/12-cli.md
+++ b/documentation/docs/12-cli.md
@@ -40,4 +40,6 @@ Like `svelte-kit dev`, it accepts the following options:
 
 ### svelte-kit package
 
+> `svelte-kit package` is experimental, and may undergo breaking changes.
+
 For package authors, see [packaging](/docs/packaging).


### PR DESCRIPTION
At the last maintainer's meeting we decided to mark `svelte-kit package` as experimental, as there are certain limitations we want to address that could involve breaking changes (mainly that it doesn't work great with monorepos).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
