### PR TITLE
[chore] switch some tests from Node 14 to Node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14]
+        node-version: [16]
         os: [ubuntu-latest, macOS-latest, windows-latest]
         include:
-          - node-version: 16
+          - node-version: 14
             os: ubuntu-latest
     steps:
       - run: git config --global core.autocrlf false


### PR DESCRIPTION
I was hoping this might make the Windows tests faster. It didn't help... Not sure if we might want to do it anyway though since Node 14 is about to go EOL?