### PR TITLE
chore: update tests for vite beta

### DIFF
--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -887,7 +887,7 @@ test.describe.parallel('Errors', () => {
 		expect(await page.textContent('#message')).toBe('This is your custom error page saying: ""');
 
 		const contents = await page.textContent('#stack');
-		const location = 'endpoint.svelte:12:15';
+		const location = /endpoint\.svelte:12:9|endpoint\.svelte:12:15/; // TODO: Remove second location with Vite 2.9
 
 		if (process.env.DEV) {
 			expect(contents).toMatch(location);
@@ -905,7 +905,7 @@ test.describe.parallel('Errors', () => {
 		expect(await page.textContent('#message')).toBe('This is your custom error page saying: ""');
 
 		const contents = await page.textContent('#stack');
-		const location = 'endpoint-not-ok.svelte:12:15';
+		const location = /endpoint-not-ok\.svelte:12:9|endpoint-not-ok\.svelte:12:15/; // TODO: Remove second location with Vite 2.9
 
 		if (process.env.DEV) {
 			expect(contents).toMatch(location);


### PR DESCRIPTION
Vite 2.9 introduces some changes (https://github.com/vitejs/vite/pull/6746) which affects the line/col of the sourcemaps, and it seems to be more accurate now. 

This change is done now so that [vite-ecosystem-ci](https://github.com/vitejs/vite-ecosystem-ci)'s SvelteKit test suite passes.

The files in question that has sourcemap changes are:
- https://github.com/sveltejs/kit/blob/master/packages%2Fkit%2Ftest%2Fapps%2Fbasics%2Fsrc%2Froutes%2Ferrors%2Fendpoint.svelte
- https://github.com/sveltejs/kit/blob/master/packages%2Fkit%2Ftest%2Fapps%2Fbasics%2Fsrc%2Froutes%2Ferrors%2Fendpoint-not-ok.svelte

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
