### PR TITLE
create-svelte: Skip prompts by passing args to CLI

### DIFF
--- a/.changeset/tidy-icons-hug.md
+++ b/.changeset/tidy-icons-hug.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Make it possible to skip some or all prompts by passing arguments directly to the CLI

--- a/packages/create-svelte/README.md
+++ b/packages/create-svelte/README.md
@@ -13,7 +13,7 @@ npm create svelte@latest
 Some or all of the prompts can be skipped by supplying arguments directly to the CLI:
 
 ```bash
-npm create svelte@latest my-directory \
+npm create svelte@latest my-app \
   --name=my-new-app \
   --template=default|skeleton|skeletonlib \
   --types=checkjs|typescript|none \

--- a/packages/create-svelte/README.md
+++ b/packages/create-svelte/README.md
@@ -8,6 +8,20 @@ npm create svelte@latest
 
 ...and follow the prompts.
 
+## Arguments
+
+Some or all of the prompts can be skipped by supplying arguments directly to the CLI:
+
+```bash
+npm create svelte@latest my-directory \
+  --name=my-new-app \
+  --template=default|skeleton|skeletonlib \
+  --types=checkjs|typescript|none \
+  --prettier|--no-prettier  \
+  --eslint|--no-eslint \
+  --playwright|--no-playwright
+```
+
 ## API
 
 You can also use `create-svelte` programmatically:

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -22,12 +22,14 @@ const { version } = JSON.parse(fs.readFileSync(new URL('package.json', import.me
 async function main() {
 	console.log(gray(`\ncreate-svelte version ${version}`));
 	console.log(disclaimer);
-	const args = await yargs(hideBin(process.argv)).argv;
+
+	const args = await yargs(hideBin(process.argv)).coerce('types', (arg) =>
+		arg === 'none' ? null : arg
+	).argv;
 	prompts.override({
 		...args,
 		dir: args._[0]?.toString()
 	});
-	console.log(args);
 
 	const { dir } = await prompts([
 		{

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -5,6 +5,8 @@ import { bold, cyan, gray, green, red } from 'kleur/colors';
 import prompts from 'prompts';
 import { create } from './index.js';
 import { dist } from './utils.js';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 
 // prettier-ignore
 const disclaimer = `
@@ -20,33 +22,32 @@ const { version } = JSON.parse(fs.readFileSync(new URL('package.json', import.me
 async function main() {
 	console.log(gray(`\ncreate-svelte version ${version}`));
 	console.log(disclaimer);
+	const args = await yargs(hideBin(process.argv)).argv;
+	prompts.override({
+		...args,
+		dir: args._[0]?.toString()
+	});
+	console.log(args);
 
-	let cwd = process.argv[2] || '.';
-
-	if (cwd === '.') {
-		const opts = await prompts([
-			{
-				type: 'text',
-				name: 'dir',
-				message: 'Where should we create your project?\n  (leave blank to use current directory)'
-			}
-		]);
-
-		if (opts.dir) {
-			cwd = opts.dir;
+	const { dir } = await prompts([
+		{
+			type: 'text',
+			name: 'dir',
+			message: 'Where should we create your project?\n  (leave blank to use current directory)'
 		}
-	}
+	]);
+	const cwd = dir || '.';
 
 	if (fs.existsSync(cwd)) {
 		if (fs.readdirSync(cwd).length > 0) {
 			const response = await prompts({
 				type: 'confirm',
-				name: 'value',
+				name: 'overwrite',
 				message: 'Directory not empty. Continue?',
 				initial: false
 			});
 
-			if (!response.value) {
+			if (!response.overwrite) {
 				process.exit(1);
 			}
 		}

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -20,6 +20,7 @@
 		"@types/gitignore-parser": "^0.0.0",
 		"@types/prettier": "^2.6.3",
 		"@types/prompts": "^2.0.14",
+		"@types/yargs": "^17.0.12",
 		"gitignore-parser": "^0.0.2",
 		"prettier": "^2.6.2",
 		"prettier-plugin-svelte": "^2.7.0",
@@ -27,7 +28,8 @@
 		"svelte": "^3.48.0",
 		"svelte-preprocess": "^4.10.6",
 		"tiny-glob": "^0.2.9",
-		"uvu": "^0.5.3"
+		"uvu": "^0.5.3",
+		"yargs": "^17.5.1"
 	},
 	"scripts": {
 		"build": "node scripts/build-templates",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,7 @@ importers:
       '@types/gitignore-parser': ^0.0.0
       '@types/prettier': ^2.6.3
       '@types/prompts': ^2.0.14
+      '@types/yargs': ^17.0.12
       gitignore-parser: ^0.0.2
       kleur: ^4.1.4
       prettier: ^2.6.2
@@ -220,6 +221,7 @@ importers:
       svelte-preprocess: ^4.10.6
       tiny-glob: ^0.2.9
       uvu: ^0.5.3
+      yargs: ^17.5.1
     dependencies:
       kleur: 4.1.5
       prompts: 2.4.2
@@ -229,6 +231,7 @@ importers:
       '@types/gitignore-parser': 0.0.0
       '@types/prettier': 2.6.3
       '@types/prompts': 2.0.14
+      '@types/yargs': 17.0.12
       gitignore-parser: 0.0.2
       prettier: 2.7.1
       prettier-plugin-svelte: 2.7.0_nakrehnrzdf7fdea5k3a4dfy4m
@@ -237,6 +240,7 @@ importers:
       svelte-preprocess: 4.10.7_svelte@3.48.0
       tiny-glob: 0.2.9
       uvu: 0.5.4
+      yargs: 17.5.1
 
   packages/create-svelte/templates/default:
     specifiers:
@@ -1275,6 +1279,16 @@ packages:
     resolution: {integrity: sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==}
     dependencies:
       '@types/node': 16.11.42
+    dev: true
+
+  /@types/yargs-parser/21.0.0:
+    resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
+    dev: true
+
+  /@types/yargs/17.0.12:
+    resolution: {integrity: sha512-Nz4MPhecOFArtm81gFQvQqdV7XYCrWKx5uUt6GNHredFHn1i2mtWqXTON7EPXMtNi1qjtjEM/VCHDhcHsAMLXQ==}
+    dependencies:
+      '@types/yargs-parser': 21.0.0
     dev: true
 
   /@typescript/twoslash/3.1.0:


### PR DESCRIPTION
This PR makes it possible to skip some or all prompts when creating a new SvelteKit project with the `create-svelte` package. eg.:

```bash
npm create svelte@latest my-app \
  --name=my-new-app \
  --template=default \
  --types=checkjs \
  --prettier  \
  --no-eslint \
  --no-playwright
```

## The problem

In Storybook we have a system for creating new projects with the different frameworks programmatically, to continuously ensure Storybook works out of the box with all the frameworks. But that's a bit hard for us to do with SvelteKit, because `create-svelte` is an interactive experience and thus not easy to automate.

Instead of hacking around it internally in Storybook I thought it would be better to solve it for everyone. This is also useful in tutorial/guide situations where an author wants to simplify the learning path by removing prompts that a beginner might not understand.

## The solution

As per [the example in the `prompts` docs](https://github.com/terkelg/prompts#override), [`yargs`](https://github.com/yargs/yargs) is used to implicitly override any of the prompts if they are passed as named arguments. The implicitness is important here, because it means that if we add or change the prompts later they will automatically be overwritable by args.

I have _not_ documented this feature in the official docs because there didn't seem to be a good place to do it. I'm open to add it somewhere though if you think it makes sense.
It is however documented in the package's readme similarly to how the programmatic API is documented.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
