### PR TITLE
[fix] Generate types when Svelte file missing

### DIFF
--- a/.changeset/ninety-vans-talk.md
+++ b/.changeset/ninety-vans-talk.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Generate types when Svelte file missing, fix layout params

--- a/packages/kit/src/core/sync/write_types.js
+++ b/packages/kit/src/core/sync/write_types.js
@@ -162,10 +162,11 @@ function get_groups(manifest_data, routes_dir) {
 		/** @type {Node} */
 		const node = { ...nodes[i] }; // shallow copy so we don't mutate the original when setting parent
 
+		const file_path = /** @type {string} */ (node.component ?? node.shared ?? node.server);
 		// skip default layout/error
-		if (!node?.component?.startsWith(routes_dir)) continue;
+		if (!file_path.startsWith(routes_dir)) continue;
 
-		const parts = /** @type {string} */ (node.component ?? node.shared ?? node.server).split('/');
+		const parts = file_path.split('/');
 
 		const file = /** @type {string} */ (parts.pop());
 		const dir = parts.join('/').slice(routes_dir.length + 1);
@@ -284,7 +285,7 @@ function write_types_for_dir(config, manifest_data, routes_dir, dir, groups, ts)
 		manifest_data.routes.forEach((route) => {
 			if (route.type === 'page' && route.id.startsWith(dir + '/')) {
 				// TODO this is O(n^2), see if we need to speed it up
-				for (const name of parse_route_id(route.id).names) {
+				for (const name of parse_route_id(route.id.slice(dir.length + 1)).names) {
 					layout_params.add(name);
 				}
 			}


### PR DESCRIPTION
Fixes #6044
Also fixes layout params. They wrongfully contained the slugs above them, too.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
