### PR TITLE
[feat] support Azure Static Web Apps in adapter-auto

### DIFF
--- a/.changeset/eight-vans-exercise.md
+++ b/.changeset/eight-vans-exercise.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-auto': patch
+---
+
+[feat] support Azure SWA

--- a/packages/adapter-auto/README.md
+++ b/packages/adapter-auto/README.md
@@ -9,6 +9,7 @@ The following environments are supported out-of-the-box, meaning a newly created
 - [Cloudflare Pages](https://developers.cloudflare.com/pages/) via [adapter-cloudflare](../adapter-cloudflare)
 - [Netlify](https://netlify.com/) via [adapter-netlify](../adapter-netlify)
 - [Vercel](https://vercel.com/) via [adapter-vercel](../adapter-vercel)
+- [Azure Static Web Apps](https://docs.microsoft.com/en-us/azure/static-web-apps/) via [svelte-adapter-azure-swa](https://github.com/geoffrich/svelte-adapter-azure-swa)
 
 ## Community adapters
 

--- a/packages/adapter-auto/adapters.js
+++ b/packages/adapter-auto/adapters.js
@@ -13,5 +13,10 @@ export const adapters = [
 		name: 'Netlify',
 		test: () => !!process.env.NETLIFY,
 		module: '@sveltejs/adapter-netlify'
+	},
+	{
+		name: 'Azure Static Web Apps',
+		test: () => process.env.GITHUB_ACTION_REPOSITORY === 'Azure/static-web-apps-deploy',
+		module: 'svelte-adapter-azure-swa'
 	}
 ];


### PR DESCRIPTION
This PR adds a check for [Azure Static Web Apps](https://docs.microsoft.com/en-us/azure/static-web-apps/overview) to adapter-auto. If it succeeds, it uses [svelte-adapter-azure-swa](https://github.com/geoffrich/svelte-adapter-azure-swa), which I maintain. This package is not automatically added as a dependency of adapter-auto, users need to install it first.

The check uses the `GITHUB_ACTION_REPOSITORY` [environment variable](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables) to check if we are building using the [Azure SWA action](https://github.com/Azure/static-web-apps-deploy). Azure SWA builds on GitHub actions by default.

I tested this using patch-package on one of my SWA projects and it seemed to work.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
