### PR TITLE
base64-encode binary responses

### DIFF
--- a/.changeset/lovely-flies-care.md
+++ b/.changeset/lovely-flies-care.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+Encode binary responses as base64

--- a/packages/adapter-netlify/src/serverless.js
+++ b/packages/adapter-netlify/src/serverless.js
@@ -10,7 +10,7 @@ export function init(manifest) {
 	const server = new Server(manifest);
 
 	return async (event, context) => {
-		const rendered = await server.respond(to_request(event), {
+		const response = await server.respond(to_request(event), {
 			platform: { context },
 			getClientAddress() {
 				return event.headers['x-nf-client-connection-ip'];
@@ -18,25 +18,25 @@ export function init(manifest) {
 		});
 
 		const partial_response = {
-			statusCode: rendered.status,
-			...split_headers(rendered.headers)
+			statusCode: response.status,
+			...split_headers(response.headers)
 		};
 
 		// TODO this is probably wrong now?
-		if (rendered.body instanceof Uint8Array) {
+		if (!is_text(response.headers.get('content-type'))) {
 			// Function responses should be strings (or undefined), and responses with binary
 			// content should be base64 encoded and set isBase64Encoded to true.
 			// https://github.com/netlify/functions/blob/main/src/function/response.ts
 			return {
 				...partial_response,
 				isBase64Encoded: true,
-				body: Buffer.from(rendered.body).toString('base64')
+				body: Buffer.from(await response.arrayBuffer()).toString('base64')
 			};
 		}
 
 		return {
 			...partial_response,
-			body: await rendered.text()
+			body: await response.text()
 		};
 	};
 }
@@ -60,4 +60,24 @@ function to_request(event) {
 	}
 
 	return new Request(rawUrl, init);
+}
+
+const text_types = new Set([
+	'application/xml',
+	'application/json',
+	'application/x-www-form-urlencoded',
+	'multipart/form-data'
+]);
+
+/**
+ * Decides how the body should be parsed based on its mime type. Should match what's in parse_body
+ *
+ * @param {string | undefined | null} content_type The `content-type` header of a request/response.
+ * @returns {boolean}
+ */
+function is_text(content_type) {
+	if (!content_type) return true; // defaults to json
+	const type = content_type.split(';')[0].toLowerCase(); // get the mime type
+
+	return type.startsWith('text/') || type.endsWith('+xml') || text_types.has(type);
 }

--- a/packages/adapter-netlify/src/serverless.js
+++ b/packages/adapter-netlify/src/serverless.js
@@ -22,7 +22,6 @@ export function init(manifest) {
 			...split_headers(response.headers)
 		};
 
-		// TODO this is probably wrong now?
 		if (!is_text(response.headers.get('content-type'))) {
 			// Function responses should be strings (or undefined), and responses with binary
 			// content should be base64 encoded and set isBase64Encoded to true.
@@ -70,7 +69,7 @@ const text_types = new Set([
 ]);
 
 /**
- * Decides how the body should be parsed based on its mime type. Should match what's in parse_body
+ * Decides how the body should be parsed based on its mime type
  *
  * @param {string | undefined | null} content_type The `content-type` header of a request/response.
  * @returns {boolean}

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -22,7 +22,7 @@ const text_types = new Set([
 ]);
 
 /**
- * Decides how the body should be parsed based on its mime type. Should match what's in parse_body
+ * Decides how the body should be parsed based on its mime type
  *
  * @param {string | undefined | null} content_type The `content-type` header of a request/response.
  * @returns {boolean}


### PR DESCRIPTION
closes #4174 (I think — it's awkward to test these changes without actually releasing the adapter, since everything gets installed from npm inside Netlify)

no, this isn't DRY. i don't think it's worth creating a new export just for this. we can do that if it turns out other adapters need to copy the same logic

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
