### PR TITLE
invalidate data after form submit

### DIFF
--- a/.changeset/moody-plums-mate.md
+++ b/.changeset/moody-plums-mate.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Invalidate data after form submission

--- a/.changeset/moody-plums-mate.md
+++ b/.changeset/moody-plums-mate.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/kit': patch
+'create-svelte': patch
 ---
 
 Invalidate data after form submission

--- a/packages/create-svelte/templates/default/src/lib/form.ts
+++ b/packages/create-svelte/templates/default/src/lib/form.ts
@@ -86,7 +86,7 @@ export function enhance(
 
 				const url = new URL(form.action);
 				url.search = url.hash = '';
-				invalidate(url.href);
+				invalidate();
 			} else if (error) {
 				error({ data, form, error: null, response });
 			} else {

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -151,7 +151,7 @@ declare module '$app/navigation' {
 		opts?: { replaceState?: boolean; noscroll?: boolean; keepfocus?: boolean; state?: any }
 	): Promise<void>;
 	/**
-	 * Causes any `load` functions belonging to the currently active page to re-run if they `fetch` the resource in question, or re-fetches data from a page endpoint if the invalidated resource is the page itself. If no argument is given, all resources will be invalidated. Returns a `Promise` that resolves when the page is subsequently updated.
+	 * Causes any `load` functions belonging to the currently active page to re-run if they `fetch` the resource in question. If no argument is given, all resources will be invalidated. Returns a `Promise` that resolves when the page is subsequently updated.
 	 * @param dependency The invalidated resource
 	 */
 	export function invalidate(dependency?: string | ((href: string) => boolean)): Promise<void>;


### PR DESCRIPTION
After #5778 you have to `invalidate()`, not `invalidate(location.href)`, as there's no longer just a single endpoint that corresponds to the page itself.

Fixes #6240 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
