### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/packages/kit/.eslintrc.json
+++ b/packages/kit/.eslintrc.json
@@ -13,6 +13,10 @@
 		"afterNavigate": true
 	},
 	"rules": {
+		"no-restricted-properties": [
+			"error",
+			{ "property": "substr", "message": "Use .slice instead of .substr." }
+		],
 		"@typescript-eslint/no-empty-interface": "off"
 	}
 }

--- a/packages/kit/src/core/build/prerender/crawl.js
+++ b/packages/kit/src/core/build/prerender/crawl.js
@@ -23,7 +23,7 @@ export function crawl(html) {
 			if (html[i + 1] === '!') {
 				i += 2;
 
-				if (html.substr(i, DOCTYPE.length).toUpperCase() === DOCTYPE) {
+				if (html.slice(i, i + DOCTYPE.length).toUpperCase() === DOCTYPE) {
 					i += DOCTYPE.length;
 					while (i < html.length) {
 						if (html[i++] === '>') {
@@ -33,10 +33,10 @@ export function crawl(html) {
 				}
 
 				// skip cdata
-				if (html.substr(i, CDATA_OPEN.length) === CDATA_OPEN) {
+				if (html.slice(i, i + CDATA_OPEN.length) === CDATA_OPEN) {
 					i += CDATA_OPEN.length;
 					while (i < html.length) {
-						if (html.substr(i, CDATA_CLOSE.length) === CDATA_CLOSE) {
+						if (html.slice(i, i + CDATA_CLOSE.length) === CDATA_CLOSE) {
 							i += CDATA_CLOSE.length;
 							continue main;
 						}
@@ -46,10 +46,10 @@ export function crawl(html) {
 				}
 
 				// skip comments
-				if (html.substr(i, COMMENT_OPEN.length) === COMMENT_OPEN) {
+				if (html.slice(i, i + COMMENT_OPEN.length) === COMMENT_OPEN) {
 					i += COMMENT_OPEN.length;
 					while (i < html.length) {
-						if (html.substr(i, COMMENT_CLOSE.length) === COMMENT_CLOSE) {
+						if (html.slice(i, i + COMMENT_CLOSE.length) === COMMENT_CLOSE) {
 							i += COMMENT_CLOSE.length;
 							continue main;
 						}
@@ -77,7 +77,7 @@ export function crawl(html) {
 						if (
 							html[i] === '<' &&
 							html[i + 1] === '/' &&
-							html.substr(i + 2, tag.length).toUpperCase() === tag
+							html.slice(i + 2, i + 2 + tag.length).toUpperCase() === tag
 						) {
 							continue main;
 						}


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.
