### PR TITLE
[chore] bump TS to 4.8

### DIFF
--- a/.changeset/four-meals-learn.md
+++ b/.changeset/four-meals-learn.md
@@ -1,0 +1,6 @@
+---
+'create-svelte': patch
+'@sveltejs/kit': patch
+---
+
+[chore] bump ts version and ensure it works with latest changes

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"svelte": "^3.48.0",
 		"tiny-glob": "^0.2.9",
 		"turbo": "^1.3.4",
-		"typescript": "^4.7.4"
+		"typescript": "^4.8.2"
 	},
 	"packageManager": "pnpm@7.9.5",
 	"engines": {

--- a/packages/adapter-auto/package.json
+++ b/packages/adapter-auto/package.json
@@ -36,6 +36,6 @@
 	},
 	"devDependencies": {
 		"@types/node": "^16.11.36",
-		"typescript": "^4.7.4"
+		"typescript": "^4.8.2"
 	}
 }

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -35,6 +35,6 @@
 	"devDependencies": {
 		"@cloudflare/kv-asset-handler": "^0.2.0",
 		"@types/node": "^16.11.36",
-		"typescript": "^4.7.4"
+		"typescript": "^4.8.2"
 	}
 }

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -38,7 +38,7 @@
 	"devDependencies": {
 		"@types/node": "^16.11.36",
 		"@types/ws": "^8.5.3",
-		"typescript": "^4.7.4"
+		"typescript": "^4.8.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -47,7 +47,7 @@
 		"@types/set-cookie-parser": "^2.4.2",
 		"rimraf": "^3.0.2",
 		"rollup": "^2.78.1",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"uvu": "^0.5.3"
 	}
 }

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -41,7 +41,7 @@
 		"rimraf": "^3.0.2",
 		"rollup": "^2.78.1",
 		"sirv": "^2.0.2",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"uvu": "^0.5.3"
 	},
 	"dependencies": {

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -30,7 +30,7 @@
 		"playwright-chromium": "^1.25.0",
 		"sirv": "^2.0.2",
 		"svelte": "^3.48.0",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"uvu": "^0.5.3",
 		"vite": "^3.1.0-beta.1"
 	}

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -34,6 +34,6 @@
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:*",
 		"@types/node": "^16.11.36",
-		"typescript": "^4.7.4"
+		"typescript": "^4.8.2"
 	}
 }

--- a/packages/create-svelte/templates/default/package.json
+++ b/packages/create-svelte/templates/default/package.json
@@ -12,7 +12,7 @@
 		"@sveltejs/kit": "workspace:*",
 		"svelte": "^3.48.0",
 		"svelte-preprocess": "^4.10.6",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"vite": "^3.1.0-beta.1"
 	},
 	"type": "module",

--- a/packages/create-svelte/templates/libskeleton/package.template.json
+++ b/packages/create-svelte/templates/libskeleton/package.template.json
@@ -11,7 +11,7 @@
 		"@sveltejs/package": "workspace:*",
 		"svelte": "^3.44.0",
 		"tslib": "^2.3.1",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"vite": "^3.1.0-beta.1"
 	},
 	"type": "module"

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -36,7 +36,7 @@
 		"rollup": "^2.78.1",
 		"svelte": "^3.48.0",
 		"svelte-preprocess": "^4.10.6",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"uvu": "^0.5.3",
 		"vite": "^3.1.0-beta.1"
 	},

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -181,7 +181,7 @@ function update_types(config, routes, route) {
 			`type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>`
 		);
 		// null & {} == null, we need to prevent that in some situations
