### PR TITLE
replace transformPage with transformPageChunk

### DIFF
--- a/.changeset/nasty-seahorses-know.md
+++ b/.changeset/nasty-seahorses-know.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] replace transformPage with transformPageChunk

--- a/documentation/docs/06-hooks.md
+++ b/documentation/docs/06-hooks.md
@@ -67,7 +67,7 @@ You can add call multiple `handle` functions with [the `sequence` helper functio
 `resolve` also supports a second, optional parameter that gives you more control over how the response will be rendered. That parameter is an object that can have the following fields:
 
 - `ssr: boolean` (default `true`) — if `false`, renders an empty 'shell' page instead of server-side rendering
-- `transformPageChunk(opts: { html: string, done: boolean }): string` — applies custom transforms to HTML. If `done` is true, it's the final chunk
+- `transformPageChunk(opts: { html: string, done: boolean }): MaybePromise<string | undefined>` — applies custom transforms to HTML. If `done` is true, it's the final chunk. Chunks are not guaranteed to be well-formed HTML (they could include an element's opening tag but not its closing tag, for example) but they will always be split at sensible boundaries such as `%sveltekit.head%` or layout/page components.
 
 ```js
 /// file: src/hooks.js

--- a/documentation/docs/06-hooks.md
+++ b/documentation/docs/06-hooks.md
@@ -67,7 +67,7 @@ You can add call multiple `handle` functions with [the `sequence` helper functio
 `resolve` also supports a second, optional parameter that gives you more control over how the response will be rendered. That parameter is an object that can have the following fields:
 
 - `ssr: boolean` (default `true`) — if `false`, renders an empty 'shell' page instead of server-side rendering
-- `transformPage(opts: { html: string }): string` — applies custom transforms to HTML
+- `transformPageChunk(opts: { html: string, done: boolean }): string` — applies custom transforms to HTML. If `done` is true, it's the final chunk
 
 ```js
 /// file: src/hooks.js
