### PR TITLE
[fix] disable HMR in tests

### DIFF
--- a/packages/kit/test/apps/amp/vite.config.js
+++ b/packages/kit/test/apps/amp/vite.config.js
@@ -14,7 +14,7 @@ const config = {
 		}
 	},
 	vitePlugin: {
- 	   hot: false
+		hot: false
 	}
 };
 

--- a/packages/kit/test/apps/amp/vite.config.js
+++ b/packages/kit/test/apps/amp/vite.config.js
@@ -11,10 +11,8 @@ const config = {
 	server: {
 		fs: {
 			allow: [path.resolve('../../../src')]
-		}
-	},
-	vitePlugin: {
-		hot: false
+		},
+		hmr: false
 	}
 };
 

--- a/packages/kit/test/apps/amp/vite.config.js
+++ b/packages/kit/test/apps/amp/vite.config.js
@@ -12,6 +12,9 @@ const config = {
 		fs: {
 			allow: [path.resolve('../../../src')]
 		}
+	},
+	vitePlugin: {
+ 	   hot: false
 	}
 };
 

--- a/packages/kit/test/apps/basics/vite.config.js
+++ b/packages/kit/test/apps/basics/vite.config.js
@@ -17,6 +17,9 @@ const config = {
 		fs: {
 			allow: [path.resolve('../../../src')]
 		}
+	},
+	vitePlugin: {
+ 	   hot: false
 	}
 };
 

--- a/packages/kit/test/apps/basics/vite.config.js
+++ b/packages/kit/test/apps/basics/vite.config.js
@@ -19,7 +19,7 @@ const config = {
 		}
 	},
 	vitePlugin: {
- 	   hot: false
+		hot: false
 	}
 };
 

--- a/packages/kit/test/apps/basics/vite.config.js
+++ b/packages/kit/test/apps/basics/vite.config.js
@@ -16,10 +16,8 @@ const config = {
 	server: {
 		fs: {
 			allow: [path.resolve('../../../src')]
-		}
-	},
-	vitePlugin: {
-		hot: false
+		},
+		hmr: false
 	}
 };
 

--- a/packages/kit/test/apps/options-2/vite.config.js
+++ b/packages/kit/test/apps/options-2/vite.config.js
@@ -14,7 +14,7 @@ const config = {
 		}
 	},
 	vitePlugin: {
- 	   hot: false
+		hot: false
 	}
 };
 

--- a/packages/kit/test/apps/options-2/vite.config.js
+++ b/packages/kit/test/apps/options-2/vite.config.js
@@ -11,10 +11,8 @@ const config = {
 	server: {
 		fs: {
 			allow: [path.resolve('../../../src')]
-		}
-	},
-	vitePlugin: {
-		hot: false
+		},
+		hmr: false
 	}
 };
 

--- a/packages/kit/test/apps/options-2/vite.config.js
+++ b/packages/kit/test/apps/options-2/vite.config.js
@@ -12,6 +12,9 @@ const config = {
 		fs: {
 			allow: [path.resolve('../../../src')]
 		}
+	},
+	vitePlugin: {
+ 	   hot: false
 	}
 };
 

--- a/packages/kit/test/apps/options/vite.config.js
+++ b/packages/kit/test/apps/options/vite.config.js
@@ -14,7 +14,7 @@ const config = {
 		}
 	},
 	vitePlugin: {
- 	   hot: false
+		hot: false
 	}
 };
 

--- a/packages/kit/test/apps/options/vite.config.js
+++ b/packages/kit/test/apps/options/vite.config.js
@@ -11,10 +11,8 @@ const config = {
 	server: {
 		fs: {
 			allow: [path.resolve('../../../src')]
-		}
-	},
-	vitePlugin: {
-		hot: false
+		},
+		hmr: false
 	}
 };
 

--- a/packages/kit/test/apps/options/vite.config.js
+++ b/packages/kit/test/apps/options/vite.config.js
@@ -12,6 +12,9 @@ const config = {
 		fs: {
 			allow: [path.resolve('../../../src')]
 		}
+	},
+	vitePlugin: {
+ 	   hot: false
 	}
 };
 


### PR DESCRIPTION
I had some consistent flakes locally that I tracked down to being an issue with the Vite client reloading the page. I discovered it by seeing a cancelled request using Playwright Trace that seemed to be caused by a new requesting being issued. I tracked down the request initiator with the following code inserted at the beginning of the flaky test (must be before the first page visit with JavaScript enabled):

```
if (javaScriptEnabled) {
    // ChromeDevTools/devtools-protocol#56
    // increase CallStackDepth to fix initiator stack issue in chrome
    const client = await page.context().newCDPSession(page);
    await client.send('Debugger.enable');
    await client.send('Debugger.setAsyncCallStackDepth', { maxDepth: 32 });

    // #1395
    // puppeteer request events don't propagate initiator currently
    // so register for the event directly with CDP instead
    await client.send('Network.enable');
    client.on('Network.requestWillBeSent', (params) => {
        const reqURL = params.request.url;
        console.log(`request to: ${reqURL}`);
        console.log(`from initiator: ${JSON.stringify(params.initiator)}`);
    });
}
```