### PR TITLE
[docs] Highlight different `$env/dynamic` behavior between `dev` and `prod`

### DIFF
--- a/packages/kit/scripts/special-types/$env+dynamic+private.md
+++ b/packages/kit/scripts/special-types/$env+dynamic+private.md
@@ -6,3 +6,5 @@ This module cannot be imported into client-side code.
 import { env } from '$env/dynamic/private';
 console.log(env.DEPLOYMENT_SPECIFIC_VARIABLE);
 ```
+
+> In `dev`, `$env/dynamic` always includes environment variables from `.env`. In `prod`, this behavior will depend on your adapter.


### PR DESCRIPTION
It wasn't immediately clear to me, https://github.com/sveltejs/kit/issues/6204, that `$env/dynamic` might be loaded differently depending on `dev`/`prod`. Because `$env/dynamic` included `.env` during `dev`, I erroneously assumed it would do the same during `prod` (a la dotenv) when using `adapter-node`.

The second sentence could be clearer but I don't know enough about the topic to make it so.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
