### PR TITLE
opt into `strict: true` in `tsconfig.json` by default

### DIFF
--- a/.changeset/pretty-oranges-impress.md
+++ b/.changeset/pretty-oranges-impress.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] Opt in to TypeScript strict: true by default

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -63,7 +63,8 @@ export function write_tsconfig(config) {
 						$lib: [project_relative(config.kit.files.lib)],
 						'$lib/*': [project_relative(config.kit.files.lib + '/*')]
 					},
-					rootDirs: [config_relative('.'), './types']
+					rootDirs: [config_relative('.'), './types'],
+					strict: true
 				},
 				include,
 				exclude: [config_relative('node_modules/**'), './**']


### PR DESCRIPTION
closes #4395. This is a breaking change

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
