### PR TITLE
make manifest.mimeTypes part of the public API

### DIFF
--- a/.changeset/early-pants-unite.md
+++ b/.changeset/early-pants-unite.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Make manifest.mime part of the public API
+Make `manifest.mimeTypes` part of the public API

--- a/.changeset/early-pants-unite.md
+++ b/.changeset/early-pants-unite.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Make manifest.mime part of the public API

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -49,7 +49,7 @@ export async function create_plugin(config, cwd) {
 				manifest = {
 					appDir: config.kit.appDir,
 					assets: new Set(manifest_data.assets.map((asset) => asset.file)),
-					mime: get_mime_lookup(manifest_data),
+					mimeTypes: get_mime_lookup(manifest_data),
 					_: {
 						entry: {
 							file: `/@fs${runtime}/client/start.js`,

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -49,8 +49,8 @@ export async function create_plugin(config, cwd) {
 				manifest = {
 					appDir: config.kit.appDir,
 					assets: new Set(manifest_data.assets.map((asset) => asset.file)),
+					mime: get_mime_lookup(manifest_data),
 					_: {
-						mime: get_mime_lookup(manifest_data),
 						entry: {
 							file: `/@fs${runtime}/client/start.js`,
 							css: [],

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -58,7 +58,7 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 	return `{
 		appDir: ${s(build_data.app_dir)},
 		assets: new Set(${s(assets)}),
-		mime: ${s(get_mime_lookup(build_data.manifest_data))},
+		mimeTypes: ${s(get_mime_lookup(build_data.manifest_data))},
 		_: {
 			entry: ${s(build_data.client.entry)},
 			nodes: [

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -58,8 +58,8 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 	return `{
 		appDir: ${s(build_data.app_dir)},
 		assets: new Set(${s(assets)}),
+		mime: ${s(get_mime_lookup(build_data.manifest_data))},
 		_: {
-			mime: ${s(get_mime_lookup(build_data.manifest_data))},
 			entry: ${s(build_data.client.entry)},
 			nodes: [
 				${Array.from(bundled_nodes.values()).map(node => importer(node.path)).join(',\n\t\t\t\t')}

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -155,7 +155,7 @@ export async function load_node({
 
 					if (options.read) {
 						const type = is_asset
-							? options.manifest._.mime[filename.slice(filename.lastIndexOf('.'))]
+							? options.manifest.mime[filename.slice(filename.lastIndexOf('.'))]
 							: 'text/html';
 
 						response = new Response(options.read(file), {

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -155,7 +155,7 @@ export async function load_node({
 
 					if (options.read) {
 						const type = is_asset
-							? options.manifest.mime[filename.slice(filename.lastIndexOf('.'))]
+							? options.manifest.mimeTypes[filename.slice(filename.lastIndexOf('.'))]
 							: 'text/html';
 
 						response = new Response(options.read(file), {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -241,7 +241,7 @@ export class Server {
 export interface SSRManifest {
 	appDir: string;
 	assets: Set<string>;
-	mime: Record<string, string>;
+	mimeTypes: Record<string, string>;
 
 	/** private fields */
 	_: {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -241,9 +241,10 @@ export class Server {
 export interface SSRManifest {
 	appDir: string;
 	assets: Set<string>;
+	mime: Record<string, string>;
+
 	/** private fields */
 	_: {
-		mime: Record<string, string>;
 		entry: {
 			file: string;
 			js: string[];


### PR DESCRIPTION
This moves `manifest._.mime` to `manifest.mimeTypes`, so that adapters can use it. This will enable #4276 to serve static assets without pulling in a mime library

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
