### PR TITLE
fix: load env before importing hooks during dev

### DIFF
--- a/.changeset/breezy-cooks-pump.md
+++ b/.changeset/breezy-cooks-pump.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+load env before importing hooks during dev

--- a/packages/kit/src/vite/dev/index.js
+++ b/packages/kit/src/vite/dev/index.js
@@ -245,11 +245,6 @@ export async function dev(vite, vite_config, svelte_config, illegal_imports) {
 					);
 				}
 
-				/** @type {Partial<import('types').Hooks>} */
-				const user_hooks = resolve_entry(svelte_config.kit.files.hooks)
-					? await vite.ssrLoadModule(`/${svelte_config.kit.files.hooks}`)
-					: {};
-
 				const runtime_base = process.env.BUNDLED
 					? `/${posixify(path.relative(cwd, `${svelte_config.kit.outDir}/runtime`))}`
 					: `/@fs${runtime}`;
@@ -260,6 +255,11 @@ export async function dev(vite, vite_config, svelte_config, illegal_imports) {
 				const env = get_env(vite_config.mode, svelte_config.kit.env.publicPrefix);
 				set_private_env(env.private);
 				set_public_env(env.public);
+
+				/** @type {Partial<import('types').Hooks>} */
+				const user_hooks = resolve_entry(svelte_config.kit.files.hooks)
+					? await vite.ssrLoadModule(`/${svelte_config.kit.files.hooks}`)
+					: {};
 
 				const handle = user_hooks.handle || (({ event, resolve }) => resolve(event));
 


### PR DESCRIPTION
During dev the environment was loaded after the user hooks. When accessing variables from `$env/dynamic/private` in code that is executed while importing the hooks (or any dependent modules) the environment was empty.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
