### PR TITLE
Updated accessibility doc to match hooks.server.js

### DIFF
--- a/documentation/docs/19-accessibility.md
+++ b/documentation/docs/19-accessibility.md
@@ -62,7 +62,7 @@ If your content is available in multiple languages, you should set the `lang` at
 ```
 
 ```js
-/// file: src/hooks.js
+/// file: src/hooks.server.js
 /**
  * @param {import('@sveltejs/kit').RequestEvent} event
  * @returns {string}


### PR DESCRIPTION
Accessibility docs updated to match changes of #6586. `hooks.js` should be `hooks.server.js`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
