### PR TITLE
fix: more reliable typing of JSONObject

### DIFF
--- a/.changeset/gorgeous-ads-kneel.md
+++ b/.changeset/gorgeous-ads-kneel.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: more reliable typing of JSONObject

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -136,9 +136,7 @@ export interface CspDirectives {
 
 export type HttpMethod = 'get' | 'head' | 'post' | 'put' | 'delete' | 'patch';
 
-export interface JSONObject {
-	[key: string]: JSONValue;
-}
+export type JSONObject = Record<string, JSONValue>;
 
 export type JSONValue =
 	| string


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

---

Before:
![image](https://user-images.githubusercontent.com/48261497/167956371-7349923e-59db-4f28-b673-8c9253b23444.png)

It ends with:

```
 Type 'Stuff' is not assignable to type 'JSONObject'.
    Index signature for type 'string' is missing in type 'Stuff'
```

After:
![image](https://user-images.githubusercontent.com/48261497/167956409-f1bc1c62-ca79-455e-b366-e53cab84d8fe.png)

I have no idea what's the difference, but `Record` works.

I don't plan to investigate any further.

---

```ts
type Record<K extends keyof any, T> = {
    [P in K]: T;
};
```