### PR TITLE
disable hoistTransitiveImports by default

### DIFF
--- a/.changeset/hot-mayflies-visit.md
+++ b/.changeset/hot-mayflies-visit.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+disable `rollupOptions.output.hoistTransitiveImports` by default

--- a/packages/kit/src/exports/vite/build/utils.js
+++ b/packages/kit/src/exports/vite/build/utils.js
@@ -105,7 +105,8 @@ export function get_default_build_config({ config, input, ssr, outDir }) {
 					format: 'esm',
 					entryFileNames: ssr ? '[name].js' : `${prefix}/[name]-[hash].js`,
 					chunkFileNames: ssr ? 'chunks/[name].js' : `${prefix}/chunks/[name]-[hash].js`,
-					assetFileNames: `${prefix}/assets/[name]-[hash][extname]`
+					assetFileNames: `${prefix}/assets/[name]-[hash][extname]`,
+					hoistTransitiveImports: false
 				},
 				preserveEntrySignatures: 'strict'
 			},
@@ -133,7 +134,8 @@ export function get_default_build_config({ config, input, ssr, outDir }) {
 			rollupOptions: {
 				output: {
 					entryFileNames: `${prefix}/workers/[name]-[hash].js`,
-					chunkFileNames: `${prefix}/workers/chunks/[name]-[hash].js`
+					chunkFileNames: `${prefix}/workers/chunks/[name]-[hash].js`,
+					hoistTransitiveImports: false
 				}
 			}
 		}


### PR DESCRIPTION
Fix #4644

This disables a [Rollup optimization](https://rollupjs.org/guide/en/#why-do-additional-imports-turn-up-in-my-entry-chunks-when-code-splitting) which shouldn't affect us as we use esbuild to-rebundle for most adapters.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
