### PR TITLE
[fix] beforeNavigate external link

### DIFF
--- a/.changeset/khaki-schools-trade.md
+++ b/.changeset/khaki-schools-trade.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] call beforeNavigate once with type unload on external navigation

--- a/packages/kit/test/apps/basics/src/routes/before-navigate/prevent-navigation/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/before-navigate/prevent-navigation/+page.svelte
@@ -2,12 +2,15 @@
 	import { beforeNavigate } from '$app/navigation';
 
 	let triggered = false;
-	beforeNavigate(({ cancel }) => {
+	let navigation_type;
+	beforeNavigate(({ cancel, type }) => {
 		triggered = true;
+		navigation_type = type;
 		cancel();
 	});
 </script>
 
 <h1>prevent navigation</h1>
 <a href="/before-navigate/a">a</a>
-<pre>{triggered}</pre>
+<a href="https://google.de">external</a>
+<pre>{triggered} {navigation_type}</pre>


### PR DESCRIPTION
Call beforeNavigate once with type unload on external navigation

Fixes #6726

Given the reasons in https://github.com/sveltejs/kit/issues/6726#issuecomment-1247106719 I think this is the most sensible thing to do

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
