### PR TITLE
[docs] update homepage CTA

### DIFF
--- a/sites/kit.svelte.dev/src/routes/index.svelte
+++ b/sites/kit.svelte.dev/src/routes/index.svelte
@@ -74,10 +74,7 @@
 			</p>
 
 			<p>
-				Read the <a href="https://svelte.dev/blog/whats-the-deal-with-sveltekit" class="cta"
-					>introductory blog</a
-				>
-				post to learn more.
+				<a href="https://node.new/sveltekit">Try on StackBlitz</a> or create a project locally.
 			</p>
 		</div>
 


### PR DESCRIPTION
The CTA right now it's a bit split between "Read the introductory blog post to learn more." and "npm create svelte@latest my-app". The blog post is two years old and talks quite a bit about Sapper, the code being private, Snowpack, etc. so it feels rather outdated