### PR TITLE
add cookies.serialize function and always set headers/cookies

### DIFF
--- a/.changeset/flat-owls-care.md
+++ b/.changeset/flat-owls-care.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add cookies.serialize method

--- a/.changeset/short-spies-relax.md
+++ b/.changeset/short-spies-relax.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Always apply cookies, not just for matched routes

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -71,6 +71,18 @@ export function get_cookies(request, url) {
 					maxAge: 0
 				}
 			});
+		},
+
+		/**
+		 * @param {string} name
+		 * @param {string} value
+		 * @param {import('cookie').CookieSerializeOptions} opts
+		 */
+		serialize(name, value, opts) {
+			return serialize(name, value, {
+				...DEFAULT_SERIALIZE_OPTIONS,
+				...opts
+			});
 		}
 	};
 

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -280,27 +280,22 @@ export async function respond(request, options, state) {
 		}
 	}
 
-	/**
-	 * wrapper to apply headers and cookies to the response
-	 * @param {Response} response
-	 */
-	function with_headers_and_cookies(response) {
-		if (!is_data_request) {
-			// we only want to set cookies on __data.js requests, we don't
-			// want to cache stuff erroneously etc
-			for (const key in headers) {
-				const value = headers[key];
-				response.headers.set(key, /** @type {string} */ (value));
-			}
-		}
-		add_cookies_to_headers(response.headers, Array.from(new_cookies.values()));
-		return response;
-	}
-
 	try {
 		const response = await options.hooks.handle({
 			event,
-			resolve: (event, opts) => resolve(event, opts).then(with_headers_and_cookies),
+			resolve: (event, opts) =>
+				resolve(event, opts).then((response) => {
+					if (!is_data_request) {
+						// we only want to set cookies on __data.js requests, we don't
+						// want to cache stuff erroneously etc
+						for (const key in headers) {
+							const value = headers[key];
+							response.headers.set(key, /** @type {string} */ (value));
+						}
+					}
+					add_cookies_to_headers(response.headers, Array.from(new_cookies.values()));
+					return response;
+				}),
 			// TODO remove for 1.0
 			// @ts-expect-error
 			get request() {

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -285,6 +285,8 @@ export async function respond(request, options, state) {
 			event,
 			resolve: (event, opts) =>
 				resolve(event, opts).then((response) => {
+					// add headers/cookies here, rather than inside `resolve`, so that we
+					// can do it once for all responses instead of once per `return`
 					if (!is_data_request) {
 						// we only want to set cookies on __data.js requests, we don't
 						// want to cache stuff erroneously etc

--- a/packages/kit/test/apps/basics/src/hooks.server.js
+++ b/packages/kit/test/apps/basics/src/hooks.server.js
@@ -48,6 +48,15 @@ export const handle = sequence(
 		return resolve(event);
 	},
 	async ({ event, resolve }) => {
+		if (event.url.pathname === '/cookies/serialize') {
+			event.cookies.set('before', 'before');
+			const response = await resolve(event);
+			response.headers.append('set-cookie', event.cookies.serialize('after', 'after'));
+			return response;
+		}
+		return resolve(event);
+	},
+	async ({ event, resolve }) => {
 		if (event.url.pathname === '/errors/error-in-handle') {
 			throw new Error('Error in handle');
 		}

--- a/packages/kit/test/apps/basics/src/routes/cookies/serialize/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/cookies/serialize/+server.js
@@ -1,0 +1,8 @@
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export const GET = ({ cookies }) => {
+	const response = new Response('success', {
+		status: 200
+	});
+	response.headers.append('set-cookie', cookies.serialize('endpoint', 'endpoint'));
+	return response;
+};

--- a/packages/kit/test/apps/basics/src/routes/routing/symlink-from
+++ b/packages/kit/test/apps/basics/src/routes/routing/symlink-from
@@ -1,1 +1,0 @@
-symlink-to

--- a/packages/kit/test/apps/basics/src/routes/routing/symlink-from
+++ b/packages/kit/test/apps/basics/src/routes/routing/symlink-from
@@ -1,0 +1,1 @@
+symlink-to

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -336,6 +336,18 @@ test.describe('setHeaders', () => {
 	});
 });
 
+test.describe('cookies', () => {
+	test('cookie.serialize created correct cookie header string', async ({ page }) => {
+		const response = await page.goto('/cookies/serialize');
+		const cookies = await response.headerValue('set-cookie');
+		expect(
+			cookies.includes('before=before') &&
+				cookies.includes('after=after') &&
+				cookies.includes('endpoint=endpoint')
+		).toBe(true);
+	});
+});
+
 test.describe('Miscellaneous', () => {
 	test('does not serve version.json with an immutable cache header', async ({ request }) => {
 		// this isn't actually a great test, because caching behaviour is down to adapters.

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -155,6 +155,19 @@ export interface Cookies {
 	 * Deletes a cookie by setting its value to an empty string and setting the expiry date in the past.
 	 */
 	delete(name: string, opts?: import('cookie').CookieSerializeOptions): void;
+
+	/**
+	 * Serialize a cookie name-value pair into a Set-Cookie header string.
+	 *
+	 * The `httpOnly` and `secure` options are `true` by default, and must be explicitly disabled if you want cookies to be readable by client-side JavaScript and/or transmitted over HTTP. The `sameSite` option defaults to `lax`.
+	 *
+	 * By default, the `path` of a cookie is the current pathname. In most cases you should explicitly set `path: '/'` to make the cookie available throughout your app.
+	 *
+	 * @param name the name for the cookie
+	 * @param value value to set the cookie to
+	 * @param options object containing serialization options
+	 */
+	serialize(name: string, value: string, opts?: import('cookie').CookieSerializeOptions): string;
 }
 
 export interface KitConfig {


### PR DESCRIPTION
Successor to https://github.com/sveltejs/kit/pull/6888

Closes https://github.com/sveltejs/kit/issues/6735

- fixes a bug where cookies and headers were only set when the request matched a route
- implements `cookies.serialize`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
