### PR TITLE
[breaking] remove `Prerendered.assets`

### DIFF
--- a/.changeset/witty-avocados-admire.md
+++ b/.changeset/witty-avocados-admire.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] remove Prerendered.assets

--- a/packages/kit/src/core/prerender/prerender.js
+++ b/packages/kit/src/core/prerender/prerender.js
@@ -7,6 +7,8 @@ import { is_root_relative, resolve } from '../../utils/url.js';
 import { queue } from './queue.js';
 import { crawl } from './crawl.js';
 import { escape_html_attr } from '../../utils/escape.js';
+import { logger } from '../utils.js';
+import { load_config } from '../config/index.js';
 
 /**
  * @typedef {import('types').PrerenderErrorHandler} PrerenderErrorHandler
@@ -51,24 +53,28 @@ const REDIRECT = 3;
 
 /**
  * @param {{
- *   config: import('types').ValidatedKitConfig;
  *   client_out_dir: string;
  *   manifest_path: string;
- *   log: Logger;
+ *   verbose: boolean;
  * }} opts
  */
-export async function prerender({ config, client_out_dir, manifest_path, log }) {
+export async function prerender({ client_out_dir, manifest_path, verbose }) {
 	/** @type {import('types').Prerendered} */
 	const prerendered = {
 		pages: new Map(),
-		assets: new Map(),
 		redirects: new Map(),
 		paths: []
 	};
 
+	/** @type {import('types').ValidatedKitConfig} */
+	const config = (await load_config()).kit;
+
 	if (!config.prerender.enabled) {
 		return prerendered;
 	}
+
+	/** @type {import('types').Logger} */
+	const log = logger({ verbose });
 
 	installPolyfills();
 	const { fetch } = globalThis;
@@ -304,10 +310,6 @@ export async function prerender({ config, client_out_dir, manifest_path, log }) 
 			if (is_html) {
 				prerendered.pages.set(decoded, {
 					file
-				});
-			} else {
-				prerendered.assets.set(decoded, {
-					type
 				});
 			}
 

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -273,9 +273,8 @@ function kit() {
 		 * then use this hook to kick off builds for the server and service worker.
 		 */
 		async writeBundle(_options, bundle) {
-			log = logger({
-				verbose: vite_config.logLevel === 'info'
-			});
+			const verbose = vite_config.logLevel === 'info';
+			log = logger({ verbose });
 
 			fs.writeFileSync(
 				`${paths.client_out_dir}/${svelte_config.kit.appDir}/version.json`,
@@ -321,10 +320,9 @@ function kit() {
 			log.info('Prerendering');
 
 			prerendered = await prerender({
-				config: svelte_config.kit,
 				client_out_dir: vite_config.build.outDir,
 				manifest_path,
-				log
+				verbose
 			});
 
 			if (options.service_worker_entry_file) {

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -177,13 +177,6 @@ export interface Prerendered {
 			file: string;
 		}
 	>;
-	assets: Map<
-		string,
-		{
-			/** The MIME type of the asset */
-			type: string;
-		}
-	>;
 	redirects: Map<
 		string,
 		{


### PR DESCRIPTION
I was focused on the prerendering input, but didn't think about the output :stuck_out_tongue_closed_eyes:  Let's start with this hopefully easiest one

None of our adapters use it nor do any community adapters

The only from the community that do things with `prerendered` are these two:
- https://github.com/geoffrich/svelte-adapter-azure-swa/blob/1a99b93dad5cf7f58b5e67261e03e8cc88d8aa6f/index.js#L121
- https://github.com/HalfdanJ/svelte-adapter-appengine/blob/85b90eef8d5ba5d844e95c2c736090a66f170e41/index.js#L55
