### PR TITLE
[chore] rename data-svelte to data-sveltekit

### DIFF
--- a/.changeset/tiny-hounds-glow.md
+++ b/.changeset/tiny-hounds-glow.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+rename `data-svelte` attribute to `data-sveltekit`

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -341,7 +341,7 @@ export function create_client({ target, session, base, trailing_slash }) {
 	function initialize(result) {
 		current = result.state;
 
-		const style = document.querySelector('style[data-svelte]');
+		const style = document.querySelector('style[data-sveltekit]');
 		if (style) style.remove();
 
 		page = result.props.page;

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -206,7 +206,7 @@ export async function render_response({
 	} else {
 		if (inlined_style) {
 			const attributes = [];
-			if (options.dev) attributes.push(' data-svelte');
+			if (options.dev) attributes.push(' data-sveltekit');
 			if (csp.style_needs_nonce) attributes.push(` nonce="${csp.nonce}"`);
 
 			csp.add_style(inlined_style);

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1527,7 +1527,7 @@ test.describe.parallel('Page options', () => {
 			expect(await page.textContent('h1')).toBe('content was rendered');
 		} else {
 			expect(await page.evaluate(() => document.querySelector('h1'))).toBe(null);
-			expect(await page.evaluate(() => document.querySelector('style[data-svelte]'))).toBe(null);
+			expect(await page.evaluate(() => document.querySelector('style[data-sveltekit]'))).toBe(null);
 		}
 	});
 

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -45,10 +45,10 @@ test.describe.parallel('base path', () => {
 	test('inlines CSS', async ({ page, javaScriptEnabled }) => {
 		await page.goto('/path-base/base/');
 		if (process.env.DEV) {
-			const ssr_style = await page.evaluate(() => document.querySelector('style[data-svelte]'));
+			const ssr_style = await page.evaluate(() => document.querySelector('style[data-sveltekit]'));
 
 			if (javaScriptEnabled) {
-				// <style data-svelte> is removed upon hydration
+				// <style data-sveltekit> is removed upon hydration
 				expect(ssr_style).toBeNull();
 			} else {
 				expect(ssr_style).not.toBeNull();


### PR DESCRIPTION
There's a PR that would potentially add `data-svelte` to Svelte (https://github.com/sveltejs/svelte/pull/7426). While it wouldn't cause any breakage at this point, we should probably use `data-sveltekit` to have a separate namespace. Also, it would be more consistent since we use `sveltekit` most other places in the SvelteKit code base