### PR TITLE
Move compress inside kit

### DIFF
--- a/.changeset/cyan-radios-attend.md
+++ b/.changeset/cyan-radios-attend.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-static': patch
+'@sveltejs/kit': patch
+---
+
+Move compress inside kit

--- a/.changeset/cyan-radios-attend.md
+++ b/.changeset/cyan-radios-attend.md
@@ -4,4 +4,4 @@
 '@sveltejs/kit': patch
 ---
 
-Move compress inside kit
+Move `compress` logic to `Builder` API

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -1,11 +1,5 @@
-import { createReadStream, createWriteStream, existsSync, statSync, writeFileSync } from 'fs';
-import { pipeline } from 'stream';
-import glob from 'tiny-glob';
+import { writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
-import { promisify } from 'util';
-import zlib from 'zlib';
-
-const pipe = promisify(pipeline);
 
 const files = fileURLToPath(new URL('./files', import.meta.url).href);
 
@@ -49,51 +43,9 @@ export default function (opts = {}) {
 
 			if (precompress) {
 				builder.log.minor('Compressing assets');
-				await compress(`${out}/client`);
-				await compress(`${out}/prerendered`);
+				await builder.compress(`${out}/client`);
+				await builder.compress(`${out}/prerendered`);
 			}
 		}
 	};
