### PR TITLE
fix: update vite-plugin-svelte dependency 

### DIFF
--- a/.changeset/selfish-ads-kick.md
+++ b/.changeset/selfish-ads-kick.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix peer dependency warning on vite-3.1.0-beta.1

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -10,7 +10,7 @@
 	"homepage": "https://kit.svelte.dev",
 	"type": "module",
 	"dependencies": {
-		"@sveltejs/vite-plugin-svelte": "^1.0.3",
+		"@sveltejs/vite-plugin-svelte": "^1.0.4",
 		"cookie": "^0.5.0",
 		"devalue": "^3.1.2",
 		"kleur": "^4.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,7 +272,7 @@ importers:
   packages/kit:
     specifiers:
       '@playwright/test': ^1.25.0
-      '@sveltejs/vite-plugin-svelte': ^1.0.3
+      '@sveltejs/vite-plugin-svelte': ^1.0.4
       '@types/connect': ^3.4.35
       '@types/cookie': ^0.5.1
       '@types/marked': ^4.0.3
@@ -299,7 +299,7 @@ importers:
       uvu: ^0.5.3
       vite: ^3.1.0-beta.1
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 1.0.3_le3uwffmhe7iwfccb43atcj5xe
+      '@sveltejs/vite-plugin-svelte': 1.0.4_le3uwffmhe7iwfccb43atcj5xe
       cookie: 0.5.0
       devalue: 3.1.2
       kleur: 4.1.5
@@ -1022,13 +1022,13 @@ packages:
       golden-fleece: 1.0.9
     dev: true
 
-  /@sveltejs/vite-plugin-svelte/1.0.3_le3uwffmhe7iwfccb43atcj5xe:
-    resolution: {integrity: sha512-0Qu51m2W9RBlxWPp8i31KJpnqmjWMOne8vAzgmOX6ZM9uX+/RAv6BNhEMcNoP5MsyLjyW1ZTCiJoaZZ5EeqpFg==}
+  /@sveltejs/vite-plugin-svelte/1.0.4_le3uwffmhe7iwfccb43atcj5xe:
+    resolution: {integrity: sha512-UZco2fdj0OVuRWC0SUJjEOftITc2IeHLFJNp00ym9MuQ9dShnlO4P29G8KUxRlcS7kSpzHuko6eCR9MOALj7lQ==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
       diff-match-patch: ^1.0.5
       svelte: ^3.44.0
-      vite: ^3.0.0
+      vite: ^3.0.0 || ^3.1.0-beta.1
     peerDependenciesMeta:
       diff-match-patch:
         optional: true


### PR DESCRIPTION
to avoid vite 3.1.0-beta peerDependency warning

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
