### PR TITLE
Expose `caches` to Cloudflare adapter through Platform

### DIFF
--- a/.changeset/sixty-bees-explain.md
+++ b/.changeset/sixty-bees-explain.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': minor
+---
+
+Expose Cloudflare Worker Cache API through `caches` in Platform

--- a/packages/adapter-cloudflare/README.md
+++ b/packages/adapter-cloudflare/README.md
@@ -53,7 +53,7 @@ When configuring your project settings, you must use the following settings:
 
 ## Environment variables
 
-The [`env`](https://developers.cloudflare.com/workers/runtime-apis/fetch-event#parameters) object, containing KV namespaces etc, is passed to SvelteKit via the `platform` property along with `context`, meaning you can access it in hooks and endpoints:
+The [`env`](https://developers.cloudflare.com/workers/runtime-apis/fetch-event#parameters) object, containing KV namespaces etc, is passed to SvelteKit via the `platform` property along with `context` and `caches`, meaning you can access it in hooks and endpoints:
 
 ```diff
 // src/app.d.ts
@@ -66,7 +66,8 @@ declare namespace App {
 +		};
 +		context: {
 +			waitUntil(promise: Promise<any>): void;
-+		}
++		};
++		caches: CacheStorage & { default: Cache }
 +	}
 
 	interface Session {}

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -54,7 +54,7 @@ const worker = {
 			} else {
 				// dynamically-generated pages
 				res = await server.respond(req, {
-					platform: { env, context },
+					platform: { env, context, caches },
 					getClientAddress() {
 						return req.headers.get('cf-connecting-ip');
 					}


### PR DESCRIPTION
This PR exposes [Cloudflare's Worker Cache API](https://developers.cloudflare.com/workers/runtime-apis/cache/) as `caches` in the `platform` object. This allows hooks to do elaborate caching, for example, [I use the Cache API](https://github.com/modrinth/knossos/blob/1b34ce1fb906f400fac72e753244890aba87009e/src/adapter/files/worker.js#L63-L85) to cache certain pages based on request cookies.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
