### PR TITLE
export `ValidationError` interface

### DIFF
--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -52,7 +52,7 @@ type OptionalUnion<
 > = U extends unknown ? { [P in Exclude<A, keyof U>]?: never } & U : never;
 
 // Needs to be here, else ActionData will be resolved to unknown - probably because of "d.ts file imports .js file" in combination with allowJs
-interface ValidationError<T extends Record<string, unknown> | undefined = undefined> {
+export interface ValidationError<T extends Record<string, unknown> | undefined = undefined> {
 	status: number;
 	data: T;
 }


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0



When running `svelte-check` in my repository, I get the following error:
```
/home/projects/project-1/packages/dashboard/.svelte-kit/types/src/routes/login/proxy+page.server.ts:27:14
Error: Exported variable 'actions' has or is using name 'ValidationError' from external module "/home/projects/project-1/packages/dashboard/node_modules/@sveltejs/kit/types/index" but cannot be named. 

export const actions = {
        async default({ request, cookies }) {
```

The action uses the `invalid` function from `@sveltejs/kit`, which uses the `ValidationError` interface. When exporting that interface the error disappears.