### PR TITLE
[fix] remove vestigial JSON server_data

### DIFF
--- a/.changeset/quiet-poems-tease.md
+++ b/.changeset/quiet-poems-tease.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] remove unnecessary JSON serialization of server data

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -299,15 +299,6 @@ export async function render_response({
 			);
 		}
 
-		if (branch.some((node) => node.server_data)) {
-			serialized_data.push(
-				render_json_payload_script(
-					{ type: 'server_data' },
-					branch.map(({ server_data }) => server_data)
-				)
-			);
-		}
-
 		if (validation_errors) {
 			serialized_data.push(
 				render_json_payload_script({ type: 'validation_errors' }, validation_errors)

--- a/packages/kit/src/utils/escape.spec.js
+++ b/packages/kit/src/utils/escape.spec.js
@@ -5,11 +5,13 @@ import { render_json_payload_script, escape_html_attr } from './escape.js';
 const json = suite('render_json_payload_script');
 
 json('escapes slashes', () => {
+	// The type here doesn't really matter for the purposes of escaping,
+	// but we want to avoid upsetting TypeScript.
 	assert.equal(
-		render_json_payload_script({ type: 'server_data' }, [
+		render_json_payload_script({ type: 'validation_errors' }, [
 			{ unsafe: '</script><script>alert("xss")' }
 		]),
-		'<script type="application/json" sveltekit:data-type="server_data">' +
+		'<script type="application/json" sveltekit:data-type="validation_errors">' +
 			'[{"unsafe":"\\u003C/script>\\u003Cscript>alert(\\"xss\\")"}]' +
 			'</script>'
 	);
@@ -17,10 +19,10 @@ json('escapes slashes', () => {
 
 json('escapes exclamation marks', () => {
 	assert.equal(
-		render_json_payload_script({ type: 'server_data' }, [
+		render_json_payload_script({ type: 'validation_errors' }, [
 			{ '<!--</script>...-->alert("xss")': 'unsafe' }
 		]),
-		'<script type="application/json" sveltekit:data-type="server_data">' +
+		'<script type="application/json" sveltekit:data-type="validation_errors">' +
 			'[{"\\u003C!--\\u003C/script>...-->alert(\\"xss\\")":"unsafe"}]' +
 			'</script>'
 	);

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -133,7 +133,6 @@ export interface PageNode {
 
 export type PayloadScriptAttributes =
 	| { type: 'data'; url: string; body?: string }
-	| { type: 'server_data' }
 	| { type: 'validation_errors' };
 
 export interface PrerenderDependency {


### PR DESCRIPTION
When we started serializing server data with devalue, the old JSON serialization of it was left in. This removes it.

This also updates the types so that `server_data` is no longer a valid `type` to pass to `render_json_payload_script`. This required a slight adjustment to the unit tests.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0