### PR TITLE
Updated adapter-cloudflare README

### DIFF
--- a/packages/adapter-cloudflare/README.md
+++ b/packages/adapter-cloudflare/README.md
@@ -47,9 +47,9 @@ When configuring your project settings, you must use the following settings:
 - **Build command** – `npm run build` or `svelte-kit build`
 - **Build output directory** – `.svelte-kit/cloudflare`
 - **Environment variables**
-  - `NODE_VERSION`: `16` or `14`
+  - `NODE_VERSION`: `16`
 
-> **Important:** You need to add a `NODE_VERSION` environment variable to both the "production" and "preview" environments. You can add this during project setup or later in the Pages project settings. SvelteKit requires Node `14.13` or later, so you should use `14` or `16` as the `NODE_VERSION` value.
+> **Important:** You need to add a `NODE_VERSION` environment variable to both the "production" and "preview" environments. You can add this during project setup or later in the Pages project settings. SvelteKit requires Node `16` or later, so you should use `16` as the `NODE_VERSION` value.
 
 ## Environment variables
 

--- a/packages/adapter-cloudflare/README.md
+++ b/packages/adapter-cloudflare/README.md
@@ -83,7 +83,7 @@ declare namespace App {
 
 Functions contained in the `/functions` directory at the project's root will _not_ be included in the deployment, which is compiled to a [single `_worker.js` file](https://developers.cloudflare.com/pages/platform/functions/#advanced-mode). Functions should be implemented as [endpoints](https://kit.svelte.dev/docs/routing#endpoints) in your SvelteKit app.
 
-If you want to use `_headers` or `_redirects` custom [config files](https://developers.cloudflare.com/pages/platform/headers) to modify cloudflare behaviour you should put those configs in the `/static` folder of your SvelteKit project.
+The [`_headers` and `_redirects`](config files) files specific to Cloudflare Pages are not currently supported using SvelteKit. In order to return custom headers or redirect a user, return `headers` or a redirect using [SvelteKit Endpoints](https://kit.svelte.dev/docs/routing#endpoints).
 
 ## Changelog
 

--- a/packages/adapter-cloudflare/README.md
+++ b/packages/adapter-cloudflare/README.md
@@ -84,7 +84,8 @@ declare namespace App {
 Functions contained in the `/functions` directory at the project's root will _not_ be included in the deployment, which is compiled to a [single `_worker.js` file](https://developers.cloudflare.com/pages/platform/functions/#advanced-mode). Functions should be implemented as [endpoints](https://kit.svelte.dev/docs/routing#endpoints) in your SvelteKit app.
 
 The [`_headers` and `_redirects`](config files) files specific to Cloudflare Pages can be used for static asset responses (like images) by putting them into the `/static` folder.
-However, they are not currently supported for server-side rendered pages using SvelteKit. In order to return custom headers or redirect a user on SSRed pages, return `headers` or a redirect using [SvelteKit Endpoints](https://kit.svelte.dev/docs/routing#endpoints).
+
+However, they will have no effect on responses dynamically rendered by SvelteKit, which should return custom headers or redirect responses from [endpoints](https://kit.svelte.dev/docs/routing#endpoints) or with the [`handle`](https://kit.svelte.dev/docs/hooks#handle) hook.
 
 ## Changelog
 

--- a/packages/adapter-cloudflare/README.md
+++ b/packages/adapter-cloudflare/README.md
@@ -49,7 +49,7 @@ When configuring your project settings, you must use the following settings:
 - **Environment variables**
   - `NODE_VERSION`: `16`
 
-> **Important:** You need to add a `NODE_VERSION` environment variable to both the "production" and "preview" environments. You can add this during project setup or later in the Pages project settings. SvelteKit requires Node `16` or later, so you should use `16` as the `NODE_VERSION` value.
+> **Important:** You need to add a `NODE_VERSION` environment variable to both the "production" and "preview" environments. You can add this during project setup or later in the Pages project settings. SvelteKit requires Node `16.9` or later, so you should use `16` as the `NODE_VERSION` value.
 
 ## Environment variables
 

--- a/packages/adapter-cloudflare/README.md
+++ b/packages/adapter-cloudflare/README.md
@@ -83,7 +83,8 @@ declare namespace App {
 
 Functions contained in the `/functions` directory at the project's root will _not_ be included in the deployment, which is compiled to a [single `_worker.js` file](https://developers.cloudflare.com/pages/platform/functions/#advanced-mode). Functions should be implemented as [endpoints](https://kit.svelte.dev/docs/routing#endpoints) in your SvelteKit app.
 
-The [`_headers` and `_redirects`](config files) files specific to Cloudflare Pages are not currently supported using SvelteKit. In order to return custom headers or redirect a user, return `headers` or a redirect using [SvelteKit Endpoints](https://kit.svelte.dev/docs/routing#endpoints).
+The [`_headers` and `_redirects`](config files) files specific to Cloudflare Pages can be used for static asset responses (like images) by putting them into the `/static` folder.
+However, they are not currently supported for server-side rendered pages using SvelteKit. In order to return custom headers or redirect a user on SSRed pages, return `headers` or a redirect using [SvelteKit Endpoints](https://kit.svelte.dev/docs/routing#endpoints).
 
 ## Changelog
 


### PR DESCRIPTION
This PR fixes 2 things in the `adapter-cloudflare` README.md

**Number One:**
- Per https://github.com/sveltejs/kit/issues/4916, SvelteKit has dropped Node 14 support.
- This PR updates the `adapter-cloudflare` docs to remove mentions about SvelteKit supporting Node 14.

**Number Two:**
- `_headers` and `_redirects` config files that Cloudflare Pages uses only apply to static assets, not server-side rendered pages.
- Info about these files was added to the README.md, this PR modifies this to add that important detail.
- Closes https://github.com/sveltejs/kit/issues/5575, reverts https://github.com/sveltejs/kit/pull/5453

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
