### PR TITLE
ignore packaging test fixtures

### DIFF
--- a/packages/kit/.gitignore
+++ b/packages/kit/.gitignore
@@ -7,5 +7,7 @@
 /test/**/build
 !/src/core/adapt/fixtures/*/.svelte-kit
 !/test/node_modules
+/src/packaging/test/errors/*/package
+/src/packaging/test/fixtures/*/package
 /test/apps/basics/test/errors.json
 .custom-out-dir


### PR DESCRIPTION
no idea why this didn't show up sooner, but `git clean -xdf && pnpm i && pnpm build` creates a bunch of untracked files that should be ignored