### PR TITLE
[fix] Reset navigating store upon return to site with a bfcache hit

### DIFF
--- a/.changeset/tough-dolls-relate.md
+++ b/.changeset/tough-dolls-relate.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Reset navigating store upon return to site with a bfcache hit

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1219,6 +1219,16 @@ export function create_client({ target, session, base, trailing_slash }) {
 					);
 				}
 			});
+
+			addEventListener('pageshow', (event) => {
+				// If the user navigates to another site and then uses the back button and
+				// bfcache hits, we need to set navigating to null, the site doesn't know
+				// the navigation away from it was successful.
+				// Info about bfcache here: https://web.dev/bfcache
+				if (event.persisted) {
+					stores.navigating.set(null);
+				}
+			});
 		},
 
 		_hydrate: async ({ status, error, nodes, params, routeId }) => {


### PR DESCRIPTION
Fixes #5415

The alternative fix would have been to do this in beforeunload, but this might result in more possibilities of flickering than the other way around.

I didn't know how to possibly write a test for this since this requires cross site navigation _and_ a bfcache hit.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
