### PR TITLE
Added info for using yarn berry with yarn 3.2.1

### DIFF
--- a/documentation/faq/80-integrations.md
+++ b/documentation/faq/80-integrations.md
@@ -129,8 +129,8 @@ yarn install
 
 **Yarn 3 global cache**
 
-One of the more interesting features of Yarn Berry is the ability to have a single global cache for packages, instead of having multiple copies for each project on the disk. However, setting **enableGlobalCache** to true causes building to fail, so it is recommended to add the following to the `.yarnrc.yml` file:
+One of the more interesting features of Yarn Berry is the ability to have a single global cache for packages, instead of having multiple copies for each project on the disk. However, setting `enableGlobalCache` to true causes building to fail, so it is recommended to add the following to the `.yarnrc.yml` file:
 ```
 nodeLinker: node-modules
 ```
-This will cause packages to be downloaded into a local node_modules directory but avoids the above problem and is you're best bet for using version 3 of yarn at this point in time.
+This will cause packages to be downloaded into a local node_modules directory but avoids the above problem and is your best bet for using version 3 of Yarn at this point in time.


### PR DESCRIPTION
Hi,
I had a quick look around at seeing if I could use yarn berry with enableGlobalCache set to true.
I think yarn berry is generally discouraged although I've managed to I think get it working ok with a small change to the svelte.config.js

I suspect there's been some changes to yarn version 3 which now allows it to work (or at least allows the demo app to work)
This bug doesn't seem to exist anymore https://github.com/sveltejs/kit/issues/2393

Also spotted these related to berry
  * https://github.com/sveltejs/kit/issues/993
  * https://github.com/sveltejs/kit/issues/1557

Currently I'm using Windows and yarn version 3.2.1
