### PR TITLE
fix: use inline element in heading

### DIFF
--- a/.changeset/clean-spiders-sin.md
+++ b/.changeset/clean-spiders-sin.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+[fix] use inline element in heading

--- a/packages/create-svelte/templates/default/src/routes/index.svelte
+++ b/packages/create-svelte/templates/default/src/routes/index.svelte
@@ -13,12 +13,12 @@
 
 <section>
 	<h1>
-		<div class="welcome">
+		<span class="welcome">
 			<picture>
 				<source srcset="svelte-welcome.webp" type="image/webp" />
 				<img src="svelte-welcome.png" alt="Welcome" />
 			</picture>
-		</div>
+		</span>
 
 		to your new<br />SvelteKit app
 	</h1>
@@ -44,6 +44,7 @@
 	}
 
 	.welcome {
+		display: block;
 		position: relative;
 		width: 100%;
 		height: 0;


### PR DESCRIPTION
Just created my first project with svelte kit and came across this minor issue. div is not allowed as a child for heading, changed it to span.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
