### PR TITLE
[adapter-vercel] don't use top level await in Vercel Edge Functions

### DIFF
--- a/.changeset/shiny-sloths-juggle.md
+++ b/.changeset/shiny-sloths-juggle.md
@@ -1,5 +1,6 @@
 ---
 '@sveltejs/adapter-vercel': patch
+'@sveltejs/adapter-netlify': patch
 ---
 
 Don't use top-level-await, as it is not supported right now

--- a/.changeset/shiny-sloths-juggle.md
+++ b/.changeset/shiny-sloths-juggle.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+Don't use top-level-await, as it is not supported right now

--- a/packages/adapter-netlify/src/edge.js
+++ b/packages/adapter-netlify/src/edge.js
@@ -4,7 +4,7 @@ import { manifest, prerendered } from 'MANIFEST';
 const server = new Server(manifest);
 const prefix = `/${manifest.appDir}/`;
 
-await server.init({
+const initialized = server.init({
 	// @ts-ignore
 	env: Deno.env.toObject()
 });
@@ -14,13 +14,14 @@ await server.init({
  * @param { any } context
  * @returns { Promise<Response> }
  */
-export default function handler(request, context) {
+export default async function handler(request, context) {
 	if (is_static_file(request)) {
 		// Static files can skip the handler
 		// TODO can we serve _app/immutable files with an immutable cache header?
 		return;
 	}
 
+	await initialized;
 	return server.respond(request, {
 		platform: { context },
 		getClientAddress() {

--- a/packages/adapter-vercel/files/edge.js
+++ b/packages/adapter-vercel/files/edge.js
@@ -2,15 +2,15 @@ import { Server } from 'SERVER';
 import { manifest } from 'MANIFEST';
 
 const server = new Server(manifest);
-
-await server.init({
+const initialized = server.init({
 	env: process.env
 });
 
 /**
  * @param {Request} request
  */
-export default (request) => {
+export default async (request) => {
+	await initialized;
 	return server.respond(request, {
 		getClientAddress() {
 			return request.headers.get('x-forwarded-for');


### PR DESCRIPTION
This fixes a regression created in #6327, due to the usage of top level await, which isn't supported in Vercel Edge Functions right now.
Using a deferred promise and awaiting within the response it practically the same thing, but works.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
