### PR TITLE
[breaking] disallow default and named actions next to each other

### DIFF
--- a/.changeset/tall-plums-join.md
+++ b/.changeset/tall-plums-join.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] disallow default and named actions next to each other

--- a/documentation/docs/06-form-actions.md
+++ b/documentation/docs/06-form-actions.md
@@ -46,14 +46,15 @@ We can also invoke the action from other pages (for example if there's a login w
 
 ### Named actions
 
-In addition to `default` actions, a page can have as many named actions as it needs:
+Instead of `default` actions, a page can have as many named actions as it needs:
 
 ```diff
 /// file: src/routes/login/+page.server.js
 
 /** @type {import('./$types').Actions} */
 export const actions = {
-	default: async (event) => {
+-	default: async (event) => {
++	login: async (event) => {
 		// TODO log the user in
 	},
 +	register: async (event) => {
@@ -78,13 +79,16 @@ As well as the `action` attribute, we can use the `formaction` attribute on a bu
 
 ```diff
 /// file: src/routes/login/+page.svelte
-<form method="POST">
+-<form method="POST">
++<form method="POST" action="?/login">
 	<input name="email" type="email">
 	<input name="password" type="password">
 	<button>Log in</button>
 +	<button formaction="?/register">Register</button>
 </form>
 ```
+
+> We can't have default actions next to named actions, because if you POST to a named action without a redirect, the query parameter is persisted in the URL, which means the next default POST would go through the named action from before.
 
 ### Anatomy of an action
 
@@ -95,7 +99,7 @@ Each action receives a `RequestEvent` object, allowing you to read the data with
 /// file: src/routes/login/+page.server.js
 /** @type {import('./$types').Actions} */
 export const actions = {
-	default: async ({ cookies, request }) => {
+	login: async ({ cookies, request }) => {
 		const data = await request.formData();
 		const email = data.get('email');
 		const password = data.get('password');
@@ -139,7 +143,7 @@ If the request couldn't be processed because of invalid data, you can return val
 
 /** @type {import('./$types').Actions} */
 export const actions = {
-	default: async ({ cookies, request }) => {
+	login: async ({ cookies, request }) => {
 		const data = await request.formData();
 		const email = data.get('email');
 		const password = data.get('password');
@@ -167,7 +171,7 @@ export const actions = {
 
 ```diff
 /// file: src/routes/login/+page.svelte
-<form method="POST">
+<form method="POST" action="?/login">
 -	<input name="email" type="email">
 +	{#if form?.missing}<p class="error">No user found with this email</p>{/if}
 +	<input name="email" type="email" value={form?.email ?? ''}>
@@ -193,7 +197,7 @@ Redirects (and errors) work exactly the same as in [`load`](/docs/load#redirects
 
 /** @type {import('./$types').Actions} */
 export const actions = {
-+	default: async ({ cookies, request, url }) => {
++	login: async ({ cookies, request, url }) => {
 		const data = await request.formData();
 		const email = data.get('email');
 		const password = data.get('password');

--- a/documentation/docs/06-form-actions.md
+++ b/documentation/docs/06-form-actions.md
@@ -46,7 +46,7 @@ We can also invoke the action from other pages (for example if there's a login w
 
 ### Named actions
 
-Instead of `default` actions, a page can have as many named actions as it needs:
+Instead of one `default` action, a page can have as many named actions as it needs:
 
 ```diff
 /// file: src/routes/login/+page.server.js

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -35,6 +35,8 @@ export async function handle_action_json_request(event, options, server) {
 		});
 	}
 
+	check_named_default_separate(actions);
+
 	try {
 		const data = await call_action(event, actions);
 
@@ -114,6 +116,8 @@ export async function handle_action_request(event, server) {
 		};
 	}
 
+	check_named_default_separate(actions);
+
 	try {
 		const data = await call_action(event, actions);
 
@@ -142,6 +146,17 @@ export async function handle_action_request(event, server) {
 }
 
 /**
+ * @param {import('types').Actions} actions
+ */
+function check_named_default_separate(actions) {
+	if (actions.default && Object.keys(actions).length > 1) {
+		throw new Error(
+			`When using named actions, the default action cannot be used. See the docs for more info: https://kit.svelte.dev/docs/form-actions#named-actions`
+		);
+	}
+}
+
+/**
  * @param {import('types').RequestEvent} event
  * @param {NonNullable<import('types').SSRNode['server']['actions']>} actions
  * @throws {Redirect | ValidationError | HttpError | Error}
@@ -153,6 +168,9 @@ export async function call_action(event, actions) {
 	for (const param of url.searchParams) {
 		if (param[0].startsWith('/')) {
 			name = param[0].slice(1);
+			if (name === 'default') {
+				throw new Error('Cannot use reserved action name "default"');
+			}
 			break;
 		}
 	}


### PR DESCRIPTION
We can't have default actions next to named actions, because if you POST to a named action without a redirect, the query parameter is persisted in the URL, which means the next default POST would go through the named action from before.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
