### PR TITLE
[chore] test using windows-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [16]
-        os: [ubuntu-latest , windows-2019]
+        os: [ubuntu-latest , windows-latest]
         e2e-browser: ['chromium']
         include:
           - node-version: 16


### PR DESCRIPTION
@dominikg reported that this repo doesn't build on WIndows 10. The `windows-latest` tag will use Windows Server 2022 instead of Windows Server 2019, so I was curious if that would pick up the build failure. It doesn't but maybe is still worth using `windows-latest` to align with the fact that we use `ubuntu-latest`. Or should we pin it to 2022 so that if things break when they update the latest we won't be surprised?