### PR TITLE
HandleError should return MaybePromise<void>

### DIFF
--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -168,7 +168,7 @@ export interface Handle {
 }
 
 export interface HandleError {
-	(input: { error: Error & { frame?: string }; event: RequestEvent }): void;
+	(input: { error: Error & { frame?: string }; event: RequestEvent }): MaybePromise<void>;
 }
 
 /**


### PR DESCRIPTION
In the [docs](https://kit.svelte.dev/docs/hooks#handleerror) the handleError function is async, so its return type should be `MaybePromise<void>` instead of `void`, to avoid the eslint [@typescript-eslint/no-misused-promises](https://typescript-eslint.io/rules/no-misused-promises) error :

> Promise-returning function provided to variable where a void return was expected

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
