### PR TITLE
override prompts with command line arguments

### DIFF
--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -24,6 +24,7 @@ async function main() {
 	console.log(disclaimer);
 
 	let cwd = process.argv[2] || '.';
+	if (cwd.startsWith('--')) cwd = '.';
 
 	/**
 	 * @typedef {object} params

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -24,15 +24,39 @@ async function main() {
 	console.log(disclaimer);
 
 	let cwd = process.argv[2] || '.';
-	const args = await yargs(hideBin(process.argv)).argv;
+
+	/**
+	 * @typedef {object} params
+	 * @property {string} $0
+	 * @property {(string|number)[]} _
+	 * @property {string=} template
+	 * @property {string=} types
+	 * @property {string=} eslint
+	 * @property {string=} prettier
+	 * @property {string=} playwright
+	 * @property {string=} overwrite
+	 */
+	/** @type {params} */
+	const params = await yargs(hideBin(process.argv)).argv;
 
 	const overrides = Object.fromEntries([
-		...(args?.template === undefined ? [] : [['template', fs.readdirSync(dist('templates')).includes(args?.template) ? args?.template : 'default']]),
-		...(args?.types === undefined ? [] : [['types', ['checkjs', 'typescript'].includes(args?.types) ? args?.types : null]]),
-		...(args?.eslint === undefined ? [] : [['eslint', args?.eslint === 'true']]),
-		...(args?.prettier === undefined ? [] : [['prettier', args?.prettier === 'true']]),
-		...(args?.playwright === undefined ? [] : [['playwright', args?.playwright === 'true']]),
-		...(args?.overwrite === undefined ? [] : [['overwrite', args?.overwrite === 'true']])
+		...(params?.template === undefined
+			? []
+			: [
+					[
+						'template',
+						fs.readdirSync(dist('templates')).includes(params?.template)
+							? params?.template
+							: 'default'
+					]
+			  ]),
+		...(params?.types === undefined
+			? []
+			: [['types', ['checkjs', 'typescript'].includes(params?.types) ? params?.types : null]]),
+		...(params?.eslint === undefined ? [] : [['eslint', params?.eslint === 'true']]),
+		...(params?.prettier === undefined ? [] : [['prettier', params?.prettier === 'true']]),
+		...(params?.playwright === undefined ? [] : [['playwright', params?.playwright === 'true']]),
+		...(params?.overwrite === undefined ? [] : [['overwrite', params?.overwrite === 'true']])
 	]);
 	prompts.override(overrides);
 

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -12,7 +12,8 @@
 	"main": "./index.js",
 	"dependencies": {
 		"kleur": "^4.1.4",
-		"prompts": "^2.4.2"
+		"prompts": "^2.4.2",
+		"yargs": "^17.5.1"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.25.0",
@@ -20,6 +21,7 @@
 		"@types/gitignore-parser": "^0.0.0",
 		"@types/prettier": "^2.6.3",
 		"@types/prompts": "^2.0.14",
+		"@types/yargs": "^17.0.11",
 		"gitignore-parser": "^0.0.2",
 		"prettier": "^2.6.2",
 		"prettier-plugin-svelte": "^2.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,7 @@ importers:
       '@types/gitignore-parser': ^0.0.0
       '@types/prettier': ^2.6.3
       '@types/prompts': ^2.0.14
+      '@types/yargs': ^17.0.11
       gitignore-parser: ^0.0.2
       kleur: ^4.1.4
       prettier: ^2.6.2
@@ -219,15 +220,18 @@ importers:
       svelte-preprocess: ^4.10.6
       tiny-glob: ^0.2.9
       uvu: ^0.5.3
+      yargs: ^17.5.1
     dependencies:
       kleur: 4.1.5
       prompts: 2.4.2
+      yargs: 17.5.1
     devDependencies:
       '@playwright/test': 1.25.0
       '@sveltejs/kit': link:../kit
       '@types/gitignore-parser': 0.0.0
       '@types/prettier': 2.6.3
       '@types/prompts': 2.0.14
+      '@types/yargs': 17.0.11
       gitignore-parser: 0.0.2
       prettier: 2.7.1
       prettier-plugin-svelte: 2.7.0_nakrehnrzdf7fdea5k3a4dfy4m
@@ -1146,6 +1150,16 @@ packages:
       '@types/node': 16.11.42
     dev: true
 
+  /@types/yargs-parser/21.0.0:
+    resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
+    dev: true
+
+  /@types/yargs/17.0.11:
+    resolution: {integrity: sha512-aB4y9UDUXTSMxmM4MH+YnuR0g5Cph3FLQBoWoMB21DSvFVAxRVEHEMx3TLh+zUZYMCQtKiqazz0Q4Rre31f/OA==}
+    dependencies:
+      '@types/yargs-parser': 21.0.0
+    dev: true
+
   /@typescript/twoslash/3.1.0:
     resolution: {integrity: sha512-kTwMUQ8xtAZaC4wb2XuLkPqFVBj2dNBueMQ89NWEuw87k2nLBbuafeG5cob/QEr6YduxIdTVUjix0MtC7mPlmg==}
     dependencies:
@@ -1242,7 +1256,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
   /any-promise/1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -1496,7 +1509,6 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-    dev: true
 
   /clone/1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -1519,7 +1531,6 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name/1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
@@ -1527,7 +1538,6 @@ packages:
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
 
   /color-string/1.9.1:
     resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
@@ -2012,7 +2022,6 @@ packages:
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
-    dev: true
 
   /escape-string-regexp/1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
@@ -2227,7 +2236,6 @@ packages:
   /get-caller-file/2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
-    dev: true
 
   /get-intrinsic/1.1.2:
     resolution: {integrity: sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==}
@@ -3493,7 +3501,6 @@ packages:
   /require-directory/2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /require-main-filename/1.0.1:
     resolution: {integrity: sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==}
@@ -4605,7 +4612,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
 
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -4621,7 +4627,6 @@ packages:
   /y18n/5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
-    dev: true
 
   /yallist/2.1.2:
     resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
@@ -4646,7 +4651,6 @@ packages:
   /yargs-parser/21.0.1:
     resolution: {integrity: sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==}
     engines: {node: '>=12'}
-    dev: true
 
   /yargs-parser/7.0.0:
     resolution: {integrity: sha512-WhzC+xgstid9MbVUktco/bf+KJG+Uu6vMX0LN1sLJvwmbCQVxb4D8LzogobonKycNasCZLdOzTAk1SK7+K7swg==}
@@ -4695,7 +4699,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.0.1
-    dev: true
 
   /yargs/8.0.2:
     resolution: {integrity: sha512-3RiZrpLpjrzIAKgGdPktBcMP/eG5bDFlkI+PHle1qwzyVXyDQL+pD/eZaMoOOO0Y7LLBfjpucObuUm/icvbpKQ==}


### PR DESCRIPTION
This adds support for automatically answering the interactive prompts in environments where manual entry is not possible; e.g. scripts, batch runs, etc.

### Before
`npm create svelte@latest project_directory`

### After
`npm create svelte@latest project_directory --template=skeleton --types=typescript --eslint=true --prettier=true --playwright=true --overwrite=true`

> ## All arguments are optional.

- **--template=** `default`, `libskeleton`, or `skeleton`
<img width="1136" alt="Screen Shot 2022-08-20 at 5 39 39 AM" src="https://user-images.githubusercontent.com/20136585/185746862-963d5ffa-bc63-4c4e-bb08-48ae489518a6.png">

- **--types=** `checkjs` or `typescript`
<img width="1136" alt="Screen Shot 2022-08-20 at 5 39 42 AM" src="https://user-images.githubusercontent.com/20136585/185746859-ed07ce1d-4fbe-43b0-9760-3ab9128fc926.png">

- **--eslint=** `true` or `false`
<img width="1136" alt="Screen Shot 2022-08-20 at 5 39 45 AM" src="https://user-images.githubusercontent.com/20136585/185746852-f79d957e-0e8e-4bde-be8b-17c1fd64d93a.png">

- **--prettier=** `true` or `false`
<img width="1136" alt="Screen Shot 2022-08-20 at 5 39 48 AM" src="https://user-images.githubusercontent.com/20136585/185746843-496a2fd2-9bf8-4c7c-b3ef-2cc07f43462e.png">

- **--playwright=** `true` or `false`
<img width="1136" alt="Screen Shot 2022-08-20 at 5 39 51 AM" src="https://user-images.githubusercontent.com/20136585/185746825-9298d0dc-d7ba-4915-831a-2bf6e1fb84b0.png">

- **--overwrite=** `true` or `false`
<img width="1136" alt="Screen Shot 2022-08-20 at 5 44 22 AM" src="https://user-images.githubusercontent.com/20136585/185746794-5c65cff2-842d-4eb2-ae9b-db27849461ce.png">

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
