### PR TITLE
feat: provide Vite hooks api

### DIFF
--- a/.changeset/fluffy-planes-compare.md
+++ b/.changeset/fluffy-planes-compare.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Provide a new Vite hook api

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ yarn.lock
 .turbo
 .vercel
 .test-tmp
+.idea/

--- a/packages/kit/src/vite/api.js
+++ b/packages/kit/src/vite/api.js
@@ -1,0 +1,57 @@
+export function create_vite_hooks_api() {
+	/**
+	 * @type {{
+	 *   config: import('types').KitConfigHook[],
+	 *   prerendered: import('types').PrerenderedHook[]
+	 * }}
+	 */
+	const vite_hooks = {
+		config: [],
+		prerendered: []
+	};
+
+	/**
+	 * @param {import('types').ValidatedConfig} svelte_config
+	 * @return {Promise<void>}
+	 */
+	async function call_config_hooks(svelte_config) {
+		await Promise.all(vite_hooks.config.map((h) => h?.(svelte_config)));
+	}
+
+	/**
+	 * @param {import('types').Prerendered} prerendered
+	 * @return {Promise<void>}
+	 */
+	async function call_prerendered_hooks(prerendered) {
+		await Promise.all(vite_hooks.prerendered.map((h) => h?.(prerendered)));
+	}
+
+	/**
+	 * @type {{
+	 *   call_config_hooks: Promise<void>,
+	 *   call_prerendered_hooks: Promise<void>,
+	 *   api: import('types').VitePluginApi
+	 * }}
+	 */
+	return {
+		call_config_hooks,
+		call_prerendered_hooks,
+		/* @type import('in').VitePluginApi */
+		api: {
+			/**
+			 * @param {import('types').KitConfigHook} hook
+			 * @return {void}
+			 */
+			onConfig(hook) {
+				vite_hooks.config.push(hook);
+			},
+			/**
+			 * @param {import('types').PrerenderedHook} hook
+			 * @return {void}
+			 */
+			onPrerendered(hook) {
+				vite_hooks.prerendered.push(hook);
+			}
+		}
+	};
+}

