### PR TITLE
Add platform to root relative requests

### DIFF
--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -195,6 +195,7 @@ export async function load_node({
 						{
 							getClientAddress: state.getClientAddress,
 							initiator: route,
+							platform: state.platform,
 							prerender: state.prerender
 						}
 					);


### PR DESCRIPTION
Currently `platform` is not passed forward to root relative requests. If request hooks or endpoints rely on the values in `platform`, this will cause them to not work and throw errors. This PR fixes this by adding the platform.

There is no way to test this as far as I can tell currently because there is no way to provide a platform for local development.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
