### PR TITLE
only normalise internal URLs

### DIFF
--- a/.changeset/witty-carrots-notice.md
+++ b/.changeset/witty-carrots-notice.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Only normalise internal URLs

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -238,8 +238,9 @@ export function create_client({ target, session, base, trailing_slash }) {
 			return false; // unnecessary, but TypeScript prefers it this way
 		}
 
-		// use the normalized URL from here on out
-		url = /** @type {import('./types').NavigationIntent} */ (intent).url;
+		// if this is an internal navigation intent, use the normalized
+		// URL for the rest of the function
+		url = intent?.url || url;
 
 		// abort if user navigated during update
 		if (token !== current_token) return false;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -238,6 +238,9 @@ export function create_client({ target, session, base, trailing_slash }) {
 			return false; // unnecessary, but TypeScript prefers it this way
 		}
 
+		// use the normalized URL from here on out
+		url = /** @type {import('./types').NavigationIntent} */ (intent).url;
+
 		// abort if user navigated during update
 		if (token !== current_token) return false;
 
@@ -891,9 +894,12 @@ export function create_client({ target, session, base, trailing_slash }) {
 			const params = route.exec(path);
 
 			if (params) {
-				const id = normalize_path(url.pathname, trailing_slash) + url.search;
+				const normalized = new URL(
+					url.origin + normalize_path(url.pathname, trailing_slash) + url.search + url.hash
+				);
+				const id = normalized.pathname + normalized.search;
 				/** @type {import('./types').NavigationIntent} */
-				const intent = { id, route, params: decode_params(params), url };
+				const intent = { id, route, params: decode_params(params), url: normalized };
 				return intent;
 			}
 		}
@@ -930,9 +936,6 @@ export function create_client({ target, session, base, trailing_slash }) {
 			return;
 		}
 
-		const pathname = normalize_path(url.pathname, trailing_slash);
-		const normalized = new URL(url.origin + pathname + url.search + url.hash);
-
 		update_scroll_positions(current_history_index);
 
 		accepted();
@@ -940,12 +943,12 @@ export function create_client({ target, session, base, trailing_slash }) {
 		if (started) {
 			stores.navigating.set({
 				from: current.url,
-				to: normalized
+				to: url
 			});
 		}
 
 		await update(
-			normalized,
+			url,
 			redirect_chain,
 			false,
 			{
@@ -954,7 +957,7 @@ export function create_client({ target, session, base, trailing_slash }) {
 				details
 			},
 			() => {
-				const navigation = { from, to: normalized };
+				const navigation = { from, to: url };
 				callbacks.after_navigate.forEach((fn) => fn(navigation));
 
 				stores.navigating.set(null);

--- a/packages/kit/test/apps/basics/src/routes/routing/slashes/index.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/slashes/index.svelte
@@ -1,3 +1,8 @@
+<script>
+	import { page } from '$app/stores';
+</script>
+
 <a href="/routing/">/routing/</a>
 <a href="/routing/?">/routing/?</a>
 <a href="/routing/?foo=bar">/routing/?foo=bar</a>
+<a href="http://localhost:{$page.url.searchParams.get('port')}/with-slash/">external</a>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -553,12 +553,14 @@ test.describe('Routing', () => {
 			res.end('ok');
 		});
 
-		await page.goto(`/routing/slashes?port=${port}`);
-		await page.click(`a[href="http://localhost:${port}/with-slash/"]`);
+		try {
+			await page.goto(`/routing/slashes?port=${port}`);
+			await page.click(`a[href="http://localhost:${port}/with-slash/"]`);
 
-		expect(urls).toEqual(['/with-slash/']);
-
-		await close();
+			expect(urls).toEqual(['/with-slash/']);
+		} finally {
+			await close();
+		}
 	});
 });
 

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { test } from '../../../utils.js';
+import { start_server, test } from '../../../utils.js';
 
 /** @typedef {import('@playwright/test').Response} Response */
 
@@ -543,6 +543,22 @@ test.describe('Routing', () => {
 		await page.click('[href="#target"]');
 		expect(await page.textContent('#window-hash')).toBe('#target');
 		expect(await page.textContent('#page-url-hash')).toBe('#target');
+	});
+
+	test('does not normalize external path', async ({ page }) => {
+		const urls = [];
+
+		const { port, close } = await start_server((req, res) => {
+			urls.push(req.url);
+			res.end('ok');
+		});
+
+		await page.goto(`/routing/slashes?port=${port}`);
+		await page.click(`a[href="http://localhost:${port}/with-slash/"]`);
+
+		expect(urls).toEqual(['/with-slash/']);
+
+		await close();
 	});
 });
 


### PR DESCRIPTION
fixes #5087, by only normalising URLs we're navigating to once we've established that it's a page within the app

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
