### PR TITLE
Remove use of `[].at(-1)` in client code

### DIFF
--- a/.changeset/lazy-ants-watch.md
+++ b/.changeset/lazy-ants-watch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Avoid using [].at(-1) in the client

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -345,7 +345,7 @@ export function create_client({ target, base, trailing_slash }) {
 			page = navigation_result.props.page;
 		}
 
-		const leaf_node = navigation_result.state.branch.at(-1);
+		const leaf_node = navigation_result.state.branch[navigation_result.state.branch.length - 1];
 		router_enabled = leaf_node?.node.shared?.router !== false;
 
 		if (callback) callback();


### PR DESCRIPTION
Fixes #6080. Not sure if we need a more comprehensive approach to preventing these sorts of things from slipping in, but for now I think the easiest thing is just to remove it.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
