### PR TITLE
[fix] allow Vite plugins to output mutable assets

### DIFF
--- a/.changeset/yellow-years-remember.md
+++ b/.changeset/yellow-years-remember.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] allow Vite plugins to output mutable assets

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -231,7 +231,6 @@ export async function render_response({
 		.join('');
 
 	if (page_config.router || page_config.hydrate) {
-console.log(`prefix ${options.prefix} and modulepreloads ${JSON.stringify(modulepreloads)}`);
 		head += Array.from(modulepreloads)
 			.map((dep) => `\n\t<link rel="modulepreload" href="${options.prefix + dep}">`)
 			.join('');

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -231,6 +231,7 @@ export async function render_response({
 		.join('');
 
 	if (page_config.router || page_config.hydrate) {
+console.log(`prefix ${options.prefix} and modulepreloads ${JSON.stringify(modulepreloads)}`);
 		head += Array.from(modulepreloads)
 			.map((dep) => `\n\t<link rel="modulepreload" href="${options.prefix + dep}">`)
 			.join('');

--- a/packages/kit/src/vite/build/build_server.js
+++ b/packages/kit/src/vite/build/build_server.js
@@ -67,7 +67,7 @@ export class Server {
 			manifest,
 			method_override: ${s(config.kit.methodOverride)},
 			paths: { base, assets },
-			prefix: assets + '/${config.kit.appDir}/immutable/',
+			prefix: assets + '/${config.kit.appDir}/',
 			prerender: {
 				default: ${config.kit.prerender.default},
 				enabled: ${config.kit.prerender.enabled}

--- a/packages/kit/src/vite/build/build_service_worker.js
+++ b/packages/kit/src/vite/build/build_service_worker.js
@@ -43,7 +43,7 @@ export async function build_service_worker(
 
 			export const build = [
 				${Array.from(build)
-					.map((file) => `${s(`${config.kit.paths.base}/${config.kit.appDir}/immutable/${file}`)}`)
+					.map((file) => `${s(`${config.kit.paths.base}/${config.kit.appDir}/${file}`)}`)
 					.join(',\n\t\t\t\t')}
 			];
 

--- a/packages/kit/src/vite/build/utils.js
+++ b/packages/kit/src/vite/build/utils.js
@@ -95,9 +95,9 @@ export const get_default_config = function ({ config, input, ssr, outDir }) {
 				input,
 				output: {
 					format: 'esm',
-					entryFileNames: ssr ? '[name].js' : '[name]-[hash].js',
-					chunkFileNames: 'chunks/[name]-[hash].js',
-					assetFileNames: 'assets/[name]-[hash][extname]'
+					entryFileNames: ssr ? '[name].js' : 'immutable/[name]-[hash].js',
+					chunkFileNames: 'immutable/chunks/[name]-[hash].js',
+					assetFileNames: 'immutable/assets/[name]-[hash][extname]'
 				},
 				preserveEntrySignatures: 'strict'
 			},
@@ -134,7 +134,7 @@ export function assets_base(config) {
 	// during `svelte-kit preview`, because we use a local asset path. This
 	// may be fixed in Vite 3: https://github.com/vitejs/vite/issues/2009
 	const { base, assets } = config.paths;
-	return `${assets || base}/${config.appDir}/immutable/`;
+	return `${assets || base}/${config.appDir}/`;
 }
 
 /**

--- a/packages/kit/src/vite/build/utils.js
+++ b/packages/kit/src/vite/build/utils.js
@@ -95,9 +95,9 @@ export const get_default_config = function ({ config, input, ssr, outDir }) {
 				input,
 				output: {
 					format: 'esm',
-					entryFileNames: ssr ? '[name].js' : '[name]-[hash].js',
-					chunkFileNames: 'chunks/[name]-[hash].js',
-					assetFileNames: 'assets/[name]-[hash][extname]'
+					entryFileNames: ssr ? '[name].js' : 'immutable/[name]-[hash].js',
+					chunkFileNames: 'immutable/chunks/[name]-[hash].js',
+					assetFileNames: 'immutable/assets/[name]-[hash][extname]'
 				},
 				preserveEntrySignatures: 'strict'
 			},

--- a/packages/kit/src/vite/build/utils.js
+++ b/packages/kit/src/vite/build/utils.js
@@ -95,9 +95,9 @@ export const get_default_config = function ({ config, input, ssr, outDir }) {
 				input,
 				output: {
 					format: 'esm',
-					entryFileNames: ssr ? '[name].js' : 'immutable/[name]-[hash].js',
-					chunkFileNames: 'immutable/chunks/[name]-[hash].js',
-					assetFileNames: 'immutable/assets/[name]-[hash][extname]'
+					entryFileNames: ssr ? '[name].js' : '[name]-[hash].js',
+					chunkFileNames: 'chunks/[name]-[hash].js',
+					assetFileNames: 'assets/[name]-[hash][extname]'
 				},
 				preserveEntrySignatures: 'strict'
 			},

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -95,7 +95,7 @@ function kit() {
 		const input = {
 			// Put unchanging assets in immutable directory. We don't set that in the
 			// outDir so that other plugins can add mutable assets to the bundle
-			'immutable/start': `${get_runtime_path(svelte_config.kit)}/client/start.js`
+			start: `${get_runtime_path(svelte_config.kit)}/client/start.js`
 		};
 
 		// This step is optional — Vite/Rollup will create the necessary chunks
@@ -108,7 +108,7 @@ function kit() {
 			const name = relative.startsWith('..')
 				? path.basename(file)
 				: posixify(path.join('pages', relative));
-			input[`immutable/${name}`] = resolved;
+			input[name] = resolved;
 		});
 
 		return get_default_config({

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -280,8 +280,8 @@ function kit() {
 
 			const files = new Set([
 				...static_files,
-				...chunks.map((chunk) => `${svelte_config.kit.appDir}/immutable/${chunk.fileName}`),
-				...assets.map((chunk) => `${svelte_config.kit.appDir}/immutable/${chunk.fileName}`)
+				...chunks.map((chunk) => `${svelte_config.kit.appDir}/${chunk.fileName}`),
+				...assets.map((chunk) => `${svelte_config.kit.appDir}/${chunk.fileName}`)
 			]);
 
 			// TODO is this right?

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -95,7 +95,7 @@ function kit() {
 		const input = {
 			// Put unchanging assets in immutable directory. We don't set that in the
 			// outDir so that other plugins can add mutable assets to the bundle
-			start: `${get_runtime_path(svelte_config.kit)}/client/start.js`
+			'immutable/start': `${get_runtime_path(svelte_config.kit)}/client/start.js`
 		};
 
 		// This step is optional — Vite/Rollup will create the necessary chunks
@@ -108,7 +108,7 @@ function kit() {
 			const name = relative.startsWith('..')
 				? path.basename(file)
 				: posixify(path.join('pages', relative));
-			input[name] = resolved;
+			input[`immutable/${name}`] = resolved;
 		});
 
 		return get_default_config({

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -93,6 +93,8 @@ function kit() {
 	function create_client_config() {
 		/** @type {Record<string, string>} */
 		const input = {
+			// Put unchanging assets in immutable directory. We don't set that in the
+			// outDir so that other plugins can add mutable assets to the bundle
 			'immutable/start': `${get_runtime_path(svelte_config.kit)}/client/start.js`
 		};
 

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -93,12 +93,12 @@ function kit() {
 	function create_client_config() {
 		/** @type {Record<string, string>} */
 		const input = {
-			start: `${get_runtime_path(svelte_config.kit)}/client/start.js`
+			'immutable/start': `${get_runtime_path(svelte_config.kit)}/client/start.js`
 		};
 
-		// This step is optional — Vite/Rollup will create the necessary chunks
-		// for everything regardless — but it means that entry chunks reflect
-		// their location in the source code, which is helpful for debugging
+		// Put unchanging assets in immutable directory. We don't set that in the outDir so that other
+		// plugins can add mutable assets to the bundle. Also have the entry chunks reflect their
+		// location in the source code, which is helpful for debugging
 		manifest_data.components.forEach((file) => {
 			const resolved = path.resolve(cwd, file);
 			const relative = path.relative(svelte_config.kit.files.routes, resolved);
@@ -106,14 +106,14 @@ function kit() {
 			const name = relative.startsWith('..')
 				? path.basename(file)
 				: posixify(path.join('pages', relative));
-			input[name] = resolved;
+			input[`immutable/${name}`] = resolved;
 		});
 
 		return get_default_config({
 			config: svelte_config,
 			input,
 			ssr: false,
-			outDir: `${paths.client_out_dir}/immutable`
+			outDir: `${paths.client_out_dir}`
 		});
 	}
 
@@ -225,7 +225,7 @@ function kit() {
 
 			/** @type {import('vite').Manifest} */
 			const vite_manifest = JSON.parse(
-				fs.readFileSync(`${paths.client_out_dir}/immutable/manifest.json`, 'utf-8')
+				fs.readFileSync(`${paths.client_out_dir}/manifest.json`, 'utf-8')
 			);
 
 			const entry_id = posixify(

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -98,7 +98,7 @@ function kit() {
 			start: `${get_runtime_path(svelte_config.kit)}/client/start.js`
 		};
 
-		// This step is optional — Vite/Rollup will create the necessary chunks other
+		// This step is optional — Vite/Rollup will create the necessary chunks
 		// for everything regardless — but it means that entry chunks reflect
 		// their location in the source code, which is helpful for debugging
 		manifest_data.components.forEach((file) => {

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -98,9 +98,9 @@ function kit() {
 			'immutable/start': `${get_runtime_path(svelte_config.kit)}/client/start.js`
 		};
 
-		// Put unchanging assets in immutable directory. We don't set that in the outDir so that other
-		// plugins can add mutable assets to the bundle. Also have the entry chunks reflect their
-		// location in the source code, which is helpful for debugging
+		// This step is optional — Vite/Rollup will create the necessary chunks other
+		// for everything regardless — but it means that entry chunks reflect
+		// their location in the source code, which is helpful for debugging
 		manifest_data.components.forEach((file) => {
 			const resolved = path.resolve(cwd, file);
 			const relative = path.relative(svelte_config.kit.files.routes, resolved);

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -95,7 +95,7 @@ function kit() {
 		const input = {
 			// Put unchanging assets in immutable directory. We don't set that in the
 			// outDir so that other plugins can add mutable assets to the bundle
-			'immutable/start': `${get_runtime_path(svelte_config.kit)}/client/start.js`
+			start: `${get_runtime_path(svelte_config.kit)}/client/start.js`
 		};
 
 		// This step is optional — Vite/Rollup will create the necessary chunks other
@@ -108,7 +108,7 @@ function kit() {
 			const name = relative.startsWith('..')
 				? path.basename(file)
 				: posixify(path.join('pages', relative));
-			input[`immutable/${name}`] = resolved;
+			input[name] = resolved;
 		});
 
 		return get_default_config({


### PR DESCRIPTION
@userquin is trying to get `vite-plugin-pwa` working with SvelteKit. That plugin adds a mutable manifest to the bundle. Since the bundle is written to the `outDir` we need the `outDir` to be set to `client` instead of `client/immutable`