### PR TITLE
enable suggestions for generated types `./$types`

### DIFF
--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -67,7 +67,11 @@ export function write_tsconfig(config, cwd = process.cwd()) {
 				compilerOptions: {
 					// generated options
 					baseUrl: config_relative('.'),
-					paths: get_tsconfig_paths(config),
+					paths: {
+						// enables aliased import for generated types
+						"./$types": [".svelte-kit/types/src/routes/*"],
+						...get_tsconfig_paths(config)
+					},
 					rootDirs: [config_relative('.'), './types'],
 
 					// essential options

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -69,7 +69,7 @@ export function write_tsconfig(config, cwd = process.cwd()) {
 					baseUrl: config_relative('.'),
 					paths: {
 						// enables import autocomplete for generated types aliased path
-						'./$types': [`${config.outDir}/types/src/routes/*`],
+						'./$types': [`${config.outDir}/types/src/routes/$types`],
 						...get_tsconfig_paths(config)
 					},
 					rootDirs: [config_relative('.'), './types'],

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -68,8 +68,8 @@ export function write_tsconfig(config, cwd = process.cwd()) {
 					// generated options
 					baseUrl: config_relative('.'),
 					paths: {
-						// enables aliased import for generated types
-						"./$types": [".svelte-kit/types/src/routes/*"],
+						// enables import autocomplete for generated types aliased path
+						'./$types': [`${config.outDir}/types/src/routes/*`],
 						...get_tsconfig_paths(config)
 					},
 					rootDirs: [config_relative('.'), './types'],

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -60,6 +60,8 @@ export function write_tsconfig(config, cwd = process.cwd()) {
 	include.push(config_relative(`${test_folder}/**/*.ts`));
 	include.push(config_relative(`${test_folder}/**/*.svelte`));
 
+	const types_folder = `${config.outDir}/types/src/routes`;
+
 	write_if_changed(
 		out,
 		JSON.stringify(
@@ -68,8 +70,8 @@ export function write_tsconfig(config, cwd = process.cwd()) {
 					// generated options
 					baseUrl: config_relative('.'),
 					paths: {
-						// enables import autocomplete for generated types aliased path
-						'./$types': [`${config.outDir}/types/src/routes/$types`],
+						// enables shorter import suggestions for generated types
+						'./$types': [`${types_folder}/$types`, `${types_folder}/*/$types`],
 						...get_tsconfig_paths(config)
 					},
 					rootDirs: [config_relative('.'), './types'],


### PR DESCRIPTION
Adds a path to the generated `tsconfig.json` file to resolve an import to `.svelte-kit/types/src/routes/$types` as `./$types`.

Adding this path fixes a slight issue I've had with generated types where Quick Fix does not include `'./$types'` as a suggestion.

Before:
<img width="599" alt="CleanShot 2022-09-07 at 21 00 43@2x" src="https://user-images.githubusercontent.com/54401897/188884917-2051627e-671f-4233-925f-4ab117f46dc1.png">

After:
<img width="572" alt="CleanShot 2022-09-07 at 21 03 29@2x" src="https://user-images.githubusercontent.com/54401897/188885110-b60bbb18-4a8c-4e6a-9b2e-fc86ae9fb839.png">

Sorry if this is unnecessary or implemented incorrectly. This is my first time submitting a PR.

Also, I tried to find a more variable that would lead to `.svelte-kit/types/src/routes/` but the best I could find was `config.outDir` for `.svelte-kit`. Would appreciate if anyone knew a better path variable to use.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
