### PR TITLE
move types export to the top

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -73,8 +73,8 @@
 	"exports": {
 		"./package.json": "./package.json",
 		".": {
-			"import": "./src/exports/index.js",
-			"types": "./types/index.d.ts"
+			"types": "./types/index.d.ts",
+			"import": "./src/exports/index.js"
 		},
 		"./node": {
 			"import": "./src/exports/node/index.js"


### PR DESCRIPTION
We need to place `"types"` as the first one according to https://nodejs.org/api/packages.html#community-conditions-definitions, though I don't think there's any problem so far, so we probably don't need a changeset for this.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
