### PR TITLE
only recreate manifest when necessary

### DIFF
--- a/.changeset/thirty-bees-lay.md
+++ b/.changeset/thirty-bees-lay.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Only recreate manifest when files inside `config.kit.files.routes` are added or deleted

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -163,8 +163,13 @@ export async function create_plugin(config) {
 
 			update_manifest();
 
-			vite.watcher.on('add', update_manifest);
-			vite.watcher.on('unlink', update_manifest);
+			for (const event of ['add', 'unlink']) {
+				vite.watcher.on(event, (file) => {
+					if (file.startsWith(config.kit.files.routes + path.sep)) {
+						update_manifest();
+					}
+				});
+			}
 
 			const assets = config.kit.paths.assets ? SVELTE_KIT_ASSETS : config.kit.paths.base;
 			const asset_server = sirv(config.kit.files.assets, {

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -163,8 +163,11 @@ export async function create_plugin(config) {
 
 			update_manifest();
 
+			console.error(`config.kit.files.routes: ${config.kit.files.routes}`);
+
 			for (const event of ['add', 'unlink']) {
 				vite.watcher.on(event, (file) => {
+					console.error(`${event} ${file}`);
 					if (file.startsWith(config.kit.files.routes + path.sep)) {
 						update_manifest();
 					}

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -163,11 +163,8 @@ export async function create_plugin(config) {
 
 			update_manifest();
 
-			console.error(`config.kit.files.routes: ${config.kit.files.routes}`);
-
 			for (const event of ['add', 'unlink']) {
 				vite.watcher.on(event, (file) => {
-					console.error(`${event} ${file}`);
 					if (file.startsWith(config.kit.files.routes + path.sep)) {
 						update_manifest();
 					}


### PR DESCRIPTION
this fixes some local test failures that started following #5063 (that PR wasn't to blame, it just exposed the underlying issue)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
