### PR TITLE
Fix generated path extension for AwaitedProperties types

### DIFF
--- a/.changeset/good-mails-crash.md
+++ b/.changeset/good-mails-crash.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Fix generated extension for AwaitedProperties
+Fix generated path extension for `AwaitedProperties`

--- a/.changeset/good-mails-crash.md
+++ b/.changeset/good-mails-crash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix generated extension for AwaitedProperties

--- a/packages/kit/src/core/sync/write_types.js
+++ b/packages/kit/src/core/sync/write_types.js
@@ -433,9 +433,8 @@ function process_node(ts, node, outdir, params, groups) {
 			if (proxy.exports.includes(method)) {
 				// If the file wasn't tweaked, we can use the return type of the original file.
 				// The advantage is that type updates are reflected without saving.
-				const basename = path.basename(file_path);
 				const from = proxy.modified
-					? `./proxy${replace_ext_with_js(basename)}`
+					? `./proxy${replace_ext_with_js(path.basename(file_path))}`
 					: path_to_original(outdir, file_path);
 				return `Kit.AwaitedProperties<Awaited<ReturnType<typeof import('${from}').${method}>>>`;
 			} else {

--- a/packages/kit/src/core/sync/write_types.js
+++ b/packages/kit/src/core/sync/write_types.js
@@ -435,8 +435,8 @@ function process_node(ts, node, outdir, params, groups) {
 				// The advantage is that type updates are reflected without saving.
 				const basename = path.basename(file_path);
 				const from = proxy.modified
-						? `./proxy${replace_ext_with_js(basename)}`
-						: path_to_original(outdir, file_path);
+					? `./proxy${replace_ext_with_js(basename)}`
+					: path_to_original(outdir, file_path);
 				return `Kit.AwaitedProperties<Awaited<ReturnType<typeof import('${from}').${method}>>>`;
 			} else {
 				return fallback;

--- a/packages/kit/src/core/sync/write_types.js
+++ b/packages/kit/src/core/sync/write_types.js
@@ -431,17 +431,13 @@ function process_node(ts, node, outdir, params, groups) {
 	function get_data_type(file_path, method, fallback, proxy) {
 		if (proxy) {
 			if (proxy.exports.includes(method)) {
-				if (proxy.modified) {
-					const basename = path.basename(file_path);
-					return `Kit.AwaitedProperties<Awaited<ReturnType<typeof import('./proxy${basename}').${method}>>>`;
-				} else {
-					// If the file wasn't tweaked, we can use the return type of the original file.
-					// The advantage is that type updates are reflected without saving.
-					return `Kit.AwaitedProperties<Awaited<ReturnType<typeof import("${path_to_original(
-						outdir,
-						file_path
-					)}").${method}>>>`;
-				}
+				// If the file wasn't tweaked, we can use the return type of the original file.
+				// The advantage is that type updates are reflected without saving.
+				const basename = path.basename(file_path);
+				const from = proxy.modified
+						? `./proxy${replace_ext_with_js(basename)}`
+						: path_to_original(outdir, file_path);
+				return `Kit.AwaitedProperties<Awaited<ReturnType<typeof import('${from}').${method}>>>`;
 			} else {
 				return fallback;
 			}


### PR DESCRIPTION
Fixes #5899 
Applies the `.ts` to `.js` logic from #5907 (which only changed `AwaitedErrors`) to `AwaitedProperties`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
