### PR TITLE
ensure _redirects parent exists

### DIFF
--- a/.changeset/lucky-glasses-sell.md
+++ b/.changeset/lucky-glasses-sell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+Ensure build directory exists before writing \_redirects

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -1,5 +1,5 @@
 import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'fs';
-import { join, resolve, posix } from 'path';
+import { dirname, join, resolve, posix } from 'path';
 import { fileURLToPath } from 'url';
 import glob from 'tiny-glob/sync.js';
 import esbuild from 'esbuild';
@@ -62,7 +62,7 @@ export default function ({ split = false, edge = edgeSetInEnvVar } = {}) {
 				if (split) {
 					throw new Error('Cannot use `split: true` alongside `edge: true`');
 				}
-				
+
 				await generate_edge_functions({ builder });
 			} else {
 				await generate_lambda_functions({ builder, esm, split, publish });
@@ -234,6 +234,7 @@ function generate_lambda_functions({ builder, publish, split, esm }) {
 	if (existsSync('_redirects')) {
 		builder.copy('_redirects', redirect_file);
 	}
+	builder.mkdirp(dirname(redirect_file));
 	appendFileSync(redirect_file, `\n\n${redirects.join('\n')}`);
 }
 


### PR DESCRIPTION
#4657 accidentally broke `adapter-netlify`, by attempting to write `build/_redirects` before the `build` dir was created

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
