### PR TITLE
remove unimplemented `--dir` option from `svelte-kit package`

### DIFF
--- a/.changeset/proud-cobras-swim.md
+++ b/.changeset/proud-cobras-swim.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Remove unimplemented option from CLI

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -151,7 +151,6 @@ prog
 prog
 	.command('package')
 	.describe('Create a package')
-	.option('-d, --dir', 'Destination directory', 'package')
 	.action(async () => {
 		try {
 			const config = await load_config();


### PR DESCRIPTION
closes #4484. not sure how this snuck in

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
