### PR TITLE
Fix wrong option in readme

### DIFF
--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -22,7 +22,7 @@ export default {
 
     prerender: {
       // This can be false if you're using a fallback (i.e. SPA mode)
-      default: true
+      enabled: true
     }
   }
 };


### PR DESCRIPTION
The prerender example used `default` instead of `enabled`.
