### PR TITLE
Result is a property of the use:enhance callback

### DIFF
--- a/documentation/docs/06-form-actions.md
+++ b/documentation/docs/06-form-actions.md
@@ -265,7 +265,7 @@ To customise the behaviour, you can provide a function that runs immediately bef
 		// `data` is its `FormData` object
 		// `cancel()` will prevent the submission
 
-		return async (result) => {
+		return async ({ result }) => {
 			// `result` is an `ActionResult` object
 		};
 	}}
@@ -293,7 +293,7 @@ If you provide your own callbacks, you may need to reproduce part of the default
 		// `data` is its `FormData` object
 		// `cancel()` will prevent the submission
 
-		return async (result) => {
+		return async ({ result }) => {
 			// `result` is an `ActionResult` object
 +			if (result.type === 'error') {
 +				await applyAction(result);


### PR DESCRIPTION
Docs show it as `(result)` which is not correct, instead it is a property of the argument object.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
