### PR TITLE
Revert "set Vite's `publicDir` option"

### DIFF
--- a/.changeset/modern-jars-return.md
+++ b/.changeset/modern-jars-return.md
@@ -1,6 +1,0 @@
----
-'@sveltejs/adapter-node': patch
-'@sveltejs/kit': patch
----
-
-set Vite's `publicDir` option

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -50,6 +50,7 @@ export default function (opts = {}) {
 			if (precompress) {
 				builder.log.minor('Compressing assets');
 				await compress(`${out}/client`);
+				await compress(`${out}/static`);
 				await compress(`${out}/prerendered`);
 			}
 		}

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -122,7 +122,10 @@ export function create_builder({ config, build_data, prerendered, log }) {
 		},
 
 		writeClient(dest) {
-			return [...copy(`${config.kit.outDir}/output/client`, dest)];
+			return [
+				...copy(`${config.kit.outDir}/output/client`, dest),
+				...copy(config.kit.files.assets, dest)
+			];
 		},
 
 		writePrerendered(dest, { fallback } = {}) {

--- a/packages/kit/src/core/adapt/builder.spec.js
+++ b/packages/kit/src/core/adapt/builder.spec.js
@@ -43,7 +43,13 @@ test('copy files', () => {
 	builder.writeClient(dest);
 
 	assert.equal(
-		glob('**', { cwd: `${outDir}/output/client`, dot: true }),
+		[
+			...glob('**', {
+				cwd: /** @type {import('types').ValidatedConfig} */ (mocked).kit.files.assets,
+				dot: true
+			}),
+			...glob('**', { cwd: `${outDir}/output/client`, dot: true })
+		],
 		glob('**', { cwd: dest, dot: true })
 	);
 

--- a/packages/kit/src/core/prerender/prerender.js
+++ b/packages/kit/src/core/prerender/prerender.js
@@ -158,7 +158,10 @@ export async function prerender({ config, client_out_dir, manifest_path, log }) 
 		return file;
 	}
 
-	const files = new Set(walk(client_out_dir).map(posixify));
+	const files = new Set([
+		...walk(client_out_dir).map(posixify),
+		...walk(config.files.assets).map(posixify) // TODO remove this if we use Vite publicDir option
+	]);
 	const seen = new Set();
 	const written = new Set();
 

--- a/packages/kit/src/core/prerender/prerender.js
+++ b/packages/kit/src/core/prerender/prerender.js
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { pathToFileURL, URL } from 'url';
 import { mkdirp, posixify, walk } from '../../utils/filesystem.js';
@@ -160,7 +160,7 @@ export async function prerender({ config, client_out_dir, manifest_path, log }) 
 
 	const files = new Set([
 		...walk(client_out_dir).map(posixify),
-		...walk(config.files.assets).map(posixify) // TODO remove this if we use Vite publicDir option
+		...(existsSync(config.files.assets) ? walk(config.files.assets).map(posixify) : []) // TODO remove this if we use Vite publicDir option
 	]);
 	const seen = new Set();
 	const written = new Set();

--- a/packages/kit/src/vite/build/utils.js
+++ b/packages/kit/src/vite/build/utils.js
@@ -117,7 +117,9 @@ export const get_default_config = function ({ config, input, ssr, outDir }) {
 			__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: JSON.stringify(config.kit.version.pollInterval),
 			__SVELTEKIT_DEV__: 'false'
 		},
-		publicDir: ssr ? false : config.kit.files.assets,
+		// prevent Vite copying the contents of `config.kit.files.assets`,
+		// if it happens to be 'public' instead of 'static'
+		publicDir: false,
 		resolve: {
 			alias: get_aliases(config.kit)
 		},

--- a/packages/kit/src/vite/dev/index.js
+++ b/packages/kit/src/vite/dev/index.js
@@ -186,7 +186,7 @@ export async function dev(vite, vite_config, svelte_config) {
 				/** @type {function} */ (middleware.handle).name === 'viteServeStaticMiddleware'
 		);
 
-		remove_static_middlewares(vite.middlewares);
+		remove_html_middlewares(vite.middlewares);
 
 		vite.middlewares.use(async (req, res) => {
 			try {
@@ -389,15 +389,11 @@ function not_found(res, message = 'Not found') {
 /**
  * @param {import('connect').Server} server
  */
-function remove_static_middlewares(server) {
-	// We don't use viteServePublicMiddleware because of the following issues:
-	// https://github.com/vitejs/vite/issues/9260
-	// https://github.com/vitejs/vite/issues/9236
-	// https://github.com/vitejs/vite/issues/9234
-	const static_middlewares = ['viteServePublicMiddleware', 'viteServeStaticMiddleware'];
+function remove_html_middlewares(server) {
+	const html_middlewares = ['viteServeStaticMiddleware'];
 	for (let i = server.stack.length - 1; i > 0; i--) {
-		// @ts-expect-error using internals
-		if (static_middlewares.includes(server.stack[i].handle.name)) {
+		// @ts-expect-error using internals until https://github.com/vitejs/vite/pull/4640 is merged
+		if (html_middlewares.includes(server.stack[i].handle.name)) {
 			server.stack.splice(i, 1);
 		}
 	}

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -213,7 +213,6 @@ function kit() {
 					__SVELTEKIT_DEV__: 'true',
 					__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: '0'
 				},
-				publicDir: svelte_config.kit.files.assets,
 				resolve: {
 					alias: get_aliases(svelte_config.kit)
 				},

--- a/packages/kit/src/vite/preview/index.js
+++ b/packages/kit/src/vite/preview/index.js
@@ -44,13 +44,16 @@ export async function preview(vite, config, protocol) {
 	const server = new Server(manifest);
 
 	return () => {
-		// generated client assets and the contents of `static`
+		// files in `static`
+		vite.middlewares.use(scoped(assets, mutable(config.kit.files.assets)));
+
+		// immutable generated client assets
 		vite.middlewares.use(
 			scoped(
 				assets,
 				sirv(join(config.kit.outDir, 'output/client'), {
 					setHeaders: (res, pathname) => {
-						// only apply to immutable directory, not e.g. version.json
+						// only apply to build directory, not e.g. version.json
 						if (pathname.startsWith(`/${config.kit.appDir}/immutable`)) {
 							res.setHeader('cache-control', 'public,max-age=31536000,immutable');
 						}


### PR DESCRIPTION
Reverts sveltejs/kit#5648.

I don't know this for certain (the stack trace is truncated, and I don't have time to investigate more deeply), but it's pretty clear that Vite is trying to process requests that originate from `<script>` and `<link>` elements, whereas previously we were bypassing its static file handling.

I'm just going to revert this now because it's bad breaking change that seems to have affected a lot of people — we can take another run at it later, when we can figure out how to make those requests bypass Vite.