### PR TITLE
expose `event.routeId` and `page.routeId`

### DIFF
--- a/.changeset/mean-crews-unite.md
+++ b/.changeset/mean-crews-unite.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Expose event.routeKey
+Expose `event.routeId` and `page.routeId`

--- a/.changeset/mean-crews-unite.md
+++ b/.changeset/mean-crews-unite.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Expose event.routeKey

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -44,7 +44,8 @@ const ssr = async (req, res) => {
 		request = await getRequest(origin || get_origin(req.headers), req);
 	} catch (err) {
 		res.statusCode = err.status || 400;
-		return res.end(err.reason || 'Invalid request body');
+		res.end(err.reason || 'Invalid request body');
+		return;
 	}
 
 	if (address_header && !(address_header in req.headers)) {

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -127,6 +127,7 @@ export async function create_plugin(config, cwd) {
 
 							return {
 								type: 'endpoint',
+								key: route.key,
 								pattern,
 								names,
 								types,

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -12,7 +12,7 @@ import { coalesce_to_error } from '../../utils/error.js';
 import { load_template } from '../config/index.js';
 import { sequence } from '../../hooks.js';
 import { posixify } from '../../utils/filesystem.js';
-import { parse_route_key } from '../../utils/routing.js';
+import { parse_route_id } from '../../utils/routing.js';
 
 /**
  * @param {import('types').ValidatedConfig} config
@@ -105,7 +105,7 @@ export async function create_plugin(config, cwd) {
 							};
 						}),
 						routes: manifest_data.routes.map((route) => {
-							const { pattern, names, types } = parse_route_key(route.key);
+							const { pattern, names, types } = parse_route_id(route.key);
 
 							if (route.type === 'page') {
 								return {

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -105,12 +105,12 @@ export async function create_plugin(config, cwd) {
 							};
 						}),
 						routes: manifest_data.routes.map((route) => {
-							const { pattern, names, types } = parse_route_id(route.key);
+							const { pattern, names, types } = parse_route_id(route.id);
 
 							if (route.type === 'page') {
 								return {
 									type: 'page',
-									key: route.key,
+									id: route.id,
 									pattern,
 									names,
 									types,
@@ -127,7 +127,7 @@ export async function create_plugin(config, cwd) {
 
 							return {
 								type: 'endpoint',
-								key: route.key,
+								id: route.id,
 								pattern,
 								names,
 								types,

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -1,5 +1,5 @@
 import { s } from '../../utils/misc.js';
-import { parse_route_key } from '../../utils/routing.js';
+import { parse_route_id } from '../../utils/routing.js';
 import { get_mime_lookup } from '../utils.js';
 
 /**
@@ -72,7 +72,7 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 			],
 			routes: [
 				${routes.map(route => {
-					const { pattern, names, types } = parse_route_key(route.key);
+					const { pattern, names, types } = parse_route_id(route.key);
 
 					types.forEach(type => {
 						if (type) validators.add(type);

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -99,6 +99,7 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 
 						return `{
 							type: 'endpoint',
+							key: ${s(route.key)},
 							pattern: ${pattern},
 							names: ${s(names)},
 							types: ${s(types)},

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -72,7 +72,7 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 			],
 			routes: [
 				${routes.map(route => {
-					const { pattern, names, types } = parse_route_id(route.key);
+					const { pattern, names, types } = parse_route_id(route.id);
 
 					types.forEach(type => {
 						if (type) validators.add(type);
@@ -81,7 +81,7 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 					if (route.type === 'page') {
 						return `{
 							type: 'page',
-							key: ${s(route.key)},
+							id: ${s(route.id)},
 							pattern: ${pattern},
 							names: ${s(names)},
 							types: ${s(types)},
@@ -99,7 +99,7 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 
 						return `{
 							type: 'endpoint',
-							key: ${s(route.key)},
+							id: ${s(route.id)},
 							pattern: ${pattern},
 							names: ${s(names)},
 							types: ${s(types)},

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -61,13 +61,13 @@ export default function create_manifest_data({
 
 	/**
 	 * @param {string} dir
-	 * @param {string[]} parent_key
+	 * @param {string[]} parent_id
 	 * @param {Part[][]} parent_segments
 	 * @param {string[]} parent_params
 	 * @param {Array<string|undefined>} layout_stack // accumulated __layout.svelte components
 	 * @param {Array<string|undefined>} error_stack // accumulated __error.svelte components
 	 */
-	function walk(dir, parent_key, parent_segments, parent_params, layout_stack, error_stack) {
+	function walk(dir, parent_id, parent_segments, parent_params, layout_stack, error_stack) {
 		/** @type {Item[]} */
 		let items = [];
 		fs.readdirSync(dir).forEach((basename) => {
@@ -135,7 +135,7 @@ export default function create_manifest_data({
 		items = items.sort(comparator);
 
 		items.forEach((item) => {
-			const key = parent_key.slice();
+			const id = parent_id.slice();
 			const segments = parent_segments.slice();
 
 			if (item.is_index) {
@@ -161,13 +161,13 @@ export default function create_manifest_data({
 						}
 
 						segments[segments.length - 1] = last_segment;
-						key[key.length - 1] += item.route_suffix;
+						id[id.length - 1] += item.route_suffix;
 					} else {
 						segments.push(item.parts);
 					}
 				}
 			} else {
-				key.push(item.name);
+				id.push(item.name);
 				segments.push(item.parts);
 			}
 
@@ -201,7 +201,7 @@ export default function create_manifest_data({
 
 				walk(
 					path.join(dir, item.basename),
-					key,
+					id,
 					segments,
 					params,
 					layout_reset ? [layout_reset] : layout_stack.concat(layout),
@@ -236,7 +236,7 @@ export default function create_manifest_data({
 
 				routes.push({
 					type: 'page',
-					key: key.join('/'),
+					id: id.join('/'),
 					segments: simple_segments,
 					pattern,
 					params,
@@ -250,7 +250,7 @@ export default function create_manifest_data({
 
 				routes.push({
 					type: 'endpoint',
-					key: key.join('/'),
+					id: id.join('/'),
 					segments: simple_segments,
 					pattern,
 					file: item.file,
@@ -272,15 +272,15 @@ export default function create_manifest_data({
 	const lookup = new Map();
 	for (const route of routes) {
 		if (route.type === 'page') {
-			lookup.set(route.key, route);
+			lookup.set(route.id, route);
 		}
 	}
 
 	let i = routes.length;
 	while (i--) {
 		const route = routes[i];
-		if (route.type === 'endpoint' && lookup.has(route.key)) {
-			lookup.get(route.key).shadow = route.file;
+		if (route.type === 'endpoint' && lookup.has(route.id)) {
+			lookup.get(route.id).shadow = route.file;
 			routes.splice(i, 1);
 		}
 	}

--- a/packages/kit/src/core/sync/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.spec.js
@@ -42,7 +42,7 @@ test('creates routes', () => {
 	assert.equal(routes, [
 		{
 			type: 'page',
-			key: '',
+			id: '',
 			segments: [],
 			pattern: /^\/$/,
 			params: [],
@@ -54,7 +54,7 @@ test('creates routes', () => {
 
 		{
 			type: 'page',
-			key: 'about',
+			id: 'about',
 			segments: [{ rest: false, dynamic: false, content: 'about' }],
 			pattern: /^\/about\/?$/,
 			params: [],
@@ -66,7 +66,7 @@ test('creates routes', () => {
 
 		{
 			type: 'endpoint',
-			key: 'blog.json',
+			id: 'blog.json',
 			segments: [{ rest: false, dynamic: false, content: 'blog.json' }],
 			pattern: /^\/blog\.json$/,
 			file: 'samples/basic/blog/index.json.js',
@@ -75,7 +75,7 @@ test('creates routes', () => {
 
 		{
 			type: 'page',
-			key: 'blog',
+			id: 'blog',
 			segments: [{ rest: false, dynamic: false, content: 'blog' }],
 			pattern: /^\/blog\/?$/,
 			params: [],
@@ -87,7 +87,7 @@ test('creates routes', () => {
 
 		{
 			type: 'endpoint',
-			key: 'blog/[slug].json',
+			id: 'blog/[slug].json',
 			segments: [
 				{ rest: false, dynamic: false, content: 'blog' },
 				{ rest: false, dynamic: true, content: '[slug].json' }
@@ -99,7 +99,7 @@ test('creates routes', () => {
 
 		{
 			type: 'page',
-			key: 'blog/[slug]',
+			id: 'blog/[slug]',
 			segments: [
 				{ rest: false, dynamic: false, content: 'blog' },
 				{ rest: false, dynamic: true, content: '[slug]' }
@@ -128,7 +128,7 @@ test('creates routes with layout', () => {
 	assert.equal(routes, [
 		{
 			type: 'page',
-			key: '',
+			id: '',
 			segments: [],
 			pattern: /^\/$/,
 			params: [],
@@ -140,7 +140,7 @@ test('creates routes with layout', () => {
 
 		{
 			type: 'page',
-			key: 'foo',
+			id: 'foo',
 			segments: [{ rest: false, dynamic: false, content: 'foo' }],
 			pattern: /^\/foo\/?$/,
 			params: [],
@@ -224,7 +224,7 @@ test('disallows rest parameters inside segments', () => {
 	assert.equal(routes, [
 		{
 			type: 'page',
-			key: 'prefix-[...rest]',
+			id: 'prefix-[...rest]',
 			segments: [
 				{
 					dynamic: true,
@@ -241,7 +241,7 @@ test('disallows rest parameters inside segments', () => {
 		},
 		{
 			type: 'endpoint',
-			key: '[...rest].json',
+			id: '[...rest].json',
 			segments: [
 				{
 					dynamic: true,
@@ -308,7 +308,7 @@ test('allows multiple slugs', () => {
 		[
 			{
 				type: 'endpoint',
-				key: '[file].[ext]',
+				id: '[file].[ext]',
 				segments: [{ dynamic: true, rest: false, content: '[file].[ext]' }],
 				pattern: /^\/([^/]+?)\.([^/]+?)$/,
 				file: 'samples/multiple-slugs/[file].[ext].js',
@@ -330,7 +330,7 @@ test('ignores things that look like lockfiles', () => {
 	assert.equal(routes, [
 		{
 			type: 'endpoint',
-			key: 'foo',
+			id: 'foo',
 			segments: [{ rest: false, dynamic: false, content: 'foo' }],
 			file: 'samples/lockfiles/foo.js',
 			params: [],
@@ -354,7 +354,7 @@ test('works with custom extensions', () => {
 	assert.equal(routes, [
 		{
 			type: 'page',
-			key: '',
+			id: '',
 			segments: [],
 			pattern: /^\/$/,
 			params: [],
@@ -366,7 +366,7 @@ test('works with custom extensions', () => {
 
 		{
 			type: 'page',
-			key: 'about',
+			id: 'about',
 			segments: [{ rest: false, dynamic: false, content: 'about' }],
 			pattern: /^\/about\/?$/,
 			params: [],
@@ -378,7 +378,7 @@ test('works with custom extensions', () => {
 
 		{
 			type: 'endpoint',
-			key: 'blog.json',
+			id: 'blog.json',
 			segments: [{ rest: false, dynamic: false, content: 'blog.json' }],
 			pattern: /^\/blog\.json$/,
 			file: 'samples/custom-extension/blog/index.json.js',
@@ -387,7 +387,7 @@ test('works with custom extensions', () => {
 
 		{
 			type: 'page',
-			key: 'blog',
+			id: 'blog',
 			segments: [{ rest: false, dynamic: false, content: 'blog' }],
 			pattern: /^\/blog\/?$/,
 			params: [],
@@ -399,7 +399,7 @@ test('works with custom extensions', () => {
 
 		{
 			type: 'endpoint',
-			key: 'blog/[slug].json',
+			id: 'blog/[slug].json',
 			segments: [
 				{ rest: false, dynamic: false, content: 'blog' },
 				{ rest: false, dynamic: true, content: '[slug].json' }
@@ -411,7 +411,7 @@ test('works with custom extensions', () => {
 
 		{
 			type: 'page',
-			key: 'blog/[slug]',
+			id: 'blog/[slug]',
 			segments: [
 				{ rest: false, dynamic: false, content: 'blog' },
 				{ rest: false, dynamic: true, content: '[slug]' }
@@ -449,7 +449,7 @@ test('includes nested error components', () => {
 	assert.equal(routes, [
 		{
 			type: 'page',
-			key: 'foo/bar/baz',
+			id: 'foo/bar/baz',
 			segments: [
 				{ rest: false, dynamic: false, content: 'foo' },
 				{ rest: false, dynamic: false, content: 'bar' },
@@ -482,7 +482,7 @@ test('resets layout', () => {
 	assert.equal(routes, [
 		{
 			type: 'page',
-			key: '',
+			id: '',
 			segments: [],
 			pattern: /^\/$/,
 			params: [],
@@ -493,7 +493,7 @@ test('resets layout', () => {
 		},
 		{
 			type: 'page',
-			key: 'foo',
+			id: 'foo',
 			segments: [{ rest: false, dynamic: false, content: 'foo' }],
 			pattern: /^\/foo\/?$/,
 			params: [],
@@ -508,7 +508,7 @@ test('resets layout', () => {
 		},
 		{
 			type: 'page',
-			key: 'foo/bar',
+			id: 'foo/bar',
 			segments: [
 				{ rest: false, dynamic: false, content: 'foo' },
 				{ rest: false, dynamic: false, content: 'bar' }

--- a/packages/kit/src/core/sync/write_manifest.js
+++ b/packages/kit/src/core/sync/write_manifest.js
@@ -35,7 +35,7 @@ export function write_manifest(manifest_data, base, output) {
 					const tuple = [get_indices(route.a), get_indices(route.b)];
 					if (route.shadow) tuple.push('1');
 
-					return `${s(route.key)}: [${tuple.join(', ')}]`;
+					return `${s(route.id)}: [${tuple.join(', ')}]`;
 				}
 			})
 			.filter(Boolean)

--- a/packages/kit/src/runtime/client/parse.js
+++ b/packages/kit/src/runtime/client/parse.js
@@ -1,16 +1,17 @@
-import { exec, parse_route_key } from '../../utils/routing.js';
+import { exec, parse_route_id } from '../../utils/routing.js';
 
 /**
- * @param {import("types").CSRComponentLoader[]} components
+ * @param {import('types').CSRComponentLoader[]} components
  * @param {Record<string, [number[], number[], 1?]>} dictionary
  * @param {Record<string, (param: string) => boolean>} validators
+ * @returns {import('types').CSRRoute[]}
  */
 export function parse(components, dictionary, validators) {
-	const routes = Object.entries(dictionary).map(([key, [a, b, has_shadow]]) => {
-		const { pattern, names, types } = parse_route_key(key);
+	const routes = Object.entries(dictionary).map(([id, [a, b, has_shadow]]) => {
+		const { pattern, names, types } = parse_route_id(id);
 
 		return {
-			key,
+			id,
 			/** @param {string} path */
 			exec: (path) => {
 				const match = pattern.exec(path);

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -18,6 +18,7 @@ import { set_paths } from '../paths.js';
  *     error: Error;
  *     nodes: Array<Promise<import('types').CSRComponent>>;
  *     params: Record<string, string>;
+ *     routeId: string | null;
  *   };
  * }} opts
  */

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -24,6 +24,7 @@ export interface Client {
 		error: Error;
 		nodes: Array<Promise<CSRComponent>>;
 		params: Record<string, string>;
+		routeId: string | null;
 	}) => Promise<void>;
 	_start_router: () => void;
 }

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -37,7 +37,7 @@ export function is_text(content_type) {
 /**
  * @param {import('types').RequestEvent} event
  * @param {{ [method: string]: import('types').RequestHandler }} mod
- * @returns {Promise<Response | undefined>}
+ * @returns {Promise<Response>}
  */
 export async function render_endpoint(event, mod) {
 	const method = normalize_request_method(event);
@@ -48,8 +48,17 @@ export async function render_endpoint(event, mod) {
 	if (!handler && method === 'head') {
 		handler = mod.get;
 	}
+
 	if (!handler) {
-		return;
+		return event.request.headers.get('x-sveltekit-load')
+			? // TODO would be nice to avoid these requests altogether,
+			  // by noting whether or not page endpoints export `get`
+			  new Response(undefined, {
+					status: 204
+			  })
+			: new Response('Method not allowed', {
+					status: 405
+			  });
 	}
 
 	const response = await handler(event);

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -173,14 +173,14 @@ export async function respond(request, options, state) {
 
 				if (state.prerender && state.prerender.fallback) {
 					return await render_response({
-						url: event.url,
-						params: event.params,
+						event,
 						options,
 						state,
 						$session: await options.hooks.getSession(event),
 						page_config: { router: true, hydrate: true },
 						stuff: {},
 						status: 200,
+						error: null,
 						branch: [],
 						resolve_opts: {
 							...resolve_opts,

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -117,7 +117,7 @@ export async function respond(request, options, state) {
 		params,
 		platform: state.platform,
 		request,
-		routeId: route && route.key,
+		routeId: route && route.id,
 		url
 	};
 

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -14,7 +14,7 @@ const default_transform = ({ html }) => html;
 
 /** @type {import('types').Respond} */
 export async function respond(request, options, state) {
-	const url = new URL(request.url);
+	let url = new URL(request.url);
 
 	const normalized = normalize_path(url.pathname, options.trailing_slash);
 
@@ -52,6 +52,50 @@ export async function respond(request, options, state) {
 		}
 	}
 
+	let decoded = decodeURI(url.pathname);
+
+	/** @type {import('types').SSRRoute | null} */
+	let route = null;
+
+	/** @type {Record<string, string>} */
+	let params = {};
+
+	if (options.paths.base) {
+		if (!decoded.startsWith(options.paths.base)) {
+			return new Response(undefined, { status: 404 });
+		}
+		decoded = decoded.slice(options.paths.base.length) || '/';
+	}
+
+	const is_data_request = decoded.endsWith(DATA_SUFFIX);
+
+	if (is_data_request) {
+		decoded = decoded.slice(0, -DATA_SUFFIX.length) || '/';
+
+		const normalized = normalize_path(
+			url.pathname.slice(0, -DATA_SUFFIX.length),
+			options.trailing_slash
+		);
+
+		url = new URL(url.origin + normalized + url.search);
+	}
+
+	if (!state.prerender || !state.prerender.fallback) {
+		const validators = await options.manifest._.validators();
+
+		for (const candidate of options.manifest._.routes) {
+			const match = candidate.pattern.exec(decoded);
+			if (!match) continue;
+
+			const matched = exec(match, candidate.names, candidate.types, validators);
+			if (matched) {
+				route = candidate;
+				params = decode_params(matched);
+				break;
+			}
+		}
+	}
+
 	/** @type {import('types').RequestEvent} */
 	const event = {
 		get clientAddress() {
@@ -70,9 +114,10 @@ export async function respond(request, options, state) {
 			return event.clientAddress;
 		},
 		locals: {},
-		params: {},
+		params,
 		platform: state.platform,
 		request,
+		routeKey: route && route.key,
 		url
 	};
 
@@ -115,45 +160,6 @@ export async function respond(request, options, state) {
 		transformPage: default_transform
 	};
 
-	const validators = await options.manifest._.validators();
-
-	let decoded = decodeURI(event.url.pathname);
-
-	/** @type {import('types').SSRRoute} */
-	let matched;
-
-	if (options.paths.base) {
-		if (!decoded.startsWith(options.paths.base)) {
-			return new Response(undefined, { status: 404 });
-		}
-		decoded = decoded.slice(options.paths.base.length) || '/';
-	}
-
-	const is_data_request = decoded.endsWith(DATA_SUFFIX);
-
-	if (is_data_request) {
-		decoded = decoded.slice(0, -DATA_SUFFIX.length) || '/';
-
-		const normalized = normalize_path(
-			url.pathname.slice(0, -DATA_SUFFIX.length),
-			options.trailing_slash
-		);
-
-		event.url = new URL(event.url.origin + normalized + event.url.search);
-	}
-
-	for (const route of options.manifest._.routes) {
-		const match = route.pattern.exec(decoded);
-		if (!match) continue;
-
-		const params = exec(match, route.names, route.types, validators);
-		if (params) {
-			event.params = decode_params(params);
-			matched = route;
-			break;
-		}
-	}
-
 	try {
 		const response = await options.hooks.handle({
 			event,
@@ -183,41 +189,35 @@ export async function respond(request, options, state) {
 					});
 				}
 
-				if (matched) {
-					/** @type {Response | undefined} */
+				if (route) {
+					/** @type {Response} */
 					let response;
 
-					if (is_data_request && matched.type === 'page' && matched.shadow) {
-						response = await render_endpoint(event, await matched.shadow());
+					if (is_data_request && route.type === 'page' && route.shadow) {
+						response = await render_endpoint(event, await route.shadow());
 
 						// loading data for a client-side transition is a special case
 						if (request.headers.has('x-sveltekit-load')) {
-							if (response) {
-								// since redirects are opaque to the browser, we need to repackage
-								// 3xx responses as 200s with a custom header
-								if (response.status >= 300 && response.status < 400) {
-									const location = response.headers.get('location');
+							// since redirects are opaque to the browser, we need to repackage
+							// 3xx responses as 200s with a custom header
+							if (response.status >= 300 && response.status < 400) {
+								const location = response.headers.get('location');
 
-									if (location) {
-										const headers = new Headers(response.headers);
-										headers.set('x-sveltekit-location', location);
-										response = new Response(undefined, {
-											status: 204,
-											headers
-										});
-									}
+								if (location) {
+									const headers = new Headers(response.headers);
+									headers.set('x-sveltekit-location', location);
+									response = new Response(undefined, {
+										status: 204,
+										headers
+									});
 								}
-							} else {
-								response = new Response(undefined, {
-									status: 204
-								});
 							}
 						}
 					} else {
 						response =
-							matched.type === 'endpoint'
-								? await render_endpoint(event, await matched.load())
-								: await render_page(event, matched, options, state, resolve_opts);
+							route.type === 'endpoint'
+								? await render_endpoint(event, await route.load())
+								: await render_page(event, route, options, state, resolve_opts);
 					}
 
 					if (response) {

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -117,7 +117,7 @@ export async function respond(request, options, state) {
 		params,
 		platform: state.platform,
 		request,
-		routeKey: route && route.key,
+		routeId: route && route.key,
 		url
 	};
 

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -7,7 +7,7 @@ import { respond } from './respond.js';
  * @param {import('types').SSROptions} options
  * @param {import('types').SSRState} state
  * @param {import('types').RequiredResolveOptions} resolve_opts
- * @returns {Promise<Response | undefined>}
+ * @returns {Promise<Response>}
  */
 export async function render_page(event, route, options, state, resolve_opts) {
 	if (state.initiator === route) {
@@ -30,29 +30,14 @@ export async function render_page(event, route, options, state, resolve_opts) {
 
 	const $session = await options.hooks.getSession(event);
 
-	const response = await respond({
+	return respond({
 		event,
 		options,
 		state,
 		$session,
 		resolve_opts,
-		route,
-		params: event.params // TODO this is redundant
+		route
 	});
-
-	if (response) {
-		return response;
-	}
-
-	if (state.fetched) {
-		// we came here because of a bad request in a `load` function.
-		// rather than render the error page — which could lead to an
-		// infinite loop, if the `load` belonged to the root layout,
-		// we respond with a bare-bones 500
-		return new Response(`Bad request in load function: failed to fetch ${state.fetched}`, {
-			status: 500
-		});
-	}
 }
 
 /**

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -11,8 +11,6 @@ import { coalesce_to_error } from '../../../utils/error.js';
  *   options: import('types').SSROptions;
  *   state: import('types').SSRState;
  *   route: import('types').SSRPage | null;
- *   url: URL;
- *   params: Record<string, string>;
  *   node: import('types').SSRNode;
  *   $session: any;
  *   stuff: Record<string, any>;
@@ -28,8 +26,6 @@ export async function load_node({
 	options,
 	state,
 	route,
-	url,
-	params,
 	node,
 	$session,
 	stuff,
@@ -80,8 +76,8 @@ export async function load_node({
 	} else if (module.load) {
 		/** @type {import('types').LoadInput | import('types').ErrorLoadInput} */
 		const load_input = {
-			url: state.prerender ? create_prerendering_url_proxy(url) : url,
-			params,
+			url: state.prerender ? create_prerendering_url_proxy(event.url) : event.url,
+			params: event.params,
 			props: shadow.body || {},
 			get session() {
 				uses_credentials = true;
@@ -160,7 +156,10 @@ export async function load_node({
 							headers: type ? { 'content-type': type } : {}
 						});
 					} else {
-						response = await fetch(`${url.origin}/${file}`, /** @type {RequestInit} */ (opts));
+						response = await fetch(
+							`${event.url.origin}/${file}`,
+							/** @type {RequestInit} */ (opts)
+						);
 					}
 				} else if (is_root_relative(resolved)) {
 					if (opts.credentials !== 'omit') {
@@ -187,7 +186,6 @@ export async function load_node({
 					}
 
 					response = await respond(new Request(new URL(requested, event.url).href, opts), options, {
-						fetched: requested,
 						getClientAddress: state.getClientAddress,
 						initiator: route,
 						prerender: state.prerender

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -79,6 +79,7 @@ export async function load_node({
 			url: state.prerender ? create_prerendering_url_proxy(event.url) : event.url,
 			params: event.params,
 			props: shadow.body || {},
+			routeId: event.routeId,
 			get session() {
 				uses_credentials = true;
 				return $session;

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -18,9 +18,8 @@ import { coalesce_to_error } from '../../../utils/error.js';
  *   $session: any;
  *   resolve_opts: import('types').RequiredResolveOptions;
  *   route: import('types').SSRPage;
- *   params: Record<string, string>;
  * }} opts
- * @returns {Promise<Response | undefined>}
+ * @returns {Promise<Response>}
  */
 export async function respond(opts) {
 	const { event, options, state, $session, route, resolve_opts } = opts;
@@ -38,6 +37,7 @@ export async function respond(opts) {
 			},
 			status: 200,
 			url: event.url,
+			params: event.params,
 			stuff: {}
 		});
 	}
@@ -104,14 +104,11 @@ export async function respond(opts) {
 				try {
 					loaded = await load_node({
 						...opts,
-						url: event.url,
 						node,
 						stuff,
 						is_error: false,
 						is_leaf: i === nodes.length - 1
 					});
-
-					if (!loaded) return;
 
 					set_cookie_headers = set_cookie_headers.concat(loaded.set_cookie_headers);
 
@@ -159,7 +156,6 @@ export async function respond(opts) {
 								const error_loaded = /** @type {import('./types').Loaded} */ (
 									await load_node({
 										...opts,
-										url: event.url,
 										node: error_node,
 										stuff: node_loaded.stuff,
 										is_error: true,
@@ -220,6 +216,7 @@ export async function respond(opts) {
 				...opts,
 				stuff,
 				url: event.url,
+				params: event.params,
 				page_config,
 				status,
 				error,

--- a/packages/kit/src/runtime/server/page/respond.js
+++ b/packages/kit/src/runtime/server/page/respond.js
@@ -36,8 +36,8 @@ export async function respond(opts) {
 				router: true
 			},
 			status: 200,
-			url: event.url,
-			params: event.params,
+			error: null,
+			event,
 			stuff: {}
 		});
 	}
@@ -85,8 +85,8 @@ export async function respond(opts) {
 	/** @type {number} */
 	let status = 200;
 
-	/** @type {Error|undefined} */
-	let error;
+	/** @type {Error | null} */
+	let error = null;
 
 	/** @type {string[]} */
 	let set_cookie_headers = [];
@@ -215,8 +215,7 @@ export async function respond(opts) {
 			await render_response({
 				...opts,
 				stuff,
-				url: event.url,
-				params: event.params,
+				event,
 				page_config,
 				status,
 				error,

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -41,8 +41,6 @@ export async function respond_with_error({
 				options,
 				state,
 				route: null,
-				url: event.url, // TODO this is redundant, no?
-				params,
 				node: default_layout,
 				$session,
 				stuff: {},
@@ -57,8 +55,6 @@ export async function respond_with_error({
 				options,
 				state,
 				route: null,
-				url: event.url,
-				params,
 				node: default_error,
 				$session,
 				stuff: layout_loaded ? layout_loaded.stuff : {},

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -32,9 +32,6 @@ export async function respond_with_error({
 		const default_layout = await options.manifest._.nodes[0](); // 0 is always the root layout
 		const default_error = await options.manifest._.nodes[1](); // 1 is always the root error
 
-		/** @type {Record<string, string>} */
-		const params = {}; // error page has no params
-
 		const layout_loaded = /** @type {Loaded} */ (
 			await load_node({
 				event,
@@ -77,8 +74,7 @@ export async function respond_with_error({
 			status,
 			error,
 			branch: [layout_loaded, error_loaded],
-			url: event.url,
-			params,
+			event,
 			resolve_opts
 		});
 	} catch (err) {

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -1,5 +1,5 @@
 /** @param {string} key */
-export function parse_route_key(key) {
+export function parse_route_id(key) {
 	/** @type {string[]} */
 	const names = [];
 

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -1,6 +1,6 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import { parse_route_key } from './routing.js';
+import { parse_route_id } from './routing.js';
 
 const tests = {
 	'': {
@@ -11,8 +11,8 @@ const tests = {
 };
 
 for (const [key, expected] of Object.entries(tests)) {
-	test(`parse_route_key: "${key}"`, () => {
-		const actual = parse_route_key(key);
+	test(`parse_route_id: "${key}"`, () => {
+		const actual = parse_route_id(key);
 
 		assert.equal(actual.pattern.toString(), expected.pattern.toString());
 	});

--- a/packages/kit/test/apps/basics/src/app.d.ts
+++ b/packages/kit/test/apps/basics/src/app.d.ts
@@ -2,6 +2,7 @@ declare namespace App {
 	interface Locals {
 		answer: number;
 		name: string;
+		key: string;
 		params: Record<string, string>;
 	}
 

--- a/packages/kit/test/apps/basics/src/hooks.js
+++ b/packages/kit/test/apps/basics/src/hooks.js
@@ -25,7 +25,7 @@ export const handleError = ({ event, error }) => {
 
 export const handle = sequence(
 	({ event, resolve }) => {
-		event.locals.key = event.routeKey;
+		event.locals.key = event.routeId;
 		event.locals.params = event.params;
 		event.locals.answer = 42;
 		return resolve(event);

--- a/packages/kit/test/apps/basics/src/hooks.js
+++ b/packages/kit/test/apps/basics/src/hooks.js
@@ -25,6 +25,7 @@ export const handleError = ({ event, error }) => {
 
 export const handle = sequence(
 	({ event, resolve }) => {
+		event.locals.key = event.routeKey;
 		event.locals.params = event.params;
 		event.locals.answer = 42;
 		return resolve(event);

--- a/packages/kit/test/apps/basics/src/routes/routing/params-in-handle/[x].js
+++ b/packages/kit/test/apps/basics/src/routes/routing/params-in-handle/[x].js
@@ -2,6 +2,7 @@
 export function get({ locals }) {
 	return {
 		body: {
+			key: locals.key,
 			params: locals.params
 		}
 	};

--- a/packages/kit/test/apps/basics/src/routes/routing/route-id/[x].svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/route-id/[x].svelte
@@ -1,0 +1,18 @@
+<script context="module">
+	/** @type {import('./[x]').RequestHandler} */
+	export function load({ routeId }) {
+		return {
+			props: { routeId }
+		};
+	}
+</script>
+
+<script>
+	import { page } from '$app/stores';
+
+	/** @type {string} */
+	export let routeId;
+</script>
+
+<h1>routeId in load: {routeId}</h1>
+<h2>routeId in store: {$page.routeId}</h2>

--- a/packages/kit/test/apps/basics/src/routes/routing/route-id/[x].svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/route-id/[x].svelte
@@ -1,5 +1,5 @@
 <script context="module">
-	/** @type {import('./[x]').RequestHandler} */
+	/** @type {import('./[x]').Load} */
 	export function load({ routeId }) {
 		return {
 			props: { routeId }

--- a/packages/kit/test/apps/basics/src/routes/routing/route-id/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/route-id/index.svelte
@@ -1,0 +1,1 @@
+<a href="/routing/route-id/foo">/routing/route-id/foo</a>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -2164,6 +2164,14 @@ test.describe.parallel('Routing', () => {
 			params: { x: 'banana' }
 		});
 	});
+
+	test('exposes page.routeId', async ({ page, clicknav }) => {
+		await page.goto('/routing/route-id');
+		await clicknav('[href="/routing/route-id/foo"]');
+
+		expect(await page.textContent('h1')).toBe('routeId in load: routing/route-id/[x]');
+		expect(await page.textContent('h2')).toBe('routeId in store: routing/route-id/[x]');
+	});
 });
 
 test.describe.parallel('Session', () => {

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -2160,6 +2160,7 @@ test.describe.parallel('Routing', () => {
 	test('event.params are available in handle', async ({ request }) => {
 		const response = await request.get('/routing/params-in-handle/banana');
 		expect(await response.json()).toStrictEqual({
+			key: 'routing/params-in-handle/[x]',
 			params: { x: 'banana' }
 		});
 	});

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -204,6 +204,7 @@ export interface Navigation {
 export interface Page<Params extends Record<string, string> = Record<string, string>> {
 	url: URL;
 	params: Params;
+	routeId: string | null;
 	stuff: App.Stuff;
 	status: number;
 	error: Error | null;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -68,6 +68,7 @@ export type CSRComponent = any; // TODO
 export type CSRComponentLoader = () => Promise<CSRComponent>;
 
 export type CSRRoute = {
+	id: string;
 	exec: (path: string) => undefined | Record<string, string>;
 	a: CSRComponentLoader[];
 	b: CSRComponentLoader[];

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -77,7 +77,7 @@ export type CSRRoute = {
 
 export interface EndpointData {
 	type: 'endpoint';
-	key: string;
+	id: string;
 	segments: RouteSegment[];
 	pattern: RegExp;
 	params: string[];
@@ -127,7 +127,7 @@ export type NormalizedLoadOutput = {
 
 export interface PageData {
 	type: 'page';
-	key: string;
+	id: string;
 	shadow: string | null;
 	segments: RouteSegment[];
 	pattern: RegExp;
@@ -217,7 +217,7 @@ export type SSRComponentLoader = () => Promise<SSRComponent>;
 
 export interface SSREndpoint {
 	type: 'endpoint';
-	key: string;
+	id: string;
 	pattern: RegExp;
 	names: string[];
 	types: string[];
@@ -278,7 +278,7 @@ export interface SSROptions {
 
 export interface SSRPage {
 	type: 'page';
-	key: string;
+	id: string;
 	pattern: RegExp;
 	names: string[];
 	types: string[];

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -216,6 +216,7 @@ export type SSRComponentLoader = () => Promise<SSRComponent>;
 
 export interface SSREndpoint {
 	type: 'endpoint';
+	key: string;
 	pattern: RegExp;
 	names: string[];
 	types: string[];
@@ -276,6 +277,7 @@ export interface SSROptions {
 
 export interface SSRPage {
 	type: 'page';
+	key: string;
 	pattern: RegExp;
 	names: string[];
 	types: string[];
@@ -304,7 +306,6 @@ export type SSRRoute = SSREndpoint | SSRPage;
 
 export interface SSRState {
 	fallback?: string;
-	fetched?: string;
 	getClientAddress: () => string;
 	initiator?: SSRPage | null;
 	platform?: any;

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -162,12 +162,13 @@ export interface LoadInput<
 	Params extends Record<string, string> = Record<string, string>,
 	Props extends Record<string, any> = Record<string, any>
 > {
-	url: URL;
+	fetch(info: RequestInfo, init?: RequestInit): Promise<Response>;
 	params: Params;
 	props: Props;
-	fetch(info: RequestInfo, init?: RequestInit): Promise<Response>;
+	routeId: string | null;
 	session: App.Session;
 	stuff: Partial<App.Stuff>;
+	url: URL;
 }
 
 export interface LoadOutput<Props extends Record<string, any> = Record<string, any>> {

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -235,7 +235,7 @@ export interface RequestEvent<Params extends Record<string, string> = Record<str
 	params: Params;
 	platform: Readonly<App.Platform>;
 	request: Request;
-	routeKey: string | null;
+	routeId: string | null;
 	url: URL;
 }
 

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -235,6 +235,7 @@ export interface RequestEvent<Params extends Record<string, string> = Record<str
 	params: Params;
 	platform: Readonly<App.Platform>;
 	request: Request;
+	routeKey: string | null;
 	url: URL;
 }
 


### PR DESCRIPTION
closes #3840 (and #3907) by exposing the internal `route.key` as `event.routeKey`. This is a string based on the filename of the page/endpoint:

| filename                                            | `event.routeKey`                             |
|-----------------------------------------------------|---------------------------------|
| src/routes/index.svelte                             | `""`                            |
| src/routes/about.svelte                             | `"about"`                       |
| src/routes/blog/index.js                            | `"blog"`                        |
| src/routes/blog/index.svelte                        | `"blog"`                        |
| src/routes/blog/[slug].svelte                       | `"blog/[slug]"`                 |
| src/routes/blog/archive/[page=integer]/index.svelte | `"blog/archive/[page=integer]"` |
| src/routes/[...catchall]                            | `"[...catchall]"`               |

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
