### PR TITLE
select adapter immediately on startup

### DIFF
--- a/.changeset/cool-crabs-listen.md
+++ b/.changeset/cool-crabs-listen.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Allow adapter.adapt to be synchronous

--- a/.changeset/tasty-squids-share.md
+++ b/.changeset/tasty-squids-share.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-auto': patch
+---
+
+Select adapter immediately

--- a/packages/adapter-auto/index.js
+++ b/packages/adapter-auto/index.js
@@ -1,40 +1,56 @@
 import { adapters } from './adapters.js';
 
-/** @type {import('.')} **/
-export default function () {
-	return {
-		name: '@sveltejs/adapter-auto',
+/** @type {import('./index')} */
+let fn;
 
-		async adapt(builder) {
-			for (const candidate of adapters) {
-				if (candidate.test()) {
-					builder.log.info(`Detected environment: ${candidate.name}. Using ${candidate.module}`);
+let info = '';
 
-					let module;
+for (const candidate of adapters) {
+	if (candidate.test()) {
+		info = `Detected environment: ${candidate.name}. Using ${candidate.module}`;
 
-					try {
-						module = await import(candidate.module);
-					} catch (error) {
-						if (
-							error.code === 'ERR_MODULE_NOT_FOUND' &&
-							error.message.startsWith(`Cannot find package '${candidate.module}'`)
-						) {
-							throw new Error(
-								`It looks like ${candidate.module} is not installed. Please install it and try building your project again.`
-							);
-						}
+		/** @type {{ default: () => import('@sveltejs/kit').Adapter }} */
+		let module;
 
-						throw error;
+		try {
+			module = await import(candidate.module);
+
+			fn = () => {
+				const adapter = module.default();
+				return {
+					...adapter,
+					adapt: (builder) => {
+						builder.log.info(info);
+						return adapter.adapt(builder);
 					}
+				};
+			};
 
-					const adapter = module.default();
-					return adapter.adapt(builder);
-				}
+			break;
+		} catch (error) {
+			if (
+				error.code === 'ERR_MODULE_NOT_FOUND' &&
+				error.message.startsWith(`Cannot find package '${candidate.module}'`)
+			) {
+				throw new Error(
+					`It looks like ${candidate.module} is not installed. Please install it and try building your project again.`
+				);
 			}
 
+			throw error;
+		}
+	}
+}
+
+if (!fn) {
+	fn = () => ({
+		name: '@sveltejs/adapter-auto',
+		adapt: (builder) => {
 			builder.log.warn(
 				'Could not detect a supported production environment. See https://kit.svelte.dev/docs/adapters to learn how to configure your app to run on the platform of your choosing'
 			);
 		}
-	};
+	});
 }
+
+export default fn;

--- a/packages/adapter-auto/index.js
+++ b/packages/adapter-auto/index.js
@@ -3,12 +3,8 @@ import { adapters } from './adapters.js';
 /** @type {import('./index')} */
 let fn;
 
-let info = '';
-
 for (const candidate of adapters) {
 	if (candidate.test()) {
-		info = `Detected environment: ${candidate.name}. Using ${candidate.module}`;
-
 		/** @type {{ default: () => import('@sveltejs/kit').Adapter }} */
 		let module;
 
@@ -20,7 +16,7 @@ for (const candidate of adapters) {
 				return {
 					...adapter,
 					adapt: (builder) => {
-						builder.log.info(info);
+						builder.log.info(`Detected environment: ${candidate.name}. Using ${candidate.module}`);
 						return adapter.adapt(builder);
 					}
 				};

--- a/packages/adapter-auto/tsconfig.json
+++ b/packages/adapter-auto/tsconfig.json
@@ -6,6 +6,7 @@
 		"noImplicitAny": true,
 		"module": "esnext",
 		"target": "esnext",
+		"moduleResolution": "node",
 		"baseUrl": ".",
 		"paths": {
 			"@sveltejs/kit": ["../kit/types/index"]

--- a/packages/adapter-auto/tsconfig.json
+++ b/packages/adapter-auto/tsconfig.json
@@ -4,6 +4,8 @@
 		"checkJs": true,
 		"noEmit": true,
 		"noImplicitAny": true,
+		"module": "esnext",
+		"target": "esnext",
 		"baseUrl": ".",
 		"paths": {
 			"@sveltejs/kit": ["../kit/types/index"]

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -28,7 +28,7 @@ import { SSRNodeLoader, SSRRoute, ValidatedConfig } from './internal';
 
 export interface Adapter {
 	name: string;
-	adapt(builder: Builder): Promise<void>;
+	adapt(builder: Builder): MaybePromise<void>;
 }
 
 export interface Builder {


### PR DESCRIPTION
While working on #4289, I found a use case for adapter-auto determining the adapter early, rather than waiting until `adapt` is called. I think this is very likely to come up in other ways, so I figured we may as well come up with a solution.

In this PR, the checking is done as soon as the module executes. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
