### PR TITLE
don't create changelog for test-basics

### DIFF
--- a/.changeset/swift-dots-cry.md
+++ b/.changeset/swift-dots-cry.md
@@ -1,6 +1,5 @@
 ---
 '@sveltejs/kit': patch
-'test-basics': patch
 ---
 
 Returns errors from page endpoints as JSON where appropriate


### PR DESCRIPTION
https://github.com/sveltejs/kit/pull/5394 looks screwed up. we probably need to do this before cutting a release