-		declarations.push(`type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;`);
+		declarations.push(`type EnsureParentData<T> = T extends null | undefined ? {} : T;`);
 	}
 
 	if (route.leaf) {

--- a/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/$types.d.ts
@@ -10,7 +10,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Partial<Pick<App.PageData, keyof T & keyof App.PageData>> &
 		Record<string, any>
 >;
-type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
+type EnsureParentData<T> = T extends null | undefined ? {} : T;
 type LayoutParams = RouteParams & {};
 type LayoutParentData = EnsureParentData<{}>;
 

--- a/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/(main)/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/(main)/$types.d.ts
@@ -10,7 +10,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Partial<Pick<App.PageData, keyof T & keyof App.PageData>> &
 		Record<string, any>
 >;
-type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
+type EnsureParentData<T> = T extends null | undefined ? {} : T;
 type PageParentData = EnsureParentData<import('../$types.js').LayoutData>;
 type LayoutParams = RouteParams & {};
 type LayoutServerParentData = EnsureParentData<import('../$types.js').LayoutServerData>;

--- a/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/(main)/sub/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/(main)/sub/$types.d.ts
@@ -10,7 +10,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Partial<Pick<App.PageData, keyof T & keyof App.PageData>> &
 		Record<string, any>
 >;
-type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
+type EnsureParentData<T> = T extends null | undefined ? {} : T;
 type PageParentData = Omit<
 	EnsureParentData<import('../../$types.js').LayoutData>,
 	keyof import('../$types.js').LayoutData

--- a/packages/kit/src/core/sync/write_types/test/layout/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/layout/_expected/$types.d.ts
@@ -10,7 +10,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Partial<Pick<App.PageData, keyof T & keyof App.PageData>> &
 		Record<string, any>
 >;
-type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
+type EnsureParentData<T> = T extends null | undefined ? {} : T;
 type PageServerParentData = EnsureParentData<LayoutServerData>;
 type PageParentData = EnsureParentData<LayoutData>;
 type LayoutParams = RouteParams & {};

--- a/packages/kit/src/core/sync/write_types/test/simple-page-server-and-shared/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/simple-page-server-and-shared/_expected/$types.d.ts
@@ -10,7 +10,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Partial<Pick<App.PageData, keyof T & keyof App.PageData>> &
 		Record<string, any>
 >;
-type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
+type EnsureParentData<T> = T extends null | undefined ? {} : T;
 type PageServerParentData = EnsureParentData<LayoutServerData>;
 type PageParentData = EnsureParentData<LayoutData>;
 type LayoutParams = RouteParams & {};

--- a/packages/kit/src/core/sync/write_types/test/simple-page-server-only/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/simple-page-server-only/_expected/$types.d.ts
@@ -10,7 +10,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Partial<Pick<App.PageData, keyof T & keyof App.PageData>> &
 		Record<string, any>
 >;
-type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
+type EnsureParentData<T> = T extends null | undefined ? {} : T;
 type PageServerParentData = EnsureParentData<LayoutServerData>;
 type PageParentData = EnsureParentData<LayoutData>;
 type LayoutParams = RouteParams & {};

--- a/packages/kit/src/core/sync/write_types/test/simple-page-shared-only/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/simple-page-shared-only/_expected/$types.d.ts
@@ -10,7 +10,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Partial<Pick<App.PageData, keyof T & keyof App.PageData>> &
 		Record<string, any>
 >;
-type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
+type EnsureParentData<T> = T extends null | undefined ? {} : T;
 type PageParentData = EnsureParentData<LayoutData>;
 type LayoutParams = RouteParams & {};
 type LayoutParentData = EnsureParentData<{}>;

--- a/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/$types.d.ts
@@ -10,7 +10,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Partial<Pick<App.PageData, keyof T & keyof App.PageData>> &
 		Record<string, any>
 >;
-type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
+type EnsureParentData<T> = T extends null | undefined ? {} : T;
 type LayoutParams = RouteParams & { rest?: string; slug?: string };
 type LayoutParentData = EnsureParentData<{}>;
 

--- a/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/$types.d.ts
@@ -10,7 +10,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Partial<Pick<App.PageData, keyof T & keyof App.PageData>> &
 		Record<string, any>
 >;
-type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
+type EnsureParentData<T> = T extends null | undefined ? {} : T;
 type LayoutParams = RouteParams & { rest?: string };
 type LayoutParentData = EnsureParentData<import('../$types.js').LayoutData>;
 

--- a/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/[...rest]/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/[...rest]/$types.d.ts
@@ -10,7 +10,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Partial<Pick<App.PageData, keyof T & keyof App.PageData>> &
 		Record<string, any>
 >;
-type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
+type EnsureParentData<T> = T extends null | undefined ? {} : T;
 type PageParentData = Omit<
 	EnsureParentData<import('../../$types.js').LayoutData>,
 	keyof import('../$types.js').LayoutData

--- a/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/[slug]/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/[slug]/$types.d.ts
@@ -10,7 +10,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Partial<Pick<App.PageData, keyof T & keyof App.PageData>> &
 		Record<string, any>
 >;
-type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
+type EnsureParentData<T> = T extends null | undefined ? {} : T;
 type PageParentData = EnsureParentData<import('../../$types.js').LayoutData>;
 
 export type PageServerData = null;

--- a/packages/kit/src/core/sync/write_types/test/slugs/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs/_expected/$types.d.ts
@@ -10,7 +10,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Partial<Pick<App.PageData, keyof T & keyof App.PageData>> &
 		Record<string, any>
 >;
-type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
+type EnsureParentData<T> = T extends null | undefined ? {} : T;
 type LayoutParams = RouteParams & { rest?: string; slug?: string };
 type LayoutParentData = EnsureParentData<{}>;
 

--- a/packages/kit/src/core/sync/write_types/test/slugs/_expected/[...rest]/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs/_expected/[...rest]/$types.d.ts
@@ -10,7 +10,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Partial<Pick<App.PageData, keyof T & keyof App.PageData>> &
 		Record<string, any>
 >;
-type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
+type EnsureParentData<T> = T extends null | undefined ? {} : T;
 type PageParentData = EnsureParentData<import('../$types.js').LayoutData>;
 
 export type PageServerData = null;

--- a/packages/kit/src/core/sync/write_types/test/slugs/_expected/[slug]/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs/_expected/[slug]/$types.d.ts
@@ -10,7 +10,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Partial<Pick<App.PageData, keyof T & keyof App.PageData>> &
 		Record<string, any>
 >;
-type EnsureParentData<T> = NonNullable<T> extends never ? {} : T;
+type EnsureParentData<T> = T extends null | undefined ? {} : T;
 type PageParentData = EnsureParentData<import('../$types.js').LayoutData>;
 
 export type PageServerData = null;

--- a/packages/kit/test/apps/amp/package.json
+++ b/packages/kit/test/apps/amp/package.json
@@ -18,7 +18,7 @@
 		"purify-css": "^1.2.5",
 		"svelte": "^3.48.0",
 		"svelte-check": "^2.7.1",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"vite": "^3.1.0-beta.1"
 	},
 	"type": "module"

