### PR TITLE
Generate tsconfig when running svelte-kit package

### DIFF
--- a/.changeset/twenty-windows-build.md
+++ b/.changeset/twenty-windows-build.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+generate tsconfig when running svelte-kit package

--- a/packages/kit/src/packaging/index.js
+++ b/packages/kit/src/packaging/index.js
@@ -90,9 +90,6 @@ export async function build(config, cwd = process.cwd()) {
  * @param {import('types').ValidatedConfig} config
  */
 export async function watch(config, cwd = process.cwd()) {
-	// Make sure generated tsconfig is up-to-date
-	write_tsconfig(config);
-
 	await build(config, cwd);
 
 	const message = `\nWatching ${relative(cwd, config.kit.files.lib)} for changes...\n`;

--- a/packages/kit/src/packaging/index.js
+++ b/packages/kit/src/packaging/index.js
@@ -6,6 +6,7 @@ import { preprocess } from 'svelte/compiler';
 import { copy, mkdirp, rimraf } from '../utils/filesystem.js';
 import { analyze, generate_pkg, resolve_lib_alias, scan, strip_lang_tags, write } from './utils.js';
 import { emit_dts, transpile_ts } from './typescript.js';
+import { write_tsconfig } from '../core/sync/write_tsconfig.js';
 
 const essential_files = ['README', 'LICENSE', 'CHANGELOG', '.gitignore', '.npmignore'];
 
@@ -23,6 +24,9 @@ export async function build(config, cwd = process.cwd()) {
 
 	rimraf(dir);
 	mkdirp(dir);
+
+	// Make sure generated tsconfig is up-to-date
+	write_tsconfig(config);
 
 	const files = scan(config);
 
@@ -86,6 +90,9 @@ export async function build(config, cwd = process.cwd()) {
  * @param {import('types').ValidatedConfig} config
  */
 export async function watch(config, cwd = process.cwd()) {
+	// Make sure generated tsconfig is up-to-date
+	write_tsconfig(config);
+
 	await build(config, cwd);
 
 	const message = `\nWatching ${relative(cwd, config.kit.files.lib)} for changes...\n`;


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

Currently sveltekit package does not update the generated tsconfig when packaging, this fixes that