### PR TITLE
added server and prod env variables

### DIFF
--- a/.changeset/great-bags-worry.md
+++ b/.changeset/great-bags-worry.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Added `server` and `prod` env variables

--- a/packages/kit/src/runtime/app/env.js
+++ b/packages/kit/src/runtime/app/env.js
@@ -1,7 +1,15 @@
 /**
+ * @type {import('$app/env').server}
+ */
+export const server = !!import.meta.env.SSR;
+/**
  * @type {import('$app/env').browser}
  */
 export const browser = !import.meta.env.SSR;
+/**
+ * @type {import('$app/env').prod}
+ */
+export const prod = !import.meta.env.DEV;
 /**
  * @type {import('$app/env').dev}
  */

--- a/packages/kit/src/runtime/app/env.js
+++ b/packages/kit/src/runtime/app/env.js
@@ -1,19 +1,23 @@
 /**
- * @type {import('$app/env').server}
- */
-export const server = !!import.meta.env.SSR;
-/**
  * @type {import('$app/env').browser}
  */
 export const browser = !import.meta.env.SSR;
+
 /**
- * @type {import('$app/env').prod}
+ * @type {import('$app/env').server}
  */
-export const prod = !import.meta.env.DEV;
+export const server = !!import.meta.env.SSR;
+
 /**
  * @type {import('$app/env').dev}
  */
 export const dev = !!import.meta.env.DEV;
+
+/**
+ * @type {import('$app/env').prod}
+ */
+export const prod = !import.meta.env.DEV;
+
 /**
  * @type {import('$app/env').mode}
  */

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -49,7 +49,7 @@ declare namespace App {
 
 /**
  * ```ts
- * import { browser, server, dev, prod, mode, prerendering } from '$app/env';
+ * import { browser, dev, mode, prerendering, prod, server } from '$app/env';
  * ```
  */
 declare module '$app/env' {
@@ -57,28 +57,33 @@ declare module '$app/env' {
 	 * `true` if the app is running in the browser.
 	 */
 	export const browser: boolean;
+
 	/**
-	 * `true` if the app is running on the server.
-	 */
-	export const server: boolean;
-	/**
-	 * `true` in production mode, `false` in development.
+	 * `true` in development mode, `false` in production.
 	 */
 	export const dev: boolean;
-	/**
-	 * `true` when prerendering, `false` otherwise.
-	 */
-	export const prod: boolean;
+	
 	/**
 	 * The Vite.js mode the app is running in. Configure in `config.kit.vite.mode`.
 	 * Vite.js loads the dotenv file associated with the provided mode, `.env.[mode]` or `.env.[mode].local`.
 	 * By default, `svelte-kit dev` runs with `mode=development` and `svelte-kit build` runs with `mode=production`.
 	 */
 	export const mode: string;
+
 	/**
-	 * `true` in development mode, `false` in production.
+	 * `true` when prerendering, `false` otherwise.
 	 */
 	export const prerendering: boolean;
+	
+	/**
+	 * `true` in production mode, `false` in development.
+	 */
+	export const prod: boolean;
+
+	/**
+	 * `true` if the app is running on the server.
+	 */
+	export const server: boolean;
 }
 
 /**

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -49,36 +49,36 @@ declare namespace App {
 
 /**
  * ```ts
- * import { server, browser, prod, dev, mode, prerendering } from '$app/env';
+ * import { browser, server, dev, prod, mode, prerendering } from '$app/env';
  * ```
  */
 declare module '$app/env' {
-	/**
-	 * `true` if the app is running on the server.
-	 */
-	export const server: boolean;
 	/**
 	 * `true` if the app is running in the browser.
 	 */
 	export const browser: boolean;
 	/**
-	 * `true` in production mode, `false` in development.
+	 * `true` if the app is running on the server.
 	 */
-	export const prod: boolean;
+	export const server: boolean;
 	/**
-	 * `true` in development mode, `false` in production.
+	 * `true` in production mode, `false` in development.
 	 */
 	export const dev: boolean;
 	/**
 	 * `true` when prerendering, `false` otherwise.
 	 */
-	export const prerendering: boolean;
+	export const prod: boolean;
 	/**
 	 * The Vite.js mode the app is running in. Configure in `config.kit.vite.mode`.
 	 * Vite.js loads the dotenv file associated with the provided mode, `.env.[mode]` or `.env.[mode].local`.
 	 * By default, `svelte-kit dev` runs with `mode=development` and `svelte-kit build` runs with `mode=production`.
 	 */
 	export const mode: string;
+	/**
+	 * `true` in development mode, `false` in production.
+	 */
+	export const prerendering: boolean;
 }
 
 /**

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -49,14 +49,22 @@ declare namespace App {
 
 /**
  * ```ts
- * import { browser, dev, mode, prerendering } from '$app/env';
+ * import { server, browser, prod, dev, mode, prerendering } from '$app/env';
  * ```
  */
 declare module '$app/env' {
 	/**
-	 * Whether the app is running in the browser or on the server.
+	 * `true` if the app is running on the server.
+	 */
+	export const server: boolean;
+	/**
+	 * `true` if the app is running in the browser.
 	 */
 	export const browser: boolean;
+	/**
+	 * `true` in production mode, `false` in development.
+	 */
+	export const prod: boolean;
 	/**
 	 * `true` in development mode, `false` in production.
 	 */

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -62,7 +62,7 @@ declare module '$app/env' {
 	 * `true` in development mode, `false` in production.
 	 */
 	export const dev: boolean;
-	
+
 	/**
 	 * The Vite.js mode the app is running in. Configure in `config.kit.vite.mode`.
 	 * Vite.js loads the dotenv file associated with the provided mode, `.env.[mode]` or `.env.[mode].local`.
@@ -74,7 +74,7 @@ declare module '$app/env' {
 	 * `true` when prerendering, `false` otherwise.
 	 */
 	export const prerendering: boolean;
-	
+
 	/**
 	 * `true` in production mode, `false` in development.
 	 */


### PR DESCRIPTION
It feels incomplete having "browser" and "dev" env variables without their counterparts, "server" and "prod". One could argue that they're redundant because you can write `!browser` and `!dev`, but i personally like `if(server) {}` instead of `if(!browser) {}`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
