### PR TITLE
make hydration resilient to hoisted `<script>` elements

### DIFF
--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -241,7 +241,7 @@ export async function render_response({
 				.map((dep) => `\n\t<link rel="modulepreload" href="${options.prefix + dep}">`)
 				.join('');
 
-			const attributes = ['type="module"', `data-hydrate="${target}"`];
+			const attributes = ['type="module"'];
 
 			csp.add_script(init_app);
 
@@ -249,7 +249,9 @@ export async function render_response({
 				attributes.push(`nonce="${csp.nonce}"`);
 			}
 
-			body += `\n\t\t<script ${attributes.join(' ')}>${init_app}</script>`;
+			body += `\n\t\t<span data-hydrate="${target}"/><script ${attributes.join(
+				' '
+			)}>${init_app}</script>`;
 
 			body += serialized_data
 				.map(({ url, body, response }) =>

--- a/packages/kit/test/apps/basics/src/hooks.js
+++ b/packages/kit/test/apps/basics/src/hooks.js
@@ -44,6 +44,17 @@ export const handle = sequence(
 			ssr: !event.url.pathname.startsWith('/no-ssr'),
 			transformPage: event.url.pathname.startsWith('/transform-page')
 				? ({ html }) => html.replace('__REPLACEME__', 'Worked!')
+				: event.url.pathname === '/hoisted-script'
+				? ({ html }) => {
+						const scripts = [];
+
+						return html
+							.replace(/<script[^]+?<\/script>/g, (match) => {
+								scripts.push(match);
+								return '';
+							})
+							.replace('</head>', () => scripts.join('') + '</head>');
+				  }
 				: undefined
 		});
 		response.headers.append('set-cookie', 'name=SvelteKit; path=/; HttpOnly');

--- a/packages/kit/test/apps/basics/src/routes/hoisted-script/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/hoisted-script/index.svelte
@@ -1,0 +1,10 @@
+<!--
+	This page has its hydration script moved to the root of the <body>
+	in src/hooks.js, to check that hydration still works correctly
+	(https://github.com/sveltejs/kit/issues/4685)
+-->
+<script>
+	import { browser } from '$app/env';
+</script>
+
+<h1>Hello from the {browser ? 'browser' : 'server'}</h1>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -2459,3 +2459,12 @@ test.describe.parallel('XSS', () => {
 		);
 	});
 });
+
+test.describe.parallel('Hydration', () => {
+	test('Hydration survives scripts being hoisted', async ({ page, javaScriptEnabled }) => {
+		await page.goto('/hoisted-script');
+		expect(await page.textContent('body h1')).toBe(
+			`Hello from the ${javaScriptEnabled ? 'browser' : 'server'}`
+		);
+	});
+});


### PR DESCRIPTION
This is a possible solution to #4685, though in the process of working on it I realised it's probably easier to solve it in userland — will add details on the issue

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
