### PR TITLE
prevent test suites getting published

### DIFF
--- a/.changeset/hip-trains-vanish.md
+++ b/.changeset/hip-trains-vanish.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+prevent test suites from getting published

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -50,7 +50,6 @@
 	"files": [
 		"src",
 		"!src/**/*.spec.js",
-		"!src/packaging/test",
 		"!src/core/**/fixtures",
 		"!src/core/sync/create_manifest_data/test",
 		"types",
@@ -65,7 +64,7 @@
 		"prepublishOnly": "npm run build",
 		"test": "npm run test:unit && npm run test:integration",
 		"test:integration": "pnpm run -r --workspace-concurrency 1 --filter=\"./test/**\" test",
-		"test:unit": "uvu src \"(spec\\.js|test[\\\\/]index\\.js)\" -i packaging",
+		"test:unit": "uvu src \"(spec\\.js|test[\\\\/]index\\.js)\"",
 		"types": "node scripts/extract-types.js",
 		"postinstall": "node svelte-kit.js sync"
 	},

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -51,7 +51,7 @@
 		"src",
 		"!src/**/*.spec.js",
 		"!src/core/**/fixtures",
-		"!src/core/sync/create_manifest_data/test",
+		"!src/core/**/test",
 		"types",
 		"svelte-kit.js"
 	],


### PR DESCRIPTION
Removed some obsolete packaging references, and updated the glob pattern as we're still publishing [`sync/write_types` test suites](https://github.com/sveltejs/kit/tree/master/packages/kit/src/core/sync/write_types/test)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
