### PR TITLE
Fix url bug in the hooks documentation examples

### DIFF
--- a/documentation/docs/05-hooks.md
+++ b/documentation/docs/05-hooks.md
@@ -14,7 +14,7 @@ This function runs every time the SvelteKit server receives a [request](/docs/we
 /// file: src/hooks.js
 /** @type {import('@sveltejs/kit').Handle} */
 export async function handle({ event, resolve }) {
-	if (event.request.url.startsWith('/custom')) {
+	if (event.url.pathname.startsWith('/custom')) {
 		return new Response('custom response');
 	}
 


### PR DESCRIPTION
In a hook `event.request.url` will be a complete URL I believe (https://developer.mozilla.org/en-US/docs/Web/API/Request/url) meaning `event.request.url.startsWith('/custom')` will never be true. This commit fixes that.

<details>
<summary>Checklist boilerplate</summary>

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
  **I haven't bothered with this since it's such a small and hopefully non-controversial change.**
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
  **N/A but I have tried out the old example and run into this issue and changing it fixes it**

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
  **I couldn't get the project to build due to an error I was running into (https://github.com/sveltejs/kit/issues/4642) so I couldn't run these but since it's purely a docs change the code base shouldn't be impacted.**

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
  **N/A**
</details>
