### PR TITLE
[fix] consider `paths.assets` for `version.json`

### DIFF
--- a/.changeset/silent-crews-change.md
+++ b/.changeset/silent-crews-change.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+consider `paths.assets` for `version.json`

--- a/.changeset/silent-crews-change.md
+++ b/.changeset/silent-crews-change.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-consider `paths.assets` for `version.json`
+fetch `version.json` relative to `paths.assets`, if set

--- a/packages/kit/src/core/build/build_client.js
+++ b/packages/kit/src/core/build/build_client.js
@@ -28,7 +28,7 @@ export async function build_client({
 	client_entry_file
 }) {
 	process.env.VITE_SVELTEKIT_APP_VERSION = config.kit.version.name;
-	process.env.VITE_SVELTEKIT_APP_VERSION_FILE = `${config.kit.appDir}/version.json`;
+	process.env.VITE_SVELTEKIT_APP_VERSION_FILE = `${assets_base}version.json`;
 	process.env.VITE_SVELTEKIT_APP_VERSION_POLL_INTERVAL = `${config.kit.version.pollInterval}`;
 
 	process.env.VITE_SVELTEKIT_AMP = config.kit.amp ? 'true' : '';

--- a/packages/kit/src/core/build/build_client.js
+++ b/packages/kit/src/core/build/build_client.js
@@ -28,7 +28,7 @@ export async function build_client({
 	client_entry_file
 }) {
 	process.env.VITE_SVELTEKIT_APP_VERSION = config.kit.version.name;
-	process.env.VITE_SVELTEKIT_APP_VERSION_FILE = `${assets_base}version.json`;
+	process.env.VITE_SVELTEKIT_APP_VERSION_FILE = `${config.kit.appDir}/version.json`;
 	process.env.VITE_SVELTEKIT_APP_VERSION_POLL_INTERVAL = `${config.kit.version.pollInterval}`;
 
 	process.env.VITE_SVELTEKIT_AMP = config.kit.amp ? 'true' : '';

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -1,6 +1,5 @@
 import { writable } from 'svelte/store';
 import { hash } from '../hash.js';
-import { base } from '../paths.js';
 
 /** @param {HTMLDocument} doc */
 export function get_base_uri(doc) {
@@ -86,7 +85,7 @@ export function create_updated_store() {
 
 		const file = import.meta.env.VITE_SVELTEKIT_APP_VERSION_FILE;
 
-		const res = await fetch(`${base}/${file}`, {
+		const res = await fetch('' + file, {
 			headers: {
 				pragma: 'no-cache',
 				'cache-control': 'no-cache'

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -1,5 +1,6 @@
 import { writable } from 'svelte/store';
 import { hash } from '../hash.js';
+import { assets } from '../paths.js';
 
 /** @param {HTMLDocument} doc */
 export function get_base_uri(doc) {
@@ -85,7 +86,7 @@ export function create_updated_store() {
 
 		const file = import.meta.env.VITE_SVELTEKIT_APP_VERSION_FILE;
 
-		const res = await fetch('' + file, {
+		const res = await fetch(`${assets}/${file}`, {
 			headers: {
 				pragma: 'no-cache',
 				'cache-control': 'no-cache'


### PR DESCRIPTION
fix: https://github.com/sveltejs/kit/issues/4188

### Checklist
I checked behavior with adapter-node.
- [x] It can fetch `version.json` if `kit.paths.assets` has custom value
- [x] It can fetch `version.json` if `kit.paths.assets` doesn't set value

I couldn't find how to write tests.
So could you please teach me if there are some sample existing tests?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
