### PR TITLE
[fix] cookies.delete  

### DIFF
--- a/.changeset/cyan-elephants-accept.md
+++ b/.changeset/cyan-elephants-accept.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+cookies.delete fix #6609

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -43,6 +43,7 @@ export function get_cookies(request, url) {
 		},
 		delete(name) {
 			new_cookies.push({ name, value: '', options: { expires: new Date(0) } });
+			delete initial_cookies[name];
 		}
 	};
 

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -1,6 +1,6 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import { domain_matches, path_matches } from './cookie.js';
+import { domain_matches, path_matches, get_cookies } from './cookie.js';
 
 const domains = {
 	positive: [
@@ -37,6 +37,19 @@ paths.negative.forEach(([path, constraint]) => {
 	test(`! ${path} / ${constraint}`, () => {
 		assert.ok(!path_matches(path, constraint));
 	});
+});
+
+test('a cookie should not be present after it is deleted', () => {
+	const url = new URL('https://example.com');
+	const request = new Request(new URL('https://example.com'), {
+		headers: new Headers({
+			cookie: 'a=b;'
+		})
+	});
+	const { cookies } = get_cookies(request, url);
+	assert.equal(cookies.get('a'), 'b');
+	cookies.delete('a');
+	assert.not(cookies.get('a'));
 });
 
 test.run();


### PR DESCRIPTION
Fixes #6609. 

After a cookie is deleted with `cookies.delete('foo')`, subsequent calls in the same request to `cookies.get('foo')` will return `undefined`.

### To do:

- [ ] more tests?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
