### PR TITLE
[fix] remove builtin modules warning for adapter-node

### DIFF
--- a/.changeset/proud-dingos-sing.md
+++ b/.changeset/proud-dingos-sing.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Disable builtin modules warning

--- a/packages/adapter-netlify/rollup.config.js
+++ b/packages/adapter-netlify/rollup.config.js
@@ -18,7 +18,7 @@ const config = {
 			format: 'esm'
 		}
 	],
-	plugins: [nodeResolve(), commonjs(), json()],
+	plugins: [nodeResolve({ preferBuiltins: true }), commonjs(), json()],
 	external: (id) => id === '0SERVER' || id.startsWith('node:'),
 	preserveEntrySignatures: 'exports-only'
 };

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -61,7 +61,7 @@ export default function (opts = {}) {
 					manifest: `${tmp}/manifest.js`
 				},
 				external: [...Object.keys(pkg.dependencies || {})],
-				plugins: [nodeResolve(), commonjs(), json()]
+				plugins: [nodeResolve({ preferBuiltins: true }), commonjs(), json()]
 			});
 
 			await bundle.write({

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -10,7 +10,7 @@ export default [
 			file: 'files/index.js',
 			format: 'esm'
 		},
-		plugins: [nodeResolve(), commonjs(), json()],
+		plugins: [nodeResolve({ preferBuiltins: true }), commonjs(), json()],
 		external: ['ENV', 'HANDLER', ...builtinModules]
 	},
 	{


### PR DESCRIPTION
Fix #6931

Set `prefersBuiltin: true` explicitly for `@rollup/plugin-node-resolve` to suppress warning (it's true by default).

I also set it for the `rollup.config.js` used to build `adapter-node` and `adapter-netlify` itself for consistency.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
