### PR TITLE
[docs] Remove `alias` from configuration options 

### DIFF
--- a/documentation/docs/15-configuration.md
+++ b/documentation/docs/15-configuration.md
@@ -91,27 +91,6 @@ export default config;
 
 Run when executing `vite build` and determines how the output is converted for different platforms. See [Adapters](/docs/adapters).
 
-### alias
-
-An object containing zero or more aliases used to replace values in `import` statements. These aliases are automatically passed to Vite and TypeScript.
-
-For example, you can add aliases to a `components` and `utils` folder:
-
-```js
-/// file: svelte.config.js
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		alias: {
-			$components: 'src/components',
-			$utils: 'src/utils'
-		}
-	}
-};
-```
-
-> The built-in `$lib` alias is controlled by `config.kit.files.lib` as it is used for packaging.
-
 ### appDir
 
 The directory relative to `paths.assets` where the built JS and CSS (and imported assets) are served from. (The filenames therein contain content-based hashes, meaning they can be cached indefinitely). Must not start or end with `/`.


### PR DESCRIPTION
`alias` options should now be configured in `vite.config.js`, this makes me wonder though if we should have a short section about the `vite.config.js` file ?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
