### PR TITLE
Add link to base path suggestion

### DIFF
--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -209,7 +209,7 @@ export async function create_plugin(config, cwd) {
 								config.kit.paths.base + req.url,
 								config.kit.trailingSlash
 							);
-							return not_found(res, `Not found (did you mean ${suggestion}?)`);
+							return not_found(res, `Not found (did you mean <a href="${suggestion}">${suggestion}</a>?)`);
 						}
 
 						/** @type {Partial<import('types').Hooks>} */


### PR DESCRIPTION
When visiting `http://localhost:3000/` with a base path configured, it would be nice to render the suggested path as a link.

Also note that [vite does something similar](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/base.ts#L43-L46)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
