### PR TITLE
create-svelte: Make hooks file comply with TypeScript strictest mode

### DIFF
--- a/.changeset/healthy-pigs-fly.md
+++ b/.changeset/healthy-pigs-fly.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Make hooks file comply with TypeScript strictest mode

--- a/packages/create-svelte/templates/default/src/hooks.ts
+++ b/packages/create-svelte/templates/default/src/hooks.ts
@@ -1,15 +1,15 @@
-import cookie from 'cookie';
 import { v4 as uuid } from '@lukeed/uuid';
 import type { Handle } from '@sveltejs/kit';
+import * as cookie from 'cookie';
 
 /** @type {import('@sveltejs/kit').Handle} */
 export const handle: Handle = async ({ event, resolve }) => {
 	const cookies = cookie.parse(event.request.headers.get('cookie') || '');
-	event.locals.userid = cookies.userid || uuid();
+	event.locals.userid = cookies['userid'] || uuid();
 
 	const response = await resolve(event);
 
-	if (!cookies.userid) {
+	if (!cookies['userid']) {
 		// if this is the first time the user has visited this app,
 		// set a cookie so that we recognise them when they return
 		response.headers.set(


### PR DESCRIPTION
Fixes:

- Error: Module '@types/cookie/index' has no default export. ts(1192)
- Error: Property 'userid' comes from an index signature, so it must be accessed with ['userid']. ts(4111)

Strictest tsconfig from https://github.com/tsconfig/bases/blob/27f9097a02f960e351d69bca8dd4c7581d70e1b6/bases/strictest.json

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