--- a/packages/kit/test/apps/basics/package.json
+++ b/packages/kit/test/apps/basics/package.json
@@ -17,7 +17,7 @@
 		"rimraf": "^3.0.2",
 		"svelte": "^3.48.0",
 		"svelte-check": "^2.7.1",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"vite": "^3.1.0-beta.1"
 	},
 	"type": "module"

--- a/packages/kit/test/apps/basics/src/routes/load/server-data-reuse/with-server-load/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/server-data-reuse/with-server-load/+page.svelte
@@ -1,6 +1,6 @@
-<script lang="ts">
+<script>
 	/** @type {import('./$types').PageData} */
-	export let data 
+	export let data;
 </script>
 
 <p>Page with server load</p>

--- a/packages/kit/test/apps/dev-only/package.json
+++ b/packages/kit/test/apps/dev-only/package.json
@@ -15,7 +15,7 @@
 		"rimraf": "^3.0.2",
 		"svelte": "^3.48.0",
 		"svelte-check": "^2.7.1",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"vite": "^3.1.0-beta.1"
 	},
 	"type": "module"

--- a/packages/kit/test/apps/options-2/package.json
+++ b/packages/kit/test/apps/options-2/package.json
@@ -17,7 +17,7 @@
 		"cross-env": "^7.0.3",
 		"svelte": "^3.48.0",
 		"svelte-check": "^2.7.1",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"vite": "^3.1.0-beta.1"
 	},
 	"type": "module"

--- a/packages/kit/test/apps/options/package.json
+++ b/packages/kit/test/apps/options/package.json
@@ -16,7 +16,7 @@
 		"cross-env": "^7.0.3",
 		"svelte": "^3.48.0",
 		"svelte-check": "^2.7.1",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"vite": "^3.1.0-beta.1"
 	},
 	"type": "module"

