### PR TITLE
[chore] simplify internal prerender API

### DIFF
--- a/.changeset/soft-humans-cheer.md
+++ b/.changeset/soft-humans-cheer.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[chore] simplify internal prerender API

--- a/.changeset/soft-humans-cheer.md
+++ b/.changeset/soft-humans-cheer.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': patch
----
-
-[chore] simplify internal prerender API

--- a/packages/kit/src/core/prerender/prerender.js
+++ b/packages/kit/src/core/prerender/prerender.js
@@ -358,21 +358,3 @@ export async function prerender({ config, client_out_dir, manifest_path, log }) 
 function getClientAddress() {
 	throw new Error('Cannot read clientAddress during prerendering');
 }
-
-/**
- * @param {string} dir
- * @param {string} [curr_dir]
- */
-function get_files(dir, curr_dir = dir) {
-	const result = new Set();
-	const files = readdirSync(curr_dir);
-	for (const file of files) {
-		const name = join(curr_dir, file);
-		if (statSync(name).isDirectory()) {
-			get_files(dir, name).forEach((f) => result.add(f));
-		} else {
-			result.add(relative(dir, name));
-		}
-	}
-	return result;
-}

--- a/packages/kit/src/core/prerender/prerender.js
+++ b/packages/kit/src/core/prerender/prerender.js
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync, statSync, writeFileSync } from 'fs';
 import { dirname, join, relative } from 'path';
 import { pathToFileURL, URL } from 'url';
-import { mkdirp } from '../../utils/filesystem.js';
+import { mkdirp, walk } from '../../utils/filesystem.js';
 import { installPolyfills } from '../../node/polyfills.js';
 import { is_root_relative, normalize_path, resolve } from '../../utils/url.js';
 import { queue } from './queue.js';

--- a/packages/kit/src/core/prerender/prerender.js
+++ b/packages/kit/src/core/prerender/prerender.js
@@ -1,7 +1,7 @@
-import { readdirSync, readFileSync, statSync, writeFileSync } from 'fs';
-import { dirname, join, relative } from 'path';
+import { readFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
 import { pathToFileURL, URL } from 'url';
-import { mkdirp, posixify, walk } from '../../utils/filesystem.js';
+import { mkdirp, walk } from '../../utils/filesystem.js';
 import { installPolyfills } from '../../node/polyfills.js';
 import { is_root_relative, normalize_path, resolve } from '../../utils/url.js';
 import { queue } from './queue.js';
@@ -160,7 +160,7 @@ export async function prerender({ config, client_out_dir, manifest_path, log }) 
 		return file;
 	}
 
-	const files = new Set(walk(client_out_dir).map((f) => posixify(f)));
+	const files = new Set(walk(client_out_dir).map((f) => pathToFileURL(f)));
 	const seen = new Set();
 	const written = new Set();
 

--- a/packages/kit/src/core/prerender/prerender.js
+++ b/packages/kit/src/core/prerender/prerender.js
@@ -160,7 +160,7 @@ export async function prerender({ config, client_out_dir, manifest_path, log }) 
 		return file;
 	}
 
-	const files = new Set(walk(client_out_dir).map((f) => pathToFileURL(f).href));
+	const files = new Set(walk(client_out_dir));
 	const seen = new Set();
 	const written = new Set();
 
@@ -323,7 +323,7 @@ export async function prerender({ config, client_out_dir, manifest_path, log }) 
 		for (const entry of config.prerender.entries) {
 			if (entry === '*') {
 				/** @type {import('types').ManifestData} */
-				const { routes } = (await import(manifest_path)).manifest._;
+				const { routes } = (await import(pathToFileURL(manifest_path).href)).manifest._;
 				const entries = routes
 					.map((route) => (route.type === 'page' ? route.path : ''))
 					.filter(Boolean);

--- a/packages/kit/src/core/prerender/prerender.js
+++ b/packages/kit/src/core/prerender/prerender.js
@@ -160,7 +160,7 @@ export async function prerender({ config, client_out_dir, manifest_path, log }) 
 		return file;
 	}
 
-	const files = new Set(walk(client_out_dir).map((f) => posixify(f)));
+	const files = new Set(walk(client_out_dir).map(posixify));
 	const seen = new Set();
 	const written = new Set();
 

--- a/packages/kit/src/core/prerender/prerender.js
+++ b/packages/kit/src/core/prerender/prerender.js
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync, statSync, writeFileSync } from 'fs';
 import { dirname, join, relative } from 'path';
 import { pathToFileURL, URL } from 'url';
