### PR TITLE
[breaking] require Node 16.9

### DIFF
--- a/.changeset/angry-crabs-walk.md
+++ b/.changeset/angry-crabs-walk.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] require Node 16.9

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -97,6 +97,6 @@
 	},
 	"types": "types/index.d.ts",
 	"engines": {
-		"node": ">=16.7"
+		"node": ">=16.9"
 	}
 }


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/5370

not exactly sure why Node 16.9 is now required, but it fixes it, so :shrug: 