### PR TITLE
[fix] more robust uppercase migration

### DIFF
--- a/.changeset/seven-roses-float.md
+++ b/.changeset/seven-roses-float.md
@@ -1,0 +1,5 @@
+---
+'svelte-migrate': patch
+---
+
+[fix] more robust uppercase migration

--- a/packages/migrate/migrations/routes/migrate_page_server/samples.md
+++ b/packages/migrate/migrations/routes/migrate_page_server/samples.md
@@ -157,21 +157,25 @@ export function load() {
 ## A get function that only returns body
 
 ```js before
+import something from 'somewhere';
+
 /** @type {import('./$types').RequestHandler} */
 export function get() {
 	return {
 		body: {
-			a: 1
+			a: something
 		}
 	};
 }
 ```
 
 ```js after
+import something from 'somewhere';
+
 /** @type {import('./$types').PageServerLoad} */
 export function load() {
 	return {
-		a: 1
+		a: something
 	};
 }
 ```


### PR DESCRIPTION
Previously, any other top level statement such as an import wrongfully failed the uppercase migration

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
