### PR TITLE
improve readability of generated types

### DIFF
--- a/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/$types.d.ts
@@ -1,5 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
@@ -21,7 +22,7 @@ export type LayoutLoad<
 		| void
 > = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
 export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
-export type LayoutData = Omit<
+export type LayoutData = Expand<Omit<
 	LayoutParentData,
 	keyof Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
@@ -29,4 +30,4 @@ export type LayoutData = Omit<
 > &
 	Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
-	>;
+	>>;

--- a/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/$types.d.ts
@@ -22,12 +22,14 @@ export type LayoutLoad<
 		| void
 > = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
 export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
-export type LayoutData = Expand<Omit<
-	LayoutParentData,
-	keyof Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
-	>
-> &
-	Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
-	>>;
+export type LayoutData = Expand<
+	Omit<
+		LayoutParentData,
+		keyof Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
+		>
+	> &
+		Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
+		>
+>;

--- a/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/(main)/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/(main)/$types.d.ts
@@ -1,5 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
@@ -21,7 +22,7 @@ export type PageLoad<
 	OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>
 > = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Omit<
+export type PageData = Expand<Omit<
 	PageParentData,
 	keyof Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../../(main)/+page.js').load>>
@@ -29,14 +30,14 @@ export type PageData = Omit<
 > &
 	Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../../(main)/+page.js').load>>
-	>;
+	>>;
 export type LayoutServerLoad<
 	OutputData extends (Partial<App.PageData> & Record<string, any>) | void =
 		| (Partial<App.PageData> & Record<string, any>)
 		| void
 > = Kit.ServerLoad<LayoutParams, LayoutServerParentData, OutputData>;
 export type LayoutServerLoadEvent = Parameters<LayoutServerLoad>[0];
-export type LayoutServerData = Kit.AwaitedProperties<
+export type LayoutServerData = Expand<Kit.AwaitedProperties<
 	Awaited<ReturnType<typeof import('../../../../../../../../../(main)/+layout.server.js').load>>
->;
-export type LayoutData = Omit<LayoutParentData, keyof LayoutServerData> & LayoutServerData;
+>>;
+export type LayoutData = Expand<Omit<LayoutParentData, keyof LayoutServerData> & LayoutServerData>;

--- a/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/(main)/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/(main)/$types.d.ts
@@ -22,22 +22,26 @@ export type PageLoad<
 	OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>
 > = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Expand<Omit<
-	PageParentData,
-	keyof Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../../(main)/+page.js').load>>
-	>
-> &
-	Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../../(main)/+page.js').load>>
-	>>;
+export type PageData = Expand<
+	Omit<
+		PageParentData,
+		keyof Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../../(main)/+page.js').load>>
+		>
+	> &
+		Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../../(main)/+page.js').load>>
+		>
+>;
 export type LayoutServerLoad<
 	OutputData extends (Partial<App.PageData> & Record<string, any>) | void =
 		| (Partial<App.PageData> & Record<string, any>)
 		| void
 > = Kit.ServerLoad<LayoutParams, LayoutServerParentData, OutputData>;
 export type LayoutServerLoadEvent = Parameters<LayoutServerLoad>[0];
-export type LayoutServerData = Expand<Kit.AwaitedProperties<
-	Awaited<ReturnType<typeof import('../../../../../../../../../(main)/+layout.server.js').load>>
->>;
+export type LayoutServerData = Expand<
+	Kit.AwaitedProperties<
+		Awaited<ReturnType<typeof import('../../../../../../../../../(main)/+layout.server.js').load>>
+	>
+>;
 export type LayoutData = Expand<Omit<LayoutParentData, keyof LayoutServerData> & LayoutServerData>;

--- a/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/(main)/sub/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/(main)/sub/$types.d.ts
@@ -1,5 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
@@ -22,7 +23,7 @@ export type PageLoad<
 	OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>
 > = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Omit<
+export type PageData = Expand<Omit<
 	PageParentData,
 	keyof Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../../../(main)/sub/+page.js').load>>
@@ -30,4 +31,4 @@ export type PageData = Omit<
 > &
 	Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../../../(main)/sub/+page.js').load>>
-	>;
+	>>;

--- a/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/(main)/sub/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/layout-advanced/_expected/(main)/sub/$types.d.ts
@@ -23,12 +23,14 @@ export type PageLoad<
 	OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>
 > = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Expand<Omit<
