### PR TITLE
fix: URL instance methods work in `load`

### DIFF
--- a/.changeset/popular-pets-obey.md
+++ b/.changeset/popular-pets-obey.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] URL instance methods now work in `load`

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2,7 +2,7 @@ import { onMount, tick } from 'svelte';
 import { writable } from 'svelte/store';
 import { coalesce_to_error } from '../../utils/error.js';
 import { normalize } from '../load.js';
-import { normalize_path } from '../../utils/url.js';
+import { LoadURL, normalize_path } from '../../utils/url.js';
 import {
 	create_updated_store,
 	find_anchor,
@@ -527,6 +527,7 @@ export function create_client({ target, session, base, trailing_slash }) {
 		}
 
 		const session = $session;
+		const load_url = new LoadURL(url);
 
 		if (module.load) {
 			/** @type {import('types').LoadEvent} */
@@ -536,18 +537,6 @@ export function create_client({ target, session, base, trailing_slash }) {
 				props: props || {},
 				get url() {
 					node.uses.url = true;
-					const load_url = new URL(url);
-
-					// We could use a Proxy here, but it causes weird effects.
-					// See: https://github.com/sveltejs/kit/issues/5083
-					Object.defineProperty(load_url, 'hash', {
-						get: () => {
-							throw new Error(
-								'url.hash is inaccessible from load. Consider accessing hash from the page store within the script tag of your component.'
-							);
-						}
-					});
-
 					return load_url;
 				},
 				get session() {

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -536,18 +536,19 @@ export function create_client({ target, session, base, trailing_slash }) {
 				props: props || {},
 				get url() {
 					node.uses.url = true;
+					const load_url = new URL(url);
 
-					return new Proxy(url, {
-						get: (target, property) => {
-							if (property === 'hash') {
-								throw new Error(
-									'url.hash is inaccessible from load. Consider accessing hash from the page store within the script tag of your component.'
-								);
-							}
-
-							return Reflect.get(target, property, target);
+					// We could use a Proxy here, but it causes weird effects.
+					// See: https://github.com/sveltejs/kit/issues/5083
+					Object.defineProperty(load_url, 'hash', {
+						get: () => {
+							throw new Error(
+								'url.hash is inaccessible from load. Consider accessing hash from the page store within the script tag of your component.'
+							);
 						}
 					});
+
+					return load_url;
 				},
 				get session() {
 					node.uses.session = true;

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -4,6 +4,7 @@ import { normalize } from '../../load.js';
 import { respond } from '../index.js';
 import { is_root_relative, resolve } from '../../../utils/url.js';
 import { create_prerendering_url_proxy } from './utils.js';
+import { LoadURL } from '../../../utils/url.js';
 import { is_pojo, lowercase_keys, normalize_request_method } from '../utils.js';
 import { coalesce_to_error } from '../../../utils/error.js';
 import { domain_matches, path_matches } from './cookie.js';
@@ -84,7 +85,7 @@ export async function load_node({
 	} else if (module.load) {
 		/** @type {import('types').LoadEvent} */
 		const load_input = {
-			url: state.prerendering ? create_prerendering_url_proxy(event.url) : event.url,
+			url: state.prerendering ? create_prerendering_url_proxy(event.url) : new LoadURL(event.url),
 			params: event.params,
 			props: shadow.body || {},
 			routeId: event.routeId,

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -52,3 +52,12 @@ export function normalize_path(path, trailing_slash) {
 
 	return path;
 }
+
+export class LoadURL extends URL {
+	/** @returns {string} */
+	get hash() {
+		throw new Error(
+			'url.hash is inaccessible from load. Consider accessing hash from the page store within the script tag of your component.'
+		);
+	}
+}

--- a/packages/kit/test/apps/basics/src/routes/load/url-to-string.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/url-to-string.svelte
@@ -1,6 +1,6 @@
 <script context="module">
 	export const load = ({ url }) => {
-		const str = url.toString();
+		url.toString();
 		return {};
 	};
 </script>

--- a/packages/kit/test/apps/basics/src/routes/load/url-to-string.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/url-to-string.svelte
@@ -1,0 +1,8 @@
+<script context="module">
+	export const load = ({ url }) => {
+		const str = url.toString();
+		return {};
+	};
+</script>
+
+<h1>I didn't break!</h1>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1516,6 +1516,13 @@ test.describe.parallel('Load', () => {
 		}
 	});
 
+	test('url instance methods work in load', async ({ page, javaScriptEnabled }) => {
+		if (javaScriptEnabled) {
+			await page.goto('/load/url-to-string');
+			expect(await page.textContent('h1')).toBe("I didn't break!");
+		}
+	});
+
 	test('using window.fetch causes a warning', async ({ page, javaScriptEnabled }) => {
 		if (javaScriptEnabled && process.env.DEV) {
 			const warnings = [];


### PR DESCRIPTION
Fixes #5083.

This is the "surgical approach" -- just replace the `hash` property with a custom getter. The other option is (if we're really committed to using a Proxy):

```typescript
new Proxy(url, {
    get: (target, property, receiver) => {
        if (property === 'hash') {
            throw new Error(
                'url.hash is inaccessible from load. Consider accessing hash from the page store within the script tag of your component.'
            );
        }

        if (!(property in target)) {
          return undefined;
        }
        const value = target[property];
        return typeof value === "function"
          ? (...args) => value.apply(target, args)
          : value;
    }
});
```

This scares me a little bit, because it's a lot harder to anticipate what other side effects it might exhibit. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
