### PR TITLE
hardcode team name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  TURBO_TEAM: svelte
 
 jobs:
   Lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,9 @@ on:
       - master
 
 env:
-  TURBO_CACHE_KEY: ubuntu-latest-16  # reuse cache key from ci workflow
+  TURBO_CACHE_KEY: ubuntu-latest-16 # reuse cache key from ci workflow
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  TURBO_TEAM: svelte
 
 jobs:
   release:


### PR DESCRIPTION
Secrets are redacted from GitHub Actions logs. Since we have a `TURBO_TEAM` environment variable, to enable remote caching, we have a secret whose value is `svelte`. That results in some... interesting redactions:

![image](https://user-images.githubusercontent.com/1162160/164326560-2614c4a4-6722-496b-8440-86f86ad6514d.png)

Since it's not really a secret that we're the `svelte` team, this replaces the secret with a hardcoded value.

![image](https://user-images.githubusercontent.com/1162160/164326459-c6db18a9-cdbb-45eb-bfdd-92a988a08ba1.png)
