### PR TITLE
[chore] bump `eslint` from version 7 to 8

### DIFF
--- a/.changeset/fast-crabs-applaud.md
+++ b/.changeset/fast-crabs-applaud.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Bump `eslint` from version 7 to 8

--- a/packages/create-svelte/shared/+eslint/package.json
+++ b/packages/create-svelte/shared/+eslint/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"eslint": "^7.32.0",
+		"eslint": "^8.12.0",
 		"eslint-plugin-svelte3": "^3.2.1"
 	}
 }

--- a/packages/create-svelte/shared/+eslint/package.json
+++ b/packages/create-svelte/shared/+eslint/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
 		"eslint": "^8.12.0",
-		"eslint-plugin-svelte3": "^3.2.1"
+		"eslint-plugin-svelte3": "^4.0.0"
 	}
 }


### PR DESCRIPTION
When a user creates a SvelteKit app with `eslint` support using `create-svelte`, it ships the last `eslint` release under major version 7. With this pull request, `create-svelte` will now ship the latest `eslint` release (for now).

I'm worried that `eslint-plugin-svelte3` doesn't support `eslint@^8.0.0`, from [this discussion](https://github.com/sveltejs/eslint-plugin-svelte3/pull/155#issuecomment-1003056483).

`eslint-plugin-svelte3`'s peerDependencies [lists `eslint@>=6.0.0`](https://github.com/sveltejs/eslint-plugin-svelte3/blob/55fc0bdcb76748edec2b5613113574ba45b1a419/package.json#L28) since June 22, 2019, around when `eslint@6.0.1` was released.

Related: #3261

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
