### PR TITLE
[feat] extract and export types from `create-svelte`

### DIFF
--- a/.changeset/many-planes-taste.md
+++ b/.changeset/many-planes-taste.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+[feat] extract and export types from create-svelte

--- a/packages/create-svelte/index.js
+++ b/packages/create-svelte/index.js
@@ -2,12 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { mkdirp, copy, dist } from './utils.js';
 
-/**
- * Create a new SvelteKit project.
- *
- * @param {string} cwd - Path to the directory to create
- * @param {import('./types/internal').Options} options
- */
+/** @type {import('./types/index').create} */
 export async function create(cwd, options) {
 	mkdirp(cwd);
 

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -42,7 +42,9 @@
 		"index.js",
 		"dist",
 		"bin.js",
-		"utils.js"
+		"utils.js",
+		"types"
 	],
+	"types": "types/index.d.ts",
 	"type": "module"
 }

--- a/packages/create-svelte/types/index.d.ts
+++ b/packages/create-svelte/types/index.d.ts
@@ -1,0 +1,9 @@
+import { Options } from './internal';
+
+/**
+ * Create a new SvelteKit project.
+ *
+ * @param {string} cwd - Path to the directory to create
+ * @param {import('./internal').Options} options
+ */
+export function create(cwd: string, options: Options): Promise<void>;

--- a/packages/create-svelte/types/index.d.ts
+++ b/packages/create-svelte/types/index.d.ts
@@ -2,7 +2,6 @@ import { Options } from './internal';
 
 /**
  * Create a new SvelteKit project.
- *
  * @param {string} cwd - Path to the directory to create
  * @param {import('./internal').Options} options
  */


### PR DESCRIPTION
Export types from `create-svelte` package.

Closes #7053.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
