### PR TITLE
feat: use config.kit.paths.base for static assets

### DIFF
--- a/.changeset/smooth-waves-accept.md
+++ b/.changeset/smooth-waves-accept.md
@@ -1,0 +1,9 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-vercel': patch
+'@sveltejs/kit': patch
+---
+
+Use config.kit.paths.base prefix for static assets

--- a/.changeset/smooth-waves-accept.md
+++ b/.changeset/smooth-waves-accept.md
@@ -2,6 +2,7 @@
 '@sveltejs/adapter-cloudflare': patch
 '@sveltejs/adapter-cloudflare-workers': patch
 '@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-node': patch
 '@sveltejs/adapter-vercel': patch
 '@sveltejs/kit': patch
 ---

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -6,7 +6,7 @@ const static_asset_manifest = JSON.parse(static_asset_manifest_json);
 
 const server = new Server(manifest);
 
-const prefix = `/${manifest.appDir}/`;
+const appPath = `/${manifest.appPath}/`;
 
 export default {
 	/**
@@ -20,12 +20,12 @@ export default {
 		const url = new URL(req.url);
 
 		// static assets
-		if (url.pathname.startsWith(prefix)) {
+		if (url.pathname.startsWith(appPath)) {
 			/** @type {Response} */
 			const res = await get_asset_from_kv(req, env, context);
 			if (is_error(res.status)) return res;
 
-			const cache_control = url.pathname.startsWith(prefix + 'immutable/')
+			const cache_control = url.pathname.startsWith(appPath + 'immutable/')
 				? 'public, immutable, max-age=31536000'
 				: 'no-cache';
 

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -25,7 +25,7 @@ export default {
 			const res = await get_asset_from_kv(req, env, context);
 			if (is_error(res.status)) return res;
 
-			const cache_control = url.pathname.startsWith(appPath + 'immutable/')
+			const cache_control = url.pathname.startsWith(app_path + 'immutable/')
 				? 'public, immutable, max-age=31536000'
 				: 'no-cache';
 

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -20,7 +20,7 @@ export default {
 		const url = new URL(req.url);
 
 		// static assets
-		if (url.pathname.startsWith(appPath)) {
+		if (url.pathname.startsWith(app_path)) {
 			/** @type {Response} */
 			const res = await get_asset_from_kv(req, env, context);
 			if (is_error(res.status)) return res;

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -6,7 +6,7 @@ const static_asset_manifest = JSON.parse(static_asset_manifest_json);
 
 const server = new Server(manifest);
 
-const appPath = `/${manifest.appPath}/`;
+const app_path = `/${manifest.appPath}/`;
 
 export default {
 	/**

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -73,8 +73,9 @@ export default function () {
 			});
 
 			builder.log.minor('Copying assets...');
-			builder.writeClient(site.bucket);
-			builder.writePrerendered(site.bucket);
+			const prefixedBucket = `${site.bucket}${builder.config.kit.paths.base}`;
+			builder.writeClient(prefixedBucket);
+			builder.writePrerendered(prefixedBucket);
 		}
 	};
 }

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -73,9 +73,9 @@ export default function () {
 			});
 
 			builder.log.minor('Copying assets...');
-			const prefixedBucket = `${site.bucket}${builder.config.kit.paths.base}`;
-			builder.writeClient(prefixedBucket);
-			builder.writePrerendered(prefixedBucket);
+			const bucket_dir = `${site.bucket}${builder.config.kit.paths.base}`;
+			builder.writeClient(bucket_dir);
+			builder.writePrerendered(bucket_dir);
 		}
 	};
 }

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -23,8 +23,9 @@ export default function () {
 			builder.rimraf(tmp);
 			builder.mkdirp(tmp);
 
-			const written_files = builder.writeClient(dest);
-			builder.writePrerendered(dest);
+			const prefixedDest = `${dest}${builder.config.kit.paths.base}`;
+			const written_files = builder.writeClient(prefixedDest);
+			builder.writePrerendered(prefixedDest);
 
 			const relativePath = posix.relative(tmp, builder.getServerDirectory());
 

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -23,9 +23,9 @@ export default function () {
 			builder.rimraf(tmp);
 			builder.mkdirp(tmp);
 
-			const prefixedDest = `${dest}${builder.config.kit.paths.base}`;
-			const written_files = builder.writeClient(prefixedDest);
-			builder.writePrerendered(prefixedDest);
+			const dest_dir = `${dest}${builder.config.kit.paths.base}`;
+			const written_files = builder.writeClient(dest_dir);
+			builder.writePrerendered(dest_dir);
 
 			const relativePath = posix.relative(tmp, builder.getServerDirectory());
 

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -4,7 +4,7 @@ import * as Cache from 'worktop/cfw.cache';
 
 const server = new Server(manifest);
 
-const prefix = `/${manifest.appDir}/`;
+const appPath = `/${manifest.appPath}/`;
 
 /** @type {import('worktop/cfw').Module.Worker<{ ASSETS: import('worktop/cfw.durable').Durable.Object }>} */
 const worker = {
@@ -18,11 +18,11 @@ const worker = {
 		let { pathname } = new URL(req.url);
 
 		// static assets
-		if (pathname.startsWith(prefix)) {
+		if (pathname.startsWith(appPath)) {
 			res = await env.ASSETS.fetch(req);
 			if (!res.ok) return res;
 
-			const cache_control = pathname.startsWith(prefix + 'immutable/')
+			const cache_control = pathname.startsWith(appPath + 'immutable/')
 				? 'public, immutable, max-age=31536000'
 				: 'no-cache';
 

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -22,7 +22,7 @@ const worker = {
 			res = await env.ASSETS.fetch(req);
 			if (!res.ok) return res;
 
-			const cache_control = pathname.startsWith(appPath + 'immutable/')
+			const cache_control = pathname.startsWith(app_path + 'immutable/')
 				? 'public, immutable, max-age=31536000'
 				: 'no-cache';
 

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -18,7 +18,7 @@ const worker = {
 		let { pathname } = new URL(req.url);
 
 		// static assets
-		if (pathname.startsWith(appPath)) {
+		if (pathname.startsWith(app_path)) {
 			res = await env.ASSETS.fetch(req);
 			if (!res.ok) return res;
 

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -4,7 +4,7 @@ import * as Cache from 'worktop/cfw.cache';
 
 const server = new Server(manifest);
 
-const appPath = `/${manifest.appPath}/`;
+const app_path = `/${manifest.appPath}/`;
 
 /** @type {import('worktop/cfw').Module.Worker<{ ASSETS: import('worktop/cfw.durable').Durable.Object }>} */
 const worker = {

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -54,15 +54,16 @@ export default function ({ split = false, edge = edge_set_in_env_var } = {}) {
 			builder.log.minor(`Publishing to "${publish}"`);
 
 			builder.log.minor('Copying assets...');
-			builder.writeClient(publish);
-			builder.writePrerendered(publish);
+			const prefixedPublish = `${publish}${builder.config.kit.paths.base}`;
+			builder.writeClient(prefixedPublish);
+			builder.writePrerendered(prefixedPublish);
 
 			builder.log.minor('Writing custom headers...');
 			const headers_file = join(publish, '_headers');
 			builder.copy('_headers', headers_file);
 			appendFileSync(
 				headers_file,
-				`\n\n/${builder.config.kit.appDir}/immutable/*\n  cache-control: public\n  cache-control: immutable\n  cache-control: max-age=31536000\n`
+				`\n\n/${builder.getAppPath()}/immutable/*\n  cache-control: public\n  cache-control: immutable\n  cache-control: max-age=31536000\n`
 			);
 
 			if (edge) {

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -54,9 +54,9 @@ export default function ({ split = false, edge = edge_set_in_env_var } = {}) {
 			builder.log.minor(`Publishing to "${publish}"`);
 
 			builder.log.minor('Copying assets...');
-			const prefixedPublish = `${publish}${builder.config.kit.paths.base}`;
-			builder.writeClient(prefixedPublish);
-			builder.writePrerendered(prefixedPublish);
+			const publish_dir = `${publish}${builder.config.kit.paths.base}`;
+			builder.writeClient(publish_dir);
+			builder.writePrerendered(publish_dir);
 
 			builder.log.minor('Writing custom headers...');
 			const headers_file = join(publish, '_headers');

--- a/packages/adapter-netlify/src/edge.js
+++ b/packages/adapter-netlify/src/edge.js
@@ -2,7 +2,7 @@ import { Server } from '0SERVER';
 import { manifest, prerendered } from 'MANIFEST';
 
 const server = new Server(manifest);
-const prefix = `/${manifest.appDir}/`;
+const prefix = `/${manifest.appPath}/`;
 
 const initialized = server.init({
 	// @ts-ignore

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -30,8 +30,8 @@ export default function (opts = {}) {
 			builder.mkdirp(tmp);
 
 			builder.log.minor('Copying assets');
-			builder.writeClient(`${out}/client`);
-			builder.writePrerendered(`${out}/prerendered`);
+			builder.writeClient(`${out}/client${builder.config.kit.paths.base}`);
+			builder.writePrerendered(`${out}/prerendered${builder.config.kit.paths.base}`);
 
 			if (precompress) {
 				builder.log.minor('Compressing assets');

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -36,7 +36,7 @@ function serve(path, client = false) {
 				client &&
 				((res, pathname) => {
 					// only apply to build directory, not e.g. version.json
-					if (pathname.startsWith(`/${manifest.appDir}/immutable/`)) {
+					if (pathname.startsWith(`/${manifest.appPath}/immutable/`)) {
 						res.setHeader('cache-control', 'public,max-age=31536000,immutable');
 					}
 				})

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -118,7 +118,7 @@ export default function ({ external = [], edge, split } = {}) {
 				...redirects[builder.config.kit.trailingSlash],
 				...prerendered_redirects,
 				{
-					src: `/${builder.config.kit.appDir}/.+`,
+					src: `/${builder.getAppPath()}/.+`,
 					headers: {
 						'cache-control': 'public, immutable, max-age=31536000'
 					}

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -98,7 +98,7 @@ export default function ({ external = [], edge, split } = {}) {
 			const files = fileURLToPath(new URL('./files', import.meta.url).href);
 
 			const dirs = {
-				static: `${dir}/static`,
+				static: `${dir}/static${builder.config.kit.paths.base}`,
 				functions: `${dir}/functions`
 			};
 

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -128,6 +128,10 @@ export function create_builder({ config, build_data, routes, prerendered, log })
 			return config.kit.files.assets;
 		},
 
+		getAppPath() {
+			return build_data.app_path;
+		},
+
 		writeClient(dest) {
 			return [...copy(`${config.kit.outDir}/output/client`, dest)];
 		},

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -45,6 +45,7 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 	/** @type {import('types').SSRManifest} */
 	return `{
 		appDir: ${s(build_data.app_dir)},
+		appPath: ${s(build_data.app_path)},
 		assets: new Set(${s(assets)}),
 		mimeTypes: ${s(get_mime_lookup(build_data.manifest_data))},
 		_: {

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -59,6 +59,7 @@ export async function dev(vite, vite_config, svelte_config) {
 
 		manifest = {
 			appDir: svelte_config.kit.appDir,
+			appPath: svelte_config.kit.appDir,
 			assets: new Set(manifest_data.assets.map((asset) => asset.file)),
 			mimeTypes: get_mime_lookup(manifest_data),
 			_: {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -379,6 +379,7 @@ function kit() {
 				);
 
 				log.info('Building server');
+
 				const options = {
 					cwd,
 					config: svelte_config,
@@ -395,6 +396,9 @@ function kit() {
 				/** @type {import('types').BuildData} */
 				build_data = {
 					app_dir: svelte_config.kit.appDir,
+					app_path: `${svelte_config.kit.paths.base.slice(1)}${
+						svelte_config.kit.paths.base ? '/' : ''
+					}${svelte_config.kit.appDir}`,
 					manifest_data,
 					service_worker: options.service_worker_entry_file ? 'service-worker.js' : null, // TODO make file configurable?
 					client,

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -85,6 +85,8 @@ export interface Builder {
 	getClientDirectory(): string;
 	getServerDirectory(): string;
 	getStaticDirectory(): string;
+	/** The application path including any configured base path */
+	getAppPath(): string;
 
 	/**
 	 * @param dest the destination folder to which files should be copied
@@ -379,6 +381,7 @@ export interface ServerInitOptions {
 
 export interface SSRManifest {
 	appDir: string;
+	appPath: string;
 	assets: Set<string>;
 	mimeTypes: Record<string, string>;
 

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -47,6 +47,7 @@ export interface Asset {
 
 export interface BuildData {
 	app_dir: string;
+	app_path: string;
 	manifest_data: ManifestData;
 	service_worker: string | null;
 	client: {


### PR DESCRIPTION
Prefixes appDir with config.kit.paths.base for adapter-(cloudflare, cloudflare-workers, netlify). Didn't touch node, as there's some discussion around how that should be handled differently in #3726. Would be great if @asendia and @tv42 could test the adapters for their respective issues, since I've never used those platforms with sveltekit.

I'm aware it would be better if the base path was handled outside of SvelteKit instead of creating nested folders like this, but (at least for workers sites), I can't think of a better alternative.

fixes #4442, fixes #2843, fixes #3726

- add manifest.prefix and builder.getAppPrefixDirectory()
- adapter-cloudflare*: use manifest.prefix instead of manifest.appDir
- adapter-netlify: use prefixed appDir for cache headers
- adapter-vercel: use prefixed appDir for routes.json
- adapter-cloudflare, adapter-cloudflare-workers, adapter-netlify: write static assets to "$dest/$base"

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
