### PR TITLE
Object is serializabie when has toJSON function

### DIFF
--- a/.changeset/cuddly-rats-impress.md
+++ b/.changeset/cuddly-rats-impress.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Make check_serializability more adaptable for objects that have the toJSON method

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -114,6 +114,7 @@ function check_serializability(value, id, path) {
 		}
 
 		// ...and objects
+		if (typeof value.toJSON === 'function') return;
 		const tag = Object.prototype.toString.call(value);
 		if (tag === '[object Object]') {
 			for (const key in value) {


### PR DESCRIPTION
#6093 

Some objects like Prisma Decimal that has toJSON function should be serializable.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#tojson_behavior

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
