### PR TITLE
Fixed link to Adapter type definition

### DIFF
--- a/documentation/docs/12-adapters.md
+++ b/documentation/docs/12-adapters.md
@@ -96,7 +96,7 @@ export default function (options) {
 }
 ```
 
-The types for `Adapter` and its parameters are available in [types/config.d.ts](https://github.com/sveltejs/kit/blob/master/packages/kit/types/config.d.ts).
+The types for `Adapter` and its parameters are available in [types/index.d.ts](https://github.com/sveltejs/kit/blob/master/packages/kit/types/index.d.ts).
 
 Within the `adapt` method, there are a number of things that an adapter should do:
 


### PR DESCRIPTION
The link was broken, but the type definition exists in `index.d.ts` in the same directory, so I updated the link to that file.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
