### PR TITLE
feat: Upgrade page caching

### DIFF
--- a/.changeset/gold-bikes-chew.md
+++ b/.changeset/gold-bikes-chew.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Changed caching behavior of LoadOutput. Instead of returning a maxage property, return a cache object with a maxage property, and, optionally, a private property.

--- a/.changeset/gold-bikes-chew.md
+++ b/.changeset/gold-bikes-chew.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Changed caching behavior of LoadOutput. Instead of returning a maxage property, return a cache object with a maxage property, and, optionally, a private property.
+[breaking] Replace `maxage` with `cache` in `LoadOutput`

--- a/documentation/docs/04-loading.md
+++ b/documentation/docs/04-loading.md
@@ -119,9 +119,16 @@ If the page should redirect (because the page is deprecated, or the user needs t
 
 The `redirect` string should be a [properly encoded](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding) URI. Both absolute and relative URIs are acceptable.
 
-#### maxage
+#### cache
 
-To cause pages to be cached, return a `number` describing the page's max age in seconds. The resulting cache header will include `private` if user data was involved in rendering the page (either via `session`, or because a credentialed `fetch` was made in a `load` function), but otherwise will include `public` so that it can be cached by CDNs.
+```js
+cache: {
+  maxage: 300,
+  private: false,
+}
+```
+
+To cause pages to be cached, return a `cache` object containing a `maxage` property set to a `number` describing the page's max age in seconds. Optionally, also include a `boolean` `private` property indicating whether the resulting cache header should include `private` or not. If `cache.private` is `undefined`, the resulting cache header will include `private` if user data was involved in rendering the page (either via `session`, or because a credentialed `fetch` was made in a `load` function), but otherwise will include `public` so that it can be cached by CDNs. **Warning**: `cache.private` will **override** the default privacy behavior, meaning a `cache` object with `private === false` will result in a `public` `cache-control` header, even when `session` was used or a credentialed `fetch` was made.
 
 This only applies to pages, _not_ layouts.
 

--- a/documentation/docs/04-loading.md
+++ b/documentation/docs/04-loading.md
@@ -128,7 +128,9 @@ cache: {
 }
 ```
 
-To cause pages to be cached, return a `cache` object containing a `maxage` property set to a `number` describing the page's max age in seconds. Optionally, also include a `boolean` `private` property indicating whether the resulting cache header should include `private` or not. If `cache.private` is `undefined`, the resulting cache header will include `private` if user data was involved in rendering the page (either via `session`, or because a credentialed `fetch` was made in a `load` function), but otherwise will include `public` so that it can be cached by CDNs. **Warning**: `cache.private` will **override** the default privacy behavior, meaning a `cache` object with `private === false` will result in a `public` `cache-control` header, even when `session` was used or a credentialed `fetch` was made.
+To cause pages to be cached, return a `cache` object containing a `maxage` property set to a `number` describing the page's max age in seconds. Optionally, also include a `boolean` `private` property indicating whether the resulting `Cache-Control` header should be `private` or `public` (meaning it can be cached by CDNs in addition to individual browsers).
+
+> If `cache.private` is `undefined`, SvelteKit will set it automatically using the following heuristic: if a `load` function makes a credentialled `fetch`, or the page uses `session`, the page is considered private.
 
 This only applies to pages, _not_ layouts.
 

--- a/documentation/docs/04-loading.md
+++ b/documentation/docs/04-loading.md
@@ -121,10 +121,10 @@ The `redirect` string should be a [properly encoded](https://developer.mozilla.o
 
 #### cache
 
-```js
+```json
 cache: {
-  maxage: 300,
-  private: false,
+	"maxage": 300,
+	"private": false
 }
 ```
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -685,14 +685,6 @@ export function create_client({ target, session, base, trailing_slash }) {
 						}
 
 						if (node.loaded) {
-							// TODO remove for 1.0
-							// @ts-expect-error
-							if (node.loaded.fallthrough) {
-								throw new Error(
-									'fallthrough is no longer supported. Use matchers instead: https://kit.svelte.dev/docs/routing#advanced-routing-matching'
-								);
-							}
-
 							if (node.loaded.error) {
 								status = node.loaded.status;
 								error = node.loaded.error;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -441,9 +441,9 @@ export function create_client({ target, session, base, trailing_slash }) {
 		}
 
 		const leaf = filtered[filtered.length - 1];
-		const maxage = leaf.loaded && leaf.loaded.maxage;
+		const load_cache = leaf?.loaded?.cache;
 
-		if (maxage) {
+		if (load_cache) {
 			const key = url.pathname + url.search; // omit hash
 			let ready = false;
 
@@ -456,7 +456,7 @@ export function create_client({ target, session, base, trailing_slash }) {
 				clearTimeout(timeout);
 			};
 
-			const timeout = setTimeout(clear, maxage * 1000);
+			const timeout = setTimeout(clear, load_cache.maxage * 1000);
 
 			const unsubscribe = stores.session.subscribe(() => {
 				if (ready) clear();

--- a/packages/kit/src/runtime/load.js
+++ b/packages/kit/src/runtime/load.js
@@ -3,6 +3,19 @@
  * @returns {import('types').NormalizedLoadOutput}
  */
 export function normalize(loaded) {
+	// TODO remove for 1.0
+	// @ts-expect-error
+	if (loaded.fallthrough) {
+		throw new Error(
+			'fallthrough is no longer supported. Use matchers instead: https://kit.svelte.dev/docs/routing#advanced-routing-matching'
+		);
+	}
+
+	// TODO remove for 1.0
+	if ('maxage' in loaded) {
+		throw new Error('maxage should be replaced with cache: { maxage }');
+	}
+
 	const has_error_status =
 		loaded.status && loaded.status >= 400 && loaded.status <= 599 && !loaded.redirect;
 	if (loaded.error || has_error_status) {

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -355,14 +355,6 @@ export async function load_node({
 			// TODO do we still want to enforce this now that there's no fallthrough?
 			throw new Error(`load function must return a value${options.dev ? ` (${node.entry})` : ''}`);
 		}
-
-		// TODO remove for 1.0
-		// @ts-expect-error
-		if (loaded.fallthrough) {
-			throw new Error(
-				'fallthrough is no longer supported. Use matchers instead: https://kit.svelte.dev/docs/routing#advanced-routing-matching'
-			);
-		}
 	} else if (shadow.body) {
 		loaded = {
 			props: shadow.body

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -99,7 +99,7 @@ export async function render_response({
 				session: {
 					...session,
 					subscribe: (fn) => {
-						is_private = true;
+						is_private = cache?.private ?? true;
 						return session.subscribe(fn);
 					}
 				},

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -81,11 +81,7 @@ export async function render_response({
 			if (props) shadow_props = props;
 
 			cache = loaded?.cache;
-			if (cache?.private !== undefined) {
-				is_private = cache.private;
-			} else {
-				is_private = uses_credentials;
-			}
+			is_private = cache?.private ?? uses_credentials;
 		});
 
 		const session = writable($session);

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -63,7 +63,8 @@ export async function render_response({
 	let rendered;
 
 	let is_private = false;
-	let maxage;
+	/** @type {import('types').NormalizedLoadOutputCache | undefined} */
+	let cache;
 
 	if (error) {
 		error.stack = options.get_stack(error);
@@ -79,9 +80,12 @@ export async function render_response({
 			if (fetched && page_config.hydrate) serialized_data.push(...fetched);
 			if (props) shadow_props = props;
 
-			if (uses_credentials) is_private = true;
-
-			maxage = loaded.maxage;
+			cache = loaded?.cache;
+			if (cache?.private !== undefined) {
+				is_private = cache.private;
+			} else {
+				is_private = uses_credentials;
+			}
 		});
 
 		const session = writable($session);
@@ -282,8 +286,8 @@ export async function render_response({
 			http_equiv.push(csp_headers);
 		}
 
-		if (maxage) {
-			http_equiv.push(`<meta http-equiv="cache-control" content="max-age=${maxage}">`);
+		if (cache) {
+			http_equiv.push(`<meta http-equiv="cache-control" content="max-age=${cache.maxage}">`);
 		}
 
 		if (http_equiv.length > 0) {
@@ -304,8 +308,8 @@ export async function render_response({
 		etag: `"${hash(html)}"`
 	});
 
-	if (maxage) {
-		headers.set('cache-control', `${is_private ? 'private' : 'public'}, max-age=${maxage}`);
+	if (cache) {
+		headers.set('cache-control', `${is_private ? 'private' : 'public'}, max-age=${cache.maxage}`);
 	}
 
 	if (!options.floc) {

--- a/packages/kit/test/apps/basics/src/routes/caching/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/caching/index.svelte
@@ -2,7 +2,7 @@
 	/** @type {import('@sveltejs/kit').Load} */
 	export async function load() {
 		return {
-			maxage: 30
+			cache: { maxage: 30 }
 		};
 	}
 </script>

--- a/packages/kit/test/apps/basics/src/routes/caching/private/uses-cache-private.svelte
+++ b/packages/kit/test/apps/basics/src/routes/caching/private/uses-cache-private.svelte
@@ -1,12 +1,10 @@
 <script context="module">
 	/** @type {import('@sveltejs/kit').Load} */
 	export async function load({ url }) {
-		const cachePrivate = url.searchParams.get('private') === 'true' ? true : false;
-
 		return {
 			cache: {
 				maxage: 30,
-				private: cachePrivate
+				private: url.searchParams.get('private') === 'true'
 			}
 		};
 	}

--- a/packages/kit/test/apps/basics/src/routes/caching/private/uses-cache-private.svelte
+++ b/packages/kit/test/apps/basics/src/routes/caching/private/uses-cache-private.svelte
@@ -1,0 +1,15 @@
+<script context="module">
+	/** @type {import('@sveltejs/kit').Load} */
+	export async function load({ url }) {
+		const cachePrivate = url.searchParams.get('private') === 'true' ? true : false;
+
+		return {
+			cache: {
+				maxage: 30,
+				private: cachePrivate
+			}
+		};
+	}
+</script>
+
+<h1>this page will be cached for 30 seconds</h1>

--- a/packages/kit/test/apps/basics/src/routes/caching/private/uses-fetch.svelte
+++ b/packages/kit/test/apps/basics/src/routes/caching/private/uses-fetch.svelte
@@ -1,12 +1,6 @@
 <script context="module">
 	/** @type {import('@sveltejs/kit').Load} */
 	export async function load({ url, fetch }) {
-		const privateParam = url.searchParams.get('private');
-		let privateCache = undefined;
-		if (privateParam) {
-			privateCache = privateParam === 'true' ? true : false;
-		}
-
 		const res = await fetch('/caching/private/uses-fetch.json', {
 			credentials: /** @type {RequestCredentials} */ (url.searchParams.get('credentials'))
 		});
@@ -14,7 +8,9 @@
 		return {
 			cache: {
 				maxage: 30,
-				private: privateCache
+				private: url.searchParams.has('private')
+					? url.searchParams.get('private') === 'true'
+					: undefined
 			},
 			props: await res.json()
 		};

--- a/packages/kit/test/apps/basics/src/routes/caching/private/uses-fetch.svelte
+++ b/packages/kit/test/apps/basics/src/routes/caching/private/uses-fetch.svelte
@@ -1,12 +1,21 @@
 <script context="module">
 	/** @type {import('@sveltejs/kit').Load} */
 	export async function load({ url, fetch }) {
+		const privateParam = url.searchParams.get('private');
+		let privateCache = undefined;
+		if (privateParam) {
+			privateCache = privateParam === 'true' ? true : false;
+		}
+
 		const res = await fetch('/caching/private/uses-fetch.json', {
 			credentials: /** @type {RequestCredentials} */ (url.searchParams.get('credentials'))
 		});
 
 		return {
-			maxage: 30,
+			cache: {
+				maxage: 30,
+				private: privateCache
+			},
 			props: await res.json()
 		};
 	}

--- a/packages/kit/test/apps/basics/src/routes/caching/private/uses-session-in-init.svelte
+++ b/packages/kit/test/apps/basics/src/routes/caching/private/uses-session-in-init.svelte
@@ -1,8 +1,17 @@
 <script context="module">
 	/** @type {import('@sveltejs/kit').Load} */
-	export async function load() {
+	export async function load({ url }) {
+		const privateParam = url.searchParams.get('private');
+		let privateCache = undefined;
+		if (privateParam) {
+			privateCache = privateParam === 'true' ? true : false;
+		}
+
 		return {
-			maxage: 30
+			cache: {
+				maxage: 30,
+				private: privateCache
+			}
 		};
 	}
 </script>

--- a/packages/kit/test/apps/basics/src/routes/caching/private/uses-session-in-init.svelte
+++ b/packages/kit/test/apps/basics/src/routes/caching/private/uses-session-in-init.svelte
@@ -1,16 +1,12 @@
 <script context="module">
 	/** @type {import('@sveltejs/kit').Load} */
 	export async function load({ url }) {
-		const privateParam = url.searchParams.get('private');
-		let privateCache = undefined;
-		if (privateParam) {
-			privateCache = privateParam === 'true' ? true : false;
-		}
-
 		return {
 			cache: {
 				maxage: 30,
-				private: privateCache
+				private: url.searchParams.has('private')
+					? url.searchParams.get('private') === 'true'
+					: undefined
 			}
 		};
 	}

--- a/packages/kit/test/apps/basics/src/routes/caching/private/uses-session-in-load.svelte
+++ b/packages/kit/test/apps/basics/src/routes/caching/private/uses-session-in-load.svelte
@@ -1,13 +1,21 @@
 <script context="module">
 	/** @type {import('@sveltejs/kit').Load} */
-	export async function load({ session }) {
+	export async function load({ url, session }) {
+		const privateParam = url.searchParams.get('private');
+		let privateCache = undefined;
+		if (privateParam) {
+			privateCache = privateParam === 'true' ? true : false;
+		}
 		const session_exists = !!session;
 
 		return {
 			props: {
 				session_exists
 			},
-			maxage: 30
+			cache: {
+				maxage: 30,
+				private: privateCache
+			}
 		};
 	}
 </script>

--- a/packages/kit/test/apps/basics/src/routes/caching/private/uses-session-in-load.svelte
+++ b/packages/kit/test/apps/basics/src/routes/caching/private/uses-session-in-load.svelte
@@ -1,11 +1,6 @@
 <script context="module">
 	/** @type {import('@sveltejs/kit').Load} */
 	export async function load({ url, session }) {
-		const privateParam = url.searchParams.get('private');
-		let privateCache = undefined;
-		if (privateParam) {
-			privateCache = privateParam === 'true' ? true : false;
-		}
 		const session_exists = !!session;
 
 		return {
@@ -14,7 +9,9 @@
 			},
 			cache: {
 				maxage: 30,
-				private: privateCache
+				private: url.searchParams.has('private')
+					? url.searchParams.get('private') === 'true'
+					: undefined
 			}
 		};
 	}

--- a/packages/kit/test/apps/basics/src/routes/load/change-detection/__layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/change-detection/__layout.svelte
@@ -9,7 +9,7 @@
 		count += 1;
 
 		return {
-			maxage: 5,
+			cache: { maxage: 5 },
 			props: {
 				type,
 				loads: count
@@ -28,4 +28,4 @@
 </script>
 
 <h1>{type} loads: {loads}</h1>
-<slot></slot>
+<slot />

--- a/packages/kit/test/apps/basics/src/routes/load/change-detection/one/[x].svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/change-detection/one/[x].svelte
@@ -11,7 +11,7 @@
 		}
 
 		return {
-			maxage: 5,
+			cache: { maxage: 5 },
 			props: {
 				x: params.x,
 				loads: count

--- a/packages/kit/test/apps/basics/src/routes/load/change-detection/two/[y].svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/change-detection/two/[y].svelte
@@ -6,7 +6,7 @@
 		count += 1;
 
 		return {
-			maxage: 5,
+			cache: { maxage: 5 },
 			props: {
 				y: params.y,
 				loads: count

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -334,24 +334,72 @@ test.describe.parallel('Caching', () => {
 		expect(response.headers()['cache-control']).toBe('public, max-age=30');
 	});
 
-	test('sets cache-control: private if page uses session in load', async ({ request }) => {
+	test('sets cache-control: private if page uses session in load and cache.private is unset', async ({
+		request
+	}) => {
 		const response = await request.get('/caching/private/uses-session-in-load');
 		expect(response.headers()['cache-control']).toBe('private, max-age=30');
 	});
 
-	test('sets cache-control: private if page uses session in init', async ({ request }) => {
+	test('sets cache-control: private if page uses session in init and cache.private is unset', async ({
+		request
+	}) => {
 		const response = await request.get('/caching/private/uses-session-in-init');
 		expect(response.headers()['cache-control']).toBe('private, max-age=30');
 	});
 
-	test('sets cache-control: private if page uses fetch', async ({ request }) => {
+	test('sets cache-control: private if page uses fetch and cache.private is unset', async ({
+		request
+	}) => {
 		const response = await request.get('/caching/private/uses-fetch?credentials=include');
 		expect(response.headers()['cache-control']).toBe('private, max-age=30');
 	});
 
-	test('sets cache-control: public if page uses fetch without credentials', async ({ request }) => {
+	test('sets cache-control: public if page uses fetch without credentials and cache.private is unset', async ({
+		request
+	}) => {
 		const response = await request.get('/caching/private/uses-fetch?credentials=omit');
 		expect(response.headers()['cache-control']).toBe('public, max-age=30');
+	});
+
+	test('sets cache-control: private if cache.private is true', async ({ request }) => {
+		const response = await request.get('/caching/private/uses-cache-private?private=true');
+		expect(response.headers()['cache-control']).toBe('private, max-age=30');
+	});
+
+	test('sets cache-control: public if cache.private is false', async ({ request }) => {
+		const response = await request.get('/caching/private/uses-cache-private?private=false');
+		expect(response.headers()['cache-control']).toBe('public, max-age=30');
+	});
+
+	test('sets cache-control: public if page uses session in load and cache.private is false', async ({
+		request
+	}) => {
+		const response = await request.get('/caching/private/uses-session-in-load?private=false');
+		expect(response.headers()['cache-control']).toBe('public, max-age=30');
+	});
+
+	test('sets cache-control: public if page uses session in init and cache.private is false', async ({
+		request
+	}) => {
+		const response = await request.get('/caching/private/uses-session-in-init?private=false');
+		expect(response.headers()['cache-control']).toBe('public, max-age=30');
+	});
+
+	test('sets cache-control: public if page uses fetch and cache.private is false', async ({
+		request
+	}) => {
+		const response = await request.get(
+			'/caching/private/uses-fetch?credentials=include&private=false'
+		);
+		expect(response.headers()['cache-control']).toBe('public, max-age=30');
+	});
+
+	test('sets cache-control: private if page uses fetch without credentials and cache.private is true', async ({
+		request
+	}) => {
+		const response = await request.get('/caching/private/uses-fetch?credentials=omit&private=true');
+		expect(response.headers()['cache-control']).toBe('private, max-age=30');
 	});
 });
 

--- a/packages/kit/test/prerendering/basics/src/routes/max-age.svelte
+++ b/packages/kit/test/prerendering/basics/src/routes/max-age.svelte
@@ -2,7 +2,7 @@
 	/** @type {import('@sveltejs/kit').Load} */
 	export function load() {
 		return {
-			maxage: 300
+			cache: { maxage: 300 }
 		};
 	}
 </script>

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -207,8 +207,13 @@ export interface LoadOutput<Props extends Record<string, any> = Record<string, a
 	redirect?: string;
 	props?: Props;
 	stuff?: Partial<App.Stuff>;
-	maxage?: number;
+	cache?: LoadOutputCache;
 	dependencies?: string[];
+}
+
+export interface LoadOutputCache {
+	maxage: number;
+	private?: boolean;
 }
 
 export interface Navigation {

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -117,9 +117,14 @@ export type NormalizedLoadOutput = {
 	redirect?: string;
 	props?: Record<string, any> | Promise<Record<string, any>>;
 	stuff?: Record<string, any>;
-	maxage?: number;
+	cache?: NormalizedLoadOutputCache;
 	dependencies?: string[];
 };
+
+export interface NormalizedLoadOutputCache {
+	maxage: number;
+	private?: boolean;
+}
 
 export interface PageData {
 	type: 'page';


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

This completes #4549. A couple of notes for consideration before merging:

The `cache.private` option will override (perhaps confusingly?) behavior that's currently in place -- for example, `cache.private === false` will cause the `cache-control` header to be `public`, even if a credentialed fetch or the `session` object is accessed (whether in `init` or in `load`). Because of this, I was _extra specific_ in the tests, asserting that the override worked in every case. Even if this is a bit confusing at first, I can't think that going half way (having it not override the defaults) in some cases would be any clearer.
