### PR TITLE
Exposing event to load(), and removing the automatic header forwarding

### DIFF
--- a/.changeset/khaki-ways-applaud.md
+++ b/.changeset/khaki-ways-applaud.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+Exposing the event to server-side load() and removing the automatic header forwarding on th modded fetch()

--- a/documentation/docs/04-loading.md
+++ b/documentation/docs/04-loading.md
@@ -50,7 +50,7 @@ It is recommended that you not store per-request state in global variables, but 
 
 ### Input
 
-The `load` function receives an object containing eight fields — `url`, `params`, `props`, `fetch`, `session`, `stuff`, `status`, and `error`. The `load` function is reactive, and will re-run when its parameters change, but only if they are used in the function. Specifically, if `url`, `session` or `stuff` are used in the function, they will be re-run whenever their value changes, and likewise for the individual properties of `params`.
+The `load` function receives an object containing nine fields — `url`, `params`, `props`, `fetch`, `session`, `stuff`, `status`, `error`, and `event`. The `load` function is reactive, and will re-run when its parameters change, but only if they are used in the function. Specifically, if `url`, `session` or `stuff` are used in the function, they will be re-run whenever their value changes, and likewise for the individual properties of `params`.
 
 > Note that destructuring parameters in the function declaration is enough to count as using them.
 
@@ -104,6 +104,10 @@ If the page you're loading has an endpoint, the data returned from it is accessi
 #### error
 
 `error` is the error that was thrown (or returned from a previous `load`) when rendering an error page, or `null` otherwise.
+
+#### event
+
+`event` represents the incoming request. This will be null on the client.
 
 ### Output
 

