### PR TITLE
[docs] remove references to @next tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ You can now run SvelteKit by linking it into your project with [pnpm `overrides`
 
 Entry points to be aware of are:
 
-- [`packages/create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte) - code that's run when you create a new project with `npm init svelte@next`
+- [`packages/create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte) - code that's run when you create a new project with `npm init svelte`
 - [`packages/kit/src/packaging`](https://github.com/sveltejs/kit/tree/master/packages/kit/src/packaging) - for the `svelte-kit package` command
 - [`packages/kit/src/core/dev/index.js`](https://github.com/sveltejs/kit/blob/master/packages/kit/src/core/dev/index.js) - for the dev-mode server
 - [`packages/kit/src/core/build/index.js`](https://github.com/sveltejs/kit/blob/master/packages/kit/src/core/build/index.js) - for the production server

--- a/documentation/docs/00-introduction.md
+++ b/documentation/docs/00-introduction.md
@@ -23,7 +23,7 @@ You don't need to know Svelte to understand the rest of this guide, but it will 
 The easiest way to start building a SvelteKit app is to run `npm init`:
 
 ```bash
-npm init svelte@next my-app
+npm init svelte my-app
 cd my-app
 npm install
 npm run dev

--- a/documentation/docs/09-adapters.md
+++ b/documentation/docs/09-adapters.md
@@ -20,7 +20,7 @@ You can deploy to the following platforms with the default adapter, `adapter-aut
 
 #### Node.js
 
-To create a simple Node server, install the [`@sveltejs/adapter-node@next`](https://github.com/sveltejs/kit/tree/master/packages/adapter-node) package and update your `svelte.config.js`:
+To create a simple Node server, install the [`@sveltejs/adapter-node`](https://github.com/sveltejs/kit/tree/master/packages/adapter-node) package and update your `svelte.config.js`:
 
 ```diff
 /// file: svelte.config.js
@@ -44,7 +44,7 @@ export default {
 
 #### Static sites
 
-Most adapters will generate static HTML for any [prerenderable](/docs/page-options#prerender) pages of your site. In some cases, your entire app might be prerenderable, in which case you can use [`@sveltejs/adapter-static@next`](https://github.com/sveltejs/kit/tree/master/packages/adapter-static) to generate static HTML for _all_ your pages. A fully static site can be hosted on a wide variety of platforms, including static hosts like [GitHub Pages](https://pages.github.com/).
+Most adapters will generate static HTML for any [prerenderable](/docs/page-options#prerender) pages of your site. In some cases, your entire app might be prerenderable, in which case you can use [`@sveltejs/adapter-static`](https://github.com/sveltejs/kit/tree/master/packages/adapter-static) to generate static HTML for _all_ your pages. A fully static site can be hosted on a wide variety of platforms, including static hosts like [GitHub Pages](https://pages.github.com/).
 
 ```diff
 /// file: svelte.config.js

--- a/packages/adapter-cloudflare-workers/README.md
+++ b/packages/adapter-cloudflare-workers/README.md
@@ -17,7 +17,7 @@ _**Comparisons**_
 
 ## Usage
 
-Install with `npm i -D @sveltejs/adapter-cloudflare-workers@next`, then add the adapter to your `svelte.config.js`:
+Install with `npm i -D @sveltejs/adapter-cloudflare-workers`, then add the adapter to your `svelte.config.js`:
 
 ```js
 import adapter from '@sveltejs/adapter-cloudflare-workers';

--- a/packages/adapter-cloudflare/README.md
+++ b/packages/adapter-cloudflare/README.md
@@ -20,7 +20,7 @@ _**Comparisons**_
 ## Installation
 
 ```sh
-$ npm i --save-dev @sveltejs/adapter-cloudflare@next
+$ npm i --save-dev @sveltejs/adapter-cloudflare
 ```
 
 ## Usage

--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -6,10 +6,8 @@ If you're using [adapter-auto](../adapter-auto), you don't need to install this 
 
 ## Installation
 
-> ⚠️ For the time being, the latest version of adapter-netlify is at the @next tag. If you get the error `config.kit.adapter should be an object with an "adapt" method.`, this is a sign that you are using the wrong version (eg `1.0.0-next.0` instead of `1.0.0-next.9`).
-
 ```bash
-npm i -D @sveltejs/adapter-netlify@next
+npm i -D @sveltejs/adapter-netlify
 ```
 
 You can then configure it inside of `svelte.config.js`:

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -4,7 +4,7 @@
 
 ## Usage
 
-Install with `npm i -D @sveltejs/adapter-node@next`, then add the adapter to your `svelte.config.js`:
+Install with `npm i -D @sveltejs/adapter-node`, then add the adapter to your `svelte.config.js`:
 
 ```js
 // svelte.config.js

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -4,7 +4,7 @@
 
 ## Usage
 
-Install with `npm i -D @sveltejs/adapter-static@next`, then add the adapter to your `svelte.config.js`:
+Install with `npm i -D @sveltejs/adapter-static`, then add the adapter to your `svelte.config.js`:
 
 ```js
 // svelte.config.js

--- a/packages/adapter-static/test/apps/spa/README.md
+++ b/packages/adapter-static/test/apps/spa/README.md
@@ -8,13 +8,11 @@ If you're seeing this, you've probably already done this step. Congrats!
 
 ```bash
 # create a new project in the current directory
-npm init svelte@next
+npm init svelte
 
 # create a new project in my-app
-npm init svelte@next my-app
+npm init svelte my-app
 ```
-
-> Note: the `@next` is temporary
 
 ## Developing
 

--- a/packages/create-svelte/shared/README.md
+++ b/packages/create-svelte/shared/README.md
@@ -8,13 +8,11 @@ If you're seeing this, you've probably already done this step. Congrats!
 
 ```bash
 # create a new project in the current directory
-npm init svelte@next
+npm init svelte
 
 # create a new project in my-app
-npm init svelte@next my-app
+npm init svelte my-app
 ```
-
-> Note: the `@next` is temporary
 
 ## Developing
 

--- a/packages/create-svelte/templates/default/src/routes/about.svelte
+++ b/packages/create-svelte/templates/default/src/routes/about.svelte
@@ -26,8 +26,7 @@
 		following into your command line and following the prompts:
 	</p>
 
-	<!-- TODO lose the @next! -->
-	<pre>npm init svelte@next</pre>
+	<pre>npm init svelte</pre>
 
 	<p>
 		The page you're looking at is purely static HTML, with no client-side interactivity needed.

--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -5,7 +5,7 @@ This is the [SvelteKit](https://kit.svelte.dev) framework and CLI.
 The quickest way to get started is via the [create-svelte](https://github.com/sveltejs/kit/tree/master/packages/create-svelte) package:
 
 ```bash
-npm init svelte@next my-app
+npm init svelte my-app
 cd my-app
 npm install
 npm run dev

--- a/sites/kit.svelte.dev/src/routes/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/index.svelte
@@ -83,7 +83,7 @@
 
 		<div slot="how">
 			<pre><code>
-npm init <span class="orange-highlight">svelte@next</span> my-app
+npm init <span class="orange-highlight">svelte</span> my-app
 cd my-app
 npm install
 npm run dev -- --open


### PR DESCRIPTION
This removes the `@next` references throughout the site and various readmes, as all packages are now being published as `@latest` as well.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
