### PR TITLE
[fix] fouc regression in dev mode

### DIFF
--- a/.changeset/moody-moose-jump.md
+++ b/.changeset/moody-moose-jump.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix FOUC regression during dev


### PR DESCRIPTION
Fixes #4987.

Turns out you were right, @Rich-Harris: not all pushes were happening synchronously. 😬 

`add` was supposed to `return find_deps` but I missed it at some point. Rewrote `add_by_url` so both branches work similarly and it's readily apparent they're both promises now. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
