### PR TITLE
docs: remove `test` subheading in the project-structure

### DIFF
--- a/documentation/docs/01-project-structure.md
+++ b/documentation/docs/01-project-structure.md
@@ -78,10 +78,6 @@ A SvelteKit project is really just a [Vite](https://vitejs.dev) project that use
 
 ### Other files
 
-#### test
-
-If you choose to add tests during `npm create svelte@latest`, they will go in a `test` directory.
-
 #### .svelte-kit
 
 As you develop and build your project, SvelteKit will generate files in a `.svelte-kit` directory (configurable as [`outDir`](/docs/configuration#outdir)). You can ignore its contents, and delete them at any time (they will be regenerated when you next `dev` or `build`).


### PR DESCRIPTION
In the [project structure](https://kit.svelte.dev/docs/project-structure) docs there is a `tests` subheading listed within `Project files` and a `test` subheading listed within `Other files`. Feels like a duplication. This change will remove the `test` subheading.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
