### PR TITLE
Use latest version of svelte-create to get started

### DIFF
--- a/documentation/docs/00-introduction.md
+++ b/documentation/docs/00-introduction.md
@@ -23,7 +23,7 @@ You don't need to know Svelte to understand the rest of this guide, but it will 
 The easiest way to start building a SvelteKit app is to run `npm create`:
 
 ```bash
-npm create svelte my-app
+npm create svelte@latest my-app
 cd my-app
 npm install
 npm run dev


### PR DESCRIPTION
I've been using SvelteKit for some time now and wanted to create a bug report. When executing `npm create svelte my-app` to make a reproduction I got a project that breaks when running `npm run dev`.

Specific problem: My old version of svelte-create created a package.json that still contained `svelte-kit build` etc., but newest SvelteKit seems to need some of them replaced by `vite` commands.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
