### PR TITLE
remove default `<meta name="description">`

### DIFF
--- a/.changeset/stupid-owls-provide.md
+++ b/.changeset/stupid-owls-provide.md
@@ -2,4 +2,4 @@
 'create-svelte': patch
 ---
 
-Remove default <meta name="description">
+Remove default <meta name="description"> and add separate descriptions to each page

--- a/.changeset/stupid-owls-provide.md
+++ b/.changeset/stupid-owls-provide.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Remove default <meta name="description">

--- a/packages/create-svelte/templates/default/src/app.html
+++ b/packages/create-svelte/templates/default/src/app.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="description" content="Svelte demo app" />
 		<link rel="icon" href="%svelte.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%svelte.head%

--- a/packages/create-svelte/templates/default/src/routes/about.svelte
+++ b/packages/create-svelte/templates/default/src/routes/about.svelte
@@ -16,6 +16,7 @@
 
 <svelte:head>
 	<title>About</title>
+	<meta name="description" content="About this app" />
 </svelte:head>
 
 <div class="content">

--- a/packages/create-svelte/templates/default/src/routes/index.svelte
+++ b/packages/create-svelte/templates/default/src/routes/index.svelte
@@ -8,6 +8,7 @@
 
 <svelte:head>
 	<title>Home</title>
+	<meta name="description" content="Svelte demo app" />
 </svelte:head>
 
 <section>

--- a/packages/create-svelte/templates/default/src/routes/todos/index.svelte
+++ b/packages/create-svelte/templates/default/src/routes/todos/index.svelte
@@ -27,6 +27,7 @@
 
 <svelte:head>
 	<title>Todos</title>
+	<meta name="description" content="A todo list app" />
 </svelte:head>
 
 <div class="todos">

--- a/packages/create-svelte/templates/skeleton/src/app.html
+++ b/packages/create-svelte/templates/skeleton/src/app.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="description" content="" />
 		<link rel="icon" href="%svelte.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%svelte.head%


### PR DESCRIPTION
The project templates include a default `<meta name="description">`, which is well-intentioned (you need one to get a good lighthouse score, etc) but ultimately counterproductive since it takes precedence over ones in `<svelte:head>`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
