### PR TITLE
feat: Runtime SVELTE_PUBLIC_* env variables

### DIFF
--- a/.changeset/new-apples-confess.md
+++ b/.changeset/new-apples-confess.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add support for runtime environment variables (SVELTE*PUBLIC*\*)

--- a/packages/kit/src/runtime/app/env.js
+++ b/packages/kit/src/runtime/app/env.js
@@ -14,5 +14,22 @@ export const mode = import.meta.env.MODE;
  * @type {import('$app/env').amp}
  */
 export const amp = !!import.meta.env.VITE_SVELTEKIT_AMP;
+/**
+ * @type {import('$app/env').env}
+ */
+export const env = extractEnv();
 
 export { prerendering } from '../env.js';
+
+function extractEnv() {
+	if (typeof process === 'object' && typeof process.env === 'object') {
+		return process.env;
+	}
+	if (typeof document !== 'undefined') {
+		const el = document.querySelector('script[type="svelte/env"]');
+		if (el) {
+			return new Function('return ' + el?.textContent)();
+		}
+	}
+	return {};
+}

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -67,6 +67,11 @@ declare module '$app/env' {
 	 * By default, `svelte-kit dev` runs with `mode=development` and `svelte-kit build` runs with `mode=production`.
 	 */
 	export const mode: string;
+	/**
+	 * Runtime environment variables.
+	 * Only variables starting with "SVELTE_PUBLIC_" are available on the client, the server has access to all variables.
+	 */
+	export const env: Record<string, string | undefined>;
 }
 
 /**


### PR DESCRIPTION
Using environment variables in SvelteKit is possible via [vite's `VITE_*` variables](https://vitejs.dev/guide/env-and-mode.html#production-replacement).

The downside is that these are **compile-time** environment variables, the values are injected into the javascript files during the **dev** and **build** steps.

This PR adds **runtime** environment variables, this allow you to change the _variable_ in the _environment_ without needing to recompile.

### Use-cases:
- Setting an environment variable and restarting the server works. This allows changing a [Config Var](https://devcenter.heroku.com/articles/config-vars) on Heroku to activate instantly. (No longer needs a image rebuild & deploy)
- Using an Azure Devops Build pipeline to [create an Artifact](https://docs.microsoft.com/en-us/azure/devops/pipelines/publish-pipeline-artifact?view=azure-devops&tabs=yaml) and deploy that build to differrent environments using release pipelines.

## Usage example:

```
import { env } from "$app/env";

console.log(env.SVELTE_PUBLIC_API_ENDPOINT);
```

## How it works
At server startup a `<script type="svelte/env">` tag is generated containing values from `process.env` that start with `SVELTE_PUBLIC_`.
When importing the  `$app/env` the `env` export is populated with values from `process.env` on the server and on the client it uses the values from the 'svelte/env' tag.

## Possible future improvements:

- Add support for .env files. (Workaround `node -r dotenv/config node_modules/.bin/svelte-kit dev`)
- Allow overriding the `SVELTE_PUBLIC_` prefix/filter in the svelte.config
- Allow adapters to provide enviroment variables. (`process.env` is a NodeJS api)
- The `SVELTE_PUBLIC_` prefix naming inspiration came from [NEXT_PUBLIC_](https://nextjs.org/docs/basic-features/environment-variables), but these are also compile-time variables (via webpack)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

Related #3030
[Alternative implementation using hooks.ts](https://github.com/bfanger/svelte-project-template/blob/main/src/hooks.ts)