### PR TITLE
fix firefox test

### DIFF
--- a/packages/kit/test/apps/basics/src/routes/accessibility/__layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/accessibility/__layout.svelte
@@ -1,3 +1,5 @@
+<button>focus me</button>
+
 <nav><a href="/accessibility/a">a</a> <a href="/accessibility/b">b</a></nav>
 
 <slot />

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -19,16 +19,16 @@ test.describe('a11y', () => {
 		expect(await page.evaluate(() => (document.activeElement || {}).nodeName)).toBe('BODY');
 		await page.keyboard.press(tab);
 
-		expect(await page.evaluate(() => (document.activeElement || {}).nodeName)).toBe('A');
-		expect(await page.evaluate(() => (document.activeElement || {}).textContent)).toBe('a');
+		expect(await page.evaluate(() => (document.activeElement || {}).nodeName)).toBe('BUTTON');
+		expect(await page.evaluate(() => (document.activeElement || {}).textContent)).toBe('focus me');
 
 		await clicknav('[href="/accessibility/a"]');
 		expect(await page.innerHTML('h1')).toBe('a');
 		expect(await page.evaluate(() => (document.activeElement || {}).nodeName)).toBe('BODY');
 
 		await page.keyboard.press(tab);
-		expect(await page.evaluate(() => (document.activeElement || {}).nodeName)).toBe('A');
-		expect(await page.evaluate(() => (document.activeElement || {}).textContent)).toBe('a');
+		expect(await page.evaluate(() => (document.activeElement || {}).nodeName)).toBe('BUTTON');
+		expect(await page.evaluate(() => (document.activeElement || {}).textContent)).toBe('focus me');
 
 		expect(await page.evaluate(() => document.documentElement.getAttribute('tabindex'))).toBe(null);
 	});


### PR DESCRIPTION
This test fails in Firefox locally if you're OS settings prevent the browser from cycling through `<a>` elements (which is a completely mad, totally inaccessible default. Chrome gets this right).

This PR fixes it by using a `<button>` instead