### PR TITLE
Remove need for port-authority

### DIFF
--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -32,7 +32,6 @@
 		"@sveltejs/kit": "workspace:*",
 		"@types/node": "^16.11.36",
 		"playwright-chromium": "^1.22.2",
-		"port-authority": "^2.0.1",
 		"sirv": "^2.0.2",
 		"svelte": "^3.48.0",
 		"typescript": "^4.7.4",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -33,7 +33,6 @@
 		"marked": "^4.0.16",
 		"mime": "^3.0.0",
 		"node-fetch": "^3.2.4",
-		"port-authority": "^2.0.1",
 		"rollup": "^2.75.3",
 		"selfsigned": "^2.0.1",
 		"set-cookie-parser": "^2.4.8",

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1522,29 +1522,26 @@ test.describe('Load', () => {
 		expect(await page.textContent('h1')).toBe('text.length is 5000000');
 	});
 
-	test('handles external api', async ({ page, javaScriptEnabled }) => {
+	test('handles external api', async ({ page }) => {
 		/** @type {string[]} */
 		const requested_urls = [];
 
-		const { port, close } = await start_server(
-			async (req, res) => {
-				if (!req.url) throw new Error('Incomplete request');
-				requested_urls.push(req.url);
+		const { port, close } = await start_server(async (req, res) => {
+			if (!req.url) throw new Error('Incomplete request');
+			requested_urls.push(req.url);
 
-				if (req.url === '/server-fetch-request-modified.json') {
-					res.writeHead(200, {
-						'Access-Control-Allow-Origin': '*',
-						'content-type': 'application/json'
-					});
+			if (req.url === '/server-fetch-request-modified.json') {
+				res.writeHead(200, {
+					'Access-Control-Allow-Origin': '*',
+					'content-type': 'application/json'
+				});
 
-					res.end(JSON.stringify({ answer: 42 }));
-				} else {
-					res.statusCode = 404;
-					res.end('not found');
-				}
-			},
-			javaScriptEnabled ? 4000 : 4001
-		);
+				res.end(JSON.stringify({ answer: 42 }));
+			} else {
+				res.statusCode = 404;
+				res.end('not found');
+			}
+		});
 
 		await page.goto(`/load/server-fetch-request?port=${port}`);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,7 +166,6 @@ importers:
       '@sveltejs/kit': workspace:*
       '@types/node': ^16.11.36
       playwright-chromium: ^1.22.2
-      port-authority: ^2.0.1
       sirv: ^2.0.2
       svelte: ^3.48.0
       tiny-glob: ^0.2.9
@@ -179,7 +178,6 @@ importers:
       '@sveltejs/kit': link:../kit
       '@types/node': 16.11.42
       playwright-chromium: 1.23.1
-      port-authority: 2.0.1
       sirv: 2.0.2
       svelte: 3.48.0
       typescript: 4.7.4
@@ -308,7 +306,6 @@ importers:
       marked: ^4.0.16
       mime: ^3.0.0
       node-fetch: ^3.2.4
-      port-authority: ^2.0.1
       rollup: ^2.75.3
       sade: ^1.8.1
       selfsigned: ^2.0.1
@@ -346,7 +343,6 @@ importers:
       marked: 4.0.17
       mime: 3.0.0
       node-fetch: 3.2.6
-      port-authority: 2.0.1
       rollup: 2.75.3
       selfsigned: 2.0.1
       set-cookie-parser: 2.5.0
@@ -3966,10 +3962,6 @@ packages:
     dependencies:
       '@polka/url': 1.0.0-next.21
       trouter: 3.2.0
-    dev: true
-
-  /port-authority/2.0.1:
-    resolution: {integrity: sha512-Hz/WvSNt5+7x+Rq1Cn6DetJOZxKtLDehJ1mLCYge6ju4QvSF/PHvRgy94e1SKJVI96AJTcqEdNwkkaAFad+TXQ==}
     dev: true
 
   /postcss/8.4.14:


### PR DESCRIPTION
I was worried there was a race condition in `start_server`. If two workers find an open port, pick the same port, then try to start the server on it then there will be a failure. Using the built-in port finding mechanism would hopefully avoid this. Plus, one less dependency is always nice