-	PageParentData,
-	keyof Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../../../(main)/sub/+page.js').load>>
-	>
-> &
-	Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../../../(main)/sub/+page.js').load>>
-	>>;
+export type PageData = Expand<
+	Omit<
+		PageParentData,
+		keyof Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../../../(main)/sub/+page.js').load>>
+		>
+	> &
+		Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../../../(main)/sub/+page.js').load>>
+		>
+>;

--- a/packages/kit/src/core/sync/write_types/test/layout/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/layout/_expected/$types.d.ts
@@ -25,22 +25,26 @@ export type PageServerLoad<
 > = Kit.ServerLoad<RouteParams, PageServerParentData, OutputData>;
 export type PageServerLoadEvent = Parameters<PageServerLoad>[0];
 export type ActionData = unknown;
-export type PageServerData = Expand<Kit.AwaitedProperties<
-	Awaited<ReturnType<typeof import('../../../../../../../../+page.server.js').load>>
->>;
+export type PageServerData = Expand<
+	Kit.AwaitedProperties<
+		Awaited<ReturnType<typeof import('../../../../../../../../+page.server.js').load>>
+	>
+>;
 export type PageLoad<
 	OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>
 > = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Expand<Omit<
-	PageParentData,
-	keyof Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
-	>
-> &
-	Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
-	>>;
+export type PageData = Expand<
+	Omit<
+		PageParentData,
+		keyof Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
+		>
+	> &
+		Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
+		>
+>;
 export type Action = Kit.Action<RouteParams>;
 export type Actions = Kit.Actions<RouteParams>;
 export type LayoutServerLoad<
@@ -49,22 +53,26 @@ export type LayoutServerLoad<
 		| void
 > = Kit.ServerLoad<LayoutParams, LayoutServerParentData, OutputData>;
 export type LayoutServerLoadEvent = Parameters<LayoutServerLoad>[0];
-export type LayoutServerData = Expand<Kit.AwaitedProperties<
-	Awaited<ReturnType<typeof import('../../../../../../../../+layout.server.js').load>>
->>;
+export type LayoutServerData = Expand<
+	Kit.AwaitedProperties<
+		Awaited<ReturnType<typeof import('../../../../../../../../+layout.server.js').load>>
+	>
+>;
 export type LayoutLoad<
 	OutputData extends (Partial<App.PageData> & Record<string, any>) | void =
 		| (Partial<App.PageData> & Record<string, any>)
 		| void
 > = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
 export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
-export type LayoutData = Expand<Omit<
-	LayoutParentData,
-	keyof Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
-	>
-> &
-	Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
-	>>;
+export type LayoutData = Expand<
+	Omit<
+		LayoutParentData,
+		keyof Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
+		>
+	> &
+		Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
+		>
+>;
 export type RequestEvent = Kit.RequestEvent<RouteParams>;

--- a/packages/kit/src/core/sync/write_types/test/layout/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/layout/_expected/$types.d.ts
@@ -1,5 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
@@ -24,14 +25,14 @@ export type PageServerLoad<
 > = Kit.ServerLoad<RouteParams, PageServerParentData, OutputData>;
 export type PageServerLoadEvent = Parameters<PageServerLoad>[0];
 export type ActionData = unknown;
-export type PageServerData = Kit.AwaitedProperties<
+export type PageServerData = Expand<Kit.AwaitedProperties<
 	Awaited<ReturnType<typeof import('../../../../../../../../+page.server.js').load>>
->;
+>>;
 export type PageLoad<
 	OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>
 > = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Omit<
+export type PageData = Expand<Omit<
 	PageParentData,
 	keyof Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
@@ -39,7 +40,7 @@ export type PageData = Omit<
 > &
 	Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
-	>;
+	>>;
 export type Action = Kit.Action<RouteParams>;
 export type Actions = Kit.Actions<RouteParams>;
 export type LayoutServerLoad<
@@ -48,16 +49,16 @@ export type LayoutServerLoad<
 		| void
 > = Kit.ServerLoad<LayoutParams, LayoutServerParentData, OutputData>;
 export type LayoutServerLoadEvent = Parameters<LayoutServerLoad>[0];
