### PR TITLE
append function redirects after copying existing redirects - fixes #4722

### DIFF
--- a/.changeset/ninety-books-jam.md
+++ b/.changeset/ninety-books-jam.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-netlify': patch
 ---
 
-Copy existing \_redirects file before appending function redirects
+Copy existing `_redirects` file before appending function redirects

--- a/.changeset/ninety-books-jam.md
+++ b/.changeset/ninety-books-jam.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+Copy existing \_redirects file before appending function redirects

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -230,6 +230,9 @@ function generate_lambda_functions({ builder, publish, split, esm }) {
 		redirects.push('* /.netlify/functions/render 200');
 	}
 
+	// this should happen at the end, after builder.writeStatic(...),
+	// so that generated redirects are appended to custom redirects
+	// rather than replaced by them
 	builder.log.minor('Writing redirects...');
 	const redirect_file = join(publish, '_redirects');
 	if (existsSync('_redirects')) {

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -54,6 +54,19 @@ export default function ({ split = false, edge = edge_set_in_env_var } = {}) {
 
 			builder.log.minor(`Publishing to "${publish}"`);
 
+			builder.log.minor('Copying assets...');
+			builder.writeStatic(publish);
+			builder.writeClient(publish);
+			builder.writePrerendered(publish);
+
+			builder.log.minor('Writing custom headers...');
+			const headers_file = join(publish, '_headers');
+			builder.copy('_headers', headers_file);
+			appendFileSync(
+				headers_file,
+				`\n\n/${builder.config.kit.appDir}/*\n  cache-control: public\n  cache-control: immutable\n  cache-control: max-age=31536000\n`
+			);
+
 			// for esbuild, use ESM
 			// for zip-it-and-ship-it, use CJS until https://github.com/netlify/zip-it-and-ship-it/issues/750
 			const esm = netlify_config?.functions?.node_bundler === 'esbuild';
@@ -67,19 +80,6 @@ export default function ({ split = false, edge = edge_set_in_env_var } = {}) {
 			} else {
 				await generate_lambda_functions({ builder, esm, split, publish });
 			}
-
-			builder.log.minor('Copying assets...');
-			builder.writeStatic(publish);
-			builder.writeClient(publish);
-			builder.writePrerendered(publish);
-
-			builder.log.minor('Writing custom headers...');
-			const headers_file = join(publish, '_headers');
-			builder.copy('_headers', headers_file);
-			appendFileSync(
-				headers_file,
-				`\n\n/${builder.config.kit.appDir}/*\n  cache-control: public\n  cache-control: immutable\n  cache-control: max-age=31536000\n`
-			);
 		}
 	};
 }


### PR DESCRIPTION
Closes #4722 — fixes a bug introduced in #4657. If you have an existing `_redirects` file, it needs to be copied _before_ lambdas are generated, not after.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
