### PR TITLE
[docs] adapter-static: document prerender.default and info about disabling ssr in dev

### DIFF
--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -12,18 +12,18 @@ import adapter from '@sveltejs/adapter-static';
 
 export default {
 	kit: {
+		// Enable prerendering by default unless when in SPA mode
+		prerender.default: true,
 		adapter: adapter({
 			// default options are shown
 			pages: 'build',
 			assets: 'build',
 			fallback: null,
 			precompress: false
-		})
+		}),
 	}
 };
 ```
-
-Unless you're in [SPA mode](#spa-mode), the adapter will attempt to prerender every page of your app, regardless of whether the [`prerender`](https://kit.svelte.dev/docs/page-options#prerender) option is set.
 
 > ⚠️ You must ensure SvelteKit's [`trailingSlash`](https://kit.svelte.dev/docs/configuration#trailingslash) option is set appropriately for your environment. If your host does not render `/a.html` upon receiving a request for `/a` then you will need to set `trailingSlash: 'always'` to create `/a/index.html` instead.
 
@@ -47,7 +47,7 @@ If `true`, precompresses files with brotli and gzip. This will generate `.br` an
 
 ## SPA mode
 
-You can use `adapter-static` to create a single-page app or SPA by specifying a **fallback page**.
+You can use `adapter-static` to create a single-page app or SPA by specifying a **fallback page** and leaving the default of ``false`` for ``config.kitprerender.default``.
 
 > In most situations this is not recommended: it harms SEO, tends to slow down perceived performance, and makes your app inaccessible to users if JavaScript fails or is disabled (which happens [more often than you probably think](https://kryogenix.org/code/browser/everyonehasjs.html)).
 
@@ -65,8 +65,7 @@ export default {
 	}
 };
 ```
