### PR TITLE
render fallback page regardless of trailingSlash

### DIFF
--- a/.changeset/few-carrots-sell.md
+++ b/.changeset/few-carrots-sell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Populate fallback page when trailingSlash is "always"

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -17,7 +17,7 @@ export async function respond(request, options, state) {
 
 	const normalized = normalize_path(url.pathname, options.trailing_slash);
 
-	if (normalized !== url.pathname) {
+	if (normalized !== url.pathname && !state.prerender?.fallback) {
 		return new Response(undefined, {
 			status: 301,
 			headers: {

--- a/packages/kit/test/prerendering/options/svelte.config.js
+++ b/packages/kit/test/prerendering/options/svelte.config.js
@@ -4,7 +4,9 @@ import adapter from '../../../../adapter-static/index.js';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter(),
+		adapter: adapter({
+			fallback: '200.html'
+		}),
 
 		csp: {
 			directives: {

--- a/packages/kit/test/prerendering/options/test/test.js
+++ b/packages/kit/test/prerendering/options/test/test.js
@@ -31,4 +31,10 @@ test('does not copy `public` into `_app`', () => {
 	assert.ok(!fs.existsSync(`${build}/_app/robots.txt`));
 });
 
+// https://github.com/sveltejs/kit/issues/4340
+test('populates fallback 200.html file', () => {
+	const content = read('200.html');
+	assert.ok(content !== '');
+});
+
 test.run();


### PR DESCRIPTION
Trailing slash normalisation was causing this to be a redirect. Fixes #4340

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
