### PR TITLE
Update PR number in CHANGELOG.md

### DIFF
--- a/packages/kit/CHANGELOG.md
+++ b/packages/kit/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Revert publicDir change from 1.0.0-next.387 ([#5684](https://github.com/sveltejs/kit/pull/5684))
+- Revert publicDir change from 1.0.0-next.387 ([#5683](https://github.com/sveltejs/kit/pull/5683))
 
 ## 1.0.0-next.391
 


### PR DESCRIPTION
Automated tooling got the PR number wrong, so let's fix it. Specifically, #5683 is the PR that actually contains the code changes and justification for the changes. #5684 contains just the changeset that was forgotten in #5683. So the automated tooling picked up #5684 as the PR to put in the changelog, but #5683 is the one that anyone reading the changelog will actually care about. By switching the changelog contents to point to #5683 for this release, we let everyone avoid having to make an additional click to find the actually useful information.

I'm not including a changeset in *this* PR since it makes no code changes. Likewise, no issue link and no tests.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