-export type LayoutServerData = Kit.AwaitedProperties<
+export type LayoutServerData = Expand<Kit.AwaitedProperties<
 	Awaited<ReturnType<typeof import('../../../../../../../../+layout.server.js').load>>
->;
+>>;
 export type LayoutLoad<
 	OutputData extends (Partial<App.PageData> & Record<string, any>) | void =
 		| (Partial<App.PageData> & Record<string, any>)
 		| void
 > = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
 export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
-export type LayoutData = Omit<
+export type LayoutData = Expand<Omit<
 	LayoutParentData,
 	keyof Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
@@ -65,5 +66,5 @@ export type LayoutData = Omit<
 > &
 	Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
-	>;
+	>>;
 export type RequestEvent = Kit.RequestEvent<RouteParams>;

--- a/packages/kit/src/core/sync/write_types/test/simple-page-server-and-shared/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/simple-page-server-and-shared/_expected/$types.d.ts
@@ -24,22 +24,26 @@ export type PageServerLoad<
 > = Kit.ServerLoad<RouteParams, PageServerParentData, OutputData>;
 export type PageServerLoadEvent = Parameters<PageServerLoad>[0];
 export type ActionData = unknown;
-export type PageServerData = Expand<Kit.AwaitedProperties<
-	Awaited<ReturnType<typeof import('../../../../../../../../+page.server.js').load>>
->>;
+export type PageServerData = Expand<
+	Kit.AwaitedProperties<
+		Awaited<ReturnType<typeof import('../../../../../../../../+page.server.js').load>>
+	>
+>;
 export type PageLoad<
 	OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>
 > = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Expand<Omit<
-	PageParentData,
-	keyof Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
-	>
-> &
-	Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
-	>>;
+export type PageData = Expand<
+	Omit<
+		PageParentData,
+		keyof Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
+		>
+	> &
+		Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
+		>
+>;
 export type Action = Kit.Action<RouteParams>;
 export type Actions = Kit.Actions<RouteParams>;
 export type LayoutServerData = null;

--- a/packages/kit/src/core/sync/write_types/test/simple-page-server-and-shared/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/simple-page-server-and-shared/_expected/$types.d.ts
@@ -1,5 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
@@ -23,14 +24,14 @@ export type PageServerLoad<
 > = Kit.ServerLoad<RouteParams, PageServerParentData, OutputData>;
 export type PageServerLoadEvent = Parameters<PageServerLoad>[0];
 export type ActionData = unknown;
-export type PageServerData = Kit.AwaitedProperties<
+export type PageServerData = Expand<Kit.AwaitedProperties<
 	Awaited<ReturnType<typeof import('../../../../../../../../+page.server.js').load>>
->;
+>>;
 export type PageLoad<
 	OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>
 > = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Omit<
+export type PageData = Expand<Omit<
 	PageParentData,
 	keyof Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
@@ -38,9 +39,9 @@ export type PageData = Omit<
 > &
 	Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
-	>;
+	>>;
 export type Action = Kit.Action<RouteParams>;
 export type Actions = Kit.Actions<RouteParams>;
 export type LayoutServerData = null;
-export type LayoutData = LayoutParentData;
+export type LayoutData = Expand<LayoutParentData>;
 export type RequestEvent = Kit.RequestEvent<RouteParams>;

--- a/packages/kit/src/core/sync/write_types/test/simple-page-server-only/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/simple-page-server-only/_expected/$types.d.ts
@@ -21,12 +21,14 @@ export type PageServerLoad<
 	OutputData extends OutputDataShape<PageServerParentData> = OutputDataShape<PageServerParentData>
 > = Kit.ServerLoad<RouteParams, PageServerParentData, OutputData>;
 export type PageServerLoadEvent = Parameters<PageServerLoad>[0];
-export type ActionData = Expand<Kit.AwaitedActions<
-	typeof import('../../../../../../../../+page.server.js').actions
->>;
-export type PageServerData = Expand<Kit.AwaitedProperties<
-	Awaited<ReturnType<typeof import('../../../../../../../../+page.server.js').load>>
->>;
+export type ActionData = Expand<
+	Kit.AwaitedActions<typeof import('../../../../../../../../+page.server.js').actions>
+>;
+export type PageServerData = Expand<
+	Kit.AwaitedProperties<
+		Awaited<ReturnType<typeof import('../../../../../../../../+page.server.js').load>>
+	>
+>;
 export type PageData = Expand<Omit<PageParentData, keyof PageServerData> & PageServerData>;
 export type Action = Kit.Action<RouteParams>;
 export type Actions = Kit.Actions<RouteParams>;

