### PR TITLE
Run `kit` package tests in WebKit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: npx playwright install
       - run: pnpm turbo run test
       - name: archive test results
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install
       - run: pnpm turbo run test
       - name: archive test results
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm exec playwright install
+      - run: npx playwright install
       - run: pnpm turbo run test
       - name: archive test results
         if: failure()

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -61,7 +61,7 @@
 		"svelte-kit.js"
 	],
 	"scripts": {
-		"build": "rollup -c && node scripts/cp.js src/runtime/components assets/components && npm run types",
+		"build": "rollup -c && node scripts/cp.js src/runtime/components assets/components && npm run types && pnpm exec playwright install --with-deps",
 		"dev": "rollup -cw",
 		"lint": "eslint --ignore-path .gitignore --ignore-pattern \"src/packaging/test/**\" \"{src,test}/**/*.{ts,mjs,js,svelte}\" && npm run check-format",
 		"check": "tsc",

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -176,10 +176,10 @@ export const config = {
 	],
 	use: {
 		screenshot: 'only-on-failure',
+		trace: 'retain-on-failure',
 		// use stable chrome from host OS instead of downloading one
 		// see https://playwright.dev/docs/browsers#google-chrome--microsoft-edge
-		channel: 'chrome',
-		trace: 'retain-on-failure'
+		channel: 'chrome'
 	},
 	workers: process.env.CI ? 2 : undefined
 };

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import http from 'http';
 import * as ports from 'port-authority';
