### PR TITLE
fix: Prevent import cycles from crashing build

### DIFF
--- a/.changeset/hot-beds-tickle.md
+++ b/.changeset/hot-beds-tickle.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] Import analysis doesn't get stuck in an infinite loop when encountering cyclical imports

--- a/packages/kit/src/vite/utils.js
+++ b/packages/kit/src/vite/utils.js
@@ -273,7 +273,6 @@ const find_illegal_rollup_imports = (
 		if (chain) return [{ name, dynamic }, ...chain];
 	}
 
-	seen.delete(name);
 	return null;
 };
 
@@ -335,6 +334,5 @@ function find_illegal_vite_imports(node, illegal_imports, module_types, seen = n
 		if (chain) return [{ name, dynamic: false }, ...chain];
 	}
 
-	seen.delete(name);
 	return null;
 }


### PR DESCRIPTION
# HEADS UP!

We're about to embark on a [significant redesign](https://github.com/sveltejs/kit/discussions/5748) that will touch many parts of the codebase. Until that work is finished, PRs are very likely to result in merge conflicts, and will likely be ignored until the redesign work is complete (by which time they will likely be stale). Please consider delaying your PR until then.

Thank you for understanding!

---

This fixes #5786 and #5784. I'd like a review from someone whose brain isn't fried. The problem is that the recursive import analysis was removing modules from `seen` when all of their children did not contain an illegal module. Somehow, this removal allowed cyclical imports to infinitely get stuck in a loop, but I just can't visualize how. It _seems_ like there should be some point at which we remove modules from `seen`, but I don't know if that's right. I just can't picture it right now -- and the module graph for the reproduction in #5786 is just so insane that I'm having trouble figuring it out.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
