### PR TITLE
Improve loading sequence of hydration `<script />`  🚀 

### DIFF
--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -246,9 +246,6 @@ export async function render_response({
 		for (const dep of modulepreloads) {
 			const path = prefixed(dep);
 			link_header_preloads.add(`<${encodeURI(path)}>; rel="modulepreload"; nopush`);
-			if (state.prerendering) {
-				head += `\n\t\t<link rel="modulepreload" href="${path}">`;
-			}
 		}
 
 		const attributes = ['type="module"', `data-sveltekit-hydrate="${target}"`];
@@ -259,7 +256,7 @@ export async function render_response({
 			attributes.push(`nonce="${csp.nonce}"`);
 		}
 
-		body += `\n\t\t<script ${attributes.join(' ')}>${init_app}</script>`;
+		head += `\n\t\t<script ${attributes.join(' ')}>${init_app}</script>`;
 	}
 
 	if (page_config.ssr && page_config.csr) {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -246,6 +246,9 @@ export async function render_response({
 		for (const dep of modulepreloads) {
 			const path = prefixed(dep);
 			link_header_preloads.add(`<${encodeURI(path)}>; rel="modulepreload"; nopush`);
+			if (state.prerendering) {
+				head += `\n\t\t<link rel="modulepreload" href="${path}">`;
+			}
 		}
 
 		const attributes = ['type="module"'];

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -260,7 +260,7 @@ export async function render_response({
 		}
 
 		head += `\n\t\t<script ${attributes.join(' ')}>${init_app}</script>`;
-		body += `\n\t\t<div data-sveltekit-hydrate="${target}"></div>`
+		body += `\n<div data-sveltekit-hydrate="${target}"></div>`
 	}
 
 	if (page_config.ssr && page_config.csr) {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -248,7 +248,7 @@ export async function render_response({
 			link_header_preloads.add(`<${encodeURI(path)}>; rel="modulepreload"; nopush`);
 		}
 
-		const attributes = ['type="module"', `data-sveltekit-hydrate="${target}"`];
+		const attributes = ['type="module"'];
 
 		csp.add_script(init_app);
 
@@ -257,6 +257,7 @@ export async function render_response({
 		}
 
 		head += `\n\t\t<script ${attributes.join(' ')}>${init_app}</script>`;
+		body += `\n\t\t<div data-sveltekit-hydrate="${target}"></div>`
 	}
 
 	if (page_config.ssr && page_config.csr) {


### PR DESCRIPTION
### Improve loading sequence of hydration `<script />` 🚀

>This will help us to improve-: 
>- Improvements in FCP, LCP metric, faster time to visual-completeness.
>- Reduced developer cost for curating the loading sequence for FCP, LCP.
>- Additional optimization and predictability given the guaranteed order of execution of defer scripts.

And this is good for browsers which doesn't support `<link rel="modulepreload" />`  :)

References -:

1.  Next js current implementation -: https://github.com/vercel/next.js/discussions/24938
2. About script loading -: https://gist.github.com/jakub-g/385ee6b41085303a53ad92c7c8afd7a6


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
