### PR TITLE
[breaking] require Node 16.14

### DIFF
--- a/.changeset/young-pumpkins-approve.md
+++ b/.changeset/young-pumpkins-approve.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/kit': patch
+'@sveltejs/package': patch
+---
+
+[breaking] require Node 16.14

--- a/packages/adapter-cloudflare/README.md
+++ b/packages/adapter-cloudflare/README.md
@@ -49,7 +49,7 @@ When configuring your project settings, you must use the following settings:
 - **Environment variables**
   - `NODE_VERSION`: `16`
 
-> **Important:** You need to add a `NODE_VERSION` environment variable to both the "production" and "preview" environments. You can add this during project setup or later in the Pages project settings. SvelteKit requires Node `16.9` or later, so you should use `16` as the `NODE_VERSION` value.
+> **Important:** You need to add a `NODE_VERSION` environment variable to both the "production" and "preview" environments. You can add this during project setup or later in the Pages project settings. SvelteKit requires Node `16.14` or later, so you should use `16` as the `NODE_VERSION` value.
 
 ## Environment variables
 

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -90,6 +90,6 @@
 	},
 	"types": "types/index.d.ts",
 	"engines": {
-		"node": ">=16.9"
+		"node": ">=16.14"
 	}
 }

--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -47,6 +47,6 @@
 	},
 	"types": "types/index.d.ts",
 	"engines": {
-		"node": ">=16.9"
+		"node": ">=16.14"
 	}
 }


### PR DESCRIPTION
This resolves #6385 by bumping the required Node version to 16.14+. The third `inspect` argument to Node's custom inspect handlers wasn't added until 16.14.0 (https://github.com/nodejs/node/pull/41019) even though the documentation (https://nodejs.org/dist/latest-v16.x/docs/api/util.html#utilinspectcustom) doesn't indicate that that was when it was added. Since we're still in pre-release, it's a lot simpler to just bump the required version than it is to make this work with older versions of Node.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
