### PR TITLE
correct default package.json format

### DIFF
--- a/.changeset/curly-doors-type.md
+++ b/.changeset/curly-doors-type.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+correct default package.json format

--- a/packages/create-svelte/index.js
+++ b/packages/create-svelte/index.js
@@ -74,7 +74,7 @@ function write_common_files(cwd, options, name) {
 	pkg.devDependencies = sort_keys(pkg.devDependencies);
 	pkg.name = to_valid_package_name(name);
 
-	fs.writeFileSync(pkg_file, JSON.stringify(pkg, null, '  '));
+	fs.writeFileSync(pkg_file, JSON.stringify(pkg, null, '\t'));
 }
 
 /**

--- a/packages/create-svelte/shared/+eslint/.eslintignore
+++ b/packages/create-svelte/shared/+eslint/.eslintignore
@@ -8,7 +8,6 @@ node_modules
 !.env.example
 
 # Ignore files for PNPM, NPM and YARN
-package.json
 pnpm-lock.yaml
 package-lock.json
 yarn.lock

--- a/packages/create-svelte/shared/+prettier/.prettierignore
+++ b/packages/create-svelte/shared/+prettier/.prettierignore
@@ -8,7 +8,6 @@ node_modules
 !.env.example
 
 # Ignore files for PNPM, NPM and YARN
-package.json
 pnpm-lock.yaml
 package-lock.json
 yarn.lock


### PR DESCRIPTION
`package.json` wasn't formatted correctly by default according to `.prettierrc`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
