### PR TITLE
unify matcher name restrictions and clearer error on bad param/matcher names

### DIFF
--- a/.changeset/smooth-hornets-think.md
+++ b/.changeset/smooth-hornets-think.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+clearer error on bad matcher names

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -270,11 +270,18 @@ export default function create_manifest_data({
 			if (!config.kit.moduleExtensions.includes(ext)) continue;
 			const type = file.slice(0, -ext.length);
 
-			if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(type)) {
-				matchers[type] = path.join(params_base, file);
+			if (/^\w+$/.test(type)) {
+				const matcher_file = path.join(params_base, file);
+
+				// Disallow same matcher with different extensions
+				if (matchers[type]) {
+					throw new Error(`Duplicate matchers: ${matcher_file} and ${matchers[type]}`);
+				} else {
+					matchers[type] = matcher_file;
+				}
 			} else {
 				throw new Error(
-					`Matcher names must match /^[a-zA-Z_][a-zA-Z0-9_]*$/ — "${file}" is invalid`
+					`Matcher names can only have underscores and alphanumeric characters — "${file}" is invalid`
 				);
 			}
 		}

--- a/packages/kit/src/core/sync/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.spec.js
@@ -638,4 +638,28 @@ test('creates param matchers', () => {
 	});
 });
 
+test('errors on param matchers with bad names', () => {
+	const boogaloo = path.resolve(cwd, 'params', 'boo-galoo.js');
+	fs.writeFileSync(boogaloo, '');
+	try {
+		assert.throws(() => create('samples/basic'), /Matcher names can only have/);
+	} finally {
+		fs.unlinkSync(boogaloo);
+	}
+});
+
+test('errors on duplicate matchers', () => {
+	const ts_foo = path.resolve(cwd, 'params', 'foo.ts');
+	fs.writeFileSync(ts_foo, '');
+	try {
+		assert.throws(() => {
+			create('samples/basic', {
+				extensions: ['.js', '.ts']
+			});
+		}, /Duplicate matchers/);
+	} finally {
+		fs.unlinkSync(ts_foo);
+	}
+});
+
 test.run();

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -36,9 +36,14 @@ export function parse_route_id(id) {
 										.split(/\[(.+?)\]/)
 										.map((content, i) => {
 											if (i % 2) {
-												const [, rest, name, type] = /** @type {RegExpMatchArray} */ (
-													param_pattern.exec(content)
-												);
+												const match = param_pattern.exec(content);
+												if (!match) {
+													throw new Error(
+														`Invalid param: ${content}. Params and matcher names can only have underscores and alphanumeric characters.`
+													);
+												}
+
+												const [, rest, name, type] = match;
 												names.push(name);
 												types.push(type);
 												return rest ? '(.*?)' : '([^/]+?)';

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -55,4 +55,9 @@ for (const [key, expected] of Object.entries(tests)) {
 	});
 }
 
+test('errors on bad param name', () => {
+	assert.throws(() => parse_route_id('abc/[b-c]'), /Invalid param: b-c/);
+	assert.throws(() => parse_route_id('abc/[bc=d-e]'), /Invalid param: bc=d-e/);
+});
+
 test.run();


### PR DESCRIPTION
closes #5261

There was a discrepancy between the allowed names for matcher files and matchers in route names, took the opportunity to remove that as well. Was it there for a special reason?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
