### PR TITLE
[chore] return config from server start methods

### DIFF
--- a/.changeset/fresh-sheep-help.md
+++ b/.changeset/fresh-sheep-help.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[chore] get base from Vite server for welcome message

--- a/.changeset/fresh-sheep-help.md
+++ b/.changeset/fresh-sheep-help.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-[chore] get base from Vite server for welcome message
+[chore] return config from server start methods

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -64,25 +64,31 @@ prog
 		async function start() {
 			const { dev } = await import('./core/dev/index.js');
 
-			const { address_info, config, close } = await dev({
+			const { server, config } = await dev({
 				port,
 				host,
 				https
 			});
 
+			const address_info = /** @type {import('net').AddressInfo} */ (
+				/** @type {import('http').Server} */ (server.httpServer).address()
+			);
+
+			const vite_config = server.config;
+
 			welcome({
 				port: address_info.port,
 				host: address_info.address,
-				https: !!(https || config.server.https),
-				open: first && (open || !!config.server.open),
-				base: config.base,
-				loose: config.server.fs.strict === false,
-				allow: config.server.fs.allow
+				https: !!(https || vite_config.server.https),
+				open: first && (open || !!vite_config.server.open),
+				base: config.kit.paths.base,
+				loose: vite_config.server.fs.strict === false,
+				allow: vite_config.server.fs.allow
 			});
 
 			first = false;
 
-			return close;
+			return server.close;
 		}
 
 		async function relaunch() {
@@ -177,9 +183,9 @@ prog
 
 			const { preview } = await import('./core/preview/index.js');
 
-			const server = await preview({ port, host, https });
+			const { config } = await preview({ port, host, https });
 
-			welcome({ port, host, https, open, base: server.config.base });
+			welcome({ port, host, https, open, base: config.kit.paths.base });
 		} catch (error) {
 			handle_error(error);
 		}

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -100,13 +100,8 @@ export async function dev({ port, host, https }) {
 	const server = await vite.createServer(merged_config);
 	await server.listen(port);
 
-	const address_info = /** @type {import('net').AddressInfo} */ (
-		/** @type {import('http').Server} */ (server.httpServer).address()
-	);
-
 	return {
-		address_info,
-		config: server.config,
-		close: () => server.close()
+		server,
+		config
 	};
 }

--- a/packages/kit/src/core/dev/index.js
+++ b/packages/kit/src/core/dev/index.js
@@ -2,7 +2,7 @@ import path from 'path';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import * as vite from 'vite';
 import { deep_merge } from '../../utils/object.js';
-import { print_config_conflicts } from '../config/index.js';
+import { load_config, print_config_conflicts } from '../config/index.js';
 import { get_aliases, get_runtime_path } from '../utils.js';
 import { create_plugin } from './plugin.js';
 import * as sync from '../sync/sync.js';
@@ -14,13 +14,15 @@ const cwd = process.cwd();
  *   port: number,
  *   host?: string,
  *   https: boolean,
- *   config: import('types').ValidatedConfig
  * }} Options
  * @typedef {import('types').SSRComponent} SSRComponent
  */
 
 /** @param {Options} opts */
-export async function dev({ port, host, https, config }) {
+export async function dev({ port, host, https }) {
+	/** @type {import('types').ValidatedConfig} */
+	const config = await load_config();
+
 	sync.init(config);
 
 	const [vite_config] = deep_merge(
@@ -104,7 +106,7 @@ export async function dev({ port, host, https, config }) {
 
 	return {
 		address_info,
-		server_config: vite_config.server,
+		config: server.config,
 		close: () => server.close()
 	};
 }

--- a/packages/kit/src/core/preview/index.js
+++ b/packages/kit/src/core/preview/index.js
@@ -6,6 +6,7 @@ import sirv from 'sirv';
 import { pathToFileURL } from 'url';
 import { getRequest, setResponse } from '../../node/index.js';
 import { installPolyfills } from '../../node/polyfills.js';
+import { load_config } from '../config/index.js';
 import { SVELTE_KIT_ASSETS } from '../constants.js';
 
 /** @typedef {import('http').IncomingMessage} Req */
@@ -28,14 +29,14 @@ const mutable = (dir) =>
  * @param {{
  *   port: number;
  *   host?: string;
- *   config: import('types').ValidatedConfig;
  *   https?: boolean;
  *   cwd?: string;
  * }} opts
  */
-export async function preview({ port, host, config, https: use_https = false }) {
+export async function preview({ port, host, https: use_https = false }) {
 	installPolyfills();
 
+	const config = await load_config();
 	const { paths } = config.kit;
 	const base = paths.base;
 	const assets = paths.assets ? SVELTE_KIT_ASSETS : paths.base;

--- a/packages/kit/src/core/preview/index.js
+++ b/packages/kit/src/core/preview/index.js
@@ -164,7 +164,7 @@ export async function preview({ port, host, https: use_https = false }) {
 
 	return new Promise((fulfil) => {
 		http_server.listen(port, host, () => {
-			fulfil(http_server);
+			fulfil({ server: http_server, config });
 		});
 	});
 }


### PR DESCRIPTION
We shouldn't read the Kit config in the CLI, but rather in the Vite plugin so that it will work with the `vite` CLI as well. This doesn't move the config reading all the way to the plugin yet, but does remove it from the CLI which is a step in that direction