### PR TITLE
test: extend create-svelte tests to cover most package.json scripts

### DIFF
--- a/packages/create-svelte/test/check.js
+++ b/packages/create-svelte/test/check.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import { execSync } from 'child_process';
 import path from 'path';
 import { test } from 'uvu';
+import * as assert from 'uvu/assert';
 import { create } from '../index.js';
 import { fileURLToPath } from 'url';
 // use a directory outside of packages to ensure it isn't added to the pnpm workspace
@@ -56,9 +57,9 @@ for (const template of fs.readdirSync('templates')) {
 				name: `create-svelte-test-${template}-${types}`,
 				template,
 				types,
-				prettier: false,
-				eslint: false,
-				playwright: false
+				prettier: true,
+				eslint: true,
+				playwright: true
 			});
 			const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf-8'));
 			Object.entries(overrides).forEach(([key, value]) => {
@@ -69,13 +70,32 @@ for (const template of fs.readdirSync('templates')) {
 					pkg.dependencies[key] = value;
 				}
 			});
-			fs.writeFileSync(path.join(cwd, 'package.json'), JSON.stringify(pkg, null, '\t'));
+			pkg.private = true;
+			fs.writeFileSync(path.join(cwd, 'package.json'), JSON.stringify(pkg, null, '\t') + '\n');
 
 			// this pnpm install works in the test workspace, which redirects to our local packages again
 			execSync('pnpm install --no-frozen-lockfile', { cwd, stdio: 'inherit' });
 
-			// run check command separately
-			execSync('pnpm check', { cwd, stdio: 'inherit' });
+			// run provided scripts that are non-blocking. All of them should exit with 0
+			const scripts_to_test = ['prepare', 'check', 'lint', 'format', 'test', 'build', 'sync'];
+
+			// package script requires lib dir
+			if (fs.existsSync(path.join(cwd, 'src', 'lib'))) {
+				scripts_to_test.push('package');
+			}
+
+			// not all templates have all scripts
+			for (const script of Object.keys(pkg.scripts).filter((s) => scripts_to_test.includes(s))) {
+				const command = `pnpm run ${script}`;
+				try {
+					console.log(`executing ${command} in ${cwd}`);
+					execSync(command, { cwd, stdio: 'inherit' });
+				} catch (e) {
+					const msg = `${command} failed in ${cwd}`;
+					console.error(msg, e);
+					assert.unreachable(msg);
+				}
+			}
 		});
 	}
 }

--- a/packages/create-svelte/test/check.js
+++ b/packages/create-svelte/test/check.js
@@ -59,7 +59,7 @@ for (const template of fs.readdirSync('templates')) {
 				types,
 				prettier: true,
 				eslint: true,
-				playwright: true
+				playwright: false
 			});
 			const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf-8'));
 			Object.entries(overrides).forEach(([key, value]) => {
@@ -77,7 +77,7 @@ for (const template of fs.readdirSync('templates')) {
 			execSync('pnpm install --no-frozen-lockfile', { cwd, stdio: 'inherit' });
 
 			// run provided scripts that are non-blocking. All of them should exit with 0
-			const scripts_to_test = ['prepare', 'check', 'lint', 'format', 'test', 'build', 'sync'];
+			const scripts_to_test = ['prepare', 'check', 'lint', 'build', 'sync'];
 
 			// package script requires lib dir
 			if (fs.existsSync(path.join(cwd, 'src', 'lib'))) {


### PR DESCRIPTION
enable prettier and eslint in create-svelte test projects and test most run scripts instead of just  `pnpm run check`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
