### PR TITLE
avoid double import of `$env/dynamic/[mode]` modules

### DIFF
--- a/.changeset/nasty-shoes-mate.md
+++ b/.changeset/nasty-shoes-mate.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Prevent double import of env modules

--- a/packages/kit/src/vite/dev/index.js
+++ b/packages/kit/src/vite/dev/index.js
@@ -294,7 +294,12 @@ export async function dev(vite, vite_config, svelte_config, illegal_imports) {
 
 		remove_static_middlewares(vite.middlewares);
 
-		const runtime_base = path.relative('.', runtime_directory);
+		const runtime_base = runtime_directory.startsWith(process.cwd())
+			? `/${path.relative('.', runtime_directory)}`
+			: `/@fs${
+					// Windows/Linux separation - Windows starts with a drive letter, we need a / in front there
+					runtime_directory.startsWith('/') ? '' : '/'
+			  }${runtime_directory}`;
 
 		const { set_private_env } = await vite.ssrLoadModule(`${runtime_base}/env-private.js`);
 		const { set_public_env } = await vite.ssrLoadModule(`${runtime_base}/env-public.js`);

--- a/packages/kit/src/vite/dev/index.js
+++ b/packages/kit/src/vite/dev/index.js
@@ -286,13 +286,22 @@ export async function dev(vite, vite_config, svelte_config, illegal_imports) {
 		}
 	});
 
-	return () => {
+	return async () => {
 		const serve_static_middleware = vite.middlewares.stack.find(
 			(middleware) =>
 				/** @type {function} */ (middleware.handle).name === 'viteServeStaticMiddleware'
 		);
 
 		remove_static_middlewares(vite.middlewares);
+
+		const runtime_base = path.relative('.', runtime_directory);
+
+		const { set_private_env } = await vite.ssrLoadModule(`${runtime_base}/env-private.js`);
+		const { set_public_env } = await vite.ssrLoadModule(`${runtime_base}/env-public.js`);
+
+		const env = get_env(vite_config.mode, svelte_config.kit.env.publicPrefix);
+		set_private_env(env.private);
+		set_public_env(env.public);
 
 		vite.middlewares.use(async (req, res) => {
 			try {
@@ -319,20 +328,6 @@ export async function dev(vite, vite_config, svelte_config, illegal_imports) {
 						`Not found (did you mean ${svelte_config.kit.paths.base + req.url}?)`
 					);
 				}
-
-				// For some reason using runtime_prefix here is buggy, since Vite will later load the modules
-				// again with a slightly different url (with the drive letter) on windows
-				const runtime_base = `/@fs${
-					// Windows/Linux separation - Windows starts with a drive letter, we need a / in front there
-					runtime_directory.startsWith('/') ? '' : '/'
-				}${runtime_directory}`;
-
-				const { set_private_env } = await vite.ssrLoadModule(`${runtime_base}/env-private.js`);
-				const { set_public_env } = await vite.ssrLoadModule(`${runtime_base}/env-public.js`);
-
-				const env = get_env(vite_config.mode, svelte_config.kit.env.publicPrefix);
-				set_private_env(env.private);
-				set_public_env(env.public);
 
 				/** @type {Partial<import('types').Hooks>} */
 				const user_hooks = resolve_entry(svelte_config.kit.files.hooks)


### PR DESCRIPTION
Attempt to fix #5941. No test because the bug doesn't happen inside the workspace

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
