### PR TITLE
set errors on root component - relates to #6279

### DIFF
--- a/.changeset/funny-keys-appear.md
+++ b/.changeset/funny-keys-appear.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+set errors on root component

--- a/packages/kit/src/core/sync/write_root.js
+++ b/packages/kit/src/core/sync/write_root.js
@@ -21,7 +21,7 @@ export function write_root(manifest_data, output) {
 
 	let l = max_depth;
 
-	let pyramid = `<svelte:component this={components[${l}]} data={data_${l}}/>`;
+	let pyramid = `<svelte:component this={components[${l}]} data={data_${l}} {errors}/>`;
 
 	while (l--) {
 		pyramid = `


### PR DESCRIPTION
my page utilizing server actions was not receiving errors in `export let errors`... until now!

sorry about the half hearted PR, pretty sure this API is going to change dramatically soon anyway.

thank you for building this project

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