--- a/packages/kit/test/apps/writes/package.json
+++ b/packages/kit/test/apps/writes/package.json
@@ -17,7 +17,7 @@
 		"rimraf": "^3.0.2",
 		"svelte": "^3.48.0",
 		"svelte-check": "^2.7.1",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"vite": "^3.1.0-beta.1"
 	},
 	"type": "module"

--- a/packages/kit/test/prerendering/basics/package.json
+++ b/packages/kit/test/prerendering/basics/package.json
@@ -13,7 +13,7 @@
 		"@sveltejs/kit": "workspace:*",
 		"svelte": "^3.48.0",
 		"svelte-check": "^2.7.1",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"uvu": "^0.5.3",
 		"vite": "^3.1.0-beta.1"
 	},

--- a/packages/kit/test/prerendering/fallback/package.json
+++ b/packages/kit/test/prerendering/fallback/package.json
@@ -13,7 +13,7 @@
 		"@sveltejs/kit": "workspace:*",
 		"svelte": "^3.48.0",
 		"svelte-check": "^2.7.1",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"uvu": "^0.5.3",
 		"vite": "^3.1.0-beta.1"
 	},

--- a/packages/kit/test/prerendering/options/package.json
+++ b/packages/kit/test/prerendering/options/package.json
@@ -13,7 +13,7 @@
 		"@sveltejs/kit": "workspace:*",
 		"svelte": "^3.48.0",
 		"svelte-check": "^2.7.1",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"uvu": "^0.5.3",
 		"vite": "^3.1.0-beta.1"
 	},

--- a/packages/kit/test/prerendering/paths-base/package.json
+++ b/packages/kit/test/prerendering/paths-base/package.json
@@ -13,7 +13,7 @@
 		"@sveltejs/kit": "workspace:*",
 		"svelte": "^3.48.0",
 		"svelte-check": "^2.7.1",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"uvu": "^0.5.3",
 		"vite": "^3.1.0-beta.1"
 	},

--- a/packages/kit/test/prerendering/trailing-slash/package.json
+++ b/packages/kit/test/prerendering/trailing-slash/package.json
@@ -13,7 +13,7 @@
 		"@sveltejs/kit": "workspace:*",
 		"svelte": "^3.48.0",
 		"svelte-check": "^2.7.1",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"uvu": "^0.5.4",
 		"vite": "^3.1.0-beta.1"
 	},

--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -19,7 +19,7 @@
 		"@types/node": "^16.11.36",
 		"svelte": "^3.48.0",
 		"svelte-preprocess": "^4.10.6",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"uvu": "^0.5.3"
 	},
 	"peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
       svelte: ^3.48.0
       tiny-glob: ^0.2.9
       turbo: ^1.3.4
-      typescript: ^4.7.4
+      typescript: ^4.8.2
     devDependencies:
       '@changesets/cli': 2.23.0
       '@rollup/plugin-commonjs': 22.0.1_rollup@2.78.1
@@ -28,7 +28,7 @@ importers:
       svelte: 3.48.0
       tiny-glob: 0.2.9
       turbo: 1.3.4
-      typescript: 4.7.4
+      typescript: 4.8.2
 
   packages/adapter-auto:
     specifiers:
@@ -36,14 +36,14 @@ importers:
       '@sveltejs/adapter-netlify': workspace:*
       '@sveltejs/adapter-vercel': workspace:*
       '@types/node': ^16.11.36
-      typescript: ^4.7.4
+      typescript: ^4.8.2
     dependencies:
       '@sveltejs/adapter-cloudflare': link:../adapter-cloudflare
       '@sveltejs/adapter-netlify': link:../adapter-netlify
       '@sveltejs/adapter-vercel': link:../adapter-vercel
     devDependencies:
       '@types/node': 16.11.42
-      typescript: 4.7.4
+      typescript: 4.8.2
 
   packages/adapter-cloudflare:
     specifiers:
