### PR TITLE
increase timeout to a silly number

### DIFF
--- a/packages/kit/test/apps/amp/playwright.config.js
+++ b/packages/kit/test/apps/amp/playwright.config.js
@@ -1,6 +1,6 @@
 import { config } from '../../utils.js';
 
-config.webServer && (config.webServer.timeout = 15000); // AMP validator needs a long time to get moving
+config.webServer && (config.webServer.timeout = 45000); // AMP validator needs a long time to get moving
 
 // remove any projects with javaScriptEnabled
 const projects = config.projects || [];


### PR DESCRIPTION
seeing a lot of timeouts on the safari tests for some reason, possibly a combination of the machine being underpowered and the AMP validator being a steaming turd