--- a/packages/kit/src/core/sync/write_types/test/simple-page-server-only/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/simple-page-server-only/_expected/$types.d.ts
@@ -1,5 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
@@ -20,15 +21,15 @@ export type PageServerLoad<
 	OutputData extends OutputDataShape<PageServerParentData> = OutputDataShape<PageServerParentData>
 > = Kit.ServerLoad<RouteParams, PageServerParentData, OutputData>;
 export type PageServerLoadEvent = Parameters<PageServerLoad>[0];
-export type ActionData = Kit.AwaitedActions<
+export type ActionData = Expand<Kit.AwaitedActions<
 	typeof import('../../../../../../../../+page.server.js').actions
->;
-export type PageServerData = Kit.AwaitedProperties<
+>>;
+export type PageServerData = Expand<Kit.AwaitedProperties<
 	Awaited<ReturnType<typeof import('../../../../../../../../+page.server.js').load>>
->;
-export type PageData = Omit<PageParentData, keyof PageServerData> & PageServerData;
+>>;
+export type PageData = Expand<Omit<PageParentData, keyof PageServerData> & PageServerData>;
 export type Action = Kit.Action<RouteParams>;
 export type Actions = Kit.Actions<RouteParams>;
 export type LayoutServerData = null;
-export type LayoutData = LayoutParentData;
+export type LayoutData = Expand<LayoutParentData>;
 export type RequestEvent = Kit.RequestEvent<RouteParams>;

--- a/packages/kit/src/core/sync/write_types/test/simple-page-shared-only/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/simple-page-shared-only/_expected/$types.d.ts
@@ -1,5 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
@@ -20,7 +21,7 @@ export type PageLoad<
 	OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>
 > = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Omit<
+export type PageData = Expand<Omit<
 	PageParentData,
 	keyof Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
@@ -28,6 +29,7 @@ export type PageData = Omit<
 > &
 	Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
-	>;
+	>>;
 export type LayoutServerData = null;
-export type LayoutData = LayoutParentData;
+export type LayoutData = Expand<LayoutParentData>;
+

--- a/packages/kit/src/core/sync/write_types/test/simple-page-shared-only/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/simple-page-shared-only/_expected/$types.d.ts
@@ -21,15 +21,16 @@ export type PageLoad<
 	OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>
 > = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Expand<Omit<
-	PageParentData,
-	keyof Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
-	>
-> &
-	Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
-	>>;
+export type PageData = Expand<
+	Omit<
+		PageParentData,
+		keyof Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
+		>
+	> &
+		Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../+page.js').load>>
+		>
+>;
 export type LayoutServerData = null;
 export type LayoutData = Expand<LayoutParentData>;
-

--- a/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/$types.d.ts
@@ -20,12 +20,14 @@ export type LayoutLoad<
 	OutputData extends OutputDataShape<LayoutParentData> = OutputDataShape<LayoutParentData>
 > = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
 export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
-export type LayoutData = Expand<Omit<
-	LayoutParentData,
-	keyof Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
-	>
-> &
-	Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
-	>>;
+export type LayoutData = Expand<
+	Omit<
+		LayoutParentData,
+		keyof Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
+		>
+	> &
+		Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
+		>
+>;

--- a/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/$types.d.ts
@@ -1,5 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
@@ -19,7 +20,7 @@ export type LayoutLoad<
 	OutputData extends OutputDataShape<LayoutParentData> = OutputDataShape<LayoutParentData>
 > = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
 export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
-export type LayoutData = Omit<
+export type LayoutData = Expand<Omit<
 	LayoutParentData,
 	keyof Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
@@ -27,4 +28,4 @@ export type LayoutData = Omit<
 > &
 	Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
-	>;
+	>>;

--- a/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/$types.d.ts
@@ -22,12 +22,14 @@ export type LayoutLoad<
 		| void
 > = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
 export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
