### PR TITLE
feat: csp report-only mode

### DIFF
--- a/.changeset/warm-dingos-try.md
+++ b/.changeset/warm-dingos-try.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+support CSP report-only mode

--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -108,6 +108,7 @@ An object containing zero or more of the following values:
 
 - `mode` — 'hash', 'nonce' or 'auto'
 - `directives` — an object of `[directive]: value[]` pairs.
+- `reportOnly` — enables or disables Content Security Policy report-only mode
 
 [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) configuration. CSP helps to protect your users against cross-site scripting (XSS) attacks, by limiting the places resources can be loaded from. For example, a configuration like this...
 
@@ -119,7 +120,8 @@ const config = {
 		csp: {
 			directives: {
 				'script-src': ['self']
-			}
+			},
+			reportOnly: false
 		}
 	}
 };

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -52,7 +52,8 @@ const get_defaults = (prefix = '') => ({
 				'block-all-mixed-content': false,
 				'plugin-types': undefined,
 				referrer: undefined
-			}
+			},
+			reportOnly: false
 		},
 		endpointExtensions: ['.js', '.ts'],
 		files: {

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -100,7 +100,8 @@ const options = object(
 					'block-all-mixed-content': boolean(false),
 					'plugin-types': string_array(),
 					referrer: string_array()
-				})
+				}),
+				reportOnly: boolean(false)
 			}),
 
 			endpointExtensions: string_array(['.js', '.ts']),

--- a/packages/kit/src/runtime/server/page/csp.js
+++ b/packages/kit/src/runtime/server/page/csp.js
@@ -61,6 +61,9 @@ export class Csp {
 	/** @type {import('types').CspDirectives} */
 	#directives;
 
+	/** @type {boolean} */
+	#report_only;
+
 	/** @type {import('types').Csp.Source[]} */
 	#script_src;
 
@@ -71,6 +74,7 @@ export class Csp {
 	 * @param {{
 	 *   mode: string,
 	 *   directives: import('types').CspDirectives
+	 *   report_only?: boolean,
 	 * }} config
 	 * @param {{
 	 *   dev: boolean;
@@ -78,10 +82,11 @@ export class Csp {
 	 *   needs_nonce: boolean;
 	 * }} opts
 	 */
-	constructor({ mode, directives }, { dev, prerender, needs_nonce }) {
+	constructor({ mode, directives, report_only = false }, { dev, prerender, needs_nonce }) {
 		this.#use_hashes = mode === 'hash' || (mode === 'auto' && prerender);
 		this.#directives = dev ? { ...directives } : directives; // clone in dev so we can safely mutate
 		this.#dev = dev;
+		this.#report_only = report_only;
 
 		const d = this.#directives;
 
@@ -206,6 +211,8 @@ export class Csp {
 
 	get_meta() {
 		const content = escape_html_attr(this.get_header(true));
-		return `<meta http-equiv="content-security-policy" content=${content}>`;
+		return `<meta http-equiv=${`"content-security-policy${
+			this.#report_only ? '-report-only"' : '"'
+		}`} content=${content}>`;
 	}
 }

--- a/packages/kit/src/runtime/server/page/csp.spec.js
+++ b/packages/kit/src/runtime/server/page/csp.spec.js
@@ -36,6 +36,28 @@ test('generates CSP header with directive', () => {
 	assert.equal(csp.get_header(), "default-src 'self'");
 });
 
+test('generates CSP header with hash in report only mode', () => {
+	const csp = new Csp(
+		{
+			mode: 'hash',
+			directives: {
+				'default-src': ['self']
+			},
+			report_only: true
+		},
+		{
+			dev: false,
+			prerender: false,
+			needs_nonce: false
+		}
+	);
+
+	assert.equal(
+		csp.get_meta(),
+		'<meta http-equiv="content-security-policy-report-only" content="default-src \'self\'">'
+	);
+});
+
 test('generates CSP header with nonce', () => {
 	const csp = new Csp(
 		{
@@ -54,6 +76,33 @@ test('generates CSP header with nonce', () => {
 	csp.add_script('');
 
 	assert.ok(csp.get_header().startsWith("default-src 'self'; script-src 'self' 'nonce-"));
+});
+
+test('generates CSP header with nonce in report only mode', () => {
+	const csp = new Csp(
+		{
+			mode: 'nonce',
+			directives: {
+				'default-src': ['self']
+			},
+			report_only: true
+		},
+		{
+			dev: false,
+			prerender: false,
+			needs_nonce: false
+		}
+	);
+
+	csp.add_script('');
+
+	assert.ok(
+		csp
+			.get_meta()
+			.startsWith(
+				"<meta http-equiv=\"content-security-policy-report-only\" content=\"default-src 'self'; script-src 'self' 'nonce-"
+			)
+	);
 });
 
 test('skips nonce with unsafe-inline', () => {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -297,8 +297,9 @@ export async function render_response({
 
 	if (!state.prerender) {
 		const csp_header = csp.get_header();
+		const is_report_only = options.csp.reportOnly ? '-report-only' : '';
 		if (csp_header) {
-			headers.set('content-security-policy', csp_header);
+			headers.set('content-security-policy' + is_report_only, csp_header);
 		}
 	}
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -101,6 +101,7 @@ export interface Config {
 		csp?: {
 			mode?: 'hash' | 'nonce' | 'auto';
 			directives?: CspDirectives;
+			reportOnly?: boolean;
 		};
 		endpointExtensions?: string[];
 		files?: {


### PR DESCRIPTION
## Description
I implemented the `reportOnly` flag for the CSP configuration and verified that it works by running it against a `kit-sandbox` repo.

Let me know if the documentation needs to be worded differently or in case other changes are necessary.

## Changes
- update respective code to toggle between CSP modes
- add unit tests for CSP report-only mode
- update CSP configuration docs with reportOnly flag

Closes https://github.com/sveltejs/kit/issues/3556

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
