### PR TITLE
fix: prevent optimizeDeps for @sveltejs/kit

### DIFF
--- a/.changeset/famous-boxes-tap.md
+++ b/.changeset/famous-boxes-tap.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+prevent duplicate module ids by disabling optimizeDeps for @sveltejs/kit

--- a/packages/kit/src/vite/build/utils.js
+++ b/packages/kit/src/vite/build/utils.js
@@ -123,6 +123,9 @@ export function get_default_build_config({ config, input, ssr, outDir }) {
 		resolve: {
 			alias: get_aliases(config.kit)
 		},
+		optimizeDeps: {
+			exclude: ['@sveltejs/kit']
+		},
 		ssr: {
 			noExternal: ['@sveltejs/kit']
 		},

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -273,7 +273,10 @@ function kit() {
 					// under different IDs, which breaks a bunch of stuff
 					// https://github.com/vitejs/vite/pull/9296
 					external: ['@sveltejs/kit']
-				}
+				},
+				optimizeDeps: {
+					exclude: ['@sveltejs/kit']
+				},
 			};
 
 			deferred_warning = warn_overridden_config(config, result);

--- a/packages/kit/src/vite/index.js
+++ b/packages/kit/src/vite/index.js
@@ -276,7 +276,7 @@ function kit() {
 				},
 				optimizeDeps: {
 					exclude: ['@sveltejs/kit']
-				},
+				}
 			};
 
 			deferred_warning = warn_overridden_config(config, result);


### PR DESCRIPTION
part of solution for https://github.com/sveltejs/kit/issues/5952

see https://github.com/sveltejs/kit/issues/5952#issuecomment-1218844057, where some of the ids mentioned are in `.vite` and the `?v=hash` query is also a sign

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
