### PR TITLE
[feat] invalidate with predicate

### DIFF
--- a/.changeset/hungry-weeks-exercise.md
+++ b/.changeset/hungry-weeks-exercise.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+`invalidate` with `predicate` function

--- a/packages/kit/test/apps/basics/src/global.d.ts
+++ b/packages/kit/test/apps/basics/src/global.d.ts
@@ -1,5 +1,6 @@
 declare global {
 	interface Window {
+		invalidated: boolean;
 		oops: string;
 		pageContext: any;
 		fulfil_navigation: (value: any) => void;

--- a/packages/kit/test/apps/basics/src/routes/load/change-detection/one/[x].svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/change-detection/one/[x].svelte
@@ -1,5 +1,6 @@
 <script context="module">
 	import { browser } from '$app/env';
+	import { invalidate } from '$app/navigation';
 
 	let count = 0;
 
@@ -28,3 +29,10 @@
 </script>
 
 <h2>x: {x}: {loads}</h2>
+
+<button
+	on:click={async () => {
+		await invalidate((dep) => dep.includes('change-detection/data.json'));
+		window.invalidated = true;
+	}}>invalidate change-detection/data.json</button
+>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1202,7 +1202,8 @@ test.describe.parallel('Load', () => {
 			expect(await page.textContent('h1')).toBe('layout loads: 4');
 			expect(await page.textContent('h2')).toBe('x: b: 2');
 
-			await app.invalidate((dep) => dep.includes('change-detection/data.json'));
+			await page.click('button');
+			await page.waitForFunction('window.invalidated');
 			expect(await page.textContent('h1')).toBe('layout loads: 5');
 			expect(await page.textContent('h2')).toBe('x: b: 2');
 		}

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1201,6 +1201,10 @@ test.describe.parallel('Load', () => {
 			await app.invalidate('custom:change-detection-layout');
 			expect(await page.textContent('h1')).toBe('layout loads: 4');
 			expect(await page.textContent('h2')).toBe('x: b: 2');
+
+			await app.invalidate((dep) => dep.includes('change-detection/data.json'));
+			expect(await page.textContent('h1')).toBe('layout loads: 5');
+			expect(await page.textContent('h2')).toBe('x: b: 2');
 		}
 	});
 

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -103,14 +103,9 @@ declare module '$app/navigation' {
 	): Promise<void>;
 	/**
 	 * Causes any `load` functions belonging to the currently active page to re-run if they `fetch` the resource in question. Returns a `Promise` that resolves when the page is subsequently updated.
-	 * @param href The invalidated resource
+	 * @param dependency The invalidated resource
 	 */
-	export function invalidate(href: string): Promise<void>;
-	/**
-	 * Causes any `load` functions belonging to the currently active page to re-run if the `predicate` evaluates to `true`. Returns a `Promise` that resolves when the page is subsequently updated.
-	 * @param predicate Is run for each fetched resource
-	 */
-	export function invalidate(predicate: (href: string) => boolean): Promise<void>;
+	export function invalidate(dependency: string | ((href: string) => boolean)): Promise<void>;
 	/**
 	 * Programmatically prefetches the given page, which means
 	 *  1. ensuring that the code for the page is loaded, and

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -107,6 +107,11 @@ declare module '$app/navigation' {
 	 */
 	export function invalidate(href: string): Promise<void>;
 	/**
+	 * Causes any `load` functions belonging to the currently active page to re-run if the `predicate` evaluates to `true`. Returns a `Promise` that resolves when the page is subsequently updated.
+	 * @param predicate Is run for each fetched resource
+	 */
+	export function invalidate(predicate: (href: string) => boolean): Promise<void>;
+	/**
 	 * Programmatically prefetches the given page, which means
 	 *  1. ensuring that the code for the page is loaded, and
 	 *  2. calling the page's load function with the appropriate options.


### PR DESCRIPTION
Closes #4540

### Problem

The current implementation of `invalidate` is quite limiting because the provided argument has to match the URL of the fetched resource exactly. It's not possible to invalidate resources that match a certain pattern. (Take a look at #4540 for more detailed problem description) 

### Solution

Extend invalidate to take a `predicate` function as argument (similar to `Array.prototype.some`).
The `predicate` is run for each item of [`dependencies`](https://github.com/sveltejs/kit/blob/83f60af73dd6b7a86167281bca7f85122c83818e/packages/kit/src/runtime/client/client.js#L474) and will cause a rerun of `load` if `true` is returned.

**Signature:**
```ts
function invalidate(href: string): Promise<void>;
function invalidate(predicate: (dep: string) => boolean): Promise<void>;
```

**Example usage:**
```svelte
<script context="module">
export async function load({fetch, url}) {
  const response = await fetch(`/collections${url.search}`);
  const data = await response.json();
  
  return { props: { data }};
}
</script>
<script>
  import { invalidate } from '$app/navigation';
  const isCollectionURL = (dep) => dep.includes('/collections');
</script>

<button on:click={() => invalidate(isCollectionURL)}>Reload collection</button>
```

This makes the `invalidate` function far more useful IMO and would not break how it's currently used.



### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
