### PR TITLE
[docs] Add missing property `kit.prerender.default`

### DIFF
--- a/documentation/docs/13-configuration.md
+++ b/documentation/docs/13-configuration.md
@@ -59,6 +59,7 @@ const config = {
 		prerender: {
 			concurrency: 1,
 			crawl: true,
+			default: false,
 			enabled: true,
 			entries: ['*'],
 			onError: 'fail'


### PR DESCRIPTION
https://github.com/sveltejs/kit/pull/4192 added `kit.prerender.default` but the default values of svelte.config.js don't appear it.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
