### PR TITLE
Warn about incorrect `data-sveltekit-x` values

### DIFF
--- a/.changeset/spicy-games-trade.md
+++ b/.changeset/spicy-games-trade.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Warn about incorrect data-sveltekit-x values

--- a/documentation/docs/09-link-options.md
+++ b/documentation/docs/09-link-options.md
@@ -70,3 +70,5 @@ To apply an attribute to an element conditionally, do this:
 ```html
 <div data-sveltekit-reload={shouldReload ? '' : 'off'}>
 ```
+
+> This works because in HTML, `<element attribute>` is equivalent to `<element attribute="">`

--- a/documentation/docs/09-link-options.md
+++ b/documentation/docs/09-link-options.md
@@ -64,3 +64,9 @@ To disable any of these options inside an element where they have been enabled, 
 	</div>
 </div>
 ```
+
+To apply an attribute to an element conditionally, do this:
+
+```html
+<div data-sveltekit-reload={shouldReload ? '' : 'off'}>
+```

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1184,7 +1184,7 @@ export function create_client({ target, base, trailing_slash }) {
 			/** @param {Event} event */
 			const trigger_prefetch = (event) => {
 				const { url, options } = find_anchor(event);
-				if (url && options.prefetch === '') {
+				if (url && options.prefetch) {
 					if (is_external_url(url)) return;
 					prefetch(url);
 				}
@@ -1234,7 +1234,7 @@ export function create_client({ target, base, trailing_slash }) {
 				// 2. 'rel' attribute includes external
 				const rel = (a.getAttribute('rel') || '').split(/\s+/);
 
-				if (a.hasAttribute('download') || rel.includes('external') || options.reload === '') {
+				if (a.hasAttribute('download') || rel.includes('external') || options.reload) {
 					return;
 				}
 
@@ -1260,7 +1260,7 @@ export function create_client({ target, base, trailing_slash }) {
 
 				navigate({
 					url,
-					scroll: options.noscroll === '' ? scroll_state() : null,
+					scroll: options.noscroll ? scroll_state() : null,
 					keepfocus: false,
 					redirect_chain: [],
 					details: {

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -27,16 +27,14 @@ export function find_anchor(event) {
 	/** @type {HTMLAnchorElement | SVGAElement | undefined} */
 	let a;
 
-	const options = {
-		/** @type {string | null} */
-		noscroll: null,
+	/** @type {boolean | null} */
+	let noscroll = null;
 
-		/** @type {string | null} */
-		prefetch: null,
+	/** @type {boolean | null} */
+	let prefetch = null;
 
-		/** @type {string | null} */
-		reload: null
-	};
+	/** @type {boolean | null} */
+	let reload = null;
 
 	for (const element of event.composedPath()) {
 		if (!(element instanceof Element)) continue;
@@ -46,22 +44,43 @@ export function find_anchor(event) {
 			a = /** @type {HTMLAnchorElement | SVGAElement} */ (element);
 		}
 
-		if (options.noscroll === null) {
-			options.noscroll = element.getAttribute('data-sveltekit-noscroll');
-		}
-
-		if (options.prefetch === null) {
-			options.prefetch = element.getAttribute('data-sveltekit-prefetch');
-		}
-
-		if (options.reload === null) {
-			options.reload = element.getAttribute('data-sveltekit-reload');
-		}
+		if (noscroll === null) noscroll = get_link_option(element, 'data-sveltekit-noscroll');
+		if (prefetch === null) prefetch = get_link_option(element, 'data-sveltekit-prefetch');
+		if (reload === null) reload = get_link_option(element, 'data-sveltekit-reload');
 	}
 
 	const url = a && new URL(a instanceof SVGAElement ? a.href.baseVal : a.href, document.baseURI);
 
-	return { a, url, options };
+	return {
+		a,
+		url,
+		options: {
+			noscroll,
+			prefetch,
+			reload
+		}
+	};
+}
+
+const warned = new WeakSet();
+
+/**
+ * @param {Element} element
+ * @param {string} attribute
+ */
+function get_link_option(element, attribute) {
+	const value = element.getAttribute(attribute);
+	if (value === null) return value;
+
+	if (value === '') return true;
+	if (value === 'off') return false;
+
+	if (!warned.has(element)) {
+		console.error(`Unexpected value for ${attribute} — should be "" or "off"`, element);
+		warned.add(element);
+	}
+
+	return false;
 }
 
 /** @param {any} value */

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -75,7 +75,7 @@ function get_link_option(element, attribute) {
 	if (value === '') return true;
 	if (value === 'off') return false;
 
-	if (!warned.has(element)) {
+	if (__SVELTEKIT_DEV__ && !warned.has(element)) {
 		console.error(`Unexpected value for ${attribute} — should be "" or "off"`, element);
 		warned.add(element);
 	}


### PR DESCRIPTION
#6532. This updates the docs to clarify that `data-sveltekit-prefetch` and `data-sveltekit-prefetch=""` are equivalent, and also adds console errors at dev time if you pass an incorrect value.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
