### PR TITLE
always create $types.d.ts for a route with layout, leaf or endpoint

### DIFF
--- a/.changeset/small-apples-visit.md
+++ b/.changeset/small-apples-visit.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Always create \$types for a route with a layout, leaf or endpoint

--- a/.changeset/small-apples-visit.md
+++ b/.changeset/small-apples-visit.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Always create \$types for a route with a layout, leaf or endpoint
+Always create `$types` for a route with a layout, leaf or endpoint

--- a/packages/kit/src/core/sync/write_types.js
+++ b/packages/kit/src/core/sync/write_types.js
@@ -112,7 +112,7 @@ function update_types(config, manifest_data, route) {
 		input_files.push(route.endpoint.file);
 	}
 
-	if (input_files.length === 0) return; // nothing to do
+	if (!route.leaf && !route.layout && !route.endpoint) return; // nothing to do
 
 	try {
 		fs.mkdirSync(outdir, { recursive: true });


### PR DESCRIPTION
Introduced a bug in #6174 — a route without a `+page|layout[.server].js` or `+server.js` wouldn't have `$types.d.ts` created for it, even though that file would be referenced by a child route that inherited from it. This is the correct check.

No test added because it was already causing failures (at a loss as to how it snuck through CI previously, but 🤷)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
