### PR TITLE
account for documentation in site build inputs

### DIFF
--- a/documentation/docs/00-introduction.md
+++ b/documentation/docs/00-introduction.md
@@ -2,8 +2,6 @@
 title: Introduction
 ---
 
-testing testing 1 2 3
-
 ### Before we begin
 
 > SvelteKit is in early development, and some things may change before we hit version 1.0. This document is a work-in-progress. If you get stuck, reach out for help in the [Discord chatroom](https://svelte.dev/chat).

--- a/documentation/docs/00-introduction.md
+++ b/documentation/docs/00-introduction.md
@@ -2,6 +2,8 @@
 title: Introduction
 ---
 
+testing testing 1 2 3
+
 ### Before we begin
 
 > SvelteKit is in early development, and some things may change before we hit version 1.0. This document is a work-in-progress. If you get stuck, reach out for help in the [Discord chatroom](https://svelte.dev/chat).

--- a/turbo.json
+++ b/turbo.json
@@ -1,17 +1,20 @@
 {
 	"$schema": "https://turborepo.org/schema.json",
 	"pipeline": {
+		"@sveltejs/kit#build": {
+			"dependsOn": ["^build"],
+			"inputs": ["src/**", "scripts/**"],
+			"outputs": ["dist/**", "docs/**", "assets/**"]
+		},
+		"kit.svelte.dev#build": {
+			"dependsOn": ["^build", "$VERCEL"],
+			"inputs": ["src/**", "../../documentation/**"],
+			"outputs": [".vercel_build_output/**"]
+		},
 		"build": {
 			"dependsOn": ["^build", "$VERCEL"],
 			"inputs": ["src/**", "scripts/**", "shared/**", "templates/**"],
-			"outputs": [
-				"files/**",
-				"dist/**",
-				"docs/**",
-				"assets/**",
-				".svelte-kit/**",
-				".vercel_build_output/**"
-			]
+			"outputs": ["files/**", "dist/**", ".svelte-kit/**", ".vercel_build_output/**"]
 		},
 		"check": {
 			"outputs": []


### PR DESCRIPTION
Realised that turbo doesn't know `sites/kit.svelte.dev` depends on `documentation`, oops