### PR TITLE
filter top-level 'pnpm build' to just packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "monorepo for @sveltejs/kit and friends",
 	"private": true,
 	"scripts": {
-		"build": "turbo run build",
+		"build": "turbo run build --filter=./packages/*",
 		"test": "turbo run test --filter=./packages/*",
 		"check": "turbo run check",
 		"lint": "turbo run lint",


### PR DESCRIPTION
Running `pnpm build` at the top of the repo was giving the same types of errors as were fixed in #5362 for the release job.

This adds a `--filter` so that `pnpm build` only tries to build packages and not individual tests. (It also doesn't try to build kit.svelte.dev, which makes the build much faster.)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
