### PR TITLE
Deprioritise migration guide

### DIFF
--- a/documentation/docs/80-migrating.md
+++ b/documentation/docs/80-migrating.md
@@ -1,5 +1,6 @@
 ---
 title: Migrating from Sapper
+rank: 1
 ---
 
 SvelteKit is the successor to Sapper and shares many elements of its design.

--- a/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
+++ b/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
@@ -27,11 +27,11 @@
 
 		let time = Date.now();
 		for (const block of blocks) {
-			const title = block.breadcrumbs[block.breadcrumbs.length - 1];
+			const title = block.breadcrumbs.pop();
 			lookup.set(block.href, {
 				title,
 				href: block.href,
-				breadcrumbs: block.breadcrumbs.slice(0, -1),
+				breadcrumbs: block.breadcrumbs,
 				content: block.content
 			});
 			indexes[block.rank ?? 0].add(block.href, `${title} ${block.content}`);

--- a/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
+++ b/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
@@ -18,10 +18,11 @@
 		const { blocks } = await response.json();
 
 		// we have multiple indexes, so we can rank sections (migration guide comes last)
-		indexes = [
-			new flexsearch.Index({ tokenize: 'forward' }),
-			new flexsearch.Index({ tokenize: 'forward' })
-		];
+		const max_rank = Math.max(...blocks.map((block) => block.rank ?? 0));
+		indexes = Array.from(
+			{ length: max_rank + 1 },
+			() => new flexsearch.Index({ tokenize: 'forward' })
+		);
 
 		lookup = new Map();
 

--- a/sites/kit.svelte.dev/src/routes/content.json.js
+++ b/sites/kit.svelte.dev/src/routes/content.json.js
@@ -2,7 +2,6 @@ import fs from 'fs';
 import { extract_frontmatter, transform } from '$lib/docs/server/markdown';
 import { render_modules } from '$lib/docs/server/modules';
 import { slugify } from '../lib/docs/server';
-import { modules } from '../../../../documentation/types.js';
 
 const categories = [
 	{
@@ -39,13 +38,14 @@ export function get() {
 			const { body, metadata } = extract_frontmatter(markdown);
 
 			const sections = body.trim().split(/^### /m);
-
 			const intro = sections.shift().trim();
+			const rank = +metadata.rank || undefined;
 
 			blocks.push({
 				breadcrumbs: [...breadcrumbs, metadata.title],
 				href: category.href([slug]),
-				content: plaintext(intro)
+				content: plaintext(intro),
+				rank
 			});
 
 			for (const section of sections) {
@@ -60,7 +60,8 @@ export function get() {
 				blocks.push({
 					breadcrumbs: [...breadcrumbs, metadata.title, h3],
 					href: category.href([slug, slugify(h3)]),
-					content: plaintext(intro)
+					content: plaintext(intro),
+					rank
 				});
 
 				for (const subsection of subsections) {
@@ -70,7 +71,8 @@ export function get() {
 					blocks.push({
 						breadcrumbs: [...breadcrumbs, metadata.title, h3, h4],
 						href: category.href([slug, slugify(h3), slugify(h4)]),
-						content: plaintext(lines.join('\n').trim())
+						content: plaintext(lines.join('\n').trim()),
+						rank
 					});
 				}
 			}


### PR DESCRIPTION
Supersedes #4522. Adds a declarative method for ranking doc sections, since `boost` is unreliable. Only applies to the migration guide, _not_ the types, since it's quite likely people are searching for those.