@@ -51,7 +51,7 @@ importers:
       '@types/node': ^16.11.36
       '@types/ws': ^8.5.3
       esbuild: ^0.14.48
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       worktop: 0.8.0-next.14
     dependencies:
       '@cloudflare/workers-types': 3.14.0
@@ -60,7 +60,7 @@ importers:
     devDependencies:
       '@types/node': 16.11.42
       '@types/ws': 8.5.3
-      typescript: 4.7.4
+      typescript: 4.8.2
 
   packages/adapter-cloudflare-workers:
     specifiers:
@@ -69,7 +69,7 @@ importers:
       '@iarna/toml': ^2.2.5
       '@types/node': ^16.11.36
       esbuild: ^0.14.48
-      typescript: ^4.7.4
+      typescript: ^4.8.2
     dependencies:
       '@cloudflare/workers-types': 3.14.0
       '@iarna/toml': 2.2.5
@@ -77,7 +77,7 @@ importers:
     devDependencies:
       '@cloudflare/kv-asset-handler': 0.2.0
       '@types/node': 16.11.42
-      typescript: 4.7.4
+      typescript: 4.8.2
 
   packages/adapter-netlify:
     specifiers:
@@ -94,7 +94,7 @@ importers:
       rollup: ^2.78.1
       set-cookie-parser: ^2.4.8
       tiny-glob: ^0.2.9
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       uvu: ^0.5.3
     dependencies:
       '@iarna/toml': 2.2.5
@@ -111,7 +111,7 @@ importers:
       '@types/set-cookie-parser': 2.4.2
       rimraf: 3.0.2
       rollup: 2.78.1
-      typescript: 4.7.4
+      typescript: 4.8.2
       uvu: 0.5.4
 
   packages/adapter-node:
@@ -126,7 +126,7 @@ importers:
       rimraf: ^3.0.2
       rollup: ^2.78.1
       sirv: ^2.0.2
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       uvu: ^0.5.3
     dependencies:
       esbuild: 0.14.54
@@ -140,7 +140,7 @@ importers:
       rimraf: 3.0.2
       rollup: 2.78.1
       sirv: 2.0.2
-      typescript: 4.7.4
+      typescript: 4.8.2
       uvu: 0.5.4
 
   packages/adapter-static:
@@ -150,7 +150,7 @@ importers:
       playwright-chromium: ^1.25.0
       sirv: ^2.0.2
       svelte: ^3.48.0
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       uvu: ^0.5.3
       vite: ^3.1.0-beta.1
     devDependencies:
@@ -159,7 +159,7 @@ importers:
       playwright-chromium: 1.25.0
       sirv: 2.0.2
       svelte: 3.48.0
-      typescript: 4.7.4
+      typescript: 4.8.2
       uvu: 0.5.4
       vite: 3.1.0-beta.1
 
@@ -193,14 +193,14 @@ importers:
       '@types/node': ^16.11.36
       '@vercel/nft': ^0.22.0
       esbuild: ^0.14.48
-      typescript: ^4.7.4
+      typescript: ^4.8.2
     dependencies:
       '@vercel/nft': 0.22.0
       esbuild: 0.14.54
     devDependencies:
       '@sveltejs/kit': link:../kit
       '@types/node': 16.11.42
-      typescript: 4.7.4
+      typescript: 4.8.2
 
   packages/amp:
     specifiers: {}
@@ -249,7 +249,7 @@ importers:
       cookie: ^0.5.0
       svelte: ^3.48.0
       svelte-preprocess: ^4.10.6
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       vite: ^3.1.0-beta.1
     dependencies:
       '@fontsource/fira-mono': 4.5.8
@@ -259,8 +259,8 @@ importers:
       '@sveltejs/adapter-auto': link:../../../adapter-auto
       '@sveltejs/kit': link:../../../kit
       svelte: 3.48.0
-      svelte-preprocess: 4.10.7_lvfi2wesz6u4l5rfbnetbucfmm
-      typescript: 4.7.4
+      svelte-preprocess: 4.10.7_rzeu6t3zqu2xw2nsnbtx3gkaoe
+      typescript: 4.8.2
       vite: 3.1.0-beta.1
 
   packages/create-svelte/templates/skeleton:
