### PR TITLE
docs(endpoint): adding example regarding parsing url params

### DIFF
--- a/documentation/docs/01-routing.md
+++ b/documentation/docs/01-routing.md
@@ -241,6 +241,25 @@ export async function post({ request }) {
 }
 ```
 
+#### URL parsing
+
+The `url` object is an instance of the standard [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) class at the `searchParams` key. As such, you can access the params sent using query params.
+
+```js
+// @filename: index.js
+// /foo?limit=10&offset=20
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function get({ url }) {
+	const limit = url.searchParams.get("limit");
+	const offset = url.searchParams.get("offset"); 
+
+	const response = await expensiveSearch({ limit, offset });
+	const items = await response.json();
+
+	return { items, status: 201 };
+}
+```
+
 #### Setting cookies
 
 Endpoints can set cookies by returning a `headers` object with `set-cookie`. To set multiple cookies simultaneously, return an array:


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

## Changes

Hi, thanks for the amazing job on this project. I have been using SvelteKit for a while, but wasn't able to find a proper example on how to access params sent using URL params: `/foo?a=1&b=2`.

This PR adds an example regarding the use of URL search params using [endpoints](https://kit.svelte.dev/docs/routing#endpoints).

Note: I sent this fix at #4552 , but it looks like the pull bot ended up removing my changes. 😓 