### PR TITLE
[fix] Fix params and parent data types

### DIFF
--- a/.changeset/sour-cherries-play.md
+++ b/.changeset/sour-cherries-play.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Tighten up params typings, fix load function typings, add event typings to generated types

--- a/packages/kit/src/core/sync/write_types.js
+++ b/packages/kit/src/core/sync/write_types.js
@@ -249,13 +249,15 @@ function write_types_for_dir(config, manifest_data, routes_dir, dir, groups, ts)
 			exports.push(
 				`export type PageLoad<OutputData extends Record<string, any> | void = Record<string, any> | void> = ${load};`
 			);
+			exports.push('export type PageLoadEvent = Parameters<PageLoad>[0];');
 		}
 
 		exports.push(`export type PageServerData = ${server_data};`);
 		if (server_load) {
 			exports.push(
-				`export type PageServerLoad<OutputData extends Kit.JSONObject | void = Kit.JSONObject | void> = ${server_load};`
+				`export type PageServerLoad<OutputData extends Record<string, any> | void = Record<string, any> | void> = ${server_load};`
 			);
+			exports.push('export type PageServerLoadEvent = Parameters<PageServerLoad>[0];');
 		}
 
 		if (group.leaf.server) {
@@ -299,13 +301,15 @@ function write_types_for_dir(config, manifest_data, routes_dir, dir, groups, ts)
 				exports.push(
 					`export type LayoutLoad<OutputData extends Record<string, any> | void = Record<string, any> | void> = ${load};`
 				);
+				exports.push('export type LayoutLoadEvent = Parameters<LayoutLoad>[0];');
 			}
 
 			exports.push(`export type LayoutServerData = ${server_data};`);
 			if (server_load) {
 				exports.push(
-					`export type LayoutServerLoad<OutputData extends Kit.JSONObject | void = Kit.JSONObject | void> = ${server_load};`
+					`export type LayoutServerLoad<OutputData extends Record<string, any> | void = Record<string, any> | void> = ${server_load};`
 				);
+				exports.push('export type LayoutServerLoadEvent = Parameters<LayoutServerLoad>[0];');
 			}
 		}
 
@@ -320,7 +324,13 @@ function write_types_for_dir(config, manifest_data, routes_dir, dir, groups, ts)
 			const load_exports = [];
 
 			/** @type {string[]} */
+			const load_event_exports = [];
+
+			/** @type {string[]} */
 			const server_load_exports = [];
+
+			/** @type {string[]} */
+			const server_load_event_exports = [];
 
 			for (const [name, node] of group.named_layouts) {
 				const { data, server_data, load, server_load, written_proxies } = process_node(
@@ -337,27 +347,36 @@ function write_types_for_dir(config, manifest_data, routes_dir, dir, groups, ts)
 					load_exports.push(
 						`export type ${name}<OutputData extends Record<string, any> | void = Record<string, any> | void> = ${load};`
 					);
+					load_event_exports.push(`export type ${name} = Parameters<LayoutLoad.${name}>[0];`);
 				}
 				if (server_load) {
 					server_load_exports.push(
-						`export type ${name}<OutputData extends Kit.JSONObject | void = Kit.JSONObject | void> = ${load};`
+						`export type ${name}<OutputData extends Record<string, any> | void = Record<string, any> | void> = ${load};`
+					);
+					server_load_event_exports.push(
+						`export type ${name} = Parameters<LayoutServerLoad.${name}>[0];`
 					);
 				}
 			}
 
 			exports.push(`\nexport namespace LayoutData {\n\t${data_exports.join('\n\t')}\n}`);
 			exports.push(`\nexport namespace LayoutLoad {\n\t${load_exports.join('\n\t')}\n}`);
+			exports.push(`\nexport namespace LayoutLoadEvent {\n\t${load_event_exports.join('\n\t')}\n}`);
 			exports.push(
 				`\nexport namespace LayoutServerData {\n\t${server_data_exports.join('\n\t')}\n}`
 			);
 			exports.push(
 				`\nexport namespace LayoutServerLoad {\n\t${server_load_exports.join('\n\t')}\n}`
 			);
