### PR TITLE
remove <data-lsp> altogether if no content - fixes #5238

### DIFF
--- a/sites/kit.svelte.dev/src/lib/docs/server/index.js
+++ b/sites/kit.svelte.dev/src/lib/docs/server/index.js
@@ -103,9 +103,13 @@ export async function read_file(dir, file) {
 
 				// we need to be able to inject the LSP attributes as HTML, not text, so we
 				// turn &lt; into &amp;lt;
-				html = html.replace(/<data-lsp lsp='(.+?)' *>(\w+)<\/data-lsp>/g, (match, lsp, name) => {
-					return `<data-lsp lsp='${lsp.replace(/&/g, '&amp;')}'>${name}</data-lsp>`;
-				});
+				html = html.replace(
+					/<data-lsp lsp='([^']*)'([^>]*)>(\w+)<\/data-lsp>/g,
+					(match, lsp, attrs, name) => {
+						if (!lsp) return name;
+						return `<data-lsp lsp='${lsp.replace(/&/g, '&amp;')}'${attrs}>${name}</data-lsp>`;
+					}
+				);
 
 				// preserve blank lines in output (maybe there's a more correct way to do this?)
 				html = `<div class="code-block">${


### PR DESCRIPTION
`<data-lsp lsp=''>foo</data-lsp>` can simply be replaced with `foo`. Closes #5238 