### PR TITLE
[fix] incorrect path to generated tsconfig.json

### DIFF
--- a/documentation/docs/14-types.md
+++ b/documentation/docs/14-types.md
@@ -73,4 +73,4 @@ export async function get({ params }) {
 
 > For this to work, your own `tsconfig.json` or `jsconfig.json` should extend from the generated `.svelte-kit/tsconfig.json`:
 >
->     { "extends": ".svelte-kit/tsconfig.json" }
+>     { "extends": "./.svelte-kit/tsconfig.json" }


### PR DESCRIPTION
When attempting to update my existing sveltekit project I  added `"extends": ".svelte-kit/tsconfig.json"` like the docs say and was met with the error `'.svelte-kit/tsconfig.json' not found.` I checked the template and the correct path was `./.svelte-kit/tsconfig.json`. Without the `./`, the project fails to build and every svelte file has an error.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
