### PR TITLE
set Vite's `publicDir` option

### DIFF
--- a/.changeset/modern-jars-return.md
+++ b/.changeset/modern-jars-return.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/adapter-node': patch
+'@sveltejs/kit': patch
+---
+
+set Vite's `publicDir` option

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -50,7 +50,6 @@ export default function (opts = {}) {
 			if (precompress) {
 				builder.log.minor('Compressing assets');
 				await compress(`${out}/client`);
-				await compress(`${out}/static`);
 				await compress(`${out}/prerendered`);
 			}
 		}

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -122,10 +122,7 @@ export function create_builder({ config, build_data, prerendered, log }) {
 		},
 
 		writeClient(dest) {
-			return [
-				...copy(`${config.kit.outDir}/output/client`, dest),
-				...copy(config.kit.files.assets, dest)
-			];
+			return [...copy(`${config.kit.outDir}/output/client`, dest)];
 		},
 
 		writePrerendered(dest, { fallback } = {}) {

--- a/packages/kit/src/core/adapt/builder.spec.js
+++ b/packages/kit/src/core/adapt/builder.spec.js
@@ -43,13 +43,7 @@ test('copy files', () => {
 	builder.writeClient(dest);
 
 	assert.equal(
-		[
-			...glob('**', {
-				cwd: /** @type {import('types').ValidatedConfig} */ (mocked).kit.files.assets,
-				dot: true
-			}),
-			...glob('**', { cwd: `${outDir}/output/client`, dot: true })
-		],
+		glob('**', { cwd: `${outDir}/output/client`, dot: true }),
 		glob('**', { cwd: dest, dot: true })
 	);
 

--- a/packages/kit/src/vite/build/utils.js
+++ b/packages/kit/src/vite/build/utils.js
@@ -117,9 +117,7 @@ export const get_default_config = function ({ config, input, ssr, outDir }) {
 			__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: JSON.stringify(config.kit.version.pollInterval),
 			__SVELTEKIT_DEV__: 'false'
 		},
-		// prevent Vite copying the contents of `config.kit.files.assets`,
-		// if it happens to be 'public' instead of 'static'
-		publicDir: false,
+		publicDir: ssr ? false : config.kit.files.assets,
 		resolve: {
 			alias: get_aliases(config.kit)
 		},

--- a/packages/kit/src/vite/dev/index.js
+++ b/packages/kit/src/vite/dev/index.js
@@ -198,6 +198,7 @@ export async function dev(vite, vite_config, svelte_config) {
 
 				const decoded = decodeURI(new URL(base + req.url).pathname);
 
+				let wrong_case = false;
 				if (decoded.startsWith(assets)) {
 					const pathname = decoded.slice(assets.length);
 					const file = svelte_config.kit.files.assets + pathname;
@@ -207,6 +208,8 @@ export async function dev(vite, vite_config, svelte_config) {
 							req.url = encodeURI(pathname); // don't need query/hash
 							asset_server(req, res);
 							return;
+						} else {
+							wrong_case = true;
 						}
 					}
 				}
@@ -217,7 +220,7 @@ export async function dev(vite, vite_config, svelte_config) {
 					!vite_config.server.fs.strict ||
 					vite_config.server.fs.allow.some((dir) => file.startsWith(dir));
 
-				if (is_file && allowed) {
+				if (is_file && allowed && !wrong_case) {
 					// @ts-expect-error
 					serve_static_middleware.handle(req, res);
 					return;

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -209,6 +209,7 @@ function kit() {
 					__SVELTEKIT_DEV__: 'true',
 					__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: '0'
 				},
+				publicDir: svelte_config.kit.files.assets,
 				resolve: {
 					alias: get_aliases(svelte_config.kit)
 				},

--- a/packages/kit/src/vite/preview/index.js
+++ b/packages/kit/src/vite/preview/index.js
@@ -47,13 +47,13 @@ export async function preview(vite, config, protocol) {
 		// files in `static`
 		vite.middlewares.use(scoped(assets, mutable(config.kit.files.assets)));
 
-		// immutable generated client assets
+		// generated client assets
 		vite.middlewares.use(
 			scoped(
 				assets,
 				sirv(join(config.kit.outDir, 'output/client'), {
 					setHeaders: (res, pathname) => {
-						// only apply to build directory, not e.g. version.json
+						// only apply to immutable directory, not e.g. version.json
 						if (pathname.startsWith(`/${config.kit.appDir}/immutable`)) {
 							res.setHeader('cache-control', 'public,max-age=31536000,immutable');
 						}

--- a/packages/kit/src/vite/preview/index.js
+++ b/packages/kit/src/vite/preview/index.js
@@ -44,9 +44,6 @@ export async function preview(vite, config, protocol) {
 	const server = new Server(manifest);
 
 	return () => {
-		// files in `static`
-		vite.middlewares.use(scoped(assets, mutable(config.kit.files.assets)));
-
 		// generated client assets and the contents of `static`
 		vite.middlewares.use(
 			scoped(

--- a/packages/kit/src/vite/preview/index.js
+++ b/packages/kit/src/vite/preview/index.js
@@ -47,7 +47,7 @@ export async function preview(vite, config, protocol) {
 		// files in `static`
 		vite.middlewares.use(scoped(assets, mutable(config.kit.files.assets)));
 
-		// generated client assets
+		// generated client assets and the contents of `static`
 		vite.middlewares.use(
 			scoped(
 				assets,


### PR DESCRIPTION
Trying https://github.com/sveltejs/kit/commit/14c18e3cdf023b587e1946e1b012f33cadb8d82a again, but in a way that will pass the CI this time

This sets the `publicDir` option, but still uses our own `sirv` middleware to serve static assets. Having `publicDir` set though means that assets end up where expected for Vite plugins like `vite-plugin-pwa` and that they can find where we keep our assets