### PR TITLE
[chore] upgrade to Undici 5.8.1

### DIFF
--- a/.changeset/violet-jars-visit.md
+++ b/.changeset/violet-jars-visit.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[chore] upgrade to Undici 5.8.1

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -42,7 +42,7 @@
 		"svelte2tsx": "~0.5.10",
 		"tiny-glob": "^0.2.9",
 		"typescript": "^4.7.4",
-		"undici": "^5.6.1",
+		"undici": "^5.8.1",
 		"uvu": "^0.5.3",
 		"vite": "^3.0.0"
 	},

--- a/packages/kit/test/apps/basics/src/routes/load/large-response/text.txt.js
+++ b/packages/kit/test/apps/basics/src/routes/load/large-response/text.txt.js
@@ -6,6 +6,8 @@ for (let i = 0; i < chunk_size; i += 1) {
 	chunk += String(i % 10);
 }
 
+const encoder = new TextEncoder();
+
 export function GET() {
 	let i = 0;
 
@@ -13,7 +15,7 @@ export function GET() {
 		body: new ReadableStream({
 			pull: (controller) => {
 				if (i++ < chunk_count) {
-					controller.enqueue(chunk);
+					controller.enqueue(encoder.encode(chunk));
 				} else {
 					controller.close();
 				}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,7 +298,7 @@ importers:
       svelte2tsx: ~0.5.10
       tiny-glob: ^0.2.9
       typescript: ^4.7.4
-      undici: ^5.6.1
+      undici: ^5.8.1
       uvu: ^0.5.3
       vite: ^3.0.0
     dependencies:
@@ -333,7 +333,7 @@ importers:
       svelte2tsx: 0.5.11_lvfi2wesz6u4l5rfbnetbucfmm
       tiny-glob: 0.2.9
       typescript: 4.7.4
-      undici: 5.6.1
+      undici: 5.8.1
       uvu: 0.5.4
       vite: 3.0.0
 
@@ -4405,8 +4405,8 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
-  /undici/5.6.1:
-    resolution: {integrity: sha512-yYVqywdCbNb99f/w045wqmv++WExXDjY0FEvLSB7QUZZH6izxrVkF4dJn1aimcvN0+WAhv75Gg7v6VJoqmRtJQ==}
+  /undici/5.8.1:
+    resolution: {integrity: sha512-iDRmWX4Zar/4A/t+1LrKQRm102zw2l9Wgat3LtTlTn8ykvMZmAmpq9tjyHEigx18FsY7IfATvyN3xSw9BDz0eA==}
     engines: {node: '>=12.18'}
     dev: true
 


### PR DESCRIPTION
Had to update a test because Undici got a bit stricter about the spec in https://github.com/nodejs/undici/pull/1550

This test file will be moved in https://github.com/sveltejs/kit/pull/5778, but other than that should not cause any merge conflicts