### PR TITLE
fix: actually expose platform.caches in adapter-cloudflare-workers

### DIFF
--- a/.changeset/smooth-bags-sell.md
+++ b/.changeset/smooth-bags-sell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+---
+
+expose caches on platform

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -67,7 +67,7 @@ export default {
 
 		// dynamically-generated pages
 		return await server.respond(req, {
-			platform: { env, context },
+			platform: { env, context, caches },
 			getClientAddress() {
 				return req.headers.get('cf-connecting-ip');
 			}


### PR DESCRIPTION
https://github.com/sveltejs/kit/pull/5081 already did it for adapter-cloudflare and both the docs and types for adapter-cloudflare-workers mention it, alas it wasn't returned.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
