### PR TITLE
Add dir=ltr to generated html-tags by default

### DIFF
--- a/.changeset/blue-trees-worry.md
+++ b/.changeset/blue-trees-worry.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/adapter-static': patch
+'default-template': patch
+'create-svelte': patch
+---
+
+Add dir=ltr as a default to all generated html-tags in templates

--- a/packages/adapter-static/test/apps/prerendered/src/app.html
+++ b/packages/adapter-static/test/apps/prerendered/src/app.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/adapter-static/test/apps/spa/src/app.html
+++ b/packages/adapter-static/test/apps/spa/src/app.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/create-svelte/templates/default/src/app.html
+++ b/packages/create-svelte/templates/default/src/app.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%svelte.assets%/favicon.png" />

--- a/packages/create-svelte/templates/skeleton/src/app.html
+++ b/packages/create-svelte/templates/skeleton/src/app.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%svelte.assets%/favicon.png" />

--- a/packages/kit/test/apps/basics/src/app.html
+++ b/packages/kit/test/apps/basics/src/app.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/kit/test/apps/options-2/src/app.html
+++ b/packages/kit/test/apps/options-2/src/app.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/kit/test/apps/options/source/template.html
+++ b/packages/kit/test/apps/options/source/template.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/kit/test/prerendering/basics/src/app.html
+++ b/packages/kit/test/prerendering/basics/src/app.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/kit/test/prerendering/disabled/src/app.html
+++ b/packages/kit/test/prerendering/disabled/src/app.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/kit/test/prerendering/options/src/app.html
+++ b/packages/kit/test/prerendering/options/src/app.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/kit/test/prerendering/paths-base/src/app.html
+++ b/packages/kit/test/prerendering/paths-base/src/app.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/kit/test/prerendering/trailing-slash/src/app.html
+++ b/packages/kit/test/prerendering/trailing-slash/src/app.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
The web is expanding it's native handling towards logical properties for layouts to not be bound to left-to-right-languages anymore.

To follow this trend in svelte, it would be nice to have `dir=ltr` on all `html`-tags created by the framework per default. `dir=ltr` is the logical default, given we already have `lang=en` set. With this little addition, css/js can correctly target the writing-mode right from the project setup. Additionally, tools like `postcss-logical` are depending on this attribute to be set.

Would make my life a little bit easier as I don't have to do it manually on project-setup. Thanks for this awesome framework!

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0