### PR TITLE
[docs] Search - deprioritize type/migration and include category

### DIFF
--- a/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
+++ b/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
@@ -20,7 +20,7 @@
 		index = new flexsearch.Index({
 			tokenize: 'forward',
 			// deprioritize type and migration related docs in search
-			boost: (words) => (/type|migrat/.test(words[0]) ? 0.5 : 1)
+			boost: (words) => (/types|migrating/.test(words[0]) ? 0.5 : 1)
 		});
 
 		lookup = new Map();

--- a/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
+++ b/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
@@ -9,7 +9,6 @@
 	let modal;
 
 	let results = [];
-	let backspace_pressed;
 
 	let index;
 	let lookup;
@@ -19,7 +18,9 @@
 		const { blocks } = await response.json();
 
 		index = new flexsearch.Index({
-			tokenize: 'forward'
+			tokenize: 'forward',
+			// deprioritize type and migration related docs in search
+			boost: (words) => (/type|migrat/.test(words[0]) ? 0.5 : 1)
 		});
 
 		lookup = new Map();
@@ -27,13 +28,14 @@
 		let time = Date.now();
 		for (const block of blocks) {
 			const title = block.breadcrumbs[block.breadcrumbs.length - 1];
+			const category = block.breadcrumbs.length > 1 ? `${block.breadcrumbs[0]} ` : '';
 			lookup.set(block.href, {
 				title,
 				href: block.href,
 				breadcrumbs: block.breadcrumbs.slice(0, -1),
 				content: block.content
 			});
-			index.add(block.href, `${title} ${block.content}`);
+			index.add(block.href, `${category}${title} ${block.content}`);
 
 			// poor man's way of preventing blocking
 			if (Date.now() - time > 25) {


### PR DESCRIPTION
This is attempt number two to improve searching the docs. 
Sorry for keeping y'all from working on more important PRs 🙇‍♂️

After a very clumsy solution in #4503, I think I now found a way to deprioritize type/migration related search results that as a side effect also genuinely makes the search better as well!

To recap the problem: when searching the documentation, type and migration related search results clutter the view by appearing at the very top, basically doubling the search results the user has to scan to find what they're looking for.

I embarrassingly misunderstood the flexsearch docs and thought the ``boost()`` function that allows influencing the ranking  was not available for ``tokenizer: "forward"`` but this limitation is only about how ``boost`` works internally.

For the ranking manipulation to work, I included the "category" (the very first breadcrumb) into the content for each entry and returned a boost of 0.5 (lower than 1 deprioritizes) for entries with relevant categories.
This works like a charm and has the nice side effect that when searching for let's say "faq" now all pages inside the faq section appear as search results.

Closes #3865
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
