### PR TITLE
[fix] Use vite preview port in templates for playwright config

### DIFF
--- a/.changeset/lemon-elephants-chew.md
+++ b/.changeset/lemon-elephants-chew.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': patch
----
-
-Align `playwright` server ports with `vite` preview server port

--- a/.changeset/lemon-elephants-chew.md
+++ b/.changeset/lemon-elephants-chew.md
@@ -1,6 +1,4 @@
 ---
-'create-svelte': patch
-'test-basics': patch
 '@sveltejs/kit': patch
 ---
 

--- a/.changeset/lemon-elephants-chew.md
+++ b/.changeset/lemon-elephants-chew.md
@@ -1,0 +1,7 @@
+---
+'create-svelte': patch
+'test-basics': patch
+'@sveltejs/kit': patch
+---
+
+Align `playwright` server ports with `vite` preview server port

--- a/packages/create-svelte/shared/+playwright+typescript/playwright.config.ts
+++ b/packages/create-svelte/shared/+playwright+typescript/playwright.config.ts
@@ -3,7 +3,7 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 const config: PlaywrightTestConfig = {
 	webServer: {
 		command: 'npm run build && npm run preview',
-		port: 3000
+		port: 4173
 	}
 };
 

--- a/packages/create-svelte/shared/+playwright-typescript/playwright.config.js
+++ b/packages/create-svelte/shared/+playwright-typescript/playwright.config.js
@@ -2,7 +2,7 @@
 const config = {
 	webServer: {
 		command: 'npm run build && npm run preview',
-		port: 3000
+		port: 4173
 	}
 };
 

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1639,8 +1639,7 @@ test.describe('Load', () => {
 	});
 
 	test('using window.fetch causes a warning', async ({ page, javaScriptEnabled }) => {
-		const DEV_SERVER_PORT = 3000;
-		const PREVIEW_SERVER_PORT = 4173;
+		const port = process.env.DEV ? 3000 : 4173;
 
 		if (javaScriptEnabled && process.env.DEV) {
 			const warnings = [];

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1654,9 +1654,7 @@ test.describe('Load', () => {
 			expect(await page.textContent('h1')).toBe('42');
 
 			expect(warnings).toContain(
-				`Loading http://localhost:${
-					process.env.DEV ? DEV_SERVER_PORT : PREVIEW_SERVER_PORT
-				}/load/window-fetch/data.json using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/loading#input-fetch`
+				`Loading http://localhost:${port}/load/window-fetch/data.json using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/loading#input-fetch`
 			);
 
 			warnings.length = 0;

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1663,9 +1663,7 @@ test.describe('Load', () => {
 			expect(await page.textContent('h1')).toBe('42');
 
 			expect(warnings).not.toContain(
-				`Loading http://localhost:${
-					process.env.DEV ? DEV_SERVER_PORT : PREVIEW_SERVER_PORT
-				}/load/window-fetch/data.json using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/loading#input-fetch`
+				`Loading http://localhost:${port}/load/window-fetch/data.json using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/loading#input-fetch`
 			);
 		}
 	});

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1638,7 +1638,10 @@ test.describe('Load', () => {
 		}
 	});
 
-	test('using window.fetch causes a warning', async ({ page, javaScriptEnabled }) => {
+	test.only('using window.fetch causes a warning', async ({ page, javaScriptEnabled }) => {
+		const DEV_SERVER_PORT = 3000;
+		const PREVIEW_SERVER_PORT = 4173;
+
 		if (javaScriptEnabled && process.env.DEV) {
 			const warnings = [];
 
@@ -1652,7 +1655,9 @@ test.describe('Load', () => {
 			expect(await page.textContent('h1')).toBe('42');
 
 			expect(warnings).toContain(
-				'Loading http://localhost:3000/load/window-fetch/data.json using `window.fetch`. For best results, use the `fetch` that is passed to your `load` function: https://kit.svelte.dev/docs/loading#input-fetch'
+				`Loading http://localhost:${
+					process.env.DEV ? DEV_SERVER_PORT : PREVIEW_SERVER_PORT
+				}/load/window-fetch/data.json using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/loading#input-fetch`
 			);
 
 			warnings.length = 0;
@@ -1661,7 +1666,9 @@ test.describe('Load', () => {
 			expect(await page.textContent('h1')).toBe('42');
 
 			expect(warnings).not.toContain(
-				'Loading http://localhost:3000/load/window-fetch/data.json using `window.fetch`. For best results, use the `fetch` that is passed to your `load` function: https://kit.svelte.dev/docs/loading#input-fetch'
+				`Loading http://localhost:${
+					process.env.DEV ? DEV_SERVER_PORT : PREVIEW_SERVER_PORT
+				}/load/window-fetch/data.json using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/loading#input-fetch`
 			);
 		}
 	});

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1638,7 +1638,7 @@ test.describe('Load', () => {
 		}
 	});
 
-	test.only('using window.fetch causes a warning', async ({ page, javaScriptEnabled }) => {
+	test('using window.fetch causes a warning', async ({ page, javaScriptEnabled }) => {
 		const DEV_SERVER_PORT = 3000;
 		const PREVIEW_SERVER_PORT = 4173;
 

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -144,18 +144,14 @@ if (!test_browser_device) {
 	);
 }
 
-const port = 3000;
-
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 export const config = {
 	forbidOnly: !!process.env.CI,
 	// generous timeouts on CI
 	timeout: process.env.CI ? 45000 : 15000,
 	webServer: {
-		command: process.env.DEV
-			? `npm run dev -- --port ${port}`
-			: `npm run build && npm run preview -- --port ${port}`,
-		port
+		command: process.env.DEV ? 'npm run dev' : 'npm run build && npm run preview',
+		port: process.env.DEV ? 3000 : 4173
 	},
 	retries: process.env.CI ? 5 : 0,
 	projects: [


### PR DESCRIPTION
Closes #5429 which was introduced with #5392.

I have changed the web server port from 3000 to 4173 in the `playwright.config.js` templates to be in line with the preview server ports from `vite`.

I am not totally sure if the changes to the tests are good enough. But if the `vite` ports will change in the future the tests should be failing.

I am also not quite sure if my selections for the changeset are correct.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0