### PR TITLE
use free variable for native fetch

### DIFF
--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -616,7 +616,7 @@ export function create_client({ target, session, base, trailing_slash }) {
 					increment();
 					loaded = await module.load.call(null, load_input);
 				} finally {
-					decrement();
+					unlock_fetch();
 				}
 			} else {
 				loaded = await module.load.call(null, load_input);

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -11,7 +11,7 @@ import {
 	notifiable_store,
 	scroll_state
 } from './utils.js';
-import { increment, decrement, initial_fetch, native_fetch } from './fetcher.js';
+import { increment as lock_fetch, decrement as unlock_fetch, initial_fetch, native_fetch } from './fetcher.js';
 import { parse } from './parse.js';
 
 import Root from '__GENERATED__/root.svelte';

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -11,7 +11,7 @@ import {
 	notifiable_store,
 	scroll_state
 } from './utils.js';
-import { increment as lock_fetch, decrement as unlock_fetch, initial_fetch, native_fetch } from './fetcher.js';
+import { lock_fetch, unlock_fetch, initial_fetch, native_fetch } from './fetcher.js';
 import { parse } from './parse.js';
 
 import Root from '__GENERATED__/root.svelte';

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -11,7 +11,7 @@ import {
 	notifiable_store,
 	scroll_state
 } from './utils.js';
-import * as fetcher from './fetcher.js';
+import { increment, decrement, initial_fetch, native_fetch } from './fetcher.js';
 import { parse } from './parse.js';
 
 import Root from '__GENERATED__/root.svelte';
@@ -594,7 +594,7 @@ export function create_client({ target, session, base, trailing_slash }) {
 					add_dependency(normalized);
 
 					// prerendered pages may be served from any origin, so `initial_fetch` urls shouldn't be normalized
-					return started ? fetcher.native(normalized, init) : fetcher.initial(requested, init);
+					return started ? native_fetch(normalized, init) : initial_fetch(requested, init);
 				},
 				status: status ?? null,
 				error: error ?? null
@@ -613,10 +613,10 @@ export function create_client({ target, session, base, trailing_slash }) {
 
 			if (import.meta.env.DEV) {
 				try {
-					fetcher.increment();
+					increment();
 					loaded = await module.load.call(null, load_input);
 				} finally {
-					fetcher.decrement();
+					decrement();
 				}
 			} else {
 				loaded = await module.load.call(null, load_input);
@@ -704,7 +704,7 @@ export function create_client({ target, session, base, trailing_slash }) {
 					const is_shadow_page = has_shadow && i === a.length - 1;
 
 					if (is_shadow_page) {
-						const res = await fetcher.native(
+						const res = await native_fetch(
 							`${url.pathname}${url.pathname.endsWith('/') ? '' : '/'}__data.json${url.search}`,
 							{
 								headers: {

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -613,7 +613,7 @@ export function create_client({ target, session, base, trailing_slash }) {
 
 			if (import.meta.env.DEV) {
 				try {
-					increment();
+					lock_fetch();
 					loaded = await module.load.call(null, load_input);
 				} finally {
 					unlock_fetch();

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -4,11 +4,11 @@ let loading = 0;
 
 export const native_fetch = window.fetch;
 
-export function increment() {
+export function lock_fetch() {
 	loading += 1;
 }
 
-export function decrement() {
+export function unlock_fetch() {
 	loading -= 1;
 }
 

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -2,7 +2,7 @@ import { hash } from '../hash.js';
 
 let loading = 0;
 
-export const native = window.fetch;
+export const native_fetch = window.fetch;
 
 export function increment() {
 	loading += 1;
@@ -32,7 +32,8 @@ if (import.meta.env.DEV) {
 				`Loading ${url} using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/loading#input-fetch`
 			);
 		}
-		return native(input, init);
+
+		return native_fetch(input, init);
 	};
 }
 
@@ -40,7 +41,7 @@ if (import.meta.env.DEV) {
  * @param {RequestInfo} resource
  * @param {RequestInit} [opts]
  */
-export function initial(resource, opts) {
+export function initial_fetch(resource, opts) {
 	const url = JSON.stringify(typeof resource === 'string' ? resource : resource.url);
 
 	let selector = `script[sveltekit\\:data-type="data"][sveltekit\\:data-url=${url}]`;
@@ -55,5 +56,5 @@ export function initial(resource, opts) {
 		return Promise.resolve(new Response(body, init));
 	}
 
-	return native(resource, opts);
+	return native_fetch(resource, opts);
 }


### PR DESCRIPTION
i have ABSOLUTELY NO IDEA how this passed CI in the first place, but apparently #5041 broke a bunch of stuff somehow? my browser suddenly started complaining that you can't call `fetch` if it's a property of something that isn't `window`. seems like a weird constraint but who am i to judge.

no changeset because #5041 wasn't released yet, so no need

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
