### PR TITLE
use Vite defaults for port and strictPort

### DIFF
--- a/.changeset/dull-ducks-report.md
+++ b/.changeset/dull-ducks-report.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] Use Vite defaults for port and strictPort

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -156,10 +156,6 @@ function kit() {
 						input: `${get_runtime_path(svelte_config.kit)}/client/start.js`
 					}
 				},
-				preview: {
-					port: config.preview?.port ?? 3000,
-					strictPort: config.preview?.strictPort ?? true
-				},
 				resolve: {
 					alias: get_aliases(svelte_config.kit)
 				},
@@ -177,8 +173,6 @@ function kit() {
 							])
 						]
 					},
-					port: config.server?.port ?? 3000,
-					strictPort: config.server?.strictPort ?? true,
 					watch: {
 						ignored: [
 							// Ignore all siblings of config.kit.outDir/generated

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -136,14 +136,18 @@ export const test = base.extend({
 	}
 });
 
+const port = 3000;
+
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 export const config = {
 	forbidOnly: !!process.env.CI,
 	// generous timeouts on CI
 	timeout: process.env.CI ? 45000 : 15000,
 	webServer: {
-		command: process.env.DEV ? 'npm run dev' : 'npm run build && npm run preview',
-		port: 3000
+		command: process.env.DEV
+			? `npm run dev -- --port ${port}`
+			: `npm run build && npm run preview -- --port ${port}`,
+		port
 	},
 	retries: process.env.CI ? 5 : 0,
 	projects: [


### PR DESCRIPTION
These made sense when we were using `svelte-kit dev` etc, but I'm not sure they do any more

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
