### PR TITLE
[fix] skip `fetch` caching if some server node was invalidated

### DIFF
--- a/.changeset/hip-forks-hunt.md
+++ b/.changeset/hip-forks-hunt.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Skip `fetch` caching if some server node was invalidated (fixes #6357)

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -720,7 +720,8 @@ export function create_client({ target, base, trailing_slash }) {
 					{
 						headers: {
 							'x-sveltekit-invalidated': invalid_server_nodes.map((x) => (x ? '1' : '')).join(',')
-						}
+						},
+						cache: 'no-cache'
 					}
 				);
 


### PR DESCRIPTION
fixes #6357

and maybe also #6354 and #6349

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
