### PR TITLE
Workaround hydration scrolling bug

### DIFF
--- a/sites/kit.svelte.dev/package.json
+++ b/sites/kit.svelte.dev/package.json
@@ -2,10 +2,10 @@
 	"name": "kit.svelte.dev",
 	"version": "0.0.1",
 	"scripts": {
-		"dev": "svelte-kit dev",
-		"build": "svelte-kit build --verbose",
+		"dev": "node ./svelte-kit.js dev",
+		"build": "node ./svelte-kit.js build --verbose",
 		"prebuild": "test \"$CI\" = true && npx pnpm install --store=node_modules/.pnpm-store || echo skipping pnpm install",
-		"preview": "svelte-kit preview"
+		"preview": "node ./svelte-kit.js preview"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "workspace:*",

--- a/sites/kit.svelte.dev/src/routes/__layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/__layout.svelte
@@ -47,17 +47,6 @@
 		</NavItem>
 	</svelte:fragment>
 </Nav>
-	<a target="_blank" rel="noopener noreferrer" href="https://www.stopputin.net/"
-		><div class="ukr" bind:clientHeight={h} bind:clientWidth={w}>
-			{#if w < 830}
-				<strong>We stand with Ukraine.</strong>
-				Donate →
-			{:else}
-				<strong>We stand with Ukraine.</strong>
-				Petition your leaders. Show your support.
-			{/if}
-		</div></a
-	>
 
 <main id="main" style="padding-bottom: {h}px;">
 	<slot />
@@ -66,6 +55,18 @@
 		<SearchBox />
 	{/if}
 </main>
+
+<a target="_blank" rel="noopener noreferrer" href="https://www.stopputin.net/">
+	<div class="ukr" bind:clientHeight={h} bind:clientWidth={w}>
+		{#if w < 830}
+			<strong>We stand with Ukraine.</strong>
+			Donate →
+		{:else}
+			<strong>We stand with Ukraine.</strong>
+			Petition your leaders. Show your support.
+		{/if}
+	</div>
+</a>
 
 <style>
 	main {

--- a/sites/kit.svelte.dev/src/routes/__layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/__layout.svelte
@@ -5,10 +5,6 @@
 	import { Icon, Icons, Nav, NavItem, PreloadingIndicator, SkipLink } from '@sveltejs/site-kit';
 	import Search from '$lib/search/Search.svelte';
 	import SearchBox from '$lib/search/SearchBox.svelte';
-
-	let h = 0;
-	let w = 0;
-	$: browser && document.documentElement.style.setProperty('--ukr-footer-height', `${h}px`);
 </script>
 
 <Icons />
@@ -48,7 +44,7 @@
 	</svelte:fragment>
 </Nav>
 
-<main id="main" style="padding-bottom: {h}px;">
+<main id="main">
 	<slot />
 
 	{#if browser}
@@ -57,14 +53,13 @@
 </main>
 
 <a target="_blank" rel="noopener noreferrer" href="https://www.stopputin.net/">
-	<div class="ukr" bind:clientHeight={h} bind:clientWidth={w}>
-		{#if w < 830}
-			<strong>We stand with Ukraine.</strong>
-			Donate →
-		{:else}
-			<strong>We stand with Ukraine.</strong>
-			Petition your leaders. Show your support.
-		{/if}
+	<div class="ukr">
+		<span class="small">
+			<strong>We stand with Ukraine.</strong> Donate →
+		</span>
+		<span class="large">
+			<strong>We stand with Ukraine.</strong> Petition your leaders. Show your support.
+		</span>
 	</div>
 </a>
 
@@ -137,22 +132,36 @@
 		font-size: 1.6rem !important;
 	}
 
+	/** Ukraine banner */
+	:root {
+		--ukr-footer-height: 48px;
+	}
+
+	main {
+		padding-bottom: var(--ukr-footer-height);
+	}
+
 	.ukr {
 		background-color: #0066cc;
 		color: white;
 		position: fixed;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 		bottom: 0;
 		width: 100vw;
-		text-align: center;
-		padding: 0.75em;
+		height: var(--ukr-footer-height);
 		z-index: 999;
 	}
+
 	:global(.examples-container, .repl-outer, .tutorial-outer) {
 		height: calc(100vh - var(--nav-h) - var(--ukr-footer-height)) !important;
 	}
+
 	:global(.toggle) {
 		bottom: var(--ukr-footer-height) !important;
 	}
+
 	@media (max-width: 830px) {
 		:global(aside) {
 			z-index: 9999 !important;

--- a/sites/kit.svelte.dev/svelte-kit.js
+++ b/sites/kit.svelte.dev/svelte-kit.js
@@ -1,0 +1,14 @@
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const [node, , ...args] = process.argv;
+const mode = process.env.CI ? 'dist' : 'src';
+const bin = fileURLToPath(new URL(`../../packages/kit/${mode}/cli.js`, import.meta.url));
+
+const child = spawn(node, [bin, ...args], {
+	stdio: 'inherit'
+});
+
+if (child) {
+	child.on('exit', process.exit);
+}


### PR DESCRIPTION
Fixes #4216. Just leaving this here for now — I plan to come back and tidy up the implementation so that it's not using `bind:clientHeight` at all, but thought it worth showing that moving the element with that binding below the element with the `{@html ...}` prevents the bug from manifesting. 

Ultimately this is something that needs to be fixed in Svelte.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
