### PR TITLE
[docs] clarification for prerendering default

### DIFF
--- a/documentation/docs/13-configuration.md
+++ b/documentation/docs/13-configuration.md
@@ -232,7 +232,7 @@ See [Prerendering](/docs/page-options#prerender). An object containing zero or m
 
 - `concurrency` — how many pages can be prerendered simultaneously. JS is single-threaded, but in cases where prerendering performance is network-bound (for example loading content from a remote CMS) this can speed things up by processing other tasks while waiting on the network response
 - `crawl` — determines whether SvelteKit should find pages to prerender by following links from the seed page(s)
-- `default` — set to `true` to prerender every page without `export const prerender = false`
+- `default` — set to `true` to prerender encountered pages not containing `export const prerender = false`
 - `enabled` — set to `false` to disable prerendering altogether
 - `entries` — an array of pages to prerender, or start crawling from (if `crawl: true`). The `*` string includes all non-dynamic routes (i.e. pages with no `[parameters]` )
 - `onError`


### PR DESCRIPTION
A user reported on Discord that they were misled by our current wording of "every page" as they thought it caused `entries` to be ignored