### PR TITLE
ignore .css files when building route manifest - 

### DIFF
--- a/.changeset/sweet-houses-worry.md
+++ b/.changeset/sweet-houses-worry.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Ignore .css files when building route manifest

--- a/packages/kit/src/core/create_manifest_data/index.js
+++ b/packages/kit/src/core/create_manifest_data/index.js
@@ -76,6 +76,10 @@ export default function create_manifest_data({
 
 			const ext = config.extensions.find((ext) => basename.endsWith(ext)) || path.extname(basename);
 
+			// treat .css files as a special case (https://github.com/sveltejs/kit/issues/3997)
+			// TODO do we want to treat all non-.js/.ts files similarly?
+			if (ext === '.css') return;
+
 			const name = ext ? basename.slice(0, -ext.length) : basename;
 
 			// TODO remove this after a while

--- a/packages/kit/test/apps/basics/src/routes/index.css
+++ b/packages/kit/test/apps/basics/src/routes/index.css
@@ -1,0 +1,4 @@
+/* https://github.com/sveltejs/kit/issues/3997 */
+h1 {
+	color: blue;
+}

--- a/packages/kit/test/apps/basics/src/routes/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/index.svelte
@@ -11,6 +11,8 @@
 </script>
 
 <script>
+	import './index.css';
+
 	/** @type {number} */
 	export let answer;
 </script>


### PR DESCRIPTION
fixes #3997. I think we can punt on the question of whether we want to treat all `.js`/`.ts` files similarly — I think the `.css` case is fairly unambiguous. If we decide to make it more expansive in future, `.css` files would be included in that, so this is forward-compatible

then again this could be a can of worms if people start asking about `.scss` and what-have-you...

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
