### PR TITLE
remove incorrect vercel.json files

### DIFF
--- a/packages/create-svelte/templates/default/vercel.json
+++ b/packages/create-svelte/templates/default/vercel.json
@@ -1,5 +1,0 @@
-{
-	"github": {
-		"silent": true
-	}
-}

--- a/sites/kit.svelte.dev/vercel.json
+++ b/sites/kit.svelte.dev/vercel.json
@@ -1,5 +1,0 @@
-{
-	"github": {
-		"silent": true
-	}
-}


### PR DESCRIPTION
Not sure what changed, but these started resulting in deployment errors:

<img width="917" alt="image" src="https://user-images.githubusercontent.com/1162160/187990500-1defc047-5587-411c-a94c-e945ff3dcfa0.png">

They don't seem to be doing anything anyway, so I'll just delete them