### PR TITLE
future-proof `invalidate()`

### DIFF
--- a/.changeset/ninety-tables-switch.md
+++ b/.changeset/ninety-tables-switch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] call `invalidate(fn)` predicates with a URL instead of a string

--- a/.changeset/rude-nails-work.md
+++ b/.changeset/rude-nails-work.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] replace invalidate() with invalidateAll()

--- a/.changeset/shiny-vans-jam.md
+++ b/.changeset/shiny-vans-jam.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Use `invalidateAll()`

--- a/documentation/docs/05-load.md
+++ b/documentation/docs/05-load.md
@@ -125,7 +125,7 @@ import * as api from '$lib/api';
 export async function load({ depends }) {
 	depends(
 		`${api.base}/foo`,
-		`${api.base}/bar`
+		`${api.base}/bar`,
 		'my-stuff:foo'
 	);
 

--- a/packages/create-svelte/templates/default/src/lib/form.ts
+++ b/packages/create-svelte/templates/default/src/lib/form.ts
@@ -1,4 +1,4 @@
-import { invalidate } from '$app/navigation';
+import { invalidateAll } from '$app/navigation';
 
 // this action (https://svelte.dev/tutorial/actions) allows us to
 // progressively enhance a <form> that already works without JS
@@ -83,7 +83,7 @@ export function enhance(
 
 			if (response.ok) {
 				if (result) result({ data, form, response });
-				invalidate();
+				invalidateAll();
 			} else if (error) {
 				error({ data, form, error: null, response });
 			} else {

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -16,6 +16,7 @@ export const disableScrollHandling = ssr
 	: client.disable_scroll_handling;
 export const goto = ssr ? guard('goto') : client.goto;
 export const invalidate = ssr ? guard('invalidate') : client.invalidate;
+export const invalidateAll = ssr ? guard('invalidateAll') : client.invalidateAll;
 export const prefetch = ssr ? guard('prefetch') : client.prefetch;
 export const prefetchRoutes = ssr ? guard('prefetchRoutes') : client.prefetch_routes;
 export const beforeNavigate = ssr ? () => {} : client.before_navigate;

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -3,6 +3,7 @@ import {
 	beforeNavigate,
 	goto,
 	invalidate,
+	invalidateAll,
 	prefetch,
 	prefetchRoutes
 } from '$app/navigation';
@@ -17,6 +18,7 @@ export interface Client {
 	disable_scroll_handling: () => void;
 	goto: typeof goto;
 	invalidate: typeof invalidate;
+	invalidateAll: typeof invalidateAll;
 	prefetch: typeof prefetch;
 	prefetch_routes: typeof prefetchRoutes;
 

--- a/packages/kit/test/apps/basics/src/routes/load/change-detection/one/[x]/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/change-detection/one/[x]/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { invalidate } from '$app/navigation';
+	import { invalidate, invalidateAll } from '$app/navigation';
 
 	/** @type {import('./$types').PageData} */
 	export let data;
@@ -10,7 +10,7 @@
 <button
 	on:click={async () => {
 		window.invalidated = false;
-		await invalidate((dep) => dep.includes('change-detection/data.json'));
+		await invalidate((url) => url.pathname.includes('change-detection/data.json'));
 		window.invalidated = true;
 	}}>invalidate change-detection/data.json</button
 >
@@ -18,7 +18,7 @@
 <button
 	on:click={async () => {
 		window.invalidated = false;
-		await invalidate();
+		await invalidateAll();
 		window.invalidated = true;
 	}}>invalidate all</button
 >

--- a/packages/kit/test/apps/basics/src/routes/load/invalidation/forced/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/invalidation/forced/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { invalidate } from '$app/navigation';
+	import { invalidateAll } from '$app/navigation';
 
 	/** @type {import('./$types').PageData} */
 	export let data;
@@ -7,4 +7,4 @@
 
 <h1>a: {data.a}, b: {data.b}</h1>
 
-<button on:click={() => invalidate()}>invalidate</button>
+<button on:click={invalidateAll}>invalidate</button>

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -113,10 +113,15 @@ declare module '$app/navigation' {
 		opts?: { replaceState?: boolean; noscroll?: boolean; keepfocus?: boolean; state?: any }
 	): Promise<void>;
 	/**
-	 * Causes any `load` functions belonging to the currently active page to re-run if they `fetch` the resource in question. If no argument is given, all resources will be invalidated. Returns a `Promise` that resolves when the page is subsequently updated.
+	 * Causes any `load` functions belonging to the currently active page to re-run if they `fetch` the resource in question. Returns a `Promise` that resolves when the page is subsequently updated.
 	 * @param dependency The invalidated resource
 	 */
-	export function invalidate(dependency?: string | ((href: string) => boolean)): Promise<void>;
+	export function invalidate(dependency: string | ((url: URL) => boolean)): Promise<void>;
+	/**
+	 * Causes all `load` functions belonging to the currently active page to re-run. Returns a `Promise` that resolves when the page is subsequently updated.
+	 * @param dependency The invalidated resource
+	 */
+	export function invalidateAll(): Promise<void>;
 	/**
 	 * Programmatically prefetches the given page, which means
 	 *  1. ensuring that the code for the page is loaded, and

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -116,7 +116,7 @@ declare module '$app/navigation' {
 	 * Causes any `load` functions belonging to the currently active page to re-run if they `fetch` the resource in question. Returns a `Promise` that resolves when the page is subsequently updated.
 	 * @param dependency The invalidated resource
 	 */
-	export function invalidate(dependency: string | ((url: URL) => boolean)): Promise<void>;
+	export function invalidate(url: string | URL | ((url: URL) => boolean)): Promise<void>;
 	/**
 	 * Causes all `load` functions belonging to the currently active page to re-run. Returns a `Promise` that resolves when the page is subsequently updated.
 	 * @param dependency The invalidated resource

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -121,9 +121,9 @@ declare module '$app/navigation' {
 	 * The `function` argument can be used define a custom predicate. It receives the full `URL` and causes `load` to rerun if `true` is returned.
 	 * This can be useful if you want to invalidate based on a pattern instead of a exact match.
 	 *
-	 * ```js
+	 * ```ts
 	 * // Example: Match '/path' regardless of the query parameters
-	 * invalidate((url) => url.pathname === '/path')`
+	 * invalidate((url) => url.pathname === '/path');
 	 * ```
 	 * @param url The invalidated URL
 	 */


### PR DESCRIPTION
Closes #6354.

Related to #6489, #6274 and #5305 (we can remove the `breaking change` label from the latter two once this is merged).

It's very possible that we'd need to add an `options` object to `invalidate(...)` in future. Since overloaded functions are a terrible idea, that'd mean that to accommodate the no-argument case where you want to invalidate everything, we'd have to do this...

```js
invalidate(undefined, {...});
```

...which is sinful. A better approach, which happens to be clearer and easier to document, is to create a new `invalidateAll` function:

```diff
<script>
-  import { invalidate } from '$app/navigation';
+  import { invalidateAll } from '$app/navigation';
</script>

-<button on:click={() => invalidate()}>reload</button>
+<button on:click={() => invalidateAll()}>reload</button>
```

Separately, I think it's probably more useful if the predicate form takes a `URL` instead of a string:

```diff
-invalidate((dep) => dep.includes('/some/matched/pathname'));
+invalidate((url) => url.pathname.startsWith('/some/matched/pathname'));
```

Unfortunately this second part is the sort of breaking change that's basically impossible to add a runtime error for. If people think a string (i.e. `url.href`) is preferable, then we could keep it as it is.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
