### PR TITLE
apply linking logic to inline code spans

### DIFF
--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -215,13 +215,9 @@ export interface ParamMatcher {
 }
 
 /**
- * A function exported from an endpoint that corresponds to an
- * HTTP verb (`get`, `put`, `patch`, etc) and handles requests with
- * that method. Note that since 'delete' is a reserved word in
- * JavaScript, delete handles are called `del` instead.
+ * A `(event: RequestEvent) => RequestHandlerOutput` function exported from an endpoint that corresponds to an HTTP verb (`get`, `put`, `patch`, etc) and handles requests with that method. Note that since 'delete' is a reserved word in JavaScript, delete handles are called `del` instead.
  *
- * Note that you can use [generated types](/docs/types#generated-types)
- * instead of manually specifying the `Params` generic argument.
+ * Note that you can use [generated types](/docs/types#generated-types) instead of manually specifying the `Params` generic argument.
  */
 export interface RequestHandler<
 	Params extends Record<string, string> = Record<string, string>,

--- a/sites/kit.svelte.dev/src/lib/docs/server/index.js
+++ b/sites/kit.svelte.dev/src/lib/docs/server/index.js
@@ -171,6 +171,16 @@ export async function read_file(dir, file) {
 							.join('');
 					}
 				);
+		},
+		codespan: (text) => {
+			return (
+				'<code>' +
+				text.replace(type_regex, (match, prefix, name) => {
+					const link = `<a href="${type_links.get(name)}">${name}</a>`;
+					return `${prefix || ''}${link}`;
+				}) +
+				'</code>'
+			);
 		}
 	});
 
@@ -241,7 +251,8 @@ export function read_headings(dir) {
 				file,
 				// gross hack to accommodate FAQ
 				slug: dir === 'faq' ? slug : undefined,
-				code: () => ''
+				code: () => '',
+				codespan: () => ''
 			});
 
 			return {
@@ -259,9 +270,10 @@ export function read_headings(dir) {
  *   file: string;
  *   slug: string;
  *   code: (source: string, language: string, current: string) => string;
+ *   codespan: (source: string) => string;
  * }} opts
  */
-function parse({ body, file, slug, code }) {
+function parse({ body, file, slug, code, codespan }) {
 	const headings = slug ? [slug] : [];
 	const sections = [];
 
@@ -307,7 +319,8 @@ function parse({ body, file, slug, code }) {
 
 			return `<h${level} id="${slug}">${html}<a href="#${slug}" class="anchor"><span class="visually-hidden">permalink</span></a></h${level}>`;
 		},
-		code: (source, language) => code(source, language, current)
+		code: (source, language) => code(source, language, current),
+		codespan
 	});
 
 	return {


### PR DESCRIPTION
This is a possible solution to #4445 — it makes references to types in inline `<code>` spans link to their definitions, and [updates the `RequestHandler` type accordingly](https://kit-svelte-dev-git-link-inline-codespans-svelte.vercel.app/docs/types#sveltejs-kit-requesthandler):

<img width="738" alt="image" src="https://user-images.githubusercontent.com/1162160/161115190-5a117b50-8378-4393-b3ff-804b1d715016.png">

This seems more scalable/less invasive than the alternative, to me