### PR TITLE
move some dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
 	"homepage": "https://github.com/sveltejs/kit#readme",
 	"devDependencies": {
 		"@changesets/cli": "^2.22.0",
-		"@rollup/plugin-commonjs": "^22.0.1",
 		"@rollup/plugin-json": "^4.1.0",
 		"@rollup/plugin-node-resolve": "^13.3.0",
 		"@sveltejs/eslint-config": "github:sveltejs/eslint-config#v5.8.0",

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -36,7 +36,9 @@
 		"tiny-glob": "^0.2.9"
 	},
 	"devDependencies": {
+		"@rollup/plugin-commonjs": "^22.0.1",
 		"@rollup/plugin-json": "^4.1.0",
+		"@rollup/plugin-node-resolve": "^13.3.0",
 		"@sveltejs/kit": "workspace:*",
 		"@types/compression": "^1.7.2",
 		"@types/node": "^16.11.36",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -16,6 +16,8 @@
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.23.3",
+		"@rollup/plugin-commonjs": "^22.0.1",
+		"@rollup/plugin-node-resolve": "^13.3.0",
 		"@rollup/plugin-replace": "^4.0.0",
 		"@types/connect": "^3.4.35",
 		"@types/cookie": "^0.5.1",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -35,6 +35,7 @@
 		"marked": "^4.0.16",
 		"mime": "^3.0.0",
 		"node-fetch": "^3.2.4",
+		"prettier": "^2.6.2",
 		"rollup": "^2.75.7",
 		"selfsigned": "^2.0.1",
 		"set-cookie-parser": "^2.4.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ importers:
   .:
     specifiers:
       '@changesets/cli': ^2.22.0
-      '@rollup/plugin-commonjs': ^22.0.1
       '@rollup/plugin-json': ^4.1.0
       '@rollup/plugin-node-resolve': ^13.3.0
       '@sveltejs/eslint-config': github:sveltejs/eslint-config#v5.8.0
@@ -25,7 +24,6 @@ importers:
       typescript: ^4.7.4
     devDependencies:
       '@changesets/cli': 2.23.0
-      '@rollup/plugin-commonjs': 22.0.1_rollup@2.75.7
       '@rollup/plugin-json': 4.1.0_rollup@2.75.7
       '@rollup/plugin-node-resolve': 13.3.0_rollup@2.75.7
       '@sveltejs/eslint-config': github.com/sveltejs/eslint-config/9a7d728e03ac433e5856a6e06775c17ee986d641_5nge3uy3zvbeyedwlvrgstgizy

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,7 +130,9 @@ importers:
 
   packages/adapter-node:
     specifiers:
+      '@rollup/plugin-commonjs': ^22.0.1
       '@rollup/plugin-json': ^4.1.0
+      '@rollup/plugin-node-resolve': ^13.3.0
       '@sveltejs/kit': workspace:*
       '@types/compression': ^1.7.2
       '@types/node': ^16.11.36
@@ -147,7 +149,9 @@ importers:
     dependencies:
       tiny-glob: 0.2.9
     devDependencies:
+      '@rollup/plugin-commonjs': 22.0.1_rollup@2.75.7
       '@rollup/plugin-json': 4.1.0_rollup@2.75.7
+      '@rollup/plugin-node-resolve': 13.3.0_rollup@2.75.7
       '@sveltejs/kit': link:../kit
       '@types/compression': 1.7.2
       '@types/node': 16.11.42
@@ -287,6 +291,8 @@ importers:
   packages/kit:
     specifiers:
       '@playwright/test': ^1.23.3
+      '@rollup/plugin-commonjs': ^22.0.1
+      '@rollup/plugin-node-resolve': ^13.3.0
       '@rollup/plugin-replace': ^4.0.0
       '@sveltejs/vite-plugin-svelte': ^1.0.1
       '@types/connect': ^3.4.35
@@ -326,6 +332,8 @@ importers:
       sade: 1.8.1
     devDependencies:
       '@playwright/test': 1.23.3
+      '@rollup/plugin-commonjs': 22.0.1_rollup@2.75.7
+      '@rollup/plugin-node-resolve': 13.3.0_rollup@2.75.7
       '@rollup/plugin-replace': 4.0.0_rollup@2.75.7
       '@types/connect': 3.4.35
       '@types/cookie': 0.5.1
@@ -943,7 +951,7 @@ packages:
       glob: 7.2.3
       is-reference: 1.2.1
       magic-string: 0.25.9
-      resolve: 1.22.0
+      resolve: 1.22.1
       rollup: 2.75.7
     dev: true
 
@@ -967,7 +975,7 @@ packages:
       deepmerge: 4.2.2
       is-builtin-module: 3.1.0
       is-module: 1.0.0
-      resolve: 1.22.0
+      resolve: 1.22.1
       rollup: 2.75.7
     dev: true
 
@@ -1170,7 +1178,7 @@ packages:
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 16.11.42
+      '@types/node': 18.0.0
     dev: true
 
   /@types/sade/1.7.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,6 +310,7 @@ importers:
       marked: ^4.0.16
       mime: ^3.0.0
       node-fetch: ^3.2.4
+      prettier: ^2.6.2
       rollup: ^2.75.7
       sade: ^1.8.1
       selfsigned: ^2.0.1
@@ -349,6 +350,7 @@ importers:
       marked: 4.0.17
       mime: 3.0.0
       node-fetch: 3.2.6
+      prettier: 2.7.1
       rollup: 2.75.7
       selfsigned: 2.0.1
       set-cookie-parser: 2.5.0


### PR DESCRIPTION
While debugging a site deployment failure in #5529, I realised we can probably speed up deployments by only installing dependencies for `@sveltejs/kit` and `kit.svelte.dev`. That failed, because we still have some dependencies that are in the root package.json instead of in `packages`