### PR TITLE
make URL property getters non-enumerable

### DIFF
--- a/.changeset/young-students-relate.md
+++ b/.changeset/young-students-relate.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Make url property getters non-enumerable

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1546,7 +1546,8 @@ function add_url_properties(type, target) {
 				throw new Error(
 					`The navigation shape changed - ${type}.${prop} should now be ${type}.url.${prop}`
 				);
-			}
+			},
+			enumerable: false
 		});
 	}
 


### PR DESCRIPTION
#6770. Small QOL improvement — if you log the navigation object, it shouldn't invoke the getters that throw an error telling you not to use `from` and `to` as URLs

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