+			exports.push(
+				`\nexport namespace LayoutServerLoadEvent {\n\t${server_load_event_exports.join('\n\t')}\n}`
+			);
 		}
 	}
 
 	if (group.endpoint) {
 		exports.push(`export type RequestHandler = Kit.RequestHandler<RouteParams>;`);
+		exports.push(`export type RequestEvent = Kit.RequestEvent<RouteParams>;`);
 	}
 
 	const output = [imports.join('\n'), declarations.join('\n'), exports.join('\n')]

--- a/packages/kit/src/core/sync/write_types.js
+++ b/packages/kit/src/core/sync/write_types.js
@@ -468,7 +468,7 @@ function process_node(ts, node, outdir, params, groups) {
 			parent = parent_layout.parent;
 		}
 
-		let parent_str = parent_imports[0] || 'null';
+		let parent_str = parent_imports[0] || 'Record<never, never>';
 		for (let i = 1; i < parent_imports.length; i++) {
 			// Omit is necessary because a parent could have a property with the same key which would
 			// cause a type conflict. At runtime the child overwrites the parent property in this case,

--- a/packages/kit/src/core/sync/write_types.js
+++ b/packages/kit/src/core/sync/write_types.js
@@ -246,12 +246,16 @@ function write_types_for_dir(config, manifest_data, routes_dir, dir, groups, ts)
 
 		exports.push(`export type PageData = ${data};`);
 		if (load) {
-			exports.push(`export type PageLoad = ${load};`);
+			exports.push(
+				`export type PageLoad<OutputData extends Record<string, any> | void = Record<string, any> | void> = ${load};`
+			);
 		}
 
 		exports.push(`export type PageServerData = ${server_data};`);
 		if (server_load) {
-			exports.push(`export type PageServerLoad = ${server_load};`);
+			exports.push(
+				`export type PageServerLoad<OutputData extends Kit.JSONObject | void = Kit.JSONObject | void> = ${server_load};`
+			);
 		}
 
 		if (group.leaf.server) {
@@ -292,12 +296,16 @@ function write_types_for_dir(config, manifest_data, routes_dir, dir, groups, ts)
 
 			exports.push(`export type LayoutData = ${data};`);
 			if (load) {
-				exports.push(`export type LayoutLoad = ${load};`);
+				exports.push(
+					`export type LayoutLoad<OutputData extends Record<string, any> | void = Record<string, any> | void> = ${load};`
+				);
 			}
 
 			exports.push(`export type LayoutServerData = ${server_data};`);
 			if (server_load) {
-				exports.push(`export type LayoutServerLoad = ${server_load};`);
+				exports.push(
+					`export type LayoutServerLoad<OutputData extends Kit.JSONObject | void = Kit.JSONObject | void> = ${server_load};`
+				);
 			}
 		}
 
@@ -326,10 +334,14 @@ function write_types_for_dir(config, manifest_data, routes_dir, dir, groups, ts)
 				data_exports.push(`export type ${name} = ${data};`);
 				server_data_exports.push(`export type ${name} = ${server_data};`);
 				if (load) {
-					load_exports.push(`export type ${name} = ${load};`);
+					load_exports.push(
+						`export type ${name}<OutputData extends Record<string, any> | void = Record<string, any> | void> = ${load};`
+					);
 				}
 				if (server_load) {
-					server_load_exports.push(`export type ${name} = ${load};`);
+					server_load_exports.push(
+						`export type ${name}<OutputData extends Kit.JSONObject | void = Kit.JSONObject | void> = ${load};`
+					);
 				}
 			}
 
@@ -384,7 +396,7 @@ function process_node(ts, node, outdir, params, groups) {
 		}
 
 		server_data = get_data_type(node.server, 'load', 'null', proxy);
-		server_load = `Kit.ServerLoad<${params}, ${get_parent_type('LayoutServerData')}>`;
+		server_load = `Kit.ServerLoad<${params}, ${get_parent_type('LayoutServerData')}, OutputData>`;
 
 		if (proxy) {
 			const types = [];
@@ -415,7 +427,7 @@ function process_node(ts, node, outdir, params, groups) {
 		}
 
 		data = get_data_type(node.shared, 'load', server_data, proxy);
-		load = `Kit.Load<${params}, ${server_data}, ${get_parent_type('LayoutData')}>`;
+		load = `Kit.Load<${params}, ${server_data}, ${get_parent_type('LayoutData')}, OutputData>`;
 	} else {
 		data = server_data;
 	}

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -448,7 +448,7 @@ export function create_client({ target, base, trailing_slash }) {
 	 *   url: URL;
 	 *   params: Record<string, string>;
 	 *   routeId: string | null;
-	 * 	 server_data: import('types').JSONObject | null;
+	 * 	 server_data: Record<string, any> | null;
 	 * }} options
 	 * @returns {Promise<import('./types').BranchNode>}
 	 */

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -6,7 +6,7 @@ import {
 	prefetch,
 	prefetchRoutes
 } from '$app/navigation';
