### PR TITLE
[fix] omit Content-Length header from requests made by load fetch

### DIFF
--- a/.changeset/lazy-owls-run.md
+++ b/.changeset/lazy-owls-run.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] prevent `Content-Length` header from being incorrectly inherited by requests made from `load`'s `fetch` during SSR

--- a/packages/kit/src/runtime/server/page/fetch.js
+++ b/packages/kit/src/runtime/server/page/fetch.js
@@ -52,6 +52,7 @@ export function create_fetch({ event, options, state, route }) {
 			if (
 				key !== 'authorization' &&
 				key !== 'connection' &&
+				key !== 'content-length' &&
 				key !== 'cookie' &&
 				key !== 'host' &&
 				key !== 'if-none-match' &&


### PR DESCRIPTION
Fixes #5870.

If your app is, say, sitting behind some sort of API gateway that injects `Content-Length` into its incoming requests, and then you try to use `fetch` in `load` during SSR, Undici is going to have a bad time with that header.

This PR adds this header to the blacklist. This seemed like a pain to test because ordinarily this header isn't present, so I did not add a test.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
