### PR TITLE
make resolution failures more appealing

### DIFF
--- a/.changeset/early-eagles-boil.md
+++ b/.changeset/early-eagles-boil.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+Print friendlier message if adapter-vercel fails to resolve dependencies

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -152,6 +152,7 @@ export default function ({ external = [], edge, split } = {}) {
 				);
 
 				await create_function_bundle(
+					builder,
 					`${tmp}/index.js`,
 					`${dirs.functions}/${name}.func`,
 					`nodejs${node_version.major}.x`
@@ -288,21 +289,51 @@ function get_node_version() {
 }
 
 /**
+ * @param {import('@sveltejs/kit').Builder} builder
  * @param {string} entry
  * @param {string} dir
  * @param {string} runtime
  */
-async function create_function_bundle(entry, dir, runtime) {
+async function create_function_bundle(builder, entry, dir, runtime) {
 	let base = entry;
 	while (base !== (base = path.dirname(base)));
 
 	const traced = await nodeFileTrace([entry], { base });
 
+	/** @type {Map<string, string[]>} */
+	const resolution_failures = new Map();
+
 	traced.warnings.forEach((error) => {
 		// pending https://github.com/vercel/nft/issues/284
 		if (error.message.startsWith('Failed to resolve dependency node:')) return;
-		console.error(error);
+
+		if (error.message.startsWith('Failed to resolve dependency')) {
+			const match = /Cannot find module '(.+?)' loaded from (.+)/;
+			const [, module, importer] = match.exec(error.message);
+
+			if (!resolution_failures.has(importer)) {
+				resolution_failures.set(importer, []);
+			}
+
+			resolution_failures.get(importer).push(module);
+		} else {
+			throw error;
+		}
 	});
+
+	if (resolution_failures.size > 0) {
+		const cwd = process.cwd();
+		builder.log.warn(
+			`The following modules failed to locate dependencies that may (or may not) be required for your app to work:`
+		);
+
+		for (const [importer, modules] of resolution_failures) {
+			console.error(`  ${path.relative(cwd, importer)}`);
+			for (const module of modules) {
+				console.error(`    - \u001B[1m\u001B[36m${module}\u001B[39m\u001B[22m`);
+			}
+		}
+	}
 
 	// find common ancestor directory
 	let common_parts;

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -324,7 +324,7 @@ async function create_function_bundle(builder, entry, dir, runtime) {
 	if (resolution_failures.size > 0) {
 		const cwd = process.cwd();
 		builder.log.warn(
-			`The following modules failed to locate dependencies that may (or may not) be required for your app to work:`
+			'The following modules failed to locate dependencies that may (or may not) be required for your app to work:'
 		);
 
 		for (const [importer, modules] of resolution_failures) {


### PR DESCRIPTION
closes #5543.

before:

<img width="1199" alt="image" src="https://user-images.githubusercontent.com/1162160/179271789-d80953b9-1167-424f-9ebf-1a4eb0bd88ad.png">

after:

<img width="785" alt="image" src="https://user-images.githubusercontent.com/1162160/179271879-2225379c-17b8-4e3c-ba47-ace3874c1d64.png">

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
