### PR TITLE
[fix] type definition update for typescript 4.8

### DIFF
--- a/.changeset/two-pianos-stare.md
+++ b/.changeset/two-pianos-stare.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+fix type definition issue that caused a svelte-check error when using TS 4.8

--- a/packages/create-svelte/templates/default/src/lib/form.ts
+++ b/packages/create-svelte/templates/default/src/lib/form.ts
@@ -26,7 +26,7 @@ import { invalidate } from '$app/navigation';
  *     response: Response;
  *     form: HTMLFormElement;
  *   }) => void;
- * }} [opts]
+ * }} opts
  */
 export function enhance(
 	form: HTMLFormElement,


### PR DESCRIPTION
error:
```
/home/dominikg/develop/sveltejs/kit/.test-tmp/create-svelte/default-checkjs/src/lib/form.js:31:31
Error: A binding pattern parameter cannot be optional in an implementation signature. 
 */
export function enhance(form, { pending, error, result } = {}) {
        let current_token;
```        

see https://github.com/microsoft/TypeScript/issues/49869

first caught by vite-ecosystem-ci but also fails kit's own ci.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
