### PR TITLE
[fix] correct parent data type for layouts

### DIFF
--- a/.changeset/wise-berries-pay.md
+++ b/.changeset/wise-berries-pay.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix parent data type for layouts referencing named layouts in the same folder

--- a/packages/kit/src/core/sync/write_types.spec.js
+++ b/packages/kit/src/core/sync/write_types.spec.js
@@ -160,6 +160,14 @@ test('Finds nearest layout (named)', () => {
 	});
 });
 
+test('Finds nearest named layout from layout', () => {
+	assert.equal(find_nearest_layout('src/routes', nodes, 1), {
+		key: '',
+		folder_depth_diff: 0,
+		name: ''
+	});
+});
+
 test('Finds nearest layout (recursively named)', () => {
 	assert.equal(find_nearest_layout('src/routes', nodes, 3), {
 		key: '',


### PR DESCRIPTION
Was wrong if a layout referenced a named layout in the same folder
Fixes #6013

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
