### PR TITLE
[chore] use consistent Vite options in test projects

### DIFF
--- a/packages/kit/test/apps/amp/vite.config.js
+++ b/packages/kit/test/apps/amp/vite.config.js
@@ -3,6 +3,10 @@ import { plugin } from '../../utils.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
+	build: {
+		minify: false
+	},
+	clearScreen: false,
 	plugins: [plugin()],
 	server: {
 		fs: {

--- a/packages/kit/test/apps/options-2/vite.config.js
+++ b/packages/kit/test/apps/options-2/vite.config.js
@@ -3,6 +3,10 @@ import { plugin } from '../../utils.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
+	build: {
+		minify: false
+	},
+	clearScreen: false,
 	plugins: [plugin()],
 	server: {
 		fs: {


### PR DESCRIPTION
We're using these options in two of the test projects, but not in the other two. It probably makes sense to use them in all