### PR TITLE
Update `engines` to specify that Node 16.7 is required

### DIFF
--- a/.changeset/tricky-beers-unite.md
+++ b/.changeset/tricky-beers-unite.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+Update `engines` to specify that Node 16.7 is required

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -77,6 +77,6 @@
 	},
 	"types": "types/index.d.ts",
 	"engines": {
-		"node": ">=16"
+		"node": ">=16.7"
 	}
 }


### PR DESCRIPTION
Necessary for https://nodejs.org/api/webcrypto.html