### PR TITLE
include type descriptions in package

### DIFF
--- a/.changeset/unlucky-elephants-appear.md
+++ b/.changeset/unlucky-elephants-appear.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Include type descriptions for ambient declarations

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -53,7 +53,8 @@
 		"!src/core/**/fixtures",
 		"!src/core/**/test",
 		"types",
-		"svelte-kit.js"
+		"svelte-kit.js",
+		"scripts/special-types"
 	],
 	"scripts": {
 		"build": "npm run types",


### PR DESCRIPTION
#6413 broke everything — `svelte-kit sync` no longer works in `postinstall` (or indeed anywhere else) because the files `write_ambient` depends on aren't included in the package.

Gonna expedite a release for this one as it's... quite a bad bug