### PR TITLE
fix(5383): undici works better with two arguments

### DIFF
--- a/packages/kit/src/runtime/server/page/load_node.js
+++ b/packages/kit/src/runtime/server/page/load_node.js
@@ -256,7 +256,7 @@ export async function load_node({
 					opts.headers.delete('connection');
 
 					const external_request = new Request(requested, /** @type {RequestInit} */ (opts));
-					response = await options.hooks.externalFetch.call(null, external_request);
+					response = await options.hooks.externalFetch.call(null, external_request.url, external_request);
 				}
 
 				const set_cookie = response.headers.get('set-cookie');


### PR DESCRIPTION
Fixes #5383

I don't know why this works better, but something is wrong on undici's side at step 25:

https://github.com/nodejs/undici/blob/5ca25c23500d649a629865d9a7a28ce653d5e991/lib/fetch/request.js#L321-L341

Specifically, when only one argument is given (as before this PR), `init.method` gets a default value of `GET` and erases `request.method`.

---

After a bit of research, this was fixed in https://github.com/nodejs/undici/pull/1529

---

For people that want a quick workaround: patch `node_modules/@sveltejs/kit/assets/server/index.js:2304` with:

```ts
const external_request = new Request(requested, /** @type {RequestInit} */ (opts));
response = await options.hooks.externalFetch.call(null, external_request.url, external_request);
```

and restart the dev server.

---

I'll open the PR nonetheless because svelte-kit seems to release faster than undici.

----

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
