### PR TITLE
[breaking] only allow enhance on form; pass abort controller

### DIFF
--- a/.changeset/violet-wolves-reflect.md
+++ b/.changeset/violet-wolves-reflect.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] remove element property; enhance can only be used on form elements

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -37,24 +37,10 @@ export function enhance(form, submit = () => {}) {
 	async function handle_submit(event) {
 		event.preventDefault();
 
-		let action = form.action;
-		const element_action = /** @type {HTMLButtonElement | HTMLInputElement | null} */ (
-			event.submitter
-		)?.formAction;
-		// the browser will always set formAction - if not set, it defaults to the url;
-		// we therefore have to check that formAction is indeed set
-		if (action !== element_action && element_action) {
-			if (
-				// different urls
-				action.split('?')[0] !== element_action.split('?')[0] ||
-				// same url - formAction needs to be set to something or else we ignore it.
-				// we take advantage of the fact that there cannot be a default and named action
-				// at the same time.
-				element_action.includes('?')
-			) {
-				action = element_action;
-			}
-		}
+		// We can't do submitter.formAction directly because that property is always set
+		const action = event.submitter?.hasAttribute('formaction')
+			? /** @type {HTMLButtonElement | HTMLInputElement} */ (event.submitter).formAction
+			: form.action;
 		const data = new FormData(form);
 		const controller = new AbortController();
 

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -40,6 +40,9 @@ export function enhance(element, submit = () => {}) {
 		element instanceof HTMLFormElement ? element : /** @type {HTMLFormElement} */ (element.form);
 	if (!form) throw new Error('Element is not associated with a form');
 
+	/** @type {AbortController} */
+	let abort_controller;
+
 	/** @param {SubmitEvent} event */
 	async function handle_submit(event) {
 		event.preventDefault();
@@ -60,6 +63,12 @@ export function enhance(element, submit = () => {}) {
 			}) ?? fallback_callback;
 		if (cancelled) return;
 
+		if (abort_controller) {
+			abort_controller.abort();
+		}
+
+		abort_controller = new AbortController();
+
 		/** @type {import('types').ActionResult} */
 		let result;
 
@@ -69,7 +78,8 @@ export function enhance(element, submit = () => {}) {
 				headers: {
 					accept: 'application/json'
 				},
-				body: data
+				body: data,
+				signal: abort_controller.signal
 			});
 
 			result = await response.json();

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.server.js
@@ -18,5 +18,8 @@ export const actions = {
 		return {
 			result: 'register: ' + fields.get('username')
 		};
+	},
+	slow: async () => {
+		await new Promise((resolve) => setTimeout(resolve, 500));
 	}
 };

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.server.js
@@ -7,10 +7,16 @@ export function load() {
 
 /** @type {import('./$types').Actions} */
 export const actions = {
-	default: async ({ request }) => {
+	login: async ({ request }) => {
 		const fields = await request.formData();
 		return {
 			result: fields.get('username')
+		};
+	},
+	register: async ({ request }) => {
+		const fields = await request.formData();
+		return {
+			result: 'register: ' + fields.get('username')
 		};
 	}
 };

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.svelte
@@ -3,11 +3,27 @@
 
 	/** @type {import('./$types').ActionData} */
 	export let form;
+
+	/** @type {AbortController | undefined} */
+	let previous;
+	let count = 0;
 </script>
 
 <pre>{JSON.stringify(form)}</pre>
 
 <form method="post" use:enhance>
 	<input name="username" type="text" />
-	<button>Submit</button>
+	<button class="form1">Submit</button>
+</form>
+
+<span class="count">{count}</span>
+<form
+	method="post"
+	use:enhance={({ controller }) => {
+		previous?.abort();
+		previous = controller;
+		return () => count++;
+	}}
+>
+	<button class="form2">Submit</button>
 </form>

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.svelte
@@ -11,14 +11,16 @@
 
 <pre>{JSON.stringify(form)}</pre>
 
-<form method="post" use:enhance>
+<form method="post" action="?/login" use:enhance>
 	<input name="username" type="text" />
 	<button class="form1">Submit</button>
+	<button class="form1-register" formAction="?/register">Submit</button>
 </form>
 
 <span class="count">{count}</span>
 <form
 	method="post"
+	action="?/login"
 	use:enhance={({ controller }) => {
 		previous?.abort();
 		previous = controller;

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.svelte
@@ -20,7 +20,7 @@
 <span class="count">{count}</span>
 <form
 	method="post"
-	action="?/login"
+	action="?/slow"
 	use:enhance={({ controller }) => {
 		previous?.abort();
 		previous = controller;

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1814,4 +1814,18 @@ test.describe('Actions', () => {
 			await expect(page.locator('span.count')).toHaveText('1');
 		}
 	});
+
+	test('use:enhance button with formAction', async ({ page, app }) => {
+		await page.goto('/actions/enhance');
+
+		expect(await page.textContent('pre')).toBe(JSON.stringify(null));
+
+		await page.type('input[name="username"]', 'foo');
+		await Promise.all([
+			page.waitForRequest((request) => request.url().includes('/actions/enhance')),
+			page.click('button.form1-register')
+		]);
+
+		await expect(page.locator('pre')).toHaveText(JSON.stringify({ result: 'register: foo' }));
+	});
 });

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1792,9 +1792,26 @@ test.describe('Actions', () => {
 		await page.type('input[name="username"]', 'foo');
 		await Promise.all([
 			page.waitForRequest((request) => request.url().includes('/actions/enhance')),
-			page.click('button')
+			page.click('button.form1')
 		]);
 
 		await expect(page.locator('pre')).toHaveText(JSON.stringify({ result: 'foo' }));
+	});
+
+	test('use:enhance abort controller', async ({ page, javaScriptEnabled }) => {
+		await page.goto('/actions/enhance');
+
+		expect(await page.textContent('span.count')).toBe('0');
+
+		if (javaScriptEnabled) {
+			await Promise.all([
+				page.waitForRequest((request) => request.url().includes('/actions/enhance')),
+				page.click('button.form2'),
+				page.click('button.form2')
+			]);
+			await page.waitForTimeout(500); // to make sure locator doesn't run exactly between submission 1 and 2
+
+			await expect(page.locator('span.count')).toHaveText('1');
+		}
 	});
 });

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -103,6 +103,7 @@ declare module '$app/forms' {
 		data: FormData;
 		form: HTMLFormElement;
 		element: Element;
+		controller: AbortController;
 		cancel: () => void;
 	}) =>
 		| void
@@ -127,6 +128,7 @@ declare module '$app/forms' {
 		/**
 		 * Called upon submission with the given FormData.
 		 * If `cancel` is called, the form will not be submitted.
+		 * You can use the abort `controller` to cancel the submission in case another one starts.
 		 * If a function is returned, that function is called with the response from the server.
 		 * If nothing is returned, the fallback will be used.
 		 *

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -96,21 +96,19 @@ declare module '$app/forms' {
 	import type { ActionResult } from '@sveltejs/kit';
 
 	export type SubmitFunction<
-		Element extends HTMLFormElement | HTMLInputElement | HTMLButtonElement = HTMLFormElement,
 		Success extends Record<string, unknown> | undefined = Record<string, any>,
 		Invalid extends Record<string, unknown> | undefined = Record<string, any>
 	> = (input: {
+		action: string;
 		data: FormData;
 		form: HTMLFormElement;
-		element: Element;
 		controller: AbortController;
 		cancel: () => void;
 	}) =>
 		| void
 		| ((opts: {
-				data: FormData;
 				form: HTMLFormElement;
-				element: Element;
+				action: string;
 				result: ActionResult<Success, Invalid>;
 		  }) => void);
 
@@ -120,13 +118,12 @@ declare module '$app/forms' {
 	 * @param options Callbacks for different states of the form lifecycle
 	 */
 	export function enhance<
-		Element extends HTMLFormElement | HTMLInputElement | HTMLButtonElement = HTMLFormElement,
 		Success extends Record<string, unknown> | undefined = Record<string, any>,
 		Invalid extends Record<string, unknown> | undefined = Record<string, any>
 	>(
-		element: Element,
+		form: HTMLFormElement,
 		/**
-		 * Called upon submission with the given FormData.
+		 * Called upon submission with the given FormData and the `action` that should be triggered.
 		 * If `cancel` is called, the form will not be submitted.
 		 * You can use the abort `controller` to cancel the submission in case another one starts.
 		 * If a function is returned, that function is called with the response from the server.
@@ -139,7 +136,7 @@ declare module '$app/forms' {
 		 * - redirects in case of a redirect response
 		 * - redirects to the nearest error page in case of an unexpected error
 		 */
-		submit?: SubmitFunction<Element, Success, Invalid>
+		submit?: SubmitFunction<Success, Invalid>
 	): { destroy: () => void };
 
 	/**


### PR DESCRIPTION
This is a breaking change because the `element` property was removed from `enhance` and the action only is possible to apply to forms again; also the interface generic has been removed accordingly.

Fixes #6660
Superseedes/closes #6658 
Reverts #6633, because we can achieve the same with `event.submitter`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
