### PR TITLE
dev server hints if `paths.base` prefix is missing; `--open` uses `paths.base`

### DIFF
--- a/.changeset/lovely-hairs-applaud.md
+++ b/.changeset/lovely-hairs-applaud.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add missing paths.base prefix in dev, if necessary

--- a/.changeset/lovely-hairs-applaud.md
+++ b/.changeset/lovely-hairs-applaud.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Add missing paths.base prefix in dev, if necessary
+Hint if `paths.base` is missing in dev

--- a/.changeset/new-rules-vanish.md
+++ b/.changeset/new-rules-vanish.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+Respect `paths.base` when using `--open`

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -25,8 +25,9 @@ function handle_error(e) {
 /**
  * @param {number} port
  * @param {boolean} https
+ * @param {string} base
  */
-async function launch(port, https) {
+async function launch(port, https, base) {
 	const { exec } = await import('child_process');
 	let cmd = 'open';
 	if (process.platform == 'win32') {
@@ -38,7 +39,7 @@ async function launch(port, https) {
 			cmd = 'xdg-open';
 		}
 	}
-	exec(`${cmd} ${https ? 'https' : 'http'}://localhost:${port}`);
+	exec(`${cmd} ${https ? 'https' : 'http'}://localhost:${port}${base}`);
 }
 
 const prog = sade('svelte-kit').version('__VERSION__');
@@ -75,6 +76,7 @@ prog
 				host: address_info.address,
 				https: !!(https || server_config.https),
 				open: open || !!server_config.open,
+				base: config.kit.paths.base,
 				loose: server_config.fs.strict === false,
 				allow: server_config.fs.allow,
 				cwd
@@ -142,7 +144,7 @@ prog
 
 			await preview({ port, host, config, https });
 
-			welcome({ port, host, https, open });
+			welcome({ port, host, https, open, base: config.kit.paths.base });
 		} catch (error) {
 			handle_error(error);
 		}
@@ -211,13 +213,14 @@ async function check_port(port) {
  *   host: string;
  *   https: boolean;
  *   port: number;
+ *   base: string;
  *   loose?: boolean;
  *   allow?: string[];
  *   cwd?: string;
  * }} param0
  */
-function welcome({ port, host, https, open, loose, allow, cwd }) {
-	if (open) launch(port, https);
+function welcome({ port, host, https, open, base, loose, allow, cwd }) {
+	if (open) launch(port, https, base);
 
 	console.log(colors.bold().cyan(`\n  SvelteKit v${'__VERSION__'}\n`));
 

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -203,7 +203,14 @@ export async function create_plugin(config, cwd) {
 
 						if (req.url === '/favicon.ico') return not_found(res);
 
-						if (!decoded.startsWith(config.kit.paths.base)) return not_found(res);
+						if (!decoded.startsWith(config.kit.paths.base)) {
+							res.writeHead(307, {
+								location: config.kit.paths.base + req.url
+							});
+							res.end();
+
+							return;
+						}
 
 						/** @type {Partial<import('types').Hooks>} */
 						const user_hooks = resolve_entry(config.kit.files.hooks)

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -13,6 +13,7 @@ import { load_template } from '../config/index.js';
 import { sequence } from '../../hooks.js';
 import { posixify } from '../../utils/filesystem.js';
 import { parse_route_id } from '../../utils/routing.js';
+import { normalize_path } from '../../utils/url.js';
 
 /**
  * @param {import('types').ValidatedConfig} config
@@ -204,12 +205,11 @@ export async function create_plugin(config, cwd) {
 						if (req.url === '/favicon.ico') return not_found(res);
 
 						if (!decoded.startsWith(config.kit.paths.base)) {
-							res.writeHead(307, {
-								location: config.kit.paths.base + req.url
-							});
-							res.end();
-
-							return;
+							const suggestion = normalize_path(
+								config.kit.paths.base + req.url,
+								config.kit.trailingSlash
+							);
+							return not_found(res, `Not found (did you mean ${suggestion}?)`);
 						}
 
 						/** @type {Partial<import('types').Hooks>} */
@@ -366,9 +366,9 @@ export async function create_plugin(config, cwd) {
 }
 
 /** @param {import('http').ServerResponse} res */
-function not_found(res) {
+function not_found(res, message = 'Not found') {
 	res.statusCode = 404;
-	res.end('Not found');
+	res.end(message);
 }
 
 /**


### PR DESCRIPTION
closes #4418 — if `path.base` is `/blah` and the developer visits `/foo` in dev, they are redirected to `/blah/foo`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
