### PR TITLE
[fix] wrong reuse of server load data

### DIFF
--- a/.changeset/rotten-mice-compete.md
+++ b/.changeset/rotten-mice-compete.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] don't reuse server load data from previous page if current doesn't have a load function

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -638,9 +638,10 @@ export function create_client({ target, base, trailing_slash }) {
 
 	/**
 	 * @param {import('types').ServerDataNode | import('types').ServerDataSkippedNode | null} node
+	 * @param {import('./types').DataNode | null} [previous]
 	 * @returns {import('./types').DataNode | null}
 	 */
-	function create_data_node(node) {
+	function create_data_node(node, previous) {
 		if (node?.type === 'data') {
 			return {
 				type: 'data',
@@ -652,6 +653,8 @@ export function create_client({ target, base, trailing_slash }) {
 					url: !!node.uses.url
 				}
 			};
+		} else if (node?.type === 'skip') {
+			return previous ?? null;
 		}
 		return null;
 	}
@@ -765,7 +768,7 @@ export function create_client({ target, base, trailing_slash }) {
 					}
 					return data;
 				},
-				server_data_node: create_data_node(server_data_node) ?? previous?.server ?? null
+				server_data_node: create_data_node(server_data_node, previous?.server)
 			});
 		});
 

--- a/packages/kit/test/apps/basics/src/routes/load/server-data-reuse/no-load/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/server-data-reuse/no-load/+page.svelte
@@ -1,0 +1,7 @@
+<script>
+	export let data 
+</script>
+
+<p>Page without load</p>
+
+<pre>{JSON.stringify(data)}</pre>

--- a/packages/kit/test/apps/basics/src/routes/load/server-data-reuse/with-server-load/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/server-data-reuse/with-server-load/+page.server.js
@@ -1,0 +1,4 @@
+/** @type {import('.$/types').ServerLoad} */
+export function load() {
+	return { server: true };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/server-data-reuse/with-server-load/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/server-data-reuse/with-server-load/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	/** @type {import('./$types').PageData} */
+	export let data 
+</script>
+
+<p>Page with server load</p>
+
+<pre>{JSON.stringify(data)}</pre>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -360,6 +360,18 @@ test.describe('Load', () => {
 		expect(await page.textContent('h1')).toBe("I didn't break!");
 	});
 
+	test.only('server data from previous is not reused if next page has no load function', async ({
+		page,
+		app
+	}) => {
+		await page.goto('/load/server-data-reuse/with-server-load');
+		expect(await page.textContent('pre')).toBe(
+			JSON.stringify({ foo: { bar: 'Custom layout' }, server: true })
+		);
+		await app.goto('/load/server-data-reuse/no-load');
+		expect(await page.textContent('pre')).toBe(JSON.stringify({ foo: { bar: 'Custom layout' } }));
+	});
+
 	if (process.env.DEV) {
 		test('using window.fetch causes a warning', async ({ page }) => {
 			const port = 5173;

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -360,7 +360,7 @@ test.describe('Load', () => {
 		expect(await page.textContent('h1')).toBe("I didn't break!");
 	});
 
-	test.only('server data from previous is not reused if next page has no load function', async ({
+	test('server data from previous is not reused if next page has no load function', async ({
 		page,
 		app
 	}) => {

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -194,6 +194,9 @@ export type ServerData =
 	  }
 	| {
 			type: 'data';
+			/**
+			 * If `null`, then there was no load function
+			 */
 			nodes: Array<ServerDataNode | ServerDataSkippedNode | ServerErrorNode | null>;
 	  };
 


### PR DESCRIPTION
Don't reuse server load data from previous page if current doesn't have a load function

Fixes #6300

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
