### PR TITLE
move `RequestEvent` and `ResolveOptions` as public types

### DIFF
--- a/.changeset/rude-geese-roll.md
+++ b/.changeset/rude-geese-roll.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-feat: ResolveOptions and RequestEvent are now part of the public API.
+move `RequestEvent` and `ResolveOptions` as public types

--- a/.changeset/rude-geese-roll.md
+++ b/.changeset/rude-geese-roll.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+feat: ResolveOptions and RequestEvent are now part of the public API.

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -12,9 +12,7 @@ import {
 	MaybePromise,
 	Prerendered,
 	PrerenderOnErrorValue,
-	RequestEvent,
 	RequestOptions,
-	ResolveOptions,
 	ResponseHeaders,
 	RouteDefinition,
 	TrailingSlash
@@ -171,6 +169,21 @@ export interface Handle {
 
 export interface HandleError {
 	(input: { error: Error & { frame?: string }; event: RequestEvent }): void;
+}
+
+export interface RequestEvent<Params extends Record<string, string> = Record<string, string>> {
+	clientAddress: string;
+	locals: App.Locals;
+	params: Params;
+	platform: Readonly<App.Platform>;
+	request: Request;
+	routeId: string | null;
+	url: URL;
+}
+
+export interface ResolveOptions {
+	ssr?: boolean;
+	transformPage?: ({ html }: { html: string }) => MaybePromise<string>;
 }
 
 /**

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -171,21 +171,6 @@ export interface HandleError {
 	(input: { error: Error & { frame?: string }; event: RequestEvent }): void;
 }
 
-export interface RequestEvent<Params extends Record<string, string> = Record<string, string>> {
-	clientAddress: string;
-	locals: App.Locals;
-	params: Params;
-	platform: Readonly<App.Platform>;
-	request: Request;
-	routeId: string | null;
-	url: URL;
-}
-
-export interface ResolveOptions {
-	ssr?: boolean;
-	transformPage?: ({ html }: { html: string }) => MaybePromise<string>;
-}
-
 /**
  * The `(input: LoadInput) => LoadOutput` `load` function exported from `<script context="module">` in a page or layout.
  *
@@ -247,6 +232,16 @@ export interface ParamMatcher {
 	(param: string): boolean;
 }
 
+export interface RequestEvent<Params extends Record<string, string> = Record<string, string>> {
+	clientAddress: string;
+	locals: App.Locals;
+	params: Params;
+	platform: Readonly<App.Platform>;
+	request: Request;
+	routeId: string | null;
+	url: URL;
+}
+
 /**
  * A `(event: RequestEvent) => RequestHandlerOutput` function exported from an endpoint that corresponds to an HTTP verb (`get`, `put`, `patch`, etc) and handles requests with that method. Note that since 'delete' is a reserved word in JavaScript, delete handles are called `del` instead.
  *
@@ -263,6 +258,11 @@ export interface RequestHandlerOutput<Output extends ResponseBody = ResponseBody
 	status?: number;
 	headers?: Headers | Partial<ResponseHeaders>;
 	body?: Output;
+}
+
+export interface ResolveOptions {
+	ssr?: boolean;
+	transformPage?: ({ html }: { html: string }) => MaybePromise<string>;
 }
 
 export type ResponseBody = JSONValue | Uint8Array | ReadableStream | import('stream').Readable;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -7,6 +7,8 @@ import {
 	HandleError,
 	Load,
 	RequestHandler,
+	ResolveOptions,
+	RequestEvent,
 	Server,
 	SSRManifest
 } from './index';
@@ -14,9 +16,7 @@ import {
 	HttpMethod,
 	JSONObject,
 	MaybePromise,
-	RequestEvent,
 	RequestOptions,
-	ResolveOptions,
 	ResponseHeaders,
 	TrailingSlash
 } from './private';

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -6,9 +6,9 @@ import {
 	Handle,
 	HandleError,
 	Load,
+	RequestEvent,
 	RequestHandler,
 	ResolveOptions,
-	RequestEvent,
 	Server,
 	SSRManifest
 } from './index';

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -198,24 +198,9 @@ export interface PrerenderErrorHandler {
 
 export type PrerenderOnErrorValue = 'fail' | 'continue' | PrerenderErrorHandler;
 
-export interface RequestEvent<Params extends Record<string, string> = Record<string, string>> {
-	clientAddress: string;
-	locals: App.Locals;
-	params: Params;
-	platform: Readonly<App.Platform>;
-	request: Request;
-	routeId: string | null;
-	url: URL;
-}
-
 export interface RequestOptions {
 	getClientAddress: () => string;
 	platform?: App.Platform;
-}
-
-export interface ResolveOptions {
-	ssr?: boolean;
-	transformPage?: ({ html }: { html: string }) => MaybePromise<string>;
 }
 
 /** `string[]` is only for set-cookie, everything else must be type of `string` */


### PR DESCRIPTION
#4805 only explicitly requested moving `RequestEvent` to `index.d.ts`, but `ResolveOptions` is also part of `Handle`'s input API, so I moved it too. If, for some reason, we don't want that to be a publicly-accessible type, I'll move it back.

Fixes #4805.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
