### PR TITLE
allow source routes to be passed to the vercel config for deploying prebuilt apps

### DIFF
--- a/.changeset/rich-dots-watch.md
+++ b/.changeset/rich-dots-watch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+Allow passing source routes to the adapter for combining in the vercel deployment config

--- a/packages/adapter-vercel/README.md
+++ b/packages/adapter-vercel/README.md
@@ -30,10 +30,9 @@ export default {
       // instead of creating a single one for the entire app
       split: false,
 
-      // a set of source routes which comply with the rules
-      // set out in the vercel build output v3 api
-      // (https://vercel.com/docs/build-output-api/v3#build-output-configuration/supported-properties/routes)
-      source_routes: []
+      // path to your vercel config, defaults to vercel.json
+      // currently only used to configure rewrites and redirects
+      local_config_filename: string
     })
   }
 };

--- a/packages/adapter-vercel/README.md
+++ b/packages/adapter-vercel/README.md
@@ -28,7 +28,12 @@ export default {
 
       // if true, will split your app into multiple functions
       // instead of creating a single one for the entire app
-      split: false
+      split: false,
+
+      // a set of source routes which comply with the rules
+      // set out in the vercel build output v3 api
+      // (https://vercel.com/docs/build-output-api/v3#build-output-configuration/supported-properties/routes)
+      source_routes: []
     })
   }
 };

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -1,53 +1,10 @@
 import { Adapter } from '@sveltejs/kit';
 
