### PR TITLE
prevent unhandled rejections when loading page modules

### DIFF
--- a/.changeset/silver-elephants-attack.md
+++ b/.changeset/silver-elephants-attack.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Prevent unhandled rejections when loading page modules

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -612,8 +612,10 @@ export function create_client({ target, session, base, trailing_slash }) {
 		/** @type {Error | null} */
 		let error = null;
 
-		// preload modules
-		a.forEach((loader) => loader());
+		// preload modules to avoid waterfall, but handle rejections
+		// so they don't get reported to Sentry et al (we don't need
+		// to act on the failures at this point)
+		a.forEach((loader) => loader().catch(() => {}));
 
 		load: for (let i = 0; i < a.length; i += 1) {
 			/** @type {import('./types').BranchNode | undefined} */


### PR DESCRIPTION
fixes #3978. Even though the failure to load modules following a redeploy (which causes some filenames to be changed) was being dealt with (by causing the page to reload), rejections weren't being handled immediately before, when we preload modules to avoid waterfall.

This is a tricky thing to add a test for, but I verified that with this change the `unhandledrejection` event no longer happens, which should clean up Sentry logs etc.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
