### PR TITLE
fix: Add support for vite.config.ts

### DIFF
--- a/.changeset/quiet-comics-crash.md
+++ b/.changeset/quiet-comics-crash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix vite.config.ts "Cannot find module '@sveltejs/kit/vite' or its corresponding type declarations."

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -46,7 +46,7 @@ export function write_tsconfig(config, cwd = process.cwd()) {
 	/** @param {string} file */
 	const config_relative = (file) => posixify(path.relative(config.outDir, file));
 
-	const include = ['ambient.d.ts'];
+	const include = ['ambient.d.ts', config_relative('vite.config.ts')];
 	for (const dir of [config.files.routes, config.files.lib]) {
 		const relative = project_relative(path.dirname(dir));
 		include.push(config_relative(`${relative}/**/*.js`));


### PR DESCRIPTION
When using a vite.config.ts (instead of a vite.config.js) TypeScript generates an error:
```
error TS2307: Cannot find module '@sveltejs/kit/vite' or its corresponding type declarations.

1 import { sveltekit } from "@sveltejs/kit/vite";
                            ~~~~~~~~~~~~~~~~~~~~

Found 1 error in vite.config.ts:1
```

Adding the **vite.config.ts** to the includes fixes this issue.

Also closes #5443

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