-type Locale = {
-	redirect?: Record<string, string>;
-	cookie?: string;
-};
-
-type HostHasField = {
-	type: 'host';
-	value: string;
-};
-
-type HeaderHasField = {
-	type: 'header';
-	key: string;
-	value?: string;
-};
-
-type CookieHasField = {
-	type: 'cookie';
-	key: string;
-	value?: string;
-};
-
-type QueryHasField = {
-	type: 'query';
-	key: string;
-	value?: string;
-};
-
-type SourceRoute = {
-	src: string;
-	dest?: string;
-	headers?: Record<string, string>;
-	methods?: string[];
-	continue?: boolean;
-	caseSensitive?: boolean;
-	check?: boolean;
-	status?: number;
-	has?: Array<HostHasField | HeaderHasField | CookieHasField | QueryHasField>;
-	missing?: Array<HostHasField | HeaderHasField | CookieHasField | QueryHasField>;
-	locale?: Locale;
-	middlewarePath?: string;
-};
-
 type Options = {
 	edge?: boolean;
 	external?: string[];
 	split?: boolean;
-	source_routes?: Array<SourceRoute>;
+	local_config_filename?: string;
 };
 
 export default function plugin(options?: Options): Adapter;

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -1,31 +1,31 @@
 import { Adapter } from '@sveltejs/kit';
 
 type Locale = {
-  redirect?: Record<string, string>;
-  cookie?: string;
+	redirect?: Record<string, string>;
+	cookie?: string;
 };
 
 type HostHasField = {
-  type: 'host';
-  value: string;
+	type: 'host';
+	value: string;
 };
 
 type HeaderHasField = {
-  type: 'header';
-  key: string;
-  value?: string;
+	type: 'header';
+	key: string;
+	value?: string;
 };
 
 type CookieHasField = {
-  type: 'cookie';
-  key: string;
-  value?: string;
+	type: 'cookie';
+	key: string;
+	value?: string;
 };
 
 type QueryHasField = {
-  type: 'query';
-  key: string;
-  value?: string;
+	type: 'query';
+	key: string;
+	value?: string;
 };
 
 type SourceRoute = {
@@ -38,9 +38,7 @@ type SourceRoute = {
 	check?: boolean;
 	status?: number;
 	has?: Array<HostHasField | HeaderHasField | CookieHasField | QueryHasField>;
-	missing?: Array<
-		HostHasField | HeaderHasField | CookieHasField | QueryHasField
-	>;
+	missing?: Array<HostHasField | HeaderHasField | CookieHasField | QueryHasField>;
 	locale?: Locale;
 	middlewarePath?: string;
 };
@@ -49,7 +47,7 @@ type Options = {
 	edge?: boolean;
 	external?: string[];
 	split?: boolean;
-	source_routes?: Array<SourceRoute>
+	source_routes?: Array<SourceRoute>;
 };
 
 export default function plugin(options?: Options): Adapter;

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -1,9 +1,55 @@
 import { Adapter } from '@sveltejs/kit';
 
+type Locale = {
+  redirect?: Record<string, string>;
+  cookie?: string;
+};
+
+type HostHasField = {
+  type: 'host';
+  value: string;
+};
+
+type HeaderHasField = {
+  type: 'header';
+  key: string;
+  value?: string;
+};
+
+type CookieHasField = {
+  type: 'cookie';
+  key: string;
+  value?: string;
+};
+
+type QueryHasField = {
+  type: 'query';
+  key: string;
+  value?: string;
+};
+
+type SourceRoute = {
+	src: string;
+	dest?: string;
+	headers?: Record<string, string>;
+	methods?: string[];
+	continue?: boolean;
+	caseSensitive?: boolean;
+	check?: boolean;
+	status?: number;
+	has?: Array<HostHasField | HeaderHasField | CookieHasField | QueryHasField>;
+	missing?: Array<
+		HostHasField | HeaderHasField | CookieHasField | QueryHasField
+	>;
+	locale?: Locale;
+	middlewarePath?: string;
+};
+
 type Options = {
 	edge?: boolean;
 	external?: string[];
 	split?: boolean;
+	source_routes?: Array<SourceRoute>
 };
 
 export default function plugin(options?: Options): Adapter;

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -82,12 +82,7 @@ const redirects = {
 };
 
 /** @type {import('.').default} **/
-export default function ({
-	external = [],
-	edge,
-	split,
-	source_routes = []
-} = {}) {
+export default function ({ external = [], edge, split, source_routes = [] } = {}) {
 	return {
 		name: '@sveltejs/adapter-vercel',
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -82,7 +82,12 @@ const redirects = {
 };
 
 /** @type {import('.').default} **/
-export default function ({ external = [], edge, split } = {}) {
+export default function ({
+	external = [],
+	edge,
+	split,
+	source_routes = []
+} = {}) {
 	return {
 		name: '@sveltejs/adapter-vercel',
 
@@ -117,6 +122,7 @@ export default function ({ external = [], edge, split } = {}) {
 			const routes = [
 				...redirects[builder.config.kit.trailingSlash],
 				...prerendered_redirects,
+				...source_routes,
 				{
 					src: `/${builder.config.kit.appDir}/.+`,
 					headers: {

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { nodeFileTrace } from '@vercel/nft';
 import esbuild from 'esbuild';
-import { getTransformedRoutes } from '@vercel/routing-utils'
+import { getTransformedRoutes } from '@vercel/routing-utils';
 
 // rules for clean URLs and trailing slash handling,
 // generated with @vercel/routing-utils
@@ -83,7 +83,12 @@ const platform_redirects = {
 };
 
 /** @type {import('.').default} **/
-export default function ({ external = [], edge, split, local_config_filename = 'vercel.json' } = {}) {
+export default function ({
+	external = [],
+	edge,
+	split,
+	local_config_filename = 'vercel.json'
+} = {}) {
 	return {
 		name: '@sveltejs/adapter-vercel',
 
@@ -264,17 +269,17 @@ export default function ({ external = [], edge, split, local_config_filename = '
 }
 
 /**
- * @param {string} local_config_filename 
+ * @param {string} local_config_filename
  */
 function parse_routing_config(local_config_filename) {
 	const config_path = path.resolve(process.cwd(), local_config_filename);
 	if (!fs.existsSync(config_path)) {
-		return []
+		return [];
 	}
 	const vercel_config = fs.readFileSync(config_path, 'utf8');
 	const { redirects = [], rewrites = [] } = JSON.parse(vercel_config);
-	const { routes } = getTransformedRoutes({ redirects, rewrites});
-	return routes.filter(route => route.handle !== 'filesystem');
+	const { routes } = getTransformedRoutes({ redirects, rewrites });
+	return routes.filter((route) => route.handle !== 'filesystem');
 }
 
 /**

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -29,6 +29,7 @@
 	},
 	"dependencies": {
 		"@vercel/nft": "^0.21.0",
+		"@vercel/routing-utils": "^2.0.0",
 		"esbuild": "^0.14.48"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,10 +195,12 @@ importers:
       '@sveltejs/kit': workspace:*
       '@types/node': ^16.11.36
       '@vercel/nft': ^0.21.0
+      '@vercel/routing-utils': ^2.0.0
       esbuild: ^0.14.48
       typescript: ^4.7.4
     dependencies:
       '@vercel/nft': 0.21.0
+      '@vercel/routing-utils': 2.0.0
       esbuild: 0.14.48
     devDependencies:
       '@sveltejs/kit': link:../kit
@@ -1163,6 +1165,14 @@ packages:
       - supports-color
     dev: false
 
+  /@vercel/routing-utils/2.0.0:
+    resolution: {integrity: sha512-laDhH96e+IzU6GnufS5QZ3YvfqA4h5bw8j+k7+t7wPzRjtDhHDfbI45MypVWbVul7BhEZTaHztnzR0zo/YiFMw==}
+    dependencies:
+      path-to-regexp: 6.1.0
+    optionalDependencies:
+      ajv: 6.12.6
+    dev: false
+
   /abbrev/1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
     dev: false
@@ -1181,6 +1191,17 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+
+  /ajv/6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+    requiresBuild: true
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+    dev: false
+    optional: true
 
   /ansi-colors/4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -2037,6 +2058,11 @@ packages:
       tmp: 0.0.33
     dev: true
 
+  /fast-deep-equal/3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: false
+    optional: true
+
   /fast-glob/3.2.11:
     resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==}
     engines: {node: '>=8.6.0'}
@@ -2047,6 +2073,11 @@ packages:
       merge2: 1.4.1
       micromatch: 4.0.5
     dev: true
+
+  /fast-json-stable-stringify/2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+    dev: false
+    optional: true
 
   /fastq/1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
@@ -2637,6 +2668,11 @@ packages:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
     dev: true
 
+  /json-schema-traverse/0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+    dev: false
+    optional: true
+
   /jsonc-parser/3.0.0:
     resolution: {integrity: sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==}
     dev: true
@@ -3193,6 +3229,10 @@ packages:
   /path-parse/1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  /path-to-regexp/6.1.0:
+    resolution: {integrity: sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==}
+    dev: false
+
   /path-type/2.0.0:
     resolution: {integrity: sha512-dUnb5dXUf+kzhC/W/F4e5/SkluXIFf5VUHolW1Eg1irn1hGWjPGdsRcvYJ1nD6lhk8Ir7VM0bHJKsYTx8Jx9OQ==}
     engines: {node: '>=4'}
@@ -3352,6 +3392,12 @@ packages:
       end-of-stream: 1.4.4
       once: 1.4.0
     dev: true
+
+  /punycode/2.1.1:
+    resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
+    engines: {node: '>=6'}
+    dev: false
+    optional: true
 
   /purify-css/1.2.5:
     resolution: {integrity: sha512-Vy4jRnV2w/kUjTyxzQOKbFkqwUe6RNLuZgIWR/IRQ8nCqRwiFgwC9XiO9+8poq5KL053uWAQnCSbsfihq77zPg==}
@@ -4414,6 +4460,13 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
     dev: true
+
+  /uri-js/4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+    dependencies:
+      punycode: 2.1.1
+    dev: false
+    optional: true
 
   /urix/0.1.0:
     resolution: {integrity: sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==}


### PR DESCRIPTION
I noticed when deploying via the CLI with --prebuilt (for example, if you use vercel build or if you use your own CI to build SvelteKit apps), the redirects and rewrites defined in `vercel.json` are ignored, or applied inconsistently.

This allows those routes (and more powerful directives) to be defined via the new build output API, which the adapter now uses.

You can now pass an array `source_routes` as an option to `adapter()`. This array should contain anything listed in the build output api docs - https://vercel.com/docs/build-output-api/v3

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
