### PR TITLE
[docs] update wrangler.toml example to wrangler@2

### DIFF
--- a/.changeset/hip-kangaroos-check.md
+++ b/.changeset/hip-kangaroos-check.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+---
+
+Simplify example wrangler.toml, and fix outdated README

--- a/packages/adapter-cloudflare-workers/README.md
+++ b/packages/adapter-cloudflare-workers/README.md
@@ -43,35 +43,32 @@ Generate this file using `wrangler` from your project directory
 wrangler init --site my-site-name
 ```
 
-Now you should get some details from Cloudflare. You should get your:
-
-1. Account ID
-2. And your Zone-ID (Optional)
+Now you should get some details from Cloudflare. You should get your Account ID.
 
 Get them by visiting your [Cloudflare dashboard](https://dash.cloudflare.com) and click on any domain. There, you can scroll down and on the left, you can see your details under **API**.
 
-Then configure your sites build directory and your account-details in the config file:
+Then configure your sites build directory and your account-details in the
+config file:
 
 ```toml
+main = "./worker.mjs"
 account_id = 'YOUR ACCOUNT_ID'
-zone_id    = 'YOUR ZONE_ID' # optional, if you don't specify this a workers.dev subdomain will be used.
 
-type = "javascript"
+# A compatibility_date is required when publishing. Add one to your
+# wrangler.toml file, or pass it in your terminal as --compatibility-date
+compatibility_date = '2022-06-09'
 
 [build]
-# Assume it's already been built. You can make this "npm run build" to ensure a build before publishing
+# Assume it's already been built. You can make this "npm run build" to ensure a
+# build before publishing
 command = ""
-
-[build.upload]
-format = "modules"
-main = "./worker.mjs"
 
 [site]
 bucket = "./.cloudflare/assets"
-entry-point = "./.cloudflare/worker"
 ```
 
-It's recommended that you add the `build` and `workers-site` folders (or whichever other folders you specify) to your `.gitignore`.
+It's recommended that you add the `build` and `workers-site` folders
+(or whichever other folders you specify) to your `.gitignore`.
 
 Now, log in with wrangler:
 

--- a/packages/adapter-cloudflare-workers/README.md
+++ b/packages/adapter-cloudflare-workers/README.md
@@ -33,58 +33,41 @@ export default {
 
 ## Basic Configuration
 
-**You will need [Wrangler](https://developers.cloudflare.com/workers/cli-wrangler/install-update) installed on your system**
-
-This adapter expects to find a [wrangler.toml](https://developers.cloudflare.com/workers/platform/sites/configuration) file in the project root. It will determine where to write static assets and the worker based on the `site.bucket` and `site.entry-point` settings.
-
-Generate this file using `wrangler` from your project directory
-
-```sh
-wrangler init --site my-site-name
-```
-
-Now you should get some details from Cloudflare. You should get your Account ID.
-
-Get them by visiting your [Cloudflare dashboard](https://dash.cloudflare.com) and click on any domain. There, you can scroll down and on the left, you can see your details under **API**.
-
-Then configure your sites build directory and your account-details in the
-config file:
+This adapter expects to find a [wrangler.toml](https://developers.cloudflare.com/workers/platform/sites/configuration) file in the project root. It should look something like this:
 
 ```toml
-main = "./worker.mjs"
-account_id = 'YOUR ACCOUNT_ID'
+name = "<your-service-name>"
+account_id = "<your-account-id>"
 
-# A compatibility_date is required when publishing. Add one to your
-# wrangler.toml file, or pass it in your terminal as --compatibility-date
-compatibility_date = '2022-06-09'
+main = "./.cloudflare/worker.js"
+site.bucket = "./.cloudflare/public"
 
-[build]
-# Assume it's already been built. You can make this "npm run build" to ensure a
-# build before publishing
-command = ""
+build.command = "npm run build"
 
-[site]
-bucket = "./.cloudflare/assets"
+compatibility_date = "2021-11-12"
+workers_dev = true
 ```
 
-It's recommended that you add the `build` and `workers-site` folders
-(or whichever other folders you specify) to your `.gitignore`.
+`<your-service-name>` can be anything. `<your-account-id>` can be found by logging into your [Cloudflare dashboard](https://dash.cloudflare.com) and grabbing it from the end of the URL:
 
-Now, log in with wrangler:
+```
+https://dash.cloudflare.com/<your-account-id>
+```
 
-```sh
+> It's recommended that you add the `.cloudflare` directory (or whichever directories you specified for `main` and `site.bucket`) to your `.gitignore`.
+
+You will need to install [wrangler](https://developers.cloudflare.com/workers/wrangler/get-started/) and log in, if you haven't already:
+
+```
+npm i -g wrangler
 wrangler login
 ```
 
-Build your project and publish it:
+Then, you can build your app and deploy it:
 
 ```sh
-npm run build && wrangler publish
+wrangler publish
 ```
-
-**You are done!**
-
-More info on configuring a cloudflare worker site can be found [here](https://developers.cloudflare.com/workers/platform/sites/start-from-existing)
 
 ## Changelog
 

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -116,7 +116,6 @@ function validate_config(builder) {
 
 		name = "<your-site-name>"
 		account_id = "<your-account-id>"
-		route = "<your-route>"
 
 		main = "./.cloudflare/worker.js"
 		site.bucket = "./.cloudflare/public"


### PR DESCRIPTION
Updates the example provided for `wrangler.toml` file for
the `adapter-cloudflare-workers` documentation, to follow
the specs on wrangler@2.

Changes from Cloudflare include:

- The `type` key is no longer needed.
- The `zone_id` is unnecessary since they can deduce this from routes directly.
- The `compatibility_date` is required when publishing.
- The `main` key belongs to the global scope, instead of the `build.upload` section
- The `format` key  is inferred automatically from the code.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
