### PR TITLE
hotfix: Small issues with recent environment variables PR

### DIFF
--- a/.changeset/tiny-eels-hear.md
+++ b/.changeset/tiny-eels-hear.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] Environment variable generated types

--- a/packages/kit/scripts/special-types/$env+static+private.md
+++ b/packages/kit/scripts/special-types/$env+static+private.md
@@ -1,4 +1,4 @@
-Environment variables [loaded by Vite](https://vitejs.dev/guide/env-and-mode.html#env-files) from `.env` files and `process.env`. Like [`$env/dynamic/private`](https://kit.svelte.dev/docs/modules#$env-dynamic-platform), this module cannot be imported into client-side code.
+Environment variables [loaded by Vite](https://vitejs.dev/guide/env-and-mode.html#env-files) from `.env` files and `process.env`. Like [`$env/dynamic/private`](https://kit.svelte.dev/docs/modules#$env-dynamic-platform), this module cannot be imported into client-side code. This module only includes variables that _do not_ begin with [`config.kit.env.publicPrefix`](https://kit.svelte.dev/docs/configuration#kit-env-publicprefix).
 
 _Unlike_ [`$env/dynamic/private`](https://kit.svelte.dev/docs/modules#$env-dynamic-platform), the values exported from this module are statically injected into your bundle at build time, enabling optimisations like dead code elimination.
 

--- a/packages/kit/src/core/sync/write_env.js
+++ b/packages/kit/src/core/sync/write_env.js
@@ -60,7 +60,7 @@ function create_module(id, env) {
 			continue;
 		}
 
-		const comment = `/** @type {import('${id}'}').${key}} */`;
+		const comment = `/** @type {import('${id}').${key}} */`;
 		const declaration = `export const ${key} = ${JSON.stringify(env[key])};`;
 
 		declarations.push(`${comment}\n${declaration}`);

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -102,7 +102,8 @@ declare module '$app/env' {
 /**
  * This module provides access to runtime environment variables, as defined by the platform you're running on. For example
  * if you're using [`adapter-node`](https://github.com/sveltejs/kit/tree/master/packages/adapter-node) (or running
- * [`vite preview`](https://kit.svelte.dev/docs/cli)), this is equivalent to `process.env`.
+ * [`vite preview`](https://kit.svelte.dev/docs/cli)), this is equivalent to `process.env`. This module only includes
+ * variables that _do not_ begin with [`config.kit.env.publicPrefix`](https://kit.svelte.dev/docs/configuration#kit-env-publicprefix).
  *
  * This module cannot be imported into client-side code.
  *


### PR DESCRIPTION
Generated JSDoc comments were malformed, and the current documentation didn't specify which variables are loaded to private modules (which, given the link to Vite, made it look like they were controlled by Vite's prefixing).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
