### PR TITLE
remove console warning in `adapter-static` test

### DIFF
--- a/packages/adapter-static/test/apps/spa/jsconfig.json
+++ b/packages/adapter-static/test/apps/spa/jsconfig.json
@@ -1,9 +1,4 @@
 {
-	"compilerOptions": {
-		"baseUrl": ".",
-		"paths": {
-			"$lib/*": ["src/lib/*"]
-		}
-	},
+	"extends": "./.svelte-kit/tsconfig.json",
 	"include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte"]
 }


### PR DESCRIPTION
Adds the new extends to static adapter `jsconfig.json` test suite to silence the console warning

On a somewhat related note, the windows test CI seems to be consistently timing out, and it's also failing locally for me in setting the `config.paths` option for the test in `kit/test/apps/options/test/test.js`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
