### PR TITLE
ensure tmp dir is created

### DIFF
--- a/.changeset/eight-pets-clean.md
+++ b/.changeset/eight-pets-clean.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+Ensure tmp dir is created

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -88,6 +88,12 @@ export default function ({ split = false, edge = edgeSetInEnvVar } = {}) {
  * @param {import('@sveltejs/kit').Builder} params.builder
  */
 async function generate_edge_functions({ builder }) {
+	const tmp = builder.getBuildDirectory('netlify-tmp');
+	builder.rimraf(tmp);
+	builder.mkdirp(tmp);
+
+	builder.mkdirp('.netlify/edge-functions');
+
 	// Don't match the static directory
 	const pattern = '^/.*$';
 
@@ -104,11 +110,6 @@ async function generate_edge_functions({ builder }) {
 		],
 		version: 1
 	};
-	const tmp = builder.getBuildDirectory('netlify-tmp');
-
-	builder.rimraf(tmp);
-
-	builder.mkdirp('.netlify/edge-functions');
 
 	builder.log.minor('Generating Edge Function...');
 	const relativePath = posix.relative(tmp, builder.getServerDirectory());


### PR DESCRIPTION
I don't totally understand why #4692 happens (and it's difficult to test without publishing a new version of the adapter) but hopefully this fixes it

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
