### PR TITLE
Prerendered server redirects

### DIFF
--- a/.changeset/gorgeous-snakes-pretend.md
+++ b/.changeset/gorgeous-snakes-pretend.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Generate \_\_data.json files for server-side redirects when prerendering

--- a/.changeset/gorgeous-snakes-pretend.md
+++ b/.changeset/gorgeous-snakes-pretend.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Generate \_\_data.json files for server-side redirects when prerendering
+Generate `__data.json` files for server-side redirects when prerendering

--- a/packages/kit/test/prerendering/basics/src/routes/redirect-server/+page.server.js
+++ b/packages/kit/test/prerendering/basics/src/routes/redirect-server/+page.server.js
@@ -1,0 +1,6 @@
+import { redirect } from '@sveltejs/kit';
+
+/** @type {import('@sveltejs/kit').Load} */
+export function load() {
+	throw redirect(301, 'https://example.com/redirected');
+}

--- a/packages/kit/test/prerendering/basics/test/test.js
+++ b/packages/kit/test/prerendering/basics/test/test.js
@@ -21,6 +21,20 @@ test('renders a redirect', () => {
 	);
 });
 
+test('renders a server-side redirect', () => {
+	const html = read('redirect-server.html');
+	assert.equal(html, '<meta http-equiv="refresh" content="0;url=https://example.com/redirected">');
+
+	const json = read('redirect-server/__data.json');
+	assert.equal(
+		json,
+		JSON.stringify({
+			type: 'redirect',
+			location: 'https://example.com/redirected'
+		})
+	);
+});
+
 test('does not double-encode redirect locations', () => {
 	const content = read('redirect-encoded.html');
 	assert.equal(


### PR DESCRIPTION
Fixes the docs (currently if you client-side-nav to `/docs`, it hangs)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
