### PR TITLE
[docs] remove references to route fallthrough

### DIFF
--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -92,8 +92,6 @@ The job of a [request handler](/docs/types#sveltejs-kit-requesthandler) is to re
 - `4xx` — client error
 - `5xx` — server error
 
-> If `{fallthrough: true}` is returned SvelteKit will [fall through](/docs/routing#advanced-routing-fallthrough-routes) to other routes until something responds, or will respond with a generic 404.
-
 #### Page endpoints
 
 If an endpoint has the same filename as a page (except for the extension), the page gets its props from the endpoint — via `fetch` during client-side navigation, or via direct function call during SSR.

--- a/documentation/docs/03-loading.md
+++ b/documentation/docs/03-loading.md
@@ -30,8 +30,6 @@ As with [endpoints](/docs/routing#endpoints), pages can import [generated types]
 
 `load` is similar to `getStaticProps` or `getServerSideProps` in Next.js, except that `load` runs on both the server and the client. In the example above, if a user clicks on a link to this page the data will be fetched from `cms.example.com` without going via our server.
 
-If `load` returns `{fallthrough: true}`, SvelteKit will [fall through](/docs/routing#advanced-routing-fallthrough-routes) to other routes until something responds, or will respond with a generic 404.
-
 SvelteKit's `load` receives an implementation of `fetch`, which has the following special properties:
 
 - it has access to cookies on the server

--- a/documentation/docs/80-migrating.md
+++ b/documentation/docs/80-migrating.md
@@ -113,7 +113,7 @@ You access them differently in SvelteKit. `stores` is now `getStores`, but in mo
 
 #### Routing
 
-Regex routes are no longer supported. Instead, use [fallthrough routes](/docs/routing#advanced-routing-fallthrough-routes).
+Regex routes are no longer supported. Instead, use [advanced route matching](/docs/routing#advanced-routing-matching).
 
 #### URLs
 

--- a/documentation/faq/30-fallthrough.md
+++ b/documentation/faq/30-fallthrough.md
@@ -1,5 +1,0 @@
----
-title: Why am I getting a 404?
----
-
-Please make sure you're returning something from your page's `load` function. See the section about [fallthrough routes](/docs/routing#advanced-routing-fallthrough-routes) for more details.


### PR DESCRIPTION
There are a few references to fallthrough routes that survived in the docs.

A couple of the references can be removed in a fairly naive way. One of the FAQ entries was removed because I don't see what it would make sense to replace it with. The reference in the Sapper migration docs about regex routes has been updated to refer to the new route matching feature.

I'm definitely open to more elegant ways of handling some of these changes, if anyone has ideas.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
