### PR TITLE
Docs: Rename validators to matchers in "sorting" section

### DIFF
--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -352,7 +352,7 @@ SvelteKit needs to know which route is being requested. To do so, it sorts them 
 
 - More specific routes are higher priority
 - Standalone endpoints have higher priority than pages with the same specificity
-- Parameters with [validators](#validation) (`[name=type]`) are higher priority than those without (`[name]`)
+- Parameters with [matchers](#advanced-routing-matching) (`[name=type]`) are higher priority than those without (`[name]`)
 - Rest parameters have lowest priority
 - Ties are resolved alphabetically
 


### PR DESCRIPTION
Just a docs change. The sorting section still referenced param "validators" instead of "matchers".

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
