### PR TITLE
feat: Added "server" and "prod" env variables

### DIFF
--- a/packages/kit/src/runtime/app/env.js
+++ b/packages/kit/src/runtime/app/env.js
@@ -1,4 +1,8 @@
 /**
+ * @type {import('$app/env').server}
+ */
+ export const server = !!import.meta.env.SSR;
+/**
  * @type {import('$app/env').browser}
  */
 export const browser = !import.meta.env.SSR;
@@ -6,6 +10,10 @@ export const browser = !import.meta.env.SSR;
  * @type {import('$app/env').dev}
  */
 export const dev = !!import.meta.env.DEV;
+/**
+ * @type {import('$app/env').prod}
+ */
+ export const prod = !import.meta.env.DEV;
 /**
  * @type {import('$app/env').mode}
  */


### PR DESCRIPTION
It feels incomplete having "browser" and "dev" env variables without their counterparts, "server" and "prod". Once could argue that they're redundant because you can write `!browser` and `!dev`, but i would rather see `if(server) {}` instead of `if(!browser) {}`


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0