### PR TITLE
Fix netlify-adapter to only glob files

### DIFF
--- a/.changeset/cold-penguins-share.md
+++ b/.changeset/cold-penguins-share.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+Update adapter to only glob files

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -163,7 +163,7 @@ async function generate_lambda_functions({ builder, publish, split, esm }) {
 	if (esm) {
 		builder.copy(`${files}/esm`, '.netlify', { replace });
 	} else {
-		glob('**/*.js', { cwd: '.netlify/server' }).forEach((file) => {
+		glob('**/*.js', { cwd: '.netlify/server', filesOnly: true }).forEach((file) => {
 			const filepath = `.netlify/server/${file}`;
 			const input = readFileSync(filepath, 'utf8');
 			const output = esbuild.transformSync(input, { format: 'cjs', target: 'node12' }).code;


### PR DESCRIPTION
Closes #6490

With this PR `tiny-glob` only grab files and skip over directories. Currently it's possible to trip netlify-adapter if a route name ends in .js



### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
