### PR TITLE
Revert change to render fallback when prerendering is disabled

### DIFF
--- a/.changeset/red-adults-wonder.md
+++ b/.changeset/red-adults-wonder.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Revert change to render fallback when prerendering is disabled
+Only render fallback when prerendering is enabled

--- a/.changeset/red-adults-wonder.md
+++ b/.changeset/red-adults-wonder.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Revert change to render fallback when prerendering is disabled

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -71,6 +71,8 @@ export default {
 
 When operating in SPA mode, you can omit `config.kit.prerender.default` (or set it to `false`, its default value), and only pages that have the [`prerender`](https://kit.svelte.dev/docs/page-options#prerender) option set will be prerendered at build time.
 
+If Node.js throws errors when loading your pages during the build process and this is hard for you to work around, setting `config.kit.prerender.entries` to `[]` will prevent the build process from attempting to load any page or layout components. Do not set `config.kit.prerender.enabled` to `false` because that will also prevent the fallback page from being generated.
+
 > ⚠️ During development, SvelteKit will still attempt to server-side render your routes. This means accessing things that are only available in the browser (such as the `window` object) will result in errors, even though this would be valid in the output app. To align the behavior of SvelteKit's dev mode with your SPA, you can [call `resolve()` with a parameter of `{ssr: false}` inside the `handle()` hook](https://kit.svelte.dev/docs/hooks#handle).
 
 ## GitHub Pages

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -71,7 +71,7 @@ export default {
 
 When operating in SPA mode, you can omit `config.kit.prerender.default` (or set it to `false`, its default value), and only pages that have the [`prerender`](https://kit.svelte.dev/docs/page-options#prerender) option set will be prerendered at build time.
 
-If Node.js throws errors when loading your pages during the build process and this is hard for you to work around, setting `config.kit.prerender.entries` to `[]` will prevent the build process from attempting to load any page or layout components. Do not set `config.kit.prerender.enabled` to `false` because that will also prevent the fallback page from being generated.
+SvelteKit will still crawl your app's entry points looking for prerenderable pages. If `svelte-kit build` fails because of pages that can't be loaded outside the browser, you can set `config.kit.prerender.entries` to `[]` to prevent this from happening. (Setting `config.kit.prerender.enabled` also has this effect, but would prevent the fallback page from being generated.)
 
 > ⚠️ During development, SvelteKit will still attempt to server-side render your routes. This means accessing things that are only available in the browser (such as the `window` object) will result in errors, even though this would be valid in the output app. To align the behavior of SvelteKit's dev mode with your SPA, you can [call `resolve()` with a parameter of `{ssr: false}` inside the `handle()` hook](https://kit.svelte.dev/docs/hooks#handle).
 

--- a/packages/kit/src/core/build/prerender/prerender.js
+++ b/packages/kit/src/core/build/prerender/prerender.js
@@ -55,6 +55,10 @@ export async function prerender({ config, entries, files, log }) {
 		paths: []
 	};
 
+	if (!config.kit.prerender.enabled) {
+		return prerendered;
+	}
+
 	installFetch();
 
 	const server_root = join(config.kit.outDir, 'output');
@@ -70,23 +74,6 @@ export async function prerender({ config, entries, files, log }) {
 	});
 
 	const server = new Server(manifest);
-
-	const rendered = await server.respond(new Request('http://sveltekit-prerender/[fallback]'), {
-		getClientAddress,
-		prerender: {
-			fallback: true,
-			default: false,
-			dependencies: new Map()
-		}
-	});
-
-	const file = `${config.kit.outDir}/output/prerendered/fallback.html`;
-	mkdirp(dirname(file));
-	writeFileSync(file, await rendered.text());
-
-	if (!config.kit.prerender.enabled) {
-		return prerendered;
-	}
 
 	const error = normalise_error_handler(log, config.kit.prerender.onError);
 
@@ -280,6 +267,19 @@ export async function prerender({ config, entries, files, log }) {
 
 		await q.done();
 	}
+
+	const rendered = await server.respond(new Request('http://sveltekit-prerender/[fallback]'), {
+		getClientAddress,
+		prerender: {
+			fallback: true,
+			default: false,
+			dependencies: new Map()
+		}
+	});
+
+	const file = `${config.kit.outDir}/output/prerendered/fallback.html`;
+	mkdirp(dirname(file));
+	writeFileSync(file, await rendered.text());
 
 	return prerendered;
 }

--- a/packages/kit/test/prerendering/disabled/package.json
+++ b/packages/kit/test/prerendering/disabled/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "prerendering-test-basics",
+	"private": true,
+	"version": "0.0.2-next.0",
+	"scripts": {
+		"dev": "node ../../cli.js dev",
+		"build": "node ../../cli.js build",
+		"preview": "node ../../cli.js preview",
+		"check": "tsc && svelte-check",
+		"test": "npm run build"
+	},
+	"devDependencies": {
+		"@sveltejs/kit": "workspace:*",
+		"svelte": "^3.43.0",
+		"svelte-check": "^2.5.0",
+		"typescript": "~4.6.2",
+		"uvu": "^0.5.2"
+	},
+	"type": "module"
+}

--- a/packages/kit/test/prerendering/disabled/src/app.html
+++ b/packages/kit/test/prerendering/disabled/src/app.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%svelte.head%
+	</head>
+	<body>
+		%svelte.body%
+	</body>
+</html>

--- a/packages/kit/test/prerendering/disabled/src/hooks.js
+++ b/packages/kit/test/prerendering/disabled/src/hooks.js
@@ -1,0 +1,1 @@
+throw new Error('this file should not be loaded if prerendering is disabled');

--- a/packages/kit/test/prerendering/disabled/src/routes/index.svelte
+++ b/packages/kit/test/prerendering/disabled/src/routes/index.svelte
@@ -1,0 +1,1 @@
+<h1>not prerendered</h1>

--- a/packages/kit/test/prerendering/disabled/svelte.config.js
+++ b/packages/kit/test/prerendering/disabled/svelte.config.js
@@ -1,0 +1,27 @@
+import path from 'path';
+import adapter from '../../../../adapter-static/index.js';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	kit: {
+		adapter: adapter(),
+
+		prerender: {
+			enabled: false
+		},
+
+		vite: {
+			build: {
+				minify: false
+			},
+			clearScreen: false,
+			server: {
+				fs: {
+					allow: [path.resolve('../../../src')]
+				}
+			}
+		}
+	}
+};
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,6 +380,20 @@ importers:
       typescript: 4.6.2
       uvu: 0.5.2
 
+  packages/kit/test/prerendering/disabled:
+    specifiers:
+      '@sveltejs/kit': workspace:*
+      svelte: ^3.43.0
+      svelte-check: ^2.5.0
+      typescript: ~4.6.2
+      uvu: ^0.5.2
+    devDependencies:
+      '@sveltejs/kit': link:../../..
+      svelte: 3.44.2
+      svelte-check: 2.5.0_svelte@3.44.2
+      typescript: 4.6.2
+      uvu: 0.5.2
+
   packages/kit/test/prerendering/options:
     specifiers:
       '@sveltejs/kit': workspace:*


### PR DESCRIPTION
Fixes #4492. 

Loading `hooks.js` and/or executing the `handle` hook during the build process causes problems for some people, and so rendering the fallback page event when prerendering is disabled presents those people with build failures that can not be worked around. This PR reverts  #4443, which enabled that behavior after the prerender process was moved into the build step.

For those like me who need a fallback page but are saddled with code that causes the build process to fail because Node.js throws a tantrum when you even try to `import` a page component, a configuration workaround is presented in the README for `adapter-static`. (An example is dependencies that are ESM compatible, but not in the exact one way that Node requires them to be.)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