-
-When operating in SPA mode, only pages that have the [`prerender`](https://kit.svelte.dev/docs/page-options#prerender) option set will be prerendered.
+When operating in SPA mode, only pages that have the [`prerender`](https://kit.svelte.dev/docs/page-options#prerender) option set will be prerendered at build time.
 
 ## GitHub Pages
 

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -20,7 +20,7 @@ export default {
 			assets: 'build',
 			fallback: null,
 			precompress: false
-		}),
+		})
 	}
 };
 ```

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -66,6 +66,7 @@ export default {
 };
 ```
 When operating in SPA mode, only pages that have the [`prerender`](https://kit.svelte.dev/docs/page-options#prerender) option set will be prerendered at build time.
+> ⚠️  During development, SvelteKit will still attempt to server-side render your routes. This means accessing things that are only available in the browser (such as the ``window`` object) will result in errors, even though this would be valid in the output app. To align the behavior of SvelteKit's dev mode with your SPA, you can [call ``resolve()`` with a parameter of ``ssr`` set to ``false`` inside the ``handle()`` hook](https://kit.svelte.dev/docs/hooks#handle).
 
 ## GitHub Pages
 

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -12,7 +12,7 @@ import adapter from '@sveltejs/adapter-static';
 
 export default {
 	kit: {
-		// Enable prerendering by default unless when in SPA mode
+		// Enable prerendering by default. Remove if using SPA mode
 		prerender.default: true,
 		adapter: adapter({
 			// default options are shown

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -66,7 +66,7 @@ export default {
 };
 ```
 When operating in SPA mode, only pages that have the [`prerender`](https://kit.svelte.dev/docs/page-options#prerender) option set will be prerendered at build time.
-> ⚠️  During development, SvelteKit will still attempt to server-side render your routes. This means accessing things that are only available in the browser (such as the ``window`` object) will result in errors, even though this would be valid in the output app. To align the behavior of SvelteKit's dev mode with your SPA, you can [call ``resolve()`` with a parameter of ``ssr`` set to ``false`` inside the ``handle()`` hook](https://kit.svelte.dev/docs/hooks#handle).
+> ⚠️  During development, SvelteKit will still attempt to server-side render your routes. This means accessing things that are only available in the browser (such as the ``window`` object) will result in errors, even though this would be valid in the output app. To align the behavior of SvelteKit's dev mode with your SPA, you can [call ``resolve()`` with a parameter of ``{ssr: false}`` inside the ``handle()`` hook](https://kit.svelte.dev/docs/hooks#handle).
 
 ## GitHub Pages
 

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -12,15 +12,18 @@ import adapter from '@sveltejs/adapter-static';
 
 export default {
 	kit: {
-		// Enable prerendering by default. Remove if using SPA mode
-		prerender.default: true,
 		adapter: adapter({
 			// default options are shown
 			pages: 'build',
 			assets: 'build',
 			fallback: null,
 			precompress: false
-		})
+		}),
+
+		prerender: {
+			// This can be false if you're using a fallback (i.e. SPA mode)
+			default: true
+		}
 	}
 };
 ```

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -50,7 +50,7 @@ If `true`, precompresses files with brotli and gzip. This will generate `.br` an
 
 ## SPA mode
 
-You can use `adapter-static` to create a single-page app or SPA by specifying a **fallback page** and leaving the default of `false` for `config.kitprerender.default`.
+You can use `adapter-static` to create a single-page app or SPA by specifying a **fallback page**.
 
 > In most situations this is not recommended: it harms SEO, tends to slow down perceived performance, and makes your app inaccessible to users if JavaScript fails or is disabled (which happens [more often than you probably think](https://kryogenix.org/code/browser/everyonehasjs.html)).
 
@@ -69,7 +69,7 @@ export default {
 };
 ```
 
-When operating in SPA mode, only pages that have the [`prerender`](https://kit.svelte.dev/docs/page-options#prerender) option set will be prerendered at build time.
+When operating in SPA mode, you can omit `config.kit.prerender.default` (or set it to `false`, its default value), and only pages that have the [`prerender`](https://kit.svelte.dev/docs/page-options#prerender) option set will be prerendered at build time.
 
 > ⚠️ During development, SvelteKit will still attempt to server-side render your routes. This means accessing things that are only available in the browser (such as the `window` object) will result in errors, even though this would be valid in the output app. To align the behavior of SvelteKit's dev mode with your SPA, you can [call `resolve()` with a parameter of `{ssr: false}` inside the `handle()` hook](https://kit.svelte.dev/docs/hooks#handle).
 

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -47,7 +47,7 @@ If `true`, precompresses files with brotli and gzip. This will generate `.br` an
 
 ## SPA mode
 
-You can use `adapter-static` to create a single-page app or SPA by specifying a **fallback page** and leaving the default of ``false`` for ``config.kitprerender.default``.
+You can use `adapter-static` to create a single-page app or SPA by specifying a **fallback page** and leaving the default of `false` for `config.kitprerender.default`.
 
 > In most situations this is not recommended: it harms SEO, tends to slow down perceived performance, and makes your app inaccessible to users if JavaScript fails or is disabled (which happens [more often than you probably think](https://kryogenix.org/code/browser/everyonehasjs.html)).
 
@@ -65,8 +65,10 @@ export default {
 	}
 };
 ```
+
 When operating in SPA mode, only pages that have the [`prerender`](https://kit.svelte.dev/docs/page-options#prerender) option set will be prerendered at build time.
-> ⚠️  During development, SvelteKit will still attempt to server-side render your routes. This means accessing things that are only available in the browser (such as the ``window`` object) will result in errors, even though this would be valid in the output app. To align the behavior of SvelteKit's dev mode with your SPA, you can [call ``resolve()`` with a parameter of ``{ssr: false}`` inside the ``handle()`` hook](https://kit.svelte.dev/docs/hooks#handle).
+
+> ⚠️ During development, SvelteKit will still attempt to server-side render your routes. This means accessing things that are only available in the browser (such as the `window` object) will result in errors, even though this would be valid in the output app. To align the behavior of SvelteKit's dev mode with your SPA, you can [call `resolve()` with a parameter of `{ssr: false}` inside the `handle()` hook](https://kit.svelte.dev/docs/hooks#handle).
 
 ## GitHub Pages
 


### PR DESCRIPTION
#4192 introduced a configuration setting for prerendering by default, which explicitly has to be set to true for adapter-static to work in non-SPA mode. Currently adapter-static only tells the user to do so when actually building, but having it in the docs is good for obvious reasons.
I also lumped in a small mention about disabling ssr in the handle() hook, to make developing an SPA with svelte-kit aligned with how it will actually works when built. I hope it's okay that I made a single PR for two changes, just let me know if changes are required!

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

