### PR TITLE
Add explainer on configuring hosts with SPA mode.

### DIFF
--- a/packages/adapter-static/README.md
+++ b/packages/adapter-static/README.md
@@ -92,6 +92,8 @@ export default {
 };
 ```
 
+> How to configure this behaviour does however depend on your hosting solution and is not part of SvelteKit, it is recommended to search the host's documentation on how to redirect requests. 
+
 When operating in SPA mode, you can omit the [`prerender`](https://kit.svelte.dev/docs/page-options#prerender) option from your root layout (or set it to `false`, its default value), and only pages that have the `prerender` option set will be prerendered at build time.
 
 SvelteKit will still crawl your app's entry points looking for prerenderable pages. If `svelte-kit build` fails because of pages that can't be loaded outside the browser, you can set `config.kit.prerender.entries` to `[]` to prevent this from happening. (Setting `config.kit.prerender.enabled` to `false` also has this effect, but would prevent the fallback page from being generated.)


### PR DESCRIPTION
An often recurring question using the static adapter in SPA mode is why it keeps seeing "file not found" after being deployed.  This confusion stems from the idea that SvelteKit can somehow handle the redirects necessary.  This change adds a small explainer text to remind developers that this is something they have to configure themselves as it fully depends on what kind of server they use.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
