### PR TITLE
[docs] Added .htaccess for static on Apache

### DIFF
--- a/documentation/docs/10-adapters.md
+++ b/documentation/docs/10-adapters.md
@@ -56,6 +56,23 @@ You can also use `adapter-static` to generate single-page apps (SPAs) by specify
 
 > You must ensure [`trailingSlash`](configuration#trailingslash) is set appropriately for your environment. If your host does not render `/a.html` upon receiving a request for `/a` then you will need to set `trailingSlash: 'always'` to create `/a/index.html` instead.
 
+#### Static sites on Apache
+
+For a Single Page Application on an `Apache` Server, you need a `.htaccess` to route all of the requests into the entry file for the routing to work, unless it will throw a 404 error once you refresh or visit a page that isn't compiled.
+
+```
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteBase /
+  RewriteRule ^app\.html$ - [L]
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteRule . /app.html [L]
+</IfModule>
+```
+
+You can also create a `.htaccess` file in the static folder to automatically include the `.htaccess` on every build.
+
 #### Platform-specific context
 
 Some adapters may have access to additional information about the request. For example, Cloudflare Workers can access an `env` object containing KV namespaces etc. This can be passed to the `RequestEvent` used in [hooks](/docs/hooks) and [server routes](/docs/routing#server) as the `platform` property — consult each adapter's documentation to learn more.

--- a/documentation/docs/10-adapters.md
+++ b/documentation/docs/10-adapters.md
@@ -71,7 +71,7 @@ For a Single Page Application on an `Apache` Server, you need an `.htaccess` to 
 </IfModule>
 ```
 
-You can also create a `.htaccess` file in the static folder to automatically include the `.htaccess` on every build.
+You can also create an `.htaccess` file in the static folder to automatically include the `.htaccess` on every build.
 
 #### Platform-specific context
 

--- a/documentation/docs/10-adapters.md
+++ b/documentation/docs/10-adapters.md
@@ -58,7 +58,7 @@ You can also use `adapter-static` to generate single-page apps (SPAs) by specify
 
 #### Static sites on Apache
 
-For a Single Page Application on an `Apache` Server, you need a `.htaccess` to route all of the requests into the entry file for the routing to work, unless it will throw a 404 error once you refresh or visit a page that isn't compiled.
+For a Single Page Application on an `Apache` Server, you need an `.htaccess` to route all of the requests into the entry file for the routing to work, unless it will throw a 404 error once you refresh or visit a page that isn't compiled.
 
 ```
 <IfModule mod_rewrite.c>


### PR DESCRIPTION
Once I build the project using `@sveltejs/adapter-static` and upload it on an Apache server, at first it works fine, but when I visit nested pages that aren't compiled, it will throw a `404 error` since the page or the file doesn't exist in the project directory.

The .htaccess will load the `app.html` if the file doesn't exist in the project directory.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
