### PR TITLE
Use general purpose edge functions for vercel-adapter

### DIFF
--- a/.changeset/rich-singers-taste.md
+++ b/.changeset/rich-singers-taste.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+Use general purpose Edge Functions instead of piggybacking Middleware for Edge Deployment + fix split mode

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -329,7 +329,7 @@ async function v3(builder, external, edge, split) {
 			})
 		);
 
-		routes.push({ src: pattern, middlewarePath: name });
+		routes.push({ src: pattern, dest: `/${name}` });
 	}
 
 	const generate_function = edge ? generate_edge_function : generate_serverless_function;

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -348,11 +348,11 @@ async function v3(builder, external, edge, split) {
 						.replace(/\\\//g, '/');
 
 					// replace the root route "^/" with "^/?"
-					if (slicedPattern === '^/') {
-						slicedPattern = '^/?';
+					if (sliced_pattern === '^/') {
+						sliced_pattern = '^/?';
 					}
 
-					const src = `${slicedPattern}(?:/__data.json)?$`; // TODO adding /__data.json is a temporary workaround — those endpoints should be treated as distinct routes
+					const src = `${sliced_pattern}(?:/__data.json)?$`; // TODO adding /__data.json is a temporary workaround — those endpoints should be treated as distinct routes
 
 					await generate_function(route.id || 'index', src, entry.generateManifest);
 				}

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -340,10 +340,19 @@ async function v3(builder, external, edge, split) {
 				id: route.pattern.toString(), // TODO is `id` necessary?
 				filter: (other) => route.pattern.toString() === other.pattern.toString(),
 				complete: async (entry) => {
-					const src = `${route.pattern
+					let slicedPattern = route.pattern
 						.toString()
-						.slice(1, -2) // remove leading / and trailing $/
-						.replace(/\\\//g, '/')}(?:/__data.json)?$`; // TODO adding /__data.json is a temporary workaround — those endpoints should be treated as distinct routes
+						// remove leading / and trailing $/
+						.slice(1, -2)
+						// replace escaped \/ with /
+						.replace(/\\\//g, '/');
+
+					// replace the root route "^/" with "^/?"
+					if (slicedPattern === '^/') {
+						slicedPattern = '^/?';
+					}
+
+					const src = `${slicedPattern}(?:/__data.json)?$`; // TODO adding /__data.json is a temporary workaround — those endpoints should be treated as distinct routes
 
 					await generate_function(route.id || 'index', src, entry.generateManifest);
 				}

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -340,7 +340,7 @@ async function v3(builder, external, edge, split) {
 				id: route.pattern.toString(), // TODO is `id` necessary?
 				filter: (other) => route.pattern.toString() === other.pattern.toString(),
 				complete: async (entry) => {
-					let slicedPattern = route.pattern
+					let sliced_pattern = route.pattern
 						.toString()
 						// remove leading / and trailing $/
 						.slice(1, -2)


### PR DESCRIPTION
The current implementation of Edge deployment on Vercel is piggybacking Middleware.
This PR uses the new general purpose Edge Function deployment mechanism to deploy them.
This enables Cache-Control support, for instance, and a more streamlined configuration (no `middlewarePath`, and using `dest` instead when rewriting).

I also fixed a bug for the root `/__data.json` file when running in `split: true` mode.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
