### PR TITLE
Use ESM eslint config files

### DIFF
--- a/.changeset/lovely-foxes-visit.md
+++ b/.changeset/lovely-foxes-visit.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Use ESM eslint config files

--- a/packages/create-svelte/shared/+eslint+prettier+typescript/.eslintrc.js
+++ b/packages/create-svelte/shared/+eslint+prettier+typescript/.eslintrc.js
@@ -1,7 +1,7 @@
-module.exports = {
+export default {
 	root: true,
 	parser: '@typescript-eslint/parser',
-	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
 	plugins: ['svelte3', '@typescript-eslint'],
 	ignorePatterns: ['*.cjs'],
 	overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],

--- a/packages/create-svelte/shared/+eslint+prettier-typescript/.eslintrc.js
+++ b/packages/create-svelte/shared/+eslint+prettier-typescript/.eslintrc.js
@@ -1,6 +1,6 @@
-module.exports = {
+export default {
 	root: true,
-	extends: ['eslint:recommended'],
+	extends: ['eslint:recommended', 'prettier'],
 	plugins: ['svelte3'],
 	overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],
 	parserOptions: {

--- a/packages/create-svelte/shared/+eslint+typescript/.eslintrc.js
+++ b/packages/create-svelte/shared/+eslint+typescript/.eslintrc.js
@@ -1,7 +1,7 @@
-module.exports = {
+export default {
 	root: true,
 	parser: '@typescript-eslint/parser',
-	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
 	plugins: ['svelte3', '@typescript-eslint'],
 	ignorePatterns: ['*.cjs'],
 	overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],

--- a/packages/create-svelte/shared/+eslint-typescript/.eslintrc.js
+++ b/packages/create-svelte/shared/+eslint-typescript/.eslintrc.js
@@ -1,6 +1,6 @@
-module.exports = {
+export default {
 	root: true,
-	extends: ['eslint:recommended', 'prettier'],
+	extends: ['eslint:recommended'],
 	plugins: ['svelte3'],
 	overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],
 	parserOptions: {


### PR DESCRIPTION
I'm not sure why this uses `.cjs` files. Maybe a holdover from an old version of eslint