### PR TITLE
[chore] fix start_server type

### DIFF
--- a/packages/kit/test/utils.d.ts
+++ b/packages/kit/test/utils.d.ts
@@ -32,7 +32,7 @@ export const config: PlaywrightTestConfig;
 export const start_server: (
 	handler: (req: IncomingMessage, res: ServerResponse) => void,
 	start?: number
-) => {
+) => Promise<{
 	server: Server;
 	port: number;
-};
+}>;

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -171,10 +171,8 @@ export const config = {
 };
 
 /**
- *
  * @param {(req: http.IncomingMessage, res: http.ServerResponse) => void} handler
  * @param {number} [start]
- * @returns
  */
 export async function start_server(handler, start = 4000) {
 	const port = await ports.find(start);


### PR DESCRIPTION
It needs to return a `Promise` since it's `async` or else you get warnings about unnecessary `await` calls