### PR TITLE
New page option for "key"

### DIFF
--- a/.changeset/small-mirrors-warn.md
+++ b/.changeset/small-mirrors-warn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+New page option for "key"

--- a/documentation/docs/11-page-options.md
+++ b/documentation/docs/11-page-options.md
@@ -22,6 +22,26 @@ In certain circumstances you might need to disable [client-side routing](/docs/a
 
 Note that this will disable client-side routing for any navigation from this page, regardless of whether the router is already active.
 
+### key
+
+By default, changing route parameters isn't considered a route change in SvelteKit. It's considered the same route with
+params and loaded data that update reactively via props.
+
+If instead you want to treat each logical URL as a separate route, with its own component instance and lifecycle, you can do that
+by exporting a key function. Internally, SvelteKit wraps the top-level components in a `{#key}` block so they can be destroyed
+and recreated based on arbitrary conditions, even when navigating to another route of the same pattern.
+
+The function accepts an object with url (URL instance) and params (a plain JS object), and returns a key used for
+equality comparison in a `{#key}` block.
+
+```html
+<script context="module">
+	export function key({ url, params }) {
+		return url.pathname;
+	}
+</script>
+```
+
 ### hydrate
 
 Ordinarily, SvelteKit [hydrates](/docs/appendix#hydration) your server-rendered HTML into an interactive page. Some pages don't require JavaScript at all — many blog posts and 'about' pages fall into this category. In these cases you can skip hydration when the app boots up with the app-wide [`browser.hydrate` config option](/docs/configuration#browser) or the page-level `hydrate` export:

--- a/packages/kit/src/core/sync/write_root.js
+++ b/packages/kit/src/core/sync/write_root.js
@@ -21,16 +21,20 @@ export function write_root(manifest_data, output) {
 
 	let l = max_depth;
 
-	let pyramid = `<svelte:component this={components[${l}]} {...(props_${l} || {})}/>`;
+	let pyramid = `{#key key_${l}}<svelte:component this={components[${l}]} {...(props_${l} || {})}/>{/key}`;
 
 	while (l--) {
 		pyramid = `
 			{#if components[${l + 1}]}
-				<svelte:component this={components[${l}]} {...(props_${l} || {})}>
-					${pyramid.replace(/\n/g, '\n\t\t\t\t\t')}
-				</svelte:component>
+				{#key key_${l}}
+					<svelte:component this={components[${l}]} {...(props_${l} || {})}>
+						${pyramid.replace(/\n/g, '\n\t\t\t\t\t')}
+					</svelte:component>
+				{/key}
 			{:else}
-				<svelte:component this={components[${l}]} {...(props_${l} || {})} />
+				{#key key_${l}}
+					<svelte:component this={components[${l}]} {...(props_${l} || {})} />
+				{/key}
 			{/if}
 		`
 			.replace(/^\t\t\t/gm, '')
@@ -50,6 +54,7 @@ export function write_root(manifest_data, output) {
 
 				export let components;
 				${levels.map((l) => `export let props_${l} = null;`).join('\n\t\t\t\t')}
+				${levels.map((l) => `export let key_${l} = null;`).join('\n\t\t\t\t')}
 
 				setContext('__svelte__', stores);
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -411,6 +411,9 @@ export function create_client({ target, session, base, trailing_slash }) {
 		for (let i = 0; i < filtered.length; i += 1) {
 			const loaded = filtered[i].loaded;
 			result.props[`props_${i}`] = loaded ? await loaded.props : null;
+			if (filtered[i].module.key) {
+				result.props[`key_${i}`] = filtered[i].module.key({ url, params });
+			}
 		}
 
 		const page_changed =


### PR DESCRIPTION
Fixes #3506

Highly doubt this would be accepted but, maybe still useful in case anyone wants to patch it in.

I wanted to consider each logical URL as distinct as far as routing is concerned. Unlike query strings which could be considered the same location with different params, "path params" aren't exactly a real thing at least as far as old school CGI is concerned. `/foo/1` and `/foo/2` are just two different locations.

If you want to tear down all the state and re-instantiate your route component when the path params change, and not have to mess around with `afterNavigation`, this gives you a way.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
