### PR TITLE
feat: reference kit types in ambient file

### DIFF
--- a/.changeset/tricky-moose-sip.md
+++ b/.changeset/tricky-moose-sip.md
@@ -1,0 +1,7 @@
+---
+'default-template': patch
+'create-svelte': patch
+'@sveltejs/kit': patch
+---
+
+[feat] include reference to `@sveltejs/kit` types in ambient file

--- a/.changeset/tricky-moose-sip.md
+++ b/.changeset/tricky-moose-sip.md
@@ -1,5 +1,4 @@
 ---
-'default-template': patch
 'create-svelte': patch
 '@sveltejs/kit': patch
 ---

--- a/packages/create-svelte/templates/default/src/app.d.ts
+++ b/packages/create-svelte/templates/default/src/app.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="@sveltejs/kit" />
-
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 // and what to do when importing types

--- a/packages/create-svelte/templates/skeleton/src/app.d.ts
+++ b/packages/create-svelte/templates/skeleton/src/app.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="@sveltejs/kit" />
-
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 // and what to do when importing types

--- a/packages/kit/src/core/sync/sync.js
+++ b/packages/kit/src/core/sync/sync.js
@@ -6,7 +6,7 @@ import { write_matchers } from './write_matchers.js';
 import { write_root } from './write_root.js';
 import { write_tsconfig } from './write_tsconfig.js';
 import { write_types } from './write_types.js';
-import { write_env } from './write_env.js';
+import { write_ambient } from './write_ambient.js';
 
 /**
  * Initialize SvelteKit's generated files.
@@ -17,7 +17,7 @@ export function init(config, mode) {
 	copy_assets(path.join(config.kit.outDir, 'runtime'));
 
 	write_tsconfig(config.kit);
-	write_env(config.kit, mode);
+	write_ambient(config.kit, mode);
 }
 
 /**

--- a/packages/kit/src/core/sync/write_ambient.js
+++ b/packages/kit/src/core/sync/write_ambient.js
@@ -7,33 +7,34 @@ const autogen_comment = '// this file is generated — do not edit it\n';
 const types_reference = '/// <reference types="@sveltejs/kit" />\n\n';
 
 /**
- * Writes the existing environment variables in process.env to
+ * Writes ambient declarations including types reference to @sveltejs/kit,
+ * and the existing environment variables in process.env to
  * $env/static/private and $env/static/public
  * @param {import('types').ValidatedKitConfig} config
  * @param {string} mode The Vite mode
  */
-export function write_env(config, mode) {
+export function write_ambient(config, mode) {
 	const env = get_env(mode, config.env.publicPrefix);
 
 	// TODO when testing src, `$app` points at `src/runtime/app`... will
 	// probably need to fiddle with aliases
 	write_if_changed(
 		path.join(config.outDir, 'runtime/env/static/public.js'),
-		create_module('$env/static/public', env.public)
+		create_env_module('$env/static/public', env.public)
 	);
 
 	write_if_changed(
 		path.join(config.outDir, 'runtime/env/static/private.js'),
-		create_module('$env/static/private', env.private)
+		create_env_module('$env/static/private', env.private)
 	);
 
 	write_if_changed(
 		path.join(config.outDir, 'ambient.d.ts'),
 		autogen_comment +
 			types_reference +
-			create_types('$env/static/public', env.public) +
+			create_env_types('$env/static/public', env.public) +
 			'\n\n' +
-			create_types('$env/static/private', env.private)
+			create_env_types('$env/static/private', env.private)
 	);
 }
 
@@ -42,7 +43,7 @@ export function write_env(config, mode) {
  * @param {Record<string, string>} env
  * @returns {string}
  */
-function create_module(id, env) {
+function create_env_module(id, env) {
 	/** @type {string[]} */
 	const declarations = [];
 
@@ -76,7 +77,7 @@ function create_module(id, env) {
  * @param {Record<string, string>} env
  * @returns {string}
  */
-function create_types(id, env) {
+function create_env_types(id, env) {
 	const declarations = Object.keys(env)
 		.filter((k) => valid_identifier.test(k))
 		.map((k) => `\texport const ${k}: string;`)

--- a/packages/kit/src/core/sync/write_env.js
+++ b/packages/kit/src/core/sync/write_env.js
@@ -4,6 +4,7 @@ import { get_env } from '../../vite/utils.js';
 import { write_if_changed, reserved, valid_identifier } from './utils.js';
 
 const autogen_comment = '// this file is generated — do not edit it\n';
+const types_reference = '/// <reference types="@sveltejs/kit" />\n\n';
 
 /**
  * Writes the existing environment variables in process.env to
@@ -29,6 +30,7 @@ export function write_env(config, mode) {
 	write_if_changed(
 		path.join(config.outDir, 'ambient.d.ts'),
 		autogen_comment +
+			types_reference +
 			create_types('$env/static/public', env.public) +
 			'\n\n' +
 			create_types('$env/static/private', env.private)


### PR DESCRIPTION
Closes #5677. Includes reference to `@sveltejs/kit` types in ambient file, and removes reference from `app.d.ts`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
