### PR TITLE
fix(3748): made %sveltekit.assets% an absolute path

### DIFF
--- a/.changeset/rude-tips-march.md
+++ b/.changeset/rude-tips-march.md
@@ -1,0 +1,8 @@
+---
+"@sveltejs/kit": patch
+"test-basics": patch
+"test-options-2": patch
+"test-options": patch
+---
+
+Made %sveltekit.assets% an absolute path (fixes #3748)

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -292,12 +292,13 @@ export async function render_response({
 		}
 	}
 
-	const segments = event.url.pathname.slice(options.paths.base.length).split('/').slice(2);
-	const assets =
-		options.paths.assets || (segments.length > 0 ? segments.map(() => '..').join('/') : '.');
-
 	const html = await resolve_opts.transformPage({
-		html: options.template({ head, body, assets, nonce: /** @type {string} */ (csp.nonce) })
+		html: options.template({
+			head,
+			body,
+			assets: options.paths.assets,
+			nonce: /** @type {string} */ (csp.nonce)
+		})
 	});
 
 	const headers = new Headers({

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1046,15 +1046,15 @@ test.describe('$app/paths', () => {
 		);
 	});
 
-	test('replaces %sveltekit.assets% in template with relative path', async ({ page }) => {
+	test('replaces %sveltekit.assets% in template with an absolute path', async ({ page }) => {
 		await page.goto('/');
-		expect(await page.getAttribute('link[rel=icon]', 'href')).toBe('./favicon.png');
+		expect(await page.getAttribute('link[rel=icon]', 'href')).toBe('/favicon.png');
 
 		await page.goto('/routing');
-		expect(await page.getAttribute('link[rel=icon]', 'href')).toBe('./favicon.png');
+		expect(await page.getAttribute('link[rel=icon]', 'href')).toBe('/favicon.png');
 
 		await page.goto('/routing/rest/foo/bar/baz');
-		expect(await page.getAttribute('link[rel=icon]', 'href')).toBe('../../../../favicon.png');
+		expect(await page.getAttribute('link[rel=icon]', 'href')).toBe('/favicon.png');
 	});
 });
 

--- a/packages/kit/test/apps/options-2/src/app.html
+++ b/packages/kit/test/apps/options-2/src/app.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		%sveltekit.head%
 	</head>
 	<body>

--- a/packages/kit/test/apps/options-2/test/test.js
+++ b/packages/kit/test/apps/options-2/test/test.js
@@ -15,6 +15,11 @@ test.describe('paths.base', () => {
 		const response = await request.get('/basepath/answer.txt');
 		expect(await response.text()).toBe('42');
 	});
+
+	test('replaces %sveltekit.assets% in template with an absolute path', async ({ page }) => {
+		await page.goto('/basepath/');
+		expect(await page.getAttribute('link[rel=icon]', 'href')).toBe('/basepath/favicon.png');
+	});
 });
 
 test.describe('Service worker', () => {

--- a/packages/kit/test/apps/options/source/template.html
+++ b/packages/kit/test/apps/options/source/template.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<link rel="icon" type="image/png" href="%sveltekit.assets%/favicon.png" />
 		%sveltekit.head%
 	</head>
 	<body>

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -32,6 +32,18 @@ test.describe('base path', () => {
 		expect(await page.textContent('[data-source="assets"]')).toBe('/_svelte_kit_assets');
 	});
 
+	test('replaces %sveltekit.assets% in template with _svelte_kit_assets', async ({
+		page,
+		request
+	}) => {
+		await page.goto('/path-base/');
+		expect(await page.getAttribute('link[rel=icon]', 'href')).toBe(
+			'/_svelte_kit_assets/favicon.png'
+		);
+		const response = await request.get('/_svelte_kit_assets/answer.html');
+		expect(await response.text()).toContain('42');
+	});
+
 	test.skip('loads javascript', async ({ page, javaScriptEnabled }) => {
 		await page.goto('/path-base/base/');
 		expect(await page.textContent('button')).toBe('clicks: 0');


### PR DESCRIPTION
This should fix #3748, but it reverts a design choice made some time ago

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
