### PR TITLE
remove try-catch around `server.respond`

### DIFF
--- a/.changeset/brave-rabbits-provide.md
+++ b/.changeset/brave-rabbits-provide.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+---
+
+[breaking] Remove try-catch around server.respond

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -60,16 +60,12 @@ export default {
 		}
 
 		// dynamically-generated pages
-		try {
-			return await server.respond(req, {
-				platform: { env, context },
-				getClientAddress() {
-					return req.headers.get('cf-connecting-ip');
-				}
-			});
-		} catch (e) {
-			return new Response('Error rendering route: ' + (e.message || e.toString()), { status: 500 });
-		}
+		return await server.respond(req, {
+			platform: { env, context },
+			getClientAddress() {
+				return req.headers.get('cf-connecting-ip');
+			}
+		});
 	}
 };
 
@@ -79,24 +75,19 @@ export default {
  * @param {any} context
  */
 async function get_asset_from_kv(req, env, context, map = mapRequestToAsset) {
-	try {
-		return await getAssetFromKV(
-			{
-				request: req,
-				waitUntil(promise) {
-					return context.waitUntil(promise);
-				}
-			},
-			{
-				ASSET_NAMESPACE: env.__STATIC_CONTENT,
-				ASSET_MANIFEST: static_asset_manifest,
-				mapRequestToAsset: map
+	return await getAssetFromKV(
+		{
+			request: req,
+			waitUntil(promise) {
+				return context.waitUntil(promise);
 			}
-		);
-	} catch (e) {
-		const status = is_error(e.status) ? e.status : 500;
-		return new Response(e.message || e.toString(), { status });
-	}
+		},
+		{
+			ASSET_NAMESPACE: env.__STATIC_CONTENT,
+			ASSET_MANIFEST: static_asset_manifest,
+			mapRequestToAsset: map
+		}
+	);
 }
 
 /**

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -9,62 +9,58 @@ const prefix = `/${manifest.appDir}/`;
 /** @type {import('worktop/cfw').Module.Worker<{ ASSETS: import('worktop/cfw.durable').Durable.Object }>} */
 const worker = {
 	async fetch(req, env, context) {
-		try {
-			// skip cache if "cache-control: no-cache" in request
-			let pragma = req.headers.get('cache-control') || '';
-			let res = !pragma.includes('no-cache') && (await Cache.lookup(req));
-			if (res) return res;
+		// skip cache if "cache-control: no-cache" in request
+		let pragma = req.headers.get('cache-control') || '';
+		let res = !pragma.includes('no-cache') && (await Cache.lookup(req));
+		if (res) return res;
 
-			let { pathname } = new URL(req.url);
+		let { pathname } = new URL(req.url);
 
-			// static assets
-			if (pathname.startsWith(prefix)) {
-				res = await env.ASSETS.fetch(req);
+		// static assets
+		if (pathname.startsWith(prefix)) {
+			res = await env.ASSETS.fetch(req);
 
-				res = new Response(res.body, {
-					headers: {
-						// include original cache headers, minus cache-control which
-						// is overridden, and etag which is no longer useful
-						'cache-control': 'public, immutable, max-age=31536000',
-						'content-type': res.headers.get('content-type'),
-						'x-robots-tag': 'noindex'
-					}
-				});
-			} else {
-				// prerendered pages and index.html files
-				pathname = pathname.replace(/\/$/, '') || '/';
-
-				let file = pathname.substring(1);
-
-				try {
-					file = decodeURIComponent(file);
-				} catch (err) {
-					// ignore
+			res = new Response(res.body, {
+				headers: {
+					// include original cache headers, minus cache-control which
+					// is overridden, and etag which is no longer useful
+					'cache-control': 'public, immutable, max-age=31536000',
+					'content-type': res.headers.get('content-type'),
+					'x-robots-tag': 'noindex'
 				}
+			});
+		} else {
+			// prerendered pages and index.html files
+			pathname = pathname.replace(/\/$/, '') || '/';
 
-				if (
-					manifest.assets.has(file) ||
-					manifest.assets.has(file + '/index.html') ||
-					prerendered.has(pathname)
-				) {
-					res = await env.ASSETS.fetch(req);
-				} else {
-					// dynamically-generated pages
-					res = await server.respond(req, {
-						platform: { env, context },
-						getClientAddress() {
-							return req.headers.get('cf-connecting-ip');
-						}
-					});
-				}
+			let file = pathname.substring(1);
+
+			try {
+				file = decodeURIComponent(file);
+			} catch (err) {
+				// ignore
 			}
 
-			// Writes to Cache only if allowed & specified
-			pragma = res.headers.get('cache-control');
-			return pragma ? Cache.save(req, res, context) : res;
-		} catch (e) {
-			return new Response('Error rendering route: ' + (e.message || e.toString()), { status: 500 });
+			if (
+				manifest.assets.has(file) ||
+				manifest.assets.has(file + '/index.html') ||
+				prerendered.has(pathname)
+			) {
+				res = await env.ASSETS.fetch(req);
+			} else {
+				// dynamically-generated pages
+				res = await server.respond(req, {
+					platform: { env, context },
+					getClientAddress() {
+						return req.headers.get('cf-connecting-ip');
+					}
+				});
+			}
 		}
+
+		// Writes to Cache only if allowed & specified
+		pragma = res.headers.get('cache-control');
+		return pragma ? Cache.save(req, res, context) : res;
 	}
 };
 

--- a/packages/adapter-netlify/src/edge.js
+++ b/packages/adapter-netlify/src/edge.js
@@ -9,24 +9,18 @@ const prefix = `/${manifest.appDir}/`;
  * @param { any } context
  * @returns { Promise<Response> }
  */
-export default async function handler(request, context) {
+export default function handler(request, context) {
 	if (is_static_file(request)) {
 		// Static files can skip the handler
 		return;
 	}
-	try {
-		const response = await server.respond(request, {
-			platform: { context },
-			getClientAddress() {
-				return request.headers.get('x-nf-client-connection-ip');
-			}
-		});
-		return response;
-	} catch (error) {
-		return new Response('Error rendering route:' + (error.message || error.toString()), {
-			status: 500
-		});
-	}
+
+	return server.respond(request, {
+		platform: { context },
+		getClientAddress() {
+			return request.headers.get('x-nf-client-connection-ip');
+		}
+	});
 }
 
 /**


### PR DESCRIPTION
It doesn't make sense to wrap `server.respond` in a try-catch — if an uncaught error happens during rendering (which should never happen) it should be handled by the platform (e.g. surfaced in error logs). It definitely shouldn't just cause a 500 to be returned silently. More discussion in https://github.com/sveltejs/kit/issues/4635#issuecomment-1108954358.

In any case, we weren't doing it consistently across adapters. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
