### PR TITLE
[chore] more robust tests

### DIFF
--- a/packages/kit/test/apps/basics/src/routes/store/data/only-data-changes/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/store/data/only-data-changes/+page.svelte
@@ -1,9 +1,8 @@
 <script>
-    import { page, session } from '$app/stores';
+    import { session } from '$app/stores';
     export let data;
 </script>
 
 <pre id="page-data">{JSON.stringify(data)}</pre>
-<pre id="store-data">{JSON.stringify($page.data)}</pre>
 
 <button on:click={() => $session = { answer: 1337 }}>Update Session</button>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -132,15 +132,15 @@ test.describe('Scrolling', () => {
 		await page.evaluate((y) => scrollTo(0, y), target_scroll_y);
 
 		await page.click('[href="/scroll/cross-document/b"]');
-		expect(await page.textContent('h1')).toBe('b');
+		await expect(page.locator('h1')).toHaveText('b');
 		await page.waitForSelector('body.started');
 
 		await clicknav('[href="/scroll/cross-document/c"]');
-		expect(await page.textContent('h1')).toBe('c');
+		await expect(page.locator('h1')).toHaveText('c');
 
 		await page.goBack(); // client-side back
 		await page.goBack(); // native back
-		expect(await page.textContent('h1')).toBe('a');
+		await expect(page.locator('h1')).toHaveText('a');
 		await page.waitForSelector('body.started');
 
 		await page.waitForTimeout(250); // needed for the test to fail reliably without the fix
@@ -223,10 +223,10 @@ test.describe('Scrolling', () => {
 test.describe('afterNavigate', () => {
 	test('calls callback', async ({ page, clicknav }) => {
 		await page.goto('/after-navigate/a');
-		expect(await page.textContent('h1')).toBe('undefined -> /after-navigate/a');
+		await expect(page.locator('h1')).toHaveText('undefined -> /after-navigate/a');
 
 		await clicknav('[href="/after-navigate/b"]');
-		expect(await page.textContent('h1')).toBe('/after-navigate/a -> /after-navigate/b');
+		await expect(page.locator('h1')).toHaveText('/after-navigate/a -> /after-navigate/b');
 	});
 });
 
@@ -268,8 +268,8 @@ test.describe('Errors', () => {
 	test('client-side load errors', async ({ page }) => {
 		await page.goto('/errors/load-client');
 
-		expect(await page.textContent('footer')).toBe('Custom layout');
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('footer')).toHaveText('Custom layout');
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "Crashing now"'
 		);
 	});
@@ -277,8 +277,8 @@ test.describe('Errors', () => {
 	test('client-side module context errors', async ({ page }) => {
 		await page.goto('/errors/module-scope-client');
 
-		expect(await page.textContent('footer')).toBe('Custom layout');
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('footer')).toHaveText('Custom layout');
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "Crashing now"'
 		);
 	});
@@ -286,8 +286,8 @@ test.describe('Errors', () => {
 	test('client-side error from load()', async ({ page }) => {
 		await page.goto('/errors/load-error-client');
 
-		expect(await page.textContent('footer')).toBe('Custom layout');
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('footer')).toHaveText('Custom layout');
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "Not found"'
 		);
 		expect(await page.innerHTML('h1')).toBe('555');
@@ -296,8 +296,8 @@ test.describe('Errors', () => {
 	test('client-side 4xx status without error from load()', async ({ page }) => {
 		await page.goto('/errors/load-status-without-error-client');
 
-		expect(await page.textContent('footer')).toBe('Custom layout');
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('footer')).toHaveText('Custom layout');
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "Error: 401"'
 		);
 		expect(await page.innerHTML('h1')).toBe('401');
@@ -307,75 +307,75 @@ test.describe('Errors', () => {
 test.describe('Load', () => {
 	test('load function is only called when necessary', async ({ app, page }) => {
 		await page.goto('/load/change-detection/one/a');
-		expect(await page.textContent('h1')).toBe('layout loads: 1');
-		expect(await page.textContent('h2')).toBe('x: a: 1');
+		await expect(page.locator('h1')).toHaveText('layout loads: 1');
+		await expect(page.locator('h2')).toHaveText('x: a: 1');
 
 		await app.goto('/load/change-detection/one/a?unused=whatever');
-		expect(await page.textContent('h2')).toBe('x: a: 1');
+		await expect(page.locator('h2')).toHaveText('x: a: 1');
 
 		await app.goto('/load/change-detection/two/b');
-		expect(await page.textContent('h2')).toBe('y: b: 1');
+		await expect(page.locator('h2')).toHaveText('y: b: 1');
 
 		await app.goto('/load/change-detection/one/a');
-		expect(await page.textContent('h2')).toBe('x: a: 2');
+		await expect(page.locator('h2')).toHaveText('x: a: 2');
 
 		await app.goto('/load/change-detection/one/b');
-		expect(await page.textContent('h2')).toBe('x: b: 3');
+		await expect(page.locator('h2')).toHaveText('x: b: 3');
 
 		await app.invalidate('/load/change-detection/data.json');
-		expect(await page.textContent('h1')).toBe('layout loads: 2');
-		expect(await page.textContent('h2')).toBe('x: b: 3');
+		await expect(page.locator('h1')).toHaveText('layout loads: 2');
+		await expect(page.locator('h2')).toHaveText('x: b: 3');
 
 		await app.invalidate('/load/change-detection/data.json');
-		expect(await page.textContent('h1')).toBe('layout loads: 3');
-		expect(await page.textContent('h2')).toBe('x: b: 3');
+		await expect(page.locator('h1')).toHaveText('layout loads: 3');
+		await expect(page.locator('h2')).toHaveText('x: b: 3');
 
 		await app.invalidate('custom:change-detection-layout');
-		expect(await page.textContent('h1')).toBe('layout loads: 4');
-		expect(await page.textContent('h2')).toBe('x: b: 3');
+		await expect(page.locator('h1')).toHaveText('layout loads: 4');
+		await expect(page.locator('h2')).toHaveText('x: b: 3');
 
 		await page.click('button:has-text("invalidate change-detection/data.json")');
 		await page.waitForFunction('window.invalidated');
-		expect(await page.textContent('h1')).toBe('layout loads: 5');
-		expect(await page.textContent('h2')).toBe('x: b: 3');
+		await expect(page.locator('h1')).toHaveText('layout loads: 5');
+		await expect(page.locator('h2')).toHaveText('x: b: 3');
 
 		await page.click('button:has-text("invalidate all")');
 		await page.waitForFunction('window.invalidated');
-		expect(await page.textContent('h1')).toBe('layout loads: 6');
-		expect(await page.textContent('h2')).toBe('x: b: 4');
+		await expect(page.locator('h1')).toHaveText('layout loads: 6');
+		await expect(page.locator('h2')).toHaveText('x: b: 4');
 	});
 
 	test('load function is only called on session change when used in load', async ({ page }) => {
 		await page.goto('/load/change-detection/session/used');
-		expect(await page.textContent('h2')).toBe('1');
+		await expect(page.locator('h2')).toHaveText('1');
 		await page.click('button');
-		expect(await page.textContent('h2')).toBe('2');
+		await expect(page.locator('h2')).toHaveText('2');
 
 		await page.goto('/load/change-detection/session/unused');
-		expect(await page.textContent('h2')).toBe('1');
+		await expect(page.locator('h2')).toHaveText('1');
 		await page.click('button');
-		expect(await page.textContent('h2')).toBe('1');
+		await expect(page.locator('h2')).toHaveText('1');
 	});
 
 	test('accessing url.hash from load errors and suggests using page store', async ({ page }) => {
 		await page.goto('/load/url-hash#please-dont-send-me-to-load');
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "url.hash is inaccessible from load. Consider accessing hash from the page store within the script tag of your component."'
 		);
 	});
 
 	test('url instance methods work in load', async ({ page }) => {
 		await page.goto('/load/url-to-string');
-		expect(await page.textContent('h1')).toBe("I didn't break!");
+		await expect(page.locator('h1')).toHaveText("I didn't break!");
 	});
 
 	test("layout props don't cause rerender when unchanged", async ({ page, clicknav }) => {
 		await page.goto('/load/layout-props/a');
-		expect(await page.textContent('h1')).toBe('1');
+		await expect(page.locator('h1')).toHaveText('1');
 		await clicknav('[href="/load/layout-props/b"]');
-		expect(await page.textContent('h1')).toBe('1');
+		await expect(page.locator('h1')).toHaveText('1');
 		await page.click('button');
-		expect(await page.textContent('h1')).toBe('2');
+		await expect(page.locator('h1')).toHaveText('2');
 	});
 
 	if (process.env.DEV) {
@@ -392,7 +392,7 @@ test.describe('Load', () => {
 			});
 
 			await page.goto('/load/window-fetch/incorrect');
-			expect(await page.textContent('h1')).toBe('42');
+			await expect(page.locator('h1')).toHaveText('42');
 
 			expect(warnings).toContain(
 				`Loading http://localhost:${port}/load/window-fetch/data.json using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/load#input-fetch`
@@ -401,7 +401,7 @@ test.describe('Load', () => {
 			warnings.length = 0;
 
 			await page.goto('/load/window-fetch/correct');
-			expect(await page.textContent('h1')).toBe('42');
+			await expect(page.locator('h1')).toHaveText('42');
 
 			expect(warnings).not.toContain(
 				`Loading http://localhost:${port}/load/window-fetch/data.json using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/load#input-fetch`
@@ -415,25 +415,25 @@ test.describe('Page options', () => {
 		await page.goto('/no-router/a');
 
 		await page.click('button');
-		expect(await page.textContent('button')).toBe('clicks: 1');
+		await expect(page.locator('button')).toHaveText('clicks: 1');
 
 		await Promise.all([page.waitForNavigation(), page.click('[href="/no-router/b"]')]);
-		expect(await page.textContent('button')).toBe('clicks: 0');
+		await expect(page.locator('button')).toHaveText('clicks: 0');
 
 		// wait until hydration before interacting with button
 		await page.waitForSelector('body.started');
 
 		await page.click('button');
-		expect(await page.textContent('button')).toBe('clicks: 1');
+		await expect(page.locator('button')).toHaveText('clicks: 1');
 
 		// wait until hydration before attempting backwards client-side navigation
 		await page.waitForSelector('body.started');
 
 		await clicknav('[href="/no-router/a"]');
-		expect(await page.textContent('button')).toBe('clicks: 1');
+		await expect(page.locator('button')).toHaveText('clicks: 1');
 
 		await Promise.all([page.waitForNavigation(), page.click('[href="/no-router/b"]')]);
-		expect(await page.textContent('button')).toBe('clicks: 0');
+		await expect(page.locator('button')).toHaveText('clicks: 0');
 	});
 
 	test('applies generated component styles with ssr=false (hides announcer)', async ({
@@ -533,7 +533,7 @@ test.describe('Routing', () => {
 		page.on('request', (r) => requests.push(r.url()));
 
 		await clicknav('a[href="/routing/a"]');
-		expect(await page.textContent('h1')).toBe('a');
+		await expect(page.locator('h1')).toHaveText('a');
 
 		expect(requests).toEqual([]);
 	});
@@ -541,22 +541,22 @@ test.describe('Routing', () => {
 	test('navigates programmatically', async ({ page, app }) => {
 		await page.goto('/routing/a');
 		await app.goto('/routing/b');
-		expect(await page.textContent('h1')).toBe('b');
+		await expect(page.locator('h1')).toHaveText('b');
 	});
 
 	test('$page.url.hash is correctly set on page load', async ({ page }) => {
 		await page.goto('/routing/hashes/pagestore#target');
-		expect(await page.textContent('#window-hash')).toBe('#target');
-		expect(await page.textContent('#page-url-hash')).toBe('#target');
+		await expect(page.locator('#window-hash')).toHaveText('#target');
+		await expect(page.locator('#page-url-hash')).toHaveText('#target');
 	});
 
 	test('$page.url.hash is correctly set on navigation', async ({ page }) => {
 		await page.goto('/routing/hashes/pagestore');
-		expect(await page.textContent('#window-hash')).toBe('');
-		expect(await page.textContent('#page-url-hash')).toBe('');
+		await expect(page.locator('#window-hash')).toHaveText(/^$/);
+		await expect(page.locator('#page-url-hash')).toHaveText(/^$/);
 		await page.click('[href="#target"]');
-		expect(await page.textContent('#window-hash')).toBe('#target');
-		expect(await page.textContent('#page-url-hash')).toBe('#target');
+		await expect(page.locator('#window-hash')).toHaveText('#target');
+		await expect(page.locator('#page-url-hash')).toHaveText('#target');
 	});
 
 	test('does not normalize external path', async ({ page }) => {
@@ -592,7 +592,7 @@ test.describe('Shadow DOM', () => {
 		page.on('request', (r) => requests.push(r.url()));
 
 		await clicknav('div[id="clickme"]');
-		expect(await page.textContent('h1')).toBe('a');
+		await expect(page.locator('h1')).toHaveText('a');
 
 		expect(requests).toEqual([]);
 	});
@@ -601,15 +601,15 @@ test.describe('Shadow DOM', () => {
 test.describe('Page Store', () => {
 	test('Updates data if changed even when no URL change visible', async ({ page }) => {
 		await page.goto('/store/data/only-data-changes');
-		expect(await page.textContent('#page-data')).toBe('{"answer":42,"calls":0}');
-		expect(await page.textContent('#store-data')).toBe(
+		await expect(page.locator('#page-data')).toHaveText('{"answer":42,"calls":0}');
+		await expect(page.locator('#store-data')).toHaveText(
 			'{"foo":{"bar":"Custom layout"},"name":"SvelteKit","value":123,"answer":42,"calls":0}'
 		);
 
 		await page.click('button');
 
-		expect(await page.textContent('#page-data')).toBe('{"answer":1337}');
-		expect(await page.textContent('#store-data')).toBe(
+		await expect(page.locator('#page-data')).toHaveText('{"answer":1337}');
+		await expect(page.locator('#store-data')).toHaveText(
 			'{"foo":{"bar":"Custom layout"},"name":"SvelteKit","value":123,"answer":1337}'
 		);
 	});

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -171,13 +171,13 @@ test.describe('Errors', () => {
 
 	test('stack traces are not fixed twice', async ({ page }) => {
 		await page.goto('/errors/stack-trace');
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "Cannot read properties of undefined (reading \'toUpperCase\')"'
 		);
 
 		// check the stack wasn't mutated
 		await page.goto('/errors/stack-trace');
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "Cannot read properties of undefined (reading \'toUpperCase\')"'
 		);
 	});

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -151,19 +151,19 @@ test.describe('Shadowed pages', () => {
 	test('Loads props from an endpoint', async ({ page, clicknav }) => {
 		await page.goto('/shadowed');
 		await clicknav('[href="/shadowed/simple"]');
-		expect(await page.textContent('h1')).toBe('The answer is 42');
+		await expect(page.locator('h1')).toHaveText('The answer is 42');
 	});
 
 	test('Handles GET redirects', async ({ page, clicknav }) => {
 		await page.goto('/shadowed');
 		await clicknav('[href="/shadowed/redirect-get"]');
-		expect(await page.textContent('h1')).toBe('Redirection was successful');
+		await expect(page.locator('h1')).toHaveText('Redirection was successful');
 	});
 
 	test('Handles GET redirects with cookies', async ({ page, context, clicknav }) => {
 		await page.goto('/shadowed');
 		await clicknav('[href="/shadowed/redirect-get-with-cookie"]');
-		expect(await page.textContent('h1')).toBe('Redirection was successful');
+		await expect(page.locator('h1')).toHaveText('Redirection was successful');
 
 		const cookies = await context.cookies();
 		expect(cookies).toEqual(
@@ -174,13 +174,13 @@ test.describe('Shadowed pages', () => {
 	test('Handles POST redirects', async ({ page }) => {
 		await page.goto('/shadowed');
 		await Promise.all([page.waitForNavigation(), page.click('#redirect-post')]);
-		expect(await page.textContent('h1')).toBe('Redirection was successful');
+		await expect(page.locator('h1')).toHaveText('Redirection was successful');
 	});
 
 	test('Handles POST redirects with cookies', async ({ page, context }) => {
 		await page.goto('/shadowed');
 		await Promise.all([page.waitForNavigation(), page.click('#redirect-post-with-cookie')]);
-		expect(await page.textContent('h1')).toBe('Redirection was successful');
+		await expect(page.locator('h1')).toHaveText('Redirection was successful');
 
 		const cookies = await context.cookies();
 		expect(cookies).toEqual(
@@ -191,48 +191,50 @@ test.describe('Shadowed pages', () => {
 	test('Renders error page for 4xx and 5xx responses from GET', async ({ page, clicknav }) => {
 		await page.goto('/shadowed');
 		await clicknav('[href="/shadowed/error-get"]');
-		expect(await page.textContent('h1')).toBe('404');
+		await expect(page.locator('h1')).toHaveText('404');
 	});
 
 	test('Merges bodies for 4xx and 5xx responses from non-GET', async ({ page }) => {
 		await page.goto('/shadowed');
 		const [response] = await Promise.all([page.waitForNavigation(), page.click('#error-post')]);
-		expect(await page.textContent('h1')).toBe('hello from get / echo: posted data');
+		await expect(page.locator('h1')).toHaveText('hello from get / echo: posted data');
 
 		expect(response?.status()).toBe(400);
-		expect(await page.textContent('h2')).toBe('status: 400');
+		await expect(page.locator('h2')).toHaveText('status: 400');
 	});
 
 	test('Endpoint receives consistent URL', async ({ baseURL, page, clicknav }) => {
 		await page.goto('/shadowed/same-render-entry');
 		await clicknav('[href="/shadowed/same-render?param1=value1"]');
-		expect(await page.textContent('h1')).toBe(`URL: ${baseURL}/shadowed/same-render?param1=value1`);
+		await expect(page.locator('h1')).toHaveText(
+			`URL: ${baseURL}/shadowed/same-render?param1=value1`
+		);
 	});
 
 	test('Works with missing get handler', async ({ page, clicknav }) => {
 		await page.goto('/shadowed');
 		await clicknav('[href="/shadowed/no-get"]');
-		expect(await page.textContent('h1')).toBe('hello');
+		await expect(page.locator('h1')).toHaveText('hello');
 	});
 
 	test('Invalidates shadow data when URL changes', async ({ page, clicknav }) => {
 		await page.goto('/shadowed');
 		await clicknav('[href="/shadowed/dynamic/foo"]');
-		expect(await page.textContent('h1')).toBe('slug: foo');
+		await expect(page.locator('h1')).toHaveText('slug: foo');
 
 		await clicknav('[href="/shadowed/dynamic/bar"]');
-		expect(await page.textContent('h1')).toBe('slug: bar');
+		await expect(page.locator('h1')).toHaveText('slug: bar');
 
 		await page.goto('/shadowed/dynamic/foo');
-		expect(await page.textContent('h1')).toBe('slug: foo');
+		await expect(page.locator('h1')).toHaveText('slug: foo');
 		await clicknav('[href="/shadowed/dynamic/bar"]');
-		expect(await page.textContent('h1')).toBe('slug: bar');
+		await expect(page.locator('h1')).toHaveText('slug: bar');
 	});
 
 	test('Shadow redirect', async ({ page, clicknav }) => {
 		await page.goto('/shadowed/redirect');
 		await clicknav('[href="/shadowed/redirect/a"]');
-		expect(await page.textContent('h1')).toBe('done');
+		await expect(page.locator('h1')).toHaveText('done');
 	});
 
 	test('Endpoint without GET', async ({ page, clicknav, baseURL, javaScriptEnabled }) => {
@@ -244,7 +246,7 @@ test.describe('Shadowed pages', () => {
 
 		await clicknav('[href="/shadowed/missing-get"]');
 
-		expect(await page.textContent('h1')).toBe('post without get');
+		await expect(page.locator('h1')).toHaveText('post without get');
 
 		// check that the router didn't fall back to the server
 		if (javaScriptEnabled) {
@@ -330,13 +332,13 @@ test.describe('Encoded paths', () => {
 	test('allows %-encoded characters in directory names', async ({ page, clicknav }) => {
 		await page.goto('/encoded');
 		await clicknav('[href="/encoded/$SVLT"]');
-		expect(await page.textContent('h1')).toBe('$SVLT');
+		await expect(page.locator('h1')).toHaveText('$SVLT');
 	});
 
 	test('allows %-encoded characters in filenames', async ({ page, clicknav }) => {
 		await page.goto('/encoded');
 		await clicknav('[href="/encoded/@svelte"]');
-		expect(await page.textContent('h1')).toBe('@svelte');
+		await expect(page.locator('h1')).toHaveText('@svelte');
 	});
 });
 
@@ -344,17 +346,17 @@ test.describe('Env', () => {
 	test('includes environment variables', async ({ page }) => {
 		await page.goto('/env');
 
-		expect(await page.textContent('#static-private')).toBe(
+		await expect(page.locator('#static-private')).toHaveText(
 			'PRIVATE_STATIC: accessible to server-side code/replaced at build time'
 		);
-		expect(await page.textContent('#dynamic-private')).toBe(
+		await expect(page.locator('#dynamic-private')).toHaveText(
 			'PRIVATE_DYNAMIC: accessible to server-side code/evaluated at run time'
 		);
 
-		expect(await page.textContent('#static-public')).toBe(
+		await expect(page.locator('#static-public')).toHaveText(
 			'PUBLIC_STATIC: accessible anywhere/replaced at build time'
 		);
-		expect(await page.textContent('#dynamic-public')).toBe(
+		await expect(page.locator('#dynamic-public')).toHaveText(
 			'PUBLIC_DYNAMIC: accessible anywhere/evaluated at run time'
 		);
 	});
@@ -367,8 +369,8 @@ test.describe('Errors', () => {
 		test('server-side errors', async ({ page }) => {
 			await page.goto('/errors/serverside');
 
-			expect(await page.textContent('footer')).toBe('Custom layout');
-			expect(await page.textContent('#message')).toBe(
+			await expect(page.locator('footer')).toHaveText('Custom layout');
+			await expect(page.locator('#message')).toHaveText(
 				'This is your custom error page saying: "Crashing now"'
 			);
 		});
@@ -378,8 +380,8 @@ test.describe('Errors', () => {
 
 			await page.goto('/errors/module-scope-server');
 
-			expect(await page.textContent('footer')).toBe('Custom layout');
-			expect(await page.textContent('#message')).toBe(
+			await expect(page.locator('footer')).toHaveText('Custom layout');
+			await expect(page.locator('#message')).toHaveText(
 				'This is your custom error page saying: "Crashing now"'
 			);
 		});
@@ -388,8 +390,8 @@ test.describe('Errors', () => {
 	test('server-side load errors', async ({ page }) => {
 		await page.goto('/errors/load-server');
 
-		expect(await page.textContent('footer')).toBe('Custom layout');
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('footer')).toHaveText('Custom layout');
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "Crashing now"'
 		);
 
@@ -404,8 +406,8 @@ test.describe('Errors', () => {
 	test('404', async ({ page }) => {
 		const response = await page.goto('/why/would/anyone/fetch/this/url');
 
-		expect(await page.textContent('footer')).toBe('Custom layout');
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('footer')).toHaveText('Custom layout');
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "Not found: /why/would/anyone/fetch/this/url"'
 		);
 		expect(/** @type {Response} */ (response).status()).toBe(404);
@@ -414,8 +416,8 @@ test.describe('Errors', () => {
 	test('server-side error from load() is a string', async ({ page }) => {
 		const response = await page.goto('/errors/load-error-string-server');
 
-		expect(await page.textContent('footer')).toBe('Custom layout');
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('footer')).toHaveText('Custom layout');
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "Not found"'
 		);
 		expect(/** @type {Response} */ (response).status()).toBe(555);
@@ -424,8 +426,8 @@ test.describe('Errors', () => {
 	test('server-side error from load() is an Error', async ({ page }) => {
 		const response = await page.goto('/errors/load-error-server');
 
-		expect(await page.textContent('footer')).toBe('Custom layout');
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('footer')).toHaveText('Custom layout');
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "Not found"'
 		);
 		expect(/** @type {Response} */ (response).status()).toBe(555);
@@ -443,7 +445,9 @@ test.describe('Errors', () => {
 		}
 
 		expect(res && res.status()).toBe(500);
-		expect(await page.textContent('#message')).toBe('This is your custom error page saying: "500"');
+		await expect(page.locator('#message')).toHaveText(
+			'This is your custom error page saying: "500"'
+		);
 
 		const contents = await page.textContent('#stack');
 		const location = '+page.js:7:9';
@@ -469,7 +473,7 @@ test.describe('Errors', () => {
 		}
 
 		expect(res && res.status()).toBe(500);
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "nope"'
 		);
 
@@ -488,7 +492,7 @@ test.describe('Errors', () => {
 		expect(read_errors('/errors/endpoint-shadow-not-ok')).toBeUndefined();
 
 		expect(res && res.status()).toBe(555);
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "Error: 555"'
 		);
 	});
@@ -496,8 +500,8 @@ test.describe('Errors', () => {
 	test('error thrown in handle results in a rendered error page', async ({ page }) => {
 		await page.goto('/errors/error-in-handle');
 
-		expect(await page.textContent('footer')).toBe('Custom layout');
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('footer')).toHaveText('Custom layout');
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "Error in handle"'
 		);
 		expect(await page.innerHTML('h1')).toBe('500');
@@ -507,7 +511,7 @@ test.describe('Errors', () => {
 		page
 	}) => {
 		await page.goto('/prerendering');
-		expect(await page.textContent('h1')).toBe(
+		await expect(page.locator('h1')).toHaveText(
 			'500: Attempted to access session from a prerendered page. Session would never be populated.'
 		);
 	});
@@ -516,9 +520,9 @@ test.describe('Errors', () => {
 		page
 	}) => {
 		await page.goto('/prerendering/mutative-endpoint');
-		expect(await page.textContent('h1')).toBe('500');
+		await expect(page.locator('h1')).toHaveText('500');
 
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "Cannot prerender pages that have endpoints with mutative methods"'
 		);
 	});
@@ -530,6 +534,7 @@ test.describe('Errors', () => {
 	}) => {
 		await page.goto('/errors/page-endpoint');
 		await clicknav('#get-implicit');
+		await expect(page.locator('pre')).toHaveText(/.+/); // await text to be populated
 		const json = await page.textContent('pre');
 		if (!json) throw new Error('Could not extract content from element');
 		const { status, name, message, stack, fancy } = JSON.parse(json);
@@ -555,6 +560,7 @@ test.describe('Errors', () => {
 	}) => {
 		await page.goto('/errors/page-endpoint');
 		await clicknav('#get-explicit');
+		await expect(page.locator('pre')).toHaveText(/.+/); // await text to be populated
 		const json = await page.textContent('pre');
 		if (!json) throw new Error('Could not extract content from element');
 		const { status, message, stack } = JSON.parse(json);
@@ -575,6 +581,7 @@ test.describe('Errors', () => {
 		// It should show the __error template with our message.
 		await page.goto('/errors/page-endpoint');
 		await Promise.all([page.waitForNavigation(), page.click('#post-implicit')]);
+		await expect(page.locator('pre')).toHaveText(/.+/); // await text to be populated
 		const json = await page.textContent('pre');
 		if (!json) throw new Error('Could not extract content from element');
 		const { status, name, message, stack, fancy } = JSON.parse(json);
@@ -598,6 +605,7 @@ test.describe('Errors', () => {
 		// It should show the __error template with our message.
 		await page.goto('/errors/page-endpoint');
 		await Promise.all([page.waitForNavigation(), page.click('#post-explicit')]);
+		await expect(page.locator('pre')).toHaveText(/.+/); // await text to be populated
 		const json = await page.textContent('pre');
 		if (!json) throw new Error('Could not extract content from element');
 		const { status, message, stack } = JSON.parse(json);
@@ -621,12 +629,12 @@ test.describe('Headers', () => {
 test.describe('Load', () => {
 	test('fetch in root index.svelte works', async ({ page }) => {
 		await page.goto('/');
-		expect(await page.textContent('h1')).toBe('the answer is 42');
+		await expect(page.locator('h1')).toHaveText('the answer is 42');
 	});
 
 	test('loads', async ({ page }) => {
 		await page.goto('/load');
-		expect(await page.textContent('h1')).toBe('bar == bar?');
+		await expect(page.locator('h1')).toHaveText('bar == bar?');
 	});
 
 	test('GET fetches are serialized', async ({ page, javaScriptEnabled }) => {
@@ -656,8 +664,8 @@ test.describe('Load', () => {
 
 		await page.goto('/load/serialization-post');
 
-		expect(await page.textContent('h1')).toBe('a: X');
-		expect(await page.textContent('h2')).toBe('b: Y');
+		await expect(page.locator('h1')).toHaveText('a: X');
+		await expect(page.locator('h2')).toHaveText('b: Y');
 
 		const payload_a =
 			'{"status":200,"statusText":"","headers":{"content-type":"text/plain;charset=UTF-8"},"body":"X"}';
@@ -684,18 +692,18 @@ test.describe('Load', () => {
 
 	test('json string is returned', async ({ page }) => {
 		await page.goto('/load/relay');
-		expect(await page.textContent('h1')).toBe('42');
+		await expect(page.locator('h1')).toHaveText('42');
 	});
 
 	test('prefers static data over endpoint', async ({ page }) => {
 		await page.goto('/load/foo');
-		expect(await page.textContent('h1')).toBe('static file');
+		await expect(page.locator('h1')).toHaveText('static file');
 	});
 
 	test('data is inherited', async ({ page, javaScriptEnabled, app }) => {
 		await page.goto('/load/parent/a/b/c');
-		expect(await page.textContent('h1')).toBe('message: original + new');
-		expect(await page.textContent('pre')).toBe(
+		await expect(page.locator('h1')).toHaveText('message: original + new');
+		await expect(page.locator('pre')).toHaveText(
 			JSON.stringify({
 				foo: { bar: 'Custom layout' },
 				message: 'original + new',
@@ -708,8 +716,8 @@ test.describe('Load', () => {
 		if (javaScriptEnabled) {
 			await app.goto('/load/parent/d/e/f');
 
-			expect(await page.textContent('h1')).toBe('message: original + new');
-			expect(await page.textContent('pre')).toBe(
+			await expect(page.locator('h1')).toHaveText('message: original + new');
+			await expect(page.locator('pre')).toHaveText(
 				JSON.stringify({
 					foo: { bar: 'Custom layout' },
 					message: 'original + new',
@@ -724,21 +732,21 @@ test.describe('Load', () => {
 	test('fetch accepts a Request object', async ({ page, clicknav }) => {
 		await page.goto('/load');
 		await clicknav('[href="/load/fetch-request"]');
-		expect(await page.textContent('h1')).toBe('the answer is 42');
+		await expect(page.locator('h1')).toHaveText('the answer is 42');
 	});
 
 	test('fetch resolves urls relatively to the target page', async ({ page, clicknav }) => {
 		await page.goto('/load');
 		await clicknav('[href="/load/fetch-relative"]');
-		expect(await page.textContent('h1')).toBe('the answer is 42');
-		expect(await page.textContent('h2')).toBe('the question was ?');
+		await expect(page.locator('h1')).toHaveText('the answer is 42');
+		await expect(page.locator('h2')).toHaveText('the question was ?');
 	});
 
 	test('handles large responses', async ({ page }) => {
 		await page.goto('/load');
 
 		await page.goto('/load/large-response');
-		expect(await page.textContent('h1')).toBe('text.length is 5000000');
+		await expect(page.locator('h1')).toHaveText('text.length is 5000000');
 	});
 
 	test('handles external api', async ({ page }) => {
@@ -766,7 +774,7 @@ test.describe('Load', () => {
 			await page.goto(`/load/server-fetch-request?port=${port}`);
 
 			expect(requested_urls).toEqual(['/server-fetch-request-modified.json']);
-			expect(await page.textContent('h1')).toBe('the answer is 42');
+			await expect(page.locator('h1')).toHaveText('the answer is 42');
 		} finally {
 			await close();
 		}
@@ -775,7 +783,7 @@ test.describe('Load', () => {
 	test('makes credentialed fetches to endpoints by default', async ({ page, clicknav }) => {
 		await page.goto('/load');
 		await clicknav('[href="/load/fetch-credentialed"]');
-		expect(await page.textContent('h1')).toBe('Hello SvelteKit!');
+		await expect(page.locator('h1')).toHaveText('Hello SvelteKit!');
 	});
 
 	test('includes correct page request headers', async ({
@@ -815,18 +823,18 @@ test.describe('Load', () => {
 
 	test('does not leak props to other pages', async ({ page, clicknav }) => {
 		await page.goto('/load/props/about');
-		expect(await page.textContent('p')).toBe('Data: null');
+		await expect(page.locator('p')).toHaveText('Data: null');
 		await clicknav('[href="/load/props/"]');
-		expect(await page.textContent('p')).toBe('Data: Hello from Index!');
+		await expect(page.locator('p')).toHaveText('Data: Hello from Index!');
 		await clicknav('[href="/load/props/about"]');
-		expect(await page.textContent('p')).toBe('Data: null');
+		await expect(page.locator('p')).toHaveText('Data: null');
 	});
 
 	test('server-side fetch respects set-cookie header', async ({ page, context }) => {
 		await context.clearCookies();
 
 		await page.goto('/load/set-cookie-fetch');
-		expect(await page.textContent('h1')).toBe('the answer is 42');
+		await expect(page.locator('h1')).toHaveText('the answer is 42');
 
 		/** @type {Record<string,string>} */
 		const cookies = {};
@@ -901,40 +909,40 @@ test.describe('Nested layouts', () => {
 	test('renders a nested layout', async ({ page }) => {
 		await page.goto('/nested-layout');
 
-		expect(await page.textContent('footer')).toBe('Custom layout');
-		expect(await page.textContent('p')).toBe('This is a nested layout component');
-		expect(await page.textContent('h1')).toBe('Hello from inside the nested layout component');
+		await expect(page.locator('footer')).toHaveText('Custom layout');
+		await expect(page.locator('p')).toHaveText('This is a nested layout component');
+		await expect(page.locator('h1')).toHaveText('Hello from inside the nested layout component');
 	});
 
 	test('renders errors in the right layout', async ({ page }) => {
 		await page.goto('/nested-layout/error');
 
-		expect(await page.textContent('footer')).toBe('Custom layout');
+		await expect(page.locator('footer')).toHaveText('Custom layout');
 		expect(await page.evaluate(() => document.querySelector('p#nested'))).toBe(null);
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "Error"'
 		);
-		expect(await page.textContent('h1')).toBe('500');
+		await expect(page.locator('h1')).toHaveText('500');
 	});
 
 	test('renders errors in the right layout after client navigation', async ({ page, clicknav }) => {
 		await page.goto('/nested-layout/');
 		await clicknav('[href="/nested-layout/error"]');
-		expect(await page.textContent('footer')).toBe('Custom layout');
+		await expect(page.locator('footer')).toHaveText('Custom layout');
 		expect(await page.evaluate(() => document.querySelector('p#nested'))).toBe(null);
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "Error"'
 		);
-		expect(await page.textContent('h1')).toBe('500');
+		await expect(page.locator('h1')).toHaveText('500');
 	});
 
 	test('renders deeply-nested errors in the right layout', async ({ page }) => {
 		await page.goto('/nested-layout/foo/bar/nope');
-		expect(await page.textContent('footer')).toBe('Custom layout');
+		await expect(page.locator('footer')).toHaveText('Custom layout');
 		expect(await page.evaluate(() => document.querySelector('p#nested'))).toBeTruthy();
 		expect(await page.evaluate(() => document.querySelector('p#nested-foo'))).toBeTruthy();
 		expect(await page.evaluate(() => document.querySelector('p#nested-bar'))).toBeTruthy();
-		expect(await page.textContent('#nested-error-message')).toBe('error.message: nope');
+		await expect(page.locator('#nested-error-message')).toHaveText('error.message: nope');
 	});
 
 	test('resets layout', async ({ page }) => {
@@ -942,8 +950,8 @@ test.describe('Nested layouts', () => {
 
 		expect(await page.evaluate(() => document.querySelector('footer'))).toBe(null);
 		expect(await page.evaluate(() => document.querySelector('p'))).toBe(null);
-		expect(await page.textContent('h1')).toBe('Layout reset');
-		expect(await page.textContent('h2')).toBe('Hello');
+		await expect(page.locator('h1')).toHaveText('Layout reset');
+		await expect(page.locator('h2')).toHaveText('Hello');
 	});
 
 	test('renders the closest error page', async ({ page, clicknav }) => {
@@ -951,9 +959,9 @@ test.describe('Nested layouts', () => {
 
 		await clicknav('[href="/errors/nested-error-page/nope"]');
 
-		expect(await page.textContent('h1')).toBe('Nested error page');
-		expect(await page.textContent('#nested-error-status')).toBe('status: 500');
-		expect(await page.textContent('#nested-error-message')).toBe('error.message: nope');
+		await expect(page.locator('h1')).toHaveText('Nested error page');
+		await expect(page.locator('#nested-error-status')).toHaveText('status: 500');
+		await expect(page.locator('#nested-error-message')).toHaveText('error.message: nope');
 	});
 });
 
@@ -962,14 +970,14 @@ test.describe('Page options', () => {
 		await page.goto('/no-hydrate');
 
 		await page.click('button');
-		expect(await page.textContent('button')).toBe('clicks: 0');
+		await expect(page.locator('button')).toHaveText('clicks: 0');
 
 		if (javaScriptEnabled) {
 			await Promise.all([page.waitForNavigation(), page.click('[href="/no-hydrate/other"]')]);
 			await Promise.all([page.waitForNavigation(), page.click('[href="/no-hydrate"]')]);
 
 			await page.click('button');
-			expect(await page.textContent('button')).toBe('clicks: 1');
+			await expect(page.locator('button')).toHaveText('clicks: 1');
 		} else {
 			// ensure data wasn't inlined
 			expect(
@@ -986,7 +994,7 @@ test.describe('Page options', () => {
 	}) => {
 		if (!javaScriptEnabled) {
 			await page.goto('/no-hydrate/no-js');
-			expect(await page.textContent('h1')).toBe('look ma no javascript');
+			await expect(page.locator('h1')).toHaveText('look ma no javascript');
 			expect(
 				await page.evaluate(() => document.querySelectorAll('link[rel="modulepreload"]').length)
 			).toBe(0);
@@ -1002,7 +1010,7 @@ test.describe('Page options', () => {
 		await page.goto('/no-ssr');
 
 		if (javaScriptEnabled) {
-			expect(await page.textContent('h1')).toBe('content was rendered');
+			await expect(page.locator('h1')).toHaveText('content was rendered');
 		} else {
 			expect(await page.evaluate(() => document.querySelector('h1'))).toBe(null);
 			expect(await page.evaluate(() => document.querySelector('style[data-sveltekit]'))).toBe(null);
@@ -1056,18 +1064,18 @@ test.describe('$app/paths', () => {
 test.describe('$app/stores', () => {
 	test('can access page.url', async ({ baseURL, page }) => {
 		await page.goto('/origin');
-		expect(await page.textContent('h1')).toBe(baseURL);
+		await expect(page.locator('h1')).toHaveText(/** @type {string} */ (baseURL));
 	});
 
 	test('page store functions as expected', async ({ page, clicknav, javaScriptEnabled }) => {
 		await page.goto('/store');
 
-		expect(await page.textContent('h1')).toBe('Test');
-		expect(await page.textContent('h2')).toBe('Calls: 1');
+		await expect(page.locator('h1')).toHaveText('Test');
+		await expect(page.locator('h2')).toHaveText('Calls: 1');
 
 		await clicknav('a[href="/store/result"]');
-		expect(await page.textContent('h1')).toBe('Result');
-		expect(await page.textContent('h2')).toBe(javaScriptEnabled ? 'Calls: 1' : 'Calls: 0');
+		await expect(page.locator('h1')).toHaveText('Result');
+		await expect(page.locator('h2')).toHaveText(javaScriptEnabled ? 'Calls: 1' : 'Calls: 0');
 
 		const oops = await page.evaluate(() => window.oops);
 		expect(oops).toBeUndefined();
@@ -1078,26 +1086,26 @@ test.describe('$app/stores', () => {
 
 		const foo = { bar: 'Custom layout' };
 
-		expect(await page.textContent('#store-data')).toBe(
+		await expect(page.locator('#store-data')).toHaveText(
 			JSON.stringify({ foo, name: 'SvelteKit', value: 456, page: 'www' })
 		);
 
 		await clicknav('a[href="/store/data/zzz"]');
-		expect(await page.textContent('#store-data')).toBe(
+		await expect(page.locator('#store-data')).toHaveText(
 			JSON.stringify({ foo, name: 'SvelteKit', value: 456, page: 'zzz' })
 		);
 
 		await clicknav('a[href="/store/data/xxx"]');
-		expect(await page.textContent('#store-data')).toBe(
+		await expect(page.locator('#store-data')).toHaveText(
 			JSON.stringify({ foo, name: 'SvelteKit', value: 123 })
 		);
-		expect(await page.textContent('#store-error')).toBe('Params = xxx');
+		await expect(page.locator('#store-error')).toHaveText('Params = xxx');
 
 		await clicknav('a[href="/store/data/yyy"]');
-		expect(await page.textContent('#store-data')).toBe(
+		await expect(page.locator('#store-data')).toHaveText(
 			JSON.stringify({ foo, name: 'SvelteKit', value: 123 })
 		);
-		expect(await page.textContent('#store-error')).toBe('Params = yyy');
+		await expect(page.locator('#store-error')).toHaveText('Params = yyy');
 	});
 
 	test('should load data after reloading by goto', async ({
@@ -1127,7 +1135,7 @@ test.describe('$app/stores', () => {
 	test('navigating store contains from and to', async ({ app, page, javaScriptEnabled }) => {
 		await page.goto('/store/navigating/a');
 
-		expect(await page.textContent('#nav-status')).toBe('not currently navigating');
+		await expect(page.locator('#nav-status')).toHaveText('not currently navigating');
 
 		if (javaScriptEnabled) {
 			await app.prefetchRoutes(['/store/navigating/b']);
@@ -1140,14 +1148,14 @@ test.describe('$app/stores', () => {
 			expect(res[1]).toBe('navigating from /store/navigating/a to /store/navigating/b');
 
 			await page.waitForSelector('#not-navigating');
-			expect(await page.textContent('#nav-status')).toBe('not currently navigating');
+			await expect(page.locator('#nav-status')).toHaveText('not currently navigating');
 		}
 	});
 
 	test('navigating store clears after aborted navigation', async ({ page, javaScriptEnabled }) => {
 		await page.goto('/store/navigating/a');
 
-		expect(await page.textContent('#nav-status')).toBe('not currently navigating');
+		await expect(page.locator('#nav-status')).toHaveText('not currently navigating');
 
 		if (javaScriptEnabled) {
 			await page.click('a[href="/store/navigating/c"]');
@@ -1155,7 +1163,7 @@ test.describe('$app/stores', () => {
 			await page.click('a[href="/store/navigating/a"]');
 
 			await page.waitForSelector('#not-navigating', { timeout: 500 });
-			expect(await page.textContent('#nav-status')).toBe('not currently navigating');
+			await expect(page.locator('#nav-status')).toHaveText('not currently navigating');
 		}
 	});
 });
@@ -1190,8 +1198,8 @@ test.describe('searchParams', () => {
 
 			const json = JSON.stringify(expected);
 
-			expect(await page.textContent('#one')).toBe(json);
-			expect(await page.textContent('#two')).toBe(json);
+			await expect(page.locator('#one')).toHaveText(json);
+			await expect(page.locator('#two')).toHaveText(json);
 		});
 	});
 
@@ -1202,8 +1210,8 @@ test.describe('searchParams', () => {
 
 		const json = JSON.stringify({ bar: ['2'] });
 
-		expect(await page.textContent('#one')).toBe(json);
-		expect(await page.textContent('#two')).toBe(json);
+		await expect(page.locator('#one')).toHaveText(json);
+		await expect(page.locator('#two')).toHaveText(json);
 	});
 });
 
@@ -1214,7 +1222,7 @@ test.describe('Redirects', () => {
 		await clicknav('[href="/redirect/a"]');
 
 		await page.waitForURL('/redirect/c');
-		expect(await page.textContent('h1')).toBe('c');
+		await expect(page.locator('h1')).toHaveText('c');
 		expect(page.url()).toBe(`${baseURL}/redirect/c`);
 
 		await page.goBack();
@@ -1229,8 +1237,8 @@ test.describe('Redirects', () => {
 		if (javaScriptEnabled) {
 			await page.waitForSelector('#message');
 			expect(page.url()).toBe(`${baseURL}/redirect/loopy/a`);
-			expect(await page.textContent('h1')).toBe('500');
-			expect(await page.textContent('#message')).toBe(
+			await expect(page.locator('h1')).toHaveText('500');
+			await expect(page.locator('#message')).toHaveText(
 				'This is your custom error page saying: "Redirect loop"'
 			);
 		} else {
@@ -1255,8 +1263,8 @@ test.describe('Redirects', () => {
 		await clicknav('[href="/redirect/missing-status/a"]');
 
 		expect(page.url()).toBe(`${baseURL}/redirect/missing-status/a`);
-		expect(await page.textContent('h1')).toBe('500');
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('h1')).toHaveText('500');
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "Invalid status code"'
 		);
 
@@ -1273,8 +1281,8 @@ test.describe('Redirects', () => {
 		await clicknav('[href="/redirect/missing-status/b"]');
 
 		expect(page.url()).toBe(`${baseURL}/redirect/missing-status/b`);
-		expect(await page.textContent('h1')).toBe('500');
-		expect(await page.textContent('#message')).toBe(
+		await expect(page.locator('h1')).toHaveText('500');
+		await expect(page.locator('#message')).toHaveText(
 			'This is your custom error page saying: "Invalid status code"'
 		);
 	});
@@ -1289,7 +1297,7 @@ test.describe('Redirects', () => {
 		expect(page.url()).toBe(redirected_to_url);
 
 		if (javaScriptEnabled) {
-			expect(await page.textContent('h1')).toBe('Hazaa!');
+			await expect(page.locator('h1')).toHaveText('Hazaa!');
 		}
 	});
 });
@@ -1306,13 +1314,13 @@ test.describe('Routing', () => {
 
 		await clicknav('a[href="/routing/"]');
 		expect(page.url()).toBe(`${baseURL}/routing`);
-		expect(await page.textContent('h1')).toBe('Great success!');
+		await expect(page.locator('h1')).toHaveText('Great success!');
 
 		if (javaScriptEnabled) {
 			await page.goto(`${baseURL}/routing/slashes`);
 			await app.goto('/routing/');
 			expect(page.url()).toBe(`${baseURL}/routing`);
-			expect(await page.textContent('h1')).toBe('Great success!');
+			await expect(page.locator('h1')).toHaveText('Great success!');
 		}
 	});
 
@@ -1327,13 +1335,13 @@ test.describe('Routing', () => {
 
 		await clicknav('a[href="/routing/?"]');
 		expect(page.url()).toBe(`${baseURL}/routing`);
-		expect(await page.textContent('h1')).toBe('Great success!');
+		await expect(page.locator('h1')).toHaveText('Great success!');
 
 		if (javaScriptEnabled) {
 			await page.goto(`${baseURL}/routing/slashes`);
 			await app.goto('/routing/?');
 			expect(page.url()).toBe(`${baseURL}/routing`);
-			expect(await page.textContent('h1')).toBe('Great success!');
+			await expect(page.locator('h1')).toHaveText('Great success!');
 		}
 	});
 
@@ -1348,48 +1356,48 @@ test.describe('Routing', () => {
 
 		await clicknav('a[href="/routing/?foo=bar"]');
 		expect(page.url()).toBe(`${baseURL}/routing?foo=bar`);
-		expect(await page.textContent('h1')).toBe('Great success!');
+		await expect(page.locator('h1')).toHaveText('Great success!');
 
 		if (javaScriptEnabled) {
 			await page.goto(`${baseURL}/routing/slashes`);
 			await app.goto('/routing/?foo=bar');
 			expect(page.url()).toBe(`${baseURL}/routing?foo=bar`);
-			expect(await page.textContent('h1')).toBe('Great success!');
+			await expect(page.locator('h1')).toHaveText('Great success!');
 		}
 	});
 
 	test('serves static route', async ({ page }) => {
 		await page.goto('/routing/a');
-		expect(await page.textContent('h1')).toBe('a');
+		await expect(page.locator('h1')).toHaveText('a');
 	});
 
 	test('serves static route from dir/index.html file', async ({ page }) => {
 		await page.goto('/routing/b');
-		expect(await page.textContent('h1')).toBe('b');
+		await expect(page.locator('h1')).toHaveText('b');
 	});
 
 	test('serves static route under client directory', async ({ baseURL, page }) => {
 		await page.goto('/routing/client/foo');
 
-		expect(await page.textContent('h1')).toBe('foo');
+		await expect(page.locator('h1')).toHaveText('foo');
 
 		await page.goto(`${baseURL}/routing/client/bar`);
-		expect(await page.textContent('h1')).toBe('bar');
+		await expect(page.locator('h1')).toHaveText('bar');
 
 		await page.goto(`${baseURL}/routing/client/bar/b`);
-		expect(await page.textContent('h1')).toBe('b');
+		await expect(page.locator('h1')).toHaveText('b');
 	});
 
 	test('serves dynamic route', async ({ page }) => {
 		await page.goto('/routing/test-slug');
-		expect(await page.textContent('h1')).toBe('test-slug');
+		await expect(page.locator('h1')).toHaveText('test-slug');
 	});
 
 	test('does not attempt client-side navigation to server routes', async ({ page }) => {
 		await page.goto('/routing');
 		await page.click('[href="/routing/ambiguous/ok.json"]');
 		await page.waitForLoadState('networkidle');
-		expect(await page.textContent('body')).toBe('ok');
+		await expect(page.locator('body')).toHaveText('ok');
 	});
 
 	test('does not attempt client-side navigation to links with sveltekit:reload', async ({
@@ -1403,13 +1411,13 @@ test.describe('Routing', () => {
 		page.on('request', (r) => requests.push(r.url()));
 
 		await Promise.all([page.waitForNavigation(), page.click('[href="/routing/b"]')]);
-		expect(await page.textContent('h1')).toBe('b');
+		await expect(page.locator('h1')).toHaveText('b');
 		expect(requests).toContain(`${baseURL}/routing/b`);
 	});
 
 	test('allows reserved words as route names', async ({ page }) => {
 		await page.goto('/routing/const');
-		expect(await page.textContent('h1')).toBe('reserved words are okay as routes');
+		await expect(page.locator('h1')).toHaveText('reserved words are okay as routes');
 	});
 
 	test('resets the active element after navigation', async ({ page, clicknav }) => {
@@ -1420,25 +1428,25 @@ test.describe('Routing', () => {
 
 	test('navigates between routes with empty parts', async ({ page, clicknav }) => {
 		await page.goto('/routing/dirs/foo');
-		expect(await page.textContent('h1')).toBe('foo');
+		await expect(page.locator('h1')).toHaveText('foo');
 		await clicknav('[href="bar"]');
-		expect(await page.textContent('h1')).toBe('bar');
+		await expect(page.locator('h1')).toHaveText('bar');
 	});
 
 	test('navigates between dynamic routes with same segments', async ({ page, clicknav }) => {
 		await page.goto('/routing/dirs/bar/xyz');
-		expect(await page.textContent('h1')).toBe('A page');
+		await expect(page.locator('h1')).toHaveText('A page');
 
 		await clicknav('[href="/routing/dirs/foo/xyz"]');
-		expect(await page.textContent('h1')).toBe('B page');
+		await expect(page.locator('h1')).toHaveText('B page');
 	});
 
 	test('invalidates page when a segment is skipped', async ({ page, clicknav }) => {
 		await page.goto('/routing/skipped/x/1');
-		expect(await page.textContent('h1')).toBe('x/1');
+		await expect(page.locator('h1')).toHaveText('x/1');
 
 		await clicknav('#goto-y1');
-		expect(await page.textContent('h1')).toBe('y/1');
+		await expect(page.locator('h1')).toHaveText('y/1');
 	});
 
 	test('back button returns to initial route', async ({ page, clicknav }) => {
@@ -1446,7 +1454,7 @@ test.describe('Routing', () => {
 		await clicknav('[href="/routing/a"]');
 
 		await page.goBack();
-		expect(await page.textContent('h1')).toBe('Great success!');
+		await expect(page.locator('h1')).toHaveText('Great success!');
 	});
 
 	test('back button returns to previous route when previous route has been navigated to via hash anchor', async ({
@@ -1459,7 +1467,7 @@ test.describe('Routing', () => {
 		await clicknav('[href="/routing/hashes/b"]');
 
 		await page.goBack();
-		expect(await page.textContent('h1')).toBe('a');
+		await expect(page.locator('h1')).toHaveText('a');
 	});
 
 	test('focus works if page load has hash', async ({ page, browserName }) => {
@@ -1508,8 +1516,8 @@ test.describe('Routing', () => {
 	test('last parameter in a segment wins in cases of ambiguity', async ({ page, clicknav }) => {
 		await page.goto('/routing/split-params');
 		await clicknav('[href="/routing/split-params/x-y-z"]');
-		expect(await page.textContent('h1')).toBe('x');
-		expect(await page.textContent('h2')).toBe('y-z');
+		await expect(page.locator('h1')).toHaveText('x');
+		await expect(page.locator('h2')).toHaveText('y-z');
 	});
 
 	test('ignores navigation to URLs the app does not own', async ({ page }) => {
@@ -1529,66 +1537,66 @@ test.describe('Routing', () => {
 	test('navigates to ...rest', async ({ page, clicknav }) => {
 		await page.goto('/routing/rest/abc/xyz');
 
-		expect(await page.textContent('h1')).toBe('abc/xyz');
+		await expect(page.locator('h1')).toHaveText('abc/xyz');
 
 		await clicknav('[href="/routing/rest/xyz/abc/def/ghi"]');
-		expect(await page.textContent('h1')).toBe('xyz/abc/def/ghi');
-		expect(await page.textContent('h2')).toBe('xyz/abc/def/ghi');
+		await expect(page.locator('h1')).toHaveText('xyz/abc/def/ghi');
+		await expect(page.locator('h2')).toHaveText('xyz/abc/def/ghi');
 
 		await clicknav('[href="/routing/rest/xyz/abc/def"]');
-		expect(await page.textContent('h1')).toBe('xyz/abc/def');
-		expect(await page.textContent('h2')).toBe('xyz/abc/def');
+		await expect(page.locator('h1')).toHaveText('xyz/abc/def');
+		await expect(page.locator('h2')).toHaveText('xyz/abc/def');
 
 		await clicknav('[href="/routing/rest/xyz/abc"]');
-		expect(await page.textContent('h1')).toBe('xyz/abc');
-		expect(await page.textContent('h2')).toBe('xyz/abc');
+		await expect(page.locator('h1')).toHaveText('xyz/abc');
+		await expect(page.locator('h2')).toHaveText('xyz/abc');
 
 		await clicknav('[href="/routing/rest"]');
-		expect(await page.textContent('h1')).toBe('');
-		expect(await page.textContent('h2')).toBe('');
+		await expect(page.locator('h1')).toHaveText(/^$/);
+		await expect(page.locator('h2')).toHaveText(/^$/);
 
 		await clicknav('[href="/routing/rest/xyz/abc/deep"]');
-		expect(await page.textContent('h1')).toBe('xyz/abc');
-		expect(await page.textContent('h2')).toBe('xyz/abc');
+		await expect(page.locator('h1')).toHaveText('xyz/abc');
+		await expect(page.locator('h2')).toHaveText('xyz/abc');
 
 		await page.click('[href="/routing/rest/xyz/abc/qwe/deep.json"]');
-		expect(await page.textContent('body')).toBe('xyz/abc/qwe');
+		await expect(page.locator('body')).toHaveText('xyz/abc/qwe');
 	});
 
 	test('rest parameters do not swallow characters', async ({ page, clicknav }) => {
 		await page.goto('/routing/rest/non-greedy');
 
 		await clicknav('[href="/routing/rest/non-greedy/foo/one/two"]');
-		expect(await page.textContent('h1')).toBe('non-greedy');
-		expect(await page.textContent('h2')).toBe('{"rest":"one/two"}');
+		await expect(page.locator('h1')).toHaveText('non-greedy');
+		await expect(page.locator('h2')).toHaveText('{"rest":"one/two"}');
 
 		await clicknav('[href="/routing/rest/non-greedy/food/one/two"]');
-		expect(await page.textContent('h1')).not.toBe('non-greedy');
+		await expect(page.locator('h1')).not.toHaveText('non-greedy');
 
 		await page.goBack();
 
 		await clicknav('[href="/routing/rest/non-greedy/one-bar/two/three"]');
-		expect(await page.textContent('h1')).toBe('non-greedy');
-		expect(await page.textContent('h2')).toBe('{"dynamic":"one","rest":"two/three"}');
+		await expect(page.locator('h1')).toHaveText('non-greedy');
+		await expect(page.locator('h2')).toHaveText('{"dynamic":"one","rest":"two/three"}');
 
 		await clicknav('[href="/routing/rest/non-greedy/one-bard/two/three"]');
-		expect(await page.textContent('h1')).not.toBe('non-greedy');
+		await expect(page.locator('h1')).not.toHaveText('non-greedy');
 	});
 
 	test('reloads when navigating between ...rest pages', async ({ page, clicknav }) => {
 		await page.goto('/routing/rest/path/one');
-		expect(await page.textContent('h1')).toBe('path: /routing/rest/path/one');
+		await expect(page.locator('h1')).toHaveText('path: /routing/rest/path/one');
 
 		await clicknav('[href="/routing/rest/path/two"]');
-		expect(await page.textContent('h1')).toBe('path: /routing/rest/path/two');
+		await expect(page.locator('h1')).toHaveText('path: /routing/rest/path/two');
 
 		await clicknav('[href="/routing/rest/path/three"]');
-		expect(await page.textContent('h1')).toBe('path: /routing/rest/path/three');
+		await expect(page.locator('h1')).toHaveText('path: /routing/rest/path/three');
 	});
 
 	test('allows rest routes to have prefixes and suffixes', async ({ page }) => {
 		await page.goto('/routing/rest/complex/prefix-one/two/three');
-		expect(await page.textContent('h1')).toBe('parts: one/two/three');
+		await expect(page.locator('h1')).toHaveText('parts: one/two/three');
 	});
 
 	test('links to unmatched routes result in a full page navigation, not a 404', async ({
@@ -1597,7 +1605,7 @@ test.describe('Routing', () => {
 	}) => {
 		await page.goto('/routing');
 		await clicknav('[href="/static.json"]');
-		expect(await page.textContent('body')).toBe('"static file"\n');
+		await expect(page.locator('body')).toHaveText('"static file"\n');
 	});
 
 	test('navigation is cancelled upon subsequent navigation', async ({
@@ -1628,13 +1636,13 @@ test.describe('Routing', () => {
 		await page.goto('/routing/route-id');
 		await clicknav('[href="/routing/route-id/foo"]');
 
-		expect(await page.textContent('h1')).toBe('routeId in load: routing/route-id/[x]');
-		expect(await page.textContent('h2')).toBe('routeId in store: routing/route-id/[x]');
+		await expect(page.locator('h1')).toHaveText('routeId in load: routing/route-id/[x]');
+		await expect(page.locator('h2')).toHaveText('routeId in store: routing/route-id/[x]');
 	});
 
 	test('serves a page that clashes with a root directory', async ({ page }) => {
 		await page.goto('/static');
-		expect(await page.textContent('h1')).toBe('hello');
+		await expect(page.locator('h1')).toHaveText('hello');
 	});
 });
 
@@ -1658,16 +1666,16 @@ test.describe('Matchers', () => {
 		await page.goto('/routing/matched');
 
 		await clicknav('[href="/routing/matched/a"]');
-		expect(await page.textContent('h1')).toBe('lowercase: a');
+		await expect(page.locator('h1')).toHaveText('lowercase: a');
 
 		await clicknav('[href="/routing/matched/B"]');
-		expect(await page.textContent('h1')).toBe('uppercase: B');
+		await expect(page.locator('h1')).toHaveText('uppercase: B');
 
 		await clicknav('[href="/routing/matched/1"]');
-		expect(await page.textContent('h1')).toBe('number: 1');
+		await expect(page.locator('h1')).toHaveText('number: 1');
 
 		await clicknav('[href="/routing/matched/everything-else"]');
-		expect(await page.textContent('h1')).toBe('fallback: everything-else');
+		await expect(page.locator('h1')).toHaveText('fallback: everything-else');
 	});
 });
 
@@ -1682,7 +1690,7 @@ test.describe('XSS', () => {
 	test('escapes inline data', async ({ page, javaScriptEnabled }) => {
 		await page.goto('/xss');
 
-		expect(await page.textContent('h1')).toBe(
+		await expect(page.locator('h1')).toHaveText(
 			'user.name is </script><script>window.pwned = 1</script>'
 		);
 
@@ -1712,7 +1720,7 @@ test.describe('XSS', () => {
 
 		// @ts-expect-error - check global injected variable
 		expect(await page.evaluate(() => window.pwned)).toBeUndefined();
-		expect(await page.textContent('h1')).toBe(
+		await expect(page.locator('h1')).toHaveText(
 			'user.name is </script><script>window.pwned = 1</script>'
 		);
 	});


### PR DESCRIPTION
using
await expect(page.locator('h2')).toHaveText('2');
instead of
expect(await page.textContent('h2')).toBe('2');
makes the tests more robust because the latter retries until it times out or the text is present. The former will resolve as soon as the element is found, but it may still have an old value from before the tests action

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
