### PR TITLE
remove cookie from demo app

### DIFF
--- a/.changeset/modern-apricots-develop.md
+++ b/.changeset/modern-apricots-develop.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Remove cookie package from demo app

--- a/packages/create-svelte/templates/default/package.template.json
+++ b/packages/create-svelte/templates/default/package.template.json
@@ -14,7 +14,6 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@fontsource/fira-mono": "^4.5.0",
-		"cookie": "^0.4.1"
+		"@fontsource/fira-mono": "^4.5.0"
 	}
 }

--- a/packages/create-svelte/templates/default/src/hooks.ts
+++ b/packages/create-svelte/templates/default/src/hooks.ts
@@ -2,15 +2,16 @@ import type { Handle } from '@sveltejs/kit';
 
 /** @type {import('@sveltejs/kit').Handle} */
 export const handle: Handle = async ({ event, resolve }) => {
-	if (!event.cookies.get('userid')) {
+	let userid = event.cookies.get('userid');
+
+	if (!userid) {
 		// if this is the first time the user has visited this app,
 		// set a cookie so that we recognise them when they return
-		event.cookies.set('userid', crypto.randomUUID(), {
-			path: '/'
-		});
+		userid = crypto.randomUUID();
+		event.cookies.set('userid', userid, { path: '/' });
 	}
 
-	event.locals.userid = event.cookies.get('userid');
+	event.locals.userid = userid;
 
 	return resolve(event);
 };

--- a/packages/create-svelte/templates/default/src/hooks.ts
+++ b/packages/create-svelte/templates/default/src/hooks.ts
@@ -1,24 +1,16 @@
 import type { Handle } from '@sveltejs/kit';
-import * as cookie from 'cookie';
 
 /** @type {import('@sveltejs/kit').Handle} */
 export const handle: Handle = async ({ event, resolve }) => {
-	const cookies = cookie.parse(event.request.headers.get('cookie') || '');
-	event.locals.userid = cookies['userid'] || crypto.randomUUID();
-
-	const response = await resolve(event);
-
-	if (!cookies['userid']) {
+	if (!event.cookies.get('userid')) {
 		// if this is the first time the user has visited this app,
 		// set a cookie so that we recognise them when they return
-		response.headers.set(
-			'set-cookie',
-			cookie.serialize('userid', event.locals.userid, {
-				path: '/',
-				httpOnly: true
-			})
-		);
+		event.cookies.set('userid', crypto.randomUUID(), {
+			path: '/'
+		});
 	}
 
-	return response;
+	event.locals.userid = event.cookies.get('userid');
+
+	return resolve(event);
 };


### PR DESCRIPTION
demo app is due for a more comprehensive overhaul, but we can at least simplify stuff using the new `cookies` API in the meantime