### PR TITLE
[fix] Support override  by index file definitions

### DIFF
--- a/.changeset/odd-dots-hang.md
+++ b/.changeset/odd-dots-hang.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] Support override \$lib by index file definitions

--- a/.changeset/odd-dots-hang.md
+++ b/.changeset/odd-dots-hang.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-[fix] Support override \$lib by index file definitions
+Remove declared `$lib` module

--- a/packages/kit/scripts/extract-types.js
+++ b/packages/kit/scripts/extract-types.js
@@ -94,6 +94,14 @@ function get_types(code, statements) {
 	});
 }
 
+modules.push({
+	name: '$lib',
+	comment:
+		'This is a simple alias to `src/lib`, or whatever directory is specified as [`config.kit.files.lib`](/docs/configuration#files). It allows you to access common components and utility modules without `../../../../` nonsense.',
+	exports: [],
+	types: []
+});
+
 {
 	const code = fs.readFileSync('types/ambient.d.ts', 'utf-8');
 	const node = ts.createSourceFile('ambient.d.ts', code, ts.ScriptTarget.Latest);
@@ -115,6 +123,8 @@ function get_types(code, statements) {
 		}
 	}
 }
+
+modules.sort((a, b) => (a.name < b.name ? -1 : 1));
 
 fs.writeFileSync(
 	'../../documentation/types.js',

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -207,12 +207,6 @@ declare module '$app/stores' {
 	export const updated: Readable<boolean> & { check: () => boolean };
 }
 
-// note: this is a hack to allow `$lib` to show up at https://kit.svelte.dev/docs/modules#$lib
-/**
- * This is a simple alias to `src/lib`, or whatever directory is specified as [`config.kit.files.lib`](/docs/configuration#files). It allows you to access common components and utility modules without `../../../../` nonsense.
- */
-declare namespace $lib {}
-
 /**
  * ```ts
  * import { build, files, timestamp } from '$service-worker';

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -207,6 +207,7 @@ declare module '$app/stores' {
 	export const updated: Readable<boolean> & { check: () => boolean };
 }
 
+// note: this is a hack to allow `$lib` to show up at https://kit.svelte.dev/docs/modules#$lib
 /**
  * This is a simple alias to `src/lib`, or whatever directory is specified as [`config.kit.files.lib`](/docs/configuration#files). It allows you to access common components and utility modules without `../../../../` nonsense.
  */

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -210,7 +210,7 @@ declare module '$app/stores' {
 /**
  * This is a simple alias to `src/lib`, or whatever directory is specified as [`config.kit.files.lib`](/docs/configuration#files). It allows you to access common components and utility modules without `../../../../` nonsense.
  */
-declare module '$lib' {}
+declare namespace $lib {}
 
 /**
  * ```ts


### PR DESCRIPTION
fix: https://github.com/sveltejs/kit/issues/4215

### Check List

- [x] `import { foo } from '$lib';` doesn't show type error
  - [x] I can jump type definition when I click `foo`
- [x] after change `lib` path at `svelte.config.js`, still `import { foo } from '$lib';` doesn't show type error
  - [x] I can jump type definition when I click `foo`
- [x] Docs show `$lib` even after the change

But it seems like a very simple solution, am I missing something?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
