### PR TITLE
[chore] remove `cwd` as a method parameter

### DIFF
--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -65,10 +65,7 @@ prog
 		async function start(config) {
 			const { dev } = await import('./core/dev/index.js');
 
-			const cwd = process.cwd();
-
 			const { address_info, server_config, close } = await dev({
-				cwd,
 				port,
 				host,
 				https,
@@ -82,8 +79,7 @@ prog
 				open: first && (open || !!server_config.open),
 				base: config.kit.paths.base,
 				loose: server_config.fs.strict === false,
-				allow: server_config.fs.allow,
-				cwd
+				allow: server_config.fs.allow
 			});
 
 			first = false;

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -7,9 +7,10 @@ import { get_aliases, get_runtime_path } from '../utils.js';
 import { create_plugin } from './plugin.js';
 import * as sync from '../sync/sync.js';
 
+const cwd = process.cwd();
+
 /**
  * @typedef {{
- *   cwd: string,
  *   port: number,
  *   host?: string,
  *   https: boolean,
@@ -19,7 +20,7 @@ import * as sync from '../sync/sync.js';
  */
 
 /** @param {Options} opts */
-export async function dev({ cwd, port, host, https, config }) {
+export async function dev({ port, host, https, config }) {
 	sync.init(config);
 
 	const [vite_config] = deep_merge(
@@ -71,7 +72,7 @@ export async function dev({ cwd, port, host, https, config }) {
 				},
 				configFile: false
 			}),
-			await create_plugin(config, cwd)
+			await create_plugin(config)
 		],
 		base: '/'
 	});

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -17,12 +17,13 @@ import { parse_route_id } from '../../utils/routing.js';
 // https://github.com/vitejs/vite/blob/3edd1af56e980aef56641a5a51cf2932bb580d41/packages/vite/src/node/plugins/css.ts#L96
 const style_pattern = /\.(css|less|sass|scss|styl|stylus|pcss|postcss)$/;
 
+const cwd = process.cwd();
+
 /**
  * @param {import('types').ValidatedConfig} config
- * @param {string} cwd
  * @returns {Promise<import('vite').Plugin>}
  */
-export async function create_plugin(config, cwd) {
+export async function create_plugin(config) {
 	const runtime = get_runtime_path(config);
 
 	process.env.VITE_SVELTEKIT_APP_VERSION_POLL_INTERVAL = '0';


### PR DESCRIPTION
I don't think this needs to be passed around. Removing it simplifies things and results in less code. And if we want to use the `vite` CLI then we won't be able to pass it in the way we can from the `svelte-kit` CLI