@@ -294,7 +294,7 @@ importers:
       svelte: ^3.48.0
       svelte-preprocess: ^4.10.6
       tiny-glob: ^0.2.9
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       undici: ^5.8.1
       uvu: ^0.5.3
       vite: ^3.1.0-beta.1
@@ -323,8 +323,8 @@ importers:
       marked: 4.0.17
       rollup: 2.78.1
       svelte: 3.48.0
-      svelte-preprocess: 4.10.7_lvfi2wesz6u4l5rfbnetbucfmm
-      typescript: 4.7.4
+      svelte-preprocess: 4.10.7_rzeu6t3zqu2xw2nsnbtx3gkaoe
+      typescript: 4.8.2
       uvu: 0.5.4
       vite: 3.1.0-beta.1
 
@@ -336,7 +336,7 @@ importers:
       purify-css: ^1.2.5
       svelte: ^3.48.0
       svelte-check: ^2.7.1
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       vite: ^3.1.0-beta.1
     devDependencies:
       '@sveltejs/amp': link:../../../../amp
@@ -345,7 +345,7 @@ importers:
       purify-css: 1.2.5
       svelte: 3.48.0
       svelte-check: 2.8.0_svelte@3.48.0
-      typescript: 4.7.4
+      typescript: 4.8.2
       vite: 3.1.0-beta.1
 
   packages/kit/test/apps/basics:
@@ -355,7 +355,7 @@ importers:
       rimraf: ^3.0.2
       svelte: ^3.48.0
       svelte-check: ^2.7.1
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       vite: ^3.1.0-beta.1
     devDependencies:
       '@sveltejs/kit': link:../../..
@@ -363,7 +363,7 @@ importers:
       rimraf: 3.0.2
       svelte: 3.48.0
       svelte-check: 2.8.0_svelte@3.48.0
-      typescript: 4.7.4
+      typescript: 4.8.2
       vite: 3.1.0-beta.1
 
   packages/kit/test/apps/dev-only:
@@ -373,7 +373,7 @@ importers:
       rimraf: ^3.0.2
       svelte: ^3.48.0
       svelte-check: ^2.7.1
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       vite: ^3.1.0-beta.1
     devDependencies:
       '@sveltejs/kit': link:../../..
@@ -381,7 +381,7 @@ importers:
       rimraf: 3.0.2
       svelte: 3.48.0
       svelte-check: 2.8.0_svelte@3.48.0
-      typescript: 4.7.4
+      typescript: 4.8.2
       vite: 3.1.0-beta.1
 
   packages/kit/test/apps/options:
@@ -390,14 +390,14 @@ importers:
       cross-env: ^7.0.3
       svelte: ^3.48.0
       svelte-check: ^2.7.1
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       vite: ^3.1.0-beta.1
     devDependencies:
       '@sveltejs/kit': link:../../..
       cross-env: 7.0.3
       svelte: 3.48.0
       svelte-check: 2.8.0_svelte@3.48.0
-      typescript: 4.7.4
+      typescript: 4.8.2
       vite: 3.1.0-beta.1
 
   packages/kit/test/apps/options-2:
@@ -407,7 +407,7 @@ importers:
       cross-env: ^7.0.3
       svelte: ^3.48.0
       svelte-check: ^2.7.1
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       vite: ^3.1.0-beta.1
     devDependencies:
       '@sveltejs/adapter-node': link:../../../../adapter-node
@@ -415,7 +415,7 @@ importers:
       cross-env: 7.0.3
       svelte: 3.48.0
       svelte-check: 2.8.0_svelte@3.48.0
-      typescript: 4.7.4
+      typescript: 4.8.2
       vite: 3.1.0-beta.1
 
   packages/kit/test/apps/writes:
@@ -425,7 +425,7 @@ importers:
       rimraf: ^3.0.2
       svelte: ^3.48.0
       svelte-check: ^2.7.1
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       vite: ^3.1.0-beta.1
     devDependencies:
       '@sveltejs/kit': link:../../..
@@ -433,7 +433,7 @@ importers:
       rimraf: 3.0.2
       svelte: 3.48.0
       svelte-check: 2.8.0_svelte@3.48.0
