### PR TITLE
includes typescript-svelte-plugin in templates and generated tsconfig

### DIFF
--- a/.changeset/three-rivers-approve.md
+++ b/.changeset/three-rivers-approve.md
@@ -1,0 +1,6 @@
+---
+'create-svelte': patch
+'@sveltejs/kit': patch
+---
+
+includes typescript-svelte-plugin for out-of-the-box, non-vscode lsp client support

--- a/packages/create-svelte/shared/+checkjs/package.json
+++ b/packages/create-svelte/shared/+checkjs/package.json
@@ -5,6 +5,7 @@
 	},
 	"devDependencies": {
 		"typescript": "^4.7.2",
-		"svelte-check": "^2.7.1"
+		"svelte-check": "^2.7.1",
+		"typescript-svelte-plugin": "^0.3.3"
 	}
 }

--- a/packages/create-svelte/shared/+typescript/package.json
+++ b/packages/create-svelte/shared/+typescript/package.json
@@ -7,6 +7,7 @@
 		"typescript": "^4.7.2",
 		"tslib": "^2.3.1",
 		"svelte-check": "^2.7.1",
-		"svelte-preprocess": "^4.10.6"
+		"svelte-preprocess": "^4.10.6",
+		"typescript-svelte-plugin": "^0.3.3"
 	}
 }

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -75,7 +75,10 @@ export function write_tsconfig(config, cwd = process.cwd()) {
 					lib: ['esnext', 'DOM'],
 					moduleResolution: 'node',
 					module: 'esnext',
-					target: 'esnext'
+					target: 'esnext',
+
+					// enable lsp support for svelte files for non-vscode lsp clients
+					plugins: [{ name: 'typescript-svelte-plugin' }]
 				},
 				include,
 				exclude: [config_relative('node_modules/**'), './**']


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0


Includes `typescript-svelte-plugin` in type-checked (TS, checked JS) kit templates and enables it the generated `.svelte-kit/tsconfig.json`

Related issue: #5269 
