### PR TITLE
bump prettier format print width

### DIFF
--- a/packages/kit/scripts/extract-types.js
+++ b/packages/kit/scripts/extract-types.js
@@ -51,7 +51,7 @@ function get_types(code, statements) {
 
 			const snippet = prettier.format(code.slice(start, statement.end).trim(), {
 				parser: 'typescript',
-				printWidth: 60,
+				printWidth: 80,
 				useTabs: true,
 				singleQuote: true,
 				trailingComma: 'none'


### PR DESCRIPTION
Makes it just a tad bit nicer to read, some examples (making it in one column so that the images are still visible)

|Before/After|
|---|
|1. `Load`|
|![image](https://user-images.githubusercontent.com/8156777/179534903-77ec932a-240e-4ed3-af3c-61b2e59bd41f.png)|
|![image](https://user-images.githubusercontent.com/8156777/179534972-ae93b6e0-2876-407f-9c9f-71e38c924010.png)|
|2. `RequestHandler` & `RequestHandlerOutput`|
|![image](https://user-images.githubusercontent.com/8156777/179535743-5f7faeae-712a-450d-b766-61aa4334f28b.png)|
|![image](https://user-images.githubusercontent.com/8156777/179535848-5480c86f-6fb6-462e-b445-ba6e02f06261.png)|
|3. etc.|


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
