### PR TITLE
[fix] deduplicate injected css during dev

### DIFF
--- a/.changeset/yellow-apricots-stare.md
+++ b/.changeset/yellow-apricots-stare.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] deduplicate injected css during dev

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -73,7 +73,7 @@ export async function create_plugin(config, cwd) {
 								if (!node) throw new Error(`Could not find node for ${url}`);
 
 								const deps = new Set();
-								find_deps(node, deps);
+								await find_deps(vite, node, deps);
 
 								/** @type {Record<string, string>} */
 								const styles = {};
@@ -387,14 +387,36 @@ function remove_html_middlewares(server) {
 }
 
 /**
+ * @param {import('vite').ViteDevServer} vite
  * @param {import('vite').ModuleNode} node
  * @param {Set<import('vite').ModuleNode>} deps
  */
-function find_deps(node, deps) {
-	for (const dep of node.importedModules) {
-		if (!deps.has(dep)) {
-			deps.add(dep);
-			find_deps(dep, deps);
+function find_deps(vite, node, deps) {
+	// since `ssrTransformResult.deps` contains URLs instead of `ModuleNode`s, this process is asynchronous.
+	// instead of using `await`, we resolve all branches in parallel.
+	/** @type {Promise<void>[]} */
+	const branches = [];
+
+	/** @param {import('vite').ModuleNode} node */
+	function add(node) {
+		if (!deps.has(node)) {
+			deps.add(node);
+			branches.push(find_deps(vite, node, deps));
 		}
 	}
+
+	/** @param {string} url */
+	async function add_by_url(url) {
+		branches.push(vite.moduleGraph.getModuleByUrl(url).then((node) => node && add(node)));
+	}
+
+	if (node.ssrTransformResult) {
+		if (node.ssrTransformResult.deps) {
+			node.ssrTransformResult.deps.forEach(add_by_url);
+		}
+	} else {
+		node.importedModules.forEach(add);
+	}
+
+	return Promise.all(branches).then(() => {});
 }

--- a/packages/kit/test/apps/basics/src/routes/css/_base.css
+++ b/packages/kit/test/apps/basics/src/routes/css/_base.css
@@ -1,0 +1,3 @@
+.overridden {
+	color: red;
+}

--- a/packages/kit/test/apps/basics/src/routes/css/_styles.css
+++ b/packages/kit/test/apps/basics/src/routes/css/_styles.css
@@ -1,3 +1,9 @@
+@import '_base.css';
+
 .styled {
 	color: red;
+}
+
+.overridden {
+	color: green;
 }

--- a/packages/kit/test/apps/basics/src/routes/css/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/css/index.svelte
@@ -10,6 +10,10 @@
 	this text is blue
 </div>
 
+<div class="overridden">
+	this text is green
+</div>
+
 <a href="/css/other">other</a>
 
 <style>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -474,6 +474,13 @@ test.describe.parallel('CSS', () => {
 			).toBe('absolute');
 		}
 	});
+
+	test('applies imported styles in the correct order', async ({ page }) => {
+		await page.goto('/css');
+
+		const color = await page.$eval('.overridden', (el) => getComputedStyle(el).color);
+		expect(color).toBe('rgb(0, 128, 0)');
+	});
 });
 
 test.describe.parallel('Shadowed pages', () => {


### PR DESCRIPTION
Fixes #3497

During dev, kit inlines css files in order to prevent FOUC. The current implementation injects all imported modules indiscriminately, but this conflicts with vite's own `@import` inlining.

Given a component:
```svelte
<script>
	import '$lib/entry.css';
</script>
```

And the respective css files:
```css
/* entry.css */
@import './base.css';
html { color: green; }
/* entry.css eof */

/* base.css */
html { color: red; }
/* base.css eof */
```

By walking the `ModuleGraph` we end up inlining both `entry.css`'s and `base.css`'s _transformed_ content. Since vite inlines `base` into `entry`, we get the following injected css:
```css
/* entry.css */
/* base.css */
html { color: red; }
/* base.css eof */
html { color: green; }
/* entry.css eof */

/* base.css */
html { color: red; }
/* base.css eof */
```

The first block is `entry` and the second is `base`. If hydration is turned off, you'll get the unexpected rules applied and a confusing inspector experience. If it's turned on, you'll get a flash of _incorrectly styled_ content.

This PR walks through `ssrTransformResult` dependencies instead, such that `base` is ignored since it's already inlined into `entry`. I'm not sure how to test for this, unfortunately.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
