### PR TITLE
document `strictPort` stuff

### DIFF
--- a/documentation/docs/12-cli.md
+++ b/documentation/docs/12-cli.md
@@ -19,6 +19,8 @@ Starts a development server. It accepts the following options:
 - `-h`/`--host` — expose the server to the network.
 - `-H`/`--https` — launch an HTTPS server using a self-signed certificate. Useful for testing HTTPS-only features on an external device
 
+> This command will fail if the specified (or default) port is unavailable. To use an alternative port instead of failing, set the [`config.kit.vite.server.strictPort`](/docs/configuration#vite) option to `false`.
+
 ### svelte-kit build
 
 Builds a production version of your app, and runs your adapter if you have one specified in your [config](/docs/configuration). It accepts the following option:


### PR DESCRIPTION
closes #4018. It will still fail noisily in `svelte-kit preview`, but I think that's probably fine

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
