### PR TITLE
[fix] harden migration around imports

### DIFF
--- a/.changeset/cuddly-ads-kick.md
+++ b/.changeset/cuddly-ads-kick.md
@@ -1,0 +1,5 @@
+---
+'svelte-migrate': patch
+---
+
+handle more import cases

--- a/packages/migrate/migrations/routes/index.js
+++ b/packages/migrate/migrations/routes/index.js
@@ -9,7 +9,7 @@ import { migrate_scripts } from './migrate_scripts/index.js';
 import { migrate_page } from './migrate_page_js/index.js';
 import { migrate_page_server } from './migrate_page_server/index.js';
 import { migrate_server } from './migrate_server/index.js';
-import { adjust_imports, bail, dedent, move_file, relative, task } from './utils.js';
+import { adjust_imports, bail, move_file, relative, task } from './utils.js';
 
 export async function migrate() {
 	if (!fs.existsSync('svelte.config.js')) {

--- a/packages/migrate/migrations/routes/migrate_scripts/samples.md
+++ b/packages/migrate/migrations/routes/migrate_scripts/samples.md
@@ -125,3 +125,123 @@
 
 <Foo>{sry}</Foo>
 ```
+
+## Module context with type imports only
+
+```svelte before
+<script context="module">
+	import type { Load, LoadEvent, LoadOutput } from '@sveltejs/kit';
+	export function load() {
+		return {
+			props: {
+				sry: 'not anymore'
+			}
+		}
+	}
+</script>
+```
+
+```svelte after
+```
+
+## Module context with type imports only but used in instance script
+
+```svelte before
+<script context="module">
+	import type { Load, LoadEvent, LoadOutput } from '@sveltejs/kit';
+	export function load() {
+		return {
+			props: {
+				sry: 'not anymore'
+			}
+		}
+	}
+</script>
+
+<script>
+	const whywouldyoudothis: Load = 'I dont know lol';
+</script>
+```
+
+```svelte after
+<script context="module">
+	throw new Error("@migration task: Check code was safely removed (https://github.com/sveltejs/kit/discussions/5774#discussioncomment-3292722)");
+
+	// import type { Load, LoadEvent, LoadOutput } from '@sveltejs/kit';
+	// export function load() {
+	// 	return {
+	// 		props: {
+	// 			sry: 'not anymore'
+	// 		}
+	// 	}
+	// }
+</script>
+
+<script>
+	const whywouldyoudothis: Load = 'I dont know lol';
+</script>
+```
+
+## Module context with export * from '..'
+
+```svelte before
+<script context="module">
+	export * from './somewhere';
+</script>
+```
+
+```svelte after
+<script context="module">
+	throw new Error("@migration task: Check code was safely removed (https://github.com/sveltejs/kit/discussions/5774#discussioncomment-3292722)");
+
+	// export * from './somewhere';
+</script>
+```
+
+## Module context with named imports
+
+```svelte before
+<script context="module">
+	import { bar } from './somewhere';
+</script>
+
+<script>
+	let foo = bar;
+</script>
+```
+
+```svelte after
+<script context="module">
+	throw new Error("@migration task: Check code was safely removed (https://github.com/sveltejs/kit/discussions/5774#discussioncomment-3292722)");
+
+	// import { bar } from './somewhere';
+</script>
+
+<script>
+	let foo = bar;
+</script>
+```
+
+## Module context with named imports that have same name as a load option
+
+```svelte before
+<script context="module">
+	import { router } from './somewhere';
+</script>
+
+<script>
+	let foo = router;
+</script>
+```
+
+```svelte after
+<script context="module">
+	throw new Error("@migration task: Check code was safely removed (https://github.com/sveltejs/kit/discussions/5774#discussioncomment-3292722)");
+
+	// import { router } from './somewhere';
+</script>
+
+<script>
+	let foo = router;
+</script>
+```

--- a/packages/migrate/migrations/routes/utils.js
+++ b/packages/migrate/migrations/routes/utils.js
@@ -402,6 +402,16 @@ export function parse(content) {
 	}
 }
 
+/**
+ * @param {string} content
+ * @param {string} except
+ */
+export function except_str(content, except) {
+	const start = content.indexOf(except);
+	const end = start + except.length;
+	return content.substring(0, start) + content.substring(end);
+}
+
 /** @param {string} test_file */
 export function read_samples(test_file) {
 	const markdown = fs.readFileSync(new URL('./samples.md', test_file), 'utf8');


### PR DESCRIPTION
harden declared logic around imports:
- remove type only load imports
- handle imports with same name as load exports
- bail on `export * from ..`
- handle undefined declared map.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
