### PR TITLE
clarify that the fallback page is created by SvelteKit

### DIFF
--- a/.changeset/wise-houses-work.md
+++ b/.changeset/wise-houses-work.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-static': patch
+---
+
+Tweak fallback page README

--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -54,7 +54,7 @@ You can use `adapter-static` to create a single-page app or SPA by specifying a 
 
 > In most situations this is not recommended: it harms SEO, tends to slow down perceived performance, and makes your app inaccessible to users if JavaScript fails or is disabled (which happens [more often than you probably think](https://kryogenix.org/code/browser/everyonehasjs.html)).
 
-The fallback page is a blank HTML page that loads your SvelteKit app and navigates to the correct route. For example [Surge](https://surge.sh/help/adding-a-200-page-for-client-side-routing), a static web host, lets you add a `200.html` file that will handle any requests that don't otherwise match. We can create that file like so:
+The fallback page is an HTML page created by SvelteKit that loads your app and navigates to the correct route. For example [Surge](https://surge.sh/help/adding-a-200-page-for-client-side-routing), a static web host, lets you add a `200.html` file that will handle any requests that don't otherwise match. We can create that file like so:
 
 ```js
 // svelte.config.js


### PR DESCRIPTION
closes #3413. This makes it clearer that you're not supposed to bring your own fallback page or something