### PR TITLE
tweak turbo config

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -7,12 +7,12 @@
 			"outputs": ["dist/**", "docs/**", "assets/**"]
 		},
 		"kit.svelte.dev#build": {
-			"dependsOn": ["^build", "$VERCEL"],
+			"dependsOn": ["^build", "$VERCEL", "$ENABLE_VC_BUILD"],
 			"inputs": ["src/**", "../../packages/kit/docs/**", "../../documentation/**"],
 			"outputs": [".vercel_build_output/**"]
 		},
 		"build": {
-			"dependsOn": ["^build", "$VERCEL"],
+			"dependsOn": ["^build", "$VERCEL", "$ENABLE_VC_BUILD"],
 			"inputs": ["src/**", "scripts/**", "shared/**", "templates/**"],
 			"outputs": ["files/**", "dist/**", ".svelte-kit/**", ".vercel_build_output/**"]
 		},


### PR DESCRIPTION
i think the absence of this might be causing deploys to fail on e.g. https://github.com/sveltejs/kit/pull/5016 because it's incorrectly replaying cache hits