### PR TITLE
[fix] Update ValidationError to fix typescript error when returning `invalid` 

### DIFF
--- a/.changeset/three-lions-marry.md
+++ b/.changeset/three-lions-marry.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix shape of ValidationError for typescript. (#6836)

--- a/packages/kit/src/runtime/control.js
+++ b/packages/kit/src/runtime/control.js
@@ -41,6 +41,7 @@ export class ValidationError {
 	constructor(status, data) {
 		this.status = status;
 		this.data = data;
+		this.type = 'invalid';
 	}
 }
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -43,6 +43,7 @@ export type AwaitedActions<T extends Record<string, (...args: any) => any>> = {
 interface ValidationError<T extends Record<string, unknown> | undefined = undefined> {
 	status: number;
 	data: T;
+	type: 'invalid';
 }
 
 type UnpackValidationError<T> = T extends ValidationError<infer X> ? X : T;


### PR DESCRIPTION
Fixes #6836.  Minor change to `ValidationError`, adding `type: 'invalid'` to match the `Invalid` generic in `ActionResult`. Not sure this is the best way, but I couldn't figure out a different one.

Replaces PR #6838 which I irretrievably messed up.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
