### PR TITLE
[adapter-vercel] Make all root routes be called `index` instead of an empty string

### DIFF
--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -340,7 +340,7 @@ async function v3(builder, external, edge, split) {
 						.slice(1, -2) // remove leading / and trailing $/
 						.replace(/\\\//g, '/')}(?:/__data.json)?$`; // TODO adding /__data.json is a temporary workaround — those endpoints should be treated as distinct routes
 
-					await generate_function(route.id, src, entry.generateManifest);
+					await generate_function(createValidFunctionName(route.id), src, entry.generateManifest);
 				}
 			};
 		});
@@ -384,4 +384,21 @@ function write(file, data) {
 	}
 
 	writeFileSync(file, data);
+}
+
+/**
+ * Make all root routes be called `index`:
+ *
+ * @example
+ * ```js
+ * createValidFunctionName("") // "index"
+ * createValidFunctionName("nested") // "nested"
+ * createValidFunctionName("nested/") // "nested/index"
+ * ```
+ *
+ * @param {string} routeId
+ * @returns {string} route id that is a valid function name
+ */
+function createValidFunctionName(routeId) {
+	return routeId.replace(/(\/|^)$/, '$1index');
 }


### PR DESCRIPTION
The current implementation of `edge: true, split: true` will fail to deploy on Vercel because the Edge Function name is empty. This PR fixes that by renaming them to `index` instead.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
