### PR TITLE
[fix] set `status` to 303 when POST provides a `location`

### DIFF
--- a/.changeset/gentle-news-shout.md
+++ b/.changeset/gentle-news-shout.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fixes #5976

--- a/.changeset/gentle-news-shout.md
+++ b/.changeset/gentle-news-shout.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fixes #5976
+Return a 303 response when a `POST` handler provides a `location`

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -77,7 +77,7 @@ export async function render_page(event, route, options, state, resolve_opts) {
 					}
 
 					if (event.request.method === 'POST' && result?.location) {
-						return redirect_response(status, result.location);
+						return redirect_response(303, result.location);
 					}
 				} else {
 					event.setHeaders({

--- a/packages/kit/test/apps/basics/src/routes/shadowed/post-success-redirect/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/shadowed/post-success-redirect/+page.server.js
@@ -1,0 +1,5 @@
+export function POST() {
+	return {
+		location: '/shadowed/post-success-redirect/redirected'
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/shadowed/post-success-redirect/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shadowed/post-success-redirect/+page.svelte
@@ -1,0 +1,3 @@
+<form method="POST">
+	<button>Click me</button>
+</form>

--- a/packages/kit/test/apps/basics/src/routes/shadowed/post-success-redirect/redirected/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shadowed/post-success-redirect/redirected/+page.svelte
@@ -1,0 +1,1 @@
+<h1>POST was successful</h1>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -188,6 +188,12 @@ test.describe('Shadowed pages', () => {
 		);
 	});
 
+	test('Handles POST success with returned location', async ({ page }) => {
+		await page.goto('/shadowed/post-success-redirect');
+		await Promise.all([page.waitForNavigation(), page.click('button')]);
+		expect(await page.textContent('h1')).toBe('POST was successful');
+	});
+
 	test('Renders error page for 4xx and 5xx responses from GET', async ({ page, clicknav }) => {
 		await page.goto('/shadowed');
 		await clicknav('[href="/shadowed/error-get"]');


### PR DESCRIPTION
Closes #5976

Sets status to 303 when a POST handler returns a location.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
