### PR TITLE
feat: allows platform in externalFetch

### DIFF
--- a/packages/kit/src/core/build/build_server.js
+++ b/packages/kit/src/core/build/build_server.js
@@ -93,7 +93,7 @@ export class Server {
 				getSession: module.getSession || (() => ({})),
 				handle: module.handle || (({ event, resolve }) => resolve(event)),
 				handleError: module.handleError || (({ error }) => console.error(error.stack)),
-				externalFetch: module.externalFetch || fetch
+				externalFetch: module.externalFetch || ((r) => fetch(r))
 			};
 		}
 

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -234,7 +234,7 @@ export async function create_plugin(config, cwd) {
 										console.error(colors.gray(error.stack));
 									}
 								}),
-							externalFetch: user_hooks.externalFetch || fetch
+							externalFetch: user_hooks.externalFetch || ((r) => fetch(r))
 						};
 
 						if (/** @type {any} */ (hooks).getContext) {

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -247,7 +247,7 @@ export async function load_node({
 					}
 
 					const external_request = new Request(requested, /** @type {RequestInit} */ (opts));
-					response = await options.hooks.externalFetch.call(null, external_request);
+					response = await options.hooks.externalFetch.call(null, external_request, state.platform);
 				}
 
 				const set_cookie = response.headers.get('set-cookie');

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -155,7 +155,7 @@ export interface Config {
 }
 
 export interface ExternalFetch {
-	(req: Request): Promise<Response>;
+	(req: Request, platform?: any): Promise<Response>;
 }
 
 export interface GetSession {


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

---

Within Cloudflare workers and [service bindings](https://blog.cloudflare.com/introducing-worker-services/) the externalFetch function _could_ make sense to support a `env.MY_API.fetch` to perform that request.

As such; lets allow `state.platform` to be sent into `externalFetch` thus allowing something like;

```ts

// within Cloudflare workers _or_ pages

/** @type {import('@sveltejs/kit').ExternalFetch} */
export async function externalFetch(request, {env}) {
	if (request.url.startsWith('https://api.example.com')) {
		return env.API.fetch(request.clone());
	}

	return fetch(request);
}
```

Maybe it makes sense to support a similar suite of options that the current _handle_ hook does. 

---

Either this, or do you see the `load` module export handle this internally? aka

```svelte
<script context="module" lang="ts">
	export const prerender = false;

	export async function load({ params, fetch, platform }) {
		const req = await (platform?.env.API.fetch ?? fetch)(`https://api.example.com/orgs/${params.slug}`);

		if (!req.ok) return { status: 404 };

		return {
			status: 200,
			props: {
				org: await req.json().then((d) => d.data),
			},
		};
	}
</script>
```

> granted would mean load can be conditionally be given platform options. browser/ssr, which imo is more cumbersome. So would be more inclined to the first (and this PR) approach.