### PR TITLE
Add `fetch` to `RequestEvent`

### DIFF
--- a/.changeset/curvy-suits-sleep.md
+++ b/.changeset/curvy-suits-sleep.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add `fetch` to `RequestEvent`

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -5,8 +5,12 @@ import { parse, serialize } from 'cookie';
  * @param {URL} url
  */
 export function get_cookies(request, url) {
-	/** @type {Map<string, import('./page/types').Cookie>} */
-	const new_cookies = new Map();
+	const header = request.headers.get('cookie') ?? '';
+
+	const initial_cookies = parse(header);
+
+	/** @type {Record<string, import('./page/types').Cookie>} */
+	const new_cookies = {};
 
 	/** @type {import('cookie').CookieSerializeOptions} */
 	const defaults = {
@@ -27,7 +31,7 @@ export function get_cookies(request, url) {
 		 * @param {import('cookie').CookieParseOptions} opts
 		 */
 		get(name, opts) {
-			const c = new_cookies.get(name);
+			const c = new_cookies[name];
 			if (
 				c &&
 				domain_matches(url.hostname, c.options.domain) &&
@@ -37,7 +41,7 @@ export function get_cookies(request, url) {
 			}
 
 			const decode = opts?.decode || decodeURIComponent;
-			const req_cookies = parse(request.headers.get('cookie') ?? '', { decode });
+			const req_cookies = parse(header, { decode });
 			return req_cookies[name]; // the decoded string or undefined
 		},
 
@@ -47,14 +51,14 @@ export function get_cookies(request, url) {
 		 * @param {import('cookie').CookieSerializeOptions} opts
 		 */
 		set(name, value, opts = {}) {
-			new_cookies.set(name, {
+			new_cookies[name] = {
 				name,
 				value,
 				options: {
 					...defaults,
 					...opts
 				}
-			});
+			};
 		},
 
 		/**
@@ -62,7 +66,7 @@ export function get_cookies(request, url) {
 		 * @param {import('cookie').CookieSerializeOptions} opts
 		 */
 		delete(name, opts = {}) {
-			new_cookies.set(name, {
+			new_cookies[name] = {
 				name,
 				value: '',
 				options: {
@@ -70,7 +74,7 @@ export function get_cookies(request, url) {
 					...opts,
 					maxAge: 0
 				}
-			});
+			};
 		},
 
 		/**
@@ -86,7 +90,42 @@ export function get_cookies(request, url) {
 		}
 	};
 
-	return { cookies, new_cookies };
+	/**
+	 * @param {URL} destination
+	 * @param {string | null} header
+	 */
+	function get_cookie_header(destination, header) {
+		/** @type {Record<string, string>} */
+		const combined_cookies = {};
+
+		// cookies sent by the user agent have lowest precedence
+		for (const name in initial_cookies) {
+			combined_cookies[name] = initial_cookies[name];
+		}
+
+		// cookies previous set during this event with cookies.set have higher precedence
+		for (const key in new_cookies) {
+			const cookie = new_cookies[key];
+			if (!domain_matches(destination.hostname, cookie.options.domain)) continue;
+			if (!path_matches(destination.pathname, cookie.options.path)) continue;
+
+			combined_cookies[cookie.name] = cookie.value;
+		}
+
+		// explicit header has highest precedence
+		if (header) {
+			const parsed = parse(header);
+			for (const name in parsed) {
+				combined_cookies[name] = parsed[name];
+			}
+		}
+
+		return Object.entries(combined_cookies)
+			.map(([name, value]) => `${name}=${value}`)
+			.join('; ');
+	}
+
+	return { cookies, new_cookies, get_cookie_header };
 }
 
 /**

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -64,7 +64,7 @@ test('a cookie should not be present after it is deleted', () => {
 test('default values when set is called', () => {
 	const { cookies, new_cookies } = cookies_setup();
 	cookies.set('a', 'b');
-	const opts = new_cookies.get('a')?.options;
+	const opts = new_cookies['a']?.options;
 	assert.equal(opts?.secure, true);
 	assert.equal(opts?.httpOnly, true);
 	assert.equal(opts?.path, undefined);
@@ -74,14 +74,14 @@ test('default values when set is called', () => {
 test('default values when on localhost', () => {
 	const { cookies, new_cookies } = cookies_setup(true);
 	cookies.set('a', 'b');
-	const opts = new_cookies.get('a')?.options;
+	const opts = new_cookies['a']?.options;
 	assert.equal(opts?.secure, false);
 });
 
 test('overridden defaults when set is called', () => {
 	const { cookies, new_cookies } = cookies_setup();
 	cookies.set('a', 'b', { secure: false, httpOnly: false, sameSite: 'strict', path: '/a/b/c' });
-	const opts = new_cookies.get('a')?.options;
+	const opts = new_cookies['a']?.options;
 	assert.equal(opts?.secure, false);
 	assert.equal(opts?.httpOnly, false);
 	assert.equal(opts?.path, '/a/b/c');
@@ -91,7 +91,7 @@ test('overridden defaults when set is called', () => {
 test('default values when delete is called', () => {
 	const { cookies, new_cookies } = cookies_setup();
 	cookies.delete('a');
-	const opts = new_cookies.get('a')?.options;
+	const opts = new_cookies['a']?.options;
 	assert.equal(opts?.secure, true);
 	assert.equal(opts?.httpOnly, true);
 	assert.equal(opts?.path, undefined);
@@ -102,7 +102,7 @@ test('default values when delete is called', () => {
 test('overridden defaults when delete is called', () => {
 	const { cookies, new_cookies } = cookies_setup();
 	cookies.delete('a', { secure: false, httpOnly: false, sameSite: 'strict', path: '/a/b/c' });
-	const opts = new_cookies.get('a')?.options;
+	const opts = new_cookies['a']?.options;
 	assert.equal(opts?.secure, false);
 	assert.equal(opts?.httpOnly, false);
 	assert.equal(opts?.path, '/a/b/c');
@@ -113,7 +113,7 @@ test('overridden defaults when delete is called', () => {
 test('cannot override maxAge on delete', () => {
 	const { cookies, new_cookies } = cookies_setup();
 	cookies.delete('a', { maxAge: 1234 });
-	const opts = new_cookies.get('a')?.options;
+	const opts = new_cookies['a']?.options;
 	assert.equal(opts?.maxAge, 0);
 });
 
@@ -121,7 +121,7 @@ test('last cookie set with the same name wins', () => {
 	const { cookies, new_cookies } = cookies_setup();
 	cookies.set('a', 'foo');
 	cookies.set('a', 'bar');
-	const entry = new_cookies.get('a');
+	const entry = new_cookies['a'];
 	assert.equal(entry?.value, 'bar');
 });
 
@@ -130,8 +130,8 @@ test('cookie names are case sensitive', () => {
 	// not that one should do this, but we follow the spec...
 	cookies.set('a', 'foo');
 	cookies.set('A', 'bar');
-	const entrya = new_cookies.get('a');
-	const entryA = new_cookies.get('A');
+	const entrya = new_cookies['a'];
+	const entryA = new_cookies['A'];
 	assert.equal(entrya?.value, 'foo');
 	assert.equal(entryA?.value, 'bar');
 });

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -134,10 +134,7 @@ export function create_fetch({ event, options, state, route, get_cookie_header }
 					throw new Error('Request body must be a string or TypedArray');
 				}
 
-				response = await respond(request, options, {
-					...state,
-					initiator: route ?? undefined
-				});
+				response = await respond(request, options, state);
 
 				if (state.prerendering) {
 					dependency = { response, body: null };

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -6,20 +6,12 @@ import { respond } from './index.js';
  *   event: import('types').RequestEvent;
  *   options: import('types').SSROptions;
  *   state: import('types').SSRState;
- *   route: import('types').SSRRoute | import('types').SSRErrorPage;
- *   prerender_default?: import('types').PrerenderOption;
+ *   route: import('types').SSRRoute | import('types').SSRErrorPage | null;
  *   get_cookie_header: (url: URL, header: string | null) => string;
  * }} opts
  * @returns {typeof fetch}
  */
-export function create_fetch({
-	event,
-	options,
-	state,
-	route,
-	prerender_default,
-	get_cookie_header
-}) {
+export function create_fetch({ event, options, state, route, get_cookie_header }) {
 	return async (info, init) => {
 		const request = normalize_fetch_input(info, init, event.url);
 
@@ -143,9 +135,8 @@ export function create_fetch({
 				}
 
 				response = await respond(request, options, {
-					prerender_default,
 					...state,
-					initiator: route
+					initiator: route ?? undefined
 				});
 
 				if (state.prerendering) {

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -1,7 +1,7 @@
 import * as cookie from 'cookie';
 import * as set_cookie_parser from 'set-cookie-parser';
-import { respond } from '../index.js';
-import { domain_matches, path_matches } from '../cookie.js';
+import { respond } from './index.js';
+import { domain_matches, path_matches } from './cookie.js';
 
 /**
  * @param {{
@@ -14,12 +14,12 @@ import { domain_matches, path_matches } from '../cookie.js';
  * }} opts
  */
 export function create_fetch({ event, options, state, route, prerender_default, resolve_opts }) {
-	/** @type {import('./types').Fetched[]} */
+	/** @type {import('./page/types').Fetched[]} */
 	const fetched = [];
 
 	const initial_cookies = cookie.parse(event.request.headers.get('cookie') || '');
 
-	/** @type {import('./types').Cookie[]} */
+	/** @type {import('./page/types').Cookie[]} */
 	const set_cookies = [];
 
 	/**
@@ -191,7 +191,7 @@ export function create_fetch({ event, options, state, route, prerender_default, 
 						...set_cookie_parser.splitCookiesString(set_cookie).map((str) => {
 							const { name, value, ...options } = set_cookie_parser.parseString(str);
 							// options.sameSite is string, something more specific is required - type cast is safe
-							return /** @type{import('./types').Cookie} */ ({ name, value, options });
+							return /** @type{import('./page/types').Cookie} */ ({ name, value, options });
 						})
 					);
 				}

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -6,12 +6,11 @@ import { respond } from './index.js';
  *   event: import('types').RequestEvent;
  *   options: import('types').SSROptions;
  *   state: import('types').SSRState;
- *   route: import('types').SSRRoute | import('types').SSRErrorPage | null;
  *   get_cookie_header: (url: URL, header: string | null) => string;
  * }} opts
  * @returns {typeof fetch}
  */
-export function create_fetch({ event, options, state, route, get_cookie_header }) {
+export function create_fetch({ event, options, state, get_cookie_header }) {
 	return async (info, init) => {
 		const request = normalize_fetch_input(info, init, event.url);
 

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -10,6 +10,7 @@ import { respond } from './index.js';
  *   prerender_default?: import('types').PrerenderOption;
  *   get_cookie_header: (url: URL, header: string | null) => string;
  * }} opts
+ * @returns {typeof fetch}
  */
 export function create_fetch({
 	event,
@@ -19,11 +20,7 @@ export function create_fetch({
 	prerender_default,
 	get_cookie_header
 }) {
-	/** @type {import('./page/types').Fetched[]} */
-	const fetched = [];
-
-	/** @type {typeof fetch} */
-	const fetcher = async (info, init) => {
+	return async (info, init) => {
 		const request = normalize_fetch_input(info, init, event.url);
 
 		const request_body = init?.body;
@@ -174,8 +171,6 @@ export function create_fetch({
 			}
 		});
 	};
-
-	return { fetcher, fetched };
 }
 
 /**

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -239,15 +239,7 @@ export async function respond(request, options, state) {
 				} else if (route.endpoint && (!route.page || is_endpoint_request(event))) {
 					response = await render_endpoint(event, await route.endpoint(), state);
 				} else if (route.page) {
-					response = await render_page(
-						event,
-						route,
-						route.page,
-						options,
-						state,
-						resolve_opts,
-						get_cookie_header
-					);
+					response = await render_page(event, route, route.page, options, state, resolve_opts);
 				} else {
 					// a route will always have a page or an endpoint, but TypeScript
 					// doesn't know that

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -299,7 +299,7 @@ export async function respond(request, options, state) {
 							response.headers.set(key, /** @type {string} */ (value));
 						}
 					}
-					add_cookies_to_headers(response.headers, Array.from(Object.values(new_cookies)));
+					add_cookies_to_headers(response.headers, Object.values(new_cookies));
 
 					if (state.prerendering && event.routeId !== null) {
 						response.headers.set('x-sveltekit-routeid', encodeURI(event.routeId));

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -141,13 +141,7 @@ export async function respond(request, options, state) {
 		url
 	};
 
-	event.fetch = create_fetch({
-		event,
-		options,
-		state,
-		route,
-		get_cookie_header
-	});
+	event.fetch = create_fetch({ event, options, state, get_cookie_header });
 
 	// TODO remove this for 1.0
 	/**

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -10,6 +10,7 @@ import { render_data } from './data/index.js';
 import { DATA_SUFFIX } from '../../constants.js';
 import { add_cookies_to_headers, get_cookies } from './cookie.js';
 import { HttpError } from '../control.js';
+import { create_fetch } from './fetch.js';
 
 /* global __SVELTEKIT_ADAPTER_NAME__ */
 
@@ -103,6 +104,8 @@ export async function respond(request, options, state) {
 	/** @type {import('types').RequestEvent} */
 	const event = {
 		cookies,
+		// @ts-expect-error this is added in the next step, because `create_fetch` needs a reference to `event`
+		fetch: null,
 		getClientAddress:
 			state.getClientAddress ||
 			(() => {
@@ -137,6 +140,14 @@ export async function respond(request, options, state) {
 		},
 		url
 	};
+
+	event.fetch = create_fetch({
+		event,
+		options,
+		state,
+		route,
+		get_cookie_header
+	});
 
 	// TODO remove this for 1.0
 	/**
@@ -261,8 +272,7 @@ export async function respond(request, options, state) {
 					state,
 					status: 404,
 					error: new Error(`Not found: ${event.url.pathname}`),
-					resolve_opts,
-					get_cookie_header
+					resolve_opts
 				});
 			}
 

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -108,7 +108,6 @@ export async function render_page(
 			state,
 			route,
 			prerender_default: should_prerender,
-			resolve_opts,
 			get_cookie_header
 		});
 
@@ -179,6 +178,7 @@ export async function render_page(
 					return await load_data({
 						event,
 						fetcher,
+						fetched,
 						node,
 						parent: async () => {
 							const data = {};
@@ -187,6 +187,7 @@ export async function render_page(
 							}
 							return data;
 						},
+						resolve_opts,
 						server_data_promise: server_promises[i],
 						state
 					});

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -15,7 +15,6 @@ import {
 	is_action_json_request,
 	is_action_request
 } from './actions.js';
-import { create_fetch } from '../fetch.js';
 import { load_data, load_server_data } from './load_data.js';
 import { render_response } from './render.js';
 import { respond_with_error } from './respond_with_error.js';
@@ -102,14 +101,9 @@ export async function render_page(
 			});
 		}
 
-		const fetcher = create_fetch({
-			event,
-			options,
-			state,
-			route,
-			prerender_default: should_prerender,
-			get_cookie_header
-		});
+		// if we fetch any endpoints while loading data for this page, they should
+		// inherit the prerender option of the page
+		state.prerender_default = should_prerender;
 
 		/** @type {import('./types').Fetched[]} */
 		const fetched = [];
@@ -180,7 +174,6 @@ export async function render_page(
 				try {
 					return await load_data({
 						event,
-						fetcher,
 						fetched,
 						node,
 						parent: async () => {
@@ -309,8 +302,7 @@ export async function render_page(
 			state,
 			status: 500,
 			error,
-			resolve_opts,
-			get_cookie_header
+			resolve_opts
 		});
 	}
 }

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -15,7 +15,7 @@ import {
 	is_action_json_request,
 	is_action_request
 } from './actions.js';
-import { create_fetch } from './fetch.js';
+import { create_fetch } from '../fetch.js';
 import { load_data, load_server_data } from './load_data.js';
 import { render_response } from './render.js';
 import { respond_with_error } from './respond_with_error.js';

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -26,24 +26,17 @@ import { respond_with_error } from './respond_with_error.js';
  * @param {import('types').SSROptions} options
  * @param {import('types').SSRState} state
  * @param {import('types').RequiredResolveOptions} resolve_opts
- * @param {(url: URL, header: string | null) => string} get_cookie_header // TODO tidy this up
  * @returns {Promise<Response>}
  */
-export async function render_page(
-	event,
-	route,
-	page,
-	options,
-	state,
-	resolve_opts,
-	get_cookie_header
-) {
+export async function render_page(event, route, page, options, state, resolve_opts) {
 	if (state.initiator === route) {
 		// infinite request cycle detected
 		return new Response(`Not found: ${event.url.pathname}`, {
 			status: 404
 		});
 	}
+
+	state.initiator = route;
 
 	if (is_action_json_request(event)) {
 		const node = await options.manifest._.nodes[page.leaf]();

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -102,7 +102,7 @@ export async function render_page(
 			});
 		}
 
-		const { fetcher, fetched } = create_fetch({
+		const fetcher = create_fetch({
 			event,
 			options,
 			state,
@@ -110,6 +110,9 @@ export async function render_page(
 			prerender_default: should_prerender,
 			get_cookie_header
 		});
+
+		/** @type {import('./types').Fetched[]} */
+		const fetched = [];
 
 		if (get_option(nodes, 'ssr') === false) {
 			return await render_response({

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -68,7 +68,6 @@ export async function load_server_data({ event, state, node, parent }) {
  * Calls the user's `load` function.
  * @param {{
  *   event: import('types').RequestEvent;
- *   fetcher: typeof fetch;
  *   fetched: import('./types').Fetched[];
  *   node: import('types').SSRNode | undefined;
  *   parent: () => Promise<Record<string, any>>;
@@ -80,7 +79,6 @@ export async function load_server_data({ event, state, node, parent }) {
  */
 export async function load_data({
 	event,
-	fetcher,
 	fetched,
 	node,
 	parent,
@@ -101,7 +99,7 @@ export async function load_data({
 		data: server_data_node?.data ?? null,
 		routeId: event.routeId,
 		fetch: async (input, init) => {
-			const response = await fetcher(input, init);
+			const response = await event.fetch(input, init);
 
 			const url = new URL(input instanceof Request ? input.url : input, event.url);
 			const same_origin = url.origin === event.url.origin;

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -4,7 +4,6 @@ import { hash } from '../../hash.js';
 import { serialize_data } from './serialize_data.js';
 import { s } from '../../../utils/misc.js';
 import { Csp } from './csp.js';
-import { add_cookies_to_headers } from '../cookie.js';
 
 // TODO rename this function/module
 
@@ -18,7 +17,6 @@ const updated = {
  * @param {{
  *   branch: Array<import('./types').Loaded>;
  *   fetched: Array<import('./types').Fetched>;
- *   cookies: import('./types').Cookie[];
  *   options: import('types').SSROptions;
  *   state: import('types').SSRState;
  *   page_config: { ssr: boolean; csr: boolean };
@@ -32,7 +30,6 @@ const updated = {
 export async function render_response({
 	branch,
 	fetched,
-	cookies,
 	options,
 	state,
 	page_config,
@@ -328,8 +325,6 @@ export async function render_response({
 		if (report_only_header) {
 			headers.set('content-security-policy-report-only', report_only_header);
 		}
-
-		add_cookies_to_headers(headers, cookies);
 
 		if (link_header_preloads.size) {
 			headers.set('link', Array.from(link_header_preloads).join(', '));

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -41,7 +41,6 @@ export async function respond_with_error({
 		options,
 		state,
 		route: GENERIC_ERROR,
-		resolve_opts,
 		get_cookie_header
 	});
 
@@ -63,8 +62,10 @@ export async function respond_with_error({
 			const data = await load_data({
 				event,
 				fetcher,
+				fetched,
 				node: default_layout,
 				parent: async () => ({}),
+				resolve_opts,
 				server_data_promise,
 				state
 			});

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -24,15 +24,25 @@ import { HttpError, Redirect } from '../../control.js';
  *   status: number;
  *   error: unknown;
  *   resolve_opts: import('types').RequiredResolveOptions;
+ *   get_cookie_header: (url: URL, header: string | null) => string; // TODO tidy this up
  * }} opts
  */
-export async function respond_with_error({ event, options, state, status, error, resolve_opts }) {
-	const { fetcher, fetched, cookies } = create_fetch({
+export async function respond_with_error({
+	event,
+	options,
+	state,
+	status,
+	error,
+	resolve_opts,
+	get_cookie_header
+}) {
+	const { fetcher, fetched } = create_fetch({
 		event,
 		options,
 		state,
 		route: GENERIC_ERROR,
-		resolve_opts
+		resolve_opts,
+		get_cookie_header
 	});
 
 	try {
@@ -84,7 +94,6 @@ export async function respond_with_error({ event, options, state, status, error,
 			error: handle_error_and_jsonify(event, options, error),
 			branch,
 			fetched,
-			cookies,
 			event,
 			resolve_opts
 		});
@@ -92,7 +101,7 @@ export async function respond_with_error({ event, options, state, status, error,
 		// Edge case: If route is a 404 and the user redirects to somewhere from the root layout,
 		// we end up here.
 		if (error instanceof Redirect) {
-			return redirect_response(error.status, error.location, cookies);
+			return redirect_response(error.status, error.location);
 		}
 
 		return static_error_page(

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -36,13 +36,16 @@ export async function respond_with_error({
 	resolve_opts,
 	get_cookie_header
 }) {
-	const { fetcher, fetched } = create_fetch({
+	const fetcher = create_fetch({
 		event,
 		options,
 		state,
 		route: GENERIC_ERROR,
 		get_cookie_header
 	});
+
+	/** @type {import('./types').Fetched[]} */
+	const fetched = [];
 
 	try {
 		const branch = [];

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -2,12 +2,10 @@ import { render_response } from './render.js';
 import { load_data, load_server_data } from './load_data.js';
 import {
 	handle_error_and_jsonify,
-	GENERIC_ERROR,
 	get_option,
 	static_error_page,
 	redirect_response
 } from '../utils.js';
-import { create_fetch } from '../fetch.js';
 import { HttpError, Redirect } from '../../control.js';
 
 /**
@@ -24,26 +22,9 @@ import { HttpError, Redirect } from '../../control.js';
  *   status: number;
  *   error: unknown;
  *   resolve_opts: import('types').RequiredResolveOptions;
- *   get_cookie_header: (url: URL, header: string | null) => string; // TODO tidy this up
  * }} opts
  */
-export async function respond_with_error({
-	event,
-	options,
-	state,
-	status,
-	error,
-	resolve_opts,
-	get_cookie_header
-}) {
-	const fetcher = create_fetch({
-		event,
-		options,
-		state,
-		route: GENERIC_ERROR,
-		get_cookie_header
-	});
-
+export async function respond_with_error({ event, options, state, status, error, resolve_opts }) {
 	/** @type {import('./types').Fetched[]} */
 	const fetched = [];
 
@@ -64,7 +45,6 @@ export async function respond_with_error({
 
 			const data = await load_data({
 				event,
-				fetcher,
 				fetched,
 				node: default_layout,
 				parent: async () => ({}),

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -7,7 +7,7 @@ import {
 	static_error_page,
 	redirect_response
 } from '../utils.js';
-import { create_fetch } from './fetch.js';
+import { create_fetch } from '../fetch.js';
 import { HttpError, Redirect } from '../../control.js';
 
 /**

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -4,7 +4,8 @@ import {
 	handle_error_and_jsonify,
 	get_option,
 	static_error_page,
-	redirect_response
+	redirect_response,
+	GENERIC_ERROR
 } from '../utils.js';
 import { HttpError, Redirect } from '../../control.js';
 
@@ -34,6 +35,8 @@ export async function respond_with_error({ event, options, state, status, error,
 		const ssr = get_option([default_layout], 'ssr') ?? true;
 
 		if (ssr) {
+			state.initiator = GENERIC_ERROR;
+
 			const server_data_promise = load_server_data({
 				event,
 				state,

--- a/packages/kit/src/runtime/server/page/types.d.ts
+++ b/packages/kit/src/runtime/server/page/types.d.ts
@@ -9,12 +9,6 @@ export interface Fetched {
 	response: Response;
 }
 
-export interface FetchState {
-	fetched: Fetched[];
-	cookies: string[];
-	new_cookies: string[];
-}
-
 export type Loaded = {
 	node: SSRNode;
 	data: Record<string, any> | null;

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -2,7 +2,6 @@ import { devalue } from 'devalue';
 import { DATA_SUFFIX } from '../../constants.js';
 import { negotiate } from '../../utils/http.js';
 import { HttpError } from '../control.js';
-import { add_cookies_to_headers } from './cookie.js';
 
 /** @param {any} body */
 export function is_pojo(body) {
@@ -167,13 +166,11 @@ export function handle_error_and_jsonify(event, options, error) {
 /**
  * @param {number} status
  * @param {string} location
- * @param {import('./page/types.js').Cookie[]} [cookies]
  */
-export function redirect_response(status, location, cookies = []) {
+export function redirect_response(status, location) {
 	const response = new Response(undefined, {
 		status,
 		headers: { location }
 	});
-	add_cookies_to_headers(response.headers, cookies);
 	return response;
 }

--- a/packages/kit/test/apps/basics/src/routes/load/serialization/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization/+page.js
@@ -1,5 +1,9 @@
-/** @type {import('@sveltejs/kit').Load} */
-export async function load({ fetch }) {
-	const res = await fetch('/load/serialization.json');
-	return await res.json();
+/** @type {import('./$types').PageLoad} */
+export async function load({ fetch, data }) {
+	const { a } = data;
+
+	const res = await fetch('/load/serialization/fetched-from-shared.json');
+	const { b } = await res.json();
+
+	return { a, b, c: a + b };
 }

--- a/packages/kit/test/apps/basics/src/routes/load/serialization/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization/+page.server.js
@@ -1,0 +1,6 @@
+/** @type {import('./$types').PageServerLoad} */
+export async function load({ fetch }) {
+	const res = await fetch('/load/serialization/fetched-from-server.json');
+	const { a } = await res.json();
+	return { a };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/serialization/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization/+page.svelte
@@ -3,4 +3,4 @@
 	export let data;
 </script>
 
-<h1>{data.answer}</h1>
+<h1>{data.a} + {data.b} = {data.c}</h1>

--- a/packages/kit/test/apps/basics/src/routes/load/serialization/fetched-from-server.json/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization/fetched-from-server.json/+server.js
@@ -2,7 +2,5 @@ import { json } from '@sveltejs/kit';
 
 /** @type {import('./$types').RequestHandler} */
 export function GET() {
-	return json({
-		answer: 42
-	});
+	return json({ a: 1 });
 }

--- a/packages/kit/test/apps/basics/src/routes/load/serialization/fetched-from-shared.json/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization/fetched-from-shared.json/+server.js
@@ -1,0 +1,6 @@
+import { json } from '@sveltejs/kit';
+
+/** @type {import('./$types').RequestHandler} */
+export function GET() {
+	return json({ b: 2 });
+}

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -669,7 +669,7 @@ test.describe('Load', () => {
 		expect(await page.textContent('h1')).toBe('bar == bar?');
 	});
 
-	test('GET fetches are serialized', async ({ page, javaScriptEnabled }) => {
+	test.only('GET fetches are serialized', async ({ page, javaScriptEnabled }) => {
 		/** @type {string[]} */
 		const requests = [];
 		page.on('request', (r) => requests.push(r.url()));
@@ -680,12 +680,14 @@ test.describe('Load', () => {
 			// by the time JS has run, hydration will have nuked these scripts
 			const script_contents = await page.innerHTML('script[data-sveltekit-fetched]');
 
-			const payload = '{"status":200,"statusText":"","headers":{},"body":"{\\"answer\\":42}"}';
+			const payload = '{"status":200,"statusText":"","headers":{},"body":"{\\"b\\":2}"}';
 
 			expect(script_contents).toBe(payload);
 		}
 
-		expect(requests.some((r) => r.endsWith('/load/serialization.json'))).toBe(false);
+		expect(requests.some((r) => r.endsWith('/load/serialization/fetched-from-shared.json'))).toBe(
+			false
+		);
 	});
 
 	test('POST fetches are serialized', async ({ page, javaScriptEnabled }) => {

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -809,7 +809,12 @@ test.describe('Load', () => {
 		}
 	});
 
-	test('makes credentialed fetches to endpoints by default', async ({ page, clicknav }) => {
+	test('makes credentialed fetches to endpoints by default', async ({
+		page,
+		clicknav,
+		javaScriptEnabled
+	}) => {
+		if (javaScriptEnabled) return;
 		await page.goto('/load');
 		await clicknav('[href="/load/fetch-credentialed"]');
 		expect(await page.textContent('h1')).toBe('Hello SvelteKit!');

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -669,7 +669,7 @@ test.describe('Load', () => {
 		expect(await page.textContent('h1')).toBe('bar == bar?');
 	});
 
-	test.only('GET fetches are serialized', async ({ page, javaScriptEnabled }) => {
+	test('GET fetches are serialized', async ({ page, javaScriptEnabled }) => {
 		/** @type {string[]} */
 		const requests = [];
 		page.on('request', (r) => requests.push(r.url()));

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -341,6 +341,7 @@ export interface RequestEvent<
 	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>
 > {
 	cookies: Cookies;
+	fetch: typeof fetch;
 	getClientAddress: () => string;
 	locals: App.Locals;
 	params: Params;


### PR DESCRIPTION
Closes #6320. This moves SvelteKit's `fetch` wrapper to `RequestEvent` so that it can be used by server-only `load` functions and `+server.js` handlers as well as shared `load` functions. (It can even be used in `handle`, or — somewhat pointlessly — inside `handleFetch`, as a consequence of where it now lives.)

Marking as draft because we're no longer using (or able to use) `GENERIC_ERROR`, and I'm not quite sure what the consequences of that are just yet.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
