### PR TITLE
focus on `body` instead of `html` on navigation

### DIFF
--- a/.changeset/flat-insects-worry.md
+++ b/.changeset/flat-insects-worry.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Focus on `body` instead of `html` on navigation due to issues on Firefox

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -258,18 +258,18 @@ export function create_client({ target, session, base, trailing_slash }) {
 
 			if (!keepfocus) {
 				// Reset page selection and focus
-				// We try to mimick browsers' behaviour as closely as possible by targeting the
-				// viewport, but unfortunately it's not a perfect match — e.g. shift-tabbing won't
-				// immediately cycle from the end of the page
+				// We try to mimic browsers' behaviour as closely as possible by targeting the
+				// first scrollable region, but unfortunately it's not a perfect match — e.g.
+				// shift-tabbing won't immediately cycle up from the end of the page on Chromium
 				// See https://html.spec.whatwg.org/multipage/interaction.html#get-the-focusable-area
-				const root = document.documentElement;
+				const root = document.body;
 				const tabindex = root.getAttribute('tabindex');
 
 				getSelection()?.removeAllRanges();
 				root.tabIndex = -1;
 				root.focus();
 
-				// restore `tabindex` as to prevent the document from stealing input from elements
+				// restore `tabindex` as to prevent `root` from stealing input from elements
 				if (tabindex !== null) {
 					root.setAttribute('tabindex', tabindex);
 				} else {


### PR DESCRIPTION
Fixes #4180.

I tried to be clever by focusing on `html` during focus reset on navigation because I assumed less people would add `focus` event handlers to `html` as opposed to `body`. Unfortunately, this made Firefox add a selection outline over the entire viewport.

This keeps the `tabindex` changes but reverts to focusing on `body` instead of `html`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
