### PR TITLE
disable local playwright tracing by default

### DIFF
--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -162,7 +162,7 @@ export const config = {
 	],
 	use: {
 		screenshot: 'only-on-failure',
-		trace: 'retain-on-failure',
+		trace: process.env.CI || process.env.TRACE ? 'retain-on-failure' : 'off',
 		// use stable chrome from host OS instead of downloading one
 		// see https://playwright.dev/docs/browsers#google-chrome--microsoft-edge
 		channel: 'chrome'


### PR DESCRIPTION
This PR disables playwright tracing on local e2e tests unless `process.env.TRACE` is enabled. Tracing has a performance impact, so it makes sense to only trace tests when we're interested in them.

An alternative would be to enable retries locally and use `trace: 'on-first-retry'` instead. This would be valuable if the majority of contributors use traces as a first debugging step, otherwise requiring manual activation (ie. this pr) might be best.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
