### PR TITLE
simulate CORS errors in server-side fetch

### DIFF
--- a/.changeset/red-tomatoes-leave.md
+++ b/.changeset/red-tomatoes-leave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] simulate CORS errors in server-side fetch

--- a/packages/kit/src/runtime/server/page/fetch.js
+++ b/packages/kit/src/runtime/server/page/fetch.js
@@ -163,7 +163,7 @@ export function create_fetch({ event, options, state, route, prerender_default }
 			// - sub.my.domain.com WILL receive cookies
 			// ports do not affect the resolution
 			// leading dot prevents mydomain.com matching domain.com
-			if (`.$url.hostname}`.endsWith(`.${event.url.hostname}`) && opts.credentials !== 'omit') {
+			if (`.${url.hostname}`.endsWith(`.${event.url.hostname}`) && opts.credentials !== 'omit') {
 				const cookie = event.request.headers.get('cookie');
 				if (cookie) opts.headers.set('cookie', cookie);
 			}

--- a/packages/kit/src/runtime/server/page/fetch.js
+++ b/packages/kit/src/runtime/server/page/fetch.js
@@ -152,6 +152,8 @@ export function create_fetch({ event, options, state, route, prerender_default }
 				requested = event.url.protocol + requested;
 			}
 
+			const url = new URL(requested);
+
 			// external fetch
 			// allow cookie passthrough for "same-origin"
 			// if SvelteKit is serving my.domain.com:
@@ -161,10 +163,7 @@ export function create_fetch({ event, options, state, route, prerender_default }
 			// - sub.my.domain.com WILL receive cookies
 			// ports do not affect the resolution
 			// leading dot prevents mydomain.com matching domain.com
-			if (
-				`.${new URL(requested).hostname}`.endsWith(`.${event.url.hostname}`) &&
-				opts.credentials !== 'omit'
-			) {
+			if (`.$url.hostname}`.endsWith(`.${event.url.hostname}`) && opts.credentials !== 'omit') {
 				const cookie = event.request.headers.get('cookie');
 				if (cookie) opts.headers.set('cookie', cookie);
 			}
@@ -176,6 +175,25 @@ export function create_fetch({ event, options, state, route, prerender_default }
 
 			const external_request = new Request(requested, /** @type {RequestInit} */ (opts));
 			response = await options.hooks.externalFetch.call(null, external_request);
+
+			if (opts.mode === 'no-cors') {
+				response = new Response('', {
+					status: response.status,
+					statusText: response.statusText,
+					headers: response.headers
+				});
+			} else {
+				if (url.origin !== event.url.origin) {
+					const acao = response.headers.get('access-control-allow-origin');
+					if (!acao || (acao !== event.url.origin && acao !== '*')) {
+						throw new Error(
+							`CORS error: ${
+								acao ? 'Incorrect' : 'No'
+							} 'Access-Control-Allow-Origin' header is present on the requested resource`
+						);
+					}
+				}
+			}
 		}
 
 		const set_cookie = response.headers.get('set-cookie');

--- a/packages/kit/test/apps/basics/src/routes/load/cors/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/cors/+page.js
@@ -1,0 +1,8 @@
+/** @type {import('./$types').PageLoad} */
+export async function load({ fetch, url }) {
+	const res = await fetch(`http://localhost:${url.searchParams.get('port')}`);
+
+	return {
+		text: await res.text()
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/cors/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/cors/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	/** @type {import('./$types').PageData} */
+	export let data;
+</script>
+
+<h1>{@html data.text}</h1>

--- a/packages/kit/test/apps/basics/src/routes/load/cors/no-cors/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/cors/no-cors/+page.js
@@ -1,0 +1,10 @@
+/** @type {import('./$types').PageLoad} */
+export async function load({ fetch, url }) {
+	const res = await fetch(`http://localhost:${url.searchParams.get('port')}`, {
+		mode: 'no-cors'
+	});
+
+	return {
+		text: await res.text()
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/cors/no-cors/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/cors/no-cors/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	/** @type {import('./$types').PageData} */
+	export let data;
+</script>
+
+<h1>result: {@html data.text}</h1>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -889,6 +889,23 @@ test.describe('Load', () => {
 
 		expect(await page.textContent('h1')).toBe('true');
 	});
+
+	test('CORS errors are simulated server-side', async ({ page, read_errors }) => {
+		const { port, close } = await start_server(async (req, res) => {
+			res.end('hello');
+		});
+
+		await page.goto(`/load/cors?port=${port}`);
+		expect(await page.textContent('h1')).toBe('500');
+		expect(read_errors(`/load/cors`)).toContain(
+			`Error: CORS error: No 'Access-Control-Allow-Origin' header is present on the requested resource`
+		);
+
+		await page.goto(`/load/cors/no-cors?port=${port}`);
+		expect(await page.textContent('h1')).toBe('result: ');
+
+		await close();
+	});
 });
 
 test.describe('Method overrides', () => {


### PR DESCRIPTION
closes #5074, by increasing the fidelity of the server-side `fetch` implementation passed to `load`. If a request is made for an external resource, and it doesn't respond with an appropriate `access-control-allow-origin` header, it will fail the same way that the browser's `fetch` fails (albeit with a different error message, since there's no standardisation here). 

If the request was made with `no-cors`, we return a response with an empty body.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
