### PR TITLE
[docs] update path to vite plugin in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Entry points to be aware of are:
 
 - [`packages/create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte) - code that's run when you create a new project with `npm create svelte@latest`
 - [`packages/package`](https://github.com/sveltejs/kit/tree/master/packages/package) - for the `svelte-package` command
-- [`packages/kit/src/vite/index.js`](https://github.com/sveltejs/kit/blob/master/packages/kit/src/vite/index.js) - for the Vite plugin
+- [`packages/kit/src/vite/index.js`](https://github.com/sveltejs/kit/blob/master/packages/kit/src/exports/vite/index.js) - for the Vite plugin
 - [`packages/kit/src/core/sync/index.js`](https://github.com/sveltejs/kit/blob/master/packages/kit/src/core/sync/sync.js) - for `svelte-kit sync`, which regenerates routing info and type definitions
 - [`packages/adapter-[platform]`](https://github.com/sveltejs/kit/tree/master/packages) - for the various SvelteKit-provided adapters
 


### PR DESCRIPTION
It now lives in `exports`