### PR TITLE
fix `waitForFunction` usage

### DIFF
--- a/packages/kit/test/ambient.d.ts
+++ b/packages/kit/test/ambient.d.ts
@@ -1,7 +1,7 @@
 declare global {
 	interface Window {
 		navigated: Promise<void>;
-		started: Promise<void>;
+		started: boolean;
 	}
 
 	const goto: (

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -98,14 +98,10 @@ export const test = base.extend({
 		if (javaScriptEnabled) {
 			page.addInitScript({
 				content: `
-					window.started = new Promise((fulfil, reject) => {
-						setTimeout(() => {
-							reject(new Error('Timed out'));
-						}, 5000);
+					window.started = false;
 
-						addEventListener('sveltekit:start', () => {
-							fulfil();
-						});
+					addEventListener('sveltekit:start', () => {
+						window.started = true;
 					});
 				`
 			});
@@ -120,7 +116,7 @@ export const test = base.extend({
 			async function (url, opts) {
 				const res = await goto.call(page, url, opts);
 				if (javaScriptEnabled) {
-					await page.waitForFunction(() => window.started);
+					await page.waitForFunction(() => window.started, undefined, { timeout: 5000 });
 				}
 				return res;
 			};


### PR DESCRIPTION
We assumed playwright's `page.waitForFunction()` worked with promises, but it turns out [it doesn't](https://playwright.dev/docs/api/class-page#page-wait-for-function). Since we use it to ensure kit is initialized after a `page.goto()`, this could be _a_ source of flakiness on tests.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
