### PR TITLE
Only search for layout name in basename, rather than fully resolved pathname

### DIFF
--- a/.changeset/itchy-donuts-unite.md
+++ b/.changeset/itchy-donuts-unite.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Only search for layout name in basename

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -362,7 +362,7 @@ function trace(tree, id, layout_id = DEFAULT, project_relative) {
 			layouts.unshift(layout);
 		}
 
-		const parent_layout_id = layout?.component?.split('@')[1]?.split('.')[0];
+		const parent_layout_id = layout?.component?.split('/').at(-1)?.split('@')[1]?.split('.')[0];
 
 		if (parent_layout_id) {
 			layout_id = parent_layout_id;


### PR DESCRIPTION
Fixes #5893. No test because this depends on vagaries of where SvelteKit is running

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
