### PR TITLE
set default options for dev command

### DIFF
--- a/.changeset/yellow-eagles-leave.md
+++ b/.changeset/yellow-eagles-leave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Set default options for dev command

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -47,10 +47,10 @@ const prog = sade('svelte-kit').version('__VERSION__');
 prog
 	.command('dev')
 	.describe('Start a development server')
-	.option('-p, --port', 'Port')
-	.option('-o, --open', 'Open a browser tab')
-	.option('--host', 'Host (only use this on trusted networks)')
-	.option('--https', 'Use self-signed HTTPS certificate')
+	.option('-p, --port', 'Port', 3000)
+	.option('-o, --open', 'Open a browser tab', false)
+	.option('--host', 'Host (only use this on trusted networks)', 'localhost')
+	.option('--https', 'Use self-signed HTTPS certificate', false)
 	.option('-H', 'no longer supported, use --https instead') // TODO remove for 1.0
 	.action(async ({ port, host, https, open, H }) => {
 		try {

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -11,7 +11,7 @@ import * as sync from '../sync/sync.js';
  * @typedef {{
  *   cwd: string,
  *   port: number,
- *   host?: string,
+ *   host: string,
  *   https: boolean,
  *   config: import('types').ValidatedConfig
  * }} Options


### PR DESCRIPTION
Set default options for the `dev` command, similar to the `preview` command.

This shouldn't break anything, but could be helpful:
1. Ensure port is 3000, as Vite 3 changes to 5173. 
2. Set `--host` to `localhost` as Vite defaults to `127.0.0.1` in dev. 

Re no2, while Vite still forces `127.0.0.1` when `localhost` is specified (ref https://github.com/vitejs/vite/issues/7075), this will be changed in Vite 3 and the behaviour should be consistent with `preview` then.

Also ref: https://github.com/sveltejs/kit/pull/4729

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
