### PR TITLE
Generated types invalid for routes with matched parameter

### DIFF
--- a/packages/kit/src/core/sync/write_types.js
+++ b/packages/kit/src/core/sync/write_types.js
@@ -29,7 +29,7 @@ export function write_types(config, manifest_data) {
 		/** @type {string[]} */
 		const params = [];
 
-		const pattern = /\[(?:\.{3})?([^\]]+)\]/g;
+		const pattern = /\[(?:\.{3})?([^\]=]+)[^\]]*\]/g;
 		let match;
 
 		while ((match = pattern.exec(key))) {


### PR DESCRIPTION
# Generated types invalid for routes with matched parameter

Ref #4327 #4361

## Bug description

The automatically generated types file for routes with matched parameters are invalid.
i.e. route like `/[lang=is_lang]/[name]` will generate following

```ts
export type RequestHandler<Output extends ResponseBody = ResponseBody> = GenericRequestHandler<{ lang=is_lang: string; name: string }, Output>;
```

After this PR

```ts
export type RequestHandler<Output extends ResponseBody = ResponseBody> = GenericRequestHandler<{ lang: string; name: string }, Output>;
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
