### PR TITLE
remove Vite static asset middleware

### DIFF
--- a/.changeset/shaggy-geckos-chew.md
+++ b/.changeset/shaggy-geckos-chew.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Remove Vite static asset middleware

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -378,7 +378,8 @@ function remove_html_middlewares(server) {
 	const html_middlewares = [
 		'viteIndexHtmlMiddleware',
 		'vite404Middleware',
-		'viteSpaFallbackMiddleware'
+		'viteSpaFallbackMiddleware',
+		'viteServeStaticMiddleware'
 	];
 	for (let i = server.stack.length - 1; i > 0; i--) {
 		// @ts-expect-error using internals until https://github.com/vitejs/vite/pull/4640 is merged

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -2232,6 +2232,11 @@ test.describe.parallel('Static files', () => {
 		response = await request.get('/favicon.ico');
 		expect(response.status()).toBe(200);
 	});
+
+	test('does not use Vite middleware', async ({ request }) => {
+		const response = await request.get('/static/static.json');
+		expect(response.status()).toBe(404);
+	});
 });
 
 test.describe.parallel('Matchers', () => {


### PR DESCRIPTION
Noticed in #1634 (and I can't believe this hasn't come up sooner) that Vite will serve assets in the `static` folder, with that prefix — so `/favicon.png` can also be requested as `/static/favicon.png`. 

Fixed by removing `viteServeStaticMiddleware` in the plugin (which, aside: this feels like a _massive_ code smell and an indication that the design of the Vite dev server isn't optimal for the SSR framework use case).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
