### PR TITLE
fix: Silently skip prefetching external URLs instead of warning

### DIFF
--- a/.changeset/nice-poets-taste.md
+++ b/.changeset/nice-poets-taste.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Silently skip prefetching of external URLs instead of warning
+Silently skip prefetching of external URLs when using `data-sveltekit-prefetch`. Warn like before when calling `prefetch()` for external URLs.

--- a/.changeset/nice-poets-taste.md
+++ b/.changeset/nice-poets-taste.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Silently skip prefetching of external URLs instead of warning

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -185,8 +185,9 @@ export function create_client({ target, base, trailing_slash }) {
 	async function prefetch(url) {
 		const intent = get_navigation_intent(url);
 
-		// Prevent prefetching of URLs that don't belong to this app
-		if (!intent) return;
+		if (!intent) {
+			throw new Error('Attempted to prefetch a URL that does not belong to this app');
+		}
 
 		load_cache.promise = load_route(intent);
 		load_cache.id = intent.id;
@@ -942,7 +943,7 @@ export function create_client({ target, base, trailing_slash }) {
 
 	/** @param {URL} url */
 	function get_navigation_intent(url) {
-		if (url.origin !== location.origin || !url.pathname.startsWith(base)) return;
+		if (is_external_url(url)) return;
 
 		const path = decodeURI(url.pathname.slice(base.length) || '/');
 
@@ -959,6 +960,11 @@ export function create_client({ target, base, trailing_slash }) {
 				return intent;
 			}
 		}
+	}
+
+	/** @param {URL} url */
+	function is_external_url(url) {
+		return url.origin !== location.origin || !url.pathname.startsWith(base);
 	}
 
 	/**
@@ -1155,6 +1161,7 @@ export function create_client({ target, base, trailing_slash }) {
 			const trigger_prefetch = (event) => {
 				const { url, options } = find_anchor(event);
 				if (url && options.prefetch === '') {
+					if (is_external_url(url)) return;
 					prefetch(url);
 				}
 			};

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -185,9 +185,8 @@ export function create_client({ target, base, trailing_slash }) {
 	async function prefetch(url) {
 		const intent = get_navigation_intent(url);
 
-		if (!intent) {
-			throw new Error('Attempted to prefetch a URL that does not belong to this app');
-		}
+		// Prevent prefetching of URLs that don't belong to this app
+		if (!intent) return;
 
 		load_cache.promise = load_route(intent);
 		load_cache.id = intent.id;

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -480,12 +480,8 @@ test.describe('Prefetching', () => {
 		await app.goto('/routing/prefetched');
 		expect(requests).toEqual([]);
 
-		try {
-			await app.prefetch('https://example.com');
-			throw new Error('Error was not thrown');
-		} catch (/** @type {any} */ e) {
-			expect(e.message).toMatch('Attempted to prefetch a URL that does not belong to this app');
-		}
+		const externalPrefetch = await app.prefetch('https://example.com');
+		expect(externalPrefetch).toBe(undefined);
 	});
 
 	test('chooses correct route when hash route is prefetched but regular route is clicked', async ({

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -480,8 +480,12 @@ test.describe('Prefetching', () => {
 		await app.goto('/routing/prefetched');
 		expect(requests).toEqual([]);
 
-		const externalPrefetch = await app.prefetch('https://example.com');
-		expect(externalPrefetch).toBe(undefined);
+		try {
+			await app.prefetch('https://example.com');
+			throw new Error('Error was not thrown');
+		} catch (/** @type {any} */ e) {
+			expect(e.message).toMatch('Attempted to prefetch a URL that does not belong to this app');
+		}
 	});
 
 	test('chooses correct route when hash route is prefetched but regular route is clicked', async ({


### PR DESCRIPTION
Fix https://github.com/sveltejs/kit/issues/6463 by automatically skipping prefetching of external URLs instead of warning app developers. This aligns with how Next.js solves the same problem.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
