### PR TITLE
revert to using cjs for lambda

### DIFF
--- a/.changeset/few-scissors-agree.md
+++ b/.changeset/few-scissors-agree.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+Revert to cjs mode when building for lambda

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -145,10 +145,10 @@ async function v1(builder, external) {
 		bundle: true,
 		platform: 'node',
 		external,
-		format: 'esm'
+		format: 'cjs'
 	});
 
-	writeFileSync(`${dirs.lambda}/package.json`, JSON.stringify({ type: 'module' }));
+	writeFileSync(`${dirs.lambda}/package.json`, JSON.stringify({ type: 'commonjs' }));
 
 	builder.log.minor('Copying assets...');
 
@@ -271,7 +271,7 @@ async function v3(builder, external, edge, split) {
 			target: `node${node_version.full}`,
 			bundle: true,
 			platform: 'node',
-			format: 'esm',
+			format: 'cjs',
 			external
 		});
 
@@ -284,7 +284,7 @@ async function v3(builder, external, edge, split) {
 			})
 		);
 
-		write(`${dirs.functions}/${name}.func/package.json`, JSON.stringify({ type: 'module' }));
+		write(`${dirs.functions}/${name}.func/package.json`, JSON.stringify({ type: 'commonjs' }));
 
 		routes.push({ src: pattern, dest: `/${name}` });
 	}


### PR DESCRIPTION
fixes #4933. I don't truly understand why this was failing, but reverting to `cjs` rather than `esm` seems to fix it. If it turns out that other apps _need_ `esm` then we can expose it as a config option

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
