### PR TITLE
only generate non-SSR pages when prerendering

### DIFF
--- a/.changeset/strong-cooks-run.md
+++ b/.changeset/strong-cooks-run.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] only generate blank non-SSR pages when prerendering is enabled

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -104,6 +104,24 @@ export async function render_page(event, route, page, options, state, resolve_op
 		const should_prerender_data = nodes.some((node) => node?.server);
 		const data_pathname = `${event.url.pathname.replace(/\/$/, '')}/__data.json`;
 
+		const should_prerender =
+			leaf_node.shared?.prerender ?? leaf_node.server?.prerender ?? options.prerender.default;
+		if (should_prerender) {
+			const mod = leaf_node.server;
+			if (mod && (mod.POST || mod.PUT || mod.DELETE || mod.PATCH)) {
+				throw new Error('Cannot prerender pages that have endpoints with mutative methods');
+			}
+		} else if (state.prerendering) {
+			// if the page isn't marked as prerenderable (or is explicitly
+			// marked NOT prerenderable, if `prerender.default` is `true`),
+			// then bail out at this point
+			if (!should_prerender) {
+				return new Response(undefined, {
+					status: 204
+				});
+			}
+		}
+
 		if (!resolve_opts.ssr) {
 			return await render_response({
 				branch: [],
@@ -121,24 +139,6 @@ export async function render_page(event, route, page, options, state, resolve_op
 				state,
 				resolve_opts
 			});
-		}
-
-		const should_prerender =
-			leaf_node.shared?.prerender ?? leaf_node.server?.prerender ?? options.prerender.default;
-		if (should_prerender) {
-			const mod = leaf_node.server;
-			if (mod && (mod.POST || mod.PUT || mod.DELETE || mod.PATCH)) {
-				throw new Error('Cannot prerender pages that have endpoints with mutative methods');
-			}
-		} else if (state.prerendering) {
-			// if the page isn't marked as prerenderable (or is explicitly
-			// marked NOT prerenderable, if `prerender.default` is `true`),
-			// then bail out at this point
-			if (!should_prerender) {
-				return new Response(undefined, {
-					status: 204
-				});
-			}
 		}
 
 		/** @type {Array<Loaded | null>} */

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -104,6 +104,9 @@ export async function render_page(event, route, page, options, state, resolve_op
 		const should_prerender_data = nodes.some((node) => node?.server);
 		const data_pathname = `${event.url.pathname.replace(/\/$/, '')}/__data.json`;
 
+		// it's crucial that we do this before returning the non-SSR response, otherwise
+		// SvelteKit will erroneously believe that the path has been prerendered,
+		// causing functions to be omitted from the manifesst generated later
 		const should_prerender =
 			leaf_node.shared?.prerender ?? leaf_node.server?.prerender ?? options.prerender.default;
 		if (should_prerender) {


### PR DESCRIPTION
fixes #6243.

Explanation:

1. Unless `config.kit.prerender.enabled` is set to `false`, SvelteKit will always try to prerender pages
2. It begins with all known static paths (e.g. `/`) and crawls from there
3. If it finds that a page is not prerenderable (i.e. `config.kit.prerender.default = false` or `prerender = false`) it will bail out
4. Otherwise it will continue, and generate the `.html` file — and, if appropriate, the `__data.json` file that powers it
5. When `ssr` is `false`, it returns the response before checking to see if the page is prerenderable
6. As such, SvelteKit believes that routes were prerendered when they in fact weren't
7. Routes that we know were prerendered are removed from the generated manifest, so that servers and serverless functions don't bundle code for stuff we already know was prerendered
8. Because of the error in 5, routes are being erroneously excluded from the manifest, meaning that we have a prerendered `.html` page without a `__data.json` file, and no function to generate the `__data.json` file

This fixes it by doing the 'should we prerender this page?' check before returning the blank non-SSR response. I haven't added a test because it's very finicky to test for — we'd basically need to invent a new category of tests that would involve building a new app, slowing the whole suite down 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
