### PR TITLE
add types for config.package so the docs build

### DIFF
--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -107,7 +107,13 @@ export interface Config {
 	extensions?: string[];
 	kit?: KitConfig;
 	preprocess?: any;
-	package?: any;
+	package?: {
+		source?: string;
+		dir?: string;
+		emitTypes?: boolean;
+		exports?: (filepath: string) => boolean;
+		files?: (filepath: string) => boolean;
+	};
 	[key: string]: any;
 }
 


### PR DESCRIPTION
these types arguably don't belong in `@sveltejs/kit` but for now it's where they live, and it probably makes sense to provide them. more importantly, it gets the site building again