### PR TITLE
added inline code wrapper

### DIFF
--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -248,7 +248,7 @@ export interface RequestEvent<
 }
 
 /**
- * A `(event: RequestEvent) => Response` function exported from a +server.js file that corresponds to an HTTP verb (`GET`, `PUT`, `PATCH`, etc) and handles requests with that method.
+ * A `(event: RequestEvent) => Response` function exported from a `+server.js` file that corresponds to an HTTP verb (`GET`, `PUT`, `PATCH`, etc) and handles requests with that method.
  *
  * It receives `Params` as the first generic argument, which you can skip by using [generated types](/docs/types#generated-types) instead.
  */


### PR DESCRIPTION
I was reading the docs and saw a missing code wrap on `+server.js`.

| Before Change | After Change |
| - | - |
| ![image](https://user-images.githubusercontent.com/20136585/185929893-ac60639b-51f6-4e64-933c-fa29ea5a92fd.png) | ![image](https://user-images.githubusercontent.com/20136585/185929915-bd23a3b4-676d-4977-8a29-dfaa24ce3e2b.png) |

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
