### PR TITLE
ignore trailing slash on endpoints

### DIFF
--- a/.changeset/tender-geckos-agree.md
+++ b/.changeset/tender-geckos-agree.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Never allow trailing slash for endpoints

--- a/.changeset/tender-geckos-agree.md
+++ b/.changeset/tender-geckos-agree.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Ignore `trailingSlash` for endpoint requests, apply `trailingSlash` to pages consistently
+[breaking] Ignore `trailingSlash` for endpoint requests, apply `trailingSlash` to pages consistently

--- a/.changeset/tender-geckos-agree.md
+++ b/.changeset/tender-geckos-agree.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Never allow trailing slash for endpoints
+Ignore `trailingSlash` for endpoint requests, apply `trailingSlash` to pages consistently

--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -275,7 +275,7 @@ An object containing zero or more of the following values:
 
 ### trailingSlash
 
-Whether to remove, append, or ignore trailing slashes when resolving URLs to routes.
+Whether to remove, append, or ignore trailing slashes when resolving URLs (note that this only applies to pages, not endpoints).
 
 - `'never'` — redirect `/x/` to `/x`
 - `'always'` — redirect `/x` to `/x/`

--- a/packages/kit/src/core/preview/index.js
+++ b/packages/kit/src/core/preview/index.js
@@ -7,7 +7,6 @@ import { pathToFileURL } from 'url';
 import { getRequest, setResponse } from '../../node.js';
 import { installFetch } from '../../install-fetch.js';
 import { SVELTE_KIT_ASSETS } from '../constants.js';
-import { normalize_path } from '../../utils/url.js';
 
 /** @typedef {import('http').IncomingMessage} Req */
 /** @typedef {import('http').ServerResponse} Res */
@@ -90,7 +89,7 @@ export async function preview({ port, host, config, https: use_https = false }) 
 				return;
 			}
 
