### PR TITLE
fix: searchbox close shortcut

### DIFF
--- a/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
+++ b/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
@@ -115,7 +115,12 @@
 		if (e.key === 'k' && (navigator.platform === 'MacIntel' ? e.metaKey : e.ctrlKey)) {
 			e.preventDefault();
 			$query = '';
-			$searching = !$searching;
+
+			if ($searching) {
+				close();
+			} else {
+				$searching = true;
+			}
 		}
 
 		if (e.code === 'Escape') {


### PR DESCRIPTION
Fixes issue where you lose the ability to scroll on a page if you close the search box if you use the `ctrl` (or `cmd`) + `k` shortcut.
Fixes https://github.com/sveltejs/kit/issues/4858

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
