### PR TITLE
[docs] suggest npm create rather than npm init

### DIFF
--- a/documentation/docs/00-introduction.md
+++ b/documentation/docs/00-introduction.md
@@ -20,10 +20,10 @@ You don't need to know Svelte to understand the rest of this guide, but it will 
 
 ### Getting started
 
-The easiest way to start building a SvelteKit app is to run `npm init`:
+The easiest way to start building a SvelteKit app is to run `npm create`:
 
 ```bash
-npm init svelte my-app
+npm create svelte my-app
 cd my-app
 npm install
 npm run dev

--- a/sites/kit.svelte.dev/src/routes/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/index.svelte
@@ -82,7 +82,7 @@
 		</div>
 
 		<div slot="how">
-			<pre><code>npm init <span class="orange-highlight">svelte</span> my-app
+			<pre><code>npm create <span class="orange-highlight">svelte</span> my-app
 cd my-app
 npm install
 npm run dev -- --open</code></pre>


### PR DESCRIPTION
Suggested in https://github.com/sveltejs/sites/pull/352, which would also need to be merged if we want to do this

I think this is a good change somce it uses a command that will also work with pnpm whereas init does not