### PR TITLE
[fix] Adjust type imports to satisfy TS NodeNext moduleResolution

### DIFF
--- a/.changeset/healthy-wasps-poke.md
+++ b/.changeset/healthy-wasps-poke.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Adjust type imports to satisfy TS NodeNext moduleResolution

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="svelte" />
 /// <reference types="vite/client" />
 
-import './ambient';
+import './ambient.js';
 
 import { CompileOptions } from 'svelte/types/compiler/interfaces';
 import {
@@ -17,8 +17,8 @@ import {
 	ResponseHeaders,
 	RouteDefinition,
 	TrailingSlash
-} from './private';
-import { SSRNodeLoader, SSRRoute, ValidatedConfig } from './internal';
+} from './private.js';
+import { SSRNodeLoader, SSRRoute, ValidatedConfig } from './internal.js';
 
 export interface Adapter {
 	name: string;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -12,7 +12,7 @@ import {
 	ResolveOptions,
 	Server,
 	SSRManifest
-} from './index';
+} from './index.js';
 import {
 	HttpMethod,
 	JSONObject,
@@ -20,7 +20,7 @@ import {
 	RequestOptions,
 	ResponseHeaders,
 	TrailingSlash
-} from './private';
+} from './private.js';
 
 export interface ServerModule {
 	Server: typeof InternalServer;


### PR DESCRIPTION
Discovered through comment in #2040
This is necessary so people can use this new resolution mode and still get proper typings for things like $app/stores
This isn't all that's needed though:
- Vite 3 is needed so we get their exports map which makes vite/client resolve correctly
- Svelte bump needed to properly expose CompileOptions. It's imported from a path which isn't accessible when adhering to export maps

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
