### PR TITLE
use waitForSelector instead of waitForFunction to work around CSP heisenbug

### DIFF
--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -98,10 +98,8 @@ export const test = base.extend({
 		if (javaScriptEnabled) {
 			page.addInitScript({
 				content: `
-					window.started = false;
-
 					addEventListener('sveltekit:start', () => {
-						window.started = true;
+						document.body.classList.add('started');
 					});
 				`
 			});
@@ -116,7 +114,7 @@ export const test = base.extend({
 			async function (url, opts) {
 				const res = await goto.call(page, url, opts);
 				if (javaScriptEnabled) {
-					await page.waitForFunction(() => window.started, undefined, { timeout: 5000 });
+					await page.waitForSelector('body.started', { timeout: 5000 });
 				}
 				return res;
 			};


### PR DESCRIPTION
Since #4363, I'm seeing sporadic test failures accompanied by a message like this:

![image](https://user-images.githubusercontent.com/1162160/159059395-aff24e2b-2881-4fbd-9c8a-ddb24cd55cc8.png)

Somehow, the repeated `waitForFunction` calls violate CSP in a way that the previous single `waitForFunction` call didn't. Replacing it with `waitForSelector` seems to fix it.