### PR TITLE
fix session subscription tracking

### DIFF
--- a/.changeset/odd-coats-shake.md
+++ b/.changeset/odd-coats-shake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix session store subscription tracking during SSR

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -84,27 +84,19 @@ export async function render_response({
 			maxage = loaded.maxage;
 		});
 
-		/** @type {import('svelte/store').Writable<App.Session>} */
-		const session = {
-			subscribe: (fn) => {
-				is_private = true;
-				fn($session);
-				return () => {};
-			},
-			set: () => {
-				throw new Error('Cannot write to session during SSR');
-			},
-			update: () => {
-				throw new Error('Cannot write to session during SSR');
-			}
-		};
-
 		/** @type {Record<string, any>} */
 		const props = {
 			stores: {
 				page: writable(null),
 				navigating: writable(null),
-				session,
+				/** @type {import('svelte/store').Readable<App.Session>} */
+				session: {
+					subscribe: (fn) => {
+						is_private = true;
+						fn($session);
+						return () => {};
+					}
+				},
 				updated
 			},
 			/** @type {import('types').Page} */

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -84,17 +84,19 @@ export async function render_response({
 			maxage = loaded.maxage;
 		});
 
+		const session = writable($session);
+
 		/** @type {Record<string, any>} */
 		const props = {
 			stores: {
 				page: writable(null),
 				navigating: writable(null),
-				/** @type {import('svelte/store').Readable<App.Session>} */
+				/** @type {import('svelte/store').Writable<App.Session>} */
 				session: {
+					...session,
 					subscribe: (fn) => {
 						is_private = true;
-						fn($session);
-						return () => {};
+						return session.subscribe(fn);
 					}
 				},
 				updated

--- a/packages/kit/test/apps/basics/src/routes/caching/private/uses-session-in-init.svelte
+++ b/packages/kit/test/apps/basics/src/routes/caching/private/uses-session-in-init.svelte
@@ -1,0 +1,16 @@
+<script context="module">
+	/** @type {import('@sveltejs/kit').Load} */
+	export async function load() {
+		return {
+			maxage: 30
+		};
+	}
+</script>
+
+<script>
+	import { session } from '$app/stores';
+
+	const session_exists = !!$session;
+</script>
+
+<h1>this page will be cached for 30 seconds ({session_exists})</h1>

--- a/packages/kit/test/apps/basics/src/routes/caching/private/uses-session-in-load.svelte
+++ b/packages/kit/test/apps/basics/src/routes/caching/private/uses-session-in-load.svelte
@@ -12,4 +12,8 @@
 	}
 </script>
 
-<h1>this page will be cached for 30 seconds</h1>
+<script>
+	export let session_exists;
+</script>
+
+<h1>this page will be cached for 30 seconds ({session_exists})</h1>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -305,8 +305,13 @@ test.describe.parallel('Caching', () => {
 		expect(response.headers()['cache-control']).toBe('public, max-age=30');
 	});
 
-	test('sets cache-control: private if page uses session', async ({ request }) => {
-		const response = await request.get('/caching/private/uses-session');
+	test('sets cache-control: private if page uses session in load', async ({ request }) => {
+		const response = await request.get('/caching/private/uses-session-in-load');
+		expect(response.headers()['cache-control']).toBe('private, max-age=30');
+	});
+
+	test('sets cache-control: private if page uses session in init', async ({ request }) => {
+		const response = await request.get('/caching/private/uses-session-in-init');
 		expect(response.headers()['cache-control']).toBe('private, max-age=30');
 	});
 


### PR DESCRIPTION
closes #793 (https://github.com/sveltejs/kit/issues/793#issuecomment-1088699481 — thanks to hawkeye @istarkov). We need to detect whether session is _read_ during SSR, not _written_. brainfart on my part

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
