### PR TITLE
make action passed to enhance callback a URL

### DIFF
--- a/.changeset/tiny-houses-matter.md
+++ b/.changeset/tiny-houses-matter.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] make action passed to enhance function a URL instead of a string

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -19,7 +19,7 @@ export const applyAction = ssr ? guard('applyAction') : client.apply_action;
 export function enhance(form, submit = () => {}) {
 	/**
 	 * @param {{
-	 *   action: string;
+	 *   action: URL;
 	 *   result: import('types').ActionResult;
 	 * }} opts
 	 */
@@ -28,7 +28,7 @@ export function enhance(form, submit = () => {}) {
 			await invalidateAll();
 		}
 
-		if (location.origin + location.pathname === action.split('?')[0]) {
+		if (location.origin + location.pathname === action.origin + action.pathname) {
 			applyAction(result);
 		}
 	};
@@ -37,10 +37,13 @@ export function enhance(form, submit = () => {}) {
 	async function handle_submit(event) {
 		event.preventDefault();
 
-		// We can't do submitter.formAction directly because that property is always set
-		const action = event.submitter?.hasAttribute('formaction')
-			? /** @type {HTMLButtonElement | HTMLInputElement} */ (event.submitter).formAction
-			: form.action;
+		const action = new URL(
+			// We can't do submitter.formAction directly because that property is always set
+			event.submitter?.hasAttribute('formaction')
+				? /** @type {HTMLButtonElement | HTMLInputElement} */ (event.submitter).formAction
+				: form.action
+		);
+
 		const data = new FormData(form);
 		const controller = new AbortController();
 

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -99,7 +99,7 @@ declare module '$app/forms' {
 		Success extends Record<string, unknown> | undefined = Record<string, any>,
 		Invalid extends Record<string, unknown> | undefined = Record<string, any>
 	> = (input: {
-		action: string;
+		action: URL;
 		data: FormData;
 		form: HTMLFormElement;
 		controller: AbortController;
@@ -108,7 +108,7 @@ declare module '$app/forms' {
 		| void
 		| ((opts: {
 				form: HTMLFormElement;
-				action: string;
+				action: URL;
 				result: ActionResult<Success, Invalid>;
 		  }) => void);
 


### PR DESCRIPTION
Already had a use for the new `action` property passed to `enhance`, though I immediately wanted it to be a `URL` instead of a `string`, since the most likely thing you'll want to do with it is check `action.searchParams.has('/foo')` etc

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
