### PR TITLE
[breaking] change sveltekit.message to sveltekit.error.message

### DIFF
--- a/.changeset/forty-news-kiss.md
+++ b/.changeset/forty-news-kiss.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] change sveltekit.message to sveltekit.error.message

--- a/documentation/docs/01-project-structure.md
+++ b/documentation/docs/01-project-structure.md
@@ -44,7 +44,7 @@ The `src` directory contains the meat of your project.
   - `%sveltekit.nonce%` — a [CSP](/docs/configuration#csp) nonce for manually included links and scripts, if used
 - `error.html` (optional) is the page that is rendered when everything else fails. It can contain the following placeholders:
   - `%sveltekit.status%` — the HTTP status
-  - `%sveltekit.message%` — the error message
+  - `%sveltekit.error.message%` — the error message
 - `hooks.js` (optional) contains your application's [hooks](/docs/hooks)
 - `service-worker.js` (optional) contains your [service worker](/docs/service-workers)
 

--- a/packages/kit/src/core/config/default-error.html
+++ b/packages/kit/src/core/config/default-error.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<title>%sveltekit.message%</title>
+		<title>%sveltekit.error.message%</title>
 
 		<style>
 			body {
@@ -49,7 +49,7 @@
 		<div class="error">
 			<span class="status">%sveltekit.status%</span>
 			<div class="message">
-				<h1>%sveltekit.message%</h1>
+				<h1>%sveltekit.error.message%</h1>
 			</div>
 		</div>
 	</body>

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -33,7 +33,7 @@ const app_template = ({ head, body, assets, nonce }) => ${s(template)
 
 const error_template = ({ status, message }) => ${s(error_page)
 	.replace(/%sveltekit\.status%/g, '" + status + "')
-	.replace(/%sveltekit\.message%/g, '" + message + "')};
+	.replace(/%sveltekit\.error\.message%/g, '" + message + "')};
 
 let read = null;
 

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -436,7 +436,7 @@ export async function dev(vite, vite_config, svelte_config) {
 						error_template: ({ status, message }) => {
 							return error_page
 								.replace(/%sveltekit\.status%/g, String(status))
-								.replace(/%sveltekit\.message%/g, message);
+								.replace(/%sveltekit\.error\.message%/g, message);
 						},
 						trailing_slash: svelte_config.kit.trailingSlash
 					},

--- a/packages/kit/test/apps/basics/src/error.html
+++ b/packages/kit/test/apps/basics/src/error.html
@@ -6,6 +6,6 @@
 	</head>
 	<body>
 		<h1>Error - %sveltekit.status%</h1>
-		<p>This is the static error page with the following message: %sveltekit.message%</p>
+		<p>This is the static error page with the following message: %sveltekit.error.message%</p>
 	</body>
 </html>


### PR DESCRIPTION
If you use `error.html` and customized it, replace `%sveltekit.message%` inside it with `%sveltekit.error.message%`

Closes #6645

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
