### PR TITLE
[breaking] drop Wrangler 1 support in favour of Wrangler 2

### DIFF
--- a/.changeset/little-pots-rule.md
+++ b/.changeset/little-pots-rule.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+---
+
+[breaking] support Wrangler 2

--- a/packages/adapter-cloudflare-workers/README.md
+++ b/packages/adapter-cloudflare-workers/README.md
@@ -2,6 +2,8 @@
 
 SvelteKit adapter that creates a Cloudflare Workers site using a function for dynamic server rendering.
 
+**Requires [Wrangler v2](https://developers.cloudflare.com/workers/wrangler/get-started/).** Wrangler v1 is no longer supported.
+
 _**Comparisons**_
 
 - `adapter-cloudflare` – supports all SvelteKit features; builds for

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -1,9 +1,18 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { posix } from 'path';
+import { posix, dirname } from 'path';
 import { execSync } from 'child_process';
 import esbuild from 'esbuild';
 import toml from '@iarna/toml';
 import { fileURLToPath } from 'url';
+
+/**
+ * @typedef {{
+ *   main: string;
+ *   site: {
+ *     bucket: string;
+ *   }
+ * }} WranglerConfig
+ */
 
 /** @type {import('.')} */
 export default function (options = {}) {
@@ -11,22 +20,13 @@ export default function (options = {}) {
 		name: '@sveltejs/adapter-cloudflare-workers',
 
 		async adapt(builder) {
-			const { site, build } = validate_config(builder);
-
-			// @ts-ignore
-			const { bucket } = site;
-
-			// @ts-ignore
-			const entrypoint = site['entry-point'] || 'workers-site';
-
-			// @ts-ignore
-			const main_path = build.upload.main;
+			const { main, site } = validate_config(builder);
 
 			const files = fileURLToPath(new URL('./files', import.meta.url).href);
 			const tmp = builder.getBuildDirectory('cloudflare-workers-tmp');
 
-			builder.rimraf(bucket);
-			builder.rimraf(entrypoint);
+			builder.rimraf(site.bucket);
+			builder.rimraf(dirname(main));
 
 			builder.log.info('Installing worker dependencies...');
 			builder.copy(`${files}/_package.json`, `${tmp}/package.json`);
@@ -59,72 +59,48 @@ export default function (options = {}) {
 				platform: 'browser',
 				...options,
 				entryPoints: [`${tmp}/entry.js`],
-				outfile: `${entrypoint}/${main_path}`,
+				outfile: main,
 				bundle: true,
 				external: ['__STATIC_CONTENT_MANIFEST', ...(options?.external || [])],
 				format: 'esm'
 			});
 
-			writeFileSync(
-				`${entrypoint}/package.json`,
-				JSON.stringify({ main: main_path, type: 'module' })
-			);
-
 			builder.log.minor('Copying assets...');
-			builder.writeClient(bucket);
-			builder.writeStatic(bucket);
-			builder.writePrerendered(bucket);
+			builder.writeClient(site.bucket);
+			builder.writeStatic(site.bucket);
+			builder.writePrerendered(site.bucket);
 		}
 	};
 }
 
-/** @param {import('@sveltejs/kit').Builder} builder */
+/**
+ * @param {import('@sveltejs/kit').Builder} builder
+ * @returns {WranglerConfig}
+ */
 function validate_config(builder) {
 	if (existsSync('wrangler.toml')) {
+		/** @type {WranglerConfig} */
 		let wrangler_config;
 
 		try {
-			wrangler_config = toml.parse(readFileSync('wrangler.toml', 'utf-8'));
+			wrangler_config = /** @type {WranglerConfig} */ (
+				toml.parse(readFileSync('wrangler.toml', 'utf-8'))
+			);
 		} catch (err) {
 			err.message = `Error parsing wrangler.toml: ${err.message}`;
 			throw err;
 		}
 
-		// @ts-ignore
-		if (!wrangler_config.site || !wrangler_config.site.bucket) {
+		if (!wrangler_config.site?.bucket) {
 			throw new Error(
 				'You must specify site.bucket in wrangler.toml. Consult https://developers.cloudflare.com/workers/platform/sites/configuration'
 			);
 		}
 
-		// @ts-ignore
-		if (!wrangler_config.build || !wrangler_config.build.upload) {
+		if (!wrangler_config.main) {
 			throw new Error(
-				'You must specify build.upload options in wrangler.toml. Consult https://github.com/sveltejs/kit/tree/master/packages/adapter-cloudflare-workers'
+				'You must specify main option in wrangler.toml. Consult https://github.com/sveltejs/kit/tree/master/packages/adapter-cloudflare-workers'
 			);
-		}
-
-		// @ts-ignore
-		if (wrangler_config.build.upload.format !== 'modules') {
-			throw new Error('build.upload.format in wrangler.toml must be "modules"');
-		}
-
-		// @ts-ignore
-		const main_file = wrangler_config.build?.upload?.main;
-		const main_file_ext = main_file?.split('.').slice(-1)[0];
-		if (main_file_ext && main_file_ext !== 'mjs') {
-			// @ts-ignore
-			const upload_rules = wrangler_config.build?.upload?.rules;
-			// @ts-ignore
-			const matching_rule = upload_rules?.find(({ globs }) =>
-				// @ts-ignore
-				globs.find((glob) => glob.endsWith(`*.${main_file_ext}`))
-			);
-			if (!matching_rule) {
-				throw new Error(
-					'To support a build.upload.main value not ending in .mjs, an upload rule must be added to build.upload.rules. Consult https://developers.cloudflare.com/workers/cli-wrangler/configuration/#build'
-				);
-			}
 		}
 
 		return wrangler_config;
@@ -139,22 +115,16 @@ function validate_config(builder) {
 		Sample wrangler.toml:
 
 		name = "<your-site-name>"
-		type = "javascript"
 		account_id = "<your-account-id>"
-		workers_dev = true
-		route = ""
-		zone_id = ""
+		route = "<your-route>"
 
-		[build]
-		command = ""
+		main = "./.cloudflare/worker.js"
+		site.bucket = "./.cloudflare/public"
 
-		[build.upload]
-		format = "modules"
-		main = "./worker.mjs"
+		build.command = "npm run build"
 
-		[site]
-		bucket = "./.cloudflare/assets"
-		entry-point = "./.cloudflare/worker"`
+		compatibility_date = "2021-11-12"
+		workers_dev = true`
 			.replace(/^\t+/gm, '')
 			.trim()
 	);

--- a/packages/create-svelte/templates/default/wrangler.toml
+++ b/packages/create-svelte/templates/default/wrangler.toml
@@ -1,13 +1,12 @@
 name = "svelte-kit-demo"
-type = "webpack"
 account_id = "32a8245cd45a24083dd0acae1d482048"
+route = "cloudflare-workers-demo.svelte.dev/*"
+
+main = "./.cloudflare/worker.js"
+site.bucket = "./.cloudflare/public"
+
+build.command = "npm run build"
+
+compatibility_date = "2021-11-12"
 workers_dev = true
-route = ""
-zone_id = ""
 
-[site]
-bucket = "./.cloudflare/assets"
-entry-point = "./.cloudflare/worker"
-
-[build]
-upload = { format = "service-worker" }


### PR DESCRIPTION
closes #4885. I don't think there's much of a reason to continue supporting Wrangler 1, given Wrangler 2's overwhelming superiority.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