@@ -75,7 +75,7 @@ You can add call multiple `handle` functions with [the `sequence` helper functio
 export async function handle({ event, resolve }) {
 	const response = await resolve(event, {
 		ssr: !event.url.pathname.startsWith('/admin'),
-		transformPage: ({ html }) => html.replace('old', 'new')
+		transformPageChunk: ({ html }) => html.replace('old', 'new')
 	});
 
 	return response;

--- a/documentation/docs/17-seo.md
+++ b/documentation/docs/17-seo.md
@@ -105,15 +105,19 @@ const config = {
 export default config;
 ```
 
-...and transforming the HTML using `transformPage` along with `transform` imported from `@sveltejs/amp`:
+...and transforming the HTML using `transformPageChunk` along with `transform` imported from `@sveltejs/amp`:
 
 ```js
 import * as amp from '@sveltejs/amp';
 
 /** @type {import('@sveltejs/kit').Handle} */
 export async function handle({ event, resolve }) {
+	let buffer = '';
 	return resolve(event, {
-		transformPage: ({ html }) => amp.transform(html)
+		transformPageChunk: ({ html, done }) => {
+			buffer += html;
+			if (done) return amp.transform(html);
+		}
 	});
 }
 ```

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -171,7 +171,7 @@ export async function respond(request, options, state) {
 	/** @type {import('types').RequiredResolveOptions} */
 	let resolve_opts = {
 		ssr: true,
-		transformPage: default_transform
+		transformPageChunk: default_transform
 	};
 
 	// TODO match route before calling handle?
@@ -181,9 +181,17 @@ export async function respond(request, options, state) {
 			event,
 			resolve: async (event, opts) => {
 				if (opts) {
+					// TODO remove for 1.0
+					// @ts-expect-error
+					if (opts.transformPage) {
+						throw new Error(
+							'transformPage has been replaced by transformPageChunk — see https://github.com/sveltejs/kit/issues/4910 for more information'
+						);
+					}
+
 					resolve_opts = {
 						ssr: opts.ssr !== false,
-						transformPage: opts.transformPage || default_transform
+						transformPageChunk: opts.transformPageChunk || default_transform
 					};
 				}
 

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -185,7 +185,7 @@ export async function respond(request, options, state) {
 					// @ts-expect-error
 					if (opts.transformPage) {
 						throw new Error(
-							'transformPage has been replaced by transformPageChunk — see https://github.com/sveltejs/kit/issues/4910 for more information'
+							'transformPage has been replaced by transformPageChunk — see https://github.com/sveltejs/kit/pull/5657 for more information'
 						);
 					}
 

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -291,8 +291,10 @@ export async function render_response({
 	const assets =
 		options.paths.assets || (segments.length > 0 ? segments.map(() => '..').join('/') : '.');
 
-	const html = await resolve_opts.transformPage({
-		html: options.template({ head, body, assets, nonce: /** @type {string} */ (csp.nonce) })
+	// TODO flush chunks as early as we can
+	const html = await resolve_opts.transformPageChunk({
+		html: options.template({ head, body, assets, nonce: /** @type {string} */ (csp.nonce) }),
+		done: true
 	});
 
 	const headers = new Headers({

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -292,10 +292,11 @@ export async function render_response({
 		options.paths.assets || (segments.length > 0 ? segments.map(() => '..').join('/') : '.');
 
 	// TODO flush chunks as early as we can
-	const html = await resolve_opts.transformPageChunk({
-		html: options.template({ head, body, assets, nonce: /** @type {string} */ (csp.nonce) }),
-		done: true
-	});
+	const html =
+		(await resolve_opts.transformPageChunk({
+			html: options.template({ head, body, assets, nonce: /** @type {string} */ (csp.nonce) }),
+			done: true
+		})) || '';
 
 	const headers = new Headers({
 		'content-type': 'text/html',

--- a/packages/kit/test/apps/amp/src/hooks.js
+++ b/packages/kit/test/apps/amp/src/hooks.js
@@ -3,22 +3,28 @@ import * as amp from '@sveltejs/amp';
 
 /** @type {import('@sveltejs/kit').Handle} */
 export async function handle({ event, resolve }) {
+	let buffer = '';
+
 	const response = await resolve(event, {
-		transformPage: ({ html }) => {
-			html = amp.transform(html);
+		transformPageChunk: ({ html, done }) => {
+			buffer += html;
 
-			// remove unused CSS
-			let css = '';
-			const markup = html.replace(
-				/<style amp-custom([^>]*?)>([^]+?)<\/style>/,
-				(match, attributes, contents) => {
-					css = contents;
-					return `<style amp-custom${attributes}></style>`;
-				}
-			);
+			if (done) {
+				const html = amp.transform(buffer);
 
-			css = purify(markup, css);
-			return markup.replace('</style>', `${css}</style>`);
+				// remove unused CSS
+				let css = '';
+				const markup = html.replace(
+					/<style amp-custom([^>]*?)>([^]+?)<\/style>/,
+					(match, attributes, contents) => {
+						css = contents;
+						return `<style amp-custom${attributes}></style>`;
+					}
+				);
+
+				css = purify(markup, css);
+				return markup.replace('</style>', `${css}</style>`);
+			}
 		}
 	});
 

--- a/packages/kit/test/apps/basics/src/hooks.js
+++ b/packages/kit/test/apps/basics/src/hooks.js
@@ -47,7 +47,7 @@ export const handle = sequence(
 
 		const response = await resolve(event, {
 			ssr: !event.url.pathname.startsWith('/no-ssr'),
-			transformPage: event.url.pathname.startsWith('/transform-page')
+			transformPageChunk: event.url.pathname.startsWith('/transform-page-chunk')
 				? ({ html }) => html.replace('__REPLACEME__', 'Worked!')
 				: undefined
 		});

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1009,8 +1009,8 @@ test.describe('Page options', () => {
 		}
 	});
 
-	test('transformPage can change the html output', async ({ page }) => {
-		await page.goto('/transform-page');
+	test('transformPageChunk can change the html output', async ({ page }) => {
+		await page.goto('/transform-page-chunk');
 		expect(await page.getAttribute('meta[name="transform-page"]', 'content')).toBe('Worked!');
 	});
 

--- a/packages/kit/test/prerendering/basics/src/hooks.js
+++ b/packages/kit/test/prerendering/basics/src/hooks.js
@@ -2,13 +2,14 @@ import { prerendering } from '$app/env';
 
 const initial_prerendering = prerendering;
 
+/** @type {import('@sveltejs/kit').Handle} */
 export const handle = async ({ event, resolve }) => {
 	if (event.url.pathname === '/prerendering-true' && prerendering) {
 		return await resolve(event, {
-			transformPage: ({ html }) =>
+			transformPageChunk: ({ html }) =>
 				html
-					.replace('__INITIAL_PRERENDERING__', initial_prerendering)
-					.replace('__PRERENDERING__', prerendering)
+					.replace('__INITIAL_PRERENDERING__', String(initial_prerendering))
+					.replace('__PRERENDERING__', String(prerendering))
 		});
 	}
 	return await resolve(event);

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -261,7 +261,7 @@ export interface RequestHandlerOutput<Output = ResponseBody> {
 
 export interface ResolveOptions {
 	ssr?: boolean;
-	transformPageChunk?: (input: { html: string; done: boolean }) => MaybePromise<string>;
+	transformPageChunk?: (input: { html: string; done: boolean }) => MaybePromise<string | undefined>;
 }
 
 export type ResponseBody = JSONValue | Uint8Array | ReadableStream | Error;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -261,7 +261,7 @@ export interface RequestHandlerOutput<Output = ResponseBody> {
 
 export interface ResolveOptions {
 	ssr?: boolean;
-	transformPage?: ({ html }: { html: string }) => MaybePromise<string>;
+	transformPageChunk?: (input: { html: string; done: boolean }) => MaybePromise<string>;
 }
 
 export type ResponseBody = JSONValue | Uint8Array | ReadableStream | Error;


### PR DESCRIPTION
Closes #4910.

This replaces the `transformPage` API with `transformPageChunk`, so that we can respond in a streaming fashion in future. We're not yet taking advantage of that ability, but updating the API is the first step.

Previously, `transformPage` took the entire HTML document:

```js
export function handle({ event, resolve }) {
  return resolve(event, {
    transformPage: ({ html }) => html.replace('old', 'new')
  });
}
```

Now, it takes a _chunk_ of HTML plus a `done` boolean. Chunks are not guaranteed to be well-formed HTML (they might include the opening tag of an element but not its closing tag, for example) but nor are they arbitrary — they will always be split at sensible boundaries (like `%sveltekit.[property]%` or before the contents of a layout or page component). Because of that, many transforms will work identically:

```diff
export function handle({ event, resolve }) {
  return resolve(event, {
-    transformPage: ({ html }) => html.replace('old', 'new')
+    transformPageChunk: ({ html }) => html.replace('old', 'new')
  });
}
```

In some cases, it's necessary to operate on the entire document in one go — for example, to validate and transform an AMP document. In these situations it's easy to buffer the HTML and return the transformed document at the end:

```js
export function handle({ event, resolve }) {
  let buffer = '';
  return resolve(event, {
    transformPageChunk: ({ html, done }) => {
      buffer += html;
      if (done) return amp.transform(html);
    }
  });
}
```

Right now, `done` will always be true (i.e. there'll only be one chunk, which is the entire document) but that will change in the near future.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
