### PR TITLE
allow routes to have the same name as fallback components

### DIFF
--- a/.changeset/long-guests-trade.md
+++ b/.changeset/long-guests-trade.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Allow routes with the same name as fallback components

--- a/packages/kit/src/core/build/build_server.js
+++ b/packages/kit/src/core/build/build_server.js
@@ -160,7 +160,7 @@ export async function build_server(
 		const relative = path.relative(config.kit.files.routes, resolved);
 
 		const name = relative.startsWith('..')
-			? posixify(path.join('entries/pages', path.basename(file)))
+			? posixify(path.join('entries/fallbacks', path.basename(file)))
 			: posixify(path.join('entries/pages', relative));
 		input[name] = resolved;
 	});

--- a/packages/kit/test/apps/options/source/pages/error.svelte
+++ b/packages/kit/test/apps/options/source/pages/error.svelte
@@ -1,0 +1,1 @@
+<!-- https://github.com/sveltejs/kit/issues/4186 -->


### PR DESCRIPTION
fixes #4186, supersedes #4200. The input to Rollup was getting borked up if you had components called `src/routes/layout.svelte` or `src/routes/error.svelte`, because those match the names of fallback components

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
