### PR TITLE
prevent scroll when resetting page focus (#4065)

### DIFF
--- a/.changeset/olive-vans-talk.md
+++ b/.changeset/olive-vans-talk.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix Safari scroll bug on ssr:false page reload

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -299,7 +299,7 @@ export function create_client({ target, session, base, trailing_slash }) {
 
 				getSelection()?.removeAllRanges();
 				root.tabIndex = -1;
-				root.focus();
+				root.focus({ preventScroll: true });
 
 				// restore `tabindex` as to prevent `root` from stealing input from elements
 				if (tabindex !== null) {

--- a/packages/kit/test/apps/basics/src/routes/no-ssr/margin.svelte
+++ b/packages/kit/test/apps/basics/src/routes/no-ssr/margin.svelte
@@ -1,0 +1,14 @@
+<div class="container">
+	<span> ^this is not the top of the screen</span>
+	<div class="spacer" />
+</div>
+
+<style>
+	.container {
+		margin-top: 300px;
+	}
+
+	.spacer {
+		height: 1000px;
+	}
+</style>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -299,6 +299,13 @@ test.describe('Scrolling', () => {
 		await back();
 		expect(await page.evaluate(() => window.scrollY)).toBe(1000);
 	});
+
+	test('scroll position is top of page on ssr:false reload', async ({ page }) => {
+		await page.goto('/no-ssr/margin');
+		expect(await page.evaluate(() => window.scrollY)).toBe(0);
+		await page.reload();
+		expect(await page.evaluate(() => window.scrollY)).toBe(0);
+	});
 });
 
 test.describe.parallel('Imports', () => {


### PR DESCRIPTION
Fixes #4065. While resetting focus, Safari was scrolling over the top margin.

As it’s a Safari specific issue, the change in test from fail to pass is only visible when running Playwright with WebKit. 

This is my first PR, so let me know if I missed something in the workflow, thanks!

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
