### PR TITLE
fix: skip process.exit in dev

### DIFF
--- a/.changeset/tiny-flies-know.md
+++ b/.changeset/tiny-flies-know.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Allow server restart when config changed


### PR DESCRIPTION
Followup to https://github.com/sveltejs/kit/pull/5356. Looks like `closeBundle` is called in dev by Vite. So when updating `svelte.config.js` or `vite.config.js` which restarts the server, the process immediately exits, instead of restarting.

Closes https://github.com/sveltejs/kit/issues/5294

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
