### PR TITLE
fix: ensure isolated testing of create-svelte with local packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ yarn.lock
 .netlify
 .turbo
 .vercel
+.test-tmp

--- a/packages/create-svelte/test/check.js
+++ b/packages/create-svelte/test/check.js
@@ -3,18 +3,34 @@ import { execSync } from 'child_process';
 import path from 'path';
 import { test } from 'uvu';
 import { create } from '../index.js';
-
+import { fileURLToPath } from 'url';
 // use a directory outside of packages to ensure it isn't added to the pnpm workspace
-const dir = '../../.test-tmp/create-svelte/';
-
+const test_workspace_dir = fileURLToPath(new URL('../../../.test-tmp/create-svelte/',import.meta.url));
+const overrides = {};
+['kit','adapter-auto','adapter-cloudflare','adapter-netlify','adapter-vercel'].forEach(pkg => {
+	overrides[`@sveltejs/${pkg}`] =  `${path.resolve(test_workspace_dir,'..','..','packages',pkg)}`;//'workspace:*';
+});
 test.before(() => {
-	fs.rmSync(dir, { recursive: true, force: true });
+	try {
+		// prepare test pnpm workspace
+		fs.rmSync(test_workspace_dir, { recursive: true, force: true });
+		fs.mkdirSync(test_workspace_dir,{ recursive: true });
+		const workspace = {name:'svelte-check-test-fake-pnpm-workspace', private:true,version:'0.0.0', pnpm:{overrides},devDependencies:overrides};
+		fs.writeFileSync(path.join(test_workspace_dir,'package.json'),JSON.stringify(workspace,null,'\t'));
+		fs.writeFileSync(path.join(test_workspace_dir,'pnpm-workspace.yaml'), 'packages:\n  - ./*\n');
+
+		// force creation of pnpm-lock.yaml in test workspace
+		execSync('pnpm install', { dir: test_workspace_dir, stdio: 'inherit' });
+	} catch (e) {
+		console.error('failed to setup create-svelte test workspace',e);
+		throw e;
+	}
 });
 
 for (const template of fs.readdirSync('templates')) {
 	for (const types of ['checkjs', 'typescript']) {
 		test(`${template}: ${types}`, () => {
-			const cwd = `${dir}/${template}-${types}`;
+			const cwd = path.join(test_workspace_dir,`${template}-${types}`);
 			fs.rmSync(cwd, { recursive: true, force: true });
 
 			create(cwd, {
@@ -26,13 +42,18 @@ for (const template of fs.readdirSync('templates')) {
 				playwright: false
 			});
 			const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf-8'));
-			pkg.devDependencies['@sveltejs/kit'] = 'file:../../../packages/kit';
-			if (pkg.devDependencies['@sveltejs/adapter-auto']) {
-				pkg.devDependencies['@sveltejs/adapter-auto'] = 'file:../../../packages/adapter-auto';
-			}
+			Object.entries(overrides).forEach( ([key,value]) => {
+				if ( pkg.devDependencies?.[key]) {
+					pkg.devDependencies[key] = value;
+				}
+				if ( pkg.dependencies?.[key]) {
+					pkg.dependencies[key] = value;
+				}
+			});
 			fs.writeFileSync(path.join(cwd, 'package.json'), JSON.stringify(pkg, null, '\t'));
-			// explicitly only install in the dir under test to avoid running a pnpm workspace command
-			execSync('pnpm install .', { cwd, stdio: 'inherit' });
+
+			// this pnpm install works in the test workspace, which redirects to our local packages again
+			execSync('pnpm install', { cwd, stdio: 'inherit' });
 
 			// run check command separately
 			execSync('pnpm check', { cwd, stdio: 'inherit' });

--- a/packages/create-svelte/test/check.js
+++ b/packages/create-svelte/test/check.js
@@ -28,7 +28,7 @@ for (const template of fs.readdirSync('templates')) {
 			const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf-8'));
 			pkg.devDependencies['@sveltejs/kit'] = 'file:../../../packages/kit';
 			if (pkg.devDependencies['@sveltejs/adapter-auto']) {
-				pkg.devDependencies['@sveltejs/adapter-auto'] = 'file:../../../packages/kit';
+				pkg.devDependencies['@sveltejs/adapter-auto'] = 'file:../../../packages/adapter-auto';
 			}
 			fs.writeFileSync(path.join(cwd, 'package.json'), JSON.stringify(pkg, null, '\t'));
 			// explicitly only install in the dir under test to avoid running a pnpm workspace command

--- a/packages/create-svelte/test/check.js
+++ b/packages/create-svelte/test/check.js
@@ -33,6 +33,9 @@ for (const template of fs.readdirSync('templates')) {
 			fs.writeFileSync(path.join(cwd, 'package.json'), JSON.stringify(pkg, null, '\t'));
 			// explicitly only install in the dir under test to avoid running a pnpm workspace command
 			execSync('pnpm install .', { cwd, stdio: 'inherit' });
+
+			// run check command separately
+			execSync('pnpm check', { cwd, stdio: 'inherit' });
 		});
 	}
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,4 +5,4 @@ packages:
   - 'packages/kit/test/apps/*'
   - 'packages/kit/test/prerendering/*'
   - 'packages/create-svelte/templates/*'
-  - 'packages/create-svelte/.test-tmp/*'
+  - '!.test-tmp/**'


### PR DESCRIPTION
sets up a separate pnpm workspace and hard links local packages with absolute file paths via pnpm overrides

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
