### PR TITLE
replace timestamp in $service-worker with version

### DIFF
--- a/.changeset/five-eagles-help.md
+++ b/.changeset/five-eagles-help.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] Replace timestamp in \$service-worker with version

--- a/documentation/docs/80-migrating.md
+++ b/documentation/docs/80-migrating.md
@@ -54,10 +54,10 @@ This file also has no direct equivalent, since SvelteKit apps can run in serverl
 
 Most imports from `@sapper/service-worker` have equivalents in [`$service-worker`](/docs/modules#$service-worker):
 
-- `timestamp` is unchanged
 - `files` is unchanged
-- `shell` is now `build`
 - `routes` has been removed
+- `shell` is now `build`
+- `timestamp` is now `version`
 
 #### src/template.html
 

--- a/packages/kit/src/core/build/build_service_worker.js
+++ b/packages/kit/src/core/build/build_service_worker.js
@@ -64,7 +64,7 @@ export async function build_service_worker(
 					.join(',\n\t\t\t\t')}
 			];
 
-			export const version = ${s(config.kit.version)};
+			export const version = ${s(config.kit.version.name)};
 		`
 			.replace(/^\t{3}/gm, '')
 			.trim()

--- a/packages/kit/src/core/build/build_service_worker.js
+++ b/packages/kit/src/core/build/build_service_worker.js
@@ -39,7 +39,12 @@ export async function build_service_worker(
 	fs.writeFileSync(
 		service_worker,
 		`
-			export const timestamp = ${Date.now()};
+			// TODO remove for 1.0
+			export const timestamp = {
+				toString: () => {
+					throw new Error('\`timestamp\` has been removed from $service-worker. Use \`version\` instead');
+				}
+			};
 
 			export const build = [
 				${Array.from(app_files)
@@ -58,6 +63,8 @@ export async function build_service_worker(
 					.map((path) => s(normalize_path(path, config.kit.trailingSlash)))
 					.join(',\n\t\t\t\t')}
 			];
+
+			export const version = ${s(config.kit.version)};
 		`
 			.replace(/^\t{3}/gm, '')
 			.trim()

--- a/packages/kit/test/apps/basics/src/service-worker.js
+++ b/packages/kit/test/apps/basics/src/service-worker.js
@@ -1,6 +1,6 @@
-import { timestamp, build } from '$service-worker';
+import { build, version } from '$service-worker';
 
-const name = `cache-${timestamp}`;
+const name = `cache-${version}`;
 
 self.addEventListener('install', (event) => {
 	// @ts-expect-error
@@ -12,7 +12,7 @@ self.addEventListener('activate', (event) => {
 	event.waitUntil(
 		caches.keys().then(async (keys) => {
 			for (const key of keys) {
-				if (!key.includes(String(timestamp))) caches.delete(key);
+				if (!key.includes(version)) caches.delete(key);
 			}
 		})
 	);

--- a/packages/kit/test/apps/options-2/src/service-worker.js
+++ b/packages/kit/test/apps/options-2/src/service-worker.js
@@ -1,6 +1,6 @@
-import { timestamp, build } from '$service-worker';
+import { build, version } from '$service-worker';
 
-const name = `cache-${timestamp}`;
+const name = `cache-${version}`;
 
 self.addEventListener('install', (event) => {
 	// @ts-expect-error
@@ -12,7 +12,7 @@ self.addEventListener('activate', (event) => {
 	event.waitUntil(
 		caches.keys().then(async (keys) => {
 			for (const key of keys) {
-				if (!key.includes(String(timestamp))) caches.delete(key);
+				if (!key.includes(version)) caches.delete(key);
 			}
 		})
 	);

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -214,7 +214,7 @@ declare module '$lib' {}
 
 /**
  * ```ts
- * import { build, files, timestamp } from '$service-worker';
+ * import { build, files, prerendered, version } from '$service-worker';
  * ```
  *
  * This module is only available to [service workers](/docs/service-workers).
@@ -233,9 +233,9 @@ declare module '$service-worker' {
 	 */
 	export const prerendered: string[];
 	/**
-	 * The result of calling `Date.now()` at build time. It's useful for generating unique cache names inside your service worker, so that a later deployment of your app can invalidate old caches.
+	 * See [`config.kit.version`](/docs/configuration#version). It's useful for generating unique cache names inside your service worker, so that a later deployment of your app can invalidate old caches.
 	 */
-	export const timestamp: number;
+	export const version: string;
 }
 
 declare module '@sveltejs/kit/hooks' {


### PR DESCRIPTION
fixes #4196. Service workers that currently use `timestamp` to create cache keys will see this:

<img width="623" alt="image" src="https://user-images.githubusercontent.com/1162160/156781134-0f99115e-7467-4f61-b7ca-e9218b45d4ad.png">

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
