### PR TITLE
[fix] allow user to set dev port

### DIFF
--- a/.changeset/four-glasses-explain.md
+++ b/.changeset/four-glasses-explain.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] allow user to set dev port

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -149,12 +149,11 @@ function kit() {
 				},
 				preview: {
 					port: config.preview?.port ?? 3000,
-					strictPort: true
+					strictPort: config.preview?.strictPort ?? true
 				},
 				resolve: {
 					alias: get_aliases(svelte_config.kit)
 				},
-				root: cwd,
 				server: {
 					fs: {
 						allow: [
@@ -168,16 +167,15 @@ function kit() {
 							])
 						]
 					},
-					port: 3000,
-					strictPort: true,
+					port: config.server?.port ?? 3000,
+					strictPort: config.server?.strictPort ?? true,
 					watch: {
 						ignored: [
 							// Ignore all siblings of config.kit.outDir/generated
 							`${posixify(svelte_config.kit.outDir)}/!(generated)`
 						]
 					}
-				},
-				spa: false
+				}
 			};
 		},
 
@@ -334,8 +332,8 @@ function kit() {
 /**
  * @param {Record<string, any>} config
  * @param {Record<string, any>} enforced_config
- * @param {string} path
- * @param {string[]} out
+ * @param {string} [path]
+ * @param {string[]} [out] used locally to compute the return value
  */
 function find_overridden_config(config, enforced_config, path = '', out = []) {
 	for (const key in enforced_config) {


### PR DESCRIPTION
Closes https://github.com/sveltejs/kit/issues/5296

Array options will be merged. We only need to ensure we're not overriding the remaining primitives which are not in `enforced_config`
`spa` option does not exist and can be removed
`root` already defaults to `cwd` and can be removed