### PR TITLE
explicit recursive body validations

### DIFF
--- a/.changeset/five-cows-happen.md
+++ b/.changeset/five-cows-happen.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix `BodyValidator` for nested interfaces

--- a/packages/kit/test/typings/endpoint.test.ts
+++ b/packages/kit/test/typings/endpoint.test.ts
@@ -92,6 +92,18 @@ export const generic_case: RequestHandler<Record<string, string>, ExamplePost> =
 	};
 };
 
+interface NestedChild {
+	message: string;
+}
+interface ParentWrapper {
+	fields: NestedChild;
+}
+export const nested_interfaces: RequestHandler<Record<string, string>, ParentWrapper> = () => {
+	return {
+		body: {} as ParentWrapper
+	};
+};
+
 // --- invalid cases ---
 
 // @ts-expect-error - body must be JSON serializable

--- a/packages/kit/test/typings/endpoint.test.ts
+++ b/packages/kit/test/typings/endpoint.test.ts
@@ -106,10 +106,46 @@ export const nested_interfaces: RequestHandler<Record<string, string>, ParentWra
 
 // --- invalid cases ---
 
-// @ts-expect-error - body must be JSON serializable
-export const error_unserializable_literal: RequestHandler = () => {
+// @ts-expect-error - bigint cannot be converted to JSON string
+export const error_unserializable_literal_bigint: RequestHandler = () => {
+	return {
+		body: BigInt('')
+	};
+};
+// @ts-expect-error - bigint cannot be converted to JSON string
+export const error_unserializable_property_bigint: RequestHandler = () => {
+	return {
+		body: {
+			answer: BigInt('')
+		}
+	};
+};
+// @ts-expect-error - function cannot be converted to JSON string
+export const error_unserializable_literal_function: RequestHandler = () => {
 	return {
 		body: () => {}
+	};
+};
+// @ts-expect-error - function cannot be converted to JSON string
+export const error_unserializable_property_function: RequestHandler = () => {
+	return {
+		body: {
+			sorter() {}
+		}
+	};
+};
+// @ts-expect-error - symbol cannot be converted to JSON string
+export const error_unserializable_literal_symbol: RequestHandler = () => {
+	return {
+		body: Symbol()
+	};
+};
+// @ts-expect-error - symbol cannot be converted to JSON string
+export const error_unserializable_property_symbol: RequestHandler = () => {
+	return {
+		body: {
+			id: Symbol()
+		}
 	};
 };
 

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -27,7 +27,11 @@ export interface AdapterEntry {
 }
 
 export type BodyValidator<T> = {
-	[P in keyof T]: T[P] extends JSONValue ? BodyValidator<T[P]> : never;
+	[P in keyof T]: T[P] extends { [k: string]: infer V }
+		? BodyValidator<V> // recurse when T[P] is an object
+		: T[P] extends BigInt | Function | Symbol
+		? never
+		: T[P];
 };
 
 // Based on https://github.com/josh-hemphill/csp-typed-directives/blob/latest/src/csp.types.ts


### PR DESCRIPTION
Taking the inverse of the current approach, rather than naively `extend`-ing `JSONValue`, we will explicitly recurse when hitting an object. Other than that, we'll check whether it's an invalid type that cannot be converted to JSON string rather than checking whether it's a valid JSON type, [that should be much simpler](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#exceptions).

Fixes #4926

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
