### PR TITLE
Update one incorrect PR number in changelog

### DIFF
--- a/packages/kit/CHANGELOG.md
+++ b/packages/kit/CHANGELOG.md
@@ -80,7 +80,7 @@
 
 - Populate fallback page when trailingSlash is "always" ([#4351](https://github.com/sveltejs/kit/pull/4351))
 
-* Expose `event.routeId` and `page.routeId` ([#4344](https://github.com/sveltejs/kit/pull/4345))
+* Expose `event.routeId` and `page.routeId` ([#4345](https://github.com/sveltejs/kit/pull/4345))
 
 - [breaking] remove fallthrough routes ([#4330](https://github.com/sveltejs/kit/pull/4330))
 

--- a/packages/kit/CHANGELOG.md
+++ b/packages/kit/CHANGELOG.md
@@ -80,7 +80,7 @@
 
 - Populate fallback page when trailingSlash is "always" ([#4351](https://github.com/sveltejs/kit/pull/4351))
 
-* Expose `event.routeId` and `page.routeId` ([#4344](https://github.com/sveltejs/kit/pull/4344))
+* Expose `event.routeId` and `page.routeId` ([#4344](https://github.com/sveltejs/kit/pull/4345))
 
 - [breaking] remove fallthrough routes ([#4330](https://github.com/sveltejs/kit/pull/4330))
 


### PR DESCRIPTION
Because of how #4345 was merged into #4344, the script that automatically adds PR numbers to the changelog got the wrong PR number for the "Expose `event.routeId` and `page.routeId`" feature. This manual change to  the CHANGELOG.md file fixes that minor error.

No changeset included, for obvious reasons.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
