### PR TITLE
change use:enhance signature to support `<button formaction>`

### DIFF
--- a/.changeset/strange-adults-rest.md
+++ b/.changeset/strange-adults-rest.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] change use:enhance signature to support `<button formaction>`

--- a/packages/create-svelte/templates/default/src/routes/todos/+page.svelte
+++ b/packages/create-svelte/templates/default/src/routes/todos/+page.svelte
@@ -22,10 +22,10 @@
 		class="new"
 		action="/todos?/add"
 		method="post"
-		use:enhance={({ form }) => {
-			return (result) => {
+		use:enhance={() => {
+			return ({ element, result }) => {
 				if (result.type === 'success') {
-					form.reset();
+					element.reset();
 					invalidateAll();
 				}
 			};

--- a/packages/create-svelte/templates/default/src/routes/todos/+page.svelte
+++ b/packages/create-svelte/templates/default/src/routes/todos/+page.svelte
@@ -23,9 +23,9 @@
 		action="/todos?/add"
 		method="post"
 		use:enhance={() => {
-			return ({ element, result }) => {
+			return ({ form, result }) => {
 				if (result.type === 'success') {
-					element.reset();
+					form.reset();
 					invalidateAll();
 				}
 			};

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -20,15 +20,16 @@ export function enhance(element, submit = () => {}) {
 	/**
 	 * @param {{
 	 *   element: HTMLFormElement | HTMLButtonElement | HTMLInputElement;
+	 *   form: HTMLFormElement;
 	 *   result: import('types').ActionResult;
 	 * }} opts
 	 */
-	const fallback_callback = async ({ element, result }) => {
+	const fallback_callback = async ({ element, form, result }) => {
 		if (result.type === 'success') {
 			await invalidateAll();
 		}
 
-		const action = element instanceof HTMLFormElement ? element.action : element.formAction;
+		const action = element.formAction ?? form.action;
 
 		if (location.origin + location.pathname === action.split('?')[0]) {
 			applyAction(result);

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -83,6 +83,7 @@ export function enhance(element, submit = () => {}) {
 		callback({
 			element,
 			data,
+			// @ts-expect-error generic constraints stuff we don't care about
 			result,
 			// TODO remove for 1.0
 			get type() {

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -55,11 +55,7 @@ export function enhance(element, submit = () => {}) {
 				element,
 				data,
 				cancel,
-				// TODO remove for 1.0
-				// @ts-ignore
-				get form() {
-					throw new Error('The `form` argument is now `element`');
-				}
+				form
 			}) ?? fallback_callback;
 		if (cancelled) return;
 
@@ -83,6 +79,7 @@ export function enhance(element, submit = () => {}) {
 		callback({
 			element,
 			data,
+			form,
 			// @ts-expect-error generic constraints stuff we don't care about
 			result,
 			// TODO remove for 1.0

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -16,32 +16,58 @@ const ssr = import.meta.env.SSR;
 export const applyAction = ssr ? guard('applyAction') : client.apply_action;
 
 /** @type {import('$app/forms').enhance} */
-export function enhance(form, submit = () => {}) {
-	/** @param {import('types').ActionResult} result */
-	const fallback_callback = async (result) => {
+export function enhance(element, submit = () => {}) {
+	/**
+	 * @param {{
+	 *   element: HTMLFormElement | HTMLButtonElement | HTMLInputElement;
+	 *   result: import('types').ActionResult;
+	 * }} opts
+	 */
+	const fallback_callback = async ({ element, result }) => {
 		if (result.type === 'success') {
 			await invalidateAll();
 		}
 
-		if (location.origin + location.pathname === form.action.split('?')[0]) {
+		const action = element instanceof HTMLFormElement ? element.action : element.formAction;
+
+		if (location.origin + location.pathname === action.split('?')[0]) {
 			applyAction(result);
 		}
 	};
 
+	const form =
+		element instanceof HTMLFormElement ? element : /** @type {HTMLFormElement} */ (element.form);
+	if (!form) throw new Error('Element is not associated with a form');
+
 	/** @param {SubmitEvent} event */
 	async function handle_submit(event) {
 		event.preventDefault();
+
+		const action = element.formAction ?? form.action;
 
 		const data = new FormData(form);
 
 		let cancelled = false;
 		const cancel = () => (cancelled = true);
 
-		const callback = submit({ form, data, cancel }) ?? fallback_callback;
+		const callback =
+			submit({
+				element,
+				data,
+				cancel,
+				// TODO remove for 1.0
+				// @ts-ignore
+				get form() {
+					throw new Error('The `form` argument is now `element`');
+				}
+			}) ?? fallback_callback;
 		if (cancelled) return;
 
+		/** @type {import('types').ActionResult} */
+		let result;
+
 		try {
-			const response = await fetch(form.action, {
+			const response = await fetch(action, {
 				method: 'POST',
 				headers: {
 					accept: 'application/json'
@@ -49,10 +75,26 @@ export function enhance(form, submit = () => {}) {
 				body: data
 			});
 
-			callback(await response.json());
+			result = await response.json();
 		} catch (error) {
-			callback({ type: 'error', error });
+			result = { type: 'error', error };
 		}
+
+		callback({
+			element,
+			data,
+			result,
+			// TODO remove for 1.0
+			get type() {
+				throw new Error('(result) => {...} has changed to ({ result }) => {...}');
+			},
+			get location() {
+				throw new Error('(result) => {...} has changed to ({ result }) => {...}');
+			},
+			get error() {
+				throw new Error('(result) => {...} has changed to ({ result }) => {...}');
+			}
+		});
 	}
 
 	form.addEventListener('submit', handle_submit);

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -116,7 +116,7 @@ declare module '$app/forms' {
 		Success extends Record<string, unknown> | undefined = Record<string, any>,
 		Invalid extends Record<string, unknown> | undefined = Record<string, any>
 	>(
-		form: Element,
+		element: Element,
 		/**
 		 * Called upon submission with the given FormData.
 		 * If `cancel` is called, the form will not be submitted.

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -89,17 +89,18 @@ declare module '$app/forms' {
 	import type { ActionResult } from '@sveltejs/kit';
 
 	export type SubmitFunction<
-		Success extends Record<string, unknown> | undefined,
-		Invalid extends Record<string, unknown> | undefined
+		Element extends HTMLFormElement | HTMLInputElement | HTMLButtonElement = HTMLFormElement,
+		Success extends Record<string, unknown> | undefined = Record<string, any>,
+		Invalid extends Record<string, unknown> | undefined = Record<string, any>
 	> = (input: {
 		data: FormData;
-		element: HTMLFormElement | HTMLInputElement | HTMLButtonElement;
+		element: Element;
 		cancel: () => void;
 	}) =>
 		| void
 		| ((opts: {
 				data: FormData;
-				element: HTMLFormElement | HTMLInputElement | HTMLButtonElement;
+				element: Element;
 				result: ActionResult<Success, Invalid>;
 		  }) => void);
 
@@ -109,10 +110,11 @@ declare module '$app/forms' {
 	 * @param options Callbacks for different states of the form lifecycle
 	 */
 	export function enhance<
+		Element extends HTMLFormElement | HTMLInputElement | HTMLButtonElement = HTMLFormElement,
 		Success extends Record<string, unknown> | undefined = Record<string, any>,
 		Invalid extends Record<string, unknown> | undefined = Record<string, any>
 	>(
-		form: HTMLFormElement | HTMLButtonElement | HTMLInputElement,
+		form: Element,
 		/**
 		 * Called upon submission with the given FormData.
 		 * If `cancel` is called, the form will not be submitted.
@@ -126,7 +128,7 @@ declare module '$app/forms' {
 		 * - redirects in case of a redirect response
 		 * - redirects to the nearest error page in case of an unexpected error
 		 */
-		submit?: SubmitFunction<Success, Invalid>
+		submit?: SubmitFunction<Element, Success, Invalid>
 	): { destroy: () => void };
 
 	/**

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -93,9 +93,15 @@ declare module '$app/forms' {
 		Invalid extends Record<string, unknown> | undefined
 	> = (input: {
 		data: FormData;
-		form: HTMLFormElement;
+		element: HTMLFormElement | HTMLInputElement | HTMLButtonElement;
 		cancel: () => void;
-	}) => void | ((result: ActionResult<Success, Invalid>) => void);
+	}) =>
+		| void
+		| ((opts: {
+				data: FormData;
+				element: HTMLFormElement | HTMLInputElement | HTMLButtonElement;
+				result: ActionResult<Success, Invalid>;
+		  }) => void);
 
 	/**
 	 * This action enhances a `<form>` element that otherwise would work without JavaScript.
@@ -106,7 +112,7 @@ declare module '$app/forms' {
 		Success extends Record<string, unknown> | undefined = Record<string, any>,
 		Invalid extends Record<string, unknown> | undefined = Record<string, any>
 	>(
-		form: HTMLFormElement,
+		form: HTMLFormElement | HTMLButtonElement | HTMLInputElement,
 		/**
 		 * Called upon submission with the given FormData.
 		 * If `cancel` is called, the form will not be submitted.

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -94,12 +94,14 @@ declare module '$app/forms' {
 		Invalid extends Record<string, unknown> | undefined = Record<string, any>
 	> = (input: {
 		data: FormData;
+		form: HTMLFormElement;
 		element: Element;
 		cancel: () => void;
 	}) =>
 		| void
 		| ((opts: {
 				data: FormData;
+				form: HTMLFormElement;
 				element: Element;
 				result: ActionResult<Success, Invalid>;
 		  }) => void);


### PR DESCRIPTION
closes #6630. This makes two breaking changes to the `enhance` action:

1. the input `form` is now `element`, and refers to the element the action was added to. To type that, the function and the SubmissionFunction interface now both take three generic params instead of two.
2. The returned callback is a `({ element, form, data, result }) => {...}` function instead of just `(result) => {...}`. This makes it easier to do things like `use:enhance={() => whatever}`, where `whatever` is a function that (for example) calls `form.reset()`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
