### PR TITLE
[docs] fold alias FAQ into alias docs

### DIFF
--- a/documentation/docs/15-configuration.md
+++ b/documentation/docs/15-configuration.md
@@ -120,6 +120,8 @@ const config = {
 
 > The built-in `$lib` alias is controlled by `config.kit.files.lib` as it is used for packaging.
 
+> You will need to run `npm run dev` to have SvelteKit automatically generate the required alias configuration in `jsconfig.json` or `tsconfig.json`.
+
 ### appDir
 
 The directory relative to `paths.assets` where the built JS and CSS (and imported assets) are served from. (The filenames therein contain content-based hashes, meaning they can be cached indefinitely). Must not start or end with `/`.

--- a/documentation/faq/50-aliases.md
+++ b/documentation/faq/50-aliases.md
@@ -1,7 +1,0 @@
----
-title: How do I setup a path alias?
----
-
-Aliases can be set in `svelte.config.js` as described in the [`configuration`](/docs/configuration#alias) docs.
-
-Then run `npm run prepare` or `npm run dev` (both will execute a sync command). SvelteKit will automatically generate the required alias configuration in `jsconfig.json` or `tsconfig.json`.


### PR DESCRIPTION
this FAQ was originally about Vite stuff, but now that it's about SvelteKit it should probably just live in the main docs