### PR TITLE
[fix] Cannot get props in errors returned by shadowed route #4303

### DIFF
--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -650,8 +650,8 @@ export function create_client({ target, session, base, trailing_slash }) {
 							status = res.status;
 							let error_message = 'Failed to load data';
 							try {
-								const { message } = await res.json();
-								if ('string' === typeof message) error_message = message;
+								const { error } = await res.json();
+								if ('string' === typeof error) error_message = error;
 							} catch (e) {
 								// ignore
 							}

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -648,7 +648,14 @@ export function create_client({ target, session, base, trailing_slash }) {
 							props = await res.json();
 						} else {
 							status = res.status;
-							error = new Error('Failed to load data');
+							let error_message = 'Failed to load data';
+							try {
+								const { message } = await res.json();
+								if ('string' === typeof message) error_message = message;
+							} catch (e) {
+								// ignore
+							}
+							error = new Error(error_message);
 						}
 					}
 

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -432,7 +432,7 @@ async function load_shadow_data(route, event, options, prerender) {
 
 			if (status >= 400) {
 				let error_message = 'Failed to load data';
-				if ('string' === typeof body.message) error_message = body.message;
+				if ('string' === typeof body.error) error_message = body.error;
 				data.error = new Error(error_message);
 				return data;
 			}

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -431,7 +431,9 @@ async function load_shadow_data(route, event, options, prerender) {
 			data.status = status;
 
 			if (status >= 400) {
-				data.error = new Error('Failed to load data');
+				let error_message = 'Failed to load data';
+				if ('string' === typeof body.message) error_message = body.message;
+				data.error = new Error(error_message);
 				return data;
 			}
 

--- a/packages/kit/test/apps/basics/src/routes/shadowed/error-message/__error.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shadowed/error-message/__error.svelte
@@ -1,0 +1,14 @@
+<script context="module">
+	export function load({status, error}) {
+		return {
+			props: {status,error}
+		};
+	}
+</script>
+
+<script>
+	export let status,error;
+</script>
+
+<h1>{status}</h1>
+<p>{error.message}</p>

--- a/packages/kit/test/apps/basics/src/routes/shadowed/error-message/err.js
+++ b/packages/kit/test/apps/basics/src/routes/shadowed/error-message/err.js
@@ -1,0 +1,8 @@
+export function get() {
+	return {
+		body: {
+			message: 'A custom error message'
+		},
+		status: 451
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/shadowed/error-message/err.js
+++ b/packages/kit/test/apps/basics/src/routes/shadowed/error-message/err.js
@@ -1,7 +1,7 @@
 export function get() {
 	return {
 		body: {
-			message: 'A custom error message'
+			error: 'A custom error message'
 		},
 		status: 451
 	};

--- a/packages/kit/test/apps/basics/src/routes/shadowed/error-message/err.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shadowed/error-message/err.svelte
@@ -1,0 +1,1 @@
+<p>you can't see me</p>

--- a/packages/kit/test/apps/basics/src/routes/shadowed/error-message/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shadowed/error-message/index.svelte
@@ -1,1 +1,1 @@
-<a href="./error-message/err">shadow</a>
+<a href="/shadowed/error-message/err">shadow</a>

--- a/packages/kit/test/apps/basics/src/routes/shadowed/error-message/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shadowed/error-message/index.svelte
@@ -1,0 +1,1 @@
+<a href="./error-message/err">shadow</a>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -522,6 +522,20 @@ test.describe.parallel('Shadowed pages', () => {
 		await clicknav('[href="/shadowed/redirect/a"]');
 		expect(await page.textContent('h1')).toBe('done');
 	});
+
+	test('Display custom error message on client side shadow page', async ({ page, clicknav }) => {
+		await page.goto('/shadowed/error-message');
+		await clicknav('[href="./error-message/err"]');
+		expect(await page.textContent('h1')).toBe('451');
+		expect(await page.textContent('p')).toBe('A custom error message');
+		await page.goto('/shadowed/error-message/shadow');
+	});
+
+	test('Display custom error message on server side shadow page', async ({ page }) => {
+		await page.goto('/shadowed/error-message/err');
+		expect(await page.textContent('h1')).toBe('451');
+		expect(await page.textContent('p')).toBe('A custom error message');
+	});
 });
 
 test.describe.parallel('Endpoints', () => {

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -525,7 +525,7 @@ test.describe.parallel('Shadowed pages', () => {
 
 	test('Display custom error message on client side shadow page', async ({ page, clicknav }) => {
 		await page.goto('/shadowed/error-message');
-		await clicknav('[href="./error-message/err"]');
+		await clicknav('[href="/shadowed/error-message/err"]');
 		expect(await page.textContent('h1')).toBe('451');
 		expect(await page.textContent('p')).toBe('A custom error message');
 		await page.goto('/shadowed/error-message/shadow');


### PR DESCRIPTION
Allow display custom error message from shadow.

e.g
```
export function get() {
	return {
		body: {
			error: 'A custom error message'
		},
		status: 451
	};
}
```




fix: #4303

test:
```
cd packages\kit\test\apps\basics
npx  playwright test -g 'Display custom error message on client side shadow page'
npx  playwright test -g 'Display custom error message on server side shadow page'
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
