### PR TITLE
fix: use actual vite version in version check 

### DIFF
--- a/.changeset/quick-boxes-reflect.md
+++ b/.changeset/quick-boxes-reflect.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+improve vite version check to work with custom resolutions, eg. pnpm overrides

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import colors from 'kleur';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
-import { searchForWorkspaceRoot, version as vite_version } from 'vite';
+import * as vite from 'vite';
 import { mkdirp, posixify, rimraf } from '../utils/filesystem.js';
 import * as sync from '../core/sync/sync.js';
 import { build_server } from './build/build_server.js';
@@ -222,7 +222,7 @@ function kit() {
 								svelte_config.kit.outDir,
 								path.resolve(cwd, 'src'),
 								path.resolve(cwd, 'node_modules'),
-								path.resolve(searchForWorkspaceRoot(cwd), 'node_modules')
+								path.resolve(vite.searchForWorkspaceRoot(cwd), 'node_modules')
 							])
 						]
 					},
@@ -402,9 +402,11 @@ function kit() {
 }
 
 function check_vite_version() {
-	const current_vite_major = parseInt(vite_version.split('.')[0], 10);
 	// TODO parse from kit peer deps and maybe do a full semver compare if we ever require feature releases a min
 	const min_required_vite_major = 3;
+	const vite_version = vite.version ?? '2.x'; // vite started exporting it's version in 3.0
+	const current_vite_major = parseInt(vite_version.split('.')[0], 10);
+
 	if (current_vite_major < min_required_vite_major) {
 		throw new Error(
 			`Vite version ${current_vite_major} is no longer supported. Please upgrade to version ${min_required_vite_major}`

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import colors from 'kleur';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
-import { searchForWorkspaceRoot } from 'vite';
+import { searchForWorkspaceRoot, version as vite_version } from 'vite';
 import { mkdirp, posixify, rimraf } from '../utils/filesystem.js';
 import * as sync from '../core/sync/sync.js';
 import { build_server } from './build/build_server.js';
@@ -402,18 +402,12 @@ function kit() {
 }
 
 function check_vite_version() {
-	let vite_major = 3;
-
-	try {
-		const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
-		vite_major = +pkg.devDependencies['vite'].replace(/^[~^]/, '')[0];
-	} catch {
-		// do nothing
-	}
-
-	if (vite_major < 3) {
+	const current_vite_major = parseInt(vite_version.split('.')[0], 10);
+	// TODO parse from kit peer deps and maybe do a full semver compare if we ever require feature releases a min
+	const min_required_vite_major = 3;
+	if (current_vite_major < min_required_vite_major) {
 		throw new Error(
-			`Vite version ${vite_major} is no longer supported. Please upgrade to version 3`
+			`Vite version ${current_vite_major} is no longer supported. Please upgrade to version ${min_required_vite_major}`
 		);
 	}
 }


### PR DESCRIPTION
to allow custom resolutions, local links etc

the previous implementation did a read of local devDependencies. That does not work when pnpm overrides are used, or the local devDependency is set to a link of a local version etc.

Vite exports it's version so just use that instead.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
