### PR TITLE
fix: prettier not working for svelte files in create-svelte projects

### DIFF
--- a/.changeset/light-eagles-call.md
+++ b/.changeset/light-eagles-call.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+fix prettier not formatting svelte files

--- a/.changeset/light-eagles-call.md
+++ b/.changeset/light-eagles-call.md
@@ -2,4 +2,4 @@
 'create-svelte': patch
 ---
 
-fix prettier not formatting svelte files
+[fix] prettier not formatting svelte files

--- a/packages/create-svelte/shared/+eslint+prettier/package.json
+++ b/packages/create-svelte/shared/+eslint+prettier/package.json
@@ -3,7 +3,7 @@
 		"eslint-config-prettier": "^8.3.0"
 	},
 	"scripts": {
-		"lint": "prettier --check . && eslint .",
-		"format": "prettier --write ."
+		"lint": "prettier --plugin-search-dir . --check . && eslint .",
+		"format": "prettier --plugin-search-dir . --write ."
 	}
 }

--- a/packages/create-svelte/shared/+prettier/.prettierrc
+++ b/packages/create-svelte/shared/+prettier/.prettierrc
@@ -3,6 +3,7 @@
 	"singleQuote": true,
 	"trailingComma": "none",
 	"printWidth": 100,
+	"plugins": ["prettier-plugin-svelte"],
 	"pluginSearchDirs": ["."],
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }

--- a/packages/create-svelte/shared/-eslint+prettier/package.json
+++ b/packages/create-svelte/shared/-eslint+prettier/package.json
@@ -1,6 +1,6 @@
 {
 	"scripts": {
-		"lint": "prettier --check .",
-		"format": "prettier --write ."
+		"lint": "prettier --plugin-search-dir . --check .",
+		"format": "prettier --plugin-search-dir . --write ."
 	}
 }

--- a/packages/create-svelte/test/check.js
+++ b/packages/create-svelte/test/check.js
@@ -26,9 +26,9 @@ const overrides = { ...existing_workspace_overrides };
 
 try {
 	const kit_dir = fileURLToPath(new URL('../../../packages/kit', import.meta.url));
-	const ls_vite_result = execSync(`pnpm ls --json vite`,{cwd: kit_dir});
+	const ls_vite_result = execSync(`pnpm ls --json vite`, { cwd: kit_dir });
 	const vite_version = JSON.parse(ls_vite_result)[0].devDependencies.vite.version;
-	overrides.vite=vite_version;
+	overrides.vite = vite_version;
 } catch (e) {
 	console.error('failed to parse installed vite version from packages/kit');
 	throw e;
@@ -108,7 +108,7 @@ for (const template of fs.readdirSync('templates')) {
 
 			// not all templates have all scripts
 			console.group(`${template}-${types}`);
-			for (const script of scripts_to_test.filter(s => !!pkg.scripts[s])) {
+			for (const script of scripts_to_test.filter((s) => !!pkg.scripts[s])) {
 				try {
 					execSync(`pnpm run ${script}`, { cwd, stdio: 'pipe' });
 					console.log(`✅ ${script}`);

--- a/packages/create-svelte/test/check.js
+++ b/packages/create-svelte/test/check.js
@@ -2,7 +2,6 @@ import fs from 'fs';
 import { execSync } from 'child_process';
 import path from 'path';
 import { test } from 'uvu';
-import { Writable } from 'stream';
 import * as assert from 'uvu/assert';
 import { create } from '../index.js';
 import { fileURLToPath } from 'url';
@@ -24,6 +23,16 @@ const overrides = { ...existing_workspace_overrides };
 	const name = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).name;
 	overrides[name] = path.dirname(path.resolve(pkgPath));
 });
+
+try {
+	const kit_dir = fileURLToPath(new URL('../../../packages/kit', import.meta.url));
+	const ls_vite_result = execSync(`pnpm ls --json vite`,{cwd: kit_dir});
+	const vite_version = JSON.parse(ls_vite_result)[0].devDependencies.vite.version;
+	overrides.vite=vite_version;
+} catch (e) {
+	console.error('failed to parse installed vite version from packages/kit');
+	throw e;
+}
 
 test.before(() => {
 	try {
@@ -90,7 +99,7 @@ for (const template of fs.readdirSync('templates')) {
 			execSync('pnpm install --no-frozen-lockfile', { cwd, stdio: 'ignore' });
 
 			// run provided scripts that are non-blocking. All of them should exit with 0
-			const scripts_to_test = ['prepare', 'check', 'lint', 'build', 'sync'];
+			const scripts_to_test = ['sync', 'format', 'lint', 'check', 'build'];
 
 			// package script requires lib dir
 			if (fs.existsSync(path.join(cwd, 'src', 'lib'))) {
@@ -99,7 +108,7 @@ for (const template of fs.readdirSync('templates')) {
 
 			// not all templates have all scripts
 			console.group(`${template}-${types}`);
-			for (const script of Object.keys(pkg.scripts).filter((s) => scripts_to_test.includes(s))) {
+			for (const script of scripts_to_test.filter(s => !!pkg.scripts[s])) {
 				try {
 					execSync(`pnpm run ${script}`, { cwd, stdio: 'pipe' });
 					console.log(`✅ ${script}`);


### PR DESCRIPTION
fixes #6804 

i'm not sure why this is needed again, it was previously removed in favor of the `pluginSearchDirs` setting in prettierrc. 
Now we use both.

Note: the tests for create-svelte received 2 updates
1) pin them to the same vite version kit uses to avoid type incompatibility errors with `pnpm check` during tests
2) updated list of tested commands to include `format`, remove `prepare` and sort them differently

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
