### PR TITLE
remove unnecessary CHANGELOG.md

### DIFF
--- a/.changeset/witty-chicken-teach.md
+++ b/.changeset/witty-chicken-teach.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+remove unnecessary CHANGELOG.md

--- a/packages/create-svelte/templates/default/CHANGELOG.md
+++ b/packages/create-svelte/templates/default/CHANGELOG.md
@@ -1,8 +1,0 @@
-# default-template
-
-## 0.0.2-next.0
-### Patch Changes
-
-
-
-- [chore] upgrade cookie library ([#4592](https://github.com/sveltejs/kit/pull/4592))


### PR DESCRIPTION
Remove the project created by selecting `SvelteKit demo app` in `npm init svelte` as it contains unnecessary `CHANGELOG.md`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpx changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
