### PR TITLE
move MaybePromise from RequestHandlerOutput to RequestHandler return value

### DIFF
--- a/.changeset/strong-apples-walk.md
+++ b/.changeset/strong-apples-walk.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Move MaybePromise from RequestHandlerOutput to RequestHandler return value

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -226,11 +226,11 @@ export interface RequestHandler<
 	(event: RequestEvent<Params>): MaybePromise<RequestHandlerOutput<Output>>;
 }
 
-export type RequestHandlerOutput<Output extends ResponseBody = ResponseBody> = {
+export interface RequestHandlerOutput<Output extends ResponseBody = ResponseBody> {
 	status?: number;
 	headers?: Headers | Partial<ResponseHeaders>;
 	body?: Output;
-};
+}
 
 export type ResponseBody = JSONValue | Uint8Array | ReadableStream | import('stream').Readable;
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -223,14 +223,14 @@ export interface RequestHandler<
 	Params extends Record<string, string> = Record<string, string>,
 	Output extends ResponseBody = ResponseBody
 > {
-	(event: RequestEvent<Params>): RequestHandlerOutput<Output>;
+	(event: RequestEvent<Params>): MaybePromise<RequestHandlerOutput<Output>>;
 }
 
-export type RequestHandlerOutput<Output extends ResponseBody = ResponseBody> = MaybePromise<{
+export type RequestHandlerOutput<Output extends ResponseBody = ResponseBody> = {
 	status?: number;
 	headers?: Headers | Partial<ResponseHeaders>;
 	body?: Output;
-}>;
+};
 
 export type ResponseBody = JSONValue | Uint8Array | ReadableStream | import('stream').Readable;
 


### PR DESCRIPTION
closes #4138, though the original issue was already fixed a while back — this fixes the thing identified in https://github.com/sveltejs/kit/issues/4138#issuecomment-1052447052, namely that it makes more sense for `RequestHandler` to return a `MaybePromise<RequestHandlerOutput>` than for the latter type to _include_ `MaybePromise`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
