### PR TITLE
fix some tests that fail locally

### DIFF
--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1,7 +1,5 @@
 import fs from 'fs';
 import path from 'path';
-import http from 'http';
-import * as ports from 'port-authority';
 import { expect } from '@playwright/test';
 import { fileURLToPath } from 'url';
 import { start_server, test } from '../../../utils.js';

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1405,12 +1405,11 @@ test.describe.parallel('Load', () => {
 
 	test('handles external api', async ({ page }) => {
 		await page.goto('/load');
-		const port = await ports.find(5000);
 
 		/** @type {string[]} */
 		const requested_urls = [];
 
-		const server = http.createServer(async (req, res) => {
+		const { port, server } = await start_server(async (req, res) => {
 			if (!req.url) throw new Error('Incomplete request');
 			requested_urls.push(req.url);
 
@@ -1425,10 +1424,6 @@ test.describe.parallel('Load', () => {
 				res.statusCode = 404;
 				res.end('not found');
 			}
-		});
-
-		await new Promise((fulfil) => {
-			server.listen(port, () => fulfil(undefined));
 		});
 
 		await page.goto(`/load/server-fetch-request?port=${port}`);

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -182,7 +182,7 @@ export async function start_server(handler, start = 4000) {
 	const server = http.createServer(handler);
 
 	await new Promise((fulfil) => {
-		server.listen(port, () => fulfil(undefined));
+		server.listen(port, 'localhost', () => fulfil(undefined));
 	});
 
 	return { port, server };


### PR DESCRIPTION
The test suite recently started failing for me locally — turns out the Control Center app on Monterey likes to occupy port 5000. Not sure why this only started happening recently. Anyway, this seems to get things running again

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
