### PR TITLE
[fix] type check exception handling on form action

### DIFF
--- a/.changeset/fuzzy-news-raise.md
+++ b/.changeset/fuzzy-news-raise.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+type check exception handling on form action

--- a/packages/create-svelte/templates/default/src/lib/form.ts
+++ b/packages/create-svelte/templates/default/src/lib/form.ts
@@ -65,8 +65,8 @@ export function enhance(
 			} else {
 				console.error(await response.text());
 			}
-		} catch (e: any) {
-			if (error) {
+		} catch (e: unknown) {
+			if (error && e instanceof Error) {
 				error({ data, form, error: e, response: null });
 			} else {
 				throw e;


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

`form.ts` in the default demo app currently uses an `any` type for catching an error thrown during the request. Switch to an `unknown` type and explicitly check for the correct type before passing to the `error` function which expects an argument of type `Error`.