### PR TITLE
recurse whole object

### DIFF
--- a/.changeset/nine-rats-bake.md
+++ b/.changeset/nine-rats-bake.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix `BodyValidator` handling for nested object literals

--- a/packages/kit/test/typings/endpoint.test.ts
+++ b/packages/kit/test/typings/endpoint.test.ts
@@ -104,6 +104,23 @@ export const nested_interfaces: RequestHandler<Record<string, string>, ParentWra
 	};
 };
 
+interface NestedLiteral {
+	date: {
+		published: string;
+		updated?: string;
+		time: {
+			hour: number;
+			min: number;
+			sec?: number;
+		};
+	};
+}
+export const nested_literal: RequestHandler<Record<string, string>, NestedLiteral> = () => {
+	return {
+		body: {} as NestedLiteral
+	};
+};
+
 // --- invalid cases ---
 
 // @ts-expect-error - bigint cannot be converted to JSON string

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -27,8 +27,8 @@ export interface AdapterEntry {
 }
 
 export type BodyValidator<T> = {
-	[P in keyof T]: T[P] extends { [k: string]: infer V }
-		? BodyValidator<V> // recurse when T[P] is an object
+	[P in keyof T]: T[P] extends { [k: string]: unknown }
+		? BodyValidator<T[P]> // recurse when T[P] is an object
 		: T[P] extends BigInt | Function | Symbol
 		? never
 		: T[P];


### PR DESCRIPTION
We shouldn't be spreading the values but instead pass in the whole object or information would be lost when recursing. This was my mistake.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
