### PR TITLE
use `clicknav` utility in test suites

### DIFF
--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -781,18 +781,14 @@ test.describe.serial('Invalidation', () => {
 		await expect(page.locator('p.redirect-state')).toHaveText('Redirect state: done');
 	});
 
-	test('+layout(.server).js is re-run when server dep is invalidated', async ({
-		page,
-		clicknav
-	}) => {
+	test('+layout(.server).js is re-run when server dep is invalidated', async ({ page }) => {
 		await page.goto('/load/invalidation/depends');
 		const server = await page.textContent('p.server');
 		const shared = await page.textContent('p.shared');
 		expect(server).toBeDefined();
 		expect(shared).toBeDefined();
 
-		await clicknav('button.server');
-		await page.waitForLoadState('networkidle');
+		await Promise.all([page.click('button.server'), page.waitForLoadState('networkidle')]);
 		await page.waitForTimeout(200);
 		const next_server = await page.textContent('p.server');
 		const next_shared = await page.textContent('p.shared');
@@ -807,8 +803,7 @@ test.describe.serial('Invalidation', () => {
 		expect(server).toBeDefined();
 		expect(shared).toBeDefined();
 
-		await clicknav('button.shared');
-		await page.waitForLoadState('networkidle');
+		await Promise.all([page.click('button.shared'), page.waitForLoadState('networkidle')]);
 		await page.waitForTimeout(200);
 		const next_server = await page.textContent('p.server');
 		const next_shared = await page.textContent('p.shared');

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -320,9 +320,9 @@ test.describe.serial('Errors', () => {
 		);
 	});
 
-	test('Root 404 redirects somewhere due to root layout', async ({ page, baseURL }) => {
+	test('Root 404 redirects somewhere due to root layout', async ({ page, baseURL, clicknav }) => {
 		await page.goto('/errors/error-html');
-		await Promise.all([page.waitForNavigation(), page.click('button:text-is("Redirect")')]);
+		await clicknav('button:text-is("Redirect")');
 		expect(page.url()).toBe(baseURL + '/load');
 	});
 });
@@ -781,14 +781,18 @@ test.describe.serial('Invalidation', () => {
 		await expect(page.locator('p.redirect-state')).toHaveText('Redirect state: done');
 	});
 
-	test('+layout(.server).js is re-run when server dep is invalidated', async ({ page }) => {
+	test('+layout(.server).js is re-run when server dep is invalidated', async ({
+		page,
+		clicknav
+	}) => {
 		await page.goto('/load/invalidation/depends');
 		const server = await page.textContent('p.server');
 		const shared = await page.textContent('p.shared');
 		expect(server).toBeDefined();
 		expect(shared).toBeDefined();
 
-		await Promise.all([page.click('button.server'), page.waitForLoadState('networkidle')]);
+		await clicknav('button.server');
+		await page.waitForLoadState('networkidle');
 		await page.waitForTimeout(200);
 		const next_server = await page.textContent('p.server');
 		const next_shared = await page.textContent('p.shared');
@@ -796,14 +800,15 @@ test.describe.serial('Invalidation', () => {
 		expect(shared).not.toBe(next_shared);
 	});
 
-	test('+layout.js is re-run when shared dep is invalidated', async ({ page }) => {
+	test('+layout.js is re-run when shared dep is invalidated', async ({ page, clicknav }) => {
 		await page.goto('/load/invalidation/depends');
 		const server = await page.textContent('p.server');
 		const shared = await page.textContent('p.shared');
 		expect(server).toBeDefined();
 		expect(shared).toBeDefined();
 
-		await Promise.all([page.click('button.shared'), page.waitForLoadState('networkidle')]);
+		await clicknav('button.shared');
+		await page.waitForLoadState('networkidle');
 		await page.waitForTimeout(200);
 		const next_server = await page.textContent('p.server');
 		const next_shared = await page.textContent('p.shared');

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -188,15 +188,15 @@ test.describe('Shadowed pages', () => {
 		);
 	});
 
-	test('Handles POST redirects', async ({ page }) => {
+	test('Handles POST redirects', async ({ page, clicknav }) => {
 		await page.goto('/shadowed');
-		await Promise.all([page.waitForNavigation(), page.click('#redirect-post')]);
+		await clicknav('#redirect-post');
 		expect(await page.textContent('h1')).toBe('Redirection was successful');
 	});
 
-	test('Handles POST redirects with cookies', async ({ page, context }) => {
+	test('Handles POST redirects with cookies', async ({ page, context, clicknav }) => {
 		await page.goto('/shadowed');
-		await Promise.all([page.waitForNavigation(), page.click('#redirect-post-with-cookie')]);
+		await clicknav('#redirect-post-with-cookie');
 		expect(await page.textContent('h1')).toBe('Redirection was successful');
 
 		const cookies = await context.cookies();
@@ -205,9 +205,9 @@ test.describe('Shadowed pages', () => {
 		);
 	});
 
-	test('Handles POST success with returned location', async ({ page }) => {
+	test('Handles POST success with returned location', async ({ page, clicknav }) => {
 		await page.goto('/shadowed/post-success-redirect');
-		await Promise.all([page.waitForNavigation(), page.click('button')]);
+		await clicknav('button');
 		expect(await page.textContent('h1')).toBe('POST was successful');
 	});
 
@@ -606,12 +606,13 @@ test.describe('Errors', () => {
 
 	test('page endpoint POST unexpected error message is preserved', async ({
 		page,
+		clicknav,
 		read_errors
 	}) => {
 		// The case where we're submitting a POST request via a form.
 		// It should show the __error template with our message.
 		await page.goto('/errors/page-endpoint');
-		await Promise.all([page.waitForNavigation(), page.click('#post-implicit')]);
+		await clicknav('#post-implicit');
 
 		expect(await page.textContent('pre')).toBe(
 			JSON.stringify({ status: 500, message: 'oops' }, null, '  ')
@@ -631,11 +632,15 @@ test.describe('Errors', () => {
 		}
 	});
 
-	test('page endpoint POST HttpError error message is preserved', async ({ page, read_errors }) => {
+	test('page endpoint POST HttpError error message is preserved', async ({
+		page,
+		clicknav,
+		read_errors
+	}) => {
 		// The case where we're submitting a POST request via a form.
 		// It should show the __error template with our message.
 		await page.goto('/errors/page-endpoint');
-		await Promise.all([page.waitForNavigation(), page.click('#post-explicit')]);
+		await clicknav('#post-explicit');
 
 		expect(await page.textContent('pre')).toBe(
 			JSON.stringify({ status: 400, message: 'oops' }, null, '  ')
@@ -1390,7 +1395,8 @@ test.describe('Routing', () => {
 
 	test('does not attempt client-side navigation to links with data-sveltekit-reload', async ({
 		baseURL,
-		page
+		page,
+		clicknav
 	}) => {
 		await page.goto('/routing');
 
@@ -1398,7 +1404,7 @@ test.describe('Routing', () => {
 		const requests = [];
 		page.on('request', (r) => requests.push(r.url()));
 
-		await Promise.all([page.waitForNavigation(), page.click('[href="/routing/b"]')]);
+		await clicknav('[href="/routing/b"]');
 		expect(await page.textContent('h1')).toBe('b');
 		expect(requests).toContain(`${baseURL}/routing/b`);
 	});


### PR DESCRIPTION
Dedup `Promise.all([page.waitForNavigation(), ...` by using `clicknav` test utility

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
