### PR TITLE
[feat] more specific types for `kit.prerender.entries` config

### DIFF
--- a/.changeset/long-turkeys-boil.md
+++ b/.changeset/long-turkeys-boil.md
@@ -2,4 +2,4 @@
 "@sveltejs/kit": patch
 ---
 
-fix: more reliable typings of config.kit.prerender.entries
+[feat] more specific types for `kit.prerender.entries` config

--- a/.changeset/long-turkeys-boil.md
+++ b/.changeset/long-turkeys-boil.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: more reliable typings of config.kit.prerender.entries

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -284,6 +284,7 @@ test('fails if prerender.entries are invalid', () => {
 		validate_config({
 			kit: {
 				prerender: {
+					// @ts-expect-error - given value expected to throw
 					entries: ['foo']
 				}
 			}

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -136,7 +136,7 @@ export interface Config {
 			crawl?: boolean;
 			default?: boolean;
 			enabled?: boolean;
-			entries?: string[];
+			entries?: Array<'*' | `/${string}`>;
 			onError?: PrerenderOnErrorValue;
 		};
 		routes?: (filepath: string) => boolean;


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

This PR adds stricter typings for `config.kit.prerender.entries`.
Before, editors won't flag the following as incorrect (but the compiler will):
```ts
/** @type {import('@sveltejs/kit').Config} */
const config = {
	kit: {
		prerender: {
			entries: ['afdasd'],
		},
	},
};
```

With this PR, the type of `entries` is stricter, making it easier to debug before building.