### PR TITLE
[fix] decode routeIds in headers for prerendering

### DIFF
--- a/.changeset/pretty-pigs-give.md
+++ b/.changeset/pretty-pigs-give.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] decode routeIds in headers for prerendering

--- a/packages/kit/src/core/prerender/prerender.js
+++ b/packages/kit/src/core/prerender/prerender.js
@@ -244,10 +244,13 @@ export async function prerender() {
 
 			const prerender = headers['x-sveltekit-prerender'];
 			if (prerender) {
-				const route_id = headers['x-sveltekit-routeid'];
-				const existing_value = prerender_map.get(route_id);
-				if (existing_value !== 'auto') {
-					prerender_map.set(route_id, prerender === 'true' ? true : 'auto');
+				const encoded_route_id = headers['x-sveltekit-routeid'];
+				if (encoded_route_id != null) {
+					const route_id = decodeURI(encoded_route_id);
+					const existing_value = prerender_map.get(route_id);
+					if (existing_value !== 'auto') {
+						prerender_map.set(route_id, prerender === 'true' ? true : 'auto');
+					}
 				}
 			}
 
@@ -305,7 +308,8 @@ export async function prerender() {
 
 		if (written.has(file)) return;
 
-		const route_id = response.headers.get('x-sveltekit-routeid');
+		const encoded_route_id = response.headers.get('x-sveltekit-routeid');
+		const route_id = encoded_route_id != null ? decodeURI(encoded_route_id) : null;
 		if (route_id !== null) prerendered_routes.add(route_id);
 
 		if (response_type === REDIRECT) {

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -298,7 +298,7 @@ export async function respond(request, options, state) {
 					add_cookies_to_headers(response.headers, Array.from(new_cookies.values()));
 
 					if (state.prerendering && event.routeId !== null) {
-						response.headers.set('x-sveltekit-routeid', event.routeId);
+						response.headers.set('x-sveltekit-routeid', encodeURI(event.routeId));
 					}
 
 					return response;

--- a/packages/kit/test/prerendering/basics/src/routes/初めまして/+page.svelte
+++ b/packages/kit/test/prerendering/basics/src/routes/初めまして/+page.svelte
@@ -1,0 +1,1 @@
+<p>Test for characters that need to be en/decoded during prerendering</p>


### PR DESCRIPTION
Fixes #7074

From what I can see the proposed changes in the issue are correct, there's nothing encoding the routeId prior to the code where it is then encoded for the header

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
