### PR TITLE
revert dev command default options

### DIFF
--- a/.changeset/moody-roses-search.md
+++ b/.changeset/moody-roses-search.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Fix dev --host command behaviour
+Revert dev command default options

--- a/.changeset/moody-roses-search.md
+++ b/.changeset/moody-roses-search.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix dev --host command behaviour

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -47,10 +47,10 @@ const prog = sade('svelte-kit').version('__VERSION__');
 prog
 	.command('dev')
 	.describe('Start a development server')
-	.option('-p, --port', 'Port', 3000)
-	.option('-o, --open', 'Open a browser tab', false)
-	.option('--host', 'Host (only use this on trusted networks)', 'localhost')
-	.option('--https', 'Use self-signed HTTPS certificate', false)
+	.option('-p, --port', 'Port')
+	.option('-o, --open', 'Open a browser tab')
+	.option('--host', 'Host (only use this on trusted networks)')
+	.option('--https', 'Use self-signed HTTPS certificate')
 	.option('-H', 'no longer supported, use --https instead') // TODO remove for 1.0
 	.action(async ({ port, host, https, open, H }) => {
 		try {

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -35,7 +35,8 @@ export async function dev({ cwd, port, host, https, config }) {
 							path.resolve(cwd, 'node_modules'),
 							path.resolve(vite.searchForWorkspaceRoot(cwd), 'node_modules')
 						])
-					]
+					],
+					port: 3000
 				},
 				strictPort: true
 			}

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -79,9 +79,7 @@ export async function dev({ cwd, port, host, https, config }) {
 
 	// optional config from command-line flags
 	// these should take precedence, but not print conflict warnings
-	if (host) {
-		merged_config.server.host = host;
-	}
+	merged_config.server.host = host;
 
 	// if https is already enabled then do nothing. it could be an object and we
 	// don't want to overwrite with a boolean

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -80,7 +80,9 @@ export async function dev({ cwd, port, host, https, config }) {
 
 	// optional config from command-line flags
 	// these should take precedence, but not print conflict warnings
-	merged_config.server.host = host;
+	if (host) {
+		merged_config.server.host = host;
+	}
 
 	// if https is already enabled then do nothing. it could be an object and we
 	// don't want to overwrite with a boolean

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -11,7 +11,7 @@ import * as sync from '../sync/sync.js';
  * @typedef {{
  *   cwd: string,
  *   port: number,
- *   host: string,
+ *   host?: string,
  *   https: boolean,
  *   config: import('types').ValidatedConfig
  * }} Options


### PR DESCRIPTION
fix #4947

Turns out setting the default `host` value to `localhost`, makes plain `--host` option be `""` instead of `true`. 

Reverting #4932 as there isn't a nice way to handle this. Re Vite port being `5173` in the future, I've made `3000` as the default port in the base config.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
