### PR TITLE
Fix hard dependance on ES modules

### DIFF
--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -19,7 +19,7 @@ const address_header = env('ADDRESS_HEADER', '').toLowerCase();
 const protocol_header = env('PROTOCOL_HEADER', '').toLowerCase();
 const host_header = env('HOST_HEADER', 'host').toLowerCase();
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = __dirname || path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * @param {string} path


### PR DESCRIPTION
Previously, __dirname was redefined to a value derived from import.meta.url. This meant when the adapter was transpiled to commonJS, __dirname would be undefined, crashing the server. Now it only redefined if it does not have a truthy value.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
  - (I'm not sure adding esbuild for just one test is a great idea)

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
