### PR TITLE
remove credentials when creating request object

### DIFF
--- a/.changeset/lazy-berries-decide.md
+++ b/.changeset/lazy-berries-decide.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Remove credentials when creating request object in server-side fetch

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -186,11 +186,18 @@ export async function load_node({
 						throw new Error('Request body must be a string');
 					}
 
-					response = await respond(new Request(new URL(requested, event.url).href, opts), options, {
-						getClientAddress: state.getClientAddress,
-						initiator: route,
-						prerender: state.prerender
-					});
+					response = await respond(
+						// we set `credentials` to `undefined` to workaround a bug in Cloudflare
+						// (https://github.com/sveltejs/kit/issues/3728) — which is fine, because
+						// we only need the headers
+						new Request(new URL(requested, event.url).href, { ...opts, credentials: undefined }),
+						options,
+						{
+							getClientAddress: state.getClientAddress,
+							initiator: route,
+							prerender: state.prerender
+						}
+					);
 
 					if (state.prerender) {
 						dependency = { response, body: null };


### PR DESCRIPTION
#3728. Remains to be seen if it fixes the issue, but there's a good chance it does. Basically, you can't do this in a Cloudflare worker:

```js
new Request(url, { credentials: 'omit' });
```

We don't actually need to include `credentials` when constructing the `Request` object for a server-side fetch (it only makes sense in the browser context, where you want to include `cookie` and `authorization` headers but don't have programmatic access to their values), so this shouldn't affect anything.

No test because I have no idea how you'd test this.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
