### PR TITLE
robustify error handling

### DIFF
--- a/.changeset/dry-cars-dance.md
+++ b/.changeset/dry-cars-dance.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Reload page to recover from HMR errors

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -10,7 +10,7 @@
 	"homepage": "https://kit.svelte.dev",
 	"type": "module",
 	"dependencies": {
-		"@sveltejs/vite-plugin-svelte": "^1.0.0-next.44",
+		"@sveltejs/vite-plugin-svelte": "^1.0.0-next.46",
 		"chokidar": "^3.5.3",
 		"sade": "^1.7.4",
 		"vite": "^2.9.9"

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -512,6 +512,9 @@ export const svelte = function (svelte_config) {
 			...svelte_config.compilerOptions,
 			hydratable: !!svelte_config.kit.browser.hydrate
 		},
+		hot: {
+			optimistic: false
+		},
 		configFile: false
 	});
 };

--- a/packages/kit/src/core/dev/plugin.js
+++ b/packages/kit/src/core/dev/plugin.js
@@ -512,9 +512,6 @@ export const svelte = function (svelte_config) {
 			...svelte_config.compilerOptions,
 			hydratable: !!svelte_config.kit.browser.hydrate
 		},
-		hot: {
-			optimistic: false
-		},
 		configFile: false
 	});
 };

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -986,6 +986,12 @@ export function create_client({ target, session, base, trailing_slash }) {
 		return new Promise(() => {});
 	}
 
+	if (import.meta.hot) {
+		import.meta.hot.on('vite:beforeUpdate', () => {
+			if (current.error) location.reload();
+		});
+	}
+
 	return {
 		after_navigate: (fn) => {
 			onMount(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,7 +201,7 @@ importers:
 
   packages/kit:
     specifiers:
-      '@sveltejs/vite-plugin-svelte': ^1.0.0-next.44
+      '@sveltejs/vite-plugin-svelte': ^1.0.0-next.46
       '@types/connect': ^3.4.35
       '@types/cookie': ^0.5.0
       '@types/marked': ^4.0.1
@@ -221,7 +221,7 @@ importers:
       svelte: ^3.48.0
       vite: ^2.9.9
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 1.0.0-next.44_svelte@3.48.0+vite@2.9.9
+      '@sveltejs/vite-plugin-svelte': 1.0.0-next.46_svelte@3.48.0+vite@2.9.9
       chokidar: 3.5.3
       sade: 1.7.4
       vite: 2.9.9
@@ -1325,8 +1325,8 @@ packages:
       golden-fleece: 1.0.9
     dev: true
 
-  /@sveltejs/vite-plugin-svelte/1.0.0-next.44_svelte@3.48.0+vite@2.9.9:
-    resolution: {integrity: sha512-n+sssEWbzykPS447FmnNyU5GxEhrBPDVd0lxNZnxRGz9P6651LjjwAnISKr3CKgT9v8IybP8VD0n2i5XzbqExg==}
+  /@sveltejs/vite-plugin-svelte/1.0.0-next.46_svelte@3.48.0+vite@2.9.9:
+    resolution: {integrity: sha512-dumtaI5XusnDgXoQ3vxQAdoCaTWf8zKVezJdiTGjuaS/GSsmLIvtHUvMt0NlwEikPQ/hL53eIzMliRQ/j35w9w==}
     engines: {node: ^14.13.1 || >= 16}
     peerDependencies:
       diff-match-patch: ^1.0.5
@@ -1342,7 +1342,7 @@ packages:
       kleur: 4.1.4
       magic-string: 0.26.2
       svelte: 3.48.0
-      svelte-hmr: 0.14.11_svelte@3.48.0
+      svelte-hmr: 0.14.12_svelte@3.48.0
       vite: 2.9.9
     transitivePeerDependencies:
       - supports-color
@@ -5485,8 +5485,8 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-hmr/0.14.11_svelte@3.48.0:
-    resolution: {integrity: sha512-R9CVfX6DXxW1Kn45Jtmx+yUe+sPhrbYSUp7TkzbW0jI5fVPn6lsNG9NEs5dFg5qRhFNAoVdRw5qQDLALNKhwbQ==}
+  /svelte-hmr/0.14.12_svelte@3.48.0:
+    resolution: {integrity: sha512-4QSW/VvXuqVcFZ+RhxiR8/newmwOCTlbYIezvkeN6302YFRE8cXy0naamHcjz8Y9Ce3ITTZtrHrIL0AGfyo61w==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       svelte: '>=3.19.0'

--- a/turbo.json
+++ b/turbo.json
@@ -27,7 +27,9 @@
 			"outputs": []
 		},
 		"format": {},
-		"sync": {},
+		"sync": {
+			"outputs": [".svelte-kit/types/**", ".custom-out-dir/types/**"]
+		},
 		"test": {
 			"dependsOn": ["^build", "$CI", "$TURBO_CACHE_KEY"],
 			"outputs": []


### PR DESCRIPTION
Currently, if you introduce an error into a component that causes rendering to fail...

```svelte
<p>{this_variable_does_not_exist}</p>
```

...fixing the component won't cause the page to recover, because Svelte itself is now in a broken state. (We plan to make Svelte more resilient to this sort of thing, but it's a ways off.) Adding `hot.optimistic: false` to the `vite-plugin-svelte` options causes the page to reload on HMR updates after a rendering error is encountered.

That solves half the problem. If the page reloads and it's _still_ broken, the server will render an error page. Since the error page generally won't use the component where the error was, subsequent HMR updates will be ignored, so fixing the component won't cause the error page to go away.

I think a reasonable way to fix that is to _always_ reload the page when an HMR update occurs, _if you're on an error page_.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
