### PR TITLE
small fix in init_service_worker

### DIFF
--- a/.changeset/ninety-dodos-exercise.md
+++ b/.changeset/ninety-dodos-exercise.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+Use anonymous function in service worker init script to support legacy browsers

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -188,6 +188,8 @@ export async function render_response({
 		});
 	`;
 
+	// we use an anonymous function instead of an arrow function to support
+	// older browsers (https://github.com/sveltejs/kit/pull/5417)
 	const init_service_worker = `
 		if ('serviceWorker' in navigator) {
 			addEventListener('load', function () {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -190,7 +190,7 @@ export async function render_response({
 
 	const init_service_worker = `
 		if ('serviceWorker' in navigator) {
-			addEventListener('load', () => {
+			addEventListener('load', function () {
 				navigator.serviceWorker.register('${options.service_worker}');
 			});
 		}


### PR DESCRIPTION
Replaced arrow function with anonymous function in the init_service_worker script for support old browsers

This is necessary for the application to work in WebView on Android >= 5.1 (Chromium >= 39).
Arrow functions are only supported in Android WebView >= 45, [see MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
