### PR TITLE
Return 404s from `fetch` in `load` during prerender

### DIFF
--- a/.changeset/stale-dogs-rule.md
+++ b/.changeset/stale-dogs-rule.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Return 404 when fetching missing data during prerender

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -259,6 +259,10 @@ export async function respond(request, options, state = {}) {
 					});
 				}
 
+				if (state.prerender) {
+					return new Response('not found', { status: 404 });
+				}
+
 				// we can't load the endpoint from our own manifest,
 				// so we need to make an actual HTTP request
 				return await fetch(request);

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -190,7 +190,8 @@ export async function load_node({
 
 					response = await respond(new Request(new URL(requested, event.url).href, opts), options, {
 						fetched: requested,
-						initiator: route
+						initiator: route,
+						prerender: state.prerender
 					});
 
 					if (state.prerender) {

--- a/packages/kit/test/prerendering/basics/src/routes/fetch-404.svelte
+++ b/packages/kit/test/prerendering/basics/src/routes/fetch-404.svelte
@@ -1,0 +1,17 @@
+<script context="module">
+	/** @type {import('./fetch-404').Load} */
+	export async function load({ fetch }) {
+		const { status } = await fetch('/missing.json');
+
+		return {
+			props: { status }
+		};
+	}
+</script>
+
+<script>
+	/** @type {number} */
+	export let status;
+</script>
+
+<h1>status: {status}</h1>

--- a/packages/kit/test/prerendering/basics/test/test.js
+++ b/packages/kit/test/prerendering/basics/test/test.js
@@ -109,4 +109,9 @@ test('prerendering is set to true in global code of hooks.js', () => {
 	assert.ok(content.includes('<h1>prerendering: true/true</h1>'), content);
 });
 
+test('fetching missing content results in a 404', () => {
+	const content = read('fetch-404.html');
+	assert.ok(content.includes('<h1>status: 404</h1>'), content);
+});
+
 test.run();


### PR DESCRIPTION
This is a fairly minor bug — when calling `fetch('/missing.json')` inside `load` during prerender, SvelteKit currently returns a 500 because it's trying to make an actual `fetch` to a meaningless URL. This ensures the correct status code, and prevents the terminal filling up with gibberish.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
