### PR TITLE
refactor: use Module Worker pattern instead of Service Worker, add error handling

### DIFF
--- a/.changeset/few-walls-obey.md
+++ b/.changeset/few-walls-obey.md
@@ -6,6 +6,7 @@
 
 #### add the following to your wrangler.toml
 ```toml
-[build.upload]
-format = "modules"
+		[build.upload]
+		format = "modules"
+		main = "./worker.mjs"
 ```

--- a/.changeset/few-walls-obey.md
+++ b/.changeset/few-walls-obey.md
@@ -2,4 +2,10 @@
 '@sveltejs/adapter-cloudflare-workers': patch
 ---
 
-refactor implementation from "Service Worker" pattern to "Module Worker" used in adapter-cloudflare
+[Breaking] refactor implementation from "Service Worker" pattern to "Module Worker" used in adapter-cloudflare
+
+#### add the following to your wrangler.toml
+```toml
+[build.upload]
+format = "modules"
+```

--- a/.changeset/few-walls-obey.md
+++ b/.changeset/few-walls-obey.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+---
+
+refactor implementation from "Service Worker" pattern to "Module Worker" used in adapter-cloudflare

--- a/packages/adapter-cloudflare-workers/README.md
+++ b/packages/adapter-cloudflare-workers/README.md
@@ -53,7 +53,6 @@ Then configure your sites build directory and your account-details in the config
 ```toml
 account_id = 'YOUR ACCOUNT_ID'
 zone_id    = 'YOUR ZONE_ID' # optional, if you don't specify this a workers.dev subdomain will be used.
-site = {bucket = "./build", entry-point = "./workers-site"}
 
 type = "javascript"
 
@@ -62,7 +61,12 @@ type = "javascript"
 command = ""
 
 [build.upload]
-format = "service-worker"
+format = "modules"
+main = "./worker.mjs"
+
+[site]
+bucket = "./.cloudflare/assets"
+entry-point = "./.cloudflare/worker"
 ```
 
 It's recommended that you add the `build` and `workers-site` folders (or whichever other folders you specify) to your `.gitignore`.

--- a/packages/adapter-cloudflare-workers/ambient.d.ts
+++ b/packages/adapter-cloudflare-workers/ambient.d.ts
@@ -9,9 +9,7 @@ declare module 'MANIFEST' {
 	export const prerendered: Set<string>;
 }
 
