### PR TITLE
[breaking] request creation cleanup

### DIFF
--- a/.changeset/red-cherries-fly.md
+++ b/.changeset/red-cherries-fly.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-vercel': patch
+'@sveltejs/kit': patch
+---
+
+[breaking] request creation cleanup

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -49,7 +49,7 @@ const ssr = async (req, res) => {
 	let request;
 
 	try {
-		request = await getRequest(origin || get_origin(req.headers), req);
+		request = await getRequest({ base: origin || get_origin(req.headers), request: req });
 	} catch (err) {
 		res.statusCode = err.status || 400;
 		res.end(err.reason || 'Invalid request body');

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -20,7 +20,7 @@ export default async (req, res) => {
 	let request;
 
 	try {
-		request = await getRequest(`https://${req.headers.host}`, req);
+		request = await getRequest({ base: `https://${req.headers.host}`, request: req });
 	} catch (err) {
 		res.statusCode = err.status || 400;
 		return res.end(err.reason || 'Invalid request body');

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -391,10 +391,13 @@ export async function dev(vite, vite_config, svelte_config) {
 				let request;
 
 				try {
-					request = await getRequest(base, req);
+					request = await getRequest({
+						base,
+						request: req
+					});
 				} catch (/** @type {any} */ err) {
 					res.statusCode = err.status || 400;
-					return res.end(err.reason || 'Invalid request body');
+					return res.end(err.message || 'Invalid request body');
 				}
 
 				const template = load_template(cwd, svelte_config);

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -131,10 +131,13 @@ export async function preview(vite, vite_config, svelte_config) {
 			let request;
 
 			try {
-				request = await getRequest(`${protocol}://${host}`, req);
+				request = await getRequest({
+					base: `${protocol}://${host}`,
+					request: req
+				});
 			} catch (/** @type {any} */ err) {
 				res.statusCode = err.status || 400;
-				return res.end(err.reason || 'Invalid request body');
+				return res.end(err.message || 'Invalid request body');
 			}
 
 			setResponse(

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -408,10 +408,10 @@ declare module '@sveltejs/kit/node/polyfills' {
  * Utilities used by adapters for Node-like environments.
  */
 declare module '@sveltejs/kit/node' {
-	export function getRequest(
-		base: string,
-		request: import('http').IncomingMessage
-	): Promise<Request>;
+	export function getRequest(opts: {
+		base: string;
+		request: import('http').IncomingMessage;
+	}): Promise<Request>;
 	export function setResponse(res: import('http').ServerResponse, response: Response): void;
 }
 


### PR DESCRIPTION
A few things changed here:
- allow HTTP/2 streaming. i.e. undefined `content-length` when using HTTP/2
- I have no idea wtf `err.reason` was. Changed it to `err.message`
- made `getRequest` take a single arg so that we can easily add a new option to it like `bodySizeLimit` (https://github.com/sveltejs/kit/issues/6542) if we want the adapter to handle that option