### PR TITLE
fix: couple remnants of app.render in docs, error msg

### DIFF
--- a/.changeset/breezy-ears-fetch.md
+++ b/.changeset/breezy-ears-fetch.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix error message for invalid request object

--- a/documentation/docs/09-adapters.md
+++ b/documentation/docs/09-adapters.md
@@ -104,7 +104,7 @@ Within the `adapt` method, there are a number of things that an adapter should d
   - Imports `App` from `${builder.getServerDirectory()}/app.js`
   - Instantiates the app with a manifest generated with `builder.generateManifest({ relativePath })`
   - Listens for requests from the platform, converts them to a standard [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) if necessary, calls the `render` function to generate a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) and responds with it
-  - expose any platform-specific information to SvelteKit via the `platform` option passed to `app.render`
+  - expose any platform-specific information to SvelteKit via the `platform` option passed to `server.respond`
   - Globally shims `fetch` to work on the target platform, if necessary. SvelteKit provides a `@sveltejs/kit/install-fetch` helper for platforms that can use `node-fetch`
 - Bundle the output to avoid needing to install dependencies on the target platform, if necessary
 - Put the user's static files and the generated JS/CSS in the correct location for the target platform

--- a/packages/kit/src/core/build/build_server.js
+++ b/packages/kit/src/core/build/build_server.js
@@ -97,7 +97,7 @@ export class Server {
 
 	respond(request, options = {}) {
 		if (!(request instanceof Request)) {
-			throw new Error('The first argument to app.render must be a Request object. See https://github.com/sveltejs/kit/pull/3384 for details');
+			throw new Error('The first argument to server.respond must be a Request object. See https://github.com/sveltejs/kit/pull/3384 for details');
 		}
 
 		return respond(request, this.options, options);


### PR DESCRIPTION
#4034 missed a couple of `app.render`'s in the docs and an error message. This PR fixes that :).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
