### PR TITLE
use spaces in README.md files

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -11,6 +11,13 @@
 			}
 		},
 		{
+			"files": ["packages/*/README.md"],
+			"options": {
+				"useTabs": false,
+				"tabWidth": 2
+			}
+		},
+		{
 			"files": [
 				"**/CHANGELOG.md",
 				"packages/kit/src/packaging/test/fixtures/**/expected/**/*",

--- a/packages/adapter-cloudflare-workers/README.md
+++ b/packages/adapter-cloudflare-workers/README.md
@@ -23,9 +23,9 @@ Install with `npm i -D @sveltejs/adapter-cloudflare-workers`, then add the adapt
 import adapter from '@sveltejs/adapter-cloudflare-workers';
 
 export default {
-	kit: {
-		adapter: adapter()
-	}
+  kit: {
+    adapter: adapter()
+  }
 };
 ```
 

--- a/packages/adapter-cloudflare/README.md
+++ b/packages/adapter-cloudflare/README.md
@@ -31,9 +31,9 @@ You can include these changes in your `svelte.config.js` configuration file:
 import adapter from '@sveltejs/adapter-cloudflare';
 
 export default {
-	kit: {
-		adapter: adapter()
-	}
+  kit: {
+    adapter: adapter()
+  }
 };
 ```
 
@@ -77,7 +77,7 @@ declare namespace App {
 
 ```js
 export async function post({ request, platform }) {
-	const counter = platform.env.COUNTER.idFromName('A');
+  const counter = platform.env.COUNTER.idFromName('A');
 }
 ```
 

--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -16,19 +16,19 @@ You can then configure it inside of `svelte.config.js`:
 import adapter from '@sveltejs/adapter-netlify';
 
 export default {
-	kit: {
-		// default options are shown
-		adapter: adapter({
-			// if true, will create a Netlify Edge Function rather
-			// than using standard Node-based functions
-			edge: false,
+  kit: {
+    // default options are shown
+    adapter: adapter({
+      // if true, will create a Netlify Edge Function rather
+      // than using standard Node-based functions
+      edge: false,
 
-			// if true, will split your app into multiple functions
-			// instead of creating a single one for the entire app.
-			// if `edge` is true, this option cannot be used
-			split: false
-		})
-	}
+      // if true, will split your app into multiple functions
+      // instead of creating a single one for the entire app.
+      // if `edge` is true, this option cannot be used
+      split: false
+    })
+  }
 };
 ```
 

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -11,9 +11,9 @@ Install with `npm i -D @sveltejs/adapter-node`, then add the adapter to your `sv
 import adapter from '@sveltejs/adapter-node';
 
 export default {
-	kit: {
-		adapter: adapter()
-	}
+  kit: {
+    adapter: adapter()
+  }
 };
 ```
 
@@ -78,14 +78,14 @@ The adapter can be configured with various options:
 import adapter from '@sveltejs/adapter-node';
 
 export default {
-	kit: {
-		adapter: adapter({
-			// default options are shown
-			out: 'build',
-			precompress: false,
-			envPrefix: ''
-		})
-	}
+  kit: {
+    adapter: adapter({
+      // default options are shown
+      out: 'build',
+      precompress: false,
+      envPrefix: ''
+    })
+  }
 };
 ```
 
@@ -127,14 +127,14 @@ const app = express();
 
 // add a route that lives separately from the SvelteKit app
 app.get('/healthcheck', (req, res) => {
-	res.end('ok');
+  res.end('ok');
 });
 
 // let SvelteKit handle everything else, including serving prerendered pages and static assets
 app.use(handler);
 
 app.listen(3000, () => {
-	console.log('listening on port 3000');
+  console.log('listening on port 3000');
 });
 ```
 

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -11,20 +11,20 @@ Install with `npm i -D @sveltejs/adapter-static`, then add the adapter to your `
 import adapter from '@sveltejs/adapter-static';
 
 export default {
-	kit: {
-		adapter: adapter({
-			// default options are shown
-			pages: 'build',
-			assets: 'build',
-			fallback: null,
-			precompress: false
-		}),
+  kit: {
+    adapter: adapter({
+      // default options are shown
+      pages: 'build',
+      assets: 'build',
+      fallback: null,
+      precompress: false
+    }),
 
-		prerender: {
-			// This can be false if you're using a fallback (i.e. SPA mode)
-			default: true
-		}
-	}
+    prerender: {
+      // This can be false if you're using a fallback (i.e. SPA mode)
+      default: true
+    }
+  }
 };
 ```
 
@@ -61,11 +61,11 @@ The fallback page is a blank HTML page that loads your SvelteKit app and navigat
 import adapter from '@sveltejs/adapter-static';
 
 export default {
-	kit: {
-		adapter: adapter({
-			fallback: '200.html'
-		})
-	}
+  kit: {
+    adapter: adapter({
+      fallback: '200.html'
+    })
+  }
 };
 ```
 

--- a/packages/adapter-vercel/README.md
+++ b/packages/adapter-vercel/README.md
@@ -16,23 +16,23 @@ Then in your `svelte.config.js`:
 import vercel from '@sveltejs/adapter-vercel';
 
 export default {
-	kit: {
-		// default options are shown
-		adapter: vercel({
-			// if true, will deploy the app using edge functions
-			// (https://vercel.com/docs/concepts/functions/edge-functions)
-			// rather than serverless functions
-			edge: false,
+  kit: {
+    // default options are shown
+    adapter: vercel({
+      // if true, will deploy the app using edge functions
+      // (https://vercel.com/docs/concepts/functions/edge-functions)
+      // rather than serverless functions
+      edge: false,
 
-			// an array of dependencies that esbuild should treat
-			// as external when bundling functions
-			external: [],
+      // an array of dependencies that esbuild should treat
+      // as external when bundling functions
+      external: [],
 
-			// if true, will split your app into multiple functions
-			// instead of creating a single one for the entire app
-			split: false
-		})
-	}
+      // if true, will split your app into multiple functions
+      // instead of creating a single one for the entire app
+      split: false
+    })
+  }
 };
 ```
 


### PR DESCRIPTION
In general we use tabs everywhere, because we are sensible. GitHub's CSS, however, is _not_ sensible:

<img width="1034" alt="image" src="https://user-images.githubusercontent.com/1162160/165314431-ec368c7c-252d-4339-8a48-89dfd2a2133b.png">

This PR adjusts the Prettier config so that we can link to individual package READMEs as documentation without feeling embarrassed. (I thought `.editorconfig` was supposed to fix this, which would be better since code copied from the READMEs would contain tabs, but clearly it doesn't.)

<img width="1028" alt="image" src="https://user-images.githubusercontent.com/1162160/165314621-aaae1450-9c88-40d5-a155-31dea3eff48a.png">
