### PR TITLE
use touchend instead of touchstart

### DIFF
--- a/sites/kit.svelte.dev/src/lib/search/Search.svelte
+++ b/sites/kit.svelte.dev/src/lib/search/Search.svelte
@@ -15,7 +15,7 @@
 			e.target.value = '';
 		}}
 		on:mousedown|preventDefault={() => ($searching = true)}
-		on:touchstart|preventDefault={() => ($searching = true)}
+		on:touchend|preventDefault={() => ($searching = true)}
 		type="search"
 		name="q"
 		placeholder="Search"


### PR DESCRIPTION
we get dinged on lighthouse for not using a passive event listener. we _can't_ make the `touchstart` passive because we need to prevent the event default (otherwise the input gets focused, which we don't want); this seems like the best alternative

<img width="812" alt="image" src="https://user-images.githubusercontent.com/1162160/174704424-033c185f-e908-44a2-a830-e9b4f0a71743.png">
