### PR TITLE
[docs] Change from "sync" to "prepare" script in alias FAQ

### DIFF
--- a/documentation/faq/50-aliases.md
+++ b/documentation/faq/50-aliases.md
@@ -4,4 +4,4 @@ title: How do I setup a path alias?
 
 Aliases can be set in `svelte.config.js` as described in the [`configuration`](/docs/configuration#alias) docs.
 
-Then run `npm run sync` or `npm run dev` (which will execute `sync`). SvelteKit will automatically generate the required alias configuration in `jsconfig.json` or `tsconfig.json`.
+Then run `npm run prepare` or `npm run dev` (which will execute `prepare`). SvelteKit will automatically generate the required alias configuration in `jsconfig.json` or `tsconfig.json`.

--- a/documentation/faq/50-aliases.md
+++ b/documentation/faq/50-aliases.md
@@ -4,4 +4,4 @@ title: How do I setup a path alias?
 
 Aliases can be set in `svelte.config.js` as described in the [`configuration`](/docs/configuration#alias) docs.
 
-Then run `npm run prepare` or `npm run dev` (which will execute `prepare`). SvelteKit will automatically generate the required alias configuration in `jsconfig.json` or `tsconfig.json`.
+Then run `npm run prepare` or `npm run dev` (both will execute a sync command). SvelteKit will automatically generate the required alias configuration in `jsconfig.json` or `tsconfig.json`.


### PR DESCRIPTION
The current FAQ for adding path aliases in the FAQ say to use `npm run sync` which no longer exists. From my understanding, it was replaced with `npm run prepare`, so I have updated the script name in the docs to prevent confusion.



### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
