### PR TITLE
feat: `create-svelte` support for scoped packages

### DIFF
--- a/.changeset/cuddly-stingrays-boil.md
+++ b/.changeset/cuddly-stingrays-boil.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Now asks for project name instead of inferring it from filepath

--- a/packages/create-svelte/index.js
+++ b/packages/create-svelte/index.js
@@ -72,7 +72,7 @@ function write_common_files(cwd, options, name) {
 
 	pkg.dependencies = sort_keys(pkg.dependencies);
 	pkg.devDependencies = sort_keys(pkg.devDependencies);
-	pkg.name = to_valid_package_name(name);
+	pkg.name = name;
 
 	fs.writeFileSync(pkg_file, JSON.stringify(pkg, null, '  '));
 }
@@ -133,14 +133,4 @@ function sort_keys(obj) {
 		});
 
 	return sorted;
-}
-
-/** @param {string} name */
-function to_valid_package_name(name) {
-	return name
-		.trim()
-		.toLowerCase()
-		.replace(/\s+/g, '-')
-		.replace(/^[._]/, '')
-		.replace(/[^a-z0-9~.-]+/g, '-');
 }


### PR DESCRIPTION
Fixes #4754.

Currently `create-svelte` does not support creating projects with scoped names, i.e. `@my-fancy-scope/my-fancy-package`. This is a crack at fixing that in a way that's as un-frustrating to developers as possible.

The current approach is to try to turn the base path of the provided project location into a package name. This has some weird edge cases, and is especially gross with `@scope/package` semantics, as that's obviously two folders (or a folder and a file with no extension) from a filesystem perspective.

For ease of understanding, here's the current behavior vs. the new behavior:

- Current
    - Accept the project path as the first positional argument
    - If that's not provided, ask for a path to put the project in
    - Do our best to yoink the package name from the provided path (eg. `./@myscope/mypackage` becomes `mypackage`, and `./.my folder name with spaces` becomes `my-folder-name-with-spaces`).
- New
    - Continue to accept the project path as the first positional argument
    - Prompt user for package name. Use a validator to make sure the provided name is valid (accepts both scoped and normal package names).
        - This does NOT kick the user out of the interface for providing a bad package name -- it just provides a descriptive error message and prevents them from continuing until they provide a valid one.
    - If the user provided the CLI folder path, continue as normal using that folder.
    - If not:
        - Prompt the user `Where should we create your project? (leave blank to use default: ${provided_package_name})`
        - If blank, use the provided package name as the folder. Else, use the provided folder.Examples:
            - `@my-scope/my-package => ./@my-scope/my-package`
            - `my-package => my-package`
            - All package characters are allowed filesystem characters, so there shouldn't be any problems with this approach.

All in all, this adds one prompt and makes the project naming much more user-controllable. At worst, it requires typing out one more answer than current -- at best, it's still the same number of inputs.

One other fringe benefit of this is that the `to_valid_package_name` (and the scoped package edge-cases that come with it) function is no longer needed at all -- since the package name is validated at the CLI, we know it's a valid package name already.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
