### PR TITLE
Work around vite bug

### DIFF
--- a/.changeset/tame-horses-design.md
+++ b/.changeset/tame-horses-design.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Work around SSR transform bug

--- a/packages/create-svelte/templates/default/src/routes/sverdle/+page.server.ts
+++ b/packages/create-svelte/templates/default/src/routes/sverdle/+page.server.ts
@@ -1,5 +1,5 @@
 import { invalid } from '@sveltejs/kit';
-import { answers, allowed } from './words.server';
+import { words, allowed } from './words.server';
 import type { PageServerLoad, Actions } from './$types';
 
 /** @type {import('./$types').PageServerLoad} */
@@ -88,12 +88,12 @@ class Game {
 			this.guesses = guesses ? guesses.split(' ') : [];
 			this.answers = answers ? answers.split(' ') : [];
 		} else {
-			this.index = Math.floor(Math.random() * answers.length);
+			this.index = Math.floor(Math.random() * words.length);
 			this.guesses = ['', '', '', '', '', ''];
 			this.answers = /** @type {string[]} */ [] /***/;
 		}
 
-		this.answer = answers[this.index];
+		this.answer = words[this.index];
 	}
 
 	/**

--- a/packages/create-svelte/templates/default/src/routes/sverdle/words.server.ts
+++ b/packages/create-svelte/templates/default/src/routes/sverdle/words.server.ts
@@ -1,5 +1,5 @@
-/** The list of possible answers */
-export const answers = [
+/** The list of possible words */
+export const words = [
 	'aback',
 	'abase',
 	'abate',
@@ -2317,9 +2317,9 @@ export const answers = [
 	'zonal'
 ];
 
-/** The list of valid guesses, of which the list of possible answers is a subset */
+/** The list of valid guesses, of which the list of possible words is a subset */
 export const allowed = new Set([
-	...answers,
+	...words,
 	'aahed',
 	'aalii',
 	'aargh',


### PR DESCRIPTION
There's a bug in Vite's SSR module transformation — this code...

https://github.com/sveltejs/kit/blob/99929adca2834b09af37d8259d3f0280e8a7c1df/packages/create-svelte/templates/default/src/routes/sverdle/%2Bpage.server.ts#L83-L97

...breaks because the `const [index, guesses, answers]` line causes it to mistakenly think that the `answers` import is shadowed, when it's actually in a different scope. I don't have time to create a repro/issue on Vite right now, but fixing the demo app is a high priority.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
