### PR TITLE
prevent Vite from copying static assets if directory is called public

### DIFF
--- a/.changeset/brave-toys-joke.md
+++ b/.changeset/brave-toys-joke.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Prevent Vite from copying static assets if directory is called "public"

--- a/packages/kit/src/core/build/build_client.js
+++ b/packages/kit/src/core/build/build_client.js
@@ -89,7 +89,10 @@ export async function build_client({
 					hydratable: !!config.kit.browser.hydrate
 				}
 			})
-		]
+		],
+		// prevent Vite copying the contents of `config.kit.files.assets`,
+		// if it happens to be 'public' instead of 'static'
+		publicDir: false
 	});
 
 	print_config_conflicts(conflicts, 'kit.vite.', 'build_client');

--- a/packages/kit/test/prerendering/options/public/robots.txt
+++ b/packages/kit/test/prerendering/options/public/robots.txt
@@ -1,0 +1,3 @@
+# https://www.robotstxt.org/robotstxt.html
+User-agent: *
+Disallow:

--- a/packages/kit/test/prerendering/options/svelte.config.js
+++ b/packages/kit/test/prerendering/options/svelte.config.js
@@ -12,6 +12,10 @@ const config = {
 			}
 		},
 
+		files: {
+			assets: 'public'
+		},
+
 		paths: {
 			base: '/path-base',
 			assets: 'https://cdn.example.com/stuff'

--- a/packages/kit/test/prerendering/options/test/test.js
+++ b/packages/kit/test/prerendering/options/test/test.js
@@ -27,4 +27,8 @@ test('adds CSP headers via meta tag', () => {
 	);
 });
 
+test('does not copy `public` into `_app`', () => {
+	assert.ok(!fs.existsSync(`${build}/_app/robots.txt`));
+});
+
 test.run();


### PR DESCRIPTION
closes #587 with the fix suggested by @theodorejb

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
