### PR TITLE
Remove initial-scale=1 from <meta name="viewport">

### DIFF
--- a/packages/adapter-static/test/apps/prerendered/src/app.html
+++ b/packages/adapter-static/test/apps/prerendered/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width" />
 		%sveltekit.head%
 	</head>
 	<body>

--- a/packages/adapter-static/test/apps/spa/src/app.html
+++ b/packages/adapter-static/test/apps/spa/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width" />
 		%sveltekit.head%
 	</head>
 	<body>

--- a/packages/create-svelte/templates/default/src/app.html
+++ b/packages/create-svelte/templates/default/src/app.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width" />
 		%sveltekit.head%
 	</head>
 	<body>

--- a/packages/create-svelte/templates/skeleton/src/app.html
+++ b/packages/create-svelte/templates/skeleton/src/app.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width" />
 		%sveltekit.head%
 	</head>
 	<body>

--- a/packages/kit/test/apps/amp/src/app.html
+++ b/packages/kit/test/apps/amp/src/app.html
@@ -2,7 +2,7 @@
 <html ⚡ lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width" />
 		<link rel="canonical" href="https://example.com" />
 		%sveltekit.head%
 	</head>

--- a/packages/kit/test/apps/basics/src/app.html
+++ b/packages/kit/test/apps/basics/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/png" href="%sveltekit.assets%/favicon.png" />
 		<meta name="transform-page" content="__REPLACEME__" />
 		%sveltekit.head%

--- a/packages/kit/test/apps/options-2/src/app.html
+++ b/packages/kit/test/apps/options-2/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width" />
 		%sveltekit.head%
 	</head>
 	<body>

--- a/packages/kit/test/apps/options/source/template.html
+++ b/packages/kit/test/apps/options/source/template.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width" />
 		%sveltekit.head%
 	</head>
 	<body>

--- a/packages/kit/test/apps/writes/src/app.html
+++ b/packages/kit/test/apps/writes/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/png" href="%sveltekit.assets%/favicon.png" />
 		%sveltekit.head%
 	</head>

--- a/packages/kit/test/prerendering/basics/src/app.html
+++ b/packages/kit/test/prerendering/basics/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width" />
 		%sveltekit.head%
 	</head>
 	<body>

--- a/packages/kit/test/prerendering/fallback/src/app.html
+++ b/packages/kit/test/prerendering/fallback/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width" />
 		%sveltekit.head%
 	</head>
 	<body>

--- a/packages/kit/test/prerendering/options/src/app.html
+++ b/packages/kit/test/prerendering/options/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		%sveltekit.head%
 	</head>

--- a/packages/kit/test/prerendering/paths-base/src/app.html
+++ b/packages/kit/test/prerendering/paths-base/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width" />
 		%sveltekit.head%
 	</head>
 	<body>

--- a/packages/kit/test/prerendering/trailing-slash/src/app.html
+++ b/packages/kit/test/prerendering/trailing-slash/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		%sveltekit.head%
 	</head>

--- a/sites/kit.svelte.dev/src/app.html
+++ b/sites/kit.svelte.dev/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en" class="theme-default typo-default">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width,initial-scale=1" />
+		<meta name="viewport" content="width=device-width" />
 		<meta name="theme-color" content="#ff3e00" />
 
 		<link rel="manifest" href="/manifest.json" />


### PR DESCRIPTION
This saves some bytes and avoids propagating an obsolete workaround. The initial scale _already_ defaults to 1. `initial-scale=1` in `viewport` was propagated widely by https://css-tricks.com/probably-use-initial-scale1/ (though css-tricks itself doesn't use it). It was necessary to work around [the orientation change bug](https://webdesignerwall.com/tutorials/iphone-safari-viewport-scaling-bug) in Safari for iOS < 9. iOS 9 was released in 2015 and iOS < 9 usage is extremely low in 2022.

https://webhint.io/docs/user-guide/hints/hint-meta-viewport/ seems authoritative about it no longer being necessary.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
