### PR TITLE
default to insecure cookies on http://localhost

### DIFF
--- a/.changeset/honest-tips-wonder.md
+++ b/.changeset/honest-tips-wonder.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Default to insecure cookies when serving on http://localhost

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -1,12 +1,5 @@
 import { parse, serialize } from 'cookie';
 
-/** @type {import('cookie').CookieSerializeOptions} */
-const DEFAULT_SERIALIZE_OPTIONS = {
-	httpOnly: true,
-	secure: true,
-	sameSite: 'lax'
-};
-
 /**
  * @param {Request} request
  * @param {URL} url
@@ -14,6 +7,13 @@ const DEFAULT_SERIALIZE_OPTIONS = {
 export function get_cookies(request, url) {
 	/** @type {Map<string, import('./page/types').Cookie>} */
 	const new_cookies = new Map();
+
+	/** @type {import('cookie').CookieSerializeOptions} */
+	const defaults = {
+		httpOnly: true,
+		sameSite: 'lax',
+		secure: url.hostname === 'localhost' && url.protocol === 'http:' ? false : true
+	};
 
 	/** @type {import('types').Cookies} */
 	const cookies = {
@@ -51,7 +51,7 @@ export function get_cookies(request, url) {
 				name,
 				value,
 				options: {
-					...DEFAULT_SERIALIZE_OPTIONS,
+					...defaults,
 					...opts
 				}
 			});
@@ -66,7 +66,7 @@ export function get_cookies(request, url) {
 				name,
 				value: '',
 				options: {
-					...DEFAULT_SERIALIZE_OPTIONS,
+					...defaults,
 					...opts,
 					maxAge: 0
 				}
@@ -80,7 +80,7 @@ export function get_cookies(request, url) {
 		 */
 		serialize(name, value, opts) {
 			return serialize(name, value, {
-				...DEFAULT_SERIALIZE_OPTIONS,
+				...defaults,
 				...opts
 			});
 		}

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -42,8 +42,9 @@ paths.negative.forEach(([path, constraint]) => {
 	});
 });
 
-const cookies_setup = () => {
-	const url = new URL('https://example.com');
+/** @param {boolean} localhost */
+const cookies_setup = (localhost = false) => {
+	const url = new URL(localhost ? 'http://localhost:1234' : 'https://example.com');
 	const request = new Request(url, {
 		headers: new Headers({
 			cookie: 'a=b;'
@@ -68,6 +69,13 @@ test('default values when set is called', () => {
 	assert.equal(opts?.httpOnly, true);
 	assert.equal(opts?.path, undefined);
 	assert.equal(opts?.sameSite, 'lax');
+});
+
+test('default values when on localhost', () => {
+	const { cookies, new_cookies } = cookies_setup(true);
+	cookies.set('a', 'b');
+	const opts = new_cookies.get('a')?.options;
+	assert.equal(opts?.secure, false);
 });
 
 test('overridden defaults when set is called', () => {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -151,7 +151,7 @@ export interface Cookies {
 	/**
 	 * Sets a cookie. This will add a `set-cookie` header to the response, but also make the cookie available via `cookies.get` during the current request.
 	 *
-	 * The `httpOnly` and `secure` options are `true` by default, and must be explicitly disabled if you want cookies to be readable by client-side JavaScript and/or transmitted over HTTP. The `sameSite` option defaults to `lax`.
+	 * The `httpOnly` and `secure` options are `true` by default (except on http://localhost, when `secure` is `false`), and must be explicitly disabled if you want cookies to be readable by client-side JavaScript and/or transmitted over HTTP. The `sameSite` option defaults to `lax`.
 	 *
 	 * By default, the `path` of a cookie is the 'directory' of the current pathname. In most cases you should explicitly set `path: '/'` to make the cookie available throughout your app.
 	 */
@@ -165,7 +165,7 @@ export interface Cookies {
 	/**
 	 * Serialize a cookie name-value pair into a Set-Cookie header string.
 	 *
-	 * The `httpOnly` and `secure` options are `true` by default, and must be explicitly disabled if you want cookies to be readable by client-side JavaScript and/or transmitted over HTTP. The `sameSite` option defaults to `lax`.
+	 * The `httpOnly` and `secure` options are `true` by default (except on http://localhost, when `secure` is `false`), and must be explicitly disabled if you want cookies to be readable by client-side JavaScript and/or transmitted over HTTP. The `sameSite` option defaults to `lax`.
 	 *
 	 * By default, the `path` of a cookie is the current pathname. In most cases you should explicitly set `path: '/'` to make the cookie available throughout your app.
 	 *

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -151,7 +151,7 @@ export interface Cookies {
 	/**
 	 * Sets a cookie. This will add a `set-cookie` header to the response, but also make the cookie available via `cookies.get` during the current request.
 	 *
-	 * The `httpOnly` and `secure` options are `true` by default (except on http://localhost, when `secure` is `false`), and must be explicitly disabled if you want cookies to be readable by client-side JavaScript and/or transmitted over HTTP. The `sameSite` option defaults to `lax`.
+	 * The `httpOnly` and `secure` options are `true` by default (except on http://localhost, where `secure` is `false`), and must be explicitly disabled if you want cookies to be readable by client-side JavaScript and/or transmitted over HTTP. The `sameSite` option defaults to `lax`.
 	 *
 	 * By default, the `path` of a cookie is the 'directory' of the current pathname. In most cases you should explicitly set `path: '/'` to make the cookie available throughout your app.
 	 */

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -165,7 +165,7 @@ export interface Cookies {
 	/**
 	 * Serialize a cookie name-value pair into a Set-Cookie header string.
 	 *
-	 * The `httpOnly` and `secure` options are `true` by default (except on http://localhost, when `secure` is `false`), and must be explicitly disabled if you want cookies to be readable by client-side JavaScript and/or transmitted over HTTP. The `sameSite` option defaults to `lax`.
+	 * The `httpOnly` and `secure` options are `true` by default (except on http://localhost, where `secure` is `false`), and must be explicitly disabled if you want cookies to be readable by client-side JavaScript and/or transmitted over HTTP. The `sameSite` option defaults to `lax`.
 	 *
 	 * By default, the `path` of a cookie is the current pathname. In most cases you should explicitly set `path: '/'` to make the cookie available throughout your app.
 	 *


### PR DESCRIPTION
Alternative to #7039. Prevents cookies from being discarded on Safari, which doesn't respect `secure` cookies when on insecure `localhost`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
