### PR TITLE
[chore] add Node 18 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
         include:
           - node-version: 16
             os: ubuntu-latest
+        include:
+          - node-version: 18
+            os: ubuntu-latest
     env:
       TURBO_CACHE_KEY: ${{ matrix.os }}-${{ matrix.node-version }}
     steps:


### PR DESCRIPTION
Can't drop Node 14 support yet because AWS Lambda still doesn't support Node 16