### PR TITLE
[chore] speed up tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,11 @@ You may need to install some dependencies first, e.g. with `npx playwright insta
 
 If there are tests that fail on the CI, you can retrieve the failed screenshots by going to the summary page of the CI run. You can usually find this by clicking on "Details" of the check results, click "Summary" at the top-left corner, and then scroll to the bottom "Artifacts" section to download the archive.
 
+It is very easy to introduce flakiness in a browser test. If you try to fix the flakiness in a test, you can run it until failure to gain some confidence you've fixed the test with a command like:
+```
+npx playwright test --workers=1 --repeat-each 1000 --max-failures 1 -g "accepts a Request object"
+```
+
 ## Working on Vite and other dependencies
 
 If you would like to test local changes to Vite or another dependency, you can build it and then use [`pnpm.overrides`](https://pnpm.io/package_json#pnpmoverrides). Please note that `pnpm.overrides` must be specified in the root `package.json` and you must first list the package as a dependency in the root `package.json`:

--- a/packages/kit/test/apps/amp/test/test.js
+++ b/packages/kit/test/apps/amp/test/test.js
@@ -1,6 +1,8 @@
 import { expect } from '@playwright/test';
 import { test } from '../../../utils.js';
 
+test.describe.configure({ mode: 'parallel' });
+
 test('renders an AMP page', async ({ page, baseURL }) => {
 	await page.goto(`${baseURL}/valid`);
 

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -6,6 +6,8 @@ import { start_server, test } from '../../../utils.js';
 
 /** @typedef {import('@playwright/test').Response} Response */
 
+test.describe.configure({ mode: 'parallel' });
+
 test.describe('a11y', () => {
 	test('resets focus', async ({ page, clicknav, browserName }) => {
 		const tab = browserName === 'webkit' ? 'Alt+Tab' : 'Tab';

--- a/packages/kit/test/apps/options-2/test/test.js
+++ b/packages/kit/test/apps/options-2/test/test.js
@@ -3,6 +3,8 @@ import { test } from '../../../utils.js';
 
 /** @typedef {import('@playwright/test').Response} Response */
 
+test.describe.configure({ mode: 'parallel' });
+
 test.describe('paths.base', () => {
 	test('serves /basepath', async ({ page }) => {
 		await page.goto('/basepath');

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -3,6 +3,8 @@ import { start_server, test } from '../../../utils.js';
 
 /** @typedef {import('@playwright/test').Response} Response */
 
+test.describe.configure({ mode: 'parallel' });
+
 test.describe('base path', () => {
 	test('serves a useful 404 when visiting unprefixed path', async ({ request }) => {
 		const response = await request.get('/');


### PR DESCRIPTION
The tests have stopped hanging for me since https://github.com/sveltejs/kit/pull/5482. There is still flakiness. I'd like to debug that, but running the tests takes too long right now, so I'm hoping to re-parallelize them. Has https://github.com/sveltejs/kit/pull/5482 fixed the increased flakiness with parallelization that others were seeing? If not, perhaps we could find a compromise option like parallelize unless on the CI?