-export type LayoutData = Expand<Omit<
-	LayoutParentData,
-	keyof Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../../nested/+layout.js').load>>
-	>
-> &
-	Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../../nested/+layout.js').load>>
-	>>;
+export type LayoutData = Expand<
+	Omit<
+		LayoutParentData,
+		keyof Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../../nested/+layout.js').load>>
+		>
+	> &
+		Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../../nested/+layout.js').load>>
+		>
+>;

--- a/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/$types.d.ts
@@ -1,5 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
@@ -21,7 +22,7 @@ export type LayoutLoad<
 		| void
 > = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
 export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
-export type LayoutData = Omit<
+export type LayoutData = Expand<Omit<
 	LayoutParentData,
 	keyof Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../../nested/+layout.js').load>>
@@ -29,4 +30,4 @@ export type LayoutData = Omit<
 > &
 	Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../../nested/+layout.js').load>>
-	>;
+	>>;

--- a/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/[...rest]/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/[...rest]/$types.d.ts
@@ -23,16 +23,18 @@ export type PageLoad<
 	OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>
 > = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Expand<Omit<
-	PageParentData,
-	keyof Kit.AwaitedProperties<
-		Awaited<
-			ReturnType<typeof import('../../../../../../../../../../nested/[...rest]/+page.js').load>
+export type PageData = Expand<
+	Omit<
+		PageParentData,
+		keyof Kit.AwaitedProperties<
+			Awaited<
+				ReturnType<typeof import('../../../../../../../../../../nested/[...rest]/+page.js').load>
+			>
 		>
-	>
-> &
-	Kit.AwaitedProperties<
-		Awaited<
-			ReturnType<typeof import('../../../../../../../../../../nested/[...rest]/+page.js').load>
+	> &
+		Kit.AwaitedProperties<
+			Awaited<
+				ReturnType<typeof import('../../../../../../../../../../nested/[...rest]/+page.js').load>
+			>
 		>
-	>>;
+>;

--- a/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/[...rest]/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/[...rest]/$types.d.ts
@@ -1,5 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 type RouteParams = { rest: string };
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
@@ -22,7 +23,7 @@ export type PageLoad<
 	OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>
 > = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Omit<
+export type PageData = Expand<Omit<
 	PageParentData,
 	keyof Kit.AwaitedProperties<
 		Awaited<
@@ -34,4 +35,4 @@ export type PageData = Omit<
 		Awaited<
 			ReturnType<typeof import('../../../../../../../../../../nested/[...rest]/+page.js').load>
 		>
-	>;
+	>>;

--- a/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/[slug]/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/_expected/nested/[slug]/$types.d.ts
@@ -1,5 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 type RouteParams = { slug: string };
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
@@ -14,4 +15,4 @@ type EnsureParentData<T> = T extends null | undefined ? {} : T;
 type PageParentData = EnsureParentData<import('../../$types.js').LayoutData>;
 
 export type PageServerData = null;
-export type PageData = PageParentData;
+export type PageData = Expand<PageParentData>;

--- a/packages/kit/src/core/sync/write_types/test/slugs/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs/_expected/$types.d.ts
@@ -1,5 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 type RouteParams = {};
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
@@ -21,7 +22,7 @@ export type LayoutLoad<
 		| void
 > = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
 export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
-export type LayoutData = Omit<
+export type LayoutData = Expand<Omit<
 	LayoutParentData,
 	keyof Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
@@ -29,4 +30,4 @@ export type LayoutData = Omit<
 > &
 	Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
-	>;
+	>>;

--- a/packages/kit/src/core/sync/write_types/test/slugs/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs/_expected/$types.d.ts
@@ -22,12 +22,14 @@ export type LayoutLoad<
 		| void
 > = Kit.Load<LayoutParams, LayoutServerData, LayoutParentData, OutputData>;
 export type LayoutLoadEvent = Parameters<LayoutLoad>[0];
-export type LayoutData = Expand<Omit<
-	LayoutParentData,
-	keyof Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
-	>
-> &
-	Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
-	>>;
+export type LayoutData = Expand<
+	Omit<
+		LayoutParentData,
+		keyof Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
+		>
+	> &
+		Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../+layout.js').load>>
+		>
+>;

--- a/packages/kit/src/core/sync/write_types/test/slugs/_expected/[...rest]/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs/_expected/[...rest]/$types.d.ts
@@ -19,12 +19,14 @@ export type PageLoad<
 	OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>
 > = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Expand<Omit<
