### PR TITLE
fix: (issue-6608) Add origin header to server-side fetch

### DIFF
--- a/.changeset/hot-steaks-hang.md
+++ b/.changeset/hot-steaks-hang.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add origin header for non-GET and external requests made with server-side fetch

--- a/packages/kit/src/runtime/server/page/fetch.js
+++ b/packages/kit/src/runtime/server/page/fetch.js
@@ -68,6 +68,13 @@ export function create_fetch({ event, options, state, route, prerender_default, 
 
 				const url = new URL(request.url);
 
+				if (
+					!request.headers.get('origin') &&
+					(url.origin !== event.url.origin || request.method !== 'GET')
+				) {
+					request.headers.set('origin', event.url.origin);
+				}
+
 				if (url.origin !== event.url.origin) {
 					// allow cookie passthrough for "same-origin"
 					// if SvelteKit is serving my.domain.com:
@@ -83,11 +90,6 @@ export function create_fetch({ event, options, state, route, prerender_default, 
 					) {
 						const cookie = get_cookie_header(url, request.headers.get('cookie'));
 						if (cookie) request.headers.set('cookie', cookie);
-					}
-
-					// Add request origin header in case it is missing
-					if (!request.headers.get('origin')) {
-						request.headers.set('origin', event.url.origin);
 					}
 
 					let response = await fetch(request);

--- a/packages/kit/src/runtime/server/page/fetch.js
+++ b/packages/kit/src/runtime/server/page/fetch.js
@@ -85,6 +85,11 @@ export function create_fetch({ event, options, state, route, prerender_default, 
 						if (cookie) request.headers.set('cookie', cookie);
 					}
 
+					// Add request origin header in case it is missing
+					if (!request.headers.get('origin')) {
+						request.headers.set('origin', event.url.origin);
+					}
+
 					let response = await fetch(request);
 
 					if (request.mode === 'no-cors') {

--- a/packages/kit/src/runtime/server/page/fetch.js
+++ b/packages/kit/src/runtime/server/page/fetch.js
@@ -68,11 +68,17 @@ export function create_fetch({ event, options, state, route, prerender_default, 
 
 				const url = new URL(request.url);
 
-				if (
-					!request.headers.get('origin') &&
-					(url.origin !== event.url.origin || request.method !== 'GET')
-				) {
+				if (!request.headers.has('origin')) {
 					request.headers.set('origin', event.url.origin);
+				}
+
+				// Remove Origin, according to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin#description
+				if (
+					(request.method === 'GET' || request.method === 'HEAD') &&
+					((request.mode === 'no-cors' && url.origin !== event.url.origin) ||
+						url.origin === event.url.origin)
+				) {
+					request.headers.delete('origin');
 				}
 
 				if (url.origin !== event.url.origin) {

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-origin-external/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-origin-external/+page.js
@@ -1,0 +1,8 @@
+/** @type {import('./$types').PageLoad} */
+export async function load({ fetch, url }) {
+	const port = url.searchParams.get('port');
+	const res = await fetch(`http://localhost:${port}`);
+
+	const { origin } = await res.json();
+	return { origin };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-origin-external/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-origin-external/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	/** @type {import('./$types').PageData} */
+	export let data;
+</script>
+
+<h1>origin: {data.origin}</h1>

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-origin-internal/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-origin-internal/+page.js
@@ -1,0 +1,10 @@
+/** @type {import('./$types').PageLoad} */
+export async function load({ fetch }) {
+	const res = await fetch('/load/fetch-origin-internal/resource', {
+		method: 'POST'
+	});
+
+	const { origin } = await res.json();
+
+	return { origin };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-origin-internal/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-origin-internal/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	/** @type {import('./$types').PageData} */
+	export let data;
+</script>
+
+<h1>origin: {data.origin}</h1>

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-origin-internal/resource/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-origin-internal/resource/+server.js
@@ -1,0 +1,7 @@
+import { json } from '@sveltejs/kit';
+
+/** @type {import('./$types').RequestHandler} */
+export function POST({ request }) {
+	const origin = request.headers.get('origin');
+	return json({ origin });
+}

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { test } from '../../../utils.js';
+import { start_server, test } from '../../../utils.js';
 import { fetch } from 'undici';
 import { createHash, randomBytes } from 'node:crypto';
 
@@ -248,6 +248,32 @@ test.describe('Load', () => {
 	test('fetch does not load a file with a # character', async ({ request }) => {
 		const response = await request.get('/load/static-file-with-hash');
 		expect(await response.text()).toContain('status: 404');
+	});
+
+	test('includes origin header on non-GET internal request', async ({ page, baseURL }) => {
+		await page.goto('/load/fetch-origin-internal');
+		expect(await page.textContent('h1')).toBe(`origin: ${new URL(baseURL).origin}`);
+	});
+
+	test('includes origin header on external request', async ({ page, baseURL }) => {
+		const { port, close } = await start_server((req, res) => {
+			if (req.url === '/') {
+				res.writeHead(200, {
+					'content-type': 'application/json',
+					'access-control-allow-origin': '*'
+				});
+
+				res.end(JSON.stringify({ origin: req.headers.origin }));
+			} else {
+				res.writeHead(404);
+				res.end('not found');
+			}
+		});
+
+		await page.goto(`/load/fetch-origin-external?port=${port}`);
+		expect(await page.textContent('h1')).toBe(`origin: ${new URL(baseURL).origin}`);
+
+		close();
 	});
 });
 


### PR DESCRIPTION
Add the `Origin` header to server-side fetch. 
The problem has been introduced with #6550, where browser CORS behaviour was simulated for the server-side requests. For CORS requests to work properly, the `Origin` header is mandatory.

Fixes: #6608 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
