### PR TITLE
feat(ci): validate github actions with actionlint

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,21 @@
+name: Actionlint
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/*.yml'
+
+jobs:
+  actionlint:
+    name: Verify actions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Actionlint
+        env:
+          ACTIONLINT_VERSION: 1.6.12
+        run: |
+          wget -q -O- "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" | tar -x -z -C . actionlint && \
+          mv actionlint /usr/local/bin
+      - name: Run Actionlint
+        run: |
+          actionlint -format '{{range $err := .}}::error file={{$err.Filepath}},line={{$err.Line}},col={{$err.Column}}::{{$err.Message}}{{end}}' -ignore 'SC2016:' .github/workflows/*.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,10 @@ jobs:
           published_packages: ${{steps.changesets.outputs.publishedPackages}}
         run: |
           sleep 20
-          cat << EOF > "$HOME/.npmrc"
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          cat << EOF > "${HOME}/.npmrc"
+            "//registry.npmjs.org/:_authToken=$NPM_TOKEN"
           EOF
-          echo $published_packages | jq -r 'map((.name + "@" + .version)) | .[]' | while read pkgver; do npm dist-tag add $pkgver latest || continue;done
+          echo "${published_packages}" | jq -r 'map((.name + "@" + .version)) | .[]' | while read -r pkgver; do npm dist-tag add "${pkgver}" latest || continue; done
 
       # TODO alert discord
       # - name: Send a Slack notification if a publish happens


### PR DESCRIPTION
Actionlint makes sure github actions are staying in line (as well as inline shell scripts through shellcheck). Fire off actionlint if there are changes to github actions in CI. Also, minor changes (quoting variables, adding `read -r`) to the release aciton to make actionlint happy.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
