### PR TITLE
ci: add step to release script that updates the latest tag 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,15 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           UPDATE_TEMPLATE_SSH_KEY: ${{ secrets.UPDATE_TEMPLATE_SSH_KEY }}
 
+      - name: Update latest tag on published packages  # only needed until we release 1.0.0 and exit pre-release mode
+        if: steps.changesets.outputs.published == 'true'
+        # wait a bit and then run "npm dist-tag add package@version latest" for all published packages
+        env:
+          published_packages: ${{steps.changesets.outputs.publishedPackages}}
+        run: |
+          sleep 20
+          echo $published_packages | jq -r 'map((.name + "@" + .version)) | .[]' | while read pkgver; do echo npm dist-tag add $pkgver latest || continue;done
+
       # TODO alert discord
       # - name: Send a Slack notification if a publish happens
       #   if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
see https://github.com/sveltejs/kit/issues/686

What this step does.
- put publishedPackages into an env var
- echo and pipe that into jq that maps it into `package@version` strings
- loop over these and call `echo npm dist-tag add package@version latest` for each published package

**The called command is `echo`ed for now to make sure it is correct.** 

After we verified it works we can remove the echo.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
