### PR TITLE
[Docs] Search - only include type/migration docs when explicitly searched for

### DIFF
--- a/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
+++ b/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
@@ -9,7 +9,6 @@
 	let modal;
 
 	let results = [];
-	let backspace_pressed;
 
 	let index;
 	let lookup;

--- a/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
+++ b/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
@@ -64,7 +64,13 @@
 	}
 
 	function update() {
-		results = (index ? index.search($query) : []).map((href) => lookup.get(href));
+		const filter = /type|migrat/;
+		let searchResults = index ? index.search($query.toLowerCase()) : [];
+		// only include type and migration docs if user is explicitly searching for them
+		if (!filter.test($query)) {
+			searchResults = searchResults.filter((href) => !filter.test(href));
+		}
+		results = searchResults.map((href) => lookup.get(href));
 	}
 
 	function escape(text) {


### PR DESCRIPTION
Closes #3865
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

When searching the SvelteKit docs, currently both the type docs and the migration docs tend to get into the way. 
This PR makes it so, that the search is filtered to only include routes containing "type" or "migrat" (stem of migrate/migration/migrating) if the query itself also contains those terms. 

I initially wanted to address this by leveraging [the boost option provided by flexsearch](https://github.com/nextapps-de/flexsearch#index-options) to give type/migration related search results a lower priority, but this option cannot yet be enabled in combination with {tokenizer: "forward"}.

PS: I also removed an unused variable from the codebase in the process.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
