### PR TITLE
[docs] fallback clarification

### DIFF
--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -54,7 +54,7 @@ You can use `adapter-static` to create a single-page app or SPA by specifying a 
 
 > In most situations this is not recommended: it harms SEO, tends to slow down perceived performance, and makes your app inaccessible to users if JavaScript fails or is disabled (which happens [more often than you probably think](https://kryogenix.org/code/browser/everyonehasjs.html)).
 
-The fallback page is an HTML page created by SvelteKit that loads your app and navigates to the correct route. For example [Surge](https://surge.sh/help/adding-a-200-page-for-client-side-routing), a static web host, lets you add a `200.html` file that will handle any requests that don't otherwise match. We can create that file like so:
+The fallback page is an HTML page created by SvelteKit that loads your app and navigates to the correct route. For example [Surge](https://surge.sh/help/adding-a-200-page-for-client-side-routing), a static web host, lets you add a `200.html` file that will handle any requests that aren't handled outside the SvelteKit application. We can create that file like so:
 
 ```js
 // svelte.config.js


### PR DESCRIPTION
It's not quite clear what "don't otherwise match" is referring to and possibly sounds like it's the application's 404 page. I changed it as you can see in the diff to keep the current sentiment, but I wonder if even that is more detail than is needed and we should simply say something like "will handle any requests to the application"