### PR TITLE
chore(cloudflare): more restrictive cache conditions

### DIFF
--- a/.changeset/honest-rice-cry.md
+++ b/.changeset/honest-rice-cry.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-cloudflare": patch
+---
+
+chore(cloudflare): more restrictive cache lookup & save conditions


### PR DESCRIPTION
Should close #4668 and handle similar requests I've received in DMs / Discord. This solution is a hold-over until the `maxage` (or similar) property has a tie-in to the `cache-control` header directly.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
