### PR TITLE
[fix] add `app.d.ts` to template

### DIFF
--- a/.changeset/few-turtles-deny.md
+++ b/.changeset/few-turtles-deny.md
@@ -1,0 +1,6 @@
+---
+'default-template': patch
+'create-svelte': patch
+---
+
+add `app.d.ts` to template

--- a/packages/create-svelte/templates/default/app.d.ts
+++ b/packages/create-svelte/templates/default/app.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@sveltejs/kit" />

--- a/packages/create-svelte/templates/skeleton/app.d.ts
+++ b/packages/create-svelte/templates/skeleton/app.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@sveltejs/kit" />


### PR DESCRIPTION
fix: https://github.com/sveltejs/kit/issues/4241

After committing https://github.com/sveltejs/kit/pull/4118 , type checker can not find ambient module.
It seems that `tsconfig.json` can only read ambient module that is a subdirectory of it.
(Now `tsconfig.json` is at inside of `.svelte-kit` folder but ambient module is inside of `./node_modules/@sveltejs/kit/types`.)
So AFAIK, we need to tell ambient module somehow.
So I added `app.d.ts` at root.
If you have a better way, please correct me!

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
