### PR TITLE
[chore] remove chokidar as dependency of kit

### DIFF
--- a/.changeset/twenty-numbers-breathe.md
+++ b/.changeset/twenty-numbers-breathe.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+[chore] remove chokidar as dependency of kit

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -11,7 +11,6 @@
 	"type": "module",
 	"dependencies": {
 		"@sveltejs/vite-plugin-svelte": "^1.0.1",
-		"chokidar": "^3.5.3",
 		"cookie": "^0.5.0",
 		"devalue": "^2.0.1",
 		"kleur": "^4.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,7 +277,6 @@ importers:
       '@types/node': ^16.11.36
       '@types/sade': ^1.7.4
       '@types/set-cookie-parser': ^2.4.2
-      chokidar: ^3.5.3
       cookie: ^0.5.0
       devalue: ^2.0.1
       kleur: ^4.1.4
@@ -298,7 +297,6 @@ importers:
       vite: 3.0.2
     dependencies:
       '@sveltejs/vite-plugin-svelte': 1.0.1_svelte@3.48.0+vite@3.0.2
-      chokidar: 3.5.3
       cookie: 0.5.0
       devalue: 2.0.1
       kleur: 4.1.5


### PR DESCRIPTION
Now that `svelte-kit package` is no longer a part of core SvelteKit, it no longer needs `chokidar` as a dependency.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
