### PR TITLE
always bundle devdependencies

### DIFF
--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -29,11 +29,8 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:*",
-		"cookie": "^0.5.0",
-		"devalue": "^2.0.1",
 		"playwright-chromium": "^1.21.0",
 		"port-authority": "^1.1.2",
-		"set-cookie-parser": "^2.4.8",
 		"sirv": "^2.0.0",
 		"svelte": "^3.44.2",
 		"typescript": "^4.6.2",

--- a/packages/kit/src/core/build/build_server.js
+++ b/packages/kit/src/core/build/build_server.js
@@ -191,6 +191,17 @@ export async function build_server(
 	const default_config = {
 		build: {
 			target: 'es2020'
+		},
+		ssr: {
+			// when developing against the Kit src code, we want to ensure that
+			// our dependencies are bundled so that apps don't need to install
+			// them as peerDependencies
+			noExternal: process.env.BUNDLED
+				? []
+				: Object.keys(
+						JSON.parse(fs.readFileSync(new URL('../../../package.json', import.meta.url), 'utf-8'))
+							.devDependencies
+				  )
 		}
 	};
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,11 +154,8 @@ importers:
   packages/adapter-static:
     specifiers:
       '@sveltejs/kit': workspace:*
-      cookie: ^0.5.0
-      devalue: ^2.0.1
       playwright-chromium: ^1.21.0
       port-authority: ^1.1.2
-      set-cookie-parser: ^2.4.8
       sirv: ^2.0.0
       svelte: ^3.44.2
       tiny-glob: ^0.2.9
@@ -168,11 +165,8 @@ importers:
       tiny-glob: 0.2.9
     devDependencies:
       '@sveltejs/kit': link:../kit
-      cookie: 0.5.0
-      devalue: 2.0.1
       playwright-chromium: 1.21.0
       port-authority: 1.1.2
-      set-cookie-parser: 2.4.8
       sirv: 2.0.0
       svelte: 3.44.2
       typescript: 4.6.2
@@ -421,7 +415,6 @@ importers:
       '@sveltejs/kit': workspace:*
       '@sveltejs/site-kit': ^2.1.0
       '@types/node': ^16.11.11
-      devalue: ^2.0.1
       flexsearch: ^0.7.21
       marked: ^4.0.5
       prism-svelte: ^0.5.0
@@ -437,7 +430,6 @@ importers:
       '@sveltejs/kit': link:../../packages/kit
       '@sveltejs/site-kit': 2.1.0
       '@types/node': 16.11.11
-      devalue: 2.0.1
       flexsearch: 0.7.21
       marked: 4.0.5
       prism-svelte: 0.5.0

--- a/sites/kit.svelte.dev/package.json
+++ b/sites/kit.svelte.dev/package.json
@@ -13,7 +13,6 @@
 		"@sveltejs/kit": "workspace:*",
 		"@sveltejs/site-kit": "^2.1.0",
 		"@types/node": "^16.11.11",
-		"devalue": "^2.0.1",
 		"flexsearch": "^0.7.21",
 		"marked": "^4.0.5",
 		"prism-svelte": "^0.5.0",


### PR DESCRIPTION
Fixes the issue described in https://github.com/sveltejs/kit/issues/4642#issuecomment-1100720329. With this change, apps built with the Kit `src` don't need to have their own dependencies on packages like `devalue` and `cookie`.