-declare abstract class FetchEvent extends Event {
-	readonly request: Request;
-	respondWith(promise: Response | Promise<Response>): void;
-	passThroughOnException(): void;
-	waitUntil(promise: Promise<any>): void;
+declare module '__STATIC_CONTENT_MANIFEST' {
+	const json: string;
+	export default json;
 }

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -1,61 +1,101 @@
 import { Server } from 'SERVER';
 import { manifest, prerendered } from 'MANIFEST';
 import { getAssetFromKV } from '@cloudflare/kv-asset-handler';
+import static_asset_manifest_json from '__STATIC_CONTENT_MANIFEST';
+const static_asset_manifest = JSON.parse(static_asset_manifest_json);
 
 const server = new Server(manifest);
 
 const prefix = `/${manifest.appDir}/`;
 
-addEventListener('fetch', (/** @type {FetchEvent} */ event) => {
-	event.respondWith(handle(event));
-});
+export default {
+	/**
+	 * @param {Request} req
+	 * @param {any} env
+	 * @param {any} context
+	 */
+	async fetch(req, env, context) {
+		const url = new URL(req.url);
+
+		// static assets
+		if (url.pathname.startsWith(prefix)) {
+			/** @type {Response} */
+			const res = await get_asset_from_kv(req, env, context);
+			if (is_error(res.status)) {
+				return res;
+			}
+			return new Response(res.body, {
+				headers: {
+					// include original cache headers, minus cache-control which
+					// is overridden, and etag which is no longer useful
+					'cache-control': 'public, immutable, max-age=31536000',
+					'content-type': res.headers.get('content-type'),
+					'x-robots-tag': 'noindex'
+				}
+			});
+		}
+
+		// prerendered pages and index.html files
+		const pathname = url.pathname.replace(/\/$/, '');
+		let file = pathname.substring(1);
+
+		try {
+			file = decodeURIComponent(file);
+		} catch (err) {
+			// ignore
+		}
+
+		if (
+			manifest.assets.has(file) ||
+			manifest.assets.has(file + '/index.html') ||
+			prerendered.has(pathname || '/')
+		) {
+			return get_asset_from_kv(req, env, context);
+		}
+
+		// dynamically-generated pages
+		try {
+			return await server.respond(req, {
+				platform: { env, context },
+				getClientAddress() {
+					return req.headers.get('cf-connecting-ip');
+				}
+			});
+		} catch (e) {
+			return new Response('Error rendering route: ' + (e.message || e.toString()), { status: 500 });
+		}
+	}
+};
 
 /**
- * @param {FetchEvent} event
- * @returns {Promise<Response>}
+ * @param {Request} req
+ * @param {any} env
+ * @param {any} context
  */
-async function handle(event) {
-	const { request } = event;
-
-	const url = new URL(request.url);
-
-	// generated assets
-	if (url.pathname.startsWith(prefix)) {
-		const res = await getAssetFromKV(event);
-		return new Response(res.body, {
-			headers: {
-				'cache-control': 'public, immutable, max-age=31536000',
-				'content-type': res.headers.get('content-type')
-			}
-		});
-	}
-
-	// prerendered pages and index.html files
-	const pathname = url.pathname.replace(/\/$/, '');
-	let file = pathname.substring(1);
-
+async function get_asset_from_kv(req, env, context) {
 	try {
-		file = decodeURIComponent(file);
-	} catch (err) {
-		// ignore
-	}
-
-	if (
-		manifest.assets.has(file) ||
-		manifest.assets.has(file + '/index.html') ||
-		prerendered.has(pathname || '/')
-	) {
-		return await getAssetFromKV(event);
-	}
-
-	// dynamically-generated pages
-	try {
-		return await server.respond(request, {
-			getClientAddress() {
-				return request.headers.get('cf-connecting-ip');
+		return await getAssetFromKV(
+			{
+				request: req,
+				waitUntil(promise) {
+					return context.waitUntil(promise);
+				}
+			},
+			{
+				ASSET_NAMESPACE: env.__STATIC_CONTENT,
+				ASSET_MANIFEST: static_asset_manifest
 			}
-		});
+		);
 	} catch (e) {
-		return new Response('Error rendering route:' + (e.message || e.toString()), { status: 500 });
+		const status = is_error(e.status) ? e.status : 500;
+		return new Response(e.message || e.toString(), { status });
 	}
+}
+
+/**
+ * @param {number} status
+ * @returns {boolean}
+ */
+function is_error(status) {
+	return status > 399;
 }

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -6,7 +6,7 @@ import toml from '@iarna/toml';
 import { fileURLToPath } from 'url';
 
 /** @type {import('.')} */
-export default function () {
+export default function (options = {}) {
 	return {
 		name: '@sveltejs/adapter-cloudflare-workers',
 
@@ -53,12 +53,13 @@ export default function () {
 			);
 
 			await esbuild.build({
-				entryPoints: [`${tmp}/entry.js`],
-				outfile: `${entrypoint}/${main_path}`,
 				target: 'es2020',
 				platform: 'browser',
+				...options,
+				entryPoints: [`${tmp}/entry.js`],
+				outfile: `${entrypoint}/${main_path}`,
 				bundle: true,
-				external: ['__STATIC_CONTENT_MANIFEST'],
+				external: ['__STATIC_CONTENT_MANIFEST', ...(options?.external || [])],
 				format: 'esm'
 			});
 

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -95,6 +95,18 @@ function validate_config(builder) {
 		}
 
 		// @ts-ignore
+		if (!wrangler_config.build || !wrangler_config.build.upload) {
+			throw new Error(
+				'You must specify build.upload options in wrangler.toml. Consult https://github.com/sveltejs/kit/tree/master/packages/adapter-cloudflare-workers'
+			);
+		}
+
+		// @ts-ignore
+		if (wrangler_config.build.upload.format !== 'modules') {
+			throw new Error('build.upload.format in wrangler.toml must be "modules"');
+		}
+
+		// @ts-ignore
 		const main_file = wrangler_config.build?.upload?.main;
 		const main_file_ext = main_file?.split('.').slice(-1)[0];
 		if (main_file_ext && main_file_ext !== 'mjs') {


### PR DESCRIPTION
as discussed on discord.

- switch to ModuleWorker pattern
- add error handling for static kv requests
- pass platform to server.respond

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
