### PR TITLE
Bundle non-prod dependencies with esbuild

### DIFF
--- a/.changeset/big-trainers-love.md
+++ b/.changeset/big-trainers-love.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Bundle non-production dependencies with esbuild

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -140,11 +140,13 @@ app.listen(3000, () => {
 
 ## Deploying
 
-You will need the output directory (`build` by default), the project's `package.json`, and the production dependencies in `node_modules` to run the application. Production dependencies can be generated with `npm ci --prod`, you can also skip this step if your app doesn't have any dependencies. You can then start your app with
+You will need the output directory (`build` by default), the project's `package.json`, and the production dependencies in `node_modules` to run the application. Production dependencies can be generated with `npm ci --prod` (you can skip this step if your app doesn't have any dependencies). You can then start your app with
 
 ```bash
 node build
 ```
+
+Development dependencies will be bundled into your app using `esbuild`. To control whether a given package is bundled or externalised, place it in `devDependencies` or `dependencies` respectively in your `package.json`.
 
 ## Changelog
 

--- a/packages/adapter-node/ambient.d.ts
+++ b/packages/adapter-node/ambient.d.ts
@@ -1,8 +1,16 @@
-declare module 'SERVER' {
-	export { Server } from '@sveltejs/kit';
+declare module 'ENV' {
+	export function env(key: string, fallback?: any): string;
+}
+
+declare module 'HANDLER' {
+	export const handler: import('polka').Middleware;
 }
 
 declare module 'MANIFEST' {
 	import { SSRManifest } from '@sveltejs/kit';
 	export const manifest: SSRManifest;
+}
+
+declare module 'SERVER' {
+	export { Server } from '@sveltejs/kit';
 }

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -43,5 +43,8 @@
 		"sirv": "^2.0.2",
 		"typescript": "^4.7.4",
 		"uvu": "^0.5.3"
+	},
+	"dependencies": {
+		"esbuild": "^0.14.48"
 	}
 }

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -1,19 +1,35 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
+import { builtinModules } from 'module';
 
 export default [
 	{
-		input: {
-			index: 'src/index.js',
-			handler: 'src/handler.js',
-			shims: 'src/shims.js'
-		},
+		input: 'src/index.js',
 		output: {
-			dir: 'files',
+			file: 'files/index.js',
 			format: 'esm'
 		},
 		plugins: [nodeResolve(), commonjs(), json()],
-		external: ['SERVER', 'MANIFEST', ...require('module').builtinModules]
+		external: ['ENV', 'HANDLER', ...builtinModules]
+	},
+	{
+		input: 'src/env.js',
+		output: {
+			file: 'files/env.js',
+			format: 'esm'
+		},
+		plugins: [nodeResolve(), commonjs(), json()],
+		external: ['HANDLER', ...builtinModules]
+	},
+	{
+		input: 'src/handler.js',
+		output: {
+			file: 'files/handler.js',
+			format: 'esm',
+			inlineDynamicImports: true
+		},
+		plugins: [nodeResolve(), commonjs(), json()],
+		external: ['ENV', 'MANIFEST', 'SERVER', ...builtinModules]
 	}
 ];

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'url';
 import { getRequest, setResponse } from '@sveltejs/kit/node';
 import { Server } from 'SERVER';
 import { manifest } from 'MANIFEST';
-import { env } from './env.js';
+import { env } from 'ENV';
 
 /* global ENV_PREFIX */
 
@@ -19,7 +19,7 @@ const address_header = env('ADDRESS_HEADER', '').toLowerCase();
 const protocol_header = env('PROTOCOL_HEADER', '').toLowerCase();
 const host_header = env('HOST_HEADER', 'host').toLowerCase();
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const dir = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * @param {string} path
@@ -132,9 +132,9 @@ function get_origin(headers) {
 
 export const handler = sequence(
 	[
-		serve(path.join(__dirname, '/client'), true),
-		serve(path.join(__dirname, '/static')),
-		serve(path.join(__dirname, '/prerendered')),
+		serve(path.join(dir, 'client'), true),
+		serve(path.join(dir, 'static')),
+		serve(path.join(dir, 'prerendered')),
 		ssr
 	].filter(Boolean)
 );

--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -1,5 +1,5 @@
-import { handler } from './handler.js';
-import { env } from './env.js';
+import { handler } from 'HANDLER';
+import { env } from 'ENV';
 import polka from 'polka';
 
 export const path = env('SOCKET_PATH', false);

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -99,7 +99,7 @@ export interface Builder {
 	/**
 	 * @param {string} directory Path to the directory containing the files to be compressed
 	 */
-	compress(directory: string): void;
+	compress(directory: string): Promise<void>;
 }
 
 export interface Config {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,7 @@ importers:
       '@sveltejs/kit': workspace:*
       '@types/node': ^16.11.36
       c8: ^7.11.3
+      esbuild: ^0.14.48
       node-fetch: ^3.2.4
       polka: ^1.0.0-next.22
       rimraf: ^3.0.2
@@ -127,6 +128,8 @@ importers:
       sirv: ^2.0.2
       typescript: ^4.7.4
       uvu: ^0.5.3
+    dependencies:
+      esbuild: 0.14.54
     devDependencies:
       '@rollup/plugin-json': 4.1.0_rollup@2.75.7
       '@sveltejs/kit': link:../kit


### PR DESCRIPTION
This closes #3176, by always bundling dev dependencies using `esbuild`. Supersedes #6301.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
