### PR TITLE
fix port override

### DIFF
--- a/.changeset/odd-pumas-grow.md
+++ b/.changeset/odd-pumas-grow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix default port override

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -35,9 +35,9 @@ export async function dev({ cwd, port, host, https, config }) {
 							path.resolve(cwd, 'node_modules'),
 							path.resolve(vite.searchForWorkspaceRoot(cwd), 'node_modules')
 						])
-					],
-					port: 3000
+					]
 				},
+				port: 3000,
 				strictPort: true
 			}
 		},


### PR DESCRIPTION
it's `server.port`, not `server.fs.port`. This sets us up for Vite 3 (which changes the default port to 5173)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
