### PR TITLE
fix: Generated types no longer permanently delete themselves

### DIFF
--- a/.changeset/lemon-planets-sit.md
+++ b/.changeset/lemon-planets-sit.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] svelte-kit sync no longer permanently deletes the types directory

--- a/packages/kit/src/core/sync/utils.js
+++ b/packages/kit/src/core/sync/utils.js
@@ -17,6 +17,16 @@ export function write_if_changed(file, code) {
 	}
 }
 
+/**
+ * @param {string} file
+ * @param {string} code
+ */
+export function write(file, code) {
+	previous_contents.set(file, code);
+	mkdirp(path.dirname(file));
+	fs.writeFileSync(file, code);
+}
+
 /** @param {string} str */
 export function trim(str) {
 	const indentation = /** @type {RegExpExecArray} */ (/\n?(\s*)/.exec(str))[1];

--- a/packages/kit/src/core/sync/utils.js
+++ b/packages/kit/src/core/sync/utils.js
@@ -11,7 +11,7 @@ const previous_contents = new Map();
  */
 export function write_if_changed(file, code) {
 	if (code !== previous_contents.get(file)) {
-		write(file, code)
+		write(file, code);
 	}
 }
 

--- a/packages/kit/src/core/sync/utils.js
+++ b/packages/kit/src/core/sync/utils.js
@@ -11,9 +11,7 @@ const previous_contents = new Map();
  */
 export function write_if_changed(file, code) {
 	if (code !== previous_contents.get(file)) {
-		previous_contents.set(file, code);
-		mkdirp(path.dirname(file));
-		fs.writeFileSync(file, code);
+		write(file, code)
 	}
 }
 

--- a/packages/kit/src/core/sync/write_types.js
+++ b/packages/kit/src/core/sync/write_types.js
@@ -1,6 +1,6 @@
 import { rimraf } from '../../utils/filesystem.js';
 import { parse_route_id } from '../../utils/routing.js';
-import { write_if_changed } from './utils.js';
+import { write } from './utils.js';
 
 /** @param {string} imports */
 const header = (imports) => `
@@ -76,9 +76,6 @@ export function write_types(config, manifest_data) {
 		const parts = (key || 'index').split('/');
 		parts.push('__types', /** @type {string} */ (parts.pop()));
 
-		write_if_changed(
-			`${config.kit.outDir}/types/${parts.join('/')}.d.ts`,
-			content.join('\n').trim()
-		);
+		write(`${config.kit.outDir}/types/${parts.join('/')}.d.ts`, content.join('\n').trim());
 	});
 }


### PR DESCRIPTION
Fixes #5059.

`svelte-kit sync` always completely deletes the `types` directory when it writes types. Then, it re-writes types by looking for changed files. If no files have been changed, the `types` directory is gone for good (or at least until a file is changed). See the repro in the linked issue.

This fixes the issue by always rewriting all of the types (since we're deleting everything, we need to rewrite everything). I'm not really sure how to test this change, though this does fix the repro.

If there's some larger issue here that needs a bigger fix, feel free to just close this and move on!

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
