### PR TITLE
fix #4944: Page endpoints will properly handle objects with .toJSON during SSR

### DIFF
--- a/.changeset/six-clouds-collect.md
+++ b/.changeset/six-clouds-collect.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Page endpoints will properly handle objects with .toJSON during SSR

--- a/packages/kit/test/apps/basics/src/routes/shadowed/tojson.js
+++ b/packages/kit/test/apps/basics/src/routes/shadowed/tojson.js
@@ -1,0 +1,10 @@
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export function get({ locals }) {
+	return {
+		body: {
+			answer: {
+				toJSON: () => locals.answer
+			}
+		}
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/shadowed/tojson.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shadowed/tojson.svelte
@@ -1,0 +1,6 @@
+<script>
+	/** @type {number} */
+	export let answer;
+</script>
+
+<h1>The answer is {answer}</h1>


### PR DESCRIPTION
In #4944, we didn't come to a conclusion that this should be added, but I wanted to see how difficult it would be to contribute to sveltekit, so here we are.

This pull request makes it so that when using something such as this as a page endpoint...
```ts
/** @type {import('@sveltejs/kit').RequestHandler} */
export function get() {
	return {
		body: {
			answer: {
				toJSON: () => 42
			}
		}
	};
}
```
...will properly pass the 42 to the `answer` prop to the page component during SSR. Without this fix, the rich object is passed directly. In both cases, the browser always has the serialized form, since `JSON.stringify` will flatten these `.toJSON` objects.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
