### PR TITLE
feat: add dark mode to docs (#6677)

### DIFF
--- a/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
+++ b/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
@@ -232,7 +232,6 @@
 			left: 0;
 			bottom: 0;
 			width: var(--sidebar-w);
-			height: 2em;
 			pointer-events: none;
 			height: var(--top-offset);
 			background: linear-gradient(
@@ -240,6 +239,15 @@
 				rgba(103, 103, 120, 0) 0%,
 				rgba(103, 103, 120, 0.7) 50%,
 				rgba(103, 103, 120, 1) 100%
+			);
+		}
+
+		:global(html.theme-dark) nav::after {
+			background: linear-gradient(
+				to bottom,
+				rgba(60, 60, 60, 0) 0%,
+				rgba(60, 60, 60, 0.7) 50%,
+				rgba(60, 60, 60, 1) 100%
 			);
 		}
 	}

--- a/sites/kit.svelte.dev/src/lib/docs/client/Tooltip.svelte
+++ b/sites/kit.svelte.dev/src/lib/docs/client/Tooltip.svelte
@@ -31,7 +31,7 @@
 
 <style>
 	.tooltip-container {
-		--bg: var(--second);
+		--bg: var(--back-api);
 		--arrow-size: 0.4rem;
 		position: absolute;
 		transform: translate(var(--offset), calc(2rem + var(--arrow-size)));
@@ -40,7 +40,7 @@
 	.tooltip {
 		margin: 0 2rem 0 0;
 		background-color: var(--bg);
-		color: #fff;
+		color: var(--text);
 		text-align: left;
 		padding: 0.4rem 0.6rem;
 		border-radius: var(--border-r);

--- a/sites/kit.svelte.dev/src/lib/docs/client/docs.css
+++ b/sites/kit.svelte.dev/src/lib/docs/client/docs.css
@@ -180,6 +180,10 @@
 	padding: 1rem;
 }
 
+html.theme-dark .content blockquote {
+	color: var(--text);
+}
+
 .content blockquote :first-child {
 	margin-top: 0;
 }
@@ -190,6 +194,10 @@
 
 .content blockquote code {
 	background: #d5e2ea;
+}
+
+html.theme-dark .content blockquote code {
+	background: var(--back-api);
 }
 
 .content blockquote pre code {

--- a/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
+++ b/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
@@ -300,7 +300,7 @@
 	}
 
 	.results-container {
-		background: white;
+		background: var(--back);
 		border-radius: 0 0 var(--border-r) var(--border-r);
 		pointer-events: all;
 	}

--- a/sites/kit.svelte.dev/src/lib/styles/theme-dark.css
+++ b/sites/kit.svelte.dev/src/lib/styles/theme-dark.css
@@ -2,9 +2,9 @@
 .theme-dark {
 	--back: #1D1D1E;
 	--back-light: #2D2D2D;
-	--back-api: #e5eef5;
+	--back-api: #676778;
 	--prime: #ff3e00;
-	--second: #AAA;
+	--second: #e5eef5;
 	--flash: #0086df;
 	--highlight: #ffff82;
 	--heading: #AAA;

--- a/sites/kit.svelte.dev/src/lib/styles/theme-dark.css
+++ b/sites/kit.svelte.dev/src/lib/styles/theme-dark.css
@@ -1,0 +1,18 @@
+/*	dark theme vars */
+.theme-dark {
+	--back: #1D1D1E;
+	--back-light: #2D2D2D;
+	--back-api: #e5eef5;
+	--prime: #ff3e00;
+	--second: #AAA;
+	--flash: #0086df;
+	--highlight: #ffff82;
+	--heading: #AAA;
+	--text: #EEE;
+	--second-text: #CCC;
+	--sidebar-text: rgba(255, 255, 255, 0.90);
+}
+
+code {
+	color: var(--second) !important;
+}

--- a/sites/kit.svelte.dev/src/routes/+layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/+layout.svelte
@@ -250,7 +250,7 @@
 		color: #ffcc00;
 	}
 
-	:global(nav) {
+	:global(html.theme-dark nav) {
 		background-color: var(--back) !important;
 	}
 

--- a/sites/kit.svelte.dev/src/routes/+layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/+layout.svelte
@@ -33,7 +33,7 @@
 		currentTheme = theme;
 	}
 
-	function toggleTheme () {
+	function toggleTheme() {
 		let theme = currentTheme === 'theme-default' ? 'theme-dark' : 'theme-default';
 		setTheme(theme);
 	}

--- a/sites/kit.svelte.dev/src/routes/+layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/+layout.svelte
@@ -26,7 +26,7 @@
 		return 'theme-default';
 	}
 
-	function setTheme (theme) {
+	function setTheme(theme) {
 		document.documentElement.classList.remove('theme-default', 'theme-dark');
 		document.documentElement.classList.add(theme);
 		localStorage.setItem('theme', theme);

--- a/sites/kit.svelte.dev/src/routes/+layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/+layout.svelte
@@ -1,4 +1,5 @@
 <script>
+	import '$lib/styles/theme-dark.css';
 	import '@sveltejs/site-kit/base.css';
 	import { browser } from '$app/environment';
 	import { page, navigating } from '$app/stores';
@@ -6,6 +7,41 @@
 	import Search from '$lib/search/Search.svelte';
 	import SearchBox from '$lib/search/SearchBox.svelte';
 	import StopWar from './stopwar.svg';
+	import { onMount } from 'svelte';
+
+	let currentTheme = 'theme-default';
+
+	function getCurrentTheme() {
+		if (browser) {
+			const theme = localStorage.getItem('theme');
+			if (!theme) {
+				const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+				if (prefersDarkMode) {
+					localStorage.setItem('theme', 'theme-dark');
+					return 'theme-dark';
+				}
+			}
+			return theme;
+		}
+		return 'theme-default';
+	}
+
+	function setTheme (theme) {
+		document.documentElement.classList.remove('theme-default', 'theme-dark');
+		document.documentElement.classList.add(theme);
+		localStorage.setItem('theme', theme);
+		currentTheme = theme;
+	}
+
+	function toggleTheme () {
+		let theme = currentTheme === 'theme-default' ? 'theme-dark' : 'theme-default';
+		setTheme(theme);
+	}
+
+	onMount(() => {
+		currentTheme = getCurrentTheme();
+		setTheme(currentTheme);
+	});
 </script>
 
 <Icons />
@@ -41,6 +77,46 @@
 		<NavItem external="https://github.com/sveltejs/kit" title="GitHub Repo">
 			<span class="small">GitHub</span>
 			<span class="large"><Icon name="github" /></span>
+		</NavItem>
+
+		<li aria-hidden="true"><span class="separator" /></li>
+
+		<NavItem title="Dark Mode toggle">
+			<span on:click={toggleTheme}>
+			{#if currentTheme === 'theme-default'}
+				<span class="small">Dark mode</span>
+				<span class="large">
+					<svg
+						width="20"
+						height="20"
+						viewBox="0 0 24 24"
+						class="icon"
+					>
+							<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+					</svg>
+				</span>
+			{:else}
+				<span class="small">Light mode</span>
+				<span class="large">
+					<svg
+						width="20"
+						height="20"
+						viewBox="0 0 24 24"
+						class="icon"
+					>
+						<circle cx="12" cy="12" r="5" />
+						<line x1="12" y1="1" x2="12" y2="3" />
+						<line x1="12" y1="21" x2="12" y2="23" />
+						<line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+						<line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+						<line x1="1" y1="12" x2="3" y2="12" />
+						<line x1="21" y1="12" x2="23" y2="12" />
+						<line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+						<line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+					</svg>
+				</span>
+			{/if}
+		</span>
 		</NavItem>
 	</svelte:fragment>
 </Nav>
@@ -169,7 +245,31 @@
 			z-index: 9999 !important;
 		}
 	}
+
 	.ukr strong {
 		color: #ffcc00;
+	}
+
+	:global(nav) {
+		background-color: var(--back) !important;
+	}
+
+	:global(body) {
+		transition: background-color 0.5s;
+	}
+
+	.icon {
+		position: relative;
+		overflow: hidden;
+		vertical-align: middle;
+		-o-object-fit: contain;
+		object-fit: contain;
+		-webkit-transform-origin: center center;
+		transform-origin: center center;
+		stroke: currentColor;
+		stroke-width: 2;
+		stroke-linecap: round;
+		stroke-linejoin: round;
+		fill: none;
 	}
 </style>

--- a/sites/kit.svelte.dev/src/routes/Hero.svelte
+++ b/sites/kit.svelte.dev/src/routes/Hero.svelte
@@ -16,7 +16,7 @@
 		<div class="hero-image">
 			<picture sizes="(min-width: 480px) 800px, (min-width: 1024px) 480px, 600px">
 				{#each Object.entries(background.sources) as [format, images]}
-					<source srcset={images.map((i) => `${i.src} ${i.w}w`).join(', ')} type={'image/' + format} /> 
+					<source srcset={images.map((i) => `${i.src} ${i.w}w`).join(', ')} type={'image/' + format} />
 				{/each}
 				<img src={background.fallback.src} {alt} />
 			</picture>
@@ -39,11 +39,14 @@ linear-gradient(0deg, #DBE7EF, #DBE7EF);
 		overflow: hidden;
 	}
 
+	:global(html.theme-dark) .hero-banner {
+		background: var(--back-light);
+	}
+
 	.hero-container {
 		width: 100%;
 		max-width: 90rem;
 		margin: 0 auto;
-		/* display: flex; */
 		justify-content: center;
 	}
 
@@ -52,6 +55,9 @@ linear-gradient(0deg, #DBE7EF, #DBE7EF);
 		flex-direction: column;
 		justify-content: center;
 		align-items: center;
+	}
+
+	:global(html.theme-default) .hero-text {
 		mix-blend-mode: multiply;
 	}
 


### PR DESCRIPTION
## Overview
This PR adds a dark mode toggle to the docs site. It uses the browser `prefers-color-scheme` and keeps the chosen state. 
I'm opening it as a PR, yet it's still a WIP, because I would like to get some opinions and preferences on the color scheme and if the current implementation is up to the expected standards of the project. 

fixes https://github.com/sveltejs/kit/issues/6677

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
