### PR TITLE
move some stuff out of client-facing code

### DIFF
--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -103,6 +103,14 @@ function create_routes_and_nodes(cwd, config, fallback) {
 		 * @param {import('types').RouteData | null} parent
 		 */
 		const walk = (depth, id, segment, parent) => {
+			if (/\]\[/.test(id)) {
+				throw new Error(`Invalid route ${id} — parameters must be separated`);
+			}
+
+			if (count_occurrences('[', id) !== count_occurrences(']', id)) {
+				throw new Error(`Invalid route ${id} — brackets are unbalanced`);
+			}
+
 			const { pattern, names, types } = parse_route_id(id);
 
 			const segments = id.split('/');
@@ -449,4 +457,16 @@ function list_files(dir) {
 	if (fs.existsSync(dir)) walk('');
 
 	return files;
+}
+
+/**
+ * @param {string} needle
+ * @param {string} haystack
+ */
+function count_occurrences(needle, haystack) {
+	let count = 0;
+	for (let i = 0; i < haystack.length; i += 1) {
+		if (haystack[i] === needle) count += 1;
+	}
+	return count;
 }

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -12,14 +12,6 @@ export function parse_route_id(id) {
 	// const add_trailing_slash = !/\.[a-z]+$/.test(key);
 	let add_trailing_slash = true;
 
-	if (/\]\[/.test(id)) {
-		throw new Error(`Invalid route ${id} — parameters must be separated`);
-	}
-
-	if (count_occurrences('[', id) !== count_occurrences(']', id)) {
-		throw new Error(`Invalid route ${id} — brackets are unbalanced`);
-	}
-
 	const pattern =
 		id === ''
 			? /^\/$/
@@ -122,16 +114,4 @@ export function exec(match, names, types, matchers) {
 	}
 
 	return params;
-}
-
-/**
- * @param {string} needle
- * @param {string} haystack
- */
-function count_occurrences(needle, haystack) {
-	let count = 0;
-	for (let i = 0; i < haystack.length; i += 1) {
-		if (haystack[i] === needle) count += 1;
-	}
-	return count;
 }


### PR DESCRIPTION
very minor fix — this stuff doesn't need to be in `parse_route_id`, where it gets included in the client runtime. We only need to do these checks at manifest generation time