### PR TITLE
Tweaks

### DIFF
--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -3,7 +3,7 @@ import path from 'path';
 import mime from 'mime';
 import { runtime_directory } from '../../utils.js';
 import { posixify } from '../../../utils/filesystem.js';
-import { parse_route_id, is_no_group } from '../../../utils/routing.js';
+import { parse_route_id, affects_path } from '../../../utils/routing.js';
 
 /**
  * @param {{
@@ -247,7 +247,7 @@ function create_routes_and_nodes(cwd, config, fallback) {
 
 			nodes.push(route.leaf);
 
-			const normalized = route.id.split('/').filter(is_no_group).join('/');
+			const normalized = route.id.split('/').filter(affects_path).join('/');
 
 			if (conflicts.has(normalized)) {
 				throw new Error(`${conflicts.get(normalized)} and ${route.id} occupy the same route`);

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -26,7 +26,7 @@ export function parse_route_id(id) {
 			: new RegExp(
 					`^${id
 						.split(/(?:\/|$)/)
-						.filter(is_no_group)
+						.filter(affects_path)
 						.map((segment, i, segments) => {
 							const decoded_segment = decodeURIComponent(segment);
 							// special case — /[...rest]/ could contain zero segments
@@ -89,9 +89,10 @@ export function parse_route_id(id) {
 }
 
 /**
+ * Returns `false` for `(group)` segments
  * @param {string} segment
  */
-export function is_no_group(segment) {
+export function affects_path(segment) {
 	return !/^\([^)]+\)$/.test(segment);
 }
 

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -155,7 +155,7 @@ export interface Respond {
 }
 
 /**
- * Represents a route segement in the app. It can either be an intermediate node
+ * Represents a route segment in the app. It can either be an intermediate node
  * with only layout/error pages, or a leaf, at which point either `page` and `leaf`
  * or `endpoint` is set.
  */


### PR DESCRIPTION
Some very minor follow-up tweaks to #6174 — fixes a typo, and changes the `is_no_group` to `affects_path`, as I tend to find predicates named _for_ something rather than _against_ something end up being more grokkable (i.e. i'm not trying to invert a negative)