### PR TITLE
adapter-cloudflare-workers: Configure custom wrangler.toml file name

### DIFF
--- a/.changeset/eleven-seahorses-report.md
+++ b/.changeset/eleven-seahorses-report.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare-workers': minor
+---
+
+Add config option to set custom `wrangler.toml` file name

--- a/packages/adapter-cloudflare-workers/README.md
+++ b/packages/adapter-cloudflare-workers/README.md
@@ -69,6 +69,20 @@ Then, you can build your app and deploy it:
 wrangler publish
 ```
 
+## Custom config
+
+If you would like to use a config file other than `wrangler.toml`, you can do like so:
+
+```js
+import adapter from '@sveltejs/adapter-cloudflare-workers';
+
+export default {
+  kit: {
+    adapter: adapter({ config: '<your-wrangler-name>.toml' })
+  }
+};
+```
+
 ## Environment variables
 
 The [`env`](https://developers.cloudflare.com/workers/runtime-apis/fetch-event#parameters) object, containing KV/DO namespaces etc, is passed to SvelteKit via the `platform` property along with `context` and `caches`, meaning you can access it in hooks and endpoints:

--- a/packages/adapter-cloudflare-workers/index.d.ts
+++ b/packages/adapter-cloudflare-workers/index.d.ts
@@ -1,3 +1,3 @@
 import { Adapter } from '@sveltejs/kit';
 
-export default function plugin(): Adapter;
+export default function plugin(options: { config?: string }): Adapter;

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -90,7 +90,9 @@ function validate_config(builder, configFile) {
 		let wrangler_config;
 
 		try {
-			wrangler_config = /** @type {WranglerConfig} */ (toml.parse(readFileSync(configFile, 'utf-8')));
+			wrangler_config = /** @type {WranglerConfig} */ (
+				toml.parse(readFileSync(configFile, 'utf-8'))
+			);
 		} catch (err) {
 			err.message = `Error parsing ${configFile}: ${err.message}`;
 			throw err;

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -81,32 +81,32 @@ export default function ({ config = 'wrangler.toml' } = {}) {
 
 /**
  * @param {import('@sveltejs/kit').Builder} builder
- * @param {string} configFile
+ * @param {string} config_file
  * @returns {WranglerConfig}
  */
-function validate_config(builder, configFile) {
-	if (existsSync(configFile)) {
+function validate_config(builder, config_file) {
+	if (existsSync(config_file)) {
 		/** @type {WranglerConfig} */
 		let wrangler_config;
 
 		try {
 			wrangler_config = /** @type {WranglerConfig} */ (
-				toml.parse(readFileSync(configFile, 'utf-8'))
+				toml.parse(readFileSync(config_file, 'utf-8'))
 			);
 		} catch (err) {
-			err.message = `Error parsing ${configFile}: ${err.message}`;
+			err.message = `Error parsing ${config_file}: ${err.message}`;
 			throw err;
 		}
 
 		if (!wrangler_config.site?.bucket) {
 			throw new Error(
-				`You must specify site.bucket in ${configFile}. Consult https://developers.cloudflare.com/workers/platform/sites/configuration`
+				`You must specify site.bucket in ${config_file}. Consult https://developers.cloudflare.com/workers/platform/sites/configuration`
 			);
 		}
 
 		if (!wrangler_config.main) {
 			throw new Error(
-				`You must specify main option in ${configFile}. Consult https://github.com/sveltejs/kit/tree/master/packages/adapter-cloudflare-workers`
+				`You must specify main option in ${config_file}. Consult https://github.com/sveltejs/kit/tree/master/packages/adapter-cloudflare-workers`
 			);
 		}
 
@@ -135,5 +135,5 @@ function validate_config(builder, configFile) {
 			.trim()
 	);
 
-	throw new Error(`Missing a ${configFile} file`);
+	throw new Error(`Missing a ${config_file} file`);
 }


### PR DESCRIPTION
Fixes: #7103 

Adds the ability to use a config file other than `wrangler.toml`, like:

```js
import adapter from '@sveltejs/adapter-cloudflare-workers';

export default {
  kit: {
    adapter: adapter({ config: '<your-wrangler-name>.toml' })
  }
};
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
