### PR TITLE
fix: Type info tooltips look wacky when they're empty

### DIFF
--- a/sites/kit.svelte.dev/src/lib/docs/client/Tooltip.svelte
+++ b/sites/kit.svelte.dev/src/lib/docs/client/Tooltip.svelte
@@ -38,11 +38,10 @@
 	}
 
 	.tooltip {
-		margin: 0 2rem 0 0;
 		background-color: var(--bg);
 		color: #fff;
 		text-align: left;
-		padding: 0.4rem 0.6rem;
+		padding: 0.4rem 1rem;
 		border-radius: var(--border-r);
 		font-family: var(--font-mono);
 		font-size: 1.2rem;


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0


Reference: #5238

* Margin is removed since not required.
* Attached image for reference.

![Screenshot 2022-06-28 at 22 45 49](https://user-images.githubusercontent.com/42613882/176244912-6f85afde-65be-4901-86a4-a70f13e5191e.png)

