### PR TITLE
Throwable responses from endpoints

### DIFF
--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -75,7 +75,22 @@ export async function render_endpoint(event, mod) {
 			  });
 	}
 
-	const response = await handler(event);
+	let response;
+	try {
+		response = await handler(event);
+	} catch (err) {
+		const parsed_status = parseInt(err.status);
+		if (isNaN(parsed_status)) {
+			throw err;
+		}
+		response = {
+			status: parsed_status,
+			headers: err.headers,
+			body: err.body,
+			error: err.error
+		};
+	}
+
 	const preface = `Invalid response from route ${event.url.pathname}`;
 
 	if (typeof response !== 'object') {

--- a/packages/kit/test/apps/basics/src/routes/endpoint-output/thrown-ok.js
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-output/thrown-ok.js
@@ -1,0 +1,7 @@
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export function get() {
+	const err = new Error();
+	err.status = 200;
+	err.body = { hello: 'world' };
+	throw err;
+}

--- a/packages/kit/test/apps/basics/src/routes/errors/endpoint-thrown-not-ok.json.js
+++ b/packages/kit/test/apps/basics/src/routes/errors/endpoint-thrown-not-ok.json.js
@@ -1,0 +1,6 @@
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export function get() {
+	const err = new Error();
+	err.status = 555;
+	throw err;
+}

--- a/packages/kit/test/apps/basics/src/routes/errors/endpoint-thrown-not-ok.svelte
+++ b/packages/kit/test/apps/basics/src/routes/errors/endpoint-thrown-not-ok.svelte
@@ -1,0 +1,18 @@
+<script context="module">
+	/** @type {import('@sveltejs/kit').Load} */
+	export async function load({ fetch }) {
+		const res = await fetch('/errors/endpoint-thrown-not-ok.json');
+		if (res.ok) {
+			return {
+				props: await res.json()
+			};
+		} else {
+			return {
+				status: res.status,
+				error: new Error(res.statusText)
+			};
+		}
+	}
+</script>
+
+<h1>this text should not appear</h1>


### PR DESCRIPTION
The idea here is that endpoints can not only return a response, but also throw one.

E.g.

```js
  // return a response from an endpoint
  export async function get() {
    return { status: 200, body: {} }
  }

  // throw a response from an endpoint
  export async function get() {
    throw { status: 401 }
  }
```

This is useful for building request validation libraries. E.g. to build an auth guard
for an endpoint without this change, you would need something like:

```js
  export async function get() {
    if (!isAuthenticated()) {
      return { status: 401 }
    }
  }
```

And with this change, you can do:

```js
  export async function get() {
    // Throws a 401 if the request is not authenticated
    verifyAuthenticated()
  }
```

This is a common pattern in other web frameworks and makes it easier to structure
your code.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
