### PR TITLE
add support for cookies and setHeaders in handle hook

### DIFF
--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -184,7 +184,6 @@ export async function respond(request, options, state) {
 	 * @param {import('types').ResolveOptions} [opts]
 	 */
 	async function resolve(event, opts) {
-		let includeCookies = false;
 		try {
 			if (opts) {
 				// TODO remove for 1.0
@@ -242,9 +241,6 @@ export async function respond(request, options, state) {
 					// want to cache stuff erroneously etc
 					add_headers_to_response(response, headers);
 				}
-				// only mark the cookies to be included
-				// if we add them to the headers it´s harder to delete them inside the handle hook
-				includeCookies = true;
 
 				return response;
 			}
@@ -282,10 +278,6 @@ export async function respond(request, options, state) {
 		} finally {
 			// reset headers
 			headers = {};
-			// clear the cookies if no valid route is found
-			if (!includeCookies) {
-				new_cookies.clear();
-			}
 		}
 	}
 

--- a/packages/kit/test/apps/basics/src/hooks.server.js
+++ b/packages/kit/test/apps/basics/src/hooks.server.js
@@ -47,6 +47,32 @@ export const handle = sequence(
 		event.locals.name = /** @type {string} */ (event.cookies.get('name'));
 		return resolve(event);
 	},
+	({ event, resolve }) => {
+		if (event.url.pathname === '/headers/set-in-handle') {
+			event.setHeaders({ 'x-handle': 'SvelteKit' });
+			return new Response('test', { status: 200 });
+		}
+		if (event.url.pathname === '/headers/set-in-handle-resolve') {
+			event.setHeaders({ 'x-handle1': 'before' });
+			const response = resolve(event);
+			event.setHeaders({ 'x-handle2': 'after' });
+			return response;
+		}
+		return resolve(event);
+	},
+	({ event, resolve }) => {
+		if (event.url.pathname === '/cookies/set-in-handle') {
+			event.cookies.set('cookie1', 'value1');
+			return new Response('test', { status: 200 });
+		}
+		if (event.url.pathname === '/cookies/set-in-handle-resolve') {
+			event.cookies.set('cookie1', 'before');
+			const response = resolve(event);
+			event.cookies.set('cookie2', 'after');
+			return response;
+		}
+		return resolve(event);
+	},
 	async ({ event, resolve }) => {
 		if (event.url.pathname === '/errors/error-in-handle') {
 			throw new Error('Error in handle');

--- a/packages/kit/test/apps/basics/src/routes/cookies/set-in-handle-resolve/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/cookies/set-in-handle-resolve/+server.js
@@ -1,0 +1,8 @@
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export function GET({ cookies }) {
+	cookies.set('endpoint', 'SvelteKit');
+
+	return new Response('endpoint', {
+		status: 200
+	});
+}

--- a/packages/kit/test/apps/basics/src/routes/headers/set-in-handle-resolve/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/headers/set-in-handle-resolve/+server.js
@@ -1,0 +1,10 @@
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export function GET({ setHeaders }) {
+	setHeaders({
+		'x-endpoint': 'SvelteKit'
+	});
+
+	return new Response('endpoint', {
+		status: 200
+	});
+}

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -334,6 +334,40 @@ test.describe('setHeaders', () => {
 		const cookies = (await response?.allHeaders())['set-cookie'];
 		expect(cookies.includes('cookie1=value1') && cookies.includes('cookie2=value2')).toBe(true);
 	});
+
+	test('setHeaders in handle hook without resolve', async ({ page }) => {
+		const response = await page.goto('/headers/set-in-handle');
+
+		const headers = await response.allHeaders();
+		expect(headers['x-handle']).toBe('SvelteKit');
+	});
+
+	test('setHeaders in handle hook after resolve', async ({ page }) => {
+		const response = await page.goto('/headers/set-in-handle-resolve');
+
+		const headers = await response.allHeaders();
+		expect(headers['x-handle1']).toBe('before');
+		expect(headers['x-handle2']).toBe('after');
+		expect(headers['x-endpoint']).toBe('SvelteKit');
+	});
+});
+
+test.describe('Cookies API in handle', () => {
+	test('allows set-cookie headers from handle without resolve', async ({ page }) => {
+		const response = await page.goto('/cookies/set-in-handle');
+		const cookies = (await response?.allHeaders())['set-cookie'];
+		expect(cookies.includes('cookie1=value1')).toBe(true);
+	});
+
+	test('allows set-cookie headers from handle after resolve', async ({ page }) => {
+		const response = await page.goto('/cookies/set-in-handle-resolve');
+		const cookies = await response.headerValue('set-cookie');
+		expect(
+			cookies.includes('cookie1=before') &&
+				cookies.includes('cookie2=after') &&
+				cookies.includes('endpoint=SvelteKit')
+		).toBe(true);
+	});
 });
 
 test.describe('Miscellaneous', () => {


### PR DESCRIPTION
Closes #6735

Enables usage of `cookies` and `setHeaders` after or without calling `resolve(event)`.
Without the ability to use these helpers in handle the developer has to manually serialize cookies which seems unnecessary.
If this is not going to be merged the docs should make it clear how the helpers can be used in the hook. Or both helpers should be excluded from the event passed to handle.

**What it does:**

Headers in `Load` or `RequestHandler` are applied upon `resolve` so they are available in handle using `response.headers`, cookies are not (so they can be overwritten).
Headers and cookies set in handle are always applied.

Not 100% sure if that´s the correct/wanted behaviour.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
