### PR TITLE
create .ts files from `<script context="module" lang="ts">`

### DIFF
--- a/.changeset/swift-seahorses-argue.md
+++ b/.changeset/swift-seahorses-argue.md
@@ -2,4 +2,4 @@
 'svelte-migrate': patch
 ---
 
-Create .ts files from <script context="module" lang="ts">
+Create `.ts` files from `<script context="module" lang="ts">`

--- a/.changeset/swift-seahorses-argue.md
+++ b/.changeset/swift-seahorses-argue.md
@@ -1,0 +1,5 @@
+---
+'svelte-migrate': patch
+---
+
+Create .ts files from <script context="module" lang="ts">

--- a/packages/migrate/migrations/routes/index.js
+++ b/packages/migrate/migrations/routes/index.js
@@ -148,7 +148,7 @@ export async function migrate() {
 
 			renamed += svelte_ext;
 
-			const { module, main } = migrate_scripts(content, is_error_page, move_to_directory);
+			const { module, main, ext } = migrate_scripts(content, is_error_page, move_to_directory);
 
 			if (move_to_directory) {
 				const dir = path.dirname(renamed);
@@ -159,8 +159,6 @@ export async function migrate() {
 
 			// if component has a <script context="module">, move it to a sibling .js file
 			if (module) {
-				const ext = /<script[^>]+?lang=['"](ts|typescript)['"][^]*?>/.test(module) ? '.ts' : '.js';
-
 				fs.writeFileSync(sibling + ext, migrate_page(module, bare));
 			}
 		} else if (module_ext) {

--- a/packages/migrate/migrations/routes/migrate_scripts/index.js
+++ b/packages/migrate/migrations/routes/migrate_scripts/index.js
@@ -19,6 +19,8 @@ export function migrate_scripts(content, is_error, moved) {
 	/** @type {string | null} */
 	let module = null;
 
+	let ext = '.js';
+
 	// instance script
 	const main = content.replace(
 		/<script([^]*?)>([^]+?)<\/script>(\n*)/g,
@@ -38,6 +40,10 @@ export function migrate_scripts(content, is_error, moved) {
 					)}`;
 
 					return `<script${attrs}>${body}</script>${whitespace}`;
+				}
+
+				if (/lang(?:uage)?=(['"])(ts|typescript)\1/.test(attrs)) {
+					ext = '.ts';
 				}
 
 				module = dedent(contents.replace(/^\n/, ''));
@@ -90,7 +96,7 @@ export function migrate_scripts(content, is_error, moved) {
 		}
 	);
 
-	return { module, main };
+	return { module, main, ext };
 }
 
 /** @param {string} content */


### PR DESCRIPTION
`npx svelte-migrate routes` creates a `+page.js` file if you have a `<script context="module" lang="ts">`, when it should instead create a `.ts` file. This fixes it

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
