### PR TITLE
[fix] change Vite's output directory from _app to client

### DIFF
--- a/.changeset/strong-cats-wonder.md
+++ b/.changeset/strong-cats-wonder.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-[fix] change Vite's output directory from \_app to client
+[fix] change Vite's output directory from `_app` to client

--- a/.changeset/strong-cats-wonder.md
+++ b/.changeset/strong-cats-wonder.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] change Vite's output directory from \_app to client

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -64,7 +64,6 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 
 	// prettier-ignore
 	return `{
-		appDir: ${s(build_data.app_dir)},
 		assets: new Set(${s(assets)}),
 		mimeTypes: ${s(get_mime_lookup(build_data.manifest_data))},
 		_: {

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -64,6 +64,7 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 
 	// prettier-ignore
 	return `{
+		appDir: ${s(build_data.app_dir)},
 		assets: new Set(${s(assets)}),
 		mimeTypes: ${s(get_mime_lookup(build_data.manifest_data))},
 		_: {

--- a/packages/kit/src/vite/build/build_server.js
+++ b/packages/kit/src/vite/build/build_server.js
@@ -73,7 +73,7 @@ export class Server {
 			manifest,
 			method_override: ${s(config.kit.methodOverride)},
 			paths: { base, assets },
-			prefix: assets + '/${config.kit.appDir}/',
+			prefix: assets + '/',
 			prerender: {
 				default: ${config.kit.prerender.default},
 				enabled: ${config.kit.prerender.enabled}

--- a/packages/kit/src/vite/build/build_service_worker.js
+++ b/packages/kit/src/vite/build/build_service_worker.js
@@ -43,7 +43,7 @@ export async function build_service_worker(
 
 			export const build = [
 				${Array.from(build)
-					.map((file) => `${s(`${config.kit.paths.base}/${config.kit.appDir}/${file}`)}`)
+					.map((file) => `${s(`${config.kit.paths.base}/${file}`)}`)
 					.join(',\n\t\t\t\t')}
 			];
 

--- a/packages/kit/src/vite/build/utils.js
+++ b/packages/kit/src/vite/build/utils.js
@@ -96,9 +96,9 @@ export const get_default_config = function ({ config, input, ssr, outDir }) {
 				input,
 				output: {
 					format: 'esm',
-					entryFileNames: ssr ? '[name].js' : 'immutable/[name]-[hash].js',
-					chunkFileNames: 'immutable/chunks/[name]-[hash].js',
-					assetFileNames: 'immutable/assets/[name]-[hash][extname]'
+					entryFileNames: ssr ? '[name].js' : `${config.kit.appDir}/immutable/[name]-[hash].js`,
+					chunkFileNames: `${config.kit.appDir}/immutable/chunks/[name]-[hash].js`,
+					assetFileNames: `${config.kit.appDir}/immutable/assets/[name]-[hash][extname]`
 				},
 				preserveEntrySignatures: 'strict'
 			},
@@ -140,7 +140,7 @@ export function assets_base(config) {
 	// during `svelte-kit preview`, because we use a local asset path. This
 	// may be fixed in Vite 3: https://github.com/vitejs/vite/issues/2009
 	const { base, assets } = config.paths;
-	return `${assets || base}/${config.appDir}/`;
+	return `${assets || base}/`;
 }
 
 /**

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -180,7 +180,7 @@ function kit() {
 			paths = {
 				build_dir: `${svelte_config.kit.outDir}/build`,
 				output_dir: `${svelte_config.kit.outDir}/output`,
-				client_out_dir: `${svelte_config.kit.outDir}/output/client/${svelte_config.kit.appDir}`
+				client_out_dir: `${svelte_config.kit.outDir}/output/client/`
 			};
 
 			if (is_build) {
@@ -271,7 +271,7 @@ function kit() {
 			});
 
 			fs.writeFileSync(
-				`${paths.client_out_dir}/version.json`,
+				`${paths.client_out_dir}/${svelte_config.kit.appDir}/version.json`,
 				JSON.stringify({ version: svelte_config.kit.version.name })
 			);
 
@@ -316,8 +316,8 @@ function kit() {
 
 			const files = new Set([
 				...static_files,
-				...chunks.map((chunk) => `${svelte_config.kit.appDir}/${chunk.fileName}`),
-				...assets.map((chunk) => `${svelte_config.kit.appDir}/${chunk.fileName}`)
+				...chunks.map((chunk) => chunk.fileName),
+				...assets.map((chunk) => chunk.fileName)
 			]);
 
 			// TODO is this right?


### PR DESCRIPTION
This fixes an issue that @userquin ran into trying to make `vite-plugin-pwa` work with SvelteKit. He was using Vite/Rollup's `emit` to output a service worker manifest and expecting it to be served from the root directory, but it was ending up under `_app`. `_app` is arguable only for stuff generated by SvelteKit though. I could imagine lots of other things like a `robots.txt` or something you might want to generate with a Vite plugin that need to go in a certain location and are impossible to put there today.

I also think the code ends up being a little nicer this was as we don't end up having to specify the app dir in quite as many places

I'm splitting this out from https://github.com/sveltejs/kit/pull/5601 as that PR was becoming too unwieldy