### PR TITLE
handle spaces in filenames when migrating

### DIFF
--- a/.changeset/famous-birds-boil.md
+++ b/.changeset/famous-birds-boil.md
@@ -1,0 +1,5 @@
+---
+'svelte-migrate': patch
+---
+
+Correctly rename files with spaces when migrating

--- a/packages/migrate/migrations/routes/utils.js
+++ b/packages/migrate/migrations/routes/utils.js
@@ -46,7 +46,7 @@ export function error(description, comment_id) {
  */
 export function move_file(file, renamed, content, use_git) {
 	if (use_git) {
-		execSync(`git mv ${file} ${renamed}`);
+		execSync(`git mv ${JSON.stringify(file)} ${JSON.stringify(renamed)}`);
 	} else {
 		fs.unlinkSync(file);
 	}


### PR DESCRIPTION
`test/prerendering/basics` failed to migrate because one of the files has spaces, which meant it was being interpreted as multiple arguments