### PR TITLE
[fix] better navigation protocol check

### DIFF
--- a/.changeset/dull-wombats-train.md
+++ b/.changeset/dull-wombats-train.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] better navigation protocol check

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1303,13 +1303,20 @@ export function create_client({ target, base, trailing_slash }) {
 
 				const is_svg_a_element = a instanceof SVGAElement;
 
-				// Ignore URL protocols that differ to the current one (e.g. `mailto:`, `tel:`, `myapp:`, etc.)
+				// Ignore URL protocols that differ to the current one and are not http(s) (e.g. `mailto:`, `tel:`, `myapp:`, etc.)
+				// This may be wrong when the protocol is x: and the link goes to y:.. which should be treated as an external
+				// navigation, but it's not clear how to handle that case and it's not likely to come up in practice.
 				// MEMO: Without this condition, firefox will open mailer twice.
 				// See:
 				// - https://github.com/sveltejs/kit/issues/4045
 				// - https://github.com/sveltejs/kit/issues/5725
 				// - https://github.com/sveltejs/kit/issues/6496
-				if (!is_svg_a_element && url.protocol !== location.protocol) return;
+				if (
+					!is_svg_a_element &&
+					url.protocol !== location.protocol &&
+					!(url.protocol === 'https:' || url.protocol === 'http:')
+				)
+					return;
 
 				// Ignore if tag has
 				// 1. 'download' attribute

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1303,12 +1303,13 @@ export function create_client({ target, base, trailing_slash }) {
 
 				const is_svg_a_element = a instanceof SVGAElement;
 
-				// Ignore non-HTTP URL protocols (e.g. `mailto:`, `tel:`, `myapp:`, etc.)
+				// Ignore URL protocols that differ to the current one (e.g. `mailto:`, `tel:`, `myapp:`, etc.)
 				// MEMO: Without this condition, firefox will open mailer twice.
 				// See:
 				// - https://github.com/sveltejs/kit/issues/4045
 				// - https://github.com/sveltejs/kit/issues/5725
-				if (!is_svg_a_element && !(url.protocol === 'https:' || url.protocol === 'http:')) return;
+				// - https://github.com/sveltejs/kit/issues/6496
+				if (!is_svg_a_element && url.protocol !== location.protocol) return;
 
 				// Ignore if tag has
 				// 1. 'download' attribute


### PR DESCRIPTION
Fixes #6496

Takes the approach mentioned here: https://github.com/sveltejs/kit/issues/6496#issuecomment-1233650328
Maybe @Rich-Harris can shed some light on what he ment with the two follow-up comments: Why checking the origin would be better, or why it isn't that easy after all (if you use the protocol check, it is easy, unless I missed something)

Edit: I'm answering this myself - when the protocol is different, we don't know if this will result in "nothing" (like `mailto:`) or an external navigation - which is why the logic isn't that easy (I guess that's what Rich meant). I think we should finalize and merge 
#6813 first and then come back to this to figure out the best way to handle this. My idea is to "take note" of the navigation if the protocol is different, and then in `beforeUnload` check if the "note" is still present, and then fire a `beforeNavigate` event with the correct data, else, nothing happens and the "note" is cleared. Having written this, maybe it's easier to incorporate this into #6813 - will take a look at that PR.

Edit 2: I think "is the protocol different, and if yes, is it something else than http(s)" will work for 99,9% of all use cases - I updated the code to that. The only thing where that should be buggy is when you are running the app on a different protocol, and the link points to yet another protocol which should be treated as an external navigation - in this case, we don't fire `beforeNavigate` when we should, but that's ok I guess. The alternative "take note" thing would look something like "in all cases where we return early from the nav click handler, populate set `before_external_navigate` variable to a function which triggers before navigate with the info about the URL, and unset it after a few miliseconds - if `beforeunload` fires within that time, we invoke that function. This is sensitive to race conditions/things making our `beforeunload` event fire too late.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
