### PR TITLE
remove .npmrc and .prettierrc from new projects

### DIFF
--- a/.changeset/quick-owls-lie.md
+++ b/.changeset/quick-owls-lie.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Reduce number of files in new project

--- a/packages/create-svelte/shared/+prettier/.prettierrc
+++ b/packages/create-svelte/shared/+prettier/.prettierrc
@@ -1,6 +1,0 @@
-{
-	"useTabs": true,
-	"singleQuote": true,
-	"trailingComma": "none",
-	"printWidth": 100
-}

--- a/packages/create-svelte/shared/+prettier/package.json
+++ b/packages/create-svelte/shared/+prettier/package.json
@@ -2,5 +2,11 @@
 	"devDependencies": {
 		"prettier": "^2.5.1",
 		"prettier-plugin-svelte": "^2.5.0"
+	},
+	"prettier": {
+		"useTabs": true,
+		"singleQuote": true,
+		"trailingComma": "none",
+		"printWidth": 100
 	}
 }

--- a/packages/create-svelte/templates/default/.npmrc
+++ b/packages/create-svelte/templates/default/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true

--- a/packages/create-svelte/templates/skeleton/.npmrc
+++ b/packages/create-svelte/templates/skeleton/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true


### PR DESCRIPTION
this might be controversial but i figured the easiest way to discuss it would be to throw up a PR.

when you create a new project, you immediately end up with a whole bunch of files:

<img width="151" alt="image" src="https://user-images.githubusercontent.com/1162160/163608653-96e525ba-f771-4016-95ef-1cfa51227a7f.png">

the more stuff we have there, the more intimidating it is to figure out what's doing what, and which files deserve attention. i feel like we could remove two of them — `.npmrc` and `.prettierrc`. there's still a lot of stuff, but it's not quite as overwhelming:

<img width="132" alt="image" src="https://user-images.githubusercontent.com/1162160/163608763-c205eb2c-34af-4985-9cd2-4d61641dced5.png">
 
`.npmrc` is presumably there because SvelteKit requires Node 14.13 or higher. But Node 12 is about to fall out of LTS, and I'd expect vanishingly few people to still be using anything below 14.13 (which was released in September 2020). Moreover, _it doesn't work_ — all it does is prevent you from _installing_ SvelteKit with an older version of Node; it only circumstantially prevents you from _running_ it. I think it's an inelegant, flawed solution, and we're better off just documenting the version requirement. (If you do try to run `svelte-kit` or an app built with `adapter-node` with Node 12, it will immediately fail with a syntax error due to the use of optional chaining.)

`.prettierrc` is redundant; the config can be expressed equivalently in `package.json`. Unfortunately we can't do the same for `.eslintrc.cjs` because one of the variants has `() => require('typescript')`.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
