### PR TITLE
make env properties optional

### DIFF
--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -131,8 +131,8 @@ export interface KitConfig {
 		reportOnly?: CspDirectives;
 	};
 	env?: {
-		dir: string;
-		publicPrefix: string;
+		dir?: string;
+		publicPrefix?: string;
 	};
 	moduleExtensions?: string[];
 	files?: {


### PR DESCRIPTION
A follow-up to #6175

I believe this should be marked as optional, as well as to make it consistent with the other properties

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
