### PR TITLE
merge `resolve` options when using `sequence`

### DIFF
--- a/.changeset/red-rice-bathe.md
+++ b/.changeset/red-rice-bathe.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] merge resolve options when using sequence helper

--- a/packages/kit/src/exports/hooks/sequence.js
+++ b/packages/kit/src/exports/hooks/sequence.js
@@ -7,19 +7,40 @@ export function sequence(...handlers) {
 	if (!length) return ({ event, resolve }) => resolve(event);
 
 	return ({ event, resolve }) => {
-		return apply_handle(0, event);
+		return apply_handle(0, event, {});
 
 		/**
 		 * @param {number} i
 		 * @param {import('types').RequestEvent} event
+		 * @param {import('types').ResolveOptions | undefined} parent_options
 		 * @returns {import('types').MaybePromise<Response>}
 		 */
-		function apply_handle(i, event) {
+		function apply_handle(i, event, parent_options) {
 			const handle = handlers[i];
 
 			return handle({
 				event,
-				resolve: i < length - 1 ? (event) => apply_handle(i + 1, event) : resolve
+				resolve: (event, options) => {
+					/** @param {{ html: string, done: boolean }} opts */
+					const transformPageChunk = async ({ html, done }) => {
+						if (options?.transformPageChunk) {
+							html = (await options.transformPageChunk({ html, done })) ?? '';
+						}
+
+						if (parent_options?.transformPageChunk) {
+							html = (await parent_options.transformPageChunk({ html, done })) ?? '';
+						}
+
+						return html;
+					};
+
+					// TODO remove post-https://github.com/sveltejs/kit/pull/6197
+					const ssr = options?.ssr ?? parent_options?.ssr;
+
+					return i < length - 1
+						? apply_handle(i + 1, event, { transformPageChunk, ssr })
+						: resolve(event, { transformPageChunk, ssr });
+				}
 			});
 		}
 	};

--- a/packages/kit/src/exports/hooks/sequence.js
+++ b/packages/kit/src/exports/hooks/sequence.js
@@ -1,13 +1,4 @@
 /**
- * Merge an array of multiple handlers into one. The `resolve` passed
- * to the first handler will call the second handler, and so on,
- * until the last handler calls the framework.
- *
- * If handlers use the `transformPageChunk` option, the functions
- * will be 'chained', meaning a transform function specified in
- * the first handler will be applied to later handlers, and
- * multiple transformations can be applied.
- *
  * @param {...import('types').Handle} handlers
  * @returns {import('types').Handle}
  */

--- a/packages/kit/src/exports/hooks/sequence.js
+++ b/packages/kit/src/exports/hooks/sequence.js
@@ -1,4 +1,13 @@
 /**
+ * Merge an array of multiple handlers into one. The `resolve` passed
+ * to the first handler will call the second handler, and so on,
+ * until the last handler calls the framework.
+ *
+ * If handlers use the `transformPageChunk` option, the functions
+ * will be 'chained', meaning a transform function specified in
+ * the first handler will be applied to later handlers, and
+ * multiple transformations can be applied.
+ *
  * @param {...import('types').Handle} handlers
  * @returns {import('types').Handle}
  */

--- a/packages/kit/src/exports/hooks/sequence.spec.js
+++ b/packages/kit/src/exports/hooks/sequence.spec.js
@@ -1,0 +1,77 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { sequence } from './sequence.js';
+import { installPolyfills } from '../node/polyfills.js';
+
+installPolyfills();
+
+test('applies handlers in sequence', async () => {
+	/** @type {string[]} */
+	const order = [];
+
+	const handler = sequence(
+		async ({ event, resolve }) => {
+			order.push('1a');
+			const response = await resolve(event);
+			order.push('1b');
+			return response;
+		},
+		async ({ event, resolve }) => {
+			order.push('2a');
+			const response = await resolve(event);
+			order.push('2b');
+			return response;
+		},
+		async ({ event, resolve }) => {
+			order.push('3a');
+			const response = await resolve(event);
+			order.push('3b');
+			return response;
+		}
+	);
+
+	const event = /** @type {import('types').RequestEvent} */ ({});
+	const response = new Response();
+
+	assert.equal(await handler({ event, resolve: () => response }), response);
+	assert.equal(order, ['1a', '2a', '3a', '3b', '2b', '1b']);
+});
+
+test('merges transformPageChunk option', async () => {
+	const handler = sequence(
+		async ({ event, resolve }) => {
+			return resolve(event, {
+				transformPageChunk: ({ html, done }) => html + (done ? '-1-done' : '-1')
+			});
+		},
+		async ({ event, resolve }) => {
+			return resolve(event, {
+				transformPageChunk: ({ html, done }) => html + (done ? '-2-done' : '-2')
+			});
+		},
+		async ({ event, resolve }) => {
+			return resolve(event, {
+				transformPageChunk: ({ html, done }) => html + (done ? '-3-done' : '-3')
+			});
+		}
+	);
+
+	const event = /** @type {import('types').RequestEvent} */ ({});
+	const response = await handler({
+		event,
+		resolve: async (_event, opts = {}) => {
+			let html = '';
+
+			const { transformPageChunk = ({ html }) => html } = opts;
+
+			html += await transformPageChunk({ html: '0', done: false });
+			html += await transformPageChunk({ html: ' 0', done: true });
+
+			return new Response(html);
+		}
+	});
+
+	assert.equal(await response.text(), '0-3-2-1 0-3-done-2-done-1-done');
+});
+
+test.run();

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -300,7 +300,13 @@ declare module '@sveltejs/kit/hooks' {
 	 * /** @type {import('@sveltejs/kit').Handle} *\/
 	 * async function first({ event, resolve }) {
 	 * 	console.log('first pre-processing');
-	 * 	const result = await resolve(event);
+	 * 	const result = await resolve(event, {
+	 * 		transformPageChunk: ({ html }) => {
+	 * 			// transforms are applied in reverse order
+	 * 			console.log('first transform');
+	 * 			return html;
+	 * 		}
+	 * 	});
 	 * 	console.log('first post-processing');
 	 * 	return result;
 	 * }
@@ -308,7 +314,12 @@ declare module '@sveltejs/kit/hooks' {
 	 * /** @type {import('@sveltejs/kit').Handle} *\/
 	 * async function second({ event, resolve }) {
 	 * 	console.log('second pre-processing');
-	 * 	const result = await resolve(event);
+	 * 	const result = await resolve(event, {
+	 * 		transformPageChunk: ({ html }) => {
+	 * 			console.log('second transform');
+	 * 			return html;
+	 * 		}
+	 * 	});
 	 * 	console.log('second post-processing');
 	 * 	return result;
 	 * }
@@ -321,6 +332,8 @@ declare module '@sveltejs/kit/hooks' {
 	 * ```
 	 * first pre-processing
 	 * second pre-processing
+	 * second transform
+	 * first transform
 	 * second post-processing
 	 * first post-processing
 	 * ```


### PR DESCRIPTION
Closes #4051.

After this change, a `transformPageChunk` option passed to the first `handle` in a sequence will be respected by later calls to `resolve`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
