### PR TITLE
[fix] get packaging test working on Windows

### DIFF
--- a/packages/kit/src/packaging/index.js
+++ b/packages/kit/src/packaging/index.js
@@ -109,6 +109,7 @@ export async function watch(config, cwd = process.cwd()) {
 	let timeout;
 
 	const watcher = chokidar.watch(lib, { ignoreInitial: true });
+	const ready = new Promise((resolve) => watcher.on('ready', resolve));
 
 	watcher.on('all', async (type, path) => {
 		const file = analyze(config, relative(lib, path));
@@ -176,6 +177,7 @@ export async function watch(config, cwd = process.cwd()) {
 
 	return {
 		watcher,
+		ready,
 		settled: () =>
 			new Promise((fulfil, reject) => {
 				fulfillers.push(fulfil);

--- a/packages/kit/src/packaging/test/index.js
+++ b/packages/kit/src/packaging/test/index.js
@@ -154,7 +154,7 @@ if (!process.env.CI) {
 		const config = await load_config({ cwd });
 		config.kit.package.dir = resolve(cwd, config.kit.package.dir);
 
-		const { watcher, settled } = await watch(config, cwd);
+		const { watcher, ready, settled } = await watch(config, cwd);
 
 		/** @param {string} file */
 		function compare(file) {
@@ -181,6 +181,8 @@ if (!process.env.CI) {
 		}
 
 		try {
+			await ready;
+
 			// completes initial build
 			compare('index.js');
 

--- a/packages/kit/src/packaging/test/watch/tsconfig.json
+++ b/packages/kit/src/packaging/test/watch/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
 		"allowJs": true,
-		"checkJs": true
+		"checkJs": true,
+		"newLine": "lf"
 	}
 }


### PR DESCRIPTION
Packaging's "watches for changes" test hasn't worked on Windows. Upon investigation it was because of two reasons:

- We need to wait for `chokidar`'s `ready` event before writing the files;
- Typescript uses `crlf` on the generated `.d.ts` files by default, causing a mismatch with our expected output.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
