### PR TITLE
only include specified headers in server-side fetch requests and serialized responses

### DIFF
--- a/.changeset/kind-ducks-vanish.md
+++ b/.changeset/kind-ducks-vanish.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] only include specified headers in server-side fetch requests and serialized responses

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -82,7 +82,7 @@ const get_defaults = (prefix = '') => ({
 		},
 		fetch: {
 			forwardedRequestHeaders: [],
-			serializedResponseHeaders: []
+			serializedResponseHeaders: ['content-type']
 		},
 		files: {
 			assets: join(prefix, 'static'),

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -80,6 +80,10 @@ const get_defaults = (prefix = '') => ({
 			dir: process.cwd(),
 			publicPrefix: 'PUBLIC_'
 		},
+		fetch: {
+			includedRequestHeaders: [],
+			includedResponseHeaders: []
+		},
 		files: {
 			assets: join(prefix, 'static'),
 			hooks: join(prefix, 'src/hooks'),

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -82,7 +82,7 @@ const get_defaults = (prefix = '') => ({
 		},
 		fetch: {
 			includedRequestHeaders: [],
-			includedResponseHeaders: []
+			serializedResponseHeaders: []
 		},
 		files: {
 			assets: join(prefix, 'static'),

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -81,7 +81,7 @@ const get_defaults = (prefix = '') => ({
 			publicPrefix: 'PUBLIC_'
 		},
 		fetch: {
-			includedRequestHeaders: [],
+			forwardedRequestHeaders: [],
 			serializedResponseHeaders: []
 		},
 		files: {

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -139,6 +139,11 @@ const options = object(
 				publicPrefix: string('PUBLIC_')
 			}),
 
+			fetch: object({
+				includedRequestHeaders: string_array([]),
+				includedResponseHeaders: string_array(['content-type'])
+			}),
+
 			files: object({
 				assets: string('static'),
 				hooks: string(join('src', 'hooks')),

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -141,7 +141,7 @@ const options = object(
 
 			fetch: object({
 				includedRequestHeaders: string_array([]),
-				includedResponseHeaders: string_array(['content-type'])
+				serializedResponseHeaders: string_array(['content-type'])
 			}),
 
 			files: object({

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -140,7 +140,7 @@ const options = object(
 			}),
 
 			fetch: object({
-				includedRequestHeaders: string_array([]),
+				forwardedRequestHeaders: string_array([]),
 				serializedResponseHeaders: string_array(['content-type'])
 			}),
 

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -58,6 +58,10 @@ export class Server {
 				check_origin: ${s(config.kit.csrf.checkOrigin)},
 			},
 			dev: false,
+			fetch: {
+				included_request_headers: ${s(config.kit.fetch.includedRequestHeaders)},
+				included_response_headers: ${s(config.kit.fetch.includedResponseHeaders)}
+			},
 			get_stack: error => String(error), // for security
 			handle_error: (error, event) => {
 				this.options.hooks.handleError({

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -59,8 +59,8 @@ export class Server {
 			},
 			dev: false,
 			fetch: {
-				included_request_headers: ${s(config.kit.fetch.includedRequestHeaders)},
-				included_response_headers: ${s(config.kit.fetch.includedResponseHeaders)}
+				forwarded_request_headers: ${s(config.kit.fetch.forwardedRequestHeaders)},
+				serialized_response_headers: ${s(config.kit.fetch.serializedResponseHeaders)}
 			},
 			get_stack: error => String(error), // for security
 			handle_error: (error, event) => {

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -383,7 +383,7 @@ export async function dev(vite, vite_config, svelte_config, illegal_imports) {
 						dev: true,
 						fetch: {
 							included_request_headers: svelte_config.kit.fetch.includedRequestHeaders,
-							included_response_headers: svelte_config.kit.fetch.includedResponseHeaders
+							serialized_response_headers: svelte_config.kit.fetch.serializedResponseHeaders
 						},
 						get_stack: (error) => fix_stack_trace(error),
 						handle_error: (error, event) => {

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -382,7 +382,7 @@ export async function dev(vite, vite_config, svelte_config, illegal_imports) {
 						},
 						dev: true,
 						fetch: {
-							included_request_headers: svelte_config.kit.fetch.includedRequestHeaders,
+							forwarded_request_headers: svelte_config.kit.fetch.forwardedRequestHeaders,
 							serialized_response_headers: svelte_config.kit.fetch.serializedResponseHeaders
 						},
 						get_stack: (error) => fix_stack_trace(error),

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -381,6 +381,10 @@ export async function dev(vite, vite_config, svelte_config, illegal_imports) {
 							check_origin: svelte_config.kit.csrf.checkOrigin
 						},
 						dev: true,
+						fetch: {
+							included_request_headers: svelte_config.kit.fetch.includedRequestHeaders,
+							included_response_headers: svelte_config.kit.fetch.includedResponseHeaders
+						},
 						get_stack: (error) => fix_stack_trace(error),
 						handle_error: (error, event) => {
 							hooks.handleError({

--- a/packages/kit/src/runtime/server/page/fetch.js
+++ b/packages/kit/src/runtime/server/page/fetch.js
@@ -49,7 +49,7 @@ export function create_fetch({ event, options, state, route, prerender_default }
 		opts.headers = new Headers(opts.headers);
 
 		// merge headers from request
-		for (const header of options.fetch.included_request_headers) {
+		for (const header of options.fetch.forwarded_request_headers) {
 			const value = event.request.headers.get(header);
 
 			if (value !== null && !opts.headers.has(header)) {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -284,7 +284,11 @@ export async function render_response({
 	}
 
 	if (page_config.ssr && page_config.csr) {
-		body += `\n\t${fetched.map((item) => serialize_data(item, !!state.prerendering)).join('\n\t')}`;
+		body += `\n\t${fetched
+			.map((item) =>
+				serialize_data(item, options.fetch.included_response_headers, !!state.prerendering)
+			)
+			.join('\n\t')}`;
 	}
 
 	if (options.service_worker) {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -286,7 +286,7 @@ export async function render_response({
 	if (page_config.ssr && page_config.csr) {
 		body += `\n\t${fetched
 			.map((item) =>
-				serialize_data(item, options.fetch.included_response_headers, !!state.prerendering)
+				serialize_data(item, options.fetch.serialized_response_headers, !!state.prerendering)
 			)
 			.join('\n\t')}`;
 	}

--- a/packages/kit/src/runtime/server/page/serialize_data.js
+++ b/packages/kit/src/runtime/server/page/serialize_data.js
@@ -35,16 +35,16 @@ const pattern = new RegExp(`[${Object.keys(replacements).join('')}]`, 'g');
  * and that the resulting string isn't further modified.
  *
  * @param {import('./types.js').Fetched} fetched
- * @param {string[]} included_response_headers
+ * @param {string[]} serialized_response_headers
  * @param {boolean} [prerendering]
  * @returns {string} The raw HTML of a script element carrying the JSON payload.
  * @example const html = serialize_data('/data.json', null, { foo: 'bar' });
  */
-export function serialize_data(fetched, included_response_headers, prerendering = false) {
+export function serialize_data(fetched, serialized_response_headers, prerendering = false) {
 	/** @type {Record<string, string>} */
 	const headers = {};
 
-	for (const header of included_response_headers) {
+	for (const header of serialized_response_headers) {
 		const value = fetched.response.headers.get(header);
 
 		if (value !== null) {

--- a/packages/kit/src/runtime/server/page/serialize_data.spec.js
+++ b/packages/kit/src/runtime/server/page/serialize_data.spec.js
@@ -4,17 +4,20 @@ import { serialize_data } from './serialize_data.js';
 
 test('escapes slashes', () => {
 	assert.equal(
-		serialize_data({
-			url: 'foo',
-			method: 'GET',
-			body: null,
-			response: {
-				status: 200,
-				statusText: 'OK',
-				headers: {},
-				body: '</script><script>alert("xss")'
-			}
-		}),
+		serialize_data(
+			{
+				url: 'foo',
+				method: 'GET',
+				body: null,
+				response: {
+					status: 200,
+					statusText: 'OK',
+					headers: new Headers(),
+					body: '</script><script>alert("xss")'
+				}
+			},
+			[]
+		),
 		'<script type="application/json" data-sveltekit-fetched data-url="foo">' +
 			'{"status":200,"statusText":"OK","headers":{},"body":"\\u003C/script>\\u003Cscript>alert(\\"xss\\")"}' +
 			'</script>'
@@ -23,17 +26,20 @@ test('escapes slashes', () => {
 
 test('escapes exclamation marks', () => {
 	assert.equal(
-		serialize_data({
-			url: 'foo',
-			method: 'GET',
-			body: null,
-			response: {
-				status: 200,
-				statusText: 'OK',
-				headers: {},
-				body: '<!--</script>...-->alert("xss")'
-			}
-		}),
+		serialize_data(
+			{
+				url: 'foo',
+				method: 'GET',
+				body: null,
+				response: {
+					status: 200,
+					statusText: 'OK',
+					headers: new Headers(),
+					body: '<!--</script>...-->alert("xss")'
+				}
+			},
+			[]
+		),
 		'<script type="application/json" data-sveltekit-fetched data-url="foo">' +
 			'{"status":200,"statusText":"OK","headers":{},"body":"\\u003C!--\\u003C/script>...-->alert(\\"xss\\")"}' +
 			'</script>'
@@ -44,17 +50,20 @@ test('escapes the attribute values', () => {
 	const raw = 'an "attr" & a \ud800';
 	const escaped = 'an &quot;attr&quot; &amp; a &#55296;';
 	assert.equal(
-		serialize_data({
-			url: raw,
-			method: 'GET',
-			body: null,
-			response: {
-				status: 200,
-				statusText: 'OK',
-				headers: {},
-				body: ''
-			}
-		}),
+		serialize_data(
+			{
+				url: raw,
+				method: 'GET',
+				body: null,
+				response: {
+					status: 200,
+					statusText: 'OK',
+					headers: new Headers(),
+					body: ''
+				}
+			},
+			[]
+		),
 		`<script type="application/json" data-sveltekit-fetched data-url="${escaped}">{"status":200,"statusText":"OK","headers":{},"body":\"\"}</script>`
 	);
 });

--- a/packages/kit/src/runtime/server/page/types.d.ts
+++ b/packages/kit/src/runtime/server/page/types.d.ts
@@ -1,4 +1,4 @@
-import { ResponseHeaders, SSRNode, CspDirectives } from 'types';
+import { SSRNode, CspDirectives } from 'types';
 import { HttpError } from '../../control.js';
 
 export interface Fetched {
@@ -8,7 +8,7 @@ export interface Fetched {
 	response: {
 		status: number;
 		statusText: string;
-		headers: ResponseHeaders;
+		headers: Headers;
 		body: string;
 	};
 }

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -818,18 +818,20 @@ test.describe('Load', () => {
 		const json = /** @type {string} */ (await page.textContent('pre'));
 		const headers = JSON.parse(json);
 
-		expect(headers).toEqual({
-			// the referer will be the previous page in the client-side
-			// navigation case
-			referer: `${baseURL}/load`,
-			// these headers aren't particularly useful, but they allow us to verify
-			// that page headers are being forwarded
-			'sec-fetch-dest':
-				browserName === 'webkit' ? undefined : javaScriptEnabled ? 'empty' : 'document',
-			'sec-fetch-mode':
-				browserName === 'webkit' ? undefined : javaScriptEnabled ? 'cors' : 'navigate',
-			connection: javaScriptEnabled ? 'keep-alive' : undefined
-		});
+		if (javaScriptEnabled) {
+			expect(headers).toEqual({
+				// the referer will be the previous page in the client-side
+				// navigation case
+				referer: `${baseURL}/load`,
+				// these headers aren't particularly useful, but they allow us to verify
+				// that page headers are being forwarded
+				'sec-fetch-dest': browserName === 'webkit' ? undefined : 'empty',
+				'sec-fetch-mode': browserName === 'webkit' ? undefined : 'cors',
+				connection: 'keep-alive'
+			});
+		} else {
+			expect(headers).toEqual({});
+		}
 	});
 
 	test('exposes rawBody to endpoints', async ({ page, clicknav }) => {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -135,7 +135,10 @@ export interface KitConfig {
 		dir?: string;
 		publicPrefix?: string;
 	};
-	moduleExtensions?: string[];
+	fetch?: {
+		includedRequestHeaders?: string[];
+		includedResponseHeaders?: string[];
+	};
 	files?: {
 		assets?: string;
 		hooks?: string;
@@ -151,6 +154,7 @@ export interface KitConfig {
 		parameter?: string;
 		allowed?: string[];
 	};
+	moduleExtensions?: string[];
 	outDir?: string;
 	paths?: {
 		assets?: string;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -137,7 +137,7 @@ export interface KitConfig {
 	};
 	fetch?: {
 		includedRequestHeaders?: string[];
-		includedResponseHeaders?: string[];
+		serializedResponseHeaders?: string[];
 	};
 	files?: {
 		assets?: string;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -136,7 +136,7 @@ export interface KitConfig {
 		publicPrefix?: string;
 	};
 	fetch?: {
-		includedRequestHeaders?: string[];
+		forwardedRequestHeaders?: string[];
 		serializedResponseHeaders?: string[];
 	};
 	files?: {

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -294,6 +294,10 @@ export interface SSROptions {
 		check_origin: boolean;
 	};
 	dev: boolean;
+	fetch: {
+		included_request_headers: string[];
+		included_response_headers: string[];
+	};
 	get_stack: (error: Error) => string | undefined;
 	handle_error(error: Error & { frame?: string }, event: RequestEvent): void;
 	hooks: Hooks;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -295,7 +295,7 @@ export interface SSROptions {
 	};
 	dev: boolean;
 	fetch: {
-		included_request_headers: string[];
+		forwarded_request_headers: string[];
 		serialized_response_headers: string[];
 	};
 	get_stack: (error: Error) => string | undefined;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -296,7 +296,7 @@ export interface SSROptions {
 	dev: boolean;
 	fetch: {
 		included_request_headers: string[];
-		included_response_headers: string[];
+		serialized_response_headers: string[];
 	};
 	get_stack: (error: Error) => string | undefined;
 	handle_error(error: Error & { frame?: string }, event: RequestEvent): void;


### PR DESCRIPTION
Closes #5253
Closes #5195
Closes #1971

This is a topic that has been discussed a lot on this repo without an adequate resolution: when making server-side `fetch` calls within a `load` function, how which (if any) of the original request headers do we include?

In the interests of making things 'just work' as far as possible, we've been including almost all headers ever since https://github.com/sveltejs/kit/pull/3631. But this causes its own problems, such as https://github.com/sveltejs/kit/issues/5253. A PR from @johnnysprinkles (#5195) removes all header forwarding, but has sat unmerged because it depends on adding the `event` object to the `load` inputs, which we definitely don't want.

This PR takes a different approach (basically the one suggested by @nhunzaker in https://github.com/sveltejs/kit/issues/5253#issuecomment-1165499804) — it allows app developers to create an allowlist of headers that should be forwarded in server-side fetches.

At the same time, we add a list of headers that should be included when we serialize the response, which means that things like `Date` don't mess up content hashing (which prevents us from responding with 304s — #1971):

```js
// svelte.config.js
export default {
  kit: {
    fetch: {
      forwardedRequestHeaders: ['x-my-custom-auth-header'],
      serializedResponseHeaders: ['x-my-custom-response-header']
    }
  }
};
```

Questions:

* Are these the right names for the options?
* What should the defaults be? Right now I included `content-type` in `serializedResponseHeaders` to get the tests to pass, but presumably there are other sensible defaults. To _some_ degree it doesn't matter, but it would be nice if most people didn't need to touch this option
* Should we go even further and remove the special handling for `cookie` and `authorization` headers when `credentials` is something other than `omit`?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
