### PR TITLE
[chore] add `@sveltejs/adapter-static` to site package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,6 +391,7 @@ importers:
   sites/kit.svelte.dev:
     specifiers:
       '@sveltejs/adapter-auto': workspace:*
+      '@sveltejs/adapter-static': workspace:^1.0.0-next.29
       '@sveltejs/kit': workspace:*
       '@sveltejs/site-kit': ^2.0.3
       '@types/node': ^16.11.11
@@ -406,6 +407,7 @@ importers:
       vite-imagetools: ^4.0.3
     devDependencies:
       '@sveltejs/adapter-auto': link:../../packages/adapter-auto
+      '@sveltejs/adapter-static': link:../../packages/adapter-static
       '@sveltejs/kit': link:../../packages/kit
       '@sveltejs/site-kit': 2.0.3
       '@types/node': 16.11.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,7 +391,7 @@ importers:
   sites/kit.svelte.dev:
     specifiers:
       '@sveltejs/adapter-auto': workspace:*
-      '@sveltejs/adapter-static': workspace:^1.0.0-next.29
+      '@sveltejs/adapter-static': workspace:*
       '@sveltejs/kit': workspace:*
       '@sveltejs/site-kit': ^2.0.3
       '@types/node': ^16.11.11

--- a/sites/kit.svelte.dev/package.json
+++ b/sites/kit.svelte.dev/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "workspace:*",
-		"@sveltejs/adapter-static": "workspace:^1.0.0-next.29",
+		"@sveltejs/adapter-static": "workspace:*",
 		"@sveltejs/kit": "workspace:*",
 		"@sveltejs/site-kit": "^2.0.3",
 		"@types/node": "^16.11.11",

--- a/sites/kit.svelte.dev/package.json
+++ b/sites/kit.svelte.dev/package.json
@@ -9,6 +9,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "workspace:*",
+		"@sveltejs/adapter-static": "workspace:^1.0.0-next.29",
 		"@sveltejs/kit": "workspace:*",
 		"@sveltejs/site-kit": "^2.0.3",
 		"@types/node": "^16.11.11",


### PR DESCRIPTION
Now deploy process seems failed. (e.g. https://app.netlify.com/sites/kit-demo/deploys/622468f183e8a9000860529a#L1048)
This PR fixes this issue.

Please see the below comments for more details.

https://github.com/sveltejs/kit/pull/4244#issuecomment-1059918414
https://github.com/sveltejs/kit/pull/4244#issuecomment-1059930302

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
