### PR TITLE
add test to prevent accidental breakage of data-hydrate mechanism

### DIFF
--- a/.changeset/eight-rivers-battle.md
+++ b/.changeset/eight-rivers-battle.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] change data-hydrate to data-sveltekit-hydrate

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -158,7 +158,7 @@ export async function render_response({
 	const init_app = `
 		import { start } from ${s(options.prefix + options.manifest._.entry.file)};
 		start({
-			target: document.querySelector('[data-hydrate="${target}"]').parentNode,
+			target: document.querySelector('[data-sveltekit-hydrate="${target}"]').parentNode,
 			paths: ${s(options.paths)},
 			session: ${try_serialize($session, (error) => {
 				throw new Error(`Failed to serialize session data: ${error.message}`);
@@ -243,7 +243,7 @@ export async function render_response({
 				.map((dep) => `\n\t<link rel="modulepreload" href="${options.prefix + dep}">`)
 				.join('');
 
-			const attributes = ['type="module"', `data-hydrate="${target}"`];
+			const attributes = ['type="module"', `data-sveltekit-hydrate="${target}"`];
 
 			csp.add_script(init_app);
 

--- a/packages/kit/test/prerendering/basics/test/test.js
+++ b/packages/kit/test/prerendering/basics/test/test.js
@@ -114,4 +114,23 @@ test('fetching missing content results in a 404', () => {
 	assert.ok(content.includes('<h1>status: 404</h1>'), content);
 });
 
+test('targets the data-hydrate parent node', () => {
+	// this test ensures that we don't accidentally change the way
+	// the body is hydrated in a way that breaks apps that need
+	// to manipulate the markup in some way:
+	// https://github.com/sveltejs/kit/issues/4685
+	const content = read('index.html');
+
+	const pattern =
+		/<body>([^]+?)<script type="module" data-hydrate="(\w+)">([^]+?)<\/script>[^]+?<\/body>/;
+
+	const match = pattern.exec(content);
+
+	assert.equal(match[1].trim(), '<h1>hello</h1>');
+
+	assert.ok(
+		match[3].includes(`target: document.querySelector('[data-hydrate="${match[2]}"]').parentNode`)
+	);
+});
+
 test.run();

--- a/packages/kit/test/prerendering/basics/test/test.js
+++ b/packages/kit/test/prerendering/basics/test/test.js
@@ -114,7 +114,7 @@ test('fetching missing content results in a 404', () => {
 	assert.ok(content.includes('<h1>status: 404</h1>'), content);
 });
 
-test('targets the data-hydrate parent node', () => {
+test('targets the data-sveltekit-hydrate parent node', () => {
 	// this test ensures that we don't accidentally change the way
 	// the body is hydrated in a way that breaks apps that need
 	// to manipulate the markup in some way:
@@ -122,14 +122,16 @@ test('targets the data-hydrate parent node', () => {
 	const content = read('index.html');
 
 	const pattern =
-		/<body>([^]+?)<script type="module" data-hydrate="(\w+)">([^]+?)<\/script>[^]+?<\/body>/;
+		/<body>([^]+?)<script type="module" data-sveltekit-hydrate="(\w+)">([^]+?)<\/script>[^]+?<\/body>/;
 
 	const match = pattern.exec(content);
 
 	assert.equal(match[1].trim(), '<h1>hello</h1>');
 
 	assert.ok(
-		match[3].includes(`target: document.querySelector('[data-hydrate="${match[2]}"]').parentNode`)
+		match[3].includes(
+			`target: document.querySelector('[data-sveltekit-hydrate="${match[2]}"]').parentNode`
+		)
 	);
 });
 


### PR DESCRIPTION
supersedes #4698, closes #4685. This is a compromise measure — it keeps the existing behaviour, but adds a test to make sure we don't accidentally change the hydration mechanism in a way that breaks apps manipulating the markup in certain ways.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
