### PR TITLE
fix server manifest generation

### DIFF
--- a/.changeset/fresh-brooms-relate.md
+++ b/.changeset/fresh-brooms-relate.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix server manifest generation

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -60,13 +60,13 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 					if (!route.page && !route.endpoint) return;
 
 					return `{
-						id: ${s(route.id)},
-						pattern: ${route.pattern},
-						names: ${s(route.names)},
-						types: ${s(route.types)},
-						page: ${s(route.page)},
-						endpoint: ${route.endpoint ? loader(`${relative_path}/${build_data.server.vite_manifest[route.endpoint.file].file}`) : 'null'}
-					}`;
+					id: ${s(route.id)},
+					pattern: ${route.pattern},
+					names: ${s(route.names)},
+					types: ${s(route.types)},
+					page: ${route.page ? `{ layouts: [${route.page.layouts.map(n => n ?? '').join(',')}], errors: [${route.page.errors.map(n => n ?? '').join(',')}], leaf: ${route.page.leaf} }` : 'null'},
+					endpoint: ${route.endpoint ? loader(`${relative_path}/${build_data.server.vite_manifest[route.endpoint.file].file}`) : 'null'}
+				}`;
 				}).filter(Boolean).join(',\n\t\t\t\t')}
 			],
 			matchers: async () => {

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -64,7 +64,7 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 					pattern: ${route.pattern},
 					names: ${s(route.names)},
 					types: ${s(route.types)},
-					page: ${route.page ? `{ layouts: [${route.page.layouts.map(n => n ?? '').join(',')}], errors: [${route.page.errors.map(n => n ?? '').join(',')}], leaf: ${route.page.leaf} }` : 'null'},
+					page: ${route.page ? `{ layouts: ${get_nodes(route.page.layouts)}, errors: ${get_nodes(route.page.errors)}, leaf: ${route.page.leaf} }` : 'null'},
 					endpoint: ${route.endpoint ? loader(`${relative_path}/${build_data.server.vite_manifest[route.endpoint.file].file}`) : 'null'}
 				}`;
 				}).filter(Boolean).join(',\n\t\t\t\t')}
@@ -75,4 +75,18 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 			}
 		}
 	}`.replace(/^\t/gm, '');
+}
+
+/** @param {Array<number | undefined>} indexes */
+function get_nodes(indexes) {
+	let string = indexes.map((n) => n ?? '').join(',');
+
+	if (indexes.at(-1) === undefined) {
+		// since JavaScript ignores trailing commas, we need to insert a dummy
+		// comma so that the array has the correct length if the last item
+		// is undefined
+		string += ',';
+	}
+
+	return `[${string}]`;
 }

--- a/packages/kit/src/runtime/client/parse.js
+++ b/packages/kit/src/runtime/client/parse.js
@@ -13,7 +13,7 @@ export function parse(nodes, server_loads, dictionary, matchers) {
 	return Object.entries(dictionary).map(([id, [leaf, layouts, errors]]) => {
 		const { pattern, names, types } = parse_route_id(id);
 
-		const route = {
+		return {
 			id,
 			/** @param {string} path */
 			exec: (path) => {
@@ -24,16 +24,6 @@ export function parse(nodes, server_loads, dictionary, matchers) {
 			layouts: [0, ...(layouts || [])].map(create_layout_loader),
 			leaf: create_leaf_loader(leaf)
 		};
-
-		// bit of a hack, but ensures that layout/error node lists are the same
-		// length, without which the wrong data will be applied if the route
-		// manifest looks like `[[a, b], [c,], d]`
-		route.errors.length = route.layouts.length = Math.max(
-			route.errors.length,
-			route.layouts.length
-		);
-
-		return route;
 	});
 
 	/**

--- a/packages/kit/src/runtime/client/parse.js
+++ b/packages/kit/src/runtime/client/parse.js
@@ -13,7 +13,7 @@ export function parse(nodes, server_loads, dictionary, matchers) {
 	return Object.entries(dictionary).map(([id, [leaf, layouts, errors]]) => {
 		const { pattern, names, types } = parse_route_id(id);
 
-		return {
+		const route = {
 			id,
 			/** @param {string} path */
 			exec: (path) => {
@@ -24,6 +24,16 @@ export function parse(nodes, server_loads, dictionary, matchers) {
 			layouts: [0, ...(layouts || [])].map(create_layout_loader),
 			leaf: create_leaf_loader(leaf)
 		};
+
+		// bit of a hack, but ensures that layout/error node lists are the same
+		// length, without which the wrong data will be applied if the route
+		// manifest looks like `[[a, b], [c,], d]`
+		route.errors.length = route.layouts.length = Math.max(
+			route.errors.length,
+			route.layouts.length
+		);
+
+		return route;
 	});
 
 	/**


### PR DESCRIPTION
I was seeing this in the CI logs:

<img width="1006" alt="image" src="https://user-images.githubusercontent.com/1162160/187923208-9fbc9444-1623-456c-af96-6ce9759b9657.png">

It's happening because `JSON.stringify` turns `undefined` to `null` inside an array, unhelpfully. Bit weird that it isn't actually causing anything to fail, but I figured it was worth fixing anyway