### PR TITLE
[docs] update asset docs

### DIFF
--- a/documentation/docs/18-assets.md
+++ b/documentation/docs/18-assets.md
@@ -2,7 +2,7 @@
 title: Asset handling
 ---
 
-### Importing
+### Caching and inlining
 
 [Vite will automatically process imported assets](https://vitejs.dev/guide/assets.html) for improved performance. Hashes will be added to the filenames so that they can be cached and assets smaller than `assetsInlineLimit` will be inlined.
 
@@ -14,7 +14,7 @@ title: Asset handling
 <img alt="The project logo" src={logo} />
 ```
 
-If you prefer to reference assets directly in the markup, you can use a preprocessor such as [svelte-preprocess-import-assets](https://github.com/bluwy/svelte-preprocess-import-assets) or [svelte-image](https://github.com/matyunya/svelte-image).
+If you prefer to reference assets directly in the markup, you can use a preprocessor such as [svelte-preprocess-import-assets](https://github.com/bluwy/svelte-preprocess-import-assets).
 
 For assets included via the CSS `url()` function, you may find the [`experimental.useVitePreprocess`](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/config.md#usevitepreprocess) option useful:
 
@@ -29,6 +29,6 @@ export default {
 };
 ```
 
-### Optimization
+### Transforming
 
-You may wish to utilize compressed image formats such as `.webp` or `.avif` or responsive images that serve a different size based on your device's screen. For images that are included statically in your project you may use a preprocessor like [svimg](https://github.com/xiphux/svimg) or a Vite plugin such as [vite-imagetools](https://github.com/JonasKruckenberg/imagetools).
+You may wish to transform your images to output compressed image formats such as `.webp` or `.avif`, responsive images with different sizes for different devices, or images with the EXIF data stripped for privacy. For images that are included statically, you may use a Vite plugin such as [vite-imagetools](https://github.com/JonasKruckenberg/imagetools). You may also consider a CDN, which can serve the appropriate transformed image based on the `Accept` HTTP header and query string parameters.


### PR DESCRIPTION
I previously removed a reference to `matyunya/svelte-image`, but missed one as well it appears. That library is unmaintained, so probably better not to mention it. Also, after digging in more to it and `xiphux/svimg` I think neither are ideal because they are preprocessors and so don't integrate well with the Vite processing pipeline.