--- a/documentation/docs/04-loading.md
+++ b/documentation/docs/04-loading.md
@@ -159,3 +159,7 @@ The combined `stuff` is available to components using the [page store](/docs/mod
 An array of strings representing URLs the page depends on, which can subsequently be used with [`invalidate`](/docs/modules#$app-navigation-invalidate) to cause `load` to rerun. You only need to add them to `dependencies` if you're using a custom API client; URLs loaded with the provided `fetch` function are added automatically.
 
 URLs can be absolute or relative to the page being loaded, and must be [encoded](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding).
+
+#### set_cookies
+
+An array of strings, each in standard cookie form with key/value and semicolon delimited attributes, e.g. "cookie1=value;maxage=3600;path=/".

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -597,7 +597,8 @@ export function create_client({ target, session, base, trailing_slash }) {
 					return started ? native_fetch(normalized, init) : initial_fetch(requested, init);
 				},
 				status: status ?? null,
-				error: error ?? null
+				error: error ?? null,
+				event: null
 			};
 
 			if (import.meta.env.DEV) {

--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -342,7 +342,8 @@ export async function load_node({
 			},
 			stuff: { ...stuff },
 			status: is_error ? status ?? null : null,
-			error: is_error ? error ?? null : null
+			error: is_error ? error ?? null : null,
+			event
 		};
 
 		if (options.dev) {

--- a/packages/kit/test/apps/basics/src/routes/load/set-cookie-fetch/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/set-cookie-fetch/index.svelte
@@ -4,8 +4,11 @@
 		const res = await fetch('/load/set-cookie-fetch/b.json');
 		const { answer } = await res.json(); // need to read the response so it gets serialized
 
+		const set_cookie = res.headers.get('set-cookie');
+
 		return {
-			props: { answer }
+			props: { answer },
+			set_cookies: set_cookie ? [ set_cookie ] : []
 		};
 	}
 </script>

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -211,6 +211,7 @@ export interface LoadOutput<Props extends Record<string, any> = Record<string, a
 	stuff?: Partial<App.Stuff>;
 	cache?: LoadOutputCache;
 	dependencies?: string[];
+	set_cookies?: string[];
 }
 
 export interface LoadOutputCache {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -200,6 +200,7 @@ export interface LoadEvent<
 	url: URL;
 	status: number | null;
 	error: Error | null;
+	event: RequestEvent | null;
 }
 
 export interface LoadOutput<Props extends Record<string, any> = Record<string, any>> {

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -120,6 +120,7 @@ export type NormalizedLoadOutput = {
 	stuff?: Record<string, any>;
 	cache?: NormalizedLoadOutputCache;
 	dependencies?: string[];
+	set_cookies?: string[];
 };
 
 export interface NormalizedLoadOutputCache {


### PR DESCRIPTION
Fixes #3503 Fixes #696
Reverts #3631 Reverts #835

Okay this is the last one of my SvelteKit wishlist items. Not sure what you'll think but it certainly makes sense to me.

This does two things, each in its own commit.

1. Exposes `event` to the load() function
2. Reverts and deletes all the logic related to passing headers and cookies to the upstream service calls.

#3631 was clearly a mistake. If we have a network call graph that looks something like this:

![Screen Shot 2022-05-30 at 9 38 42 PM](https://user-images.githubusercontent.com/32530010/171093973-0cc0d337-0fff-4232-8e96-d9084d74692f.png)

It doesn't make any sense for the Node service to pretend to be a browser. Some of the reasons:

* You're lying about the user agent. If you passed one at all it should be, perhaps, `node/sveltekit` or something
* You're passing headers unidirectionally, sending them out but but not sending the response headers back to the browser, because of course that wouldn't make any sense. The calls are many to one so what should you do, merge them?
* The type is different (HTML vs most likely JSON), so the `accept` header could be wrong
* Some of the headers are nonsensical for service-to-service calls, like `referer` which is a browser concern

There just seems to be some confusion and it seems like people are considering calls A-C in the graph to be the Z call proxied onward. When in fact those calls are unrelated to call Z, except that call Z is the reason calls A-C are being made.

But then even with all the complexity, we still can't pass along the most important information: the auth cookies. To get the full details of the incoming request you have to use an endpoint (or a hook). Endpoints should be a feature you can use if you want but shouldn't be mandatory.

In a more ops-driven, "close to the metal" kind of enterprise setup, our frontend services live among a constellation of other services, both in front as reverse proxies, and behind as upstream services. In this world things like SSL termination and endpoints are simply not wanted or needed. In this world if we want to avoid the moving target of CORS and serve our data on the same domain as our HTML, we simply put a reverse proxy in front and split traffic.

What this change does is restores control. If you want to call your backend services and spoof like you're a browser, you can do so! Copy all your headers over. If you want to forward a backend service's "set-cookie" directive to the browser, go ahead. But if you do nothing the calls to the backends get no headers, just as if you made a curl call, which seems like a pretty reasonable thing to do by default.

Here's some examples:

```javascript
export default async function load({ event, params, fetch }) {
  let response = await fetch('https://a.backend.com/data/' + event.id, {
    headers: {
      // Use end user credentials
      // You could parse the cookie string and slice out a specific auth cookie, or
      // or just pass the whole darn thing.
      cookie: event?.request.headers.get('cookie'), // only relevant server-side
      credentials: 'include', // only relevant client-side
    },
  });
  ...
}
```

If your backend sets a cookie and you want to set the same cookie in the browser, there's no way to do that explicitly, and I stripped out the automatic logic for that because, hey, making service calls shouldn't have side effects. You get the data, you do what you want with the data, end of story. So I extended some interfaces with a `set_cookies` string array.

```javascript
export default async function load({ event, params, fetch }) {
  let response = await fetch('https://a.backend.com/data/' + event.id, {
    headers: {
      cookie: event?.request.headers.get('cookie'), // only relevant server-side
      credentials: 'include', // only relevant client-side
    },
  });
  let data = await response.json();
  let set_cookie = response.headers.get('set-cookie');
  return {
    props: {
      widgets: data.widgets
    },
    set_cookies: set_cookie && [set_cookie],
}
```

**More rationale:** Even in the demo TODO app, you need access to the user's cookies to make the backend call. I know that backend is slated for removal in #4264 but as long as it remains it does prove a point. In my repro case for #4902 I have code like this:

https://github.com/johnnysprinkles/sveltekit_after_navigate_bug/commit/53dd01ad7f4f07cd1e5cfc31fb2782048ff258d1#diff-87b424ffe45157388b79be6ab8b5f706a521128cf102a15a3b58f480f4411a85R27

where I have to put the userid in session because there's no way to read it from the request in `load()`. If you don't want to put it in session and you don't want to use an endpoint, you're currently out of luck.

Anyway, I hope this might at least provoke some discussion. I know this goes against a SvelteKit value of abstracting away the differences between client and server, but that abstraction is kind of a fiction anyway.

Also, I have no idea how much this would break. Shadow endpoints? Various adapters?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
