### PR TITLE
[fix] resolve fetch requests from the target page

### DIFF
--- a/.changeset/forty-lions-give.md
+++ b/.changeset/forty-lions-give.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] resolve relative urls from the target page when using load's fetch

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-relative.json.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-relative.json.js
@@ -1,0 +1,16 @@
+export function get() {
+	return {
+		body: {
+			answer: 42
+		}
+	};
+}
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function post({ request }) {
+	return {
+		body: {
+			question: await request.text()
+		}
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-relative.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-relative.svelte
@@ -1,0 +1,19 @@
+<script context="module">
+	/** @type {import('@sveltejs/kit').Load} */
+	export async function load({ fetch }) {
+		const get = await fetch('fetch-relative.json');
+		const post = await fetch('fetch-relative.json', { method: 'post', body: '?' });
+
+		return {
+			props: { ...(await get.json()), ...(await post.json()) }
+		};
+	}
+</script>
+
+<script>
+	export let answer;
+	export let question;
+</script>
+
+<h1>the answer is {answer}</h1>
+<h2>the question was {question}</h2>

--- a/packages/kit/test/apps/basics/src/routes/load/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/index.svelte
@@ -21,6 +21,7 @@
 <h1>bar == {foo}?</h1>
 
 <a href="/load/fetch-request">fetch request</a>
+<a href="/load/fetch-relative">fetch relative</a>
 <a href="/load/fetch-credentialed">fetch credentialed</a>
 <a href="/load/fetch-headers">fetch headers</a>
 <a href="/load/large-response">large response</a>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1311,6 +1311,13 @@ test.describe.parallel('Load', () => {
 		expect(await page.textContent('h1')).toBe('the answer is 42');
 	});
 
+	test('fetch resolves urls relatively to the target page', async ({ page, clicknav }) => {
+		await page.goto('/load');
+		await clicknav('[href="/load/fetch-relative"]');
+		expect(await page.textContent('h1')).toBe('the answer is 42');
+		expect(await page.textContent('h2')).toBe('the question was ?');
+	});
+
 	test('handles large responses', async ({ page }) => {
 		await page.goto('/load');
 


### PR DESCRIPTION
When using `load`'s `fetch`, it's natural to assume URLs will be resolved relatively to the navigation's target page. Instead, they take the current page into account. This means that, in practice, we must always use absolute or root-relative URLs.

This PR resolves URLs relatively to the target page before issuing the native `fetch`. It's a simple fix, with just a couple of wrinkles we must pay attention to:

- The `Request` object is mostly read-only, so we need to consume its body and manually copy properties into the new request;
- Our ssr-included payloads wouldn't match the full URLs, so we skip normalization during hydration.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
