### PR TITLE
[fix] check for app.d.ts rather than global.d.ts

### DIFF
--- a/.changeset/wise-pens-ring.md
+++ b/.changeset/wise-pens-ring.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+[fix] check for app.d.ts rather than global.d.ts

--- a/packages/create-svelte/scripts/build-templates.js
+++ b/packages/create-svelte/scripts/build-templates.js
@@ -66,10 +66,10 @@ async function generate_templates(shared) {
 		const js = [];
 
 		for (const file of ts) {
-			// The global.d.ts file makes TS/JS aware of some ambient modules, which are
+			// The app.d.ts file makes TS/JS aware of some ambient modules, which are
 			// also needed for JS projects if people turn on "checkJs" in their jsonfig
 			if (file.name.endsWith('.d.ts')) {
-				if (file.name.endsWith('global.d.ts')) js.push(file);
+				if (file.name.endsWith('app.d.ts')) js.push(file);
 			} else if (file.name.endsWith('.ts')) {
 				const transformed = transform(file.contents, {
 					transforms: ['typescript']


### PR DESCRIPTION
Looks like we forgot to update this line when `global.d.ts` was renamed to `app.d.ts`