### PR TITLE
[fix] don't warn if custom `compilerOptions.paths` are used

### DIFF
--- a/.changeset/bright-scissors-drum.md
+++ b/.changeset/bright-scissors-drum.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] don't warn if custom compilerOptions.paths are used

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -108,9 +108,9 @@ function validate(config, cwd, out, user_file) {
 	const kind = path.basename(user_file);
 
 	if (extends_framework_config) {
-		const { paths: user_paths } = user_tsconfig.compilerOptions || {};
+		const { paths: user_paths = {} } = user_tsconfig.compilerOptions || {};
 
-		if (user_paths && fs.existsSync(config.files.lib)) {
+		if (Object.keys(user_paths).length === 0 && fs.existsSync(config.files.lib)) {
 			/** @type {string[]} */
 			const lib = user_paths['$lib'] || [];
 			/** @type {string[]} */


### PR DESCRIPTION
This is a QOL change that only emits a warning for `compilerOptions.paths` if it is missing or not set.

**Current DX**

A real world scenario is using SvelteKit for developing Svelte components in which the `tsconfig.json` [has a custom `compilerOptions.paths` set](https://github.com/metonym/svelte-bar-chart-race/blob/8faa606822e82d4e111bf9e551b398348355cd78/tsconfig.json#L5).

In this case, the warning is a false positive.

The following message is emitted when running `yarn build`.

```sh
Your compilerOptions.paths in tsconfig.json should include the following:
{
  "$lib":["src"],
  "$lib/*":["src/*"]
}
```

**Proposed DX**

SvelteKit only warns if `compilerOptions.paths` is missing or is empty. It will not warn if a custom `compilerOptions.paths` is set.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
