### PR TITLE
always bundle devDependencies

### DIFF
--- a/.changeset/selfish-cougars-kick.md
+++ b/.changeset/selfish-cougars-kick.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Update default Vite config so that devDependencies are always bundled

--- a/packages/create-svelte/shared/vite.config.ts
+++ b/packages/create-svelte/shared/vite.config.ts
@@ -1,9 +1,19 @@
+import fs from 'fs';
 import { sveltekit } from '@sveltejs/kit/vite';
 import type { UserConfig } from 'vite';
 
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
+
 /** @type {import('vite').UserConfig} */
 const config: UserConfig = {
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+
+	ssr: {
+		// bundle everything in devDependencies, so our
+		// deployment only needs prod dependencies
+		external: Object.keys(pkg.dependencies ?? {}),
+		noExternal: true
+	}
 };
 
 export default config;

--- a/packages/create-svelte/templates/default/src/lib/form.ts
+++ b/packages/create-svelte/templates/default/src/lib/form.ts
@@ -26,7 +26,7 @@ import { invalidate } from '$app/navigation';
  *     response: Response;
  *     form: HTMLFormElement;
  *   }) => void;
- * }} [opts]
+ * }} opts
  */
 export function enhance(
 	form: HTMLFormElement,


### PR DESCRIPTION
Closes #3176.

This is really just an idea, I'd be curious to know if people think it's the right one. It causes `devDependencies` (or rather, everything that isn't explicitly marked as a prod dependency) to be bundled in the Vite output, which makes the result more portable — you don't need to install `devDependencies` to run your app. If _everything_ is in `devDependencies` then it means your app is completely self-contained and you don't need to `npm install` anything to run it.

Since we use `esbuild` inside certain adapters (the ones where using `node_modules` isn't an option, like Cloudflare Workers) this change really only affects users of `adapter-node`, and we could therefore argue that it doesn't belong in the default config. It also feels a bit messy putting it here. But aside from making builds very slightly slower (albeit in a way that's completely in users' control, just by moving things between `dependencies` and `devDependencies`) it seems like the most pragmatic solution.

I also considered adding this logic to the Vite plugin so that it didn't need to be added to the user config, but that felt a bit aggressive.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
