### PR TITLE
[docs] clarify that prerendering isn't handled by adapters

### DIFF
--- a/documentation/docs/12-page-options.md
+++ b/documentation/docs/12-page-options.md
@@ -36,7 +36,7 @@ Ordinarily, SvelteKit [hydrates](/docs/appendix#hydration) your server-rendered 
 
 ### prerender
 
-It's likely that at least some pages of your app can be represented as a simple HTML file generated at build time. These pages can be [_prerendered_](/docs/appendix#prerendering) by your [adapter](/docs/adapters).
+It's likely that at least some pages of your app can be represented as a simple HTML file generated at build time. These pages can be [_prerendered_](/docs/appendix#prerendering).
 
 Prerendering happens automatically for any page with the `prerender` annotation:
 


### PR DESCRIPTION
prerendering happens in the Vite plugin - not the adapter