### PR TITLE
Fixes #6842: Routes were not found by id under group layouts

### DIFF
--- a/.changeset/six-pants-melt.md
+++ b/.changeset/six-pants-melt.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix `write_types` on windows

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -69,8 +69,8 @@ export async function write_types(config, manifest_data, file) {
 	}
 
 	const id = path.relative(config.kit.files.routes, path.dirname(file));
-
-	const route = manifest_data.routes.find((route) => route.id === id);
+	//replace '\' with '/' to fix #6842, routes not being found under layout groups
+	const route = manifest_data.routes.find((route) => route.id === id || route.id === id.replace(/\\/g, '/'));
 	if (!route) return; // this shouldn't ever happen
 
 	update_types(config, create_routes_map(manifest_data), route);

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -69,7 +69,8 @@ export async function write_types(config, manifest_data, file) {
 	}
 
 	const id = path.posix.relative(config.kit.files.routes, path.dirname(file));
-	const route = manifest_data.routes.find((route) => route.id === id || route.id === id.replace(/\\/g, '/'));
+
+	const route = manifest_data.routes.find((route) => route.id === id);
 	if (!route) return; // this shouldn't ever happen
 
 	update_types(config, create_routes_map(manifest_data), route);

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -68,7 +68,7 @@ export async function write_types(config, manifest_data, file) {
 		return;
 	}
 
-	const id = path.relative(config.kit.files.routes, path.dirname(file));
+	const id = path.posix.relative(config.kit.files.routes, path.dirname(file));
 	const route = manifest_data.routes.find((route) => route.id === id || route.id === id.replace(/\\/g, '/'));
 	if (!route) return; // this shouldn't ever happen
 

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -69,7 +69,6 @@ export async function write_types(config, manifest_data, file) {
 	}
 
 	const id = path.relative(config.kit.files.routes, path.dirname(file));
-	//replace '\' with '/' to fix #6842, routes not being found under layout groups
 	const route = manifest_data.routes.find((route) => route.id === id || route.id === id.replace(/\\/g, '/'));
 	if (!route) return; // this shouldn't ever happen
 


### PR DESCRIPTION
Fixes #6842 - Types are not properly updated for routes under group layouts

Routes were not found by id under group layouts. replacing '\' with '/' fixes this for route id's.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
