### PR TITLE
[chore] disallow test.only tests during linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,5 +6,11 @@
 	},
 	"settings": {
 		"import/ignore": "/template/"
+	},
+	"rules": {
+		"no-restricted-properties": [
+			"error",
+			{ "object": "test", "property": "only", "message": "Do not check in test.only tests." }
+		]
 	}
 }

--- a/packages/kit/.eslintrc.json
+++ b/packages/kit/.eslintrc.json
@@ -15,7 +15,8 @@
 	"rules": {
 		"no-restricted-properties": [
 			"error",
-			{ "property": "substr", "message": "Use .slice instead of .substr." }
+			{ "property": "substr", "message": "Use .slice instead of .substr." },
+			{ "object": "test", "property": "only", "message": "Do not check in test.only tests." }
 		],
 		"@typescript-eslint/no-empty-interface": "off"
 	}

--- a/packages/kit/src/core/sync/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.spec.js
@@ -551,7 +551,7 @@ test('errors on duplicate layout definition', () => {
 	);
 });
 
-test.only('errors on recursive name layout', () => {
+test('errors on recursive name layout', () => {
 	assert.throws(
 		() => create('samples/named-layout-recursive-1'),
 		/Recursive layout detected: samples\/named-layout-recursive-1\/__layout-a@b\.svelte -> samples\/named-layout-recursive-1\/__layout-b@a\.svelte -> samples\/named-layout-recursive-1\/__layout-a@b\.svelte/


### PR DESCRIPTION
We can't (yet) tell uvu to disallow `test.only` tests (https://github.com/lukeed/uvu/issues/174), so I'd like to prevent this during linting instead.

The first commit of this PR purposefully does not fix the existing `test.only` so that we can make sure it's caught by CI. Once that happens, I'll push another commit to fix it.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
