### PR TITLE
Simplify `create_manifest_data`

### DIFF
--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -39,7 +39,11 @@ export function create_builder({ config, build_data, prerendered, log }) {
 			/** @type {import('types').RouteDefinition[]} */
 			const facades = routes.map((route) => ({
 				type: route.type,
-				segments: route.segments,
+				segments: route.id.split('/').map((segment) => ({
+					dynamic: segment.includes('['),
+					rest: segment.includes('[...'),
+					content: segment
+				})),
 				pattern: route.pattern,
 				methods: route.type === 'page' ? ['get'] : build_data.server.methods[route.file]
 			}));
@@ -68,22 +72,7 @@ export function create_builder({ config, build_data, prerendered, log }) {
 				// also be included, since the page likely needs the endpoint
 				filtered.forEach((route) => {
 					if (route.type === 'page') {
-						const length = route.segments.length;
-
-						const endpoint = routes.find((candidate) => {
-							if (candidate.segments.length !== length) return false;
-
-							for (let i = 0; i < length; i += 1) {
-								const a = route.segments[i];
-								const b = candidate.segments[i];
-
-								if (i === length - 1) {
-									return b.content === `${a.content}.json`;
-								}
-
-								if (a.content !== b.content) return false;
-							}
-						});
+						const endpoint = routes.find((candidate) => candidate.id === route.id + '.json');
 
 						if (endpoint) {
 							filtered.add(endpoint);

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -112,14 +112,6 @@ export default function create_manifest_data({
 				id_parts.push(item.name);
 			}
 
-			const segments = id_parts.map((segment) => {
-				return {
-					dynamic: segment.includes('['),
-					rest: segment.includes('[...'),
-					content: segment
-				};
-			});
-
 			if (item.is_dir) {
 				const layout_reset = find_layout('__layout.reset', item.file);
 				const layout = find_layout('__layout', item.file);
@@ -139,52 +131,50 @@ export default function create_manifest_data({
 					layout_reset ? [layout_reset] : layout_stack.concat(layout),
 					layout_reset ? [error] : error_stack.concat(error)
 				);
-			} else if (item.is_page) {
-				components.push(item.file);
-
-				const concatenated = layout_stack.concat(item.file);
-				const errors = error_stack.slice();
-
-				const id = id_parts.join('/');
-
-				const { pattern } = parse_route_id(id);
-
-				let i = concatenated.length;
-				while (i--) {
-					if (!errors[i] && !concatenated[i]) {
-						errors.splice(i, 1);
-						concatenated.splice(i, 1);
-					}
-				}
-
-				i = errors.length;
-				while (i--) {
-					if (errors[i]) break;
-				}
-
-				errors.splice(i + 1);
-
-				const path = id.includes('[') ? '' : `/${id}`;
-
-				routes.push({
-					type: 'page',
-					id,
-					pattern,
-					path,
-					shadow: null,
-					a: /** @type {string[]} */ (concatenated),
-					b: /** @type {string[]} */ (errors)
-				});
 			} else {
 				const id = id_parts.join('/');
 				const { pattern } = parse_route_id(id);
 
-				routes.push({
-					type: 'endpoint',
-					id,
-					pattern,
-					file: item.file
-				});
+				if (item.is_page) {
+					components.push(item.file);
+
+					const concatenated = layout_stack.concat(item.file);
+					const errors = error_stack.slice();
+
+					let i = concatenated.length;
+					while (i--) {
+						if (!errors[i] && !concatenated[i]) {
+							errors.splice(i, 1);
+							concatenated.splice(i, 1);
+						}
+					}
+
+					i = errors.length;
+					while (i--) {
+						if (errors[i]) break;
+					}
+
+					errors.splice(i + 1);
+
+					const path = id.includes('[') ? '' : `/${id}`;
+
+					routes.push({
+						type: 'page',
+						id,
+						pattern,
+						path,
+						shadow: null,
+						a: /** @type {string[]} */ (concatenated),
+						b: /** @type {string[]} */ (errors)
+					});
+				} else {
+					routes.push({
+						type: 'endpoint',
+						id,
+						pattern,
+						file: item.file
+					});
+				}
 			}
 		});
 	}

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -169,7 +169,6 @@ export default function create_manifest_data({
 				routes.push({
 					type: 'page',
 					id,
-					segments,
 					pattern,
 					path,
 					shadow: null,
@@ -183,7 +182,6 @@ export default function create_manifest_data({
 				routes.push({
 					type: 'endpoint',
 					id,
-					segments,
 					pattern,
 					file: item.file
 				});

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -66,7 +66,7 @@ export default function create_manifest_data({
 	 */
 	function walk(dir, parent_id, layout_stack, error_stack) {
 		/** @type {Item[]} */
-		let items = [];
+		const items = [];
 
 		fs.readdirSync(dir).forEach((basename) => {
 			const resolved = path.join(dir, basename);

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -103,7 +103,7 @@ export default function create_manifest_data({
 
 		items.forEach((item) => {
 			const id = parent_id.slice();
-			const segments = parent_segments.slice();
+			const segments = parent_segments.slice(); // TODO we don't actually need this
 
 			if (item.is_index) {
 				if (item.route_suffix) {
@@ -138,15 +138,11 @@ export default function create_manifest_data({
 				segments.push(item.parts);
 			}
 
-			// TODO seems slightly backwards to derive the simple segment representation
-			// from the more complex form, rather than vice versa — maybe swap it round
-			const simple_segments = segments.map((segment) => {
+			const simple_segments = id.map((segment) => {
 				return {
-					dynamic: segment.some((part) => part.dynamic),
-					rest: segment.some((part) => part.rest),
+					dynamic: segment.includes('['),
+					rest: segment.includes('[...'),
 					content: segment
-						.map((part) => (part.dynamic ? `[${part.content}]` : part.content))
-						.join('')
 				};
 			});
 

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -249,11 +249,7 @@ function count_occurrences(needle, haystack) {
 	return count;
 }
 
-/** @param {string} path */
-function is_spread(path) {
-	const spread_pattern = /\[\.{3}/g;
-	return spread_pattern.test(path);
-}
+const spread_pattern = /\[\.{3}/;
 
 /**
  * @param {Item} a
@@ -261,9 +257,8 @@ function is_spread(path) {
  */
 function comparator(a, b) {
 	if (a.is_index !== b.is_index) {
-		if (a.is_index) return is_spread(a.file) ? 1 : -1;
-
-		return is_spread(b.file) ? -1 : 1;
+		if (a.is_index) return spread_pattern.test(a.file) ? 1 : -1;
+		return spread_pattern.test(b.file) ? -1 : 1;
 	}
 
 	const max = Math.max(a.parts.length, b.parts.length);

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -61,11 +61,10 @@ export default function create_manifest_data({
 	 * @param {string} dir
 	 * @param {string[]} parent_id
 	 * @param {Part[][]} parent_segments
-	 * @param {string[]} parent_params
 	 * @param {Array<string|undefined>} layout_stack // accumulated __layout.svelte components
 	 * @param {Array<string|undefined>} error_stack // accumulated __error.svelte components
 	 */
-	function walk(dir, parent_id, parent_segments, parent_params, layout_stack, error_stack) {
+	function walk(dir, parent_id, parent_segments, layout_stack, error_stack) {
 		/** @type {Item[]} */
 		let items = [];
 
@@ -139,9 +138,6 @@ export default function create_manifest_data({
 				segments.push(item.parts);
 			}
 
-			const params = parent_params.slice();
-			params.push(...item.parts.filter((p) => p.dynamic).map((p) => p.content));
-
 			// TODO seems slightly backwards to derive the simple segment representation
 			// from the more complex form, rather than vice versa — maybe swap it round
 			const simple_segments = segments.map((segment) => {
@@ -171,7 +167,6 @@ export default function create_manifest_data({
 					path.join(dir, item.name),
 					id,
 					segments,
-					params,
 					layout_reset ? [layout_reset] : layout_stack.concat(layout),
 					layout_reset ? [error] : error_stack.concat(error)
 				);
@@ -207,7 +202,6 @@ export default function create_manifest_data({
 					id: id.join('/'),
 					segments: simple_segments,
 					pattern,
-					params,
 					path,
 					shadow: null,
 					a: /** @type {string[]} */ (concatenated),
@@ -221,8 +215,7 @@ export default function create_manifest_data({
 					id: id.join('/'),
 					segments: simple_segments,
 					pattern,
-					file: item.file,
-					params
+					file: item.file
 				});
 			}
 		});
@@ -235,7 +228,7 @@ export default function create_manifest_data({
 
 	components.push(layout, error);
 
-	walk(config.kit.files.routes, [], [], [], [layout], [error]);
+	walk(config.kit.files.routes, [], [], [layout], [error]);
 
 	const lookup = new Map();
 	for (const route of routes) {

--- a/packages/kit/src/core/sync/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.spec.js
@@ -42,7 +42,6 @@ test('creates routes', () => {
 		{
 			type: 'page',
 			id: '',
-			segments: [],
 			pattern: /^\/$/,
 			path: '/',
 			shadow: null,
@@ -53,7 +52,6 @@ test('creates routes', () => {
 		{
 			type: 'page',
 			id: 'about',
-			segments: [{ rest: false, dynamic: false, content: 'about' }],
 			pattern: /^\/about\/?$/,
 			path: '/about',
 			shadow: null,
@@ -64,7 +62,6 @@ test('creates routes', () => {
 		{
 			type: 'endpoint',
 			id: 'blog.json',
-			segments: [{ rest: false, dynamic: false, content: 'blog.json' }],
 			pattern: /^\/blog\.json$/,
 			file: 'samples/basic/blog/index.json.js'
 		},
@@ -72,7 +69,6 @@ test('creates routes', () => {
 		{
 			type: 'page',
 			id: 'blog',
-			segments: [{ rest: false, dynamic: false, content: 'blog' }],
 			pattern: /^\/blog\/?$/,
 			path: '/blog',
 			shadow: null,
@@ -83,10 +79,6 @@ test('creates routes', () => {
 		{
 			type: 'endpoint',
 			id: 'blog/[slug].json',
-			segments: [
-				{ rest: false, dynamic: false, content: 'blog' },
-				{ rest: false, dynamic: true, content: '[slug].json' }
-			],
 			pattern: /^\/blog\/([^/]+?)\.json$/,
 			file: 'samples/basic/blog/[slug].json.ts'
 		},
@@ -94,10 +86,6 @@ test('creates routes', () => {
 		{
 			type: 'page',
 			id: 'blog/[slug]',
-			segments: [
-				{ rest: false, dynamic: false, content: 'blog' },
-				{ rest: false, dynamic: true, content: '[slug]' }
-			],
 			pattern: /^\/blog\/([^/]+?)\/?$/,
 			path: '',
 			shadow: null,
@@ -122,7 +110,6 @@ test('creates routes with layout', () => {
 		{
 			type: 'page',
 			id: '',
-			segments: [],
 			pattern: /^\/$/,
 			path: '/',
 			shadow: null,
@@ -133,7 +120,6 @@ test('creates routes with layout', () => {
 		{
 			type: 'page',
 			id: 'foo',
-			segments: [{ rest: false, dynamic: false, content: 'foo' }],
 			pattern: /^\/foo\/?$/,
 			path: '/foo',
 			shadow: null,
@@ -209,20 +195,13 @@ test('sorts routes with rest correctly', () => {
 	);
 });
 
-test('disallows rest parameters inside segments', () => {
+test('allows rest parameters inside segments', () => {
 	const { routes } = create('samples/rest-prefix-suffix');
 
 	assert.equal(routes, [
 		{
 			type: 'page',
 			id: 'prefix-[...rest]',
-			segments: [
-				{
-					dynamic: true,
-					rest: true,
-					content: 'prefix-[...rest]'
-				}
-			],
 			pattern: /^\/prefix-(.*?)\/?$/,
 			path: '',
 			shadow: null,
@@ -232,13 +211,6 @@ test('disallows rest parameters inside segments', () => {
 		{
 			type: 'endpoint',
 			id: '[...rest].json',
-			segments: [
-				{
-					dynamic: true,
-					rest: true,
-					content: '[...rest].json'
-				}
-			],
 			pattern: /^\/(.*?)\.json$/,
 			file: 'samples/rest-prefix-suffix/[...rest].json.js'
 		}
@@ -298,7 +270,6 @@ test('allows multiple slugs', () => {
 			{
 				type: 'endpoint',
 				id: '[file].[ext]',
-				segments: [{ dynamic: true, rest: false, content: '[file].[ext]' }],
 				pattern: /^\/([^/]+?)\.([^/]+?)$/,
 				file: 'samples/multiple-slugs/[file].[ext].js'
 			}
@@ -319,7 +290,6 @@ test('ignores things that look like lockfiles', () => {
 		{
 			type: 'endpoint',
 			id: 'foo',
-			segments: [{ rest: false, dynamic: false, content: 'foo' }],
 			file: 'samples/lockfiles/foo.js',
 			pattern: /^\/foo\/?$/
 		}
@@ -342,7 +312,6 @@ test('works with custom extensions', () => {
 		{
 			type: 'page',
 			id: '',
-			segments: [],
 			pattern: /^\/$/,
 			path: '/',
 			shadow: null,
@@ -353,7 +322,6 @@ test('works with custom extensions', () => {
 		{
 			type: 'page',
 			id: 'about',
-			segments: [{ rest: false, dynamic: false, content: 'about' }],
 			pattern: /^\/about\/?$/,
 			path: '/about',
 			shadow: null,
@@ -364,7 +332,6 @@ test('works with custom extensions', () => {
 		{
 			type: 'endpoint',
 			id: 'blog.json',
-			segments: [{ rest: false, dynamic: false, content: 'blog.json' }],
 			pattern: /^\/blog\.json$/,
 			file: 'samples/custom-extension/blog/index.json.js'
 		},
@@ -372,7 +339,6 @@ test('works with custom extensions', () => {
 		{
 			type: 'page',
 			id: 'blog',
-			segments: [{ rest: false, dynamic: false, content: 'blog' }],
 			pattern: /^\/blog\/?$/,
 			path: '/blog',
 			shadow: null,
@@ -383,10 +349,6 @@ test('works with custom extensions', () => {
 		{
 			type: 'endpoint',
 			id: 'blog/[slug].json',
-			segments: [
-				{ rest: false, dynamic: false, content: 'blog' },
-				{ rest: false, dynamic: true, content: '[slug].json' }
-			],
 			pattern: /^\/blog\/([^/]+?)\.json$/,
 			file: 'samples/custom-extension/blog/[slug].json.js'
 		},
@@ -394,10 +356,6 @@ test('works with custom extensions', () => {
 		{
 			type: 'page',
 			id: 'blog/[slug]',
-			segments: [
-				{ rest: false, dynamic: false, content: 'blog' },
-				{ rest: false, dynamic: true, content: '[slug]' }
-			],
 			pattern: /^\/blog\/([^/]+?)\/?$/,
 			path: '',
 			shadow: null,
@@ -431,11 +389,6 @@ test('includes nested error components', () => {
 		{
 			type: 'page',
 			id: 'foo/bar/baz',
-			segments: [
-				{ rest: false, dynamic: false, content: 'foo' },
-				{ rest: false, dynamic: false, content: 'bar' },
-				{ rest: false, dynamic: false, content: 'baz' }
-			],
 			pattern: /^\/foo\/bar\/baz\/?$/,
 			path: '/foo/bar/baz',
 			shadow: null,
@@ -463,7 +416,6 @@ test('resets layout', () => {
 		{
 			type: 'page',
 			id: '',
-			segments: [],
 			pattern: /^\/$/,
 			path: '/',
 			shadow: null,
@@ -473,7 +425,6 @@ test('resets layout', () => {
 		{
 			type: 'page',
 			id: 'foo',
-			segments: [{ rest: false, dynamic: false, content: 'foo' }],
 			pattern: /^\/foo\/?$/,
 			path: '/foo',
 			shadow: null,
@@ -487,10 +438,6 @@ test('resets layout', () => {
 		{
 			type: 'page',
 			id: 'foo/bar',
-			segments: [
-				{ rest: false, dynamic: false, content: 'foo' },
-				{ rest: false, dynamic: false, content: 'bar' }
-			],
 			pattern: /^\/foo\/bar\/?$/,
 			path: '/foo/bar',
 			shadow: null,

--- a/packages/kit/src/core/sync/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.spec.js
@@ -44,7 +44,6 @@ test('creates routes', () => {
 			id: '',
 			segments: [],
 			pattern: /^\/$/,
-			params: [],
 			path: '/',
 			shadow: null,
 			a: [layout, index],
@@ -56,7 +55,6 @@ test('creates routes', () => {
 			id: 'about',
 			segments: [{ rest: false, dynamic: false, content: 'about' }],
 			pattern: /^\/about\/?$/,
-			params: [],
 			path: '/about',
 			shadow: null,
 			a: [layout, about],
@@ -68,8 +66,7 @@ test('creates routes', () => {
 			id: 'blog.json',
 			segments: [{ rest: false, dynamic: false, content: 'blog.json' }],
 			pattern: /^\/blog\.json$/,
-			file: 'samples/basic/blog/index.json.js',
-			params: []
+			file: 'samples/basic/blog/index.json.js'
 		},
 
 		{
@@ -77,7 +74,6 @@ test('creates routes', () => {
 			id: 'blog',
 			segments: [{ rest: false, dynamic: false, content: 'blog' }],
 			pattern: /^\/blog\/?$/,
-			params: [],
 			path: '/blog',
 			shadow: null,
 			a: [layout, blog],
@@ -92,8 +88,7 @@ test('creates routes', () => {
 				{ rest: false, dynamic: true, content: '[slug].json' }
 			],
 			pattern: /^\/blog\/([^/]+?)\.json$/,
-			file: 'samples/basic/blog/[slug].json.ts',
-			params: ['slug']
+			file: 'samples/basic/blog/[slug].json.ts'
 		},
 
 		{
@@ -104,7 +99,6 @@ test('creates routes', () => {
 				{ rest: false, dynamic: true, content: '[slug]' }
 			],
 			pattern: /^\/blog\/([^/]+?)\/?$/,
-			params: ['slug'],
 			path: '',
 			shadow: null,
 			a: [layout, blog_$slug],
@@ -130,7 +124,6 @@ test('creates routes with layout', () => {
 			id: '',
 			segments: [],
 			pattern: /^\/$/,
-			params: [],
 			path: '/',
 			shadow: null,
 			a: [layout, index],
@@ -142,7 +135,6 @@ test('creates routes with layout', () => {
 			id: 'foo',
 			segments: [{ rest: false, dynamic: false, content: 'foo' }],
 			pattern: /^\/foo\/?$/,
-			params: [],
 			path: '/foo',
 			shadow: null,
 			a: [layout, foo___layout, foo],
@@ -232,7 +224,6 @@ test('disallows rest parameters inside segments', () => {
 				}
 			],
 			pattern: /^\/prefix-(.*?)\/?$/,
-			params: ['...rest'],
 			path: '',
 			shadow: null,
 			a: [layout, 'samples/rest-prefix-suffix/prefix-[...rest].svelte'],
@@ -249,8 +240,7 @@ test('disallows rest parameters inside segments', () => {
 				}
 			],
 			pattern: /^\/(.*?)\.json$/,
-			file: 'samples/rest-prefix-suffix/[...rest].json.js',
-			params: ['...rest']
+			file: 'samples/rest-prefix-suffix/[...rest].json.js'
 		}
 	]);
 });
@@ -310,8 +300,7 @@ test('allows multiple slugs', () => {
 				id: '[file].[ext]',
 				segments: [{ dynamic: true, rest: false, content: '[file].[ext]' }],
 				pattern: /^\/([^/]+?)\.([^/]+?)$/,
-				file: 'samples/multiple-slugs/[file].[ext].js',
-				params: ['file', 'ext']
+				file: 'samples/multiple-slugs/[file].[ext].js'
 			}
 		]
 	);
@@ -332,7 +321,6 @@ test('ignores things that look like lockfiles', () => {
 			id: 'foo',
 			segments: [{ rest: false, dynamic: false, content: 'foo' }],
 			file: 'samples/lockfiles/foo.js',
-			params: [],
 			pattern: /^\/foo\/?$/
 		}
 	]);
@@ -356,7 +344,6 @@ test('works with custom extensions', () => {
 			id: '',
 			segments: [],
 			pattern: /^\/$/,
-			params: [],
 			path: '/',
 			shadow: null,
 			a: [layout, index],
@@ -368,7 +355,6 @@ test('works with custom extensions', () => {
 			id: 'about',
 			segments: [{ rest: false, dynamic: false, content: 'about' }],
 			pattern: /^\/about\/?$/,
-			params: [],
 			path: '/about',
 			shadow: null,
 			a: [layout, about],
@@ -380,8 +366,7 @@ test('works with custom extensions', () => {
 			id: 'blog.json',
 			segments: [{ rest: false, dynamic: false, content: 'blog.json' }],
 			pattern: /^\/blog\.json$/,
-			file: 'samples/custom-extension/blog/index.json.js',
-			params: []
+			file: 'samples/custom-extension/blog/index.json.js'
 		},
 
 		{
@@ -389,7 +374,6 @@ test('works with custom extensions', () => {
 			id: 'blog',
 			segments: [{ rest: false, dynamic: false, content: 'blog' }],
 			pattern: /^\/blog\/?$/,
-			params: [],
 			path: '/blog',
 			shadow: null,
 			a: [layout, blog],
@@ -404,8 +388,7 @@ test('works with custom extensions', () => {
 				{ rest: false, dynamic: true, content: '[slug].json' }
 			],
 			pattern: /^\/blog\/([^/]+?)\.json$/,
-			file: 'samples/custom-extension/blog/[slug].json.js',
-			params: ['slug']
+			file: 'samples/custom-extension/blog/[slug].json.js'
 		},
 
 		{
@@ -416,7 +399,6 @@ test('works with custom extensions', () => {
 				{ rest: false, dynamic: true, content: '[slug]' }
 			],
 			pattern: /^\/blog\/([^/]+?)\/?$/,
-			params: ['slug'],
 			path: '',
 			shadow: null,
 			a: [layout, blog_$slug],
@@ -455,7 +437,6 @@ test('includes nested error components', () => {
 				{ rest: false, dynamic: false, content: 'baz' }
 			],
 			pattern: /^\/foo\/bar\/baz\/?$/,
-			params: [],
 			path: '/foo/bar/baz',
 			shadow: null,
 			a: [
@@ -484,7 +465,6 @@ test('resets layout', () => {
 			id: '',
 			segments: [],
 			pattern: /^\/$/,
-			params: [],
 			path: '/',
 			shadow: null,
 			a: [layout, 'samples/layout-reset/index.svelte'],
@@ -495,7 +475,6 @@ test('resets layout', () => {
 			id: 'foo',
 			segments: [{ rest: false, dynamic: false, content: 'foo' }],
 			pattern: /^\/foo\/?$/,
-			params: [],
 			path: '/foo',
 			shadow: null,
 			a: [
@@ -513,7 +492,6 @@ test('resets layout', () => {
 				{ rest: false, dynamic: false, content: 'bar' }
 			],
 			pattern: /^\/foo\/bar\/?$/,
-			params: [],
 			path: '/foo/bar',
 			shadow: null,
 			a: [

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -82,8 +82,6 @@ export function exec(match, names, types, matchers) {
 	/** @type {Record<string, string>} */
 	const params = {};
 
-	console.log({ match, names, types, matchers });
-
 	for (let i = 0; i < names.length; i += 1) {
 		const name = names[i];
 		const type = types[i];

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -1,7 +1,7 @@
 const param_pattern = /^(\.\.\.)?(\w+)(?:=\w+)?$/;
 
-/** @param {string} key */
-export function parse_route_id(key) {
+/** @param {string} id */
+export function parse_route_id(id) {
 	/** @type {string[]} */
 	const names = [];
 
@@ -13,10 +13,10 @@ export function parse_route_id(key) {
 	let add_trailing_slash = true;
 
 	const pattern =
-		key === ''
+		id === ''
 			? /^\/$/
 			: new RegExp(
-					`^${decodeURIComponent(key)
+					`^${decodeURIComponent(id)
 						.split('/')
 						.map((segment, i, segments) => {
 							// special case — /[...rest]/ could contain zero segments

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -1,4 +1,4 @@
-const param_pattern = /^(\.\.\.)?(\w+)(?:=\w+)?$/;
+const param_pattern = /^(\.\.\.)?(\w+)(?:=(\w+))?$/;
 
 /** @param {string} id */
 export function parse_route_id(id) {
@@ -20,7 +20,7 @@ export function parse_route_id(id) {
 						.split('/')
 						.map((segment, i, segments) => {
 							// special case — /[...rest]/ could contain zero segments
-							const match = /^\[\.\.\.(\w+)(?:=\w+)?\]$/.exec(segment);
+							const match = /^\[\.\.\.(\w+)(?:=(\w+))?\]$/.exec(segment);
 							if (match) {
 								names.push(match[1]);
 								types.push(match[2]);
@@ -81,6 +81,8 @@ export function parse_route_id(id) {
 export function exec(match, names, types, matchers) {
 	/** @type {Record<string, string>} */
 	const params = {};
+
+	console.log({ match, names, types, matchers });
 
 	for (let i = 0; i < names.length; i += 1) {
 		const name = names[i];

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -1,3 +1,5 @@
+const param_pattern = /^(\.\.\.)?(\w+)(?:=\w+)?$/;
+
 /** @param {string} key */
 export function parse_route_id(key) {
 	/** @type {string[]} */
@@ -6,13 +8,17 @@ export function parse_route_id(key) {
 	/** @type {string[]} */
 	const types = [];
 
+	// `/foo` should get an optional trailing slash, `/foo.json` should not
+	// const add_trailing_slash = !/\.[a-z]+$/.test(key);
+	let add_trailing_slash = true;
+
 	const pattern =
 		key === ''
 			? /^\/$/
 			: new RegExp(
 					`^${decodeURIComponent(key)
 						.split('/')
-						.map((segment) => {
+						.map((segment, i, segments) => {
 							// special case — /[...rest]/ could contain zero segments
 							const match = /^\[\.\.\.(\w+)(?:=\w+)?\]$/.exec(segment);
 							if (match) {
@@ -21,16 +27,46 @@ export function parse_route_id(key) {
 								return '(?:/(.*))?';
 							}
 
+							const is_last = i === segments.length - 1;
+
 							return (
 								'/' +
-								segment.replace(/\[(\.\.\.)?(\w+)(?:=(\w+))?\]/g, (m, rest, name, type) => {
-									names.push(name);
-									types.push(type);
-									return rest ? '(.*?)' : '([^/]+?)';
-								})
+								segment
+									.split(/\[(.+?)\]/)
+									.map((content, i) => {
+										if (i % 2) {
+											const [, rest, name, type] = /** @type {RegExpMatchArray} */ (
+												param_pattern.exec(content)
+											);
+											names.push(name);
+											types.push(type);
+											return rest ? '(.*?)' : '([^/]+?)';
+										}
+
+										if (is_last && content.includes('.')) add_trailing_slash = false;
+
+										return (
+											content // allow users to specify characters on the file system in an encoded manner
+												.normalize()
+												// We use [ and ] to denote parameters, so users must encode these on the file
+												// system to match against them. We don't decode all characters since others
+												// can already be epressed and so that '%' can be easily used directly in filenames
+												.replace(/%5[Bb]/g, '[')
+												.replace(/%5[Dd]/g, ']')
+												// '#', '/', and '?' can only appear in URL path segments in an encoded manner.
+												// They will not be touched by decodeURI so need to be encoded here, so
+												// that we can match against them.
+												// We skip '/' since you can't create a file with it on any OS
+												.replace(/#/g, '%23')
+												.replace(/\?/g, '%3F')
+												// escape characters that have special meaning in regex
+												.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+										); // TODO handle encoding
+									})
+									.join('')
 							);
 						})
-						.join('')}/?$`
+						.join('')}${add_trailing_slash ? '/?' : ''}$`
 			  );
 
 	return { pattern, names, types };

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -7,6 +7,36 @@ const tests = {
 		pattern: /^\/$/,
 		names: [],
 		types: []
+	},
+	blog: {
+		pattern: /^\/blog\/?$/,
+		names: [],
+		types: []
+	},
+	'blog.json': {
+		pattern: /^\/blog\.json$/,
+		names: [],
+		types: []
+	},
+	'blog/[slug]': {
+		pattern: /^\/blog\/([^/]+?)\/?$/,
+		names: ['slug'],
+		types: []
+	},
+	'blog/[slug].json': {
+		pattern: /^\/blog\/([^/]+?)\.json$/,
+		names: ['slug'],
+		types: []
+	},
+	'[...catchall]': {
+		pattern: /^(?:\/(.*))?\/?$/,
+		names: ['catchall'],
+		types: []
+	},
+	'foo/[...catchall]/bar': {
+		pattern: /^\/foo(?:\/(.*))?\/bar\/?$/,
+		names: ['catchall'],
+		types: []
 	}
 };
 

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -21,22 +21,27 @@ const tests = {
 	'blog/[slug]': {
 		pattern: /^\/blog\/([^/]+?)\/?$/,
 		names: ['slug'],
-		types: []
+		types: [undefined]
 	},
 	'blog/[slug].json': {
 		pattern: /^\/blog\/([^/]+?)\.json$/,
 		names: ['slug'],
-		types: []
+		types: [undefined]
 	},
 	'[...catchall]': {
 		pattern: /^(?:\/(.*))?\/?$/,
 		names: ['catchall'],
-		types: []
+		types: [undefined]
 	},
 	'foo/[...catchall]/bar': {
 		pattern: /^\/foo(?:\/(.*))?\/bar\/?$/,
 		names: ['catchall'],
-		types: []
+		types: [undefined]
+	},
+	'matched/[id=uuid]': {
+		pattern: /^\/matched\/([^/]+?)\/?$/,
+		names: ['id'],
+		types: ['uuid']
 	}
 };
 
@@ -45,6 +50,8 @@ for (const [key, expected] of Object.entries(tests)) {
 		const actual = parse_route_id(key);
 
 		assert.equal(actual.pattern.toString(), expected.pattern.toString());
+		assert.equal(actual.names, expected.names);
+		assert.equal(actual.types, expected.types);
 	});
 }
 

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -80,7 +80,6 @@ export interface EndpointData {
 	id: string;
 	segments: RouteSegment[];
 	pattern: RegExp;
-	params: string[];
 	file: string;
 }
 
@@ -131,7 +130,6 @@ export interface PageData {
 	shadow: string | null;
 	segments: RouteSegment[];
 	pattern: RegExp;
-	params: string[];
 	path: string;
 	a: string[];
 	b: string[];

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -78,7 +78,6 @@ export type CSRRoute = {
 export interface EndpointData {
 	type: 'endpoint';
 	id: string;
-	segments: RouteSegment[];
 	pattern: RegExp;
 	file: string;
 }
@@ -128,7 +127,6 @@ export interface PageData {
 	type: 'page';
 	id: string;
 	shadow: string | null;
-	segments: RouteSegment[];
 	pattern: RegExp;
 	path: string;
 	a: string[];


### PR DESCRIPTION
Started work on #4275, but found `create_manifest_data` quite difficult to work with because of some unnecessary complexity. This puts us on better footing by eliminating that complexity. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
