### PR TITLE
[docs] setting Node version in `adapter-netlify`

### DIFF
--- a/.changeset/honest-rats-double.md
+++ b/.changeset/honest-rats-double.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-netlify": patch
+---
+
+[docs] explain how to change node version

--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -44,7 +44,7 @@ If the `netlify.toml` file or the `build.publish` value is missing, a default va
 
 ### Node version
 
-New projects will use Node 16 by default. However, if you're upgrading a project you created awhile ago it may be stuck on an old version of Node.js. See [the Netlify docs](https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-and-javascript) for details on manually specifying Node 16 or newer.
+New projects will use Node 16 by default. However, if you're upgrading a project you created a while ago it may be stuck on an older version. See [the Netlify docs](https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-and-javascript) for details on manually specifying Node 16 or newer.
 
 ## Netlify Edge Functions (beta)
 

--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -42,6 +42,10 @@ Then, make sure you have a [netlify.toml](https://docs.netlify.com/configure-bui
 
 If the `netlify.toml` file or the `build.publish` value is missing, a default value of `"build"` will be used. Note that if you have set the publish directory in the Netlify UI to something else then you will need to set it in `netlify.toml` too, or use the default value of `"build"`.
 
+### Node version
+
+New projects will use Node 16 by default. However, if you're upgrading a project you created awhile ago it may be stuck on an old version of Node.js. See [the Netlify docs](https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-and-javascript) for details on manually specifying Node 16.
+
 ## Netlify Edge Functions (beta)
 
 SvelteKit supports the beta release of Netlify Edge Functions. If you pass the option `edge: true` to the `adapter` function, server-side rendering will happen in a Deno-based edge function that's deployed close to the site visitor. If set to `false` (the default), the site will deploy to standard Node-based Netlify Functions.

--- a/packages/adapter-netlify/README.md
+++ b/packages/adapter-netlify/README.md
@@ -44,7 +44,7 @@ If the `netlify.toml` file or the `build.publish` value is missing, a default va
 
 ### Node version
 
-New projects will use Node 16 by default. However, if you're upgrading a project you created awhile ago it may be stuck on an old version of Node.js. See [the Netlify docs](https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-and-javascript) for details on manually specifying Node 16.
+New projects will use Node 16 by default. However, if you're upgrading a project you created awhile ago it may be stuck on an old version of Node.js. See [the Netlify docs](https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-and-javascript) for details on manually specifying Node 16 or newer.
 
 ## Netlify Edge Functions (beta)
 


### PR DESCRIPTION
I tested running Node 16 on Netlify (see https://github.com/sveltejs/kit/issues/4916) and it works with the following caveat