### PR TITLE
[docs] error create note on route `+page/layout.server.js`

### DIFF
--- a/documentation/docs/03-routing.md
+++ b/documentation/docs/03-routing.md
@@ -79,6 +79,8 @@ You can find more information about these in [page options](/docs/page-options).
 
 If your `load` function can only run on the server — for example, if it needs to fetch data from a database or you need to access private [environment variables](/docs/modules#$env-static-private) like API keys — then you can rename `+page.js` to `+page.server.js` and change the `PageLoad` type to `PageServerLoad`.
 
+> note: make sure to add `+page.svelte` together with `+page.server.js` or it will throw error.
+
 ```js
 /// file: src/routes/blog/[slug]/+page.server.js
 
@@ -235,6 +237,8 @@ Data returned from a layout's `load` function is also available to all its child
 To run your layout's `load` function on the server, move it to `+layout.server.js`, and change the `LayoutLoad` type to `LayoutServerLoad`.
 
 Like `+layout.js`, `+layout.server.js` can export [page options](/docs/page-options) — `prerender`, `ssr` and `csr`.
+
+> note: make sure to add `+layout.svelte` together with `+layout.server.js` or it will throw error.
 
 ### +server
 


### PR DESCRIPTION
creating `+page.server.js` without `+page.svelte` or `+layout.server.js`  without `+layout.svelte` will throw error and it not mentioned on documentation. Mention it on docs will make easier to notify people when creating `*.server.js`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
