### PR TITLE
default to target: node14.8

### DIFF
--- a/.changeset/hungry-coats-sort.md
+++ b/.changeset/hungry-coats-sort.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Default to target: node16, so that top-level await is supported in user code

--- a/.changeset/hungry-coats-sort.md
+++ b/.changeset/hungry-coats-sort.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Default to target: node16, so that top-level await is supported in user code
+Default to target: node14.8, so that top-level await is supported in user code

--- a/packages/kit/src/core/build/build_server.js
+++ b/packages/kit/src/core/build/build_server.js
@@ -190,7 +190,7 @@ export async function build_server(
 
 	const default_config = {
 		build: {
-			target: 'es2020'
+			target: 'node16'
 		},
 		ssr: {
 			// when developing against the Kit src code, we want to ensure that

--- a/packages/kit/src/core/build/build_server.js
+++ b/packages/kit/src/core/build/build_server.js
@@ -190,7 +190,7 @@ export async function build_server(
 
 	const default_config = {
 		build: {
-			target: 'node16'
+			target: 'node14.8'
 		},
 		ssr: {
 			// when developing against the Kit src code, we want to ensure that


### PR DESCRIPTION
Fixes #1538, where I recommended that people do async setup work in `src/hooks.js` (or any other module, really) using top-level await. This works wonderfully in development, but it turns out `svelte-kit build` fails because Vite runs everything through `esbuild` (not sure why, if I'm perfectly honest, but that's a separate conversation) and we currently use `target: 'es2020'` which doesn't allow top-level await:

> chunks/hooks-4fb5bb73.js:206:0: ERROR: Top-level await is not available in the configured target environment ("es2020")

This changes it to `node16`. I tried `node14` at first, but that still didn't work even though top-level await definitely _is_ supported there. I think this is probably fine, and at any rate, you can override it in `config.kit.vite.build.target`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
