### PR TITLE
Don't pass params from the server

### DIFF
--- a/.changeset/strong-geese-collect.md
+++ b/.changeset/strong-geese-collect.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+Not passing path params to the client, computing them on the client instead

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1507,10 +1507,11 @@ export function create_client({ target, base, trailing_slash }) {
 			});
 		},
 
-		_hydrate: async ({ status, error, node_ids, params, route, data: server_data_nodes, form }) => {
+		_hydrate: async ({ status, error, node_ids, route, data: server_data_nodes, form }) => {
 			hydrated = true;
 
 			const url = new URL(location.href);
+			const params = get_navigation_intent(url, false)?.params || {};
 
 			/** @type {import('./types').NavigationFinished | undefined} */
 			let result;

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -249,7 +249,6 @@ export async function render_response({
 					status: ${status},
 					error: ${devalue.uneval(error)},
 					node_ids: [${branch.map(({ node }) => node.index).join(', ')}],
-					params: ${devalue.uneval(event.params)},
 					route: ${s(event.route)},
 					data: ${serialized.data},
 					form: ${serialized.form}


### PR DESCRIPTION
I'd argue that we shouldn't pass the path params from server to client, for the same reason we're no longer passing the URL -- the real version on the client is the authoritative version.

This to me is just a logical extension of #3942.

This change would fix #1533, and obviates #1871.

The motivation for this is, in Big Tech, you often find yourself in a Java monoculture. No problem though, adapter-static to the rescue. But the issue is, in general, every website will have parameterized paths and it's a little ugly using adapter-static with parameterized routes. You can do it but you have the regex-parse the URL yourself instead of relying on the pagestore provided params. This fixes that issue.

As with my previous PR from a few days ago, not super optimistic about this going in, but useful to have for reference in case anyone wants to patch it or make a fork.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
