### PR TITLE
remove --force

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: cd packages/kit && pnpm build
-      - run: pnpm turbo run lint check --force
+      - run: pnpm turbo run lint check
   Tests:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30


### PR DESCRIPTION
Can't remember what glitch this was masking, but `--force` defeats the object of using turbo