### PR TITLE
[fix] encode if root layout has server load

### DIFF
--- a/.changeset/short-comics-unite.md
+++ b/.changeset/short-comics-unite.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] encode if root layout has server load

--- a/packages/kit/src/core/sync/write_client_manifest.js
+++ b/packages/kit/src/core/sync/write_client_manifest.js
@@ -67,8 +67,8 @@ export function write_client_manifest(manifest_data, output) {
 						}
 					});
 
-					array.push(`[${layouts.join(',')}]`);
-					// only include non-root error nodes if they exist
+					// only include non-root layout/error nodes if they exist
+					if (layouts.length > 0 || errors.length > 0) array.push(`[${layouts.join(',')}]`);
 					if (errors.length > 0) array.push(`[${errors.join(',')}]`);
 
 					return `${s(route.id)}: [${array.join(',')}]`;

--- a/packages/kit/src/core/sync/write_client_manifest.js
+++ b/packages/kit/src/core/sync/write_client_manifest.js
@@ -47,8 +47,11 @@ export function write_client_manifest(manifest_data, output) {
 		${manifest_data.routes
 			.map((route) => {
 				if (route.page) {
+					// Skip the first error, it's always the root error page with number 1
 					const errors = route.page.errors.slice(1).map((n) => n ?? '');
-					const layouts = route.page.layouts.slice(1).map((n) => {
+					// Do _not_ skip the first layout, it's always the root layout with number 0,
+					// but we don't know whether it has a server load function or not, which we need to encode
+					const layouts = route.page.layouts.map((n) => {
 						if (n == undefined) {
 							return '';
 						}
@@ -60,8 +63,8 @@ export function write_client_manifest(manifest_data, output) {
 
 					const array = [get_node_id(manifest_data.nodes, route.page.leaf)];
 
-					// only include non-root layout/error nodes if they exist
-					if (layouts.length > 0 || errors.length > 0) array.push(`[${layouts.join(',')}]`);
+					array.push(`[${layouts.join(',')}]`);
+					// only include non-root error nodes if they exist
 					if (errors.length > 0) array.push(`[${errors.join(',')}]`);
 
 					return `${s(route.id)}: [${array.join(',')}]`;
@@ -93,5 +96,6 @@ export function write_client_manifest(manifest_data, output) {
  * @param {number} id
  */
 function get_node_id(nodes, id) {
+	console.log(nodes[id]);
 	return `${nodes[id].server ? '~' : ''}${id}`;
 }

--- a/packages/kit/src/core/sync/write_client_manifest.js
+++ b/packages/kit/src/core/sync/write_client_manifest.js
@@ -50,12 +50,7 @@ export function write_client_manifest(manifest_data, output) {
 			.map((route) => {
 				if (route.page) {
 					const errors = route.page.errors.slice(1).map((n) => n ?? '');
-					const layouts = route.page.layouts.slice(1).map((n) => {
-						if (n == undefined) {
-							return '';
-						}
-						return get_node_id(manifest_data.nodes, n);
-					});
+					const layouts = route.page.layouts.slice(1).map((n) => n ?? '');
 
 					while (layouts.at(-1) === '') layouts.pop();
 					while (errors.at(-1) === '') errors.pop();
@@ -96,14 +91,4 @@ export function write_client_manifest(manifest_data, output) {
 			export const dictionary = ${dictionary};
 		`)
 	);
-}
-
-/**
- * Encode whether or not the route uses the server data
- * using the ones' complement, to save space
- * @param {import('types').PageNode[]} nodes
- * @param {number} id
- */
-function get_node_id(nodes, id) {
-	return `${nodes[id].server ? '~' : ''}${id}`;
 }

--- a/packages/kit/src/runtime/client/ambient.d.ts
+++ b/packages/kit/src/runtime/client/ambient.d.ts
@@ -12,7 +12,7 @@ declare module '__GENERATED__/client-manifest.js' {
 	 * If the number is negative, it means it does use a server load function and the complement is the node index.
 	 * The route layout and error nodes are not referenced, they are always number 0 and 1 and always apply.
 	 */
-	export const dictionary: Record<string, [leaf: number, layouts?: number[], errors?: number[]]>;
+	export const dictionary: Record<string, [leaf: number, layouts: number[], errors?: number[]]>;
 
 	export const matchers: Record<string, ParamMatcher>;
 }

--- a/packages/kit/src/runtime/client/ambient.d.ts
+++ b/packages/kit/src/runtime/client/ambient.d.ts
@@ -7,9 +7,15 @@ declare module '__GENERATED__/client-manifest.js' {
 	export const nodes: CSRPageNodeLoader[];
 
 	/**
+	 * A list of all layout node ids that have a server load function.
+	 * Pages are not present because it's shorter to encode it on the leaf itself.
+	 */
+	export const server_loads: number[];
+
+	/**
 	 * A map of `[routeId: string]: [leaf, layouts, errors]` tuples, which
 	 * is parsed into an array of routes on startup. The numbers refer to the indices in `nodes`.
-	 * If the number is negative, it means it does use a server load function and the complement is the node index.
+	 * If the leaf number is negative, it means it does use a server load function and the complement is the node index.
 	 * The route layout and error nodes are not referenced, they are always number 0 and 1 and always apply.
 	 */
 	export const dictionary: Record<string, [leaf: number, layouts: number[], errors?: number[]]>;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -7,14 +7,14 @@ import { parse } from './parse.js';
 import { error } from '../../exports/index.js';
 
 import Root from '__GENERATED__/root.svelte';
-import { nodes, dictionary, matchers } from '__GENERATED__/client-manifest.js';
+import { nodes, server_loads, dictionary, matchers } from '__GENERATED__/client-manifest.js';
 import { HttpError, Redirect } from '../control.js';
 import { stores } from './singletons.js';
 
 const SCROLL_KEY = 'sveltekit:scroll';
 const INDEX_KEY = 'sveltekit:index';
 
-const routes = parse(nodes, dictionary, matchers);
+const routes = parse(nodes, server_loads, dictionary, matchers);
 
 const default_layout_loader = nodes[0];
 const default_error_loader = nodes[1];

--- a/packages/kit/src/runtime/client/parse.js
+++ b/packages/kit/src/runtime/client/parse.js
@@ -2,11 +2,14 @@ import { exec, parse_route_id } from '../../utils/routing.js';
 
 /**
  * @param {import('types').CSRPageNodeLoader[]} nodes
+ * @param {number[]} server_loads
  * @param {typeof import('__GENERATED__/client-manifest.js').dictionary} dictionary
  * @param {Record<string, (param: string) => boolean>} matchers
  * @returns {import('types').CSRRoute[]}
  */
-export function parse(nodes, dictionary, matchers) {
+export function parse(nodes, server_loads, dictionary, matchers) {
+	const layouts_with_server_load = new Set(server_loads);
+
 	return Object.entries(dictionary).map(([id, [leaf, layouts, errors]]) => {
 		const { pattern, names, types } = parse_route_id(id);
 
@@ -18,8 +21,8 @@ export function parse(nodes, dictionary, matchers) {
 				if (match) return exec(match, names, types, matchers);
 			},
 			errors: [1, ...(errors || [])].map((n) => nodes[n]),
-			layouts: layouts.map(create_loader),
-			leaf: create_loader(leaf)
+			layouts: [0, ...(layouts || [])].map(create_layout_loader),
+			leaf: create_leaf_loader(leaf)
 		};
 
 		// bit of a hack, but ensures that layout/error node lists are the same
@@ -37,11 +40,21 @@ export function parse(nodes, dictionary, matchers) {
 	 * @param {number} id
 	 * @returns {[boolean, import('types').CSRPageNodeLoader]}
 	 */
-	function create_loader(id) {
+	function create_leaf_loader(id) {
 		// whether or not the route uses the server data is
 		// encoded using the ones' complement, to save space
 		const uses_server_data = id < 0;
 		if (uses_server_data) id = ~id;
 		return [uses_server_data, nodes[id]];
+	}
+
+	/**
+	 * @param {number} id
+	 * @returns {[boolean, import('types').CSRPageNodeLoader]}
+	 */
+	function create_layout_loader(id) {
+		// whether or not the layout uses the server data is
+		// encoded in the layouts array, to save space
+		return [layouts_with_server_load.has(id), nodes[id]];
 	}
 }

--- a/packages/kit/src/runtime/client/parse.js
+++ b/packages/kit/src/runtime/client/parse.js
@@ -55,6 +55,6 @@ export function parse(nodes, server_loads, dictionary, matchers) {
 	function create_layout_loader(id) {
 		// whether or not the layout uses the server data is
 		// encoded in the layouts array, to save space
-		return [layouts_with_server_load.has(id), nodes[id]];
+		return id === undefined ? id : [layouts_with_server_load.has(id), nodes[id]];
 	}
 }

--- a/packages/kit/src/runtime/client/parse.js
+++ b/packages/kit/src/runtime/client/parse.js
@@ -18,7 +18,7 @@ export function parse(nodes, dictionary, matchers) {
 				if (match) return exec(match, names, types, matchers);
 			},
 			errors: [1, ...(errors || [])].map((n) => nodes[n]),
-			layouts: [0, ...(layouts || [])].map(create_loader),
+			layouts: layouts.map(create_loader),
 			leaf: create_loader(leaf)
 		};
 

--- a/packages/kit/src/runtime/client/parse.js
+++ b/packages/kit/src/runtime/client/parse.js
@@ -49,8 +49,8 @@ export function parse(nodes, server_loads, dictionary, matchers) {
 	}
 
 	/**
-	 * @param {number} id
-	 * @returns {[boolean, import('types').CSRPageNodeLoader]}
+	 * @param {number | undefined} id
+	 * @returns {[boolean, import('types').CSRPageNodeLoader] | undefined}
 	 */
 	function create_layout_loader(id) {
 		// whether or not the layout uses the server data is


### PR DESCRIPTION
Fixes #6349
Fixes #6336

While fixing it I thought of ways to make the manifest shorter. I did that in a second commit so it can be reverted if not appropriate.

No test, I can't think of a way to test this without creating another test app, which I wanted to avoid - but can do so if we feel it's necessary.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
