### PR TITLE
[chore] tiny-glob doesn't need to be dependency and devDependency

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -36,7 +36,6 @@
 		"rollup": "^2.75.7",
 		"svelte": "^3.48.0",
 		"svelte-preprocess": "^4.10.6",
-		"tiny-glob": "^0.2.9",
 		"typescript": "^4.7.4",
 		"uvu": "^0.5.3",
 		"vite": "^3.0.9"


### PR DESCRIPTION
minor cleanup I noticed