### PR TITLE
[docs] don't hardcode file extension in docs server

### DIFF
--- a/sites/kit.svelte.dev/src/lib/docs/server/index.js
+++ b/sites/kit.svelte.dev/src/lib/docs/server/index.js
@@ -92,7 +92,7 @@ export async function read_file(dir, file) {
 				})
 				.replace(/\*\\\//g, '*/');
 
-			if (language === 'js' || language === 'ts') {
+			if (language === 'js') {
 				try {
 					if (source.includes('./$types') && !source.includes('@filename: $types.d.ts')) {
 						const params = parse_route_id(options.file || `+page.${language}`)

--- a/sites/kit.svelte.dev/src/lib/docs/server/index.js
+++ b/sites/kit.svelte.dev/src/lib/docs/server/index.js
@@ -92,10 +92,10 @@ export async function read_file(dir, file) {
 				})
 				.replace(/\*\\\//g, '*/');
 
-			if (language === 'js') {
+			if (language === 'js' || language === 'ts') {
 				try {
 					if (source.includes('./$types') && !source.includes('@filename: $types.d.ts')) {
-						const params = parse_route_id(options.file || '+page.js')
+						const params = parse_route_id(options.file || `+page.${language}`)
 							.names.map((name) => `${name}: string`)
 							.join(', ');
 
@@ -115,7 +115,7 @@ export async function read_file(dir, file) {
 						} else {
 							source = source.replace(
 								/^(?!\/\/ @)/m,
-								`${injected}\n\n// @filename: index.js\n// ---cut---\n`
+								`${injected}\n\n// @filename: index.${language}\n// ---cut---\n`
 							);
 						}
 					}


### PR DESCRIPTION
This does not expose any user-visible changes, but makes it easier to enable TypeScript support to the docs backend. allowing me to write code blocks in TypeScript

![Screenshot from 2022-08-26 14-13-38](https://user-images.githubusercontent.com/322311/186991598-0c958ca3-f717-4ff0-a8a9-88cd83fba108.png)

Using this throughout the docs would require a larger overhaul to render both JS and TS and add a toggle between them, so I'm not sure that's something I'll do in the short-term. However, this is helpful in allowing me to experiment with stuff like adding a TypeScript example to our homepage to demonstrate that we provide TypeScript type declarations.