### PR TITLE
allow prerendered pages to link to non-prerenderable endpoints

### DIFF
--- a/.changeset/flat-dancers-sell.md
+++ b/.changeset/flat-dancers-sell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Allow prerendered pages to link to non-prerenderable endpoints

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -32,7 +32,14 @@ export async function render_endpoint(event, mod, state) {
 	}
 
 	if (state.prerendering && !prerender) {
-		throw new Error(`${event.routeId} is not prerenderable`);
+		if (state.initiator) {
+			// if request came from a prerendered page, bail
+			throw new Error(`${event.routeId} is not prerenderable`);
+		} else {
+			// if request came direct from the crawler, signal that
+			// this route cannot be prerendered, but don't bail
+			return new Response(undefined, { status: 204 });
+		}
 	}
 
 	try {

--- a/packages/kit/test/prerendering/options/src/routes/+layout.svelte
+++ b/packages/kit/test/prerendering/options/src/routes/+layout.svelte
@@ -1,1 +1,5 @@
+<svelte:head>
+	<link rel="alternate" href="/path-base/rss.xml" />
+</svelte:head>
+
 <slot />

--- a/packages/kit/test/prerendering/options/src/routes/rss.xml/+server.js
+++ b/packages/kit/test/prerendering/options/src/routes/rss.xml/+server.js
@@ -1,0 +1,3 @@
+export function GET() {
+	return new Response('dynamic');
+}

--- a/packages/kit/test/prerendering/options/test/test.js
+++ b/packages/kit/test/prerendering/options/test/test.js
@@ -37,4 +37,8 @@ test('populates fallback 200.html file', () => {
 	assert.ok(content !== '');
 });
 
+test('does not prerender linked +server.js route', () => {
+	assert.ok(!fs.existsSync(`${build}/rss.xml`));
+});
+
 test.run();


### PR DESCRIPTION
Fixes #5079. Most of the pieces were in place, but currently SvelteKit errors if you have a `<link>` in a prerendered page that points to a non-prerenderable `+server.js` file. 

With this PR, if the crawler hits those routes, it won't error but nor will it prerender the route.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
