### PR TITLE
[chore] clarify test names

### DIFF
--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -155,13 +155,13 @@ export const config = {
 	retries: process.env.CI ? 5 : 0,
 	projects: [
 		{
-			name: `${test_browser}-${process.env.DEV ? 'dev' : 'build'}+js`,
+			name: `${test_browser}-${process.env.DEV ? 'dev' : 'build'}`,
 			use: {
 				javaScriptEnabled: true
 			}
 		},
 		{
-			name: `${test_browser}-${process.env.DEV ? 'dev' : 'build'}-js`,
+			name: `${test_browser}-${process.env.DEV ? 'dev' : 'build'}-no-js`,
 			use: {
 				javaScriptEnabled: false
 			}


### PR DESCRIPTION
When creating test traces, Playwright converts all spaces to `-`. I want to be sure it doesn't also convert `+` to `-` as that would make the names of the tests with and without javascript equivalent. This should make it clearer which trace I'm receiving