### PR TITLE
[fix] address Vite warning when using base or asset path

### DIFF
--- a/.changeset/five-seas-end.md
+++ b/.changeset/five-seas-end.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] address Vite warning when using base or asset path

--- a/packages/kit/src/exports/vite/build/utils.js
+++ b/packages/kit/src/exports/vite/build/utils.js
@@ -147,7 +147,7 @@ export function get_default_build_config({ config, input, ssr, outDir }) {
  * @returns {string}
  */
 export function assets_base(config) {
-	return config.paths.assets || config.paths.base || './';
+	return config.paths.assets + '/' || config.paths.base + '/' || './';
 }
 
 const method_names = new Set(['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH']);


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/issues/6563

SvelteKit expects paths don't end with `/` and Vite expects that they do