### PR TITLE
fix rest param type generation

### DIFF
--- a/.changeset/happy-eggs-shop.md
+++ b/.changeset/happy-eggs-shop.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix rest param type generation

--- a/packages/kit/src/core/sync/write_types.js
+++ b/packages/kit/src/core/sync/write_types.js
@@ -29,7 +29,7 @@ export function write_types(config, manifest_data) {
 		/** @type {string[]} */
 		const params = [];
 
-		const pattern = /\[([^\]]+)\]/g;
+		const pattern = /\[(?:\.{3})?([^\]]+)\]/g;
 		let match;
 
 		while ((match = pattern.exec(key))) {


### PR DESCRIPTION
Fixes #4327.

For type generation, we manually extract the param names from the path, but we missed the existence of the spread operator.

We could get the canonical list of params from the manifest data for routes, but we don't have them for components (layouts and errors). Perhaps the manifest data could be refactored a bit so this would be available, but I have no thoughtful opinions for now—this just removes the spread operator from the names.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
