### PR TITLE
[docs] add page example to `depends`

### DIFF
--- a/documentation/docs/05-load.md
+++ b/documentation/docs/05-load.md
@@ -118,6 +118,7 @@ declare module '$lib/api' {
 }
 
 // @filename: index.js
+/// file: src/routes/+page.js
 // ---cut---
 import * as api from '$lib/api';
 
@@ -134,6 +135,24 @@ export async function load({ depends }) {
 		bar: api.client.get('/bar')
 	};
 }
+```
+
+```svelte
+/// file: src/routes/+page.svelte
+<script>
+	import { invalidate } from '$app/navigation'
+
+	/** @type {import('./$types').PageData} */
+  export let data
+
+	const pageRefresh = async () => {
+		await invalidate('my-stuff:foo')
+	}
+</script>
+
+<p>{data.foo}<p>
+<p>{data.bar}</p>
+<button on:click={pageRefresh}>Refresh my stuff</button>
 ```
 
 #### fetch
@@ -342,7 +361,7 @@ A `load` function will re-run in the following situations:
 - It references a property of `url` (such as `url.pathname` or `url.search`) whose value has changed
 - It calls `await parent()` and a parent `load` function re-ran
 - It declared a dependency on a specific URL via [`fetch`](#input-methods-fetch) or [`depends`](#input-methods-depends), and that URL was marked invalid with [`invalidate(url)`](/docs/modules#$app-navigation-invalidate)
-- All active `load` functions were forcibly re-run with [`invalidate()`](/docs/modules#$app-navigation-invalidate)
+- All active `load` functions were forcibly re-run with [`invalidateAll()`](/docs/modules#$app-navigation-invalidate)
 
 If a `load` function is triggered to re-run, the page will not remount — instead, it will update with the new `data`. This means that components' internal state is preserved. If this isn't want you want, you can reset whatever you need to reset inside an [`afterNavigate`](/docs/modules#$app-navigation-afternavigate) callback, and/or wrap your component in a [`{#key ...}`](https://svelte.dev/docs#template-syntax-key) block.
 


### PR DESCRIPTION
Closes #6788 

- Fix `invalidateAll` reference
- Add a page example for `depends` to illustrate custom URI in `invalidate`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
