### PR TITLE
[docs] remove kit.vite config from docs

### DIFF
--- a/documentation/docs/14-configuration.md
+++ b/documentation/docs/14-configuration.md
@@ -74,12 +74,8 @@ const config = {
 		version: {
 			name: Date.now().toString(),
 			pollInterval: 0
-		},
-		vite: () => ({})
+		}
 	},
-
-	// SvelteKit uses vite-plugin-svelte. Its options can be provided directly here.
-	// See the available options at https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/config.md
 
 	// options passed to svelte.preprocess (https://svelte.dev/docs#compile-time-svelte-preprocess)
 	preprocess: null
@@ -312,7 +308,3 @@ An object containing zero or more of the following values:
 Client-side navigation can be buggy if you deploy a new version of your app while people are using it. If the code for the new page is already loaded, it may have stale content; if it isn't, the app's route manifest may point to a JavaScript file that no longer exists. SvelteKit solves this problem by falling back to traditional full-page navigation if it detects that a new version has been deployed, using the `name` specified here (which defaults to a timestamp of the build).
 
 If you set `pollInterval` to a non-zero value, SvelteKit will poll for new versions in the background and set the value of the [`updated`](/docs/modules#$app-stores) store to `true` when it detects one.
-
-### vite
-
-A [Vite config object](https://vitejs.dev/config), or a function that returns one. You can pass [Vite and Rollup plugins](https://github.com/vitejs/awesome-vite#plugins) via [the `plugins` option](https://vitejs.dev/config/#plugins) to customize your build in advanced ways such as supporting image optimization, Tauri, WASM, Workbox, and more. SvelteKit will prevent you from setting certain build-related options since it depends on certain configuration values.


### PR DESCRIPTION
missed this in the last PR