### PR TITLE
change return type of cookies.get back to string|undefined

### DIFF
--- a/.changeset/chatty-moose-love.md
+++ b/.changeset/chatty-moose-love.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+The return type of cookies.get is string|undefined #6865

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -128,7 +128,7 @@ export interface Cookies {
 	/**
 	 * Gets a cookie that was previously set with `cookies.set`, or from the request headers.
 	 */
-	get(name: string, opts?: import('cookie').CookieParseOptions): string | void;
+	get(name: string, opts?: import('cookie').CookieParseOptions): string | undefined;
 
 	/**
 	 * Sets a cookie. This will add a `set-cookie` header to the response, but also make the cookie available via `cookies.get` during the current request.


### PR DESCRIPTION
Fixes #6865. The return type of `cookies.get` is `string|undefined`, not `string|void`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
