### PR TITLE
Fix preprocess etc

### DIFF
--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -19,6 +19,7 @@
 		"@types/gitignore-parser": "^0.0.0",
 		"@types/prettier": "^2.4.2",
 		"@types/prompts": "^2.0.14",
+		"eslint": "^8.11.0",
 		"gitignore-parser": "^0.0.2",
 		"prettier": "^2.5.0",
 		"prettier-plugin-svelte": "^2.5.0",
@@ -28,6 +29,7 @@
 		"tiny-glob": "^0.2.9"
 	},
 	"scripts": {
+		"start": "node bin.js",
 		"build": "node scripts/build-templates",
 		"check": "tsc",
 		"lint": "eslint --ignore-path .gitignore --ignore-path ../../.gitignore \"./*.js\" && npm run check-format",

--- a/packages/create-svelte/shared/+default-typescript/svelte.config.js
+++ b/packages/create-svelte/shared/+default-typescript/svelte.config.js
@@ -1,7 +1,12 @@
 import adapter from '@sveltejs/adapter-auto';
+import preprocess from 'svelte-preprocess';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
+	// Consult https://github.com/sveltejs/svelte-preprocess
+	// for more information about preprocessors
+	preprocess: preprocess(),
+
 	kit: {
 		adapter: adapter(),
 

--- a/packages/create-svelte/templates/default/package.template.json
+++ b/packages/create-svelte/templates/default/package.template.json
@@ -11,7 +11,8 @@
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "next",
 		"@sveltejs/kit": "next",
-		"svelte": "^3.46.0"
+		"svelte": "^3.46.0",
+		"svelte-preprocess": "^4.9.4"
 	},
 	"type": "module",
 	"dependencies": {

--- a/packages/create-svelte/templates/skeleton/svelte.config.js
+++ b/packages/create-svelte/templates/skeleton/svelte.config.js
@@ -1,9 +1,14 @@
 import adapter from '@sveltejs/adapter-auto';
+import preprocess from 'svelte-preprocess';
 
 // This config is ignored and replaced with one of the configs in the shared folder when a project is created.
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
+	// Consult https://github.com/sveltejs/svelte-preprocess
+	// for more information about preprocessors
+	preprocess: preprocess(),
+
 	kit: {
 		adapter: adapter()
 	}


### PR DESCRIPTION
Ship svelte-preprocess by default, make produced project work with latest svelte version + minor fixes (check commits)

svelte-preprocess is useful to bundle by default, so the framework user can use SASS without further config.
 
---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
