### PR TITLE
make generated type import path ends in `.js` 

### DIFF
--- a/.changeset/twelve-stingrays-cry.md
+++ b/.changeset/twelve-stingrays-cry.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+make generated type import path ends in `.js` 

--- a/packages/kit/src/core/sync/write_types.js
+++ b/packages/kit/src/core/sync/write_types.js
@@ -390,18 +390,13 @@ function process_node(ts, node, outdir, params, groups) {
 			const types = [];
 			for (const method of ['POST', 'PUT', 'PATCH']) {
 				if (proxy.exports.includes(method)) {
-					if (proxy.modified) {
-						types.push(`Kit.AwaitedErrors<typeof import('./proxy${basename}').${method}>`);
-					} else {
-						// If the file wasn't tweaked, we can use the return type of the original file.
-						// The advantage is that type updates are reflected without saving.
-						types.push(
-							`Kit.AwaitedErrors<typeof import("${path_to_original(
-								outdir,
-								node.server
-							)}").${method}>`
-						);
-					}
+					// If the file wasn't tweaked, we can use the return type of the original file.
+					// The advantage is that type updates are reflected without saving.
+					const from = proxy.modified
+						? `./proxy${basename}`
+						: path_to_original(outdir, node.server);
+
+					types.push(`Kit.AwaitedErrors<typeof import('${from}').${method}>`);
 				}
 			}
 			errors = types.length ? types.join(' | ') : 'null';

--- a/packages/kit/src/core/sync/write_types.js
+++ b/packages/kit/src/core/sync/write_types.js
@@ -393,7 +393,7 @@ function process_node(ts, node, outdir, params, groups) {
 					// If the file wasn't tweaked, we can use the return type of the original file.
 					// The advantage is that type updates are reflected without saving.
 					const from = proxy.modified
-						? `./proxy${basename}`
+						? `./proxy${basename.replace(/\.ts$/, '.js')}`
 						: path_to_original(outdir, node.server);
 
 					types.push(`Kit.AwaitedErrors<typeof import('${from}').${method}>`);

--- a/packages/kit/src/core/sync/write_types.js
+++ b/packages/kit/src/core/sync/write_types.js
@@ -393,7 +393,7 @@ function process_node(ts, node, outdir, params, groups) {
 					// If the file wasn't tweaked, we can use the return type of the original file.
 					// The advantage is that type updates are reflected without saving.
 					const from = proxy.modified
-						? `./proxy${basename.replace(/\.ts$/, '.js')}`
+						? `./proxy${replace_ext_with_js(basename)}`
 						: path_to_original(outdir, node.server);
 
 					types.push(`Kit.AwaitedErrors<typeof import('${from}').${method}>`);
@@ -489,18 +489,17 @@ function process_node(ts, node, outdir, params, groups) {
  * @param {string} file_path
  */
 function path_to_original(outdir, file_path) {
+	return posixify(path.relative(outdir, path.join(cwd, replace_ext_with_js(file_path))));
+}
+
+/**
+ * @param {string} file_path
+ */
+function replace_ext_with_js(file_path) {
+	// Another extension than `.js` (or nothing, but that fails with node16 moduleResolution)
+	// will result in TS failing to lookup the file
 	const ext = path.extname(file_path);
-	return posixify(
-		path.relative(
-			outdir,
-			path.join(
-				cwd,
-				// Another extension than `.js` (or nothing, but that fails with node16 moduleResolution)
-				// will result in TS failing to lookup the file
-				file_path.slice(0, -ext.length) + '.js'
-			)
-		)
-	);
+	return file_path.slice(0, -ext.length) + '.js';
 }
 
 /**
@@ -717,10 +716,6 @@ export function find_nearest_layout(routes_dir, nodes, start_idx) {
 		}
 
 		// matching parent layout found
-		// let import_path = posixify(path.relative(path.dirname(start_file), common_path + '/$types.js'));
-		// if (!import_path.startsWith('.')) {
-		// 	import_path = './' + import_path;
-		// }
 		let folder_depth_diff =
 			posixify(path.relative(path.dirname(start_file), common_path + '/$types.js')).split('/')
 				.length - 1;


### PR DESCRIPTION
Fixes #5899 

Is there any other possible extensions? Should we have a utility function to extract and replace the extension of a filename?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
