### PR TITLE
fix: use named imports from vite to support upcoming vite 3.0 esm

### DIFF
--- a/.changeset/short-guests-sort.md
+++ b/.changeset/short-guests-sort.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+use named imports of vite to support upcoming vite 3.0

--- a/packages/kit/src/core/build/build_service_worker.js
+++ b/packages/kit/src/core/build/build_service_worker.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import vite from 'vite';
+import { build } from 'vite';
 import { s } from '../../utils/misc.js';
 import { deep_merge } from '../../utils/object.js';
 import { normalize_path } from '../../utils/url.js';
@@ -22,12 +22,12 @@ export async function build_service_worker(
 	prerendered,
 	client_manifest
 ) {
-	const build = new Set();
+	const build_files = new Set();
 	for (const key in client_manifest) {
 		const { file, css = [], assets = [] } = client_manifest[key];
-		build.add(file);
-		css.forEach((file) => build.add(file));
-		assets.forEach((file) => build.add(file));
+		build_files.add(file);
+		css.forEach((file) => build_files.add(file));
+		assets.forEach((file) => build_files.add(file));
 	}
 
 	const service_worker = `${config.kit.outDir}/generated/service-worker.js`;
@@ -43,7 +43,7 @@ export async function build_service_worker(
 			};
 
 			export const build = [
-				${Array.from(build)
+				${Array.from(build_files)
 					.map((file) => `${s(`${config.kit.paths.base}/${config.kit.appDir}/${file}`)}`)
 					.join(',\n\t\t\t\t')}
 			];
@@ -96,5 +96,5 @@ export async function build_service_worker(
 
 	print_config_conflicts(conflicts, 'kit.vite.', 'build_service_worker');
 
-	await vite.build(merged_config);
+	await build(merged_config);
 }

--- a/packages/kit/src/core/build/utils.js
+++ b/packages/kit/src/core/build/utils.js
@@ -1,4 +1,4 @@
-import vite from 'vite';
+import { build } from 'vite';
 
 /**
  * @typedef {import('rollup').RollupOutput} RollupOutput
@@ -8,7 +8,7 @@ import vite from 'vite';
 
 /** @param {import('vite').UserConfig} config */
 export async function create_build(config) {
-	const { output } = /** @type {RollupOutput} */ (await vite.build(config));
+	const { output } = /** @type {RollupOutput} */ (await build(config));
 
 	const chunks = output.filter(
 		/** @returns {output is OutputChunk} */ (output) => output.type === 'chunk'

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
-import vite from 'vite';
+import { createServer, searchForWorkspaceRoot } from 'vite';
 import { deep_merge } from '../../utils/object.js';
 import { print_config_conflicts } from '../config/index.js';
 import { get_aliases, get_runtime_path } from '../utils.js';
@@ -33,7 +33,7 @@ export async function dev({ cwd, port, host, https, config }) {
 							config.kit.outDir,
 							path.resolve(cwd, 'src'),
 							path.resolve(cwd, 'node_modules'),
-							path.resolve(vite.searchForWorkspaceRoot(cwd), 'node_modules')
+							path.resolve(searchForWorkspaceRoot(cwd), 'node_modules')
 						])
 					]
 				},
@@ -94,7 +94,7 @@ export async function dev({ cwd, port, host, https, config }) {
 		merged_config.server.port = port;
 	}
 
-	const server = await vite.createServer(merged_config);
+	const server = await createServer(merged_config);
 	await server.listen(port);
 
 	const address_info = /** @type {import('net').AddressInfo} */ (


### PR DESCRIPTION
vite 3.0 is going to be esm first :tada: https://github.com/vitejs/vite/pull/8178

No default export means we have to change a few `import vite from 'vite'` to prevent errors like this one:
https://github.com/vitejs/vite-ecosystem-ci/runs/6549407184?check_suite_focus=true#step:7:392


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