-			const { pathname, search } = new URL(/** @type {string} */ (req.url), 'http://dummy');
+			const { pathname } = new URL(/** @type {string} */ (req.url), 'http://dummy');
 
 			// only treat this as a page if it doesn't include an extension
 			if (pathname === '/' || /\/[^./]+\/?$/.test(pathname)) {

--- a/packages/kit/src/core/preview/index.js
+++ b/packages/kit/src/core/preview/index.js
@@ -92,16 +92,6 @@ export async function preview({ port, host, config, https: use_https = false }) 
 
 			const { pathname, search } = new URL(/** @type {string} */ (req.url), 'http://dummy');
 
-			const normalized = normalize_path(pathname, config.kit.trailingSlash);
-
-			if (normalized !== pathname) {
-				res.writeHead(307, {
-					location: base + normalized + search
-				});
-				res.end();
-				return;
-			}
-
 			// only treat this as a page if it doesn't include an extension
 			if (pathname === '/' || /\/[^./]+\/?$/.test(pathname)) {
 				const file = join(

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -85,11 +85,8 @@ export async function respond(request, options, state) {
 		}
 	}
 
-	if (route) {
-		const normalized = normalize_path(
-			url.pathname,
-			route.type === 'endpoint' ? 'never' : options.trailing_slash
-		);
+	if (route?.type === 'page') {
+		const normalized = normalize_path(url.pathname, options.trailing_slash);
 
 		if (normalized !== url.pathname && !state.prerender?.fallback) {
 			return new Response(undefined, {

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -16,20 +16,6 @@ const default_transform = ({ html }) => html;
 export async function respond(request, options, state) {
 	let url = new URL(request.url);
 
-	const normalized = normalize_path(url.pathname, options.trailing_slash);
-
-	if (normalized !== url.pathname && !state.prerender?.fallback) {
-		return new Response(undefined, {
-			status: 301,
-			headers: {
-				location:
-					// ensure paths starting with '//' are not treated as protocol-relative
-					(normalized.startsWith('//') ? url.origin + normalized : normalized) +
-					(url.search === '?' ? '' : url.search)
-			}
-		});
-	}
-
 	const { parameter, allowed } = options.method_override;
 	const method_override = url.searchParams.get(parameter)?.toUpperCase();
 
@@ -96,6 +82,25 @@ export async function respond(request, options, state) {
 				params = decode_params(matched);
 				break;
 			}
+		}
+	}
+
+	if (route) {
+		const normalized = normalize_path(
+			url.pathname,
+			route.type === 'endpoint' ? 'never' : options.trailing_slash
+		);
+
+		if (normalized !== url.pathname && !state.prerender?.fallback) {
+			return new Response(undefined, {
+				status: 301,
+				headers: {
+					location:
+						// ensure paths starting with '//' are not treated as protocol-relative
+						(normalized.startsWith('//') ? url.origin + normalized : normalized) +
+						(url.search === '?' ? '' : url.search)
+				}
+			});
 		}
 	}
 

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -46,7 +46,7 @@ export function normalize_path(path, trailing_slash) {
 
 	if (trailing_slash === 'never') {
 		return path.endsWith('/') ? path.slice(0, -1) : path;
-	} else if (trailing_slash === 'always' && /\/[^./]+$/.test(path)) {
+	} else if (trailing_slash === 'always' && !path.endsWith('/')) {
 		return path + '/';
 	}
 

--- a/packages/kit/src/utils/url.spec.js
+++ b/packages/kit/src/utils/url.spec.js
@@ -67,11 +67,6 @@ test('normalizes paths', () => {
 			ignore: '/foo/',
 			always: '/foo/',
 			never: '/foo'
-		},
-		'/foo.json': {
-			ignore: '/foo.json',
-			always: '/foo.json',
-			never: '/foo.json'
 		}
 	};
 

--- a/packages/kit/test/apps/options/source/pages/endpoint.js
+++ b/packages/kit/test/apps/options/source/pages/endpoint.js
@@ -1,5 +1,5 @@
 export function get() {
 	return {
-		body: 'this should be accessible as /path-base/endpoint, not /path-base/endpoint/'
+		body: 'hi'
 	};
 }

--- a/packages/kit/test/apps/options/source/pages/endpoint.js
+++ b/packages/kit/test/apps/options/source/pages/endpoint.js
@@ -1,0 +1,5 @@
+export function get() {
+	return {
+		body: 'this should be accessible as /path-base/endpoint, not /path-base/endpoint/'
+	};
+}

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -143,6 +143,14 @@ test.describe.parallel('trailingSlash', () => {
 		expect(page.url()).toBe(`${baseURL}/path-base/slash/child/`);
 		expect(await page.textContent('h2')).toBe('/slash/child/');
 	});
+
+	test('does not add trailing slash to endpoint', async ({ baseURL, request }) => {
+		const response = await request.get('/path-base/endpoint/');
+		expect(response.url()).toBe(`${baseURL}/path-base/endpoint`);
+		expect(await response.text()).toBe(
+			'this should be accessible as /path-base/endpoint, not /path-base/endpoint/'
+		);
+	});
 });
 
 test.describe.parallel('serviceWorker', () => {

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -144,12 +144,14 @@ test.describe.parallel('trailingSlash', () => {
 		expect(await page.textContent('h2')).toBe('/slash/child/');
 	});
 
-	test('does not add trailing slash to endpoint', async ({ baseURL, request }) => {
-		const response = await request.get('/path-base/endpoint/');
-		expect(response.url()).toBe(`${baseURL}/path-base/endpoint`);
-		expect(await response.text()).toBe(
-			'this should be accessible as /path-base/endpoint, not /path-base/endpoint/'
-		);
+	test('ignores trailing slash on endpoint', async ({ baseURL, request }) => {
+		const r1 = await request.get('/path-base/endpoint/');
+		expect(r1.url()).toBe(`${baseURL}/path-base/endpoint/`);
+		expect(await r1.text()).toBe('hi');
+
+		const r2 = await request.get('/path-base/endpoint');
+		expect(r2.url()).toBe(`${baseURL}/path-base/endpoint`);
+		expect(await r2.text()).toBe('hi');
 	});
 });
 


### PR DESCRIPTION
Fixes #2796. Right now, the `trailingSlash` option applies to all paths. Now that we've got rid of fallthrough routes, and can match pathnames to routes immediately, we have the option of only applying the `trailingSlash` option to pages. I think we should take it.

This is a breaking change. An alternative would be to add a new option, like

```js
trailingSlash: { pages: 'always', endpoints: 'never' }
```

or something, but I think that'd be a mistake. Right now, `always` _really_ means 'always unless the last segment of the path includes a `.` character' (i.e. `/foo.json` never redirects to `/foo.json/`), which is really just a proxy for 'always unless it's an endpoint', except that it has both false positives and negatives.

There's some redirect logic in `adapter-vercel` that I think we'd need to get rid of as well (it applies similar logic to what we currently have, but at the router layer rather than the application layer, and I think it's unnecessary). I think that's the only adapter that would need changing.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
