### PR TITLE
add types to pkg.exports

### DIFF
--- a/.changeset/stupid-maps-hide.md
+++ b/.changeset/stupid-maps-hide.md
@@ -1,0 +1,12 @@
+---
+'@sveltejs/adapter-auto': patch
+'@sveltejs/adapter-cloudflare': patch
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-static': patch
+'@sveltejs/adapter-vercel': patch
+'@sveltejs/amp': patch
+---
+
+Add types to pkg.exports

--- a/packages/adapter-auto/package.json
+++ b/packages/adapter-auto/package.json
@@ -11,8 +11,8 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"import": "./index.js",
-			"types": "./index.d.ts"
+			"types": "./index.d.ts",
+			"import": "./index.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/adapter-auto/package.json
+++ b/packages/adapter-auto/package.json
@@ -11,7 +11,8 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"import": "./index.js"
+			"import": "./index.js",
+			"types": "./index.d.ts"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -11,8 +11,8 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"import": "./index.js",
-			"types": "./index.d.ts"
+			"types": "./index.d.ts",
+			"import": "./index.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -11,7 +11,8 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"import": "./index.js"
+			"import": "./index.js",
+			"types": "./index.d.ts"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -11,8 +11,8 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"import": "./index.js",
-			"types": "./index.d.ts"
+			"types": "./index.d.ts",
+			"import": "./index.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -11,7 +11,8 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"import": "./index.js"
+			"import": "./index.js",
+			"types": "./index.d.ts"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -11,8 +11,8 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"import": "./index.js",
-			"types": "./index.d.ts"
+			"types": "./index.d.ts",
+			"import": "./index.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -11,7 +11,8 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"import": "./index.js"
+			"import": "./index.js",
+			"types": "./index.d.ts"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -11,8 +11,8 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"import": "./index.js",
-			"types": "./index.d.ts"
+			"types": "./index.d.ts",
+			"import": "./index.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -11,7 +11,8 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"import": "./index.js"
+			"import": "./index.js",
+			"types": "./index.d.ts"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -12,8 +12,8 @@
 	"main": "index.js",
 	"exports": {
 		".": {
-			"import": "./index.js",
-			"types": "./index.d.ts"
+			"types": "./index.d.ts",
+			"import": "./index.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -12,7 +12,8 @@
 	"main": "index.js",
 	"exports": {
 		".": {
-			"import": "./index.js"
+			"import": "./index.js",
+			"types": "./index.d.ts"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -11,8 +11,8 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"import": "./index.js",
-			"types": "./index.d.ts"
+			"types": "./index.d.ts",
+			"import": "./index.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -11,7 +11,8 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"import": "./index.js"
+			"import": "./index.js",
+			"types": "./index.d.ts"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/amp/package.json
+++ b/packages/amp/package.json
@@ -11,8 +11,8 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"import": "./index.js",
-			"types": "./index.d.ts"
+			"types": "./index.d.ts",
+			"import": "./index.js"
 		},
 		"./package.json": "./package.json"
 	},

--- a/packages/amp/package.json
+++ b/packages/amp/package.json
@@ -11,7 +11,8 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"import": "./index.js"
+			"import": "./index.js",
+			"types": "./index.d.ts"
 		},
 		"./package.json": "./package.json"
 	},


### PR DESCRIPTION
fixes #5028 (I think?). No types for `@sveltejs/kit/*` but I don't think we need them because of `types/ambient.d.ts`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
