### PR TITLE
Generate ESM functions for Netlify

### DIFF
--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -1,7 +1,6 @@
 import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join, resolve, posix } from 'path';
 import { fileURLToPath } from 'url';
-import glob from 'tiny-glob/sync.js';
 import esbuild from 'esbuild';
 import toml from '@iarna/toml';
 
@@ -66,10 +65,6 @@ export default function ({ split = false, edge = edge_set_in_env_var } = {}) {
 				`\n\n/${builder.config.kit.appDir}/immutable/*\n  cache-control: public\n  cache-control: immutable\n  cache-control: max-age=31536000\n`
 			);
 
-			// for esbuild, use ESM
-			// for zip-it-and-ship-it, use CJS until https://github.com/netlify/zip-it-and-ship-it/issues/750
-			const esm = netlify_config?.functions?.node_bundler === 'esbuild';
-
 			if (edge) {
 				if (split) {
 					throw new Error('Cannot use `split: true` alongside `edge: true`');
@@ -77,7 +72,7 @@ export default function ({ split = false, edge = edge_set_in_env_var } = {}) {
 
 				await generate_edge_functions({ builder });
 			} else {
-				await generate_lambda_functions({ builder, esm, split, publish });
+				await generate_lambda_functions({ builder, split, publish });
 			}
 		}
 	};
@@ -148,9 +143,8 @@ async function generate_edge_functions({ builder }) {
  * @param {import('@sveltejs/kit').Builder} params.builder
  * @param { string } params.publish
  * @param { boolean } params.split
- * @param { boolean } params.esm
  */
-async function generate_lambda_functions({ builder, publish, split, esm }) {
+async function generate_lambda_functions({ builder, publish, split }) {
 	builder.mkdirp('.netlify/functions-internal');
 
 	/** @type {string[]} */
@@ -160,19 +154,11 @@ async function generate_lambda_functions({ builder, publish, split, esm }) {
 	const replace = {
 		'0SERVER': './server/index.js' // digit prefix prevents CJS build from using this as a variable name, which would also get replaced
 	};
-	if (esm) {
-		builder.copy(`${files}/esm`, '.netlify', { replace });
-	} else {
-		glob('**/*.js', { cwd: '.netlify/server', filesOnly: true }).forEach((file) => {
-			const filepath = `.netlify/server/${file}`;
-			const input = readFileSync(filepath, 'utf8');
-			const output = esbuild.transformSync(input, { format: 'cjs', target: 'node12' }).code;
-			writeFileSync(filepath, output);
-		});
 
-		builder.copy(`${files}/cjs`, '.netlify', { replace });
-		writeFileSync(join('.netlify', 'package.json'), JSON.stringify({ type: 'commonjs' }));
-	}
+	builder.copy(`${files}/esm`, '.netlify', { replace });
+
+	// Configuring the function to use ESM as the output format.
+	const fnConfig = JSON.stringify({ config: { nodeModuleFormat: 'esm' }, version: 1 });
 
 	if (split) {
 		builder.log.minor('Generating serverless functions...');
@@ -201,14 +187,13 @@ async function generate_lambda_functions({ builder, publish, split, esm }) {
 				complete: (entry) => {
 					const manifest = entry.generateManifest({
 						relativePath: '../server',
-						format: esm ? 'esm' : 'cjs'
+						format: 'esm'
 					});
 
-					const fn = esm
-						? `import { init } from '../serverless.js';\n\nexport const handler = init(${manifest});\n`
-						: `const { init } = require('../serverless.js');\n\nexports.handler = init(${manifest});\n`;
+					const fn = `import { init } from '../serverless.js';\n\nexport const handler = init(${manifest});\n`;
 
-					writeFileSync(`.netlify/functions-internal/${name}.js`, fn);
+					writeFileSync(`.netlify/functions-internal/${name}.mjs`, fn);
+					writeFileSync(`.netlify/functions-internal/${name}.json`, fnConfig);
 
 					redirects.push(`${pattern} /.netlify/functions/${name} 200`);
 					redirects.push(`${pattern}/__data.js /.netlify/functions/${name} 200`);
@@ -220,14 +205,13 @@ async function generate_lambda_functions({ builder, publish, split, esm }) {
 
 		const manifest = builder.generateManifest({
 			relativePath: '../server',
-			format: esm ? 'esm' : 'cjs'
+			format: 'esm'
 		});
 
-		const fn = esm
-			? `import { init } from '../serverless.js';\n\nexport const handler = init(${manifest});\n`
-			: `const { init } = require('../serverless.js');\n\nexports.handler = init(${manifest});\n`;
+		const fn = `import { init } from '../serverless.js';\n\nexport const handler = init(${manifest});\n`;
 
-		writeFileSync('.netlify/functions-internal/render.js', fn);
+		writeFileSync(`.netlify/functions-internal/render.json`, fnConfig);
+		writeFileSync('.netlify/functions-internal/render.mjs', fn);
 		redirects.push('* /.netlify/functions/render 200');
 	}
 


### PR DESCRIPTION
Netlify currently transpiles serverless functions with ESM syntax down to CJS, which is causing problems such as https://github.com/sveltejs/kit/issues/6462.

We've started to address that in https://github.com/netlify/zip-it-and-ship-it/pull/1198, which emits ESM files for functions with a `.mjs` extension. Because this is technically a breaking change, we're rolling it out gradually, but we've created a configuration property that allows frameworks like SvelteKit to opt-in to this behaviour straight away. This is done with a per-function configuration file introduced in https://github.com/netlify/zip-it-and-ship-it/pull/1030.

With that in place, this PR has the following changes:

- The conditional logic that decided whether to create CJS or ESM functions was removed, and it now generates ESM only
- The generated function files use the `.mjs` extension
- There's an additional file generated for each function, containing the configuration property mentioned above

We're in the final stages of rolling out this functionality to all customers, but wanted to get the PR in front of you sooner rather than later to gather any feedback and improve the experience for SvelteKit users as soon as possible.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
