### PR TITLE
[feat] support for other aliases in package command

### DIFF
--- a/.changeset/weak-hotels-hang.md
+++ b/.changeset/weak-hotels-hang.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/package': patch
+---
+
+Support for other aliases in package command

--- a/.changeset/weak-hotels-hang.md
+++ b/.changeset/weak-hotels-hang.md
@@ -2,4 +2,4 @@
 '@sveltejs/package': patch
 ---
 
-Support for other aliases in package command
+[feat] Support aliases set through `kit.alias`

--- a/packages/package/src/config.js
+++ b/packages/package/src/config.js
@@ -26,6 +26,7 @@ export async function load_config({ cwd = process.cwd() } = {}) {
 function process_config(config, { cwd = process.cwd() } = {}) {
 	return {
 		extensions: config.extensions ?? ['.svelte'],
+		kit: config.kit,
 		package: {
 			source: path.resolve(cwd, config.kit?.files?.lib ?? config.package?.source ?? 'src/lib'),
 			dir: config.package?.dir ?? 'package',

--- a/packages/package/src/utils.js
+++ b/packages/package/src/utils.js
@@ -18,22 +18,31 @@ import { posixify, mkdirp, walk } from './filesystem.js';
 export function resolve_lib_alias(file, content, config) {
 	/**
 	 * @param {string} match
-	 * @param {string} _
 	 * @param {string} import_path
+	 * @param {string} alias
+	 * @param {string} value
 	 */
-	const replace_import_path = (match, _, import_path) => {
-		if (!import_path.startsWith('$lib/')) {
+	const replace_import_path = (match, import_path, alias, value) => {
+		if (!import_path.startsWith(alias)) {
 			return match;
 		}
 
-		const full_path = path.join(config.package.source, file);
-		const full_import_path = path.join(config.package.source, import_path.slice('$lib/'.length));
+		const full_path = path.join(value, file);
+		const full_import_path = path.join(value, import_path.slice(alias.length));
 		let resolved = posixify(path.relative(path.dirname(full_path), full_import_path));
 		resolved = resolved.startsWith('.') ? resolved : './' + resolved;
 		return match.replace(import_path, resolved);
 	};
-	content = content.replace(/from\s+('|")([^"';,]+?)\1/g, replace_import_path);
-	content = content.replace(/import\s*\(\s*('|")([^"';,]+?)\1\s*\)/g, replace_import_path);
+
+	const aliases = { $lib: path.resolve(config.package.source), ...(config.kit?.alias ?? {}) };
+	for (const [alias, value] of Object.entries(aliases)) {
+		content = content.replace(/from\s+('|")([^"';,]+?)\1/g, (match, _, import_path) =>
+			replace_import_path(match, import_path, alias, value)
+		);
+		content = content.replace(/import\s*\(\s*('|")([^"';,]+?)\1\s*\)/g, (match, _, import_path) =>
+			replace_import_path(match, import_path, alias, value)
+		);
+	}
 	return content;
 }
 

--- a/packages/package/src/utils.js
+++ b/packages/package/src/utils.js
@@ -27,7 +27,7 @@ export function resolve_lib_alias(file, content, config) {
 			return match;
 		}
 
-		const full_path = path.join(value, file);
+		const full_path = path.join(config.package.source, file);
 		const full_import_path = path.join(value, import_path.slice(alias.length));
 		let resolved = posixify(path.relative(path.dirname(full_path), full_import_path));
 		resolved = resolved.startsWith('.') ? resolved : './' + resolved;

--- a/packages/package/test/fixtures/resolve-alias/expected/Test.svelte
+++ b/packages/package/test/fixtures/resolve-alias/expected/Test.svelte
@@ -1,4 +1,6 @@
 <script>
     import { foo } from './sub/foo';
+		import { util } from './utils';
     export let bar = foo;
+		util();
 </script>

--- a/packages/package/test/fixtures/resolve-alias/expected/package.json
+++ b/packages/package/test/fixtures/resolve-alias/expected/package.json
@@ -7,6 +7,7 @@
 	"exports": {
 		"./package.json": "./package.json",
 		"./Test.svelte": "./Test.svelte",
+		"./utils": "./utils/index.js",
 		".": "./index.js",
 		"./baz": "./baz.js",
 		"./sub/bar": "./sub/bar.js",

--- a/packages/package/test/fixtures/resolve-alias/expected/utils/index.d.ts
+++ b/packages/package/test/fixtures/resolve-alias/expected/utils/index.d.ts
@@ -1,0 +1,1 @@
+export declare const util: () => void;

--- a/packages/package/test/fixtures/resolve-alias/expected/utils/index.js
+++ b/packages/package/test/fixtures/resolve-alias/expected/utils/index.js
@@ -1,0 +1,1 @@
+export const util = () => { };

--- a/packages/package/test/fixtures/resolve-alias/src/lib/Test.svelte
+++ b/packages/package/test/fixtures/resolve-alias/src/lib/Test.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
     import { foo } from '$lib/sub/foo';
+    import { util } from '$utils';
 
     export let bar = foo;
+
+		util();
 </script>

--- a/packages/package/test/fixtures/resolve-alias/src/lib/utils/index.ts
+++ b/packages/package/test/fixtures/resolve-alias/src/lib/utils/index.ts
@@ -1,0 +1,1 @@
+export const util = () => {};

--- a/packages/package/test/fixtures/resolve-alias/svelte.config.js
+++ b/packages/package/test/fixtures/resolve-alias/svelte.config.js
@@ -1,5 +1,15 @@
 import preprocess from 'svelte-preprocess';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.join(__filename, '..');
 
 export default {
-	preprocess: preprocess()
+	preprocess: preprocess(),
+	kit: {
+		alias: {
+			$utils: path.resolve(__dirname, './src/lib/utils')
+		}
+	}
 };

--- a/packages/package/test/fixtures/resolve-alias/tsconfig.json
+++ b/packages/package/test/fixtures/resolve-alias/tsconfig.json
@@ -5,7 +5,8 @@
 		"checkJs": true,
 		"baseUrl": ".",
 		"paths": {
-			"$lib/*": ["./src/lib/*"]
+			"$lib/*": ["./src/lib/*"],
+			"$utils/*": ["./src/lib/utils/*"]
 		}
 	},
 	"include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte"]


### PR DESCRIPTION
Related to https://github.com/sveltejs/kit/issues/1950

This PR includes support for other aliases besides `$lib` for the package command. It reads the alias information from `kit` object in `svelte.config.js`.

I'm not sure this is the correct approach, open to suggestions and improvements.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
