### PR TITLE
fix: check url protocol instead of origin

### DIFF
--- a/.changeset/big-coins-suffer.md
+++ b/.changeset/big-coins-suffer.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Check url protocol to avoid mailto links navigated by kit in mobile devices

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1142,10 +1142,12 @@ export function create_client({ target, session, base, trailing_slash }) {
 				const is_svg_a_element = a instanceof SVGAElement;
 				const url = get_href(a);
 
-				// Ignore if url does not have origin (e.g. `mailto:`, `tel:`.)
+				// Ignore if SvelteKit should not navigate the url protocal (e.g. `mailto:`, `tel:` and `myapp:`.)
 				// MEMO: Without this condition, firefox will open mailer twice.
-				// See: https://github.com/sveltejs/kit/issues/4045
-				if (!is_svg_a_element && url.origin === 'null') return;
+				// See:
+				// - https://github.com/sveltejs/kit/issues/4045
+				// - https://github.com/sveltejs/kit/issues/5725
+				if (!is_svg_a_element && !(url.protocol === 'https:' || url.protocol === 'http:')) return;
 
 				// Ignore if tag has
 				// 1. 'download' attribute

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1142,7 +1142,7 @@ export function create_client({ target, session, base, trailing_slash }) {
 				const is_svg_a_element = a instanceof SVGAElement;
 				const url = get_href(a);
 
-				// Ignore if SvelteKit should not navigate the url protocal (e.g. `mailto:`, `tel:` and `myapp:`.)
+				// Ignore non-HTTP URL protocols (e.g. `mailto:`, `tel:`, `myapp:`, etc.)
 				// MEMO: Without this condition, firefox will open mailer twice.
 				// See:
 				// - https://github.com/sveltejs/kit/issues/4045


### PR DESCRIPTION
Fix #5725

Because `url.origin` is not `"null"` in all browsers, it would be better to check `protocol` instead.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
