### PR TITLE
[chore] specify `engines.node` version in templates

### DIFF
--- a/.changeset/slow-kiwis-arrive.md
+++ b/.changeset/slow-kiwis-arrive.md
@@ -1,0 +1,6 @@
+---
+'default-template': patch
+'create-svelte': patch
+---
+
+Specify a minimum Node version (>=16.7) in SvelteKit templates

--- a/packages/create-svelte/templates/default/package.template.json
+++ b/packages/create-svelte/templates/default/package.template.json
@@ -17,5 +17,8 @@
 	"dependencies": {
 		"@fontsource/fira-mono": "^4.5.0",
 		"cookie": "^0.4.1"
+	},
+	"engines": {
+		"node": ">=16.7"
 	}
 }

--- a/packages/create-svelte/templates/skeleton/package.template.json
+++ b/packages/create-svelte/templates/skeleton/package.template.json
@@ -13,5 +13,8 @@
 		"@sveltejs/kit": "workspace:*",
 		"svelte": "^3.44.0"
 	},
-	"type": "module"
+	"type": "module",
+	"engines": {
+		"node": ">=16.7"
+	}
 }


### PR DESCRIPTION
Follow-up to https://github.com/sveltejs/kit/pull/5062

SvelteKit now requires [Node >=16.7](https://github.com/sveltejs/kit/blob/91f7c99429afb45a05c2ed1da144a86d28441203/packages/kit/CHANGELOG.md#100-next344). It would be a nice for this to be explicitly specified via [`engines.node`](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines) in the `package.json`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