-import { test as base, devices } from '@playwright/test';
+import { test as base } from '@playwright/test';
 
 export const test = base.extend({
 	// @ts-expect-error
@@ -136,13 +136,6 @@ export const test = base.extend({
 	}
 });
 
-const useDesktopChrome = {
-	browserName: 'chromium',
-	// use stable chrome from host OS instead of downloading one
-	// see https://playwright.dev/docs/browsers#google-chrome--microsoft-edge
-	channel: 'chrome'
-};
-
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 export const config = {
 	forbidOnly: !!process.env.CI,
@@ -157,14 +150,12 @@ export const config = {
 		{
 			name: `${process.env.DEV ? 'dev' : 'build'}+js_chrome`,
 			use: {
-				use: useDesktopChrome,
 				javaScriptEnabled: true
 			}
 		},
 		{
 			name: `${process.env.DEV ? 'dev' : 'build'}-js_chrome`,
 			use: {
-				use: useDesktopChrome,
 				javaScriptEnabled: false
 			}
 		},
@@ -185,6 +176,9 @@ export const config = {
 	],
 	use: {
 		screenshot: 'only-on-failure',
+		// use stable chrome from host OS instead of downloading one
+		// see https://playwright.dev/docs/browsers#google-chrome--microsoft-edge
+		channel: 'chrome',
 		trace: 'retain-on-failure'
 	},
 	workers: process.env.CI ? 2 : undefined

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import http from 'http';
 import * as ports from 'port-authority';
-import { test as base } from '@playwright/test';
+import { test as base, devices } from '@playwright/test';
 
 export const test = base.extend({
 	// @ts-expect-error
@@ -136,6 +136,13 @@ export const test = base.extend({
 	}
 });
 
+const useDesktopChrome = {
+	...devices['Desktop Chrome'],
+	// use stable chrome from host OS instead of downloading one
+	// see https://playwright.dev/docs/browsers#google-chrome--microsoft-edge
+	channel: 'chrome'
+};
+
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 export const config = {
 	forbidOnly: !!process.env.CI,
@@ -148,24 +155,37 @@ export const config = {
 	retries: process.env.CI ? 5 : 0,
 	projects: [
 		{
-			name: `${process.env.DEV ? 'dev' : 'build'}+js`,
+			name: `${process.env.DEV ? 'dev' : 'build'}+js_chrome`,
 			use: {
+				use: useDesktopChrome,
 				javaScriptEnabled: true
 			}
 		},
 		{
-			name: `${process.env.DEV ? 'dev' : 'build'}-js`,
+			name: `${process.env.DEV ? 'dev' : 'build'}-js_chrome`,
 			use: {
+				use: useDesktopChrome,
+				javaScriptEnabled: false
+			}
+		},
+		{
+			name: `${process.env.DEV ? 'dev' : 'build'}+js_safari`,
+			use: {
+				use: { ...devices['Desktop Safari'] },
+				javaScriptEnabled: true
+			}
+		},
+		{
+			name: `${process.env.DEV ? 'dev' : 'build'}-js_safari`,
+			use: {
+				use: { ...devices['Desktop Safari'] },
 				javaScriptEnabled: false
 			}
 		}
 	],
 	use: {
 		screenshot: 'only-on-failure',
-		trace: 'retain-on-failure',
-		// use stable chrome from host OS instead of downloading one
-		// see https://playwright.dev/docs/browsers#google-chrome--microsoft-edge
-		channel: 'chrome'
+		trace: 'retain-on-failure'
 	},
 	workers: process.env.CI ? 2 : undefined
 };

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -162,14 +162,14 @@ export const config = {
 		{
 			name: `${process.env.DEV ? 'dev' : 'build'}+js_webkit`,
 			use: {
-				use: { browserName: 'webkit' },
+				browserName: 'webkit',
 				javaScriptEnabled: true
 			}
 		},
 		{
 			name: `${process.env.DEV ? 'dev' : 'build'}-js_webkit`,
 			use: {
-				use: { browserName: 'webkit' },
+				browserName: 'webkit',
 				javaScriptEnabled: false
 			}
 		}

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -150,12 +150,18 @@ export const config = {
 		{
 			name: `${process.env.DEV ? 'dev' : 'build'}+js_chrome`,
 			use: {
+				// use stable chrome from host OS instead of downloading one
+				// see https://playwright.dev/docs/browsers#google-chrome--microsoft-edge
+				channel: 'chrome',
 				javaScriptEnabled: true
 			}
 		},
 		{
 			name: `${process.env.DEV ? 'dev' : 'build'}-js_chrome`,
 			use: {
+				// use stable chrome from host OS instead of downloading one
+				// see https://playwright.dev/docs/browsers#google-chrome--microsoft-edge
+				channel: 'chrome',
 				javaScriptEnabled: false
 			}
 		},
@@ -176,10 +182,7 @@ export const config = {
 	],
 	use: {
 		screenshot: 'only-on-failure',
-		trace: 'retain-on-failure',
-		// use stable chrome from host OS instead of downloading one
-		// see https://playwright.dev/docs/browsers#google-chrome--microsoft-edge
-		channel: 'chrome'
+		trace: 'retain-on-failure'
 	},
 	workers: process.env.CI ? 2 : undefined
 };

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -160,14 +160,14 @@ export const config = {
 			}
 		},
 		{
-			name: `${process.env.DEV ? 'dev' : 'build'}+js_safari`,
+			name: `${process.env.DEV ? 'dev' : 'build'}+js_webkit`,
 			use: {
 				use: { browserName: 'webkit' },
 				javaScriptEnabled: true
 			}
 		},
 		{
-			name: `${process.env.DEV ? 'dev' : 'build'}-js_safari`,
+			name: `${process.env.DEV ? 'dev' : 'build'}-js_webkit`,
 			use: {
 				use: { browserName: 'webkit' },
 				javaScriptEnabled: false

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -137,7 +137,7 @@ export const test = base.extend({
 });
 
 const useDesktopChrome = {
-	...devices['Desktop Chrome'],
+	browserName: 'chromium',
 	// use stable chrome from host OS instead of downloading one
 	// see https://playwright.dev/docs/browsers#google-chrome--microsoft-edge
 	channel: 'chrome'
@@ -171,14 +171,14 @@ export const config = {
 		{
 			name: `${process.env.DEV ? 'dev' : 'build'}+js_safari`,
 			use: {
-				use: { ...devices['Desktop Safari'] },
+				use: { browserName: 'webkit' },
 				javaScriptEnabled: true
 			}
 		},
 		{
 			name: `${process.env.DEV ? 'dev' : 'build'}-js_safari`,
 			use: {
-				use: { ...devices['Desktop Safari'] },
+				use: { browserName: 'webkit' },
 				javaScriptEnabled: false
 			}
 		}


### PR DESCRIPTION
Run tests in WebKit, in addition to Chrome (existing behavior).

This builds on #4847, which was (seemingly) inspired by #4065.

According to [Statcounter Global Stats](https://gs.statcounter.com/) (used by [Can I use](https://caniuse.com/)), Safari currently has a global browser market share of 19.16%, second only to Chrome (64.34%). Additionally, all iPhone browsers are [powered by WebKit](https://9to5mac.com/2022/03/01/web-developers-challenge-apple-to-allow-other-browser-engines-on-ios/), and iOS has a global mobile OS market share of [27.68%](https://gs.statcounter.com/os-market-share/mobile/worldwide), second only to Android (71.59%).

Thus, it would be worthwhile to know if future changes to this repo cause tests to fail when using WebKit. Thanks to #4847 (mentioned above), they are passing at the moment.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
