### PR TITLE
Use abort controller in enhance action

### DIFF
--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -40,6 +40,9 @@ export function enhance(element, submit = () => {}) {
 		element instanceof HTMLFormElement ? element : /** @type {HTMLFormElement} */ (element.form);
 	if (!form) throw new Error('Element is not associated with a form');
 
+	/** @type {AbortController} */
+	let abort_controller;
+
 	/** @param {SubmitEvent} event */
 	async function handle_submit(event) {
 		event.preventDefault();
@@ -60,6 +63,12 @@ export function enhance(element, submit = () => {}) {
 			}) ?? fallback_callback;
 		if (cancelled) return;
 
+		if (abort_controller) {
+			abort_controller.abort();
+		}
+
+		abort_controller = new AbortController();
+
 		/** @type {import('types').ActionResult} */
 		let result;
 
@@ -69,7 +78,8 @@ export function enhance(element, submit = () => {}) {
 				headers: {
 					accept: 'application/json'
 				},
-				body: data
+				body: data,
+				signal: abort_controller.signal
 			});
 
 			result = await response.json();


### PR DESCRIPTION
This PR adds an `AbortController` to the `fetch` request made by the `enhance` action. It is used to cancel the request if the form is resubmitted while it is still pending, preventing users from sending many requests if they submit the form multiple times too rapidly. This is also the native browser behavior.

I didn't write any test for this because I am unsure on how to test it.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
