### PR TITLE
OPTIONS http method Added

### DIFF
--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -66,7 +66,9 @@ export async function render_page(event, route, options, state, resolve_opts) {
 			// for non-GET requests, first call handler in +page.server.js
 			// (this also determines status code)
 			try {
-				const method = /** @type {'POST' | 'PATCH' | 'PUT' | 'DELETE'} */ (event.request.method);
+				const method = /** @type {'POST' | 'PATCH' | 'PUT' | 'DELETE' | 'OPTIONS'} */ (
+					event.request.method
+				);
 				const handler = leaf_node.server[method];
 				if (handler) {
 					const result = await handler.call(null, event);

--- a/packages/kit/test/apps/basics/src/routes/endpoint-output/options/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-output/options/+server.js
@@ -1,0 +1,6 @@
+import { json } from '@sveltejs/kit';
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export function OPTIONS() {
+	return json({});
+}

--- a/packages/kit/test/apps/basics/src/routes/shadowed/simple/options/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/shadowed/simple/options/+page.server.js
@@ -1,0 +1,2 @@
+/** @type {import('./$types').Action} */
+export function OPTIONS() {}

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -50,7 +50,7 @@ test.describe('Endpoints', () => {
 	});
 
 	test('OPTIONS request', async ({ request }) => {
-		const url = '/endpoint-output/body';
+		const url = '/endpoint-output/options';
 
 		var response = await request.fetch(url, {
 			method: 'OPTIONS'

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -49,6 +49,17 @@ test.describe('Endpoints', () => {
 		expect(headers.head).toEqual(headers.get);
 	});
 
+	test('OPTIONS request', async ({ request }) => {
+		const url = '/endpoint-output/body';
+
+		var response = await request.fetch(url, {
+			method: 'OPTIONS'
+		});
+
+		expect(response.status()).toBe(200);
+		expect(response.text()).toBe('{}');
+	});
+
 	// TODO all the remaining tests in this section are really only testing
 	// setResponse, since we're not otherwise changing anything on the response.
 	// might be worth making these unit tests instead

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -220,6 +220,7 @@ export interface SSRNode {
 		PATCH?: Action;
 		PUT?: Action;
 		DELETE?: Action;
+		OPTIONS?: Action;
 	};
 }
 


### PR DESCRIPTION
Fixed #5193

Formatted using `pnpm format`

- [ issue #5193 ] 
- [ server.test.js has a test] Ideally, include a test that fails without this PR but passes with it.
- [I ran the tests] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- [no such changes ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
