### PR TITLE
bind all network interfaces on `preview --host`

### DIFF
--- a/.changeset/shiny-birds-ring.md
+++ b/.changeset/shiny-birds-ring.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] Supplying an empty `--host` option to `preview` exposes the server to both ipv4 and ipv6 networks

--- a/packages/kit/src/core/preview/index.js
+++ b/packages/kit/src/core/preview/index.js
@@ -161,7 +161,7 @@ export async function preview({ port, host, config, https: use_https = false }) 
 	});
 
 	return new Promise((fulfil) => {
-		http_server.listen(port, host || '0.0.0.0', () => {
+		http_server.listen(port, host, () => {
 			fulfil(http_server);
 		});
 	});


### PR DESCRIPTION
Something we noticed on https://github.com/sveltejs/kit/pull/4727: we bind to `0.0.0.0` on `preview --host`, which makes the server unreachable through ipv6 interfaces.

This makes `preview` defer to [node's own logic](https://nodejs.org/api/net.html#serverlistenport-host-backlog-callback) when an empty/undefined `host` is supplied, so that either `::` or `0.0.0.0` is used depending on the available network interfaces.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
