### PR TITLE
fix: change `remove` to `unlink` in vite.watcher

### DIFF
--- a/.changeset/dull-emus-tap.md
+++ b/.changeset/dull-emus-tap.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: correctly detect removal of route

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -156,7 +156,7 @@ export async function create_plugin(config, cwd) {
 			update_manifest();
 
 			vite.watcher.on('add', update_manifest);
-			vite.watcher.on('remove', update_manifest);
+			vite.watcher.on('unlink', update_manifest);
 
 			const assets = config.kit.paths.assets ? SVELTE_KIT_ASSETS : config.kit.paths.base;
 			const asset_server = sirv(config.kit.files.assets, {


### PR DESCRIPTION
Chokidar does not have `remove` event, only `unlink` for watching file removal.
https://github.com/paulmillr/chokidar#api

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
