### PR TITLE
Fixes default template app

### DIFF
--- a/packages/create-svelte/templates/default/src/hooks.server.ts
+++ b/packages/create-svelte/templates/default/src/hooks.server.ts
@@ -8,7 +8,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 		// if this is the first time the user has visited this app,
 		// set a cookie so that we recognise them when they return
 		userid = crypto.randomUUID();
-		event.cookies.set('userid', userid, { path: '/' });
+		event.cookies.set('userid', userid, { path: '/', secure: false });
 	}
 
 	event.locals.userid = userid;


### PR DESCRIPTION
This PR changes the userid cookie on the default app to non-secure. Many people will start with the example app and will want to experiment. The majority of people will be running the app on http://localhost and therefore secure cookies cannot be set.

I tried the example app for the first time and was not working for me until I changed the userid cookie to non-secure.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
