### PR TITLE
[breaking] remove `writeStatic` to align with Vite

### DIFF
--- a/.changeset/smooth-cars-reflect.md
+++ b/.changeset/smooth-cars-reflect.md
@@ -1,0 +1,11 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-static': patch
+'@sveltejs/adapter-vercel': patch
+'@sveltejs/kit': patch
+---
+
+[breaking] remove writeStatic to align with Vite

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -74,7 +74,6 @@ export default function () {
 
 			builder.log.minor('Copying assets...');
 			builder.writeClient(site.bucket);
-			builder.writeStatic(site.bucket);
 			builder.writePrerendered(site.bucket);
 		}
 	};

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -23,7 +23,6 @@ export default function () {
 			builder.rimraf(tmp);
 			builder.mkdirp(tmp);
 
-			builder.writeStatic(dest);
 			builder.writeClient(dest);
 			builder.writePrerendered(dest);
 

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -55,7 +55,6 @@ export default function ({ split = false, edge = edge_set_in_env_var } = {}) {
 			builder.log.minor(`Publishing to "${publish}"`);
 
 			builder.log.minor('Copying assets...');
-			builder.writeStatic(publish);
 			builder.writeClient(publish);
 			builder.writePrerendered(publish);
 
@@ -232,7 +231,7 @@ async function generate_lambda_functions({ builder, publish, split, esm }) {
 		redirects.push('* /.netlify/functions/render 200');
 	}
 
-	// this should happen at the end, after builder.writeStatic(...),
+	// this should happen at the end, after builder.writeClient(...),
 	// so that generated redirects are appended to custom redirects
 	// rather than replaced by them
 	builder.log.minor('Writing redirects...');

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -30,7 +30,6 @@ export default function (opts = {}) {
 			builder.log.minor('Copying assets');
 			builder.writeClient(`${out}/client`);
 			builder.writeServer(`${out}/server`);
-			builder.writeStatic(`${out}/static`);
 			builder.writePrerendered(`${out}/prerendered`);
 
 			writeFileSync(

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -43,7 +43,6 @@ export default function (options) {
 			builder.rimraf(assets);
 			builder.rimraf(pages);
 
-			builder.writeStatic(assets);
 			builder.writeClient(assets);
 			builder.writePrerendered(pages, { fallback });
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -236,7 +236,6 @@ export default function ({ external = [], edge, split } = {}) {
 
 			builder.log.minor('Copying assets...');
 
-			builder.writeStatic(dirs.static);
 			builder.writeClient(dirs.static);
 			builder.writePrerendered(dirs.static);
 

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -122,7 +122,10 @@ export function create_builder({ config, build_data, prerendered, log }) {
 		},
 
 		writeClient(dest) {
-			return copy(`${config.kit.outDir}/output/client`, dest);
+			return [
+				...copy(`${config.kit.outDir}/output/client`, dest),
+				...copy(config.kit.files.assets, dest)
+			];
 		},
 
 		writePrerendered(dest, { fallback } = {}) {
@@ -141,8 +144,13 @@ export function create_builder({ config, build_data, prerendered, log }) {
 			return copy(`${config.kit.outDir}/output/server`, dest);
 		},
 
+		// TODO remove these methods for 1.0
 		writeStatic(dest) {
-			return copy(config.kit.files.assets, dest);
+			throw new Error(
+				`writeStatic has been removed. Please ensure you are using the latest version of ${
+					config.kit.adapter.name || 'your adapter'
+				}`
+			);
 		},
 
 		// @ts-expect-error

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -145,7 +145,8 @@ export function create_builder({ config, build_data, prerendered, log }) {
 		},
 
 		// TODO remove these methods for 1.0
-		writeStatic(dest) {
+		// @ts-expect-error
+		writeStatic() {
 			throw new Error(
 				`writeStatic has been removed. Please ensure you are using the latest version of ${
 					config.kit.adapter.name || 'your adapter'
@@ -153,7 +154,6 @@ export function create_builder({ config, build_data, prerendered, log }) {
 			);
 		},
 
-		// @ts-expect-error
 		async prerender() {
 			throw new Error(
 				'builder.prerender() has been removed. Prerendering now takes place in the build phase — see builder.prerender and builder.writePrerendered'

--- a/packages/kit/src/core/adapt/builder.spec.js
+++ b/packages/kit/src/core/adapt/builder.spec.js
@@ -40,21 +40,16 @@ test('copy files', () => {
 	const dest = join(__dirname, 'output');
 
 	rmSync(dest, { recursive: true, force: true });
-	builder.writeStatic(dest);
-
-	assert.equal(
-		glob('**', {
-			cwd: /** @type {import('types').ValidatedConfig} */ (mocked).kit.files.assets,
-			dot: true
-		}),
-		glob('**', { cwd: dest, dot: true })
-	);
-
-	rmSync(dest, { recursive: true, force: true });
 	builder.writeClient(dest);
 
 	assert.equal(
-		glob('**', { cwd: `${outDir}/output/client`, dot: true }),
+		[
+			...glob('**', {
+				cwd: /** @type {import('types').ValidatedConfig} */ (mocked).kit.files.assets,
+				dot: true
+			}),
+			...glob('**', { cwd: `${outDir}/output/client`, dot: true })
+		],
 		glob('**', { cwd: dest, dot: true })
 	);
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -66,11 +66,6 @@ export interface Builder {
 	 */
 	writeServer(dest: string): string[];
 	/**
-	 * @param dest the destination folder to which files should be copied
-	 * @returns an array of paths corresponding to the files that have been created by the copy
-	 */
-	writeStatic(dest: string): string[];
-	/**
 	 * @param from the source file or folder
 	 * @param to the destination file or folder
 	 * @param opts.filter a function to determine whether a file or folder should be copied


### PR DESCRIPTION
Have `writeClient` write both the client and static files and remove `writeStatic`. This is a breaking change for adapter authors.

If we were using Vite's `publicDir` and `base` options it would put the static files into the client directory. This change will free us up to be able to utilize those options in the future. This change was prototyped in https://github.com/sveltejs/kit/pull/5601, but it's getting too large and complicated, so I'm breaking it up.