-}
-
-/**
- * @param {string} directory
- */
-async function compress(directory) {
-	if (!existsSync(directory)) {
-		return;
-	}
-
-	const files = await glob('**/*.{html,js,json,css,svg,xml,wasm}', {
-		cwd: directory,
-		dot: true,
-		absolute: true,
-		filesOnly: true
-	});
-
-	await Promise.all(
-		files.map((file) => Promise.all([compress_file(file, 'gz'), compress_file(file, 'br')]))
-	);
-}
-
-/**
- * @param {string} file
- * @param {'gz' | 'br'} format
- */
-async function compress_file(file, format = 'gz') {
-	const compress =
-		format == 'br'
-			? zlib.createBrotliCompress({
-					params: {
-						[zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT,
-						[zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,
-						[zlib.constants.BROTLI_PARAM_SIZE_HINT]: statSync(file).size
-					}
-			  })
-			: zlib.createGzip({ level: zlib.constants.Z_BEST_COMPRESSION });
-
-	const source = createReadStream(file);
-	const destination = createWriteStream(`${file}.${format}`);
-
-	await pipe(source, compress, destination);
 }

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -31,9 +31,6 @@
 		"format": "npm run lint -- --write",
 		"prepublishOnly": "npm run build"
 	},
-	"dependencies": {
-		"tiny-glob": "^0.2.9"
-	},
 	"devDependencies": {
 		"@rollup/plugin-json": "^4.1.0",
 		"@sveltejs/kit": "workspace:*",

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -1,11 +1,4 @@
-import { createReadStream, createWriteStream, statSync } from 'fs';
-import { pipeline } from 'stream';
-import glob from 'tiny-glob';
-import { promisify } from 'util';
-import zlib from 'zlib';
 import { platforms } from './platforms.js';
-
-const pipe = promisify(pipeline);
 
 /** @type {import('.').default} */
 export default function (options) {
@@ -49,13 +42,13 @@ export default function (options) {
 			if (precompress) {
 				if (pages === assets) {
 					builder.log.minor('Compressing assets and pages');
-					await compress(assets);
+					await builder.compress(assets);
 				} else {
 					builder.log.minor('Compressing assets');
-					await compress(assets);
+					await builder.compress(assets);
 
 					builder.log.minor('Compressing pages');
-					await compress(pages);
+					await builder.compress(pages);
 				}
 			}
 
@@ -68,42 +61,4 @@ export default function (options) {
 			if (!options) platform?.done(builder);
 		}
 	};
-}
-
-/**
- * @param {string} directory
- */
-async function compress(directory) {
-	const files = await glob('**/*.{html,js,json,css,svg,xml,wasm}', {
-		cwd: directory,
-		dot: true,
-		absolute: true,
-		filesOnly: true
-	});
-
-	await Promise.all(
-		files.map((file) => Promise.all([compress_file(file, 'gz'), compress_file(file, 'br')]))
-	);
-}
-
-/**
- * @param {string} file
- * @param {'gz' | 'br'} format
- */
-async function compress_file(file, format = 'gz') {
-	const compress =
-		format == 'br'
-			? zlib.createBrotliCompress({
-					params: {
-						[zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT,
-						[zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,
-						[zlib.constants.BROTLI_PARAM_SIZE_HINT]: statSync(file).size
-					}
-			  })
-			: zlib.createGzip({ level: zlib.constants.Z_BEST_COMPRESSION });
-
-	const source = createReadStream(file);
-	const destination = createWriteStream(`${file}.${format}`);
-
-	await pipe(source, compress, destination);
 }

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -24,9 +24,6 @@
 		"format": "npm run lint -- --write",
 		"test": "uvu test test.js"
 	},
-	"dependencies": {
-		"tiny-glob": "^0.2.9"
-	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:*",
 		"@types/node": "^16.11.36",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -12,7 +12,8 @@
 	"dependencies": {
 		"@sveltejs/vite-plugin-svelte": "^1.0.1",
 		"chokidar": "^3.5.3",
-		"sade": "^1.8.1"
+		"sade": "^1.8.1",
+		"tiny-glob": "^0.2.9"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.23.4",

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -80,6 +80,11 @@ export interface Builder {
 			replace?: Record<string, string>;
 		}
 	): string[];
+
+	/**
+	 * @param {string} directory A path to file that would be compress.
+	 */
+	compress(directory: string): void;
 }
 
 export interface Config {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -82,7 +82,7 @@ export interface Builder {
 	): string[];
 
 	/**
-	 * @param {string} directory A path to file that would be compress.
+	 * @param {string} directory Path to the directory containing the files to be compressed
 	 */
 	compress(directory: string): void;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,11 +125,8 @@ importers:
       rimraf: ^3.0.2
       rollup: ^2.75.7
       sirv: ^2.0.2
-      tiny-glob: ^0.2.9
       typescript: ^4.7.4
       uvu: ^0.5.3
-    dependencies:
-      tiny-glob: 0.2.9
     devDependencies:
       '@rollup/plugin-json': 4.1.0_rollup@2.75.7
       '@sveltejs/kit': link:../kit
@@ -150,12 +147,9 @@ importers:
       playwright-chromium: ^1.23.4
       sirv: ^2.0.2
       svelte: ^3.48.0
-      tiny-glob: ^0.2.9
       typescript: ^4.7.4
       uvu: ^0.5.3
       vite: ^3.0.0
-    dependencies:
-      tiny-glob: 0.2.9
     devDependencies:
       '@sveltejs/kit': link:../kit
       '@types/node': 16.11.42
@@ -305,6 +299,7 @@ importers:
       '@sveltejs/vite-plugin-svelte': 1.0.1_svelte@3.48.0+vite@3.0.0
       chokidar: 3.5.3
       sade: 1.8.1
+      tiny-glob: 0.2.9
     devDependencies:
       '@playwright/test': 1.23.4
       '@rollup/plugin-replace': 4.0.0_rollup@2.75.7
@@ -331,7 +326,6 @@ importers:
       svelte-check: 2.8.0_svelte@3.48.0
       svelte-preprocess: 4.10.7_lvfi2wesz6u4l5rfbnetbucfmm
       svelte2tsx: 0.5.11_lvfi2wesz6u4l5rfbnetbucfmm
-      tiny-glob: 0.2.9
       typescript: 4.7.4
       undici: 5.8.1
       uvu: 0.5.4


### PR DESCRIPTION
Closes #3796
This PR move `compress` inside `builder` to avoid having it duplicate inside `adapter-node` and `adapter-static`.

# HEADS UP!

We're about to embark on a [significant redesign](https://github.com/sveltejs/kit/discussions/5748) that will touch many parts of the codebase. Until that work is finished, PRs are very likely to result in merge conflicts, and will likely be ignored until the redesign work is complete (by which time they will likely be stale). Please consider delaying your PR until then.

Thank you for understanding!

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
