### PR TITLE
Make build folder of adapter-node self-sufficient

### DIFF
--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'fs';
+import { writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import * as esbuild from 'esbuild';
 
@@ -45,13 +45,13 @@ export default function (opts = {}) {
 				`export const manifest = ${builder.generateManifest({ relativePath: './' })};`
 			);
 
-			const optimizedPackageJson = builder.generatePackageJson()
+			const optimized_package_json = builder.generatePackageJson();
 			writeFileSync(
 				`${out}/package.json`,
-				optimizedPackageJson,
+				optimized_package_json
 			);
 
-			const pkg = JSON.parse(optimizedPackageJson);
+			const pkg = JSON.parse(optimized_package_json);
 
 			await esbuild.build({
 				platform: 'node',

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -46,10 +46,7 @@ export default function (opts = {}) {
 			);
 
 			const optimized_package_json = builder.generatePackageJson();
-			writeFileSync(
-				`${out}/package.json`,
-				optimized_package_json
-			);
+			writeFileSync(`${out}/package.json`, optimized_package_json);
 
 			const pkg = JSON.parse(optimized_package_json);
 

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -45,7 +45,13 @@ export default function (opts = {}) {
 				`export const manifest = ${builder.generateManifest({ relativePath: './' })};`
 			);
 
-			const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+			const optimizedPackageJson = builder.generatePackageJson()
+			writeFileSync(
+				`${out}/package.json`,
+				optimizedPackageJson,
+			);
+
+			const pkg = JSON.parse(optimizedPackageJson);
 
 			await esbuild.build({
 				platform: 'node',

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -118,7 +118,7 @@ export function create_builder({ config, build_data, routes, prerendered, log })
 			return generate_package_json({
 				build_data,
 				cwd: process.cwd()
-			})
+			});
 		},
 
 		getBuildDirectory(name) {

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -5,6 +5,7 @@ import { pipeline } from 'stream';
 import { promisify } from 'util';
 import { copy, rimraf, mkdirp } from '../../utils/filesystem.js';
 import { generate_manifest } from '../generate_manifest/index.js';
+import { generate_package_json } from '../generate_package_json/index.js';
 
 const pipe = promisify(pipeline);
 
@@ -111,6 +112,13 @@ export function create_builder({ config, build_data, routes, prerendered, log })
 				routes,
 				format
 			});
+		},
+
+		generatePackageJson: () => {
+			return generate_package_json({
+				build_data,
+				cwd: process.cwd()
+			})
 		},
 
 		getBuildDirectory(name) {

--- a/packages/kit/src/core/generate_package_json/index.js
+++ b/packages/kit/src/core/generate_package_json/index.js
@@ -45,7 +45,7 @@ export function generate_package_json({build_data, cwd}) {
  */
 function filter_import_packages(chunks, dependencies_set) {
   /** @type {string[]} */
-  const import_names = chunks.reduce((deps, chunk) => {
+  const import_names = chunks.reduce((/** @type {string[]} */ deps, chunk) => {
     if(chunk.imports.length > 0) {
       for(let i = 0; i < chunk.imports.length; i++) {
         const importName = chunk.imports[i];

--- a/packages/kit/src/core/generate_package_json/index.js
+++ b/packages/kit/src/core/generate_package_json/index.js
@@ -1,0 +1,77 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Generates a production package.json
+ * @param {{
+ *   build_data: import('types').BuildData;
+ *   cwd: string;
+ * }} opts
+ */
+export function generate_package_json({build_data, cwd}) {
+
+  const package_json_text = fs.readFileSync(path.resolve(cwd, 'package.json'), 'utf8');
+  const package_json = JSON.parse(package_json_text);
+  const dependences_with_versions = Object.assign(
+    {},
+    package_json.devDependencies || {},
+    package_json.dependencies || {}
+  );
+
+  const dependencies = Object.keys(dependences_with_versions);
+
+  /** @type {Set<string>} */
+  const dependencies_set = new Set(dependencies);
+
+  const prod_package_json = Object.assign({}, package_json);
+  delete prod_package_json.devDependencies;
+  delete prod_package_json.scripts;
+  prod_package_json.dependencies = {};
+
+  const chunks = [build_data.client.chunks, build_data.server.chunks].flat();
+  if(chunks.length > 0) {
+    /** @type {string[]} */
+    const dependency_names = filter_import_packages(chunks, dependencies_set);
+    dependency_names.sort();
+    prod_package_json.dependencies = create_dependency_object(dependency_names, dependences_with_versions);
+  }
+
+  return JSON.stringify(prod_package_json, null, 2);
+}
+/**
+ *
+ * @param {import('rollup').OutputChunk[]} chunks
+ * @param {Set<string>} dependencies_set
+ */
+function filter_import_packages(chunks, dependencies_set) {
+  /** @type {string[]} */
+  const import_names = chunks.reduce((deps, chunk) => {
+    if(chunk.imports.length > 0) {
+      for(let i = 0; i < chunk.imports.length; i++) {
+        const importName = chunk.imports[i];
+        if(dependencies_set.has(importName)) {
+          deps.push(importName);
+        }
+      }
+    }
+
+    return deps;
+  }, []);
+
+  return import_names;
+}
+
+/**
+ *
+ * @param {string[]} dependency_names
+ * @param {{[key: string]: string}} dependences_with_versions
+ */
+function create_dependency_object(dependency_names, dependences_with_versions) {
+  /** @type {{[key: string]: string}} */
+  const dependencies = {};
+  for(let i = 0; i < dependency_names.length; i++) {
+    dependencies[dependency_names[i]] = dependences_with_versions[dependency_names[i]];
+  }
+
+  return dependencies;
+}

--- a/packages/kit/src/core/generate_package_json/index.js
+++ b/packages/kit/src/core/generate_package_json/index.js
@@ -8,35 +8,37 @@ import path from 'node:path';
  *   cwd: string;
  * }} opts
  */
-export function generate_package_json({build_data, cwd}) {
+export function generate_package_json({ build_data, cwd }) {
+	const package_json_text = fs.readFileSync(path.resolve(cwd, 'package.json'), 'utf8');
+	const package_json = JSON.parse(package_json_text);
+	const dependences_with_versions = Object.assign(
+		{},
+		package_json.devDependencies || {},
+		package_json.dependencies || {}
+	);
 
-  const package_json_text = fs.readFileSync(path.resolve(cwd, 'package.json'), 'utf8');
-  const package_json = JSON.parse(package_json_text);
-  const dependences_with_versions = Object.assign(
-    {},
-    package_json.devDependencies || {},
-    package_json.dependencies || {}
-  );
+	const dependencies = Object.keys(dependences_with_versions);
 
-  const dependencies = Object.keys(dependences_with_versions);
+	/** @type {Set<string>} */
+	const dependencies_set = new Set(dependencies);
 
-  /** @type {Set<string>} */
-  const dependencies_set = new Set(dependencies);
+	const prod_package_json = Object.assign({}, package_json);
+	delete prod_package_json.devDependencies;
+	delete prod_package_json.scripts;
+	prod_package_json.dependencies = {};
 
-  const prod_package_json = Object.assign({}, package_json);
-  delete prod_package_json.devDependencies;
-  delete prod_package_json.scripts;
-  prod_package_json.dependencies = {};
+	const chunks = [build_data.client.chunks, build_data.server.chunks].flat();
+	if (chunks.length > 0) {
+		/** @type {string[]} */
+		const dependency_names = filter_import_packages(chunks, dependencies_set);
+		dependency_names.sort();
+		prod_package_json.dependencies = create_dependency_object(
+			dependency_names,
+			dependences_with_versions
+		);
+	}
 
-  const chunks = [build_data.client.chunks, build_data.server.chunks].flat();
-  if(chunks.length > 0) {
-    /** @type {string[]} */
-    const dependency_names = filter_import_packages(chunks, dependencies_set);
-    dependency_names.sort();
-    prod_package_json.dependencies = create_dependency_object(dependency_names, dependences_with_versions);
-  }
-
-  return JSON.stringify(prod_package_json, null, 2);
+	return JSON.stringify(prod_package_json, null, 2);
 }
 /**
  *
@@ -44,21 +46,21 @@ export function generate_package_json({build_data, cwd}) {
  * @param {Set<string>} dependencies_set
  */
 function filter_import_packages(chunks, dependencies_set) {
-  /** @type {string[]} */
-  const import_names = chunks.reduce((/** @type {string[]} */ deps, chunk) => {
-    if(chunk.imports.length > 0) {
-      for(let i = 0; i < chunk.imports.length; i++) {
-        const importName = chunk.imports[i];
-        if(dependencies_set.has(importName)) {
-          deps.push(importName);
-        }
-      }
-    }
+	/** @type {string[]} */
+	const import_names = chunks.reduce((/** @type {string[]} */ deps, chunk) => {
+		if (chunk.imports.length > 0) {
+			for (let i = 0; i < chunk.imports.length; i++) {
+				const importName = chunk.imports[i];
+				if (dependencies_set.has(importName)) {
+					deps.push(importName);
+				}
+			}
+		}
 
-    return deps;
-  }, []);
+		return deps;
+	}, []);
 
-  return import_names;
+	return import_names;
 }
 
 /**
@@ -67,11 +69,11 @@ function filter_import_packages(chunks, dependencies_set) {
  * @param {{[key: string]: string}} dependences_with_versions
  */
 function create_dependency_object(dependency_names, dependences_with_versions) {
-  /** @type {{[key: string]: string}} */
-  const dependencies = {};
-  for(let i = 0; i < dependency_names.length; i++) {
-    dependencies[dependency_names[i]] = dependences_with_versions[dependency_names[i]];
-  }
+	/** @type {{[key: string]: string}} */
+	const dependencies = {};
+	for (let i = 0; i < dependency_names.length; i++) {
+		dependencies[dependency_names[i]] = dependences_with_versions[dependency_names[i]];
+	}
 
-  return dependencies;
+	return dependencies;
 }

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -405,14 +405,14 @@ function kit() {
 					})};\n`
 				);
 
-			const package_json_path = `${paths.output_dir}/package.json`;
-			fs.writeFileSync(
-				package_json_path,
-				generate_package_json({
-					build_data,
-					cwd,
-				})
-			);
+				const package_json_path = `${paths.output_dir}/package.json`;
+				fs.writeFileSync(
+					package_json_path,
+					generate_package_json({
+						build_data,
+						cwd,
+					})
+				);
 
 				log.info('Prerendering');
 				await new Promise((fulfil, reject) => {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -410,7 +410,7 @@ function kit() {
 					package_json_path,
 					generate_package_json({
 						build_data,
-						cwd,
+						cwd
 					})
 				);
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -17,6 +17,7 @@ import { preview } from './preview/index.js';
 import { get_aliases, resolve_entry, prevent_illegal_rollup_imports, get_env } from './utils.js';
 import { fileURLToPath } from 'node:url';
 import { create_static_module, create_dynamic_module } from '../../core/env.js';
+import { generate_package_json } from '../../core/generate_package_json/index.js';
 
 const cwd = process.cwd();
 
@@ -403,6 +404,15 @@ function kit() {
 						routes: manifest_data.routes
 					})};\n`
 				);
+
+			const package_json_path = `${paths.output_dir}/package.json`;
+			fs.writeFileSync(
+				package_json_path,
+				generate_package_json({
+					build_data,
+					cwd,
+				})
+			);
 
 				log.info('Prerendering');
 				await new Promise((fulfil, reject) => {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -56,6 +56,7 @@ export interface Builder {
 	createEntries(fn: (route: RouteDefinition) => AdapterEntry): Promise<void>;
 
 	generateManifest: (opts: { relativePath: string; format?: 'esm' | 'cjs' }) => string;
+	generatePackageJson: () => string;
 
 	getBuildDirectory(name: string): string;
 	getClientDirectory(): string;


### PR DESCRIPTION
Currently you can't just take the content of the build folder to run the server in production.
The server won't start without an existing `package.json` file which is configured with `type: "module"`.

This PR creates a `package.json` file in the build folder.

To avoid errors after starting the server because if dependencies which should be in `dependencies` instead of `devDependencies` of `package,json`, this PR also extends the build process to create a production ready `package.json` file.

**Can't you just use the project's package.json and lockfile? Why do you need to generate a new one?**
I believe the compiler is smarter than I am, so I let it decide which packages should be dependencies in a production package.json.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
