### PR TITLE
Create fallback HTML file when prerendering is disabled

### DIFF
--- a/.changeset/sour-roses-admire.md
+++ b/.changeset/sour-roses-admire.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] Create fallback page when prerendering is disabled

--- a/.changeset/sour-roses-admire.md
+++ b/.changeset/sour-roses-admire.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-[fix] Create fallback page when prerendering is disabled
+Create fallback page when prerendering is disabled


### PR DESCRIPTION
Fixes #4441. With `prerendering.enabled = false` the fallback HTML file was not created.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

Wasn't quite sure of the best way to test this. Looks like it would require creating a new sample app in the `prerendering` test directory with this configuration and a single test that the fallback file is written. Should I do that?

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
