### PR TITLE
document that status, error, redirect, cache are ignored when rendering error pages

### DIFF
--- a/documentation/docs/04-loading.md
+++ b/documentation/docs/04-loading.md
@@ -103,7 +103,7 @@ If the page you're loading has an endpoint, the data returned from it is accessi
 
 ### Output
 
-If you return a Promise from `load`, SvelteKit will delay rendering until the promise resolves. The return value has several properties, all optional:
+If you return a Promise from `load`, SvelteKit will delay rendering until the promise resolves. The return value has several properties listed below, all of which are optional.
 
 > `status`, `error`, `redirect` and `cache` are ignored when rendering error pages.
 

--- a/documentation/docs/04-loading.md
+++ b/documentation/docs/04-loading.md
@@ -105,6 +105,8 @@ If the page you're loading has an endpoint, the data returned from it is accessi
 
 If you return a Promise from `load`, SvelteKit will delay rendering until the promise resolves. The return value has several properties, all optional:
 
+> `status`, `error`, `redirect` and `cache` are ignored when rendering error pages.
+
 #### status
 
 The HTTP status code for the page. If returning an `error` this must be a `4xx` or `5xx` response; if returning a `redirect` it must be a `3xx` response. The default is `200`.
@@ -149,5 +151,3 @@ The combined `stuff` is available to components using the [page store](/docs/mod
 An array of strings representing URLs the page depends on, which can subsequently be used with [`invalidate`](/docs/modules#$app-navigation-invalidate) to cause `load` to rerun. You only need to add them to `dependencies` if you're using a custom API client; URLs loaded with the provided `fetch` function are added automatically.
 
 URLs can be absolute or relative to the page being loaded, and must be [encoded](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding).
-
-> `status`, `error`, `redirect` and `cache` are ignored when rendering error pages.

--- a/documentation/docs/04-loading.md
+++ b/documentation/docs/04-loading.md
@@ -144,6 +144,8 @@ This will be merged with any existing `stuff` and passed to the `load` functions
 
 The combined `stuff` is available to components using the [page store](/docs/modules#$app-stores) as `$page.stuff`, providing a mechanism for pages to pass data 'upward' to layouts.
 
+> `status`, `error`, `redirect` and `cache` are ignored when rendering error pages.
+
 #### dependencies
 
 An array of strings representing URLs the page depends on, which can subsequently be used with [`invalidate`](/docs/modules#$app-navigation-invalidate) to cause `load` to rerun. You only need to add them to `dependencies` if you're using a custom API client; URLs loaded with the provided `fetch` function are added automatically.

--- a/documentation/docs/04-loading.md
+++ b/documentation/docs/04-loading.md
@@ -144,10 +144,10 @@ This will be merged with any existing `stuff` and passed to the `load` functions
 
 The combined `stuff` is available to components using the [page store](/docs/modules#$app-stores) as `$page.stuff`, providing a mechanism for pages to pass data 'upward' to layouts.
 
-> `status`, `error`, `redirect` and `cache` are ignored when rendering error pages.
-
 #### dependencies
 
 An array of strings representing URLs the page depends on, which can subsequently be used with [`invalidate`](/docs/modules#$app-navigation-invalidate) to cause `load` to rerun. You only need to add them to `dependencies` if you're using a custom API client; URLs loaded with the provided `fetch` function are added automatically.
 
 URLs can be absolute or relative to the page being loaded, and must be [encoded](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding).
+
+> `status`, `error`, `redirect` and `cache` are ignored when rendering error pages.


### PR DESCRIPTION
See #1575. We might want to add some warnings when these properties are encountered when rendering error pages, but the first step is to document the expected behaviour