### PR TITLE
allow `ActionData` to be undefined

### DIFF
--- a/.changeset/cold-wasps-flow.md
+++ b/.changeset/cold-wasps-flow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Allow ActionData to be undefined

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -308,7 +308,7 @@ function process_node(node, outdir, is_page, all_pages_have_load = true) {
 						? `./proxy${replace_ext_with_js(basename)}`
 						: path_to_original(outdir, node.server);
 
-					type = `Expand<Kit.AwaitedActions<typeof import('${from}').actions>>`;
+					type = `Expand<Kit.AwaitedActions<typeof import('${from}').actions>> | undefined`;
 				}
 			}
 			exports.push(`export type ActionData = ${type};`);

--- a/packages/kit/src/core/sync/write_types/test/simple-page-server-only/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/simple-page-server-only/_expected/$types.d.ts
@@ -21,9 +21,9 @@ export type PageServerLoad<
 	OutputData extends OutputDataShape<PageServerParentData> = OutputDataShape<PageServerParentData>
 > = Kit.ServerLoad<RouteParams, PageServerParentData, OutputData>;
 export type PageServerLoadEvent = Parameters<PageServerLoad>[0];
-export type ActionData = Expand<
-	Kit.AwaitedActions<typeof import('../../../../../../../../+page.server.js').actions>
->;
+export type ActionData =
+	| Expand<Kit.AwaitedActions<typeof import('../../../../../../../../+page.server.js').actions>>
+	| undefined;
 export type PageServerData = Expand<
 	Kit.AwaitedProperties<
 		Awaited<ReturnType<typeof import('../../../../../../../../+page.server.js').load>>


### PR DESCRIPTION
In a case like this...

```svelte
<script>
  /** @type {import('./$types').ActionData} */
  export let form;
</script>
```

...`form` is `undefined` until a form is submitted, but that isn't reflected in the types.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
