### PR TITLE
delay automatic service worker registration until load event

### DIFF
--- a/.changeset/swift-horses-march.md
+++ b/.changeset/swift-horses-march.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Delay automatic service worker registration until load event

--- a/.changeset/swift-horses-march.md
+++ b/.changeset/swift-horses-march.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Delay automatic service worker registration until load event
+[breaking] delay automatic service worker registration until load event

--- a/documentation/docs/07-service-workers.md
+++ b/documentation/docs/07-service-workers.md
@@ -6,7 +6,7 @@ Service workers act as proxy servers that handle network requests inside your ap
 
 In SvelteKit, if you have a `src/service-worker.js` file (or `src/service-worker.ts`, or `src/service-worker/index.js`, etc) it will be built with Vite and automatically registered. You can disable automatic registration if you need to register the service worker with your own logic (e.g. prompt user for update, configure periodic updates, use `workbox`, etc).
 
-> You can change the location of your service worker and disable automatic registration in your [project configuration](/docs/configuration#files).
+> You can change the [location of your service worker](/docs/configuration#files) and [disable automatic registration](/docs/configuration#serviceworker) in your project configuration.
 
 Inside the service worker you have access to the [`$service-worker` module](/docs/modules#$service-worker).
 

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -182,7 +182,9 @@ export async function render_response({
 
 	const init_service_worker = `
 		if ('serviceWorker' in navigator) {
-			navigator.serviceWorker.register('${options.service_worker}');
+			addEventListener('load', () => {
+				navigator.serviceWorker.register('${options.service_worker}');
+			});
 		}
 	`;
 


### PR DESCRIPTION
closes #3342. This is a more sensible default, and since we can disable automatic service worker registration we don't need to provide any more granular control.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
