### PR TITLE
[fix] render error page without root layout if that failed to load

### DIFF
--- a/.changeset/silver-buses-suffer.md
+++ b/.changeset/silver-buses-suffer.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] render error page without root layout if that failed to load

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -818,14 +818,19 @@ export function create_client({ target, base, trailing_slash }) {
 		/** @type {Record<string, string>} */
 		const params = {}; // error page does not have params
 
-		const root_layout = await load_node({
-			node: await default_layout,
-			url,
-			params,
-			routeId,
-			parent: () => Promise.resolve({}),
-			server_data: null // TODO!!!!!
-		});
+		let root_layout;
+		try {
+			root_layout = await load_node({
+				node: await default_layout,
+				url,
+				params,
+				routeId,
+				parent: () => Promise.resolve({}),
+				server_data: null // TODO!!!!!
+			});
+		} catch (e) {
+			// Root layout threw an error, we have to ignore it at this point
+		}
 
 		const root_error = {
 			node: await default_error,

--- a/packages/kit/test/apps/basics/src/routes/+layout.js
+++ b/packages/kit/test/apps/basics/src/routes/+layout.js
@@ -6,6 +6,9 @@ export async function load({ fetch, url }) {
 		const res = await fetch('/errors/error-in-layout/non-existent');
 		throw error(res.status);
 	}
+	if (url.searchParams.has('root-error')) {
+		throw error(500, 'Root layout error');
+	}
 
 	return {
 		foo: {

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -305,6 +305,14 @@ test.describe('Errors', () => {
 		);
 		expect(await page.innerHTML('h1')).toBe('401');
 	});
+
+	test('error in root layout renders root error page without layout', async ({ page, app }) => {
+		await page.goto('/');
+		await app.goto('/?root-error');
+		expect(await page.textContent('p')).toBe(
+			'This is your custom error page saying: "Root layout error"'
+		);
+	});
 });
 
 test.describe('Load', () => {

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -167,6 +167,13 @@ test.describe('Errors', () => {
 
 		expect(await page.textContent('h1')).toBe('the answer is 42');
 	});
+
+	test('error in root layout renders root error page without layout', async ({ page }) => {
+		await page.goto('/?root-error');
+		expect(await page.textContent('p')).toBe(
+			'This is your custom error page saying: "Root layout error"'
+		);
+	});
 });
 
 test.describe('Load', () => {


### PR DESCRIPTION
Fixes #4815
Fixes #3068

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
