### PR TITLE
Revert "remove incorrect vercel.json files"

### DIFF
--- a/packages/create-svelte/templates/default/vercel.json
+++ b/packages/create-svelte/templates/default/vercel.json
@@ -1,0 +1,5 @@
+{
+	"github": {
+		"silent": true
+	}
+}

--- a/sites/kit.svelte.dev/vercel.json
+++ b/sites/kit.svelte.dev/vercel.json
@@ -1,0 +1,5 @@
+{
+	"github": {
+		"silent": true
+	}
+}


### PR DESCRIPTION
Reverts sveltejs/kit#6513. Turns out this was a temporary glitch. The bot is super noisy so having this config is nice