-	PageParentData,
-	keyof Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../../[...rest]/+page.js').load>>
-	>
-> &
-	Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../../[...rest]/+page.js').load>>
-	>>;
+export type PageData = Expand<
+	Omit<
+		PageParentData,
+		keyof Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../../[...rest]/+page.js').load>>
+		>
+	> &
+		Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../../[...rest]/+page.js').load>>
+		>
+>;

--- a/packages/kit/src/core/sync/write_types/test/slugs/_expected/[...rest]/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs/_expected/[...rest]/$types.d.ts
@@ -1,5 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 type RouteParams = { rest: string };
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
@@ -18,7 +19,7 @@ export type PageLoad<
 	OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>
 > = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Omit<
+export type PageData = Expand<Omit<
 	PageParentData,
 	keyof Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../../[...rest]/+page.js').load>>
@@ -26,4 +27,4 @@ export type PageData = Omit<
 > &
 	Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../../[...rest]/+page.js').load>>
-	>;
+	>>;

--- a/packages/kit/src/core/sync/write_types/test/slugs/_expected/[slug]/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs/_expected/[slug]/$types.d.ts
@@ -1,5 +1,6 @@
 import type * as Kit from '@sveltejs/kit';
 
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
 type RouteParams = { slug: string };
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
 export type RequiredKeys<T> = {
@@ -18,7 +19,7 @@ export type PageLoad<
 	OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>
 > = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Omit<
+export type PageData = Expand<Omit<
 	PageParentData,
 	keyof Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../../[slug]/+page.js').load>>
@@ -26,4 +27,4 @@ export type PageData = Omit<
 > &
 	Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../../[slug]/+page.js').load>>
-	>;
+	>>;

--- a/packages/kit/src/core/sync/write_types/test/slugs/_expected/[slug]/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs/_expected/[slug]/$types.d.ts
@@ -19,12 +19,14 @@ export type PageLoad<
 	OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>
 > = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Expand<Omit<
-	PageParentData,
-	keyof Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../../[slug]/+page.js').load>>
-	>
-> &
-	Kit.AwaitedProperties<
-		Awaited<ReturnType<typeof import('../../../../../../../../../[slug]/+page.js').load>>
-	>>;
+export type PageData = Expand<
+	Omit<
+		PageParentData,
+		keyof Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../../[slug]/+page.js').load>>
+		>
+	> &
+		Kit.AwaitedProperties<
+			Awaited<ReturnType<typeof import('../../../../../../../../../[slug]/+page.js').load>>
+		>
+>;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -25,7 +25,7 @@ export interface Adapter {
 	adapt(builder: Builder): MaybePromise<void>;
 }
 
-export type AwaitedProperties<input extends Record<string, any> | void> = input extends void
+type AwaitedPropertiesUnion<input extends Record<string, any> | void> = input extends void
 	? undefined // needs to be undefined, because void will break intellisense
 	: input extends Record<string, any>
 	? {
@@ -35,14 +35,15 @@ export type AwaitedProperties<input extends Record<string, any> | void> = input 
 	? input
 	: unknown;
 
-export type AwaitedActions<T extends Record<string, (...args: any) => any>> = Expand<
-	{
-		[Key in keyof T]: OptionalUnion<UnpackValidationError<Awaited<ReturnType<T[Key]>>>>;
-	}[keyof T]
->;
+export type AwaitedProperties<input extends Record<string, any> | void> =
+	AwaitedPropertiesUnion<input> extends Record<string, any>
+		? OptionalUnion<AwaitedPropertiesUnion<input>>
+		: AwaitedPropertiesUnion<input>;
 
-// Makes sure a type is "repackaged" and therefore more readable
-type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+export type AwaitedActions<T extends Record<string, (...args: any) => any>> = {
+	[Key in keyof T]: OptionalUnion<UnpackValidationError<Awaited<ReturnType<T[Key]>>>>;
+}[keyof T];
+
 // Takes a union type and returns a union type where each type also has all properties
 // of all possible types (typed as undefined), making accessing them more ergonomic
 type OptionalUnion<


### PR DESCRIPTION
Implementing the stuff discussed in #6869

Return type of load functions are correctly merged if not returned directly ([example](https://github.com/sveltejs/kit/pull/6869#issuecomment-1250377159))
All generated `*Data` type exports are more readable.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0