### PR TITLE
implement basic alias config (closes #4734)

### DIFF
--- a/.changeset/real-mice-argue.md
+++ b/.changeset/real-mice-argue.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add `config.kit.alias`

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -39,6 +39,18 @@ const options = object(
 				return input;
 			}),
 
+			alias: validate({}, (input, keypath) => {
+				if (typeof input !== 'object') {
+					throw new Error(`${keypath} should be an object`);
+				}
+
+				for (const key in input) {
+					assert_string(input[key], `${keypath}.${key}`);
+				}
+
+				return input;
+			}),
+
 			amp: boolean(false),
 
 			appDir: validate('_app', (input, keypath) => {

--- a/packages/kit/src/core/utils.js
+++ b/packages/kit/src/core/utils.js
@@ -80,11 +80,18 @@ export function get_mime_lookup(manifest_data) {
 
 /** @param {import('types').ValidatedConfig} config */
 export function get_aliases(config) {
+	/** @type {Record<string, string>} */
 	const alias = {
 		__GENERATED__: path.posix.join(config.kit.outDir, 'generated'),
 		$app: `${get_runtime_path(config)}/app`,
+
+		// $lib should be moved into a default value for `config.kit.alias`
 		$lib: config.kit.files.lib
 	};
+
+	for (const [key, value] of Object.entries(config.kit.alias)) {
+		alias[key] = path.resolve(value);
+	}
 
 	return alias;
 }

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -95,6 +95,7 @@ export interface Config {
 	extensions?: string[];
 	kit?: {
 		adapter?: Adapter;
+		alias?: Record<string, string>;
 		amp?: boolean;
 		appDir?: string;
 		browser?: {


### PR DESCRIPTION
This PR implements `config.kit.alias`, as the proposed solution in #4734 describes.

Example usage:
```ts
const config = {
  kit: {
    alias: {
      $utils: 'src/utils'
    }
  }
};
```

Notes:
- I would like some pointers/assistance with adding the new config property, I may have messed something up.
- New tests need to be written and some existing ones need to be modified.
- We should consider deprecating/removing `config.kit.files.lib` and having it be `config.kit.alias.$lib`, but `$lib` is special for packaging and other situations.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