-      typescript: 4.7.4
+      typescript: 4.8.2
       vite: 3.1.0-beta.1
 
   packages/kit/test/prerendering/basics:
@@ -441,14 +441,14 @@ importers:
       '@sveltejs/kit': workspace:*
       svelte: ^3.48.0
       svelte-check: ^2.7.1
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       uvu: ^0.5.3
       vite: ^3.1.0-beta.1
     devDependencies:
       '@sveltejs/kit': link:../../..
       svelte: 3.48.0
       svelte-check: 2.8.0_svelte@3.48.0
-      typescript: 4.7.4
+      typescript: 4.8.2
       uvu: 0.5.4
       vite: 3.1.0-beta.1
 
@@ -457,14 +457,14 @@ importers:
       '@sveltejs/kit': workspace:*
       svelte: ^3.48.0
       svelte-check: ^2.7.1
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       uvu: ^0.5.3
       vite: ^3.1.0-beta.1
     devDependencies:
       '@sveltejs/kit': link:../../..
       svelte: 3.48.0
       svelte-check: 2.8.0_svelte@3.48.0
-      typescript: 4.7.4
+      typescript: 4.8.2
       uvu: 0.5.4
       vite: 3.1.0-beta.1
 
@@ -473,14 +473,14 @@ importers:
       '@sveltejs/kit': workspace:*
       svelte: ^3.48.0
       svelte-check: ^2.7.1
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       uvu: ^0.5.3
       vite: ^3.1.0-beta.1
     devDependencies:
       '@sveltejs/kit': link:../../..
       svelte: 3.48.0
       svelte-check: 2.8.0_svelte@3.48.0
-      typescript: 4.7.4
+      typescript: 4.8.2
       uvu: 0.5.4
       vite: 3.1.0-beta.1
 
@@ -489,14 +489,14 @@ importers:
       '@sveltejs/kit': workspace:*
       svelte: ^3.48.0
       svelte-check: ^2.7.1
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       uvu: ^0.5.3
       vite: ^3.1.0-beta.1
     devDependencies:
       '@sveltejs/kit': link:../../..
       svelte: 3.48.0
       svelte-check: 2.8.0_svelte@3.48.0
-      typescript: 4.7.4
+      typescript: 4.8.2
       uvu: 0.5.4
       vite: 3.1.0-beta.1
 
@@ -505,14 +505,14 @@ importers:
       '@sveltejs/kit': workspace:*
       svelte: ^3.48.0
       svelte-check: ^2.7.1
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       uvu: ^0.5.4
       vite: ^3.1.0-beta.1
     devDependencies:
       '@sveltejs/kit': link:../../..
       svelte: 3.48.0
       svelte-check: 2.8.0_svelte@3.48.0
-      typescript: 4.7.4
+      typescript: 4.8.2
       uvu: 0.5.4
       vite: 3.1.0-beta.1
 
@@ -531,7 +531,7 @@ importers:
       magic-string: 0.26.2
       prompts: 2.4.2
       tiny-glob: 0.2.9
-      typescript: 4.7.4
+      typescript: 4.8.2
     devDependencies:
       '@types/prompts': 2.0.14
       prettier: 2.7.1
@@ -546,18 +546,18 @@ importers:
       svelte: ^3.48.0
       svelte-preprocess: ^4.10.6
       svelte2tsx: ~0.5.10
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       uvu: ^0.5.3
     dependencies:
       chokidar: 3.5.3
       kleur: 4.1.5
       sade: 1.8.1
-      svelte2tsx: 0.5.11_lvfi2wesz6u4l5rfbnetbucfmm
+      svelte2tsx: 0.5.11_rzeu6t3zqu2xw2nsnbtx3gkaoe
     devDependencies:
       '@types/node': 16.11.42
       svelte: 3.48.0
-      svelte-preprocess: 4.10.7_lvfi2wesz6u4l5rfbnetbucfmm
-      typescript: 4.7.4
+      svelte-preprocess: 4.10.7_rzeu6t3zqu2xw2nsnbtx3gkaoe
+      typescript: 4.8.2
       uvu: 0.5.6
 
   sites/kit.svelte.dev:
