### PR TITLE
copy dotfiles from .svelte-kit/output

### DIFF
--- a/.changeset/shy-toes-punch.md
+++ b/.changeset/shy-toes-punch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Copy dotfiles from .svelte-kit/output

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -121,9 +121,7 @@ export function create_builder({ config, build_data, prerendered, log }) {
 		},
 
 		writeClient(dest) {
-			return copy(`${config.kit.outDir}/output/client`, dest, {
-				filter: (file) => file[0] !== '.'
-			});
+			return copy(`${config.kit.outDir}/output/client`, dest);
 		},
 
 		writePrerendered(dest, { fallback } = {}) {
@@ -139,9 +137,7 @@ export function create_builder({ config, build_data, prerendered, log }) {
 		},
 
 		writeServer(dest) {
-			return copy(`${config.kit.outDir}/output/server`, dest, {
-				filter: (file) => file[0] !== '.'
-			});
+			return copy(`${config.kit.outDir}/output/server`, dest);
 		},
 
 		writeStatic(dest) {

--- a/packages/kit/src/core/adapt/builder.spec.js
+++ b/packages/kit/src/core/adapt/builder.spec.js
@@ -44,20 +44,27 @@ test('copy files', () => {
 
 	assert.equal(
 		glob('**', {
-			cwd: /** @type {import('types').ValidatedConfig} */ (mocked).kit.files.assets
+			cwd: /** @type {import('types').ValidatedConfig} */ (mocked).kit.files.assets,
+			dot: true
 		}),
-		glob('**', { cwd: dest })
+		glob('**', { cwd: dest, dot: true })
 	);
 
 	rmSync(dest, { recursive: true, force: true });
 	builder.writeClient(dest);
 
-	assert.equal(glob('**', { cwd: `${outDir}/output/client` }), glob('**', { cwd: dest }));
+	assert.equal(
+		glob('**', { cwd: `${outDir}/output/client`, dot: true }),
+		glob('**', { cwd: dest, dot: true })
+	);
 
 	rmSync(dest, { recursive: true, force: true });
 	builder.writeServer(dest);
 
-	assert.equal(glob('**', { cwd: `${outDir}/output/server` }), glob('**', { cwd: dest }));
+	assert.equal(
+		glob('**', { cwd: `${outDir}/output/server`, dot: true }),
+		glob('**', { cwd: dest, dot: true })
+	);
 
 	rmSync(dest, { force: true, recursive: true });
 });

--- a/packages/kit/test/apps/basics/src/routes/.well-known/endpoint.js
+++ b/packages/kit/test/apps/basics/src/routes/.well-known/endpoint.js
@@ -1,0 +1,7 @@
+export function get() {
+	return {
+		body: {
+			answer: 42
+		}
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/.well-known/endpoint.js
+++ b/packages/kit/test/apps/basics/src/routes/.well-known/endpoint.js
@@ -1,7 +1,0 @@
-export function get() {
-	return {
-		body: {
-			answer: 42
-		}
-	};
-}


### PR DESCRIPTION
fixes #3340. At the time that issue was raised, `/.well-known/*` routes were disregarded, but in more recent versions they were handled correctly — up to a point. The `builder.writeServer(dest)` method was skipping over dotfiles in an effort to eliminate junk like `.DS_Store`, but since output JS chunks can have a `.` prefix, it was skipping those too.

We could change the chunk naming rules, or have a more specific filter, but I think this is the simplest fix. The occasional stray `.DS_Store` won't actually do any damage, after all.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
