### PR TITLE
allow endpoints to be treated as prerender entry points

### DIFF
--- a/.changeset/small-countries-doubt.md
+++ b/.changeset/small-countries-doubt.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Allow endpoints to be treated as prerender entry points

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -17,8 +17,9 @@ export function create_builder({ config, build_data, prerendered, log }) {
 	/** @param {import('types').RouteData} route */
 	// TODO routes should come pre-filtered
 	function not_prerendered(route) {
-		if (route.type === 'page' && route.path) {
-			return !prerendered_paths.has(route.path);
+		if (route.type === 'page' && !route.id.includes('[')) {
+			const path = '/' + route.id.replace(/@.+$/, '');
+			return !prerendered_paths.has(path);
 		}
 
 		return true;

--- a/packages/kit/src/core/build/index.js
+++ b/packages/kit/src/core/build/index.js
@@ -79,7 +79,7 @@ export async function build(config, { log }) {
 	const prerendered = await prerender({
 		config,
 		entries: options.manifest_data.routes
-			.map((route) => (route.type === 'page' ? route.path : ''))
+			.map((route) => (route.id.includes('[') ? '' : '/' + route.id.replace(/@.+$/, '')))
 			.filter(Boolean),
 		files,
 		log

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -85,7 +85,6 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 							pattern: ${pattern},
 							names: ${s(names)},
 							types: ${s(types)},
-							path: ${route.path ? s(route.path) : null},
 							shadow: ${route.shadow ? loader(`${relative_path}/${build_data.server.vite_manifest[route.shadow].file}`) : null},
 							a: ${s(route.a.map(get_index))},
 							b: ${s(route.b.map(get_index))}

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -234,7 +234,6 @@ export default function create_manifest_data({
 					type: 'page',
 					id: unit.id,
 					pattern: unit.pattern,
-					path: unit.id.includes('[') ? '' : `/${unit.id.replace(/@(?:[a-zA-Z0-9_-]+)/g, '')}`,
 					shadow: unit.endpoint || null,
 					a: unit.page.a,
 					b: unit.page.b

--- a/packages/kit/test/prerendering/basics/src/routes/hello.txt.js
+++ b/packages/kit/test/prerendering/basics/src/routes/hello.txt.js
@@ -1,0 +1,5 @@
+export function get() {
+	return {
+		body: 'prerendered endpoint'
+	};
+}

--- a/packages/kit/test/prerendering/basics/test/test.js
+++ b/packages/kit/test/prerendering/basics/test/test.js
@@ -114,4 +114,9 @@ test('fetching missing content results in a 404', () => {
 	assert.ok(content.includes('<h1>status: 404</h1>'), content);
 });
 
+test('prerenders an entry point endpoint', () => {
+	const content = read('hello.txt');
+	assert.equal(content, 'prerendered endpoint');
+});
+
 test.run();

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -126,7 +126,6 @@ export interface PageData {
 	id: string;
 	shadow: string | null;
 	pattern: RegExp;
-	path: string;
 	a: Array<string | undefined>;
 	b: Array<string | undefined>;
 }


### PR DESCRIPTION
fixes #2541. An endpoint like `src/routes/index.js` or `src/routes/sitemap.xml.js` or whatever should be prerenderable.

Though now that I've implemented it and I'm writing this comment, it occurs to me that this should probably only apply to endpoints that are explicitly marked as prerenderable, unless `config.kit.prerender.default === true`. Will leave this open pending #4093.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
