### PR TITLE
fix issue #4186

### DIFF
--- a/packages/kit/src/core/build/build_server.js
+++ b/packages/kit/src/core/build/build_server.js
@@ -154,14 +154,21 @@ export async function build_server(
 		}
 	});
 
+	const fallback = `${get_runtime_path(config)}/components`;
+	const default_error = posixify(path.relative(cwd, `${fallback}/error.svelte`));
+	const fix_error_name = 'entries/pages/__error.svelte';
+
 	// ...and every component used by pages
 	manifest_data.components.forEach((file) => {
 		const resolved = path.resolve(cwd, file);
 		const relative = path.relative(config.kit.files.routes, resolved);
 
-		const name = relative.startsWith('..')
-			? posixify(path.join('entries/pages', path.basename(file)))
-			: posixify(path.join('entries/pages', relative));
+		const name =
+			file === default_error
+				? fix_error_name
+				: relative.startsWith('..')
+				? posixify(path.join('entries/pages', path.basename(file)))
+				: posixify(path.join('entries/pages', relative));
 		input[name] = resolved;
 	});
 


### PR DESCRIPTION
issue #4186

fix bug:

You can see the `.svelte-kit/runtime/components/error.svelte`   add the `resolved` to `input['entries/pages']` 
![0](https://user-images.githubusercontent.com/7620293/156653567-438c965e-aeee-4d79-bcd4-9c084ef40f10.png)


And then the `rooters/error.svelte`    overrided the `resolved` input['entries/pages']`
![1](https://user-images.githubusercontent.com/7620293/156653583-e06c002e-7e51-4b26-bc5b-bfb205cabe71.png)


The `input` will effect rollupOptions.input 
```js
rollupOptions: {
input,
...
```

Finally, the  `.svelte-kit/runtime/components/error.svelte` didn't out put and the  generate manifest.json   does not contain it.



### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
