### PR TITLE
[fix] add test folder to includes

### DIFF
--- a/.changeset/hot-lions-cough.md
+++ b/.changeset/hot-lions-cough.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Add notes about includes/excludes and path aliases

--- a/.changeset/warm-pots-melt.md
+++ b/.changeset/warm-pots-melt.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add test folder to generated tsconfig

--- a/packages/create-svelte/shared/+checkjs/jsconfig.json
+++ b/packages/create-svelte/shared/+checkjs/jsconfig.json
@@ -10,4 +10,8 @@
 		"sourceMap": true,
 		"strict": true
 	}
+	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias and https://kit.svelte.dev/docs/configuration#files
+	//
+	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
+	// from the referenced tsconfig.json - TypeScript does not merge them in
 }

--- a/packages/create-svelte/shared/+typescript/tsconfig.json
+++ b/packages/create-svelte/shared/+typescript/tsconfig.json
@@ -10,7 +10,7 @@
 		"sourceMap": true,
 		"strict": true
 	}
-	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias and https://kit.svelte.dev/docs/configuration#files
+	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
 	//
 	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
 	// from the referenced tsconfig.json - TypeScript does not merge them in

--- a/packages/create-svelte/shared/+typescript/tsconfig.json
+++ b/packages/create-svelte/shared/+typescript/tsconfig.json
@@ -10,4 +10,8 @@
 		"sourceMap": true,
 		"strict": true
 	}
+	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias and https://kit.svelte.dev/docs/configuration#files
+	//
+	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
+	// from the referenced tsconfig.json - TypeScript does not merge them in
 }

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -55,7 +55,7 @@ export function write_tsconfig(config, cwd = process.cwd()) {
 	}
 	// Test folder is a special case - we advocate putting tests in a top-level test folder
 	// and it's not configurable (should we make it?)
-	const test_folder = project_relative('test');
+	const test_folder = project_relative('tests');
 	include.push(config_relative(`${test_folder}/**/*.js`));
 	include.push(config_relative(`${test_folder}/**/*.ts`));
 	include.push(config_relative(`${test_folder}/**/*.svelte`));

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -53,6 +53,12 @@ export function write_tsconfig(config, cwd = process.cwd()) {
 		include.push(config_relative(`${relative}/**/*.ts`));
 		include.push(config_relative(`${relative}/**/*.svelte`));
 	}
+	// Test folder is a special case - we advocate putting tests in a top-level test folder
+	// and it's not configurable (should we make it?)
+	const test_folder = project_relative('test');
+	include.push(config_relative(`${test_folder}/**/*.js`));
+	include.push(config_relative(`${test_folder}/**/*.ts`));
+	include.push(config_relative(`${test_folder}/**/*.svelte`));
 
 	write_if_changed(
 		out,


### PR DESCRIPTION
Also add some notes to tsconfig/jsonfig
Fixes #5833

I briefly thought about making this configurable through `kit.files`, but didn't do so because only the tsconfig includes generation would benefit from it - you'd still need to update the package.json scripts yourself.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
