### PR TITLE
use `crypto.randomUUID()`

### DIFF
--- a/.changeset/fast-islands-lick.md
+++ b/.changeset/fast-islands-lick.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Use crypto.randomUUID() instead of @lukeed/uuid

--- a/packages/create-svelte/templates/default/package.template.json
+++ b/packages/create-svelte/templates/default/package.template.json
@@ -16,7 +16,6 @@
 	"type": "module",
 	"dependencies": {
 		"@fontsource/fira-mono": "^4.5.0",
-		"@lukeed/uuid": "^2.0.0",
 		"cookie": "^0.4.1"
 	}
 }

--- a/packages/create-svelte/templates/default/src/hooks.ts
+++ b/packages/create-svelte/templates/default/src/hooks.ts
@@ -1,11 +1,10 @@
-import { v4 as uuid } from '@lukeed/uuid';
 import type { Handle } from '@sveltejs/kit';
 import * as cookie from 'cookie';
 
 /** @type {import('@sveltejs/kit').Handle} */
 export const handle: Handle = async ({ event, resolve }) => {
 	const cookies = cookie.parse(event.request.headers.get('cookie') || '');
-	event.locals.userid = cookies['userid'] || uuid();
+	event.locals.userid = cookies['userid'] || crypto.randomUUID();
 
 	const response = await resolve(event);
 


### PR DESCRIPTION
Now that we only support Node 16 and above, we can drop the dependency on `@lukeed/uuid` in favour of Using The Platform.

Closes #4929

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
