### PR TITLE
[FIX] Use the 'browser' platform setting for esbuild for Vercel Edge Functions

### DIFF
--- a/.changeset/wet-crews-smoke.md
+++ b/.changeset/wet-crews-smoke.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+Use `platform: 'browser'` for esbuild in Vercel Edge Functions.

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -186,7 +186,7 @@ export default function ({ external = [], edge, split } = {}) {
 					outfile: `${dirs.functions}/${name}.func/index.js`,
 					target: 'es2020', // TODO verify what the edge runtime supports
 					bundle: true,
-					platform: 'node',
+					platform: 'browser',
 					format: 'esm',
 					external,
 					sourcemap: 'linked'


### PR DESCRIPTION
This should use the same esbuild platform setting as the Cloudflare adapter, as Vercel Edge Functions are based on Cloudflare Workers. I discovered this issue while using the Supabase JS client.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
