### PR TITLE
[fix] don't use client-side router for same path on different origin

### DIFF
--- a/.changeset/kind-ducks-relate.md
+++ b/.changeset/kind-ducks-relate.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] don't use client-side navigation when clicking on a link to the same path on a different origin

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -202,7 +202,11 @@ export function create_client({ target, session, base, trailing_slash }) {
 		const current_token = (token = {});
 		let navigation_result = intent && (await load_route(intent, no_cache));
 
-		if (!navigation_result && url.pathname === location.pathname) {
+		if (
+			!navigation_result &&
+			url.origin === location.origin &&
+			url.pathname === location.pathname
+		) {
 			// this could happen in SPA fallback mode if the user navigated to
 			// `/non-existent-page`. if we fall back to reloading the page, it
 			// will create an infinite loop. so whereas we normally handle


### PR DESCRIPTION
Fixes #4430. The special handling for 404s in SPA mode was erroneously kicking in when we were linking to the same path on a different origin. This resulting in SvelteKit trying to do client-side navigation, which failed when the history API refused to pushstate a URL with a different origin.

I didn't add a test, and may not have time to today. If someone else wants to write one and push to this branch, feel free.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
