### PR TITLE
fix: `$env/*/private` throws for client-side imports on Windows and Tailwind doesn't freak out

### DIFF
--- a/.changeset/gold-spies-fail.md
+++ b/.changeset/gold-spies-fail.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] Windows correctly errors on `$env/*/private` imports

--- a/.changeset/gold-spies-fail.md
+++ b/.changeset/gold-spies-fail.md
@@ -3,3 +3,4 @@
 ---
 
 [fix] Windows correctly errors on `$env/*/private` imports
+[fix] Illegal module analysis in dev ignores non-js|ts|svelte files

--- a/packages/kit/src/vite/dev/index.js
+++ b/packages/kit/src/vite/dev/index.js
@@ -64,7 +64,12 @@ export async function dev(vite, vite_config, svelte_config, illegal_imports) {
 						const node = await vite.moduleGraph.getModuleByUrl(url);
 						if (!node) throw new Error(`Could not find node for ${url}`);
 
-						prevent_illegal_vite_imports(node, illegal_imports, svelte_config.kit.outDir);
+						prevent_illegal_vite_imports(
+							node,
+							illegal_imports,
+							[...svelte_config.extensions, ...svelte_config.kit.moduleExtensions],
+							svelte_config.kit.outDir
+						);
 
 						return {
 							module,

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -191,8 +191,8 @@ function kit() {
 			};
 
 			illegal_imports = new Set([
-				`${svelte_config.kit.outDir}/runtime/env/dynamic/private.js`,
-				`${svelte_config.kit.outDir}/runtime/env/static/private.js`
+				path.normalize(`${svelte_config.kit.outDir}/runtime/env/dynamic/private.js`),
+				path.normalize(`${svelte_config.kit.outDir}/runtime/env/static/private.js`)
 			]);
 
 			if (is_build) {
@@ -284,7 +284,8 @@ function kit() {
 		async writeBundle(_options, bundle) {
 			for (const file of manifest_data.components) {
 				const id = path.resolve(file);
-				const node = this.getModuleInfo(id);
+				// Rollup stores module IDs with forward slashes, even on Windows
+				const node = this.getModuleInfo(id.replace(/\\/g, '/'));
 
 				if (node) {
 					prevent_illegal_rollup_imports(

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -191,8 +191,8 @@ function kit() {
 			};
 
 			illegal_imports = new Set([
-				path.normalize(`${svelte_config.kit.outDir}/runtime/env/dynamic/private.js`),
-				path.normalize(`${svelte_config.kit.outDir}/runtime/env/static/private.js`)
+				vite.normalizePath(`${svelte_config.kit.outDir}/runtime/env/dynamic/private.js`),
+				vite.normalizePath(`${svelte_config.kit.outDir}/runtime/env/static/private.js`)
 			]);
 
 			if (is_build) {
@@ -283,9 +283,8 @@ function kit() {
 		 */
 		async writeBundle(_options, bundle) {
 			for (const file of manifest_data.components) {
-				const id = path.resolve(file);
-				// Rollup stores module IDs with forward slashes, even on Windows
-				const node = this.getModuleInfo(id.replace(/\\/g, '/'));
+				const id = vite.normalizePath(path.resolve(file));
+				const node = this.getModuleInfo(id);
 
 				if (node) {
 					prevent_illegal_rollup_imports(

--- a/packages/kit/src/vite/utils.js
+++ b/packages/kit/src/vite/utils.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { loadConfigFromFile, loadEnv } from 'vite';
+import { loadConfigFromFile, loadEnv, normalizePath } from 'vite';
 import { get_runtime_directory } from '../core/utils.js';
 
 /**
@@ -200,7 +200,7 @@ export function get_env(mode, prefix) {
 /**
  * @param {(id: string) => import('rollup').ModuleInfo | null} node_getter
  * @param {import('rollup').ModuleInfo} node
- * @param {Set<string>} illegal_imports Illegal module IDs -- be sure to call path.normalize!
+ * @param {Set<string>} illegal_imports Illegal module IDs -- be sure to call vite.normalizePath!
  * @param {string} out_dir The directory specified by config.kit.outDir
  */
 export function prevent_illegal_rollup_imports(node_getter, node, illegal_imports, out_dir) {
@@ -212,7 +212,7 @@ export function prevent_illegal_rollup_imports(node_getter, node, illegal_import
  * @param {(id: string) => import('rollup').ModuleInfo | null} node_getter
  * @param {import('rollup').ModuleInfo} node
  * @param {boolean} dynamic
- * @param {Set<string>} illegal_imports Illegal module IDs -- be sure to call path.normalize!
+ * @param {Set<string>} illegal_imports Illegal module IDs -- be sure to call vite.normalizePath!
  * @param {Set<string>} seen
  * @returns {Array<import('types').ImportNode> | undefined}
  */
@@ -223,7 +223,7 @@ const find_illegal_rollup_imports = (
 	illegal_imports,
 	seen = new Set()
 ) => {
-	const nodeId = path.normalize(node.id);
+	const nodeId = normalizePath(node.id);
 	if (seen.has(nodeId)) return;
 	seen.add(nodeId);
 
@@ -249,7 +249,7 @@ const find_illegal_rollup_imports = (
 /**
  * Throw an error if a private module is imported from a client-side node.
  * @param {import('vite').ModuleNode} node
- * @param {Set<string>} illegal_imports Illegal module IDs -- be sure to call path.normalize!
+ * @param {Set<string>} illegal_imports Illegal module IDs -- be sure to call vite.normalizePath!
  * @param {string} out_dir The directory specified by config.kit.outDir
  */
 export function prevent_illegal_vite_imports(node, illegal_imports, out_dir) {
@@ -259,13 +259,13 @@ export function prevent_illegal_vite_imports(node, illegal_imports, out_dir) {
 
 /**
  * @param {import('vite').ModuleNode} node
- * @param {Set<string>} illegal_imports Illegal module IDs -- be sure to call path.normalize!
+ * @param {Set<string>} illegal_imports Illegal module IDs -- be sure to call vite.normalizePath!
  * @param {Set<string>} seen
  * @returns {Array<import('types').ImportNode> | null}
  */
 function find_illegal_vite_imports(node, illegal_imports, seen = new Set()) {
 	if (!node.id) return null; // TODO when does this happen?
-	const nodeId = path.normalize(node.id);
+	const nodeId = normalizePath(node.id);
 	if (seen.has(nodeId)) return null;
 	seen.add(nodeId);
 

--- a/packages/kit/src/vite/utils.js
+++ b/packages/kit/src/vite/utils.js
@@ -223,29 +223,29 @@ const find_illegal_rollup_imports = (
 	illegal_imports,
 	seen = new Set()
 ) => {
-	const nodeId = normalizePath(node.id);
-	if (seen.has(nodeId)) return null;
-	seen.add(nodeId);
+	const name = normalizePath(node.id);
+	if (seen.has(name)) return null;
+	seen.add(name);
 
-	if (illegal_imports.has(nodeId)) {
-		return [{ name: nodeId, dynamic }];
+	if (illegal_imports.has(name)) {
+		return [{ name, dynamic }];
 	}
 
 	for (const id of node.importedIds) {
 		const child = node_getter(id);
 		const chain =
 			child && find_illegal_rollup_imports(node_getter, child, false, illegal_imports, seen);
-		if (chain) return [{ name: nodeId, dynamic }, ...chain];
+		if (chain) return [{ name, dynamic }, ...chain];
 	}
 
 	for (const id of node.dynamicallyImportedIds) {
 		const child = node_getter(id);
 		const chain =
 			child && find_illegal_rollup_imports(node_getter, child, true, illegal_imports, seen);
-		if (chain) return [{ name: nodeId, dynamic }, ...chain];
+		if (chain) return [{ name, dynamic }, ...chain];
 	}
 
-	seen.delete(nodeId);
+	seen.delete(name);
 	return null;
 };
 
@@ -287,20 +287,20 @@ const module_types = new Set([
  */
 function find_illegal_vite_imports(node, illegal_imports, seen = new Set()) {
 	if (!node.id) return null; // TODO when does this happen?
-	const nodeId = normalizePath(node.id);
+	const name = normalizePath(node.id);
 
-	if (seen.has(nodeId) || !module_types.has(path.extname(nodeId))) return null;
-	seen.add(nodeId);
+	if (seen.has(name) || !module_types.has(path.extname(name))) return null;
+	seen.add(name);
 
-	if (nodeId && illegal_imports.has(nodeId)) {
-		return [{ name: nodeId, dynamic: false }];
+	if (name && illegal_imports.has(name)) {
+		return [{ name, dynamic: false }];
 	}
 
 	for (const child of node.importedModules) {
 		const chain = child && find_illegal_vite_imports(child, illegal_imports, seen);
-		if (chain) return [{ name: nodeId, dynamic: false }, ...chain];
+		if (chain) return [{ name, dynamic: false }, ...chain];
 	}
 
-	seen.delete(nodeId);
+	seen.delete(name);
 	return null;
 }

--- a/packages/kit/src/vite/utils.js
+++ b/packages/kit/src/vite/utils.js
@@ -266,7 +266,18 @@ export function prevent_illegal_vite_imports(node, illegal_imports, out_dir) {
  * every file in the project. This isn't a problem for
  * Rollup during build.
  */
-const module_types = new Set(['.js', '.ts', '.svelte']);
+const module_types = new Set([
+	'.ts',
+	'.js',
+	'.svelte',
+	'.mts',
+	'.mjs',
+	'.cts',
+	'.cjs',
+	'.svelte.md',
+	'.svx',
+	'.md'
+]);
 
 /**
  * @param {import('vite').ModuleNode} node

--- a/packages/kit/src/vite/utils.spec.js
+++ b/packages/kit/src/vite/utils.spec.js
@@ -1,6 +1,6 @@
-import path from 'path';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
+import { normalizePath } from 'vite';
 import {
 	deep_merge,
 	merge_vite_configs,
@@ -261,7 +261,7 @@ const rollup_node_getter = (id) => {
 	return nodes[id] ?? null;
 };
 
-const illegal_imports = new Set([path.normalize('/illegal/boom.js')]);
+const illegal_imports = new Set([normalizePath('/illegal/boom.js')]);
 const ok_rollup_node = rollup_node_getter('/test/path1.js');
 const bad_rollup_node_static = rollup_node_getter('/bad/static.js');
 const bad_rollup_node_dynamic = rollup_node_getter('/bad/dynamic.js');

--- a/packages/kit/src/vite/utils.spec.js
+++ b/packages/kit/src/vite/utils.spec.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import {
@@ -260,7 +261,7 @@ const rollup_node_getter = (id) => {
 	return nodes[id] ?? null;
 };
 
-const illegal_imports = new Set(['/illegal/boom.js']);
+const illegal_imports = new Set([path.normalize('/illegal/boom.js')]);
 const ok_rollup_node = rollup_node_getter('/test/path1.js');
 const bad_rollup_node_static = rollup_node_getter('/bad/static.js');
 const bad_rollup_node_dynamic = rollup_node_getter('/bad/dynamic.js');


### PR DESCRIPTION
Closes #5723 and closes #5747. 

The paths for both Vite and Rollup's module graphs needed to be normalized, along with the illegal import paths.

Because Tailwind needs to analyze basically every file in your project, Vite thinks it imports all of them, meaning it'll almost always import `$env/*/private`, causing our helpful module analysis to be, well, unhelpful. In dev, we now ignore non-`js|ts|svelte` files. Rollup doesn't have this problem (because it doesn't have to worry about HMR), so we can be stricter and just analyze all imports. I think this strikes a happy medium. "Provide armor against footguns in dev, and provide even better armor when we try to go to prod."

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
