### PR TITLE
feat: get client IP from Context object rather than the request header

### DIFF
--- a/.changeset/yellow-laws-prove.md
+++ b/.changeset/yellow-laws-prove.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': minor
+---
+
+feat: get client IP from Context object rather than the request header

--- a/packages/adapter-netlify/src/edge.js
+++ b/packages/adapter-netlify/src/edge.js
@@ -19,7 +19,7 @@ export default function handler(request, context) {
 	return server.respond(request, {
 		platform: { context },
 		getClientAddress() {
-			return request.headers.get('x-nf-client-connection-ip');
+			return context.ip;
 		}
 	});
 }


### PR DESCRIPTION
Originally the Edge function integrations were written under the assumption that we'd need to get the client IP from the request header. 

However, the client IP is available in the Netlify [`Context` object](https://docs.netlify.com/netlify-labs/experimental-features/edge-functions/api/#netlify-specific-context-object), so updating the adapter to reference that object rather than the request header.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
