### PR TITLE
Fix broken doc links for App namespaces

### DIFF
--- a/.changeset/young-horses-kick.md
+++ b/.changeset/young-horses-kick.md
@@ -1,5 +1,4 @@
 ---
-'default-template': patch
 'create-svelte': patch
 ---
 

--- a/.changeset/young-horses-kick.md
+++ b/.changeset/young-horses-kick.md
@@ -1,0 +1,6 @@
+---
+'default-template': patch
+'create-svelte': patch
+---
+
+Update broken documentation links for `App` namespaces

--- a/packages/create-svelte/templates/default/src/app.d.ts
+++ b/packages/create-svelte/templates/default/src/app.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="@sveltejs/kit" />
 
-// See https://kit.svelte.dev/docs/types#the-app-namespace
+// See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 declare namespace App {
 	interface Locals {

--- a/packages/create-svelte/templates/skeleton/src/app.d.ts
+++ b/packages/create-svelte/templates/skeleton/src/app.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="@sveltejs/kit" />
 
-// See https://kit.svelte.dev/docs/types#the-app-namespace
+// See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 declare namespace App {
 	// interface Locals {}


### PR DESCRIPTION
This PR updates broken documentation links for `App` namespaces. The old links had an outdated anchor and didn't take the user to the relevant heading.
Old link:
https://kit.svelte.dev/docs/types#the-app-namespace
New link:
https://kit.svelte.dev/docs/types#app

### Note:
Some tests failed for both HEAD and my patch. Since I only modified comments, I decided to open the PR anyway to see what the CI has to say.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
