### PR TITLE
[fix] silence prop warnings

### DIFF
--- a/.changeset/gorgeous-flowers-doubt.md
+++ b/.changeset/gorgeous-flowers-doubt.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] silence prop warnings

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -43,6 +43,7 @@ function update_scroll_positions(index) {
 	scroll_positions[index] = scroll_state();
 }
 
+// TODO remove for 1.0
 /** @type {Record<string, true>} */
 let warned_about_attributes = {};
 
@@ -1545,25 +1546,26 @@ function add_url_properties(type, target) {
 
 function pre_update() {
 	if (__SVELTEKIT_DEV__) {
-		// Nasty hack to silence harmless warnings the user can do nothing about
-		const warn = console.warn;
-		console.warn = (...args) => {
-			if (
-				args.length === 1 &&
-				/<(Layout|Page)(_[\w$]+)?> was created (with unknown|without expected) prop '(data|form)'/.test(
-					args[0]
-				)
-			) {
-				return;
-			}
-			warn(...args);
-		};
-
 		return () => {
-			tick().then(() => (console.warn = warn));
 			check_for_removed_attributes();
 		};
 	}
 
 	return () => {};
+}
+
+if (__SVELTEKIT_DEV__) {
+	// Nasty hack to silence harmless warnings the user can do nothing about
+	const warn = console.warn;
+	console.warn = (...args) => {
+		if (
+			args.length === 1 &&
+			/<(Layout|Page)(_[\w$]+)?> was created (with unknown|without expected) prop '(data|form)'/.test(
+				args[0]
+			)
+		) {
+			return;
+		}
+		warn(...args);
+	};
 }


### PR DESCRIPTION
Fixes #5980
This could result in false negatives but the probability for that is minimal and not seing the warning sometimes is better than seing the warning without being able to do anything about it

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