-import { CSRPageNode, CSRRoute, JSONObject } from 'types';
+import { CSRPageNode, CSRRoute } from 'types';
 import { HttpError } from '../../index/private.js';
 import { SerializedHttpError } from '../server/page/types.js';
 
@@ -92,7 +92,7 @@ export interface ServerDataRedirected {
 export interface ServerDataLoaded {
 	type: 'data';
 	nodes: Array<{
-		data?: JSONObject | null; // TODO or `-1` to indicate 'reuse cached data'?
+		data?: Record<string, any> | null; // TODO or `-1` to indicate 'reuse cached data'?
 		status?: number;
 		message?: string;
 		error?: {

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -29,7 +29,9 @@ export async function render_endpoint(event, route) {
 		return method_not_allowed(mod, method);
 	}
 
-	const response = await handler(event);
+	const response = await handler(
+		/** @type {import('types').RequestEvent<Record<string, any>>} */ (event)
+	);
 
 	if (!(response instanceof Response)) {
 		return new Response(

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -257,7 +257,7 @@ export async function respond(request, options, state) {
 											event,
 											node,
 											parent: async () => {
-												/** @type {import('types').JSONObject} */
+												/** @type {Record<string, any>} */
 												const data = {};
 												for (let j = 0; j < i; j += 1) {
 													const parent = await promises[j];

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -137,7 +137,7 @@ export async function render_page(event, route, options, state, resolve_opts) {
 		/** @type {Error | null} */
 		let load_error = null;
 
-		/** @type {Array<Promise<import('types').JSONObject | null>>} */
+		/** @type {Array<Promise<Record<string, any> | null>>} */
 		const server_promises = nodes.map((node, i) => {
 			if (load_error) {
 				// if an error happens immediately, don't bother with the rest of the nodes
@@ -156,7 +156,7 @@ export async function render_page(event, route, options, state, resolve_opts) {
 						event,
 						node,
 						parent: async () => {
-							/** @type {import('types').JSONObject} */
+							/** @type {Record<string, any>} */
 							const data = {};
 							for (let j = 0; j < i; j += 1) {
 								Object.assign(data, await server_promises[j]);

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -5,7 +5,7 @@ import { LoadURL, PrerenderingURL } from '../../../utils/url.js';
  * @param {{
  *   event: import('types').RequestEvent;
  *   node: import('types').SSRNode | undefined;
- *   parent: () => Promise<import('types').JSONObject | null>;
+ *   parent: () => Promise<Record<string, any>>;
  * }} opts
  */
 export async function load_server_data({ event, node, parent }) {
@@ -37,7 +37,7 @@ export async function load_server_data({ event, node, parent }) {
  *   fetcher: typeof fetch;
  *   node: import('types').SSRNode | undefined;
  *   parent: () => Promise<Record<string, any>>;
- *   server_data_promise: Promise<import('types').JSONObject | null>;
+ *   server_data_promise: Promise<Record<string, any> | null>;
  *   state: import('types').SSRState;
  * }} opts
  */
@@ -70,7 +70,7 @@ export async function load_data({ event, fetcher, node, parent, server_data_prom
 
 /** @param {Record<string, any>} object */
 async function unwrap_promises(object) {
-	/** @type {import('types').JSONObject} */
+	/** @type {Record<string, any>} */
 	const unwrapped = {};
 
 	for (const key in object) {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -86,7 +86,7 @@ export async function render_response({
 			/** @type {import('types').Page} */
 			page: {
 				error,
-				params: event.params,
+				params: /** @type {Record<string, any>} */ (event.params),
 				routeId: event.routeId,
 				status,
 				url: state.prerendering ? new PrerenderingURL(event.url) : event.url,

--- a/packages/kit/src/runtime/server/page/types.d.ts
+++ b/packages/kit/src/runtime/server/page/types.d.ts
@@ -1,4 +1,4 @@
-import { JSONValue, ResponseHeaders, SSRNode, CspDirectives } from 'types';
+import { ResponseHeaders, SSRNode, CspDirectives } from 'types';
 import { HttpError } from '../../../index/private';
 
 export interface Fetched {
@@ -21,7 +21,7 @@ export interface FetchState {
 export type Loaded = {
 	node: SSRNode;
 	data: Record<string, any> | null;
-	server_data: JSONValue;
+	server_data: any;
 };
 
 type CspMode = 'hash' | 'nonce' | 'auto';

--- a/packages/kit/src/utils/escape.js
+++ b/packages/kit/src/utils/escape.js
@@ -37,7 +37,7 @@ const render_json_payload_script_regex = new RegExp(
  * Attribute names must be type-checked so we don't need to escape them.
  *
  * @param {import('types').PayloadScriptAttributes} attrs A list of attributes to be added to the element.
- * @param {import('types').JSONValue} payload The data to be carried by the element. Must be serializable to JSON.
+ * @param {any} payload The data to be carried by the element. Must be serializable to JSON.
  * @returns {string} The raw HTML of a script element carrying the JSON payload.
  * @example const html = render_json_payload_script({ type: 'data', url: '/data.json' }, { foo: 'bar' });
  */

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -194,18 +194,18 @@ export interface HandleError {
  * rather than using `Load` directly.
  */
 export interface Load<
-	Params extends Record<string, string> = Record<string, string>,
+	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
 	InputData extends JSONObject | null = JSONObject | null,
-	ParentData extends Record<string, any> | null = Record<string, any> | null,
+	ParentData extends Record<string, any> = Record<string, any>,
 	OutputData extends Record<string, any> = Record<string, any>
 > {
 	(event: LoadEvent<Params, InputData, ParentData>): MaybePromise<OutputData | void>;
 }
 
 export interface LoadEvent<
-	Params extends Record<string, string> = Record<string, string>,
+	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
 	Data extends JSONObject | null = JSONObject | null,
-	ParentData extends Record<string, any> | null = Record<string, any> | null
+	ParentData extends Record<string, any> = Record<string, any>
 > {
 	fetch(info: RequestInfo, init?: RequestInit): Promise<Response>;
 	params: Params;
@@ -235,7 +235,9 @@ export interface ParamMatcher {
 	(param: string): boolean;
 }
 
-export interface RequestEvent<Params extends Record<string, string> = Record<string, string>> {
+export interface RequestEvent<
+	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>
+> {
 	clientAddress: string;
 	locals: App.Locals;
 	params: Params;
@@ -295,21 +297,23 @@ export interface SSRManifest {
  * rather than using `ServerLoad` directly.
  */
 export interface ServerLoad<
-	Params extends Record<string, string> = Record<string, string>,
-	ParentData extends JSONObject | null = JSONObject | null,
+	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
+	ParentData extends JSONObject = JSONObject,
 	OutputData extends JSONObject | void = JSONObject | void
 > {
 	(event: ServerLoadEvent<Params, ParentData>): MaybePromise<OutputData | void>;
 }
 
 export interface ServerLoadEvent<
-	Params extends Record<string, string> = Record<string, string>,
-	ParentData extends JSONObject | null = JSONObject | null
+	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
+	ParentData extends JSONObject = JSONObject
 > extends RequestEvent<Params> {
 	parent: () => Promise<ParentData>;
 }
 
-export interface Action<Params extends Record<string, string> = Record<string, string>> {
+export interface Action<
+	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>
+> {
 	(event: RequestEvent<Params>): MaybePromise<
 		| { status?: number; errors: Record<string, string>; location?: never }
 		| { status?: never; errors?: never; location: string }

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -7,8 +7,6 @@ import { CompileOptions } from 'svelte/types/compiler/interfaces';
 import {
 	AdapterEntry,
 	CspDirectives,
-	JSONObject,
-	JSONValue,
 	Logger,
 	MaybePromise,
 	Prerendered,
@@ -195,16 +193,16 @@ export interface HandleError {
  */
 export interface Load<
 	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
-	InputData extends JSONObject | null = JSONObject | null,
+	InputData extends Record<string, any> | null = Record<string, any> | null,
 	ParentData extends Record<string, any> = Record<string, any>,
-	OutputData extends Record<string, any> = Record<string, any>
+	OutputData extends Record<string, any> | void = Record<string, any> | void
 > {
-	(event: LoadEvent<Params, InputData, ParentData>): MaybePromise<OutputData | void>;
+	(event: LoadEvent<Params, InputData, ParentData>): MaybePromise<OutputData>;
 }
 
 export interface LoadEvent<
 	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
-	Data extends JSONObject | null = JSONObject | null,
+	Data extends Record<string, any> | null = Record<string, any> | null,
 	ParentData extends Record<string, any> = Record<string, any>
 > {
 	fetch(info: RequestInfo, init?: RequestInit): Promise<Response>;
@@ -262,10 +260,6 @@ export interface ResolveOptions {
 	transformPageChunk?: (input: { html: string; done: boolean }) => MaybePromise<string | undefined>;
 }
 
-export type ResponseBody = JSONValue | Uint8Array | ReadableStream | Error;
-
-export { JSONObject };
-
 export class Server {
 	constructor(manifest: SSRManifest);
 	init(options: ServerInitOptions): void;
@@ -300,15 +294,15 @@ export interface SSRManifest {
  */
 export interface ServerLoad<
 	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
-	ParentData extends JSONObject = JSONObject,
-	OutputData extends JSONObject | void = JSONObject | void
+	ParentData extends Record<string, any> = Record<string, any>,
+	OutputData extends Record<string, any> | void = Record<string, any> | void
 > {
-	(event: ServerLoadEvent<Params, ParentData>): MaybePromise<OutputData | void>;
+	(event: ServerLoadEvent<Params, ParentData>): MaybePromise<OutputData>;
 }
 
 export interface ServerLoadEvent<
 	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
-	ParentData extends JSONObject = JSONObject
+	ParentData extends Record<string, any> = Record<string, any>
 > extends RequestEvent<Params> {
 	parent: () => Promise<ParentData>;
 }

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -264,6 +264,8 @@ export interface ResolveOptions {
 
 export type ResponseBody = JSONValue | Uint8Array | ReadableStream | Error;
 
+export { JSONObject };
+
 export class Server {
 	constructor(manifest: SSRManifest);
 	init(options: ServerInitOptions): void;

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -26,15 +26,6 @@ export interface AdapterEntry {
 	}) => MaybePromise<void>;
 }
 
-// TODO is this still used?
-export type BodyValidator<T> = {
-	[P in keyof T]: T[P] extends { [k: string]: unknown }
-		? BodyValidator<T[P]> // recurse when T[P] is an object
-		: T[P] extends BigInt | Function | Symbol
-		? never
-		: T[P];
-};
-
 // Based on https://github.com/josh-hemphill/csp-typed-directives/blob/latest/src/csp.types.ts
 //
 // MIT License
@@ -145,20 +136,6 @@ export interface CspDirectives {
 
 export type HttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
-export interface JSONObject {
-	[key: string]: JSONValue;
-}
-
-export type JSONValue =
-	| string
-	| number
-	| boolean
-	| null
-	| undefined
-	| ToJSON
-	| JSONValue[]
-	| JSONObject;
-
 export interface Logger {
 	(msg: string): void;
 	success(msg: string): void;
@@ -227,10 +204,6 @@ export interface RouteSegment {
 	content: string;
 	dynamic: boolean;
 	rest: boolean;
-}
-
-export interface ToJSON {
-	toJSON(...args: any[]): Exclude<JSONValue, ToJSON>;
 }
 
 export type TrailingSlash = 'never' | 'always' | 'ignore';


### PR DESCRIPTION
Fixes #5963, closes #5940 (by introducing the event types, which make proxy generation unnecessary if you use them)

- Tightens up the `Params` type in most places: It's `Partial<Record<string, any>>` for the generic type because if you don't type it, you don't know which values are on there. It's also needed in case of layouts where params could be present or not present dependening on the child route. This may be a breaking change for people using strict mode, not having explicitly typed the params generic, and accessing it without checking if it's defined.
- Adds event types for the load functions and the `RequestHandler`. Example: `export function load(params: PageLoadEvent) {..}` - this makes the generation of proxy JS files unnecessary (proxy files only update on file save and when sync/dev is running, which can be confusing) (#5940)
- Remove `JSONObject` because of the type limitations we encountered (#5963). If we use other serialization-methods later, it would be obsolete anyway
- Adds generics for the output to the generated load function types, so you can do this: `export const load: PageLoad<MyOutput> = ..`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