--- a/packages/kit/src/vite/api.js
+++ b/packages/kit/src/vite/api.js
@@ -1,57 +1,102 @@
-export function create_vite_hooks_api() {
-	/**
-	 * @type {{
-	 *   config: import('types').KitConfigHook[],
-	 *   prerendered: import('types').PrerenderedHook[]
-	 * }}
-	 */
-	const vite_hooks = {
-		config: [],
-		prerendered: []
-	};
+import { resolve_vite_plugins } from './utils.js';
 
-	/**
-	 * @param {import('types').ValidatedConfig} svelte_config
-	 * @return {Promise<void>}
-	 */
-	async function call_config_hooks(svelte_config) {
-		await Promise.all(vite_hooks.config.map((h) => h?.(svelte_config)));
-	}
+/**
+ * @param {import('vite').UserConfig} config
+ * @param {import('types').ViteKitOptions} options
+ * @param {import('types').ValidatedConfig} svelte_config
+ * @returns {Promise<void>}
+ */
+export async function call_vite_config_api(config, options, svelte_config) {
+	const plugins = (await resolve_vite_plugins(options, config)).filter(
+		(p) => p && 'name' in p && typeof p.api.onKitConfig === 'function'
+	);
+	if (!plugins) return;
 
-	/**
-	 * @param {import('types').Prerendered} prerendered
-	 * @return {Promise<void>}
-	 */
-	async function call_prerendered_hooks(prerendered) {
-		await Promise.all(vite_hooks.prerendered.map((h) => h?.(prerendered)));
-	}
-
-	/**
-	 * @type {{
-	 *   call_config_hooks: Promise<void>,
-	 *   call_prerendered_hooks: Promise<void>,
-	 *   api: import('types').VitePluginApi
-	 * }}
-	 */
-	return {
-		call_config_hooks,
-		call_prerendered_hooks,
-		/* @type import('in').VitePluginApi */
-		api: {
-			/**
-			 * @param {import('types').KitConfigHook} hook
-			 * @return {void}
-			 */
-			onConfig(hook) {
-				vite_hooks.config.push(hook);
-			},
-			/**
-			 * @param {import('types').PrerenderedHook} hook
-			 * @return {void}
-			 */
-			onPrerendered(hook) {
-				vite_hooks.prerendered.push(hook);
-			}
-		}
-	};
+	await Promise.all(
+		plugins.map(
+			(p) =>
+				p &&
+				'name' in p &&
+				typeof p.api.onKitConfig === 'function' &&
+				p.api.onKitConfig(svelte_config)
+		)
+	);
 }
+
+/**
+ * @param {import('vite').ResolvedConfig} config
+ * @param {import('types').Prerendered} prerendered
+ * @returns {Promise<void>}
+ */
+export async function call_vite_prerendered_api(config, prerendered) {
+	const plugins = config.plugins.filter(
+		(p) => p && 'name' in p && p.api && typeof p.api.onKitPrerendered === 'function'
+	);
+	if (!plugins) return;
+
+	await Promise.all(
+		plugins.map(
+			(p) =>
+				p &&
+				'name' in p &&
+				typeof p.api.onKitPrerendered === 'function' &&
+				p.api.onKitPrerendered(prerendered)
+		)
+	);
+}
+
+// export function create_vite_hooks_api() {
+
+/*
+ * @type {{
+ *   config: import('types').KitConfigHook[],
+ *   prerendered: import('types').PrerenderedHook[]
+ * }}
+ */
+// const vite_hooks = {
+// 	config: [],
+// 	prerendered: []
+// };
+/*
+ * @param {import('types').ValidatedConfig} svelte_config
+ * @return {Promise<void>}
+ */
+// async function call_config_hooks(svelte_config) {
+// 	await Promise.all(vite_hooks.config.map((h) => h?.(svelte_config)));
+// }
+/*
+ * @param {import('types').Prerendered} prerendered
+ * @return {Promise<void>}
+ */
+// async function call_prerendered_hooks(prerendered) {
+// 	await Promise.all(vite_hooks.prerendered.map((h) => h?.(prerendered)));
+// }
+/*
+ * @type {{
+ *   call_config_hooks: Promise<void>,
+ *   call_prerendered_hooks: Promise<void>,
+ *   api: import('types').VitePluginApi
+ * }}
+ */
+// return {
+// 	call_config_hooks,
+// 	call_prerendered_hooks,
+/* @type import('in').VitePluginApi */
+// api: {
+/*
+ * @param {import('types').KitConfigHook} hook
+ * @return {void}
+ */
+// onConfig(hook) {
+// 	vite_hooks.config.push(hook);
+// },
+/*
+ * @param {import('types').PrerenderedHook} hook
+ * @return {void}
+ */
+// 		onPrerendered(hook) {
+// 			vite_hooks.prerendered.push(hook);
+// 		}
+// 	}
+// };
+// }

--- a/packages/kit/src/vite/build/utils.js
+++ b/packages/kit/src/vite/build/utils.js
@@ -157,7 +157,7 @@ export function assets_base(config) {
  */
 export function remove_svelte_kit(config) {
 	// TODO i feel like there's a more elegant way to do this
-	// @ts-ignore TypeScript doesn't handle flattening Vite's plugin type properly
+	// @ts-ignore - it can't handle infinite type expansion
 	config.plugins = (config.plugins || [])
 		.flat(Infinity)
 		.filter((plugin) => plugin.name !== 'vite-plugin-svelte-kit');

--- a/packages/kit/src/vite/build/utils.js
+++ b/packages/kit/src/vite/build/utils.js
@@ -157,7 +157,7 @@ export function assets_base(config) {
  */
 export function remove_svelte_kit(config) {
 	// TODO i feel like there's a more elegant way to do this
-	// @ts-expect-error - it can't handle infinite type expansion
+	// @ts-ignore TypeScript doesn't handle flattening Vite's plugin type properly
 	config.plugins = (config.plugins || [])
 		.flat(Infinity)
 		.filter((plugin) => plugin.name !== 'vite-plugin-svelte-kit');

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -203,7 +203,7 @@ function kit(kitPluginOptions) {
 				const warning = warn_overridden_config(config, new_config);
 				if (warning) console.error(warning + '\n');
 
-				await call_vite_config_api(config, kitPluginOptions, svelte_config);
+				await call_vite_config_api(kitPluginOptions, svelte_config, config, config_env);
 
 				return new_config;
 			}
@@ -252,7 +252,7 @@ function kit(kitPluginOptions) {
 
 			deferred_warning = warn_overridden_config(config, result);
 
-			await call_vite_config_api(config, kitPluginOptions, svelte_config);
+			await call_vite_config_api(kitPluginOptions, svelte_config, config, config_env);
 
 			return result;
 		},
@@ -350,7 +350,7 @@ function kit(kitPluginOptions) {
 				await build_service_worker(options, prerendered, client.vite_manifest);
 			}
 
-			await call_vite_prerendered_api(vite_config, kitPluginOptions, prerendered);
+			await call_vite_prerendered_api(kitPluginOptions, svelte_config, prerendered, vite_config);
 
 			console.log(
 				`\nRun ${colors.bold().cyan('npm run preview')} to preview your production build locally.`
@@ -372,7 +372,7 @@ function kit(kitPluginOptions) {
 			if (svelte_config.kit.adapter) {
 				const { adapt } = await import('../core/adapt/index.js');
 				await adapt(svelte_config, build_data, prerendered, { log });
-				await call_vite_adapter_api(vite_config, kitPluginOptions);
+				await call_vite_adapter_api(kitPluginOptions, svelte_config, vite_config);
 			} else {
 				console.log(colors.bold().yellow('\nNo adapter specified'));
 				// prettier-ignore

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -16,9 +16,9 @@ import { find_deps, get_default_config as get_default_build_config } from './bui
 import { preview } from './preview/index.js';
 import { get_aliases, resolve_entry } from './utils.js';
 import {
-	call_vite_adapter_api,
-	call_vite_config_api,
-	call_vite_prerendered_api
+	call_vite_adapter_api_hooks,
+	call_vite_config_api_hooks,
+	call_vite_prerendered_api_hooks
 } from './vite_api_hooks.js';
 
 const cwd = process.cwd();
@@ -201,7 +201,7 @@ function kit(kitPluginOptions) {
 				const warning = warn_overridden_config(config, new_config);
 				if (warning) console.error(warning + '\n');
 
-				await call_vite_config_api(kitPluginOptions, svelte_config, config, config_env);
+				await call_vite_config_api_hooks(kitPluginOptions, svelte_config, config, config_env);
 
 				return new_config;
 			}
@@ -250,7 +250,7 @@ function kit(kitPluginOptions) {
 
 			deferred_warning = warn_overridden_config(config, result);
 
-			await call_vite_config_api(kitPluginOptions, svelte_config, config, config_env);
+			await call_vite_config_api_hooks(kitPluginOptions, svelte_config, config, config_env);
 
 			return result;
 		},
@@ -348,7 +348,12 @@ function kit(kitPluginOptions) {
 				await build_service_worker(options, prerendered, client.vite_manifest);
 			}
 
-			await call_vite_prerendered_api(kitPluginOptions, svelte_config, prerendered, vite_config);
+			await call_vite_prerendered_api_hooks(
+				kitPluginOptions,
+				svelte_config,
+				prerendered,
+				vite_config
+			);
 
 			console.log(
 				`\nRun ${colors.bold().cyan('npm run preview')} to preview your production build locally.`
@@ -370,7 +375,7 @@ function kit(kitPluginOptions) {
 			if (svelte_config.kit.adapter) {
 				const { adapt } = await import('../core/adapt/index.js');
 				await adapt(svelte_config, build_data, prerendered, { log });
-				await call_vite_adapter_api(kitPluginOptions, svelte_config, vite_config);
+				await call_vite_adapter_api_hooks(kitPluginOptions, svelte_config, vite_config);
 			} else {
 				console.log(colors.bold().yellow('\nNo adapter specified'));
 				// prettier-ignore

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -121,8 +121,6 @@ function kit(kitPluginOptions) {
 
 	let completed_build = false;
 
-	// const { call_config_hooks, call_prerendered_hooks, api } = create_vite_hooks_api();
-
 	function vite_client_build_config() {
 		/** @type {Record<string, string>} */
 		const input = {
@@ -412,11 +410,6 @@ function kit(kitPluginOptions) {
 		configurePreviewServer(vite) {
 			return preview(vite, svelte_config, vite_config.preview.https ? 'https' : 'http');
 		}
-
-		/*
-		 * Rollup intercommunication plugin api.
-		 */
-		//api
 	};
 }
 

--- a/packages/kit/src/vite/utils.js
+++ b/packages/kit/src/vite/utils.js
@@ -141,8 +141,8 @@ export function resolve_entry(entry) {
  * @param {import('vite').UserConfig} config
  * @returns {Promise<import('vite').PluginOption[]>}
  */
-export async function resolve_vite_plugins(options, config) {
-	const registeredPlugins = options.viteHooks;
+export async function resolve_vite_plugins_api_hooks(options, config) {
+	const registeredPlugins = options.viteHooks?.pluginNames;
 	if (!registeredPlugins) return [];
 
 	// resolve plugins
@@ -157,8 +157,8 @@ export async function resolve_vite_plugins(options, config) {
  * @param {import('vite').ResolvedConfig} config
  * @returns {import('vite').Plugin[]}
  */
-export function lookup_vite_plugins(options, config) {
-	const registeredPlugins = options.viteHooks;
+export function lookup_vite_plugins_api_hooks(options, config) {
+	const registeredPlugins = options.viteHooks?.pluginNames;
 	if (!registeredPlugins) return [];
 
 	// resolve plugins

--- a/packages/kit/src/vite/utils.js
+++ b/packages/kit/src/vite/utils.js
@@ -134,3 +134,32 @@ export function resolve_entry(entry) {
 
 	return null;
 }
+
+/**
+ * @param {import('types').ViteKitOptions} options
+ * @param {import('vite').UserConfig} config
+ * @returns {Promise<import('vite').PluginOption[]>}
+ */
+export async function resolve_vite_plugins(options, config) {
+	const registeredPlugins = options.viteHooks;
+	if (!registeredPlugins) return [];
+
+	// resolve plugins
+	return (await flatten_vite_plugins(config)).filter(
+		(p) => p && 'name' in p && registeredPlugins.includes(p.name) && p.api
+	);
+}
+/**
+ * @param {import('vite').UserConfig} config
+ * @returns {Promise<import('vite').PluginOption[]>}
+ */
+async function flatten_vite_plugins(config) {
+	let arr = config.plugins ?? [];
+	do {
+		// @ts-ignore TypeScript doesn't handle flattening Vite's plugin type properly
+		arr = (await Promise.all(arr)).flat(Infinity);
+		// @ts-ignore remove this comment when update to Vite 3.0.2+
+	} while (arr.some((v) => v?.then));
+
+	return arr;
+}

--- a/packages/kit/src/vite/utils.js
+++ b/packages/kit/src/vite/utils.js
@@ -136,6 +136,7 @@ export function resolve_entry(entry) {
 }
 
 /**
+ * Collects plugins array from Vite raw config.
  * @param {import('types').ViteKitOptions} options
  * @param {import('vite').UserConfig} config
  * @returns {Promise<import('vite').PluginOption[]>}
@@ -151,6 +152,7 @@ export async function resolve_vite_plugins(options, config) {
 }
 
 /**
+ * Collects plugins array from Vite resolved config.
  * @param {import('types').ViteKitOptions} options
  * @param {import('vite').ResolvedConfig} config
  * @returns {import('vite').Plugin[]}
@@ -166,6 +168,8 @@ export function lookup_vite_plugins(options, config) {
 }
 
 /**
+ * Flatten plugins array, checking for async plugins:
+ * https://github.com/vitejs/vite/blob/main/packages/vite/src/node/utils.ts#L1121
  * @param {import('vite').UserConfig} config
  * @returns {Promise<import('vite').PluginOption[]>}
  */
@@ -174,7 +178,7 @@ async function flatten_vite_plugins(config) {
 	do {
 		// @ts-ignore TypeScript doesn't handle flattening Vite's plugin type properly
 		arr = (await Promise.all(arr)).flat(Infinity);
-		// @ts-ignore remove this comment when update to Vite 3.0.2+
+		// @ts-ignore can be a Promise
 	} while (arr.some((v) => v?.then));
 
 	return arr;

--- a/packages/kit/src/vite/utils.js
+++ b/packages/kit/src/vite/utils.js
@@ -149,6 +149,22 @@ export async function resolve_vite_plugins(options, config) {
 		(p) => p && 'name' in p && registeredPlugins.includes(p.name) && p.api
 	);
 }
+
+/**
+ * @param {import('types').ViteKitOptions} options
+ * @param {import('vite').ResolvedConfig} config
+ * @returns {import('vite').Plugin[]}
+ */
+export function lookup_vite_plugins(options, config) {
+	const registeredPlugins = options.viteHooks;
+	if (!registeredPlugins) return [];
+
+	// resolve plugins
+	return config.plugins.filter(
+		(p) => p && 'name' in p && registeredPlugins.includes(p.name) && p.api
+	);
+}
+
 /**
  * @param {import('vite').UserConfig} config
  * @returns {Promise<import('vite').PluginOption[]>}

--- a/packages/kit/src/vite/vite_api_hooks.js
+++ b/packages/kit/src/vite/vite_api_hooks.js
@@ -40,7 +40,7 @@ export async function call_vite_prerendered_api_hooks(options, svelte_config, pr
 	);
 
 	await execute_hooks(options, 'prerendered', plugins, (p) =>
-		p.api.onKitPrerendered(svelte_config, prerendered, config)
+		p.api?.onKitPrerendered?.(svelte_config, prerendered, config)
 	);
 }
 
@@ -57,7 +57,7 @@ export async function call_vite_adapter_api_hooks(options, svelte_config, config
 	);
 
 	await execute_hooks(options, 'adapter', plugins, (p) =>
-		p.api.onKitAdapter(svelte_config, config)
+		p.api?.onKitAdapter?.(svelte_config, config)
 	);
 }
 
@@ -83,7 +83,7 @@ function resolve_hooks_execution(options, hook, plugins) {
  * @param {import('types').ViteKitOptions} options
  * @param {import('types').KitPluginHookName} hook
  * @param {import('vite').Plugin[]} plugins
- * @param {(plugin: import('vite').Plugin) => Promise<void>} callback
+ * @param {(plugin: import('vite').Plugin) => void | Promise<void>} callback
  * @return {Promise<void>}
  */
 async function execute_hooks(options, hook, plugins, callback) {

--- a/packages/kit/src/vite/vite_api_hooks.js
+++ b/packages/kit/src/vite/vite_api_hooks.js
@@ -1,12 +1,13 @@
 import { lookup_vite_plugins, resolve_vite_plugins } from './utils.js';
 
 /**
- * @param {import('vite').UserConfig} config
  * @param {import('types').ViteKitOptions} options
  * @param {import('types').ValidatedConfig} svelte_config
+ * @param {import('vite').UserConfig} config
+ * @param {import('vite').ConfigEnv} configEnv
  * @returns {Promise<void>}
  */
-export async function call_vite_config_api(config, options, svelte_config) {
+export async function call_vite_config_api(options, svelte_config, config, configEnv) {
 	const plugins = (await resolve_vite_plugins(options, config)).filter(
 		(p) => p && 'name' in p && typeof p.api.onKitConfig === 'function'
 	);
@@ -19,94 +20,40 @@ export async function call_vite_config_api(config, options, svelte_config) {
 				p &&
 				'name' in p &&
 				typeof p.api.onKitConfig === 'function' &&
-				p.api.onKitConfig(svelte_config)
+				p.api.onKitConfig(options, svelte_config, config, configEnv)
 		)
 	);
 }
 
 /**
- * @param {import('vite').ResolvedConfig} config
  * @param {import('types').ViteKitOptions} options
+ * @param {import('types').ValidatedConfig} svelte_config
  * @param {import('types').Prerendered} prerendered
+ * @param {import('vite').ResolvedConfig} config
  * @returns {Promise<void>}
  */
-export async function call_vite_prerendered_api(config, options, prerendered) {
+export async function call_vite_prerendered_api(options, svelte_config, prerendered, config) {
 	const plugins = lookup_vite_plugins(options, config).filter(
 		(p) => typeof p.api.onKitPrerendered === 'function'
 	);
 
 	if (!plugins) return;
 
-	await Promise.all(plugins.map((p) => p.api.onKitPrerendered(prerendered)));
+	await Promise.all(plugins.map((p) => p.api.onKitPrerendered(svelte_config, prerendered, config)));
 }
 
 /**
- * @param {import('vite').ResolvedConfig} config
  * @param {import('types').ViteKitOptions} options
+ * @param {import('types').ValidatedConfig} svelte_config
+ * @param {import('vite').ResolvedConfig} config
  * @returns {Promise<void>}
  */
-export async function call_vite_adapter_api(config, options) {
+export async function call_vite_adapter_api(options, svelte_config, config) {
 	const plugins = lookup_vite_plugins(options, config).filter(
 		(p) => typeof p.api.onKitAdapter === 'function'
 	);
 
 	if (!plugins) return;
 
-	await Promise.all(plugins.map((p) => p.api.onKitAdapter()));
+	await Promise.all(plugins.map((p) => p.api.onKitAdapter(svelte_config, config)));
 }
-
-// export function create_vite_hooks_api() {
-
-/*
- * @type {{
- *   config: import('types').KitConfigHook[],
- *   prerendered: import('types').PrerenderedHook[]
- * }}
- */
-// const vite_hooks = {
-// 	config: [],
-// 	prerendered: []
-// };
-/*
- * @param {import('types').ValidatedConfig} svelte_config
- * @return {Promise<void>}
- */
-// async function call_config_hooks(svelte_config) {
-// 	await Promise.all(vite_hooks.config.map((h) => h?.(svelte_config)));
-// }
-/*
- * @param {import('types').Prerendered} prerendered
- * @return {Promise<void>}
- */
-// async function call_prerendered_hooks(prerendered) {
-// 	await Promise.all(vite_hooks.prerendered.map((h) => h?.(prerendered)));
-// }
-/*
- * @type {{
- *   call_config_hooks: Promise<void>,
- *   call_prerendered_hooks: Promise<void>,
- *   api: import('types').VitePluginApi
- * }}
- */
-// return {
-// 	call_config_hooks,
-// 	call_prerendered_hooks,
-/* @type import('in').VitePluginApi */
-// api: {
-/*
- * @param {import('types').KitConfigHook} hook
- * @return {void}
- */
-// onConfig(hook) {
-// 	vite_hooks.config.push(hook);
-// },
-/*
- * @param {import('types').PrerenderedHook} hook
- * @return {void}
- */
-// 		onPrerendered(hook) {
-// 			vite_hooks.prerendered.push(hook);
-// 		}
-// 	}
-// };
-// }

--- a/packages/kit/src/vite/vite_api_hooks.js
+++ b/packages/kit/src/vite/vite_api_hooks.js
@@ -21,7 +21,7 @@ export async function call_vite_config_api(options, svelte_config, config, confi
 				p &&
 				'name' in p &&
 				typeof p.api.onKitConfig === 'function' &&
-				p.api.onKitConfig(options, svelte_config, config, configEnv)
+				p.api.onKitConfig(svelte_config, config, configEnv)
 		)
 	);
 }

--- a/packages/kit/src/vite/vite_api_hooks.js
+++ b/packages/kit/src/vite/vite_api_hooks.js
@@ -1,6 +1,7 @@
 import { lookup_vite_plugins, resolve_vite_plugins } from './utils.js';
 
 /**
+ * Notifies any Vite plugin with the `onKitConfig` api hook.
  * @param {import('types').ViteKitOptions} options
  * @param {import('types').ValidatedConfig} svelte_config
  * @param {import('vite').UserConfig} config
@@ -26,6 +27,7 @@ export async function call_vite_config_api(options, svelte_config, config, confi
 }
 
 /**
+ * Notifies any Vite plugin with the `onKitPrerendered` api hook.
  * @param {import('types').ViteKitOptions} options
  * @param {import('types').ValidatedConfig} svelte_config
  * @param {import('types').Prerendered} prerendered
@@ -43,6 +45,7 @@ export async function call_vite_prerendered_api(options, svelte_config, prerende
 }
 
 /**
+ * Notifies any Vite plugin with the `onKitAdapter` api hook.
  * @param {import('types').ViteKitOptions} options
  * @param {import('types').ValidatedConfig} svelte_config
  * @param {import('vite').ResolvedConfig} config

--- a/packages/kit/test/prerendering/basics/vite.config.js
+++ b/packages/kit/test/prerendering/basics/vite.config.js
@@ -4,14 +4,12 @@ import { plugin } from '../../utils.js';
 /** @type {import('vite').Plugin} */
 const hookPlugin = {
 	name: 'test-hooks-api',
-	/** @property {import('types').VitePluginApi} */
+	/** @property {import('types').ViteKitPluginHookApi} */
 	api: {
-		/** @param {import('types').ValidatedConfig} validatedConfig */
-		onKitConfig(validatedConfig) {
+		onKitConfig() {
 			console.log('onKitConfig called');
 		},
-		/** @param {import('types').Prerendered} prerendered */
-		onKitPrerendered(prerendered) {
+		onKitPrerendered() {
 			console.log('onKitPrerendered called');
 		},
 		onKitAdapter() {
@@ -26,7 +24,7 @@ const config = {
 		minify: false
 	},
 	clearScreen: false,
-	plugins: [plugin({ viteHooks: [hookPlugin.name] }), hookPlugin],
+	plugins: [plugin({ viteHooks: { pluginNames: [hookPlugin.name] } }), hookPlugin],
 	server: {
 		fs: {
 			allow: [path.resolve('../../../src')]

--- a/packages/kit/test/prerendering/basics/vite.config.js
+++ b/packages/kit/test/prerendering/basics/vite.config.js
@@ -1,13 +1,32 @@
 import * as path from 'path';
 import { plugin } from '../../utils.js';
 
+/** @type {import('vite').Plugin} */
+const hookPlugin = {
+	name: 'test-hooks-api',
+	/** @property {import('types').VitePluginApi} */
+	api: {
+		/** @param {import('types').ValidatedConfig} validatedConfig */
+		onKitConfig(validatedConfig) {
+			console.log('onKitConfig called');
+		},
+		/** @param {import('types').Prerendered} prerendered */
+		onKitPrerendered(prerendered) {
+			console.log('onKitPrerendered called');
+		},
+		onKitAdapter() {
+			console.log('onKitAdapter called');
+		}
+	}
+};
+
 /** @type {import('vite').UserConfig} */
 const config = {
 	build: {
 		minify: false
 	},
 	clearScreen: false,
-	plugins: [plugin()],
+	plugins: [plugin({ viteHooks: [hookPlugin.name] }), hookPlugin],
 	server: {
 		fs: {
 			allow: [path.resolve('../../../src')]

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -22,6 +22,10 @@ import { SSRNodeLoader, SSRRoute, ValidatedConfig, VitePluginApi } from './inter
 
 export type { VitePluginApi };
 
+export interface ViteKitOptions {
+	viteHooks?: string[];
+}
+
 export interface Adapter {
 	name: string;
 	adapt(builder: Builder): MaybePromise<void>;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -18,7 +18,9 @@ import {
 	RouteDefinition,
 	TrailingSlash
 } from './private.js';
-import { SSRNodeLoader, SSRRoute, ValidatedConfig } from './internal.js';
+import { SSRNodeLoader, SSRRoute, ValidatedConfig, VitePluginApi } from './internal.js';
+
+export type { VitePluginApi };
 
 export interface Adapter {
 	name: string;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -18,13 +18,15 @@ import {
 	RouteDefinition,
 	TrailingSlash
 } from './private.js';
-import { SSRNodeLoader, SSRRoute, ValidatedConfig, VitePluginApi } from './internal.js';
+import {
+	SSRNodeLoader,
+	SSRRoute,
+	ValidatedConfig,
+	ViteKitOptions,
+	ViteKitPluginHookApi
+} from './internal.js';
 
-export type { VitePluginApi };
-
-export interface ViteKitOptions {
-	viteHooks?: string[];
-}
+export type { ViteKitOptions, ViteKitPluginHookApi };
 
 export interface Adapter {
 	name: string;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -22,6 +22,7 @@ import {
 	ResponseHeaders,
 	TrailingSlash
 } from './private.js';
+import { ConfigEnv, ResolvedConfig, UserConfig } from 'vite';
 
 export interface ServerModule {
 	Server: typeof InternalServer;
@@ -316,21 +317,23 @@ export type ValidatedConfig = RecursiveRequired<Config>;
 
 export type ValidatedKitConfig = RecursiveRequired<KitConfig>;
 
-// export type KitConfigHook = (validatedConfig: ValidatedConfig) => void | Promise<void>;
-// export type PrerenderedHook = (prerendered: Prerendered) => void | Promise<void>;
 export interface VitePluginApi {
-	onKitConfig?: (validatedConfig: ValidatedConfig) => void | Promise<void>;
-	onKitPrerendered?: (prerendered: Prerendered) => void | Promise<void>;
-	onKitAdapter?: () => void | Promise<void>;
+	onKitConfig?: (
+		validatedConfig: ValidatedConfig,
+		userConfig: UserConfig,
+		configEnv: ConfigEnv
+	) => void | Promise<void>;
+	onKitPrerendered?: (
+		validatedConfig: ValidatedConfig,
+		prerendered: Prerendered,
+		viteConfig: ResolvedConfig
+	) => void | Promise<void>;
+	onKitAdapter?: (
+		validatedConfig: ValidatedConfig,
+		viteConfig: ResolvedConfig
+	) => void | Promise<void>;
 }
 
-// export type KitConfigHook = (validatedConfig: ValidatedConfig) => void | Promise<void>;
-// export type PrerenderedHook = (prerendered: Prerendered) => void | Promise<void>;
-// export interface VitePluginApi {
-// 	onConfig: (hook: KitConfigHook) => void;
-// 	onPrerendered: (hook: Prerendered) => void;
-// }
-//
 export * from './index';
 export * from './private';
 

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -316,13 +316,20 @@ export type ValidatedConfig = RecursiveRequired<Config>;
 
 export type ValidatedKitConfig = RecursiveRequired<KitConfig>;
 
-export type KitConfigHook = (validatedConfig: ValidatedConfig) => void | Promise<void>;
-export type PrerenderedHook = (prerendered: Prerendered) => void | Promise<void>;
+// export type KitConfigHook = (validatedConfig: ValidatedConfig) => void | Promise<void>;
+// export type PrerenderedHook = (prerendered: Prerendered) => void | Promise<void>;
 export interface VitePluginApi {
-	onConfig: (hook: KitConfigHook) => void;
-	onPrerendered: (hook: Prerendered) => void;
+	onKitConfig?: (validatedConfig: ValidatedConfig) => void | Promise<void>;
+	onKitPrerendered?: (prerendered: Prerendered) => void | Promise<void>;
 }
 
+// export type KitConfigHook = (validatedConfig: ValidatedConfig) => void | Promise<void>;
+// export type PrerenderedHook = (prerendered: Prerendered) => void | Promise<void>;
+// export interface VitePluginApi {
+// 	onConfig: (hook: KitConfigHook) => void;
+// 	onPrerendered: (hook: Prerendered) => void;
+// }
+//
 export * from './index';
 export * from './private';
 

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -321,6 +321,7 @@ export type ValidatedKitConfig = RecursiveRequired<KitConfig>;
 export interface VitePluginApi {
 	onKitConfig?: (validatedConfig: ValidatedConfig) => void | Promise<void>;
 	onKitPrerendered?: (prerendered: Prerendered) => void | Promise<void>;
+	onKitAdapter?: () => void | Promise<void>;
 }
 
 // export type KitConfigHook = (validatedConfig: ValidatedConfig) => void | Promise<void>;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -17,6 +17,7 @@ import {
 	HttpMethod,
 	JSONObject,
 	MaybePromise,
+	Prerendered,
 	RequestOptions,
 	ResponseHeaders,
 	TrailingSlash
@@ -314,6 +315,13 @@ export type StrictBody = string | Uint8Array;
 export type ValidatedConfig = RecursiveRequired<Config>;
 
 export type ValidatedKitConfig = RecursiveRequired<KitConfig>;
+
+export type KitConfigHook = (validatedConfig: ValidatedConfig) => void | Promise<void>;
+export type PrerenderedHook = (prerendered: Prerendered) => void | Promise<void>;
+export interface VitePluginApi {
+	onConfig: (hook: KitConfigHook) => void;
+	onPrerendered: (hook: Prerendered) => void;
+}
 
 export * from './index';
 export * from './private';


### PR DESCRIPTION
This PR will expose some hooks to avoid race condition on Vite, since all plugins will run in parallel and some will need the prerender process to finish: pwa plugin and sitemap for example.

There is a thread in Vite Discord server: https://discord.com/channels/804011606160703521/1000700061094776832

The latest changes @benmccann is making to the alignment of Vite and SvelteKit will not work with some plugins, even though the `process.exit` in the `closeBundle` has been removed. The main problem is that the async and parallel types of the plugins involved cause a race condition to exist on either `writeBundle` or `closeBundle`.

I also send a PR to include a new `preCloseBundle` hook: https://github.com/vitejs/vite/pull/9326

closes #5709

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
