### PR TITLE
[chore] downgrade Windows version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [14]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest, windows-2019]
         include:
           - node-version: 16
             os: ubuntu-latest


### PR DESCRIPTION
Windows is twice as slow as everything else. It seems to have gotten much worse in the past week

There are open issues suggesting it might be a regression in `windows-latest`
- https://github.com/actions/virtual-environments/issues/5166
- https://github.com/actions/virtual-environments/issues/5158