### PR TITLE
ensure correct link is highlighted in docs nav

### DIFF
--- a/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
+++ b/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
@@ -57,24 +57,25 @@
 		path = $page.url.pathname;
 	}
 
-	/** @param {Event & { currentTarget: HTMLAnchorElement }} e */
-	function select(e) {
-		const url = new URL(e.currentTarget.href);
+	/** @param {URL} url */
+	function select(url) {
+		// belt...
 		setTimeout(() => {
 			path = url.pathname + url.hash;
 		});
+
+		// ...and braces
+		window.addEventListener(
+			'scroll',
+			() => {
+				path = url.pathname + url.hash;
+			},
+			{ once: true }
+		);
 	}
 </script>
 
-<svelte:window
-	on:scroll={highlight}
-	on:resize={update}
-	on:hashchange={() => {
-		setTimeout(() => {
-			path = `${$page.url.pathname}${$page.url.hash}`;
-		});
-	}}
-/>
+<svelte:window on:scroll={highlight} on:resize={update} on:hashchange={() => select($page.url)} />
 
 <nav>
 	<ul class="sidebar">
@@ -85,7 +86,7 @@
 					class="section"
 					class:active={section.path === path}
 					href={section.path}
-					on:click={select}
+					on:click={(e) => select(new URL(e.currentTarget.href))}
 				>
 					{section.title}
 				</a>
@@ -98,7 +99,7 @@
 								class="subsection"
 								class:active={subsection.path === path}
 								href={subsection.path}
-								on:click={select}
+								on:click={(e) => select(new URL(e.currentTarget.href))}
 							>
 								{subsection.title}
 							</a>
@@ -112,7 +113,7 @@
 												class="nested subsection"
 												class:active={subsection.path === path}
 												href={subsection.path}
-												on:click={select}
+												on:click={(e) => select(new URL(e.currentTarget.href))}
 											>
 												{subsection.title}
 											</a>

--- a/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
+++ b/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
@@ -36,7 +36,8 @@
 		headings = content.querySelectorAll('[id]:not([data-scrollignore])');
 
 		positions = Array.from(headings).map((heading) => {
-			return heading.getBoundingClientRect().top - top;
+			const style = getComputedStyle(heading);
+			return heading.getBoundingClientRect().top - parseFloat(style.scrollMarginTop) - top;
 		});
 	}
 
@@ -46,7 +47,7 @@
 		let i = headings.length;
 
 		while (i--) {
-			if (positions[i] + top < 40) {
+			if (positions[i] + top < 10) {
 				const heading = headings[i];
 				path = `${$page.url.pathname}#${heading.id}`;
 				return;
@@ -55,19 +56,36 @@
 
 		path = $page.url.pathname;
 	}
+
+	/** @param {Event & { currentTarget: HTMLAnchorElement }} e */
+	function select(e) {
+		const url = new URL(e.currentTarget.href);
+		setTimeout(() => {
+			path = url.pathname + url.hash;
+		});
+	}
 </script>
 
-<svelte:window on:scroll={highlight} on:resize={update} />
+<svelte:window
+	on:scroll={highlight}
+	on:resize={update}
+	on:hashchange={() => {
+		setTimeout(() => {
+			path = `${$page.url.pathname}${$page.url.hash}`;
+		});
+	}}
+/>
 
 <nav>
 	<ul class="sidebar">
 		{#each contents as section}
 			<li>
 				<a
-					class="section"
 					sveltekit:prefetch
+					class="section"
 					class:active={section.path === path}
 					href={section.path}
+					on:click={select}
 				>
 					{section.title}
 				</a>
@@ -76,10 +94,11 @@
 					{#each section.sections as subsection}
 						<li>
 							<a
-								class="subsection"
 								sveltekit:prefetch
+								class="subsection"
 								class:active={subsection.path === path}
 								href={subsection.path}
+								on:click={select}
 							>
 								{subsection.title}
 							</a>
@@ -89,10 +108,11 @@
 									{#each subsection.sections as subsection}
 										<li>
 											<a
+												sveltekit:prefetch
 												class="nested subsection"
 												class:active={subsection.path === path}
 												href={subsection.path}
-												sveltekit:prefetch
+												on:click={select}
 											>
 												{subsection.title}
 											</a>


### PR DESCRIPTION
fixes #4620 with a belt-and-braces approach:

* factors `scroll-margin-top` into calculation of which section has been scrolled to
* forcibly highlights correct section when `hash` changes
* forcibly highlights correct section when a link is clicked

The latter two ensure that clicking on a link in the nav causes it to be highlighted even if the header in question is close enough to the bottom of the screen that the scroll-based logic would otherwise cause a different link to be highlighted, and even if the hash is current.