### PR TITLE
skip client-side nav for <a sveltekit:reload>

### DIFF
--- a/.changeset/mighty-cows-notice.md
+++ b/.changeset/mighty-cows-notice.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Skip client-side navigation for links with sveltekit:reload

--- a/.changeset/orange-wolves-fly.md
+++ b/.changeset/orange-wolves-fly.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] Skip prerendering for rel="external" links

--- a/documentation/docs/07-a-options.md
+++ b/documentation/docs/07-a-options.md
@@ -20,6 +20,22 @@ Note that prefetching will not work if the [`router`](/docs/page-options#router)
 
 You can also programmatically invoke `prefetch` from `$app/navigation`.
 
+### sveltekit:reload
+
+By default, the SvelteKit runtime intercepts clicks on `<a>` elements and bypasses the normal browser navigation for relative (same-origin) URLs that match one of your page routes. We sometimes need to tell SvelteKit that certain links need to be handled by normal browser navigation. Examples of this might be linking to another page on your domain that's not part of your SvelteKit app or linking to an endpoint.
+
+Adding a `sveltekit:reload` attribute to a link...
+
+```html
+<a sveltekit:reload href="path">Path</a>
+```
+
+...will cause browser to navigate via a full page reload when the link is clicked.
+
+> SvelteKit does not exclude these links from prerendering, which will cause 404s if the URLs are intended to be served by a separate app. Use a custom [`prerender.onError`](/docs/configuration#prerender) handler if you need to ignore them.
+
+Links with a `rel="external"` attribute will receive the same treatment.
+
 ### sveltekit:noscroll
 
 When navigating to internal links, SvelteKit mirrors the browser's default navigation behaviour: it will change the scroll position to 0,0 so that the user is at the very top left of the page (unless the link includes a `#hash`, in which case it will scroll to the element with a matching ID).
@@ -31,17 +47,3 @@ In certain cases, you may wish to disable this behaviour. Adding a `sveltekit:no
 ```
 
 ...will prevent scrolling after the link is clicked.
-
-### rel=external
-
-By default, the SvelteKit runtime intercepts clicks on `<a>` elements and bypasses the normal browser navigation for relative (same-origin) URLs that match one of your page routes. We sometimes need to tell SvelteKit that certain links need to be handled by normal browser navigation. Examples of this might be linking to another page on your domain that's not part of your SvelteKit app or linking to an endpoint.
-
-Adding a `rel=external` attribute to a link...
-
-```html
-<a rel="external" href="path">Path</a>
-```
-
-...will trigger a browser navigation when the link is clicked.
-
-> SvelteKit does not exclude root-relative external links from prerendering, which will cause 404s if these URLs are intended to be served by a separate app. Use a custom [`prerender.onError`](/docs/configuration#prerender) handler if you need to ignore them.

--- a/documentation/docs/07-a-options.md
+++ b/documentation/docs/07-a-options.md
@@ -32,9 +32,7 @@ Adding a `sveltekit:reload` attribute to a link...
 
 ...will cause browser to navigate via a full page reload when the link is clicked.
 
-> SvelteKit does not exclude these links from prerendering, which will cause 404s if the URLs are intended to be served by a separate app. Use a custom [`prerender.onError`](/docs/configuration#prerender) handler if you need to ignore them.
-
-Links with a `rel="external"` attribute will receive the same treatment.
+Links with a `rel="external"` attribute will receive the same treatment. In addition, they will be ignored during [prerendering](https://kit.svelte.dev/docs/page-options#prerender).
 
 ### sveltekit:noscroll
 

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -38,7 +38,7 @@
 		"selfsigned": "^2.0.0",
 		"sirv": "^2.0.0",
 		"svelte": "^3.44.2",
-		"svelte-check": "^2.2.10",
+		"svelte-check": "^2.5.0",
 		"svelte-preprocess": "^4.9.8",
 		"svelte2tsx": "~0.5.0",
 		"tiny-glob": "^0.2.9",

--- a/packages/kit/src/core/build/prerender/crawl.js
+++ b/packages/kit/src/core/build/prerender/crawl.js
@@ -87,6 +87,7 @@ export function crawl(html) {
 				}
 
 				let href = '';
+				let rel = '';
 
 				while (i < html.length) {
 					const start = i;
@@ -148,6 +149,8 @@ export function crawl(html) {
 
 							if (name === 'href') {
 								href = value;
+							} else if (name === 'rel') {
+								rel = value;
 							} else if (name === 'src') {
 								hrefs.push(value);
 							} else if (name === 'srcset') {
@@ -178,7 +181,7 @@ export function crawl(html) {
 					i += 1;
 				}
 
-				if (href) {
+				if (href && !/\bexternal\b/i.test(rel)) {
 					hrefs.push(href);
 				}
 			}

--- a/packages/kit/src/core/build/prerender/fixtures/include-rel-external/output.json
+++ b/packages/kit/src/core/build/prerender/fixtures/include-rel-external/output.json
@@ -1,1 +1,1 @@
-["/styles.css", "/favicon.png", "https://external.com", "/wheee"]
+["/styles.css", "/favicon.png", "https://external.com"]

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1071,7 +1071,11 @@ export function create_client({ target, session, base, trailing_slash }) {
 				// 2. 'rel' attribute includes external
 				const rel = (a.getAttribute('rel') || '').split(/\s+/);
 
-				if (a.hasAttribute('download') || rel.includes('external')) {
+				if (
+					a.hasAttribute('download') ||
+					rel.includes('external') ||
+					a.hasAttribute('sveltekit:reload')
+				) {
 					return;
 				}
 

--- a/packages/kit/test/apps/amp/package.json
+++ b/packages/kit/test/apps/amp/package.json
@@ -15,7 +15,7 @@
 		"@sveltejs/kit": "workspace:*",
 		"cross-env": "^7.0.3",
 		"svelte": "^3.43.0",
-		"svelte-check": "^2.2.10",
+		"svelte-check": "^2.5.0",
 		"typescript": "~4.6.2"
 	},
 	"type": "module"

--- a/packages/kit/test/apps/basics/package.json
+++ b/packages/kit/test/apps/basics/package.json
@@ -15,7 +15,7 @@
 		"@sveltejs/kit": "workspace:*",
 		"cross-env": "^7.0.3",
 		"svelte": "^3.43.0",
-		"svelte-check": "^2.2.10",
+		"svelte-check": "^2.5.0",
 		"typescript": "~4.6.2"
 	},
 	"type": "module"

--- a/packages/kit/test/apps/basics/src/routes/routing/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/index.svelte
@@ -5,7 +5,7 @@
 <h1>Great success!</h1>
 
 <a href="/routing/a">a</a>
-<a href="/routing/ambiguous/ok.json">ok</a>
+<a href="/routing/ambiguous/ok.json" rel="external">ok</a>
 <a href="http://localhost:{$page.url.searchParams.get('port')}">elsewhere</a>
 <a href="/static.json">static.json</a>
 

--- a/packages/kit/test/apps/basics/src/routes/routing/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/index.svelte
@@ -5,8 +5,10 @@
 <h1>Great success!</h1>
 
 <a href="/routing/a">a</a>
-<a href="/routing/ambiguous/ok.json" rel="external">ok</a>
+<a href="/routing/ambiguous/ok.json">ok</a>
 <a href="http://localhost:{$page.url.searchParams.get('port')}">elsewhere</a>
 <a href="/static.json">static.json</a>
+
+<a href="/routing/b" sveltekit:reload>b</a>
 
 <div class="hydrate-test" />

--- a/packages/kit/test/apps/basics/src/routes/routing/rest/[...rest]/deep.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/rest/[...rest]/deep.svelte
@@ -16,5 +16,5 @@
 <h1>{$page.params.rest}</h1>
 <h2>{rest}</h2>
 
-<a href="/routing/rest/xyz/abc/qwe/deep.json">deep</a>
+<a href="/routing/rest/xyz/abc/qwe/deep.json" rel="external">deep</a>
 <a href="/routing/rest/xyz/abc">back</a>

--- a/packages/kit/test/apps/basics/src/routes/routing/rest/[...rest]/deep.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/rest/[...rest]/deep.svelte
@@ -16,5 +16,5 @@
 <h1>{$page.params.rest}</h1>
 <h2>{rest}</h2>
 
-<a href="/routing/rest/xyz/abc/qwe/deep.json" rel="external">deep</a>
+<a href="/routing/rest/xyz/abc/qwe/deep.json">deep</a>
 <a href="/routing/rest/xyz/abc">back</a>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1905,6 +1905,21 @@ test.describe.parallel('Routing', () => {
 		expect(await page.textContent('body')).toBe('ok');
 	});
 
+	test('does not attempt client-side navigation to links with sveltekit:reload', async ({
+		baseURL,
+		page
+	}) => {
+		await page.goto('/routing');
+
+		/** @type {string[]} */
+		const requests = [];
+		page.on('request', (r) => requests.push(r.url()));
+
+		await Promise.all([page.waitForNavigation(), page.click('[href="/routing/b"]')]);
+		expect(await page.textContent('h1')).toBe('b');
+		expect(requests).toContain(`${baseURL}/routing/b`);
+	});
+
 	test('allows reserved words as route names', async ({ page }) => {
 		await page.goto('/routing/const');
 		expect(await page.textContent('h1')).toBe('reserved words are okay as routes');

--- a/packages/kit/test/apps/options-2/package.json
+++ b/packages/kit/test/apps/options-2/package.json
@@ -16,7 +16,7 @@
 		"@sveltejs/kit": "workspace:*",
 		"cross-env": "^7.0.3",
 		"svelte": "^3.43.0",
-		"svelte-check": "^2.2.10",
+		"svelte-check": "^2.5.0",
 		"typescript": "~4.6.2"
 	},
 	"type": "module"

--- a/packages/kit/test/apps/options/package.json
+++ b/packages/kit/test/apps/options/package.json
@@ -15,7 +15,7 @@
 		"@sveltejs/kit": "workspace:*",
 		"cross-env": "^7.0.3",
 		"svelte": "^3.43.0",
-		"svelte-check": "^2.2.10",
+		"svelte-check": "^2.5.0",
 		"typescript": "~4.6.2"
 	},
 	"type": "module"

--- a/packages/kit/test/prerendering/basics/package.json
+++ b/packages/kit/test/prerendering/basics/package.json
@@ -12,7 +12,7 @@
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:*",
 		"svelte": "^3.43.0",
-		"svelte-check": "^2.2.10",
+		"svelte-check": "^2.5.0",
 		"typescript": "~4.6.2",
 		"uvu": "^0.5.2"
 	},

--- a/packages/kit/test/prerendering/options/package.json
+++ b/packages/kit/test/prerendering/options/package.json
@@ -12,7 +12,7 @@
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:*",
 		"svelte": "^3.43.0",
-		"svelte-check": "^2.2.10",
+		"svelte-check": "^2.5.0",
 		"typescript": "~4.6.2",
 		"uvu": "^0.5.2"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,7 +268,7 @@ importers:
       selfsigned: ^2.0.0
       sirv: ^2.0.0
       svelte: ^3.44.2
-      svelte-check: ^2.2.10
+      svelte-check: ^2.5.0
       svelte-preprocess: ^4.9.8
       svelte2tsx: ~0.5.0
       tiny-glob: ^0.2.9
@@ -302,7 +302,7 @@ importers:
       selfsigned: 2.0.0
       sirv: 2.0.0
       svelte: 3.44.2
-      svelte-check: 2.2.10_svelte@3.44.2
+      svelte-check: 2.5.0_svelte@3.44.2
       svelte-preprocess: 4.9.8_svelte@3.44.2+typescript@4.6.2
       svelte2tsx: 0.5.0_svelte@3.44.2+typescript@4.6.2
       tiny-glob: 0.2.9
@@ -313,13 +313,13 @@ importers:
       '@sveltejs/kit': workspace:*
       cross-env: ^7.0.3
       svelte: ^3.43.0
-      svelte-check: ^2.2.10
+      svelte-check: ^2.5.0
       typescript: ~4.6.2
     devDependencies:
       '@sveltejs/kit': link:../../..
       cross-env: 7.0.3
       svelte: 3.44.2
-      svelte-check: 2.2.10_svelte@3.44.2
+      svelte-check: 2.5.0_svelte@3.44.2
       typescript: 4.6.2
 
   packages/kit/test/apps/basics:
@@ -327,13 +327,13 @@ importers:
       '@sveltejs/kit': workspace:*
       cross-env: ^7.0.3
       svelte: ^3.43.0
-      svelte-check: ^2.2.10
+      svelte-check: ^2.5.0
       typescript: ~4.6.2
     devDependencies:
       '@sveltejs/kit': link:../../..
       cross-env: 7.0.3
       svelte: 3.44.2
-      svelte-check: 2.2.10_svelte@3.44.2
+      svelte-check: 2.5.0_svelte@3.44.2
       typescript: 4.6.2
 
   packages/kit/test/apps/options:
@@ -341,13 +341,13 @@ importers:
       '@sveltejs/kit': workspace:*
       cross-env: ^7.0.3
       svelte: ^3.43.0
-      svelte-check: ^2.2.10
+      svelte-check: ^2.5.0
       typescript: ~4.6.2
     devDependencies:
       '@sveltejs/kit': link:../../..
       cross-env: 7.0.3
       svelte: 3.44.2
-      svelte-check: 2.2.10_svelte@3.44.2
+      svelte-check: 2.5.0_svelte@3.44.2
       typescript: 4.6.2
 
   packages/kit/test/apps/options-2:
@@ -356,27 +356,27 @@ importers:
       '@sveltejs/kit': workspace:*
       cross-env: ^7.0.3
       svelte: ^3.43.0
-      svelte-check: ^2.2.10
+      svelte-check: ^2.5.0
       typescript: ~4.6.2
     devDependencies:
       '@sveltejs/adapter-node': link:../../../../adapter-node
       '@sveltejs/kit': link:../../..
       cross-env: 7.0.3
       svelte: 3.44.2
-      svelte-check: 2.2.10_svelte@3.44.2
+      svelte-check: 2.5.0_svelte@3.44.2
       typescript: 4.6.2
 
   packages/kit/test/prerendering/basics:
     specifiers:
       '@sveltejs/kit': workspace:*
       svelte: ^3.43.0
-      svelte-check: ^2.2.10
+      svelte-check: ^2.5.0
       typescript: ~4.6.2
       uvu: ^0.5.2
     devDependencies:
       '@sveltejs/kit': link:../../..
       svelte: 3.44.2
-      svelte-check: 2.2.10_svelte@3.44.2
+      svelte-check: 2.5.0_svelte@3.44.2
       typescript: 4.6.2
       uvu: 0.5.2
 
@@ -384,13 +384,13 @@ importers:
     specifiers:
       '@sveltejs/kit': workspace:*
       svelte: ^3.43.0
-      svelte-check: ^2.2.10
+      svelte-check: ^2.5.0
       typescript: ~4.6.2
       uvu: ^0.5.2
     devDependencies:
       '@sveltejs/kit': link:../../..
       svelte: 3.44.2
-      svelte-check: 2.2.10_svelte@3.44.2
+      svelte-check: 2.5.0_svelte@3.44.2
       typescript: 4.6.2
       uvu: 0.5.2
 
@@ -1996,7 +1996,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.0
+      picomatch: 2.3.1
     dev: true
 
   /aproba/1.2.0:
@@ -3350,7 +3350,7 @@ packages:
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
-      micromatch: 4.0.4
+      micromatch: 4.0.5
     dev: true
 
   /fast-json-stable-stringify/2.1.0:
@@ -4129,7 +4129,7 @@ packages:
   /jsonfile/4.0.0:
     resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=}
     optionalDependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: 4.2.10
     dev: true
 
   /kind-of/6.0.3:
@@ -5213,7 +5213,7 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
     dependencies:
-      picomatch: 2.3.0
+      picomatch: 2.3.1
     dev: true
 
   /redent/3.0.0:
@@ -5744,22 +5744,21 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  /svelte-check/2.2.10_svelte@3.44.2:
-    resolution: {integrity: sha512-UVLd/N7hUIG2v6dytofsw8MxYn2iS2hpNSglsGz9Z9b8ZfbJ5jayl4Mm1SXhNwiFs5aklG90zSBJtd7NTK8dTg==}
+  /svelte-check/2.5.0_svelte@3.44.2:
+    resolution: {integrity: sha512-/laO032JQ1TpmYHgaaLndHNPeWW3VSL3liMB97sA9fYTEzlIy3jIo4Rgr7EzjNvieiNWG73C5voOAeNHlrwbpg==}
     hasBin: true
     peerDependencies:
       svelte: ^3.24.0
     dependencies:
-      chalk: 4.1.2
       chokidar: 3.5.2
       fast-glob: 3.2.7
       import-fresh: 3.3.0
-      minimist: 1.2.5
+      picocolors: 1.0.0
       sade: 1.7.4
       source-map: 0.7.3
       svelte: 3.44.2
-      svelte-preprocess: 4.9.8_svelte@3.44.2+typescript@4.5.5
-      typescript: 4.5.5
+      svelte-preprocess: 4.9.8_svelte@3.44.2+typescript@4.6.2
+      typescript: 4.6.2
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -5780,57 +5779,6 @@ packages:
     dependencies:
       svelte: 3.44.2
     dev: false
-
-  /svelte-preprocess/4.9.8_svelte@3.44.2+typescript@4.5.5:
-    resolution: {integrity: sha512-EQS/oRZzMtYdAprppZxY3HcysKh11w54MgA63ybtL+TAZ4hVqYOnhw41JVJjWN9dhPnNjjLzvbZ2tMhTsla1Og==}
-    engines: {node: '>= 9.11.2'}
-    requiresBuild: true
-    peerDependencies:
-      '@babel/core': ^7.10.2
-      coffeescript: ^2.5.1
-      less: ^3.11.3
-      node-sass: '*'
-      postcss: ^7 || ^8
-      postcss-load-config: ^2.1.0 || ^3.0.0
-      pug: ^3.0.0
-      sass: ^1.26.8
-      stylus: ^0.54.7
-      sugarss: ^2.0.0
-      svelte: ^3.23.0
-      typescript: ^3.9.5 || ^4.0.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      coffeescript:
-        optional: true
-      less:
-        optional: true
-      node-sass:
-        optional: true
-      postcss:
-        optional: true
-      postcss-load-config:
-        optional: true
-      pug:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@types/pug': 2.0.5
-      '@types/sass': 1.43.1
-      detect-indent: 6.1.0
-      magic-string: 0.25.7
-      sorcery: 0.10.0
-      strip-indent: 3.0.0
-      svelte: 3.44.2
-      typescript: 4.5.5
-    dev: true
 
   /svelte-preprocess/4.9.8_svelte@3.44.2+typescript@4.6.2:
     resolution: {integrity: sha512-EQS/oRZzMtYdAprppZxY3HcysKh11w54MgA63ybtL+TAZ4hVqYOnhw41JVJjWN9dhPnNjjLzvbZ2tMhTsla1Og==}


### PR DESCRIPTION
closes #546, though there's still room for bikeshedding.

One issue here is that the `sveltekit:reload` attribute gets squigglied: 

<img width="337" alt="image" src="https://user-images.githubusercontent.com/1162160/162048563-7f69eac4-c290-4ce5-b437-9df4d0a81d69.png">

I actually have no idea where `SvelteKitAnchorProps` (which determines which attributes are valid) is defined?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
