### PR TITLE
reset navigation store to null after aborted nav

### DIFF
--- a/.changeset/six-garlics-film.md
+++ b/.changeset/six-garlics-film.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Navigation to current URL is no longer a no-op

--- a/.changeset/sour-penguins-admire.md
+++ b/.changeset/sour-penguins-admire.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+navigation store resets to null after aborted nav

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -121,9 +121,6 @@ export function create_client({ target, session, base, trailing_slash }) {
 	});
 	ready = true;
 
-	/** Keeps tracks of multiple navigations caused by redirects during rendering */
-	let navigating = 0;
-
 	let router_enabled = true;
 
 	// keeping track of the history index in order to prevent popstate navigation events if needed
@@ -897,8 +894,6 @@ export function create_client({ target, session, base, trailing_slash }) {
 		update_scroll_positions(current_history_index);
 
 		accepted();
-
-		navigating++;
 
 		if (started) {
 			stores.navigating.set({

--- a/packages/kit/test/apps/basics/src/routes/store/navigating/__layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/store/navigating/__layout.svelte
@@ -2,7 +2,11 @@
 	import { navigating } from '$app/stores';
 </script>
 
-<nav><a href="/store/navigating/a">a</a> <a href="/store/navigating/b">b</a></nav>
+<nav>
+	<a href="/store/navigating/a">a</a>
+	<a href="/store/navigating/b">b</a>
+	<a href="/store/navigating/c">c</a>
+</nav>
 
 <div id="nav-status">
 	{#if $navigating}

--- a/packages/kit/test/apps/basics/src/routes/store/navigating/c.svelte
+++ b/packages/kit/test/apps/basics/src/routes/store/navigating/c.svelte
@@ -1,0 +1,9 @@
+<script context="module">
+	/** @type {import('@sveltejs/kit').Load} */
+	export async function load() {
+		await new Promise((f) => setTimeout(f, 1000));
+		return {};
+	}
+</script>
+
+<p>c</p>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1696,6 +1696,21 @@ test.describe.parallel('$app/stores', () => {
 			expect(await page.textContent('#nav-status')).toBe('not currently navigating');
 		}
 	});
+
+	test('navigating store clears after aborted navigation', async ({ page, javaScriptEnabled }) => {
+		await page.goto('/store/navigating/a');
+
+		expect(await page.textContent('#nav-status')).toBe('not currently navigating');
+
+		if (javaScriptEnabled) {
+			page.click('a[href="/store/navigating/c"]');
+			await page.waitForTimeout(100); // gross, but necessary since no navigation occurs
+			page.click('a[href="/store/navigating/a"]');
+
+			await page.waitForSelector('#not-navigating', { timeout: 500 });
+			expect(await page.textContent('#nav-status')).toBe('not currently navigating');
+		}
+	});
 });
 
 test.describe.parallel('searchParams', () => {


### PR DESCRIPTION
Fixes #4660. Instead of tracking which is the 'current' navigation, we track whether the current _update_ is aborted. If not, we reset `navigation` to `null` after it completes.

In order for this to work when the user clicks on a link to `/current-page` during a navigation to `/different-page`, we need to stop treating `/current-page` clicks as no-ops. This was something we'd talked about doing anyway. (Next step is to provide more control over when `load` reruns.)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
