### PR TITLE
chore: give verbose names to form args "e"

### DIFF
--- a/.changeset/chilled-years-smash.md
+++ b/.changeset/chilled-years-smash.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+make variable names more descriptive

--- a/packages/create-svelte/templates/default/src/lib/form.ts
+++ b/packages/create-svelte/templates/default/src/lib/form.ts
@@ -60,11 +60,11 @@ export function enhance(
 ) {
 	let current_token: unknown;
 
-	/** @param {SubmitEvent} e */
-	async function handle_submit(e: SubmitEvent) {
+	/** @param {SubmitEvent} event */
+	async function handle_submit(event: SubmitEvent) {
 		const token = (current_token = {});
 
-		e.preventDefault();
+		event.preventDefault();
 
 		const data = new FormData(form);
 
@@ -92,11 +92,11 @@ export function enhance(
 			} else {
 				console.error(await response.text());
 			}
-		} catch (e: unknown) {
-			if (error && e instanceof Error) {
-				error({ data, form, error: e, response: null });
+		} catch (err: unknown) {
+			if (error && err instanceof Error) {
+				error({ data, form, error: err, response: null });
 			} else {
-				throw e;
+				throw err;
 			}
 		}
 	}


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

This update does not quite change or add any functionality, but aims at improving the readability of the `form.ts` file from the default create-svelte app. I noticed `e` was used as the event argument, and then later in the same handler as an error variable. To me this was a bit confusing to read and it does not appear to hold significant value with a shorter variable name. For newcomers this can be off-putting or confusing reading multiple variables with the same name in the same function (despite block scoping)

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
