### PR TITLE
Update adapter entrypoint typings to be NodeNext/ESNext-compatible.

### DIFF
--- a/.changeset/lemon-timers-deliver.md
+++ b/.changeset/lemon-timers-deliver.md
@@ -1,0 +1,11 @@
+---
+"@sveltejs/adapter-auto": patch
+"@sveltejs/adapter-cloudflare-workers": patch
+"@sveltejs/adapter-cloudflare": patch
+"@sveltejs/adapter-netlify": patch
+"@sveltejs/adapter-node": patch
+"@sveltejs/adapter-static": patch
+"@sveltejs/adapter-vercel": patch
+---
+
+Update adapter entrypoint typings to be NodeNext/ESNext-compatible.

--- a/.changeset/lemon-timers-deliver.md
+++ b/.changeset/lemon-timers-deliver.md
@@ -8,4 +8,4 @@
 "@sveltejs/adapter-vercel": patch
 ---
 
-Update adapter entrypoint typings to be NodeNext/ESNext-compatible.
+Update adapter entrypoint typings to be NodeNext/ESNext-compatible

--- a/packages/adapter-auto/index.d.ts
+++ b/packages/adapter-auto/index.d.ts
@@ -1,4 +1,3 @@
 import { Adapter } from '@sveltejs/kit';
 
-declare function plugin(): Adapter;
-export = plugin;
+export default function plugin(): Adapter;

--- a/packages/adapter-auto/index.js
+++ b/packages/adapter-auto/index.js
@@ -1,6 +1,6 @@
 import { adapters } from './adapters.js';
 
-/** @type {import('./index')} */
+/** @type {import('./index').default} */
 let fn;
 
 for (const candidate of adapters) {

--- a/packages/adapter-cloudflare-workers/index.d.ts
+++ b/packages/adapter-cloudflare-workers/index.d.ts
@@ -1,4 +1,3 @@
 import { Adapter } from '@sveltejs/kit';
 
-declare function plugin(): Adapter;
-export = plugin;
+export default function plugin(): Adapter;

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -14,7 +14,7 @@ import { fileURLToPath } from 'url';
  * }} WranglerConfig
  */
 
-/** @type {import('.')} */
+/** @type {import('.').default} */
 export default function (options = {}) {
 	return {
 		name: '@sveltejs/adapter-cloudflare-workers',

--- a/packages/adapter-cloudflare/index.d.ts
+++ b/packages/adapter-cloudflare/index.d.ts
@@ -1,4 +1,3 @@
 import { Adapter } from '@sveltejs/kit';
 
-declare function plugin(): Adapter;
-export = plugin;
+export default function plugin(): Adapter;

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -3,7 +3,7 @@ import { posix } from 'path';
 import { fileURLToPath } from 'url';
 import * as esbuild from 'esbuild';
 
-/** @type {import('.')} */
+/** @type {import('.').default} */
 export default function (options = {}) {
 	return {
 		name: '@sveltejs/adapter-cloudflare',

--- a/packages/adapter-netlify/index.d.ts
+++ b/packages/adapter-netlify/index.d.ts
@@ -1,5 +1,3 @@
 import { Adapter } from '@sveltejs/kit';
 
-declare function plugin(opts?: { split?: boolean; edge?: boolean }): Adapter;
-
-export = plugin;
+export default function plugin(opts?: { split?: boolean; edge?: boolean }): Adapter;

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -34,7 +34,7 @@ const edge_set_in_env_var =
 	process.env.NETLIFY_SVELTEKIT_USE_EDGE === 'true' ||
 	process.env.NETLIFY_SVELTEKIT_USE_EDGE === '1';
 
-/** @type {import('.')} */
+/** @type {import('.').default} */
 export default function ({ split = false, edge = edge_set_in_env_var } = {}) {
 	return {
 		name: '@sveltejs/adapter-netlify',

--- a/packages/adapter-node/index.d.ts
+++ b/packages/adapter-node/index.d.ts
@@ -10,5 +10,4 @@ interface AdapterOptions {
 	envPrefix?: string;
 }
 
-declare function plugin(options?: AdapterOptions): Adapter;
-export = plugin;
+export default function plugin(options?: AdapterOptions): Adapter;

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -9,7 +9,7 @@ const pipe = promisify(pipeline);
 
 const files = fileURLToPath(new URL('./files', import.meta.url).href);
 
-/** @type {import('.')} */
+/** @type {import('.').default} */
 export default function (opts = {}) {
 	// TODO remove for 1.0
 	// @ts-expect-error

--- a/packages/adapter-static/index.d.ts
+++ b/packages/adapter-static/index.d.ts
@@ -7,5 +7,4 @@ interface AdapterOptions {
 	precompress?: boolean;
 }
 
-declare function plugin(options?: AdapterOptions): Adapter;
-export = plugin;
+export default function plugin(options?: AdapterOptions): Adapter;

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -6,7 +6,7 @@ import zlib from 'zlib';
 
 const pipe = promisify(pipeline);
 
-/** @type {import('.')} */
+/** @type {import('.').default} */
 export default function ({ pages = 'build', assets = pages, fallback, precompress = false } = {}) {
 	return {
 		name: '@sveltejs/adapter-static',

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -6,5 +6,4 @@ type Options = {
 	split?: boolean;
 };
 
-declare function plugin(options?: Options): Adapter;
-export = plugin;
+export default function plugin(options?: Options): Adapter;

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -83,7 +83,7 @@ const redirects = {
 
 const files = fileURLToPath(new URL('./files', import.meta.url).href);
 
-/** @type {import('.')} **/
+/** @type {import('.').default} **/
 export default function ({ external = [], edge, split } = {}) {
 	return {
 		name: '@sveltejs/adapter-vercel',


### PR DESCRIPTION
As discussed in #5110, the entry `index.d.ts` files of the adapters all use a node-resolution-compatible export syntax like this:

```ts
 declare function plugin(): Adapter; 
 export = plugin; 
```

However, all of these packages use ESM (instead of CommonJS) so they can instead use:

```ts
export default function plugin(): Adapter;
```

Making this change resolves a Typescript 4.7+ error where `import adapter from '@sveltejs/adapter-auto';` throws a compiler error when the `tsconfig.json` is configured with `moduleResolution` set to `NodeNext` or `ESNext`.

To make this change, all of the `index.js` files that import these types have to have their JSDoc import statements changed to explicitly grab the `default` export. E.g. `/** @type {import('.')} **/` ➡️ `/** @type {import('.').default} **/`.

Since these packages are already modules these typings are more technically correct, though it's possible that this change will result in new Typescript errors for some compiler configurations. With Typescript 4.8 (dev), I can confirm that this change results in no errors with either of the following `tsconfig` configurations:

```jsonc
// Node resolution and ES2020 targets
"compilerOptions":{
    "target": "ES2020",
    "lib": ["ES2020"],
    "module": "ES2020",
    "moduleResolution": "Node",
}
```

```jsonc
// NodeNext resolution and ESNext targtes
"compilerOptions":{
    "target": "ESNext",
    "lib": ["ESNext"],
    "module": "ESNext",
    "moduleResolution": "NodeNext",
}
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

> ⚠️ My test environment didn't have Chrome, so those tests did not pass.

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
