### PR TITLE
[fix] don't log warning if root is configured

### DIFF
--- a/.changeset/quick-chicken-hide.md
+++ b/.changeset/quick-chicken-hide.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] don't log warning if root is configured

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -49,8 +49,7 @@ const enforced_config = {
 			$lib: true,
 			'$service-worker': true
 		}
-	},
-	root: true
+	}
 };
 
 /**


### PR DESCRIPTION
`root` is no longer set since https://github.com/sveltejs/kit/pull/5303. This logs an unnecessary warning when using Storybook