### PR TITLE
Create Svelte: Default App CSS fix

### DIFF
--- a/.changeset/lemon-keys-run.md
+++ b/.changeset/lemon-keys-run.md
@@ -1,5 +1,5 @@
 ---
-'default-template': patch
+'create-svelte': patch
 ---
 
 Add touch-interaction property to button selector in Counter.svelte

--- a/.changeset/lemon-keys-run.md
+++ b/.changeset/lemon-keys-run.md
@@ -2,4 +2,4 @@
 'create-svelte': patch
 ---
 
-Add touch-interaction property to button selector in Counter.svelte
+Fix iOS double-tap zoom on counter buttons

--- a/.changeset/lemon-keys-run.md
+++ b/.changeset/lemon-keys-run.md
@@ -1,0 +1,5 @@
+---
+'default-template': patch
+---
+
+Add touch-interaction property to button selector in Counter.svelte

--- a/packages/create-svelte/templates/default/src/lib/Counter.svelte
+++ b/packages/create-svelte/templates/default/src/lib/Counter.svelte
@@ -50,6 +50,7 @@
 		justify-content: center;
 		border: 0;
 		background-color: transparent;
+		touch-action: manipulation;
 		color: var(--text-color);
 		font-size: 2rem;
 	}


### PR DESCRIPTION
This is a simple change to the CSS in the skeleton app. 

To test the issue, access any of the kit-demo links (e.g. https://cloudflare.demo.svelte.dev/) on an iOS device and attempt to tap the counter button multiple times. It will result in the page zooming in due to the native "double-tap-to-zoom" interaction on iOS. 

Adding `touch-action: manipulation` to the button's css will disable the "double-tap-to-zoom"-interaction when tapping the buttons. 

That is all.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] ~Ideally, include a test that fails without this PR but passes with it.~ (Not aware that this is possible to test)

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
