### PR TITLE
stream request bodies

### DIFF
--- a/.changeset/afraid-flowers-train.md
+++ b/.changeset/afraid-flowers-train.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Stream request bodies

--- a/packages/kit/src/node/index.js
+++ b/packages/kit/src/node/index.js
@@ -2,51 +2,41 @@ import * as set_cookie_parser from 'set-cookie-parser';
 
 /** @param {import('http').IncomingMessage} req */
 function get_raw_body(req) {
-	return new Promise((fulfil, reject) => {
-		const h = req.headers;
+	const h = req.headers;
 
-		if (!h['content-type']) {
-			return fulfil(null);
-		}
+	if (!h['content-type']) {
+		return null;
+	}
 
-		req.on('error', reject);
+	const length = Number(h['content-length']);
 
-		const length = Number(h['content-length']);
+	// https://github.com/jshttp/type-is/blob/c1f4388c71c8a01f79934e68f630ca4a15fffcd6/index.js#L81-L95
+	if (isNaN(length) && h['transfer-encoding'] == null) {
+		return null;
+	}
 
-		// https://github.com/jshttp/type-is/blob/c1f4388c71c8a01f79934e68f630ca4a15fffcd6/index.js#L81-L95
-		if (isNaN(length) && h['transfer-encoding'] == null) {
-			return fulfil(null);
-		}
+	return new ReadableStream({
+		start(controller) {
+			req.on('error', (error) => {
+				controller.error(error);
+			});
 
-		let data = new Uint8Array(length || 0);
+			let size = 0;
 
-		if (length > 0) {
-			let offset = 0;
 			req.on('data', (chunk) => {
-				const new_len = offset + Buffer.byteLength(chunk);
+				size += chunk.length;
 
-				if (new_len > length) {
-					return reject({
-						status: 413,
-						reason: 'Exceeded "Content-Length" limit'
-					});
+				if (size > length) {
+					controller.error(new Error('content-length exceeded'));
 				}
 
-				data.set(chunk, offset);
-				offset = new_len;
+				controller.enqueue(chunk);
 			});
-		} else {
-			req.on('data', (chunk) => {
-				const new_data = new Uint8Array(data.length + chunk.length);
-				new_data.set(data, 0);
-				new_data.set(chunk, data.length);
-				data = new_data;
+
+			req.on('end', () => {
+				controller.close();
 			});
 		}
-
-		req.on('end', () => {
-			fulfil(data);
-		});
 	});
 }
 
@@ -67,7 +57,7 @@ export async function getRequest(base, req) {
 	return new Request(base + req.url, {
 		method: req.method,
 		headers,
-		body: await get_raw_body(req) // TODO stream rather than buffer
+		body: get_raw_body(req)
 	});
 }
 


### PR DESCRIPTION
Closes #3419. Instead of buffering request bodies in Node, we can now turn them into `ReadableStream` objects.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
