### PR TITLE
prevent esbuild trying to bundle node:crypto

### DIFF
--- a/.changeset/small-pumpkins-grab.md
+++ b/.changeset/small-pumpkins-grab.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Prevent esbuild trying to bundle node:crypto

--- a/packages/kit/src/runtime/server/page/csp.js
+++ b/packages/kit/src/runtime/server/page/csp.js
@@ -21,7 +21,7 @@ if (typeof crypto !== 'undefined') {
 	generate_hash = sha256;
 } else {
 	// TODO: remove this in favor of web crypto API once we no longer support Node 14
-	const name = 'crypto'; // store in a variable to fool esbuild when adapters bundle kit
+	const name = 'crypto'.split('').join(''); // store in a variable to fool esbuild when adapters bundle kit
 	csp_ready = import(name).then((crypto) => {
 		generate_nonce = () => {
 			return crypto.randomBytes(16).toString('base64');


### PR DESCRIPTION
There's no good place to add a test for this, but I think it's fine because we can get rid of this whole mess as soon as we drop support for Node 14.

The issue was reported in https://github.com/sveltejs/kit/issues/4367#issuecomment-1122474272, and basically looks like this: if `config.kit.vite.build.minify === 'esbuild'`, the `'crypto'` string here...

https://github.com/sveltejs/kit/blob/7609ad0759c895600198eaf4345d735c7c6d1166/packages/kit/src/runtime/server/page/csp.js#L23-L25

...gets inlined into the `import(name)` expression, which means that a _subsequent_ esbuild run tries to import the `node:crypto` module, it will fail unless `platform: 'node'` is specified.

Making the expression more complex seems to prevent esbuild from being cute.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
