### PR TITLE
[fix] ensure completed_build is reset

### DIFF
--- a/.changeset/lucky-guests-act.md
+++ b/.changeset/lucky-guests-act.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] ensure completed_build is reset

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -176,6 +176,7 @@ function kit() {
 			vite_config_env = config_env;
 			svelte_config = await load_config();
 			is_build = config_env.command === 'build';
+			completed_build = false;
 
 			paths = {
 				build_dir: `${svelte_config.kit.outDir}/build`,


### PR DESCRIPTION
I missed this while reviewing https://github.com/sveltejs/kit/pull/5536 the first time around