@@ -574,7 +574,7 @@ importers:
       prismjs: ^1.28.0
       shiki-twoslash: ^3.0.2
       svelte: ^3.48.0
-      typescript: ^4.7.4
+      typescript: ^4.8.2
       vite: ^3.1.0-beta.1
       vite-imagetools: ^4.0.3
     devDependencies:
@@ -590,7 +590,7 @@ importers:
       prismjs: 1.28.0
       shiki-twoslash: 3.1.0
       svelte: 3.48.0
-      typescript: 4.7.4
+      typescript: 4.8.2
       vite: 3.1.0-beta.1
       vite-imagetools: 4.0.4
 
@@ -3704,7 +3704,7 @@ packages:
       '@typescript/twoslash': 3.1.0
       '@typescript/vfs': 1.3.4
       shiki: 0.10.1
-      typescript: 4.7.4
+      typescript: 4.8.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4000,8 +4000,8 @@ packages:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 3.48.0
-      svelte-preprocess: 4.10.7_lvfi2wesz6u4l5rfbnetbucfmm
-      typescript: 4.7.4
+      svelte-preprocess: 4.10.7_rzeu6t3zqu2xw2nsnbtx3gkaoe
+      typescript: 4.8.2
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -4024,7 +4024,7 @@ packages:
       svelte: 3.48.0
     dev: false
 
-  /svelte-preprocess/4.10.7_lvfi2wesz6u4l5rfbnetbucfmm:
+  /svelte-preprocess/4.10.7_rzeu6t3zqu2xw2nsnbtx3gkaoe:
     resolution: {integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==}
     engines: {node: '>= 9.11.2'}
     requiresBuild: true
@@ -4072,7 +4072,7 @@ packages:
       sorcery: 0.10.0
       strip-indent: 3.0.0
       svelte: 3.48.0
-      typescript: 4.7.4
+      typescript: 4.8.2
     dev: true
 
   /svelte-preprocess/4.10.7_svelte@3.48.0:
@@ -4129,7 +4129,7 @@ packages:
     resolution: {integrity: sha512-fN2YRm/bGumvjUpu6yI3BpvZnpIm9I6A7HR4oUNYd7ggYyIwSA/BX7DJ+UXXffLp6XNcUijyLvttbPVCYa/3xQ==}
     engines: {node: '>= 8'}
 
-  /svelte2tsx/0.5.11_lvfi2wesz6u4l5rfbnetbucfmm:
+  /svelte2tsx/0.5.11_rzeu6t3zqu2xw2nsnbtx3gkaoe:
     resolution: {integrity: sha512-Is95G1wqNvEUJZ9DITRS2zfMwVJRZztMduPs1vJJ0cm65WUg/avBl5vBXjHycQL/qmFpaqa3NG4qWnf7bCHPag==}
     peerDependencies:
       svelte: ^3.24
@@ -4138,7 +4138,7 @@ packages:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
       svelte: 3.48.0
-      typescript: 4.7.4
+      typescript: 4.8.2
     dev: false
 
   /tar-fs/2.1.1:
@@ -4419,8 +4419,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /typescript/4.7.4:
-    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
+  /typescript/4.8.2:
+    resolution: {integrity: sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==}
     engines: {node: '>=4.2.0'}
     hasBin: true
 

--- a/sites/kit.svelte.dev/package.json
+++ b/sites/kit.svelte.dev/package.json
@@ -20,7 +20,7 @@
 		"prismjs": "^1.28.0",
 		"shiki-twoslash": "^3.0.2",
 		"svelte": "^3.48.0",
-		"typescript": "^4.7.4",
+		"typescript": "^4.8.2",
 		"vite": "^3.1.0-beta.1",
 		"vite-imagetools": "^4.0.3"
 	},


### PR DESCRIPTION
Fixes a breaking change introduced by TS: NonNullable<null> is no longer never when strict null checks are false: https://github.com/microsoft/TypeScript/issues/50519

Closes #6387
This isn't a breaking change because everything is backwards compatible and only new users of `create-svelte` get a higher version (but it works with the older one, too)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
