### PR TITLE
create commonjs bundle with adapter-node, since esm output has issues

### DIFF
--- a/.changeset/fast-crews-pay.md
+++ b/.changeset/fast-crews-pay.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Create CommonJS bundle with adapter-node

--- a/packages/adapter-node/ambient.d.ts
+++ b/packages/adapter-node/ambient.d.ts
@@ -1,16 +1,16 @@
-declare module 'ENV' {
+declare module '0ENV' {
 	export function env(key: string, fallback?: any): string;
 }
 
-declare module 'HANDLER' {
+declare module '0HANDLER' {
 	export const handler: import('polka').Middleware;
 }
 
-declare module 'MANIFEST' {
+declare module '0MANIFEST' {
 	import { SSRManifest } from '@sveltejs/kit';
 	export const manifest: SSRManifest;
 }
 
-declare module 'SERVER' {
+declare module '0SERVER' {
 	export { Server } from '@sveltejs/kit';
 }

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -55,21 +55,21 @@ export default function (opts = {}) {
 				target: 'es2022',
 				entryPoints: [`${tmp}/index.js`, `${tmp}/manifest.js`],
 				outdir: `${out}/server`,
-				splitting: true,
-				format: 'esm',
 				bundle: true,
 				external: [...Object.keys(pkg.dependencies || {})]
 			});
 
 			builder.copy(files, out, {
 				replace: {
-					ENV: './env.js',
-					HANDLER: './handler.js',
-					MANIFEST: './server/manifest.js',
-					SERVER: `./server/index.js`,
+					'0ENV': './env.js',
+					'0HANDLER': './handler.js',
+					'0MANIFEST': './server/manifest.js',
+					'0SERVER': `./server/index.js`,
 					ENV_PREFIX: JSON.stringify(envPrefix)
 				}
 			});
+
+			writeFileSync(`${out}/package.json`, JSON.stringify({ type: 'commonjs' }));
 		}
 	};
 }

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -8,7 +8,7 @@ export default [
 		input: 'src/index.js',
 		output: {
 			file: 'files/index.js',
-			format: 'esm'
+			format: 'cjs'
 		},
 		plugins: [nodeResolve(), commonjs(), json()],
 		external: ['ENV', 'HANDLER', ...builtinModules]
@@ -17,7 +17,7 @@ export default [
 		input: 'src/env.js',
 		output: {
 			file: 'files/env.js',
-			format: 'esm'
+			format: 'cjs'
 		},
 		plugins: [nodeResolve(), commonjs(), json()],
 		external: ['HANDLER', ...builtinModules]
@@ -26,7 +26,7 @@ export default [
 		input: 'src/handler.js',
 		output: {
 			file: 'files/handler.js',
-			format: 'esm',
+			format: 'cjs',
 			inlineDynamicImports: true
 		},
 		plugins: [nodeResolve(), commonjs(), json()],

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -4,14 +4,15 @@ import path from 'path';
 import sirv from 'sirv';
 import { fileURLToPath } from 'url';
 import { getRequest, setResponse } from '@sveltejs/kit/node';
-import { Server } from 'SERVER';
-import { manifest } from 'MANIFEST';
-import { env } from 'ENV';
+import { Server } from '0SERVER';
+import { manifest } from '0MANIFEST';
+import { env } from '0ENV';
 
 /* global ENV_PREFIX */
 
 const server = new Server(manifest);
-await server.init({ env: process.env });
+const ready = server.init({ env: process.env });
+
 const origin = env('ORIGIN', undefined);
 const xff_depth = parseInt(env('XFF_DEPTH', '1'));
 const address_header = env('ADDRESS_HEADER', '').toLowerCase();
@@ -47,6 +48,8 @@ function serve(path, client = false) {
 /** @type {import('polka').Middleware} */
 const ssr = async (req, res) => {
 	let request;
+
+	await ready;
 
 	try {
 		request = await getRequest({

--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -1,5 +1,5 @@
-import { handler } from 'HANDLER';
-import { env } from 'ENV';
+import { handler } from '0HANDLER';
+import { env } from '0ENV';
 import polka from 'polka';
 
 export const path = env('SOCKET_PATH', false);


### PR DESCRIPTION
This is an alternative approach to #6797. By generating CommonJS instead of ESM, `esbuild` doesn't replace `require` calls for built-in modules with `__require` (which throws a 'Dynamic require of ... is not supported' error — https://github.com/evanw/esbuild/issues/1921). 

As such, it's possible to bundle libraries that have such calls, instead of having to move them to `dependencies` so that they're not bundled, which is onerous since it's very hard to figure out which are the offending packages.

The downside of this approach is that it's no longer possible to have ESM packages as external dependencies — they must always be bundled. I don't have a clear sense of which is the lesser of two evils.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
