### PR TITLE
[docs] clarify static route priority

### DIFF
--- a/documentation/docs/03-routing.md
+++ b/documentation/docs/03-routing.md
@@ -375,19 +375,22 @@ src/routes/[...catchall].svelte
 src/routes/[a].js
 src/routes/[b].svelte
 src/routes/foo-[c].svelte
+src/routes/foo-abc.svelte
 ```
 
 SvelteKit needs to know which route is being requested. To do so, it sorts them according to the following rules...
 
+- Static routes, (with no parameters) are highest priority
 - More specific routes are higher priority
 - Standalone endpoints have higher priority than pages with the same specificity
 - Parameters with [matchers](#advanced-routing-matching) (`[name=type]`) are higher priority than those without (`[name]`)
 - Rest parameters have lowest priority
 - Ties are resolved alphabetically
 
-...resulting in this ordering, meaning that `/foo-abc` will invoke `src/routes/foo-[bar].svelte` rather than a less specific route:
+...resulting in this ordering, meaning that `/foo-abc` will invoke `src/routes/foo-abc.svelte` rather than a less specific route:
 
 ```bash
+src/routes/foo-abc.svelte
 src/routes/foo-[c].svelte
 src/routes/[a].js
 src/routes/[b].svelte

--- a/documentation/docs/03-routing.md
+++ b/documentation/docs/03-routing.md
@@ -380,7 +380,7 @@ src/routes/foo-abc.svelte
 
 SvelteKit needs to know which route is being requested. To do so, it sorts them according to the following rules...
 
-- Static routes, (with no parameters) are highest priority
+- Static routes, (i.e. ones with no parameters) are highest priority
 - More specific routes are higher priority
 - Standalone endpoints have higher priority than pages with the same specificity
 - Parameters with [matchers](#advanced-routing-matching) (`[name=type]`) are higher priority than those without (`[name]`)

--- a/documentation/docs/03-routing.md
+++ b/documentation/docs/03-routing.md
@@ -380,14 +380,13 @@ src/routes/foo-abc.svelte
 
 SvelteKit needs to know which route is being requested. To do so, it sorts them according to the following rules...
 
-- Static routes, (i.e. ones with no parameters) are highest priority
-- More specific routes are higher priority
+- More specific routes are higher priority (e.g. a route with no parameters is more specific than a route with one dynamic parameter, and so on)
 - Standalone endpoints have higher priority than pages with the same specificity
 - Parameters with [matchers](#advanced-routing-matching) (`[name=type]`) are higher priority than those without (`[name]`)
 - Rest parameters have lowest priority
 - Ties are resolved alphabetically
 
-...resulting in this ordering, meaning that `/foo-abc` will invoke `src/routes/foo-abc.svelte` rather than a less specific route:
+...resulting in this ordering, meaning that `/foo-abc` will invoke `src/routes/foo-abc.svelte`, and `/foo-def` will invoke `src/routes/foo-[c].svelte` rather than less specific routes:
 
 ```bash
 src/routes/foo-abc.svelte


### PR DESCRIPTION
__Docs change__

This change adds to the [advanced routing docs](https://kit.svelte.dev/docs/routing#advanced-routing-sorting) to include a note about predefined/static routes taking precedence over dynamic ones.

I think the existing docs attempted to do this by saying "More specific routes are higher priority" but it wasn't clear that a dynamic route would be less specific than a predefined route.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
