### PR TITLE
[feat] support wrangler2 in adapter-cloudflare

### DIFF
--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -90,7 +90,7 @@ function validate_config(builder) {
 			throw err;
 		}
 
-		// rudamentary way to detect a wrangler2 config file
+		// rudimentary way to detect a wrangler2 config file
 		const is_wrangler_2 = wrangler_config['main'] != null;
 
 		// @ts-ignore

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -90,6 +90,9 @@ function validate_config(builder) {
 			throw err;
 		}
 
+		// rudamentary way to detect a wrangler2 config file
+		const is_wrangler_2 = wrangler_config['main'] != null;
+
 		// @ts-ignore
 		if (!wrangler_config.site || !wrangler_config.site.bucket) {
 			throw new Error(
@@ -97,20 +100,22 @@ function validate_config(builder) {
 			);
 		}
 
-		// @ts-ignore
-		if (!wrangler_config.build || !wrangler_config.build.upload) {
-			throw new Error(
-				'You must specify build.upload options in wrangler.toml. Consult https://github.com/sveltejs/kit/tree/master/packages/adapter-cloudflare-workers'
-			);
+		if (!is_wrangler_2) {
+			// @ts-ignore
+			if (!wrangler_config.build || !wrangler_config.build.upload) {
+				throw new Error(
+					'You must specify build.upload options in wrangler.toml. Consult https://github.com/sveltejs/kit/tree/master/packages/adapter-cloudflare-workers'
+				);
+			}
+
+			// @ts-ignore
+			if (wrangler_config.build.upload.format !== 'modules') {
+				throw new Error('build.upload.format in wrangler.toml must be "modules"');
+			}
 		}
 
 		// @ts-ignore
-		if (wrangler_config.build.upload.format !== 'modules') {
-			throw new Error('build.upload.format in wrangler.toml must be "modules"');
-		}
-
-		// @ts-ignore
-		const main_file = wrangler_config.build?.upload?.main;
+		const main_file = is_wrangler_2 ? wrangler_config.main : wrangler_config.build?.upload?.main;
 		const main_file_ext = main_file?.split('.').slice(-1)[0];
 		if (main_file_ext && main_file_ext !== 'mjs') {
 			// @ts-ignore


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

---

Wrangler 2 has a new config file, and looks somewhat different.

This aims to allow the validator to still pass when building for Cloudflare workers.

Another solution is to potentially allow bypassing validation with a flag until the wrangler 2 toml scheme is finalised.

cc @threepointone