### PR TITLE
[fix] type tweaks

### DIFF
--- a/.changeset/friendly-dodos-exercise.md
+++ b/.changeset/friendly-dodos-exercise.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] type tweaks

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -163,14 +163,9 @@ function update_types(config, routes, route) {
 	/** @type {string[]} */
 	const exports = [];
 
-	if (route.names.length > 0) {
-		const params = route.names.map((param) => `${param}: string`).join('; ');
-		declarations.push(
-			`interface RouteParams extends Partial<Record<string, string>> { ${params} }`
-		);
-	} else {
-		declarations.push(`interface RouteParams extends Partial<Record<string, string>> {}`);
-	}
+	declarations.push(
+		`type RouteParams = { ${route.names.map((param) => `${param}: string`).join('; ')} }`
+	);
 
 	if (route.layout || route.leaf) {
 		// These could also be placed in our public types, but it would bloat them unnecessarily and we may want to change these in the future
@@ -212,12 +207,11 @@ function update_types(config, routes, route) {
 			}
 		});
 
-		if (layout_params.size > 0) {
-			const params = Array.from(layout_params).map((param) => `${param}?: string`);
-			declarations.push(`interface LayoutParams extends RouteParams { ${params.join('; ')} }`);
-		} else {
-			declarations.push(`interface LayoutParams extends RouteParams {}`);
-		}
+		declarations.push(
+			`type LayoutParams = RouteParams & { ${Array.from(layout_params).map(
+				(param) => `${param}?: string`
+			)} }`
+		);
 
 		const {
 			exports: e,

--- a/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/$types.d.ts
@@ -1,6 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
-interface RouteParams extends Partial<Record<string, string>> {}
+type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
 	[K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K;
@@ -11,7 +11,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Record<string, any>
 >;
 type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
-interface LayoutParams extends RouteParams {}
+type LayoutParams = RouteParams & {};
 type LayoutParentData = EnsureParentData<{}>;
 
 export type LayoutServerData = null;

--- a/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/(main)/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/(main)/$types.d.ts
@@ -1,6 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
-interface RouteParams extends Partial<Record<string, string>> {}
+type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
 	[K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K;
@@ -12,7 +12,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 >;
 type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
 type PageParentData = EnsureParentData<import('../$types.js').LayoutData>;
-interface LayoutParams extends RouteParams {}
+type LayoutParams = RouteParams & {};
 type LayoutServerParentData = EnsureParentData<import('../$types.js').LayoutServerData>;
 type LayoutParentData = EnsureParentData<import('../$types.js').LayoutData>;
 

--- a/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/(main)/sub/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/(main)/sub/$types.d.ts
@@ -1,6 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
-interface RouteParams extends Partial<Record<string, string>> {}
+type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
 	[K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K;

--- a/packages/kit/src/core/sync/write_types/test/layout/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/layout/_expected/$types.d.ts
@@ -1,6 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
-interface RouteParams extends Partial<Record<string, string>> {}
+type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
 	[K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K;
@@ -13,7 +13,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
 type PageServerParentData = EnsureParentData<LayoutServerData>;
 type PageParentData = EnsureParentData<LayoutData>;
-interface LayoutParams extends RouteParams {}
+type LayoutParams = RouteParams & {};
 type LayoutServerParentData = EnsureParentData<{}>;
 type LayoutParentData = EnsureParentData<{}>;
 

--- a/packages/kit/src/core/sync/write_types/test/simple-page-server-and-shared/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/simple-page-server-and-shared/_expected/$types.d.ts
@@ -1,6 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
-interface RouteParams extends Partial<Record<string, string>> {}
+type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
 	[K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K;
@@ -13,7 +13,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
 type PageServerParentData = EnsureParentData<LayoutServerData>;
 type PageParentData = EnsureParentData<LayoutData>;
-interface LayoutParams extends RouteParams {}
+type LayoutParams = RouteParams & {};
 type LayoutParentData = EnsureParentData<{}>;
 
 export type PageServerLoad<

--- a/packages/kit/src/core/sync/write_types/test/simple-page-server-only/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/simple-page-server-only/_expected/$types.d.ts
@@ -1,6 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
-interface RouteParams extends Partial<Record<string, string>> {}
+type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
 	[K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K;
@@ -13,7 +13,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
 type PageServerParentData = EnsureParentData<LayoutServerData>;
 type PageParentData = EnsureParentData<LayoutData>;
-interface LayoutParams extends RouteParams {}
+type LayoutParams = RouteParams & {};
 type LayoutParentData = EnsureParentData<{}>;
 
 export type PageServerLoad<

--- a/packages/kit/src/core/sync/write_types/test/simple-page-shared-only/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/simple-page-shared-only/_expected/$types.d.ts
@@ -1,6 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
-interface RouteParams extends Partial<Record<string, string>> {}
+type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
 	[K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K;
@@ -12,7 +12,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 >;
 type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
 type PageParentData = EnsureParentData<LayoutData>;
-interface LayoutParams extends RouteParams {}
+type LayoutParams = RouteParams & {};
 type LayoutParentData = EnsureParentData<{}>;
 
 export type PageServerData = null;

--- a/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/$types.d.ts
@@ -1,6 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
-interface RouteParams extends Partial<Record<string, string>> {}
+type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
 	[K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K;
@@ -11,10 +11,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Record<string, any>
 >;
 type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
-interface LayoutParams extends RouteParams {
-	rest?: string;
-	slug?: string;
-}
+type LayoutParams = RouteParams & { rest?: string; slug?: string };
 type LayoutParentData = EnsureParentData<{}>;
 
 export type LayoutServerData = null;

--- a/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/$types.d.ts
@@ -1,6 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
-interface RouteParams extends Partial<Record<string, string>> {}
+type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
 	[K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K;
@@ -11,9 +11,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Record<string, any>
 >;
 type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
-interface LayoutParams extends RouteParams {
-	rest?: string;
-}
+type LayoutParams = RouteParams & { rest?: string };
 type LayoutParentData = EnsureParentData<import('../$types.js').LayoutData>;
 
 export type LayoutServerData = null;

--- a/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/[...rest]/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/[...rest]/$types.d.ts
@@ -1,8 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
-interface RouteParams extends Partial<Record<string, string>> {
-	rest: string;
-}
+type RouteParams = { rest: string };
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
 	[K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K;

--- a/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/[slug]/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/[slug]/$types.d.ts
@@ -1,8 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
-interface RouteParams extends Partial<Record<string, string>> {
-	slug: string;
-}
+type RouteParams = { slug: string };
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
 	[K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K;

--- a/packages/kit/src/core/sync/write_types/test/slugs/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs/_expected/$types.d.ts
@@ -1,6 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
-interface RouteParams extends Partial<Record<string, string>> {}
+type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
 	[K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K;
@@ -11,10 +11,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Record<string, any>
 >;
 type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
-interface LayoutParams extends RouteParams {
-	rest?: string;
-	slug?: string;
-}
+type LayoutParams = RouteParams & { rest?: string; slug?: string };
 type LayoutParentData = EnsureParentData<{}>;
 
 export type LayoutServerData = null;

--- a/packages/kit/src/core/sync/write_types/test/slugs/_expected/[...rest]/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs/_expected/[...rest]/$types.d.ts
@@ -1,8 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
-interface RouteParams extends Partial<Record<string, string>> {
-	rest: string;
-}
+type RouteParams = { rest: string };
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
 	[K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K;

--- a/packages/kit/src/core/sync/write_types/test/slugs/_expected/[slug]/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs/_expected/[slug]/$types.d.ts
@@ -1,8 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
-interface RouteParams extends Partial<Record<string, string>> {
-	slug: string;
-}
+type RouteParams = { slug: string };
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
 	[K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -195,17 +195,17 @@ export interface HandleError {
  */
 export interface Load<
 	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
-	InputData extends Record<string, any> | null = Record<string, any> | null,
-	ParentData extends Record<string, any> = Record<string, any>,
-	OutputData extends Record<string, any> | void = Record<string, any> | void
+	InputData extends Record<string, unknown> | null = Record<string, any> | null,
+	ParentData extends Record<string, unknown> = Record<string, any>,
+	OutputData extends Record<string, unknown> | void = Record<string, any> | void
 > {
 	(event: LoadEvent<Params, InputData, ParentData>): MaybePromise<OutputData>;
 }
 
 export interface LoadEvent<
 	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
-	Data extends Record<string, any> | null = Record<string, any> | null,
-	ParentData extends Record<string, any> = Record<string, any>
+	Data extends Record<string, unknown> | null = Record<string, any> | null,
+	ParentData extends Record<string, unknown> = Record<string, any>
 > {
 	fetch(info: RequestInfo, init?: RequestInit): Promise<Response>;
 	params: Params;
@@ -253,7 +253,9 @@ export interface RequestEvent<
  *
  * It receives `Params` as the first generic argument, which you can skip by using [generated types](/docs/types#generated-types) instead.
  */
-export interface RequestHandler<Params extends Record<string, string> = Record<string, string>> {
+export interface RequestHandler<
+	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>
+> {
 	(event: RequestEvent<Params>): MaybePromise<Response>;
 }
 


### PR DESCRIPTION
- T extends Record<string, any>  allows T to be an array, Record<string, known> doesn't, closes #6261
- RequestHandler generic is partial now to align with the other types and prevent type conflicts
- generate definite set of route params, this is more correct and makes hover info better

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