-import { mkdirp, walk } from '../../utils/filesystem.js';
+import { mkdirp, posixify, walk } from '../../utils/filesystem.js';
 import { installPolyfills } from '../../node/polyfills.js';
 import { is_root_relative, normalize_path, resolve } from '../../utils/url.js';
 import { queue } from './queue.js';
@@ -160,7 +160,7 @@ export async function prerender({ config, client_out_dir, manifest_path, log }) 
 		return file;
 	}
 
-	const files = new Set(walk(client_out_dir));
+	const files = new Set(walk(client_out_dir).map(f => posixify(f)));
 	const seen = new Set();
 	const written = new Set();
 

--- a/packages/kit/src/core/prerender/prerender.js
+++ b/packages/kit/src/core/prerender/prerender.js
@@ -160,7 +160,7 @@ export async function prerender({ config, client_out_dir, manifest_path, log }) 
 		return file;
 	}
 
-	const files = new Set(walk(client_out_dir).map(f => posixify(f)));
+	const files = new Set(walk(client_out_dir).map((f) => posixify(f)));
 	const seen = new Set();
 	const written = new Set();
 

--- a/packages/kit/src/core/prerender/prerender.js
+++ b/packages/kit/src/core/prerender/prerender.js
@@ -160,7 +160,7 @@ export async function prerender({ config, client_out_dir, manifest_path, log }) 
 		return file;
 	}
 
-	const files = get_files(client_out_dir);
+	const files = new Set(walk(client_out_dir));
 	const seen = new Set();
 	const written = new Set();
 

--- a/packages/kit/src/core/prerender/prerender.js
+++ b/packages/kit/src/core/prerender/prerender.js
@@ -160,7 +160,7 @@ export async function prerender({ config, client_out_dir, manifest_path, log }) 
 		return file;
 	}
 
-	const files = new Set(walk(client_out_dir).map((f) => pathToFileURL(f)));
+	const files = new Set(walk(client_out_dir).map((f) => pathToFileURL(f).href));
 	const seen = new Set();
 	const written = new Set();
 

--- a/packages/kit/src/core/prerender/prerender.js
+++ b/packages/kit/src/core/prerender/prerender.js
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { pathToFileURL, URL } from 'url';
-import { mkdirp, walk } from '../../utils/filesystem.js';
+import { mkdirp, posixify, walk } from '../../utils/filesystem.js';
 import { installPolyfills } from '../../node/polyfills.js';
 import { is_root_relative, normalize_path, resolve } from '../../utils/url.js';
 import { queue } from './queue.js';
@@ -160,7 +160,7 @@ export async function prerender({ config, client_out_dir, manifest_path, log }) 
 		return file;
 	}
 
-	const files = new Set(walk(client_out_dir));
+	const files = new Set(walk(client_out_dir).map((f) => posixify(f)));
 	const seen = new Set();
 	const written = new Set();
 

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -302,8 +302,9 @@ function kit() {
 				server
 			};
 
+			const manifest_path = `${paths.output_dir}/server/manifest.js`;
 			fs.writeFileSync(
-				`${paths.output_dir}/server/manifest.js`,
+				manifest_path,
 				`export const manifest = ${generate_manifest({
 					build_data,
 					relative_path: '.',
@@ -314,27 +315,10 @@ function kit() {
 			process.env.SVELTEKIT_SERVER_BUILD_COMPLETED = 'true';
 			log.info('Prerendering');
 
-			const static_files = manifest_data.assets.map((asset) => posixify(asset.file));
-
-			const files = new Set([
-				...static_files,
-				...chunks.map((chunk) => chunk.fileName),
-				...assets.map((chunk) => chunk.fileName)
-			]);
-
-			// TODO is this right?
-			static_files.forEach((file) => {
-				if (file.endsWith('/index.html')) {
-					files.add(file.slice(0, -11));
-				}
-			});
-
 			prerendered = await prerender({
 				config: svelte_config.kit,
-				entries: manifest_data.routes
-					.map((route) => (route.type === 'page' ? route.path : ''))
-					.filter(Boolean),
-				files,
+				client_out_dir: vite_config.build.outDir,
+				manifest_path,
 				log
 			});
 


### PR DESCRIPTION
Remove `entries` and `files` from `prerender` function since they're difficult to construct entities. This will make https://github.com/sveltejs/kit/issues/5306 much easier to implement