### PR TITLE
Ensure all excluded files in `_routes.json` start with /

### DIFF
--- a/.changeset/orange-rocks-return.md
+++ b/.changeset/orange-rocks-return.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-cloudflare': patch
 ---
 
-Ensure all routes start with /
+Ensure all excluded paths in `_routes.json` start with /

--- a/.changeset/orange-rocks-return.md
+++ b/.changeset/orange-rocks-return.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+Ensure all routes start with /

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -87,7 +87,8 @@ function get_routes_json(app_dir, assets) {
 				// We do want to show an example of a _routes.json that
 				// excludes more than just /_app/immutable/*, and favicons
 				// are a reasonable choice
-				.filter((filePath) => filePath.includes('favicon'))
+				.filter((file) => file.startsWith('favicon'))
+				.map((file) => `/${file}`)
 		]
 	};
 }


### PR DESCRIPTION
Looks like #6530 broke Cloudflare Pages deployments. I think this should fix it, if I understand correctly. cc @jrf0110 and @jahands for visibility

```
18:01:33.742 | Found _routes.json in output directory. Uploading.
18:01:33.761 | Validating asset output directory
18:01:34.611 | Deploying your site to Cloudflare's global network...
18:01:39.781 | Parsed 1 valid header rule.
18:01:44.711 | Success: Assets published!
18:01:45.627 | Error: Failed to publish your Function. Got error: Error 8000057: Rules must start with '/' in _routes.json
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
