### PR TITLE
fix FAQ h1 spacing

### DIFF
--- a/sites/kit.svelte.dev/src/routes/faq/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/faq/index.svelte
@@ -79,8 +79,8 @@
 	}
 
 	h2 {
-		margin: -4rem 0 1rem 0;
-		padding-top: 10rem;
+		margin: 0rem 0 1rem 0;
+		padding-top: 6rem;
 		padding-bottom: 0.2rem;
 		color: var(--text);
 		/* max-width: 24em; */


### PR DESCRIPTION
## This PR is not important as it is fixing a UX issue on the FAQ page. 
Texts were not selectable as the H1 had a negative margin (Not a good practice)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
