### PR TITLE
Remove "for an external resource" from the definition of `handleFetch`

### DIFF
--- a/documentation/docs/07-hooks.md
+++ b/documentation/docs/07-hooks.md
@@ -90,7 +90,7 @@ export async function handle({ event, resolve }) {
 
 #### handleFetch
 
-This function allows you to modify (or replace) a `fetch` request for an external resource that happens inside a `load` function that runs on the server (or during pre-rendering).
+This function allows you to modify (or replace) a `fetch` request that happens inside a `load` function that runs on the server (or during pre-rendering).
 
 Or your `load` function might make a request to a public URL like `https://api.yourapp.com` when the user performs a client-side navigation to the respective page, but during SSR it might make sense to hit the API directly (bypassing whatever proxies and load balancers sit between it and the public internet).
 


### PR DESCRIPTION
#6565 replaced the `externalFetch` hook with a more generic `handleFetch` which isn't specific to requests with external URLs. I think this part of the documentation wasn't updated to reflect that, it should no longer say "...for an external resource..." in the definition of the `handleFetch` hook.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:


- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
