### PR TITLE
synchronise port-authority versions

### DIFF
--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -32,7 +32,7 @@
 		"@sveltejs/kit": "workspace:*",
 		"@types/node": "^16.11.36",
 		"playwright-chromium": "^1.22.2",
-		"port-authority": "^1.2.0",
+		"port-authority": "^2.0.1",
 		"sirv": "^2.0.2",
 		"svelte": "^3.48.0",
 		"typescript": "^4.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,7 +160,7 @@ importers:
       '@sveltejs/kit': workspace:*
       '@types/node': ^16.11.36
       playwright-chromium: ^1.22.2
-      port-authority: ^1.2.0
+      port-authority: ^2.0.1
       sirv: ^2.0.2
       svelte: ^3.48.0
       tiny-glob: ^0.2.9
@@ -173,7 +173,7 @@ importers:
       '@sveltejs/kit': link:../kit
       '@types/node': 16.11.42
       playwright-chromium: 1.23.1
-      port-authority: 1.2.0
+      port-authority: 2.0.1
       sirv: 2.0.2
       svelte: 3.48.0
       typescript: 4.7.4
@@ -3945,10 +3945,6 @@ packages:
     dependencies:
       '@polka/url': 1.0.0-next.21
       trouter: 3.2.0
-    dev: true
-
-  /port-authority/1.2.0:
-    resolution: {integrity: sha512-izg9jj10CEbNWBX6B1IJtzs0IcMEIo+2to2IIvq0vvcqLnOi0Fz36LSL4mqp/pJsPDFB5jyrxUEEHRctmPu9Pg==}
     dev: true
 
   /port-authority/2.0.1:


### PR DESCRIPTION
found via `node scripts/check-dependencies.js`