### PR TITLE
make comment, tests & docs match the new route naming

### DIFF
--- a/documentation/docs/03-routing.md
+++ b/documentation/docs/03-routing.md
@@ -67,7 +67,7 @@ export function load({ params }) {
 
 This function runs alongside `+page.svelte`, which means it runs on the server during server-side rendering and in the browser during client-side navigation. See [`load`](/docs/load) for full details of the API.
 
-As well as `load`, `page.js` can export values that configure the page's behaviour:
+As well as `load`, `+page.js` can export values that configure the page's behaviour:
 
 - `export const prerender = true` or `false` or `'auto'`
 - `export const ssr = true` or `false`

--- a/packages/kit/src/core/sync/write_types/index.spec.js
+++ b/packages/kit/src/core/sync/write_types/index.spec.js
@@ -60,7 +60,7 @@ async function run_test(dir, config = {}) {
 	}
 }
 
-test('Create $types for page.js', async () => {
+test('Create $types for +page.js', async () => {
 	await run_test('simple-page-shared-only');
 });
 

--- a/packages/kit/src/core/sync/write_types/test/layout-advanced/(main)/+page.js
+++ b/packages/kit/src/core/sync/write_types/test/layout-advanced/(main)/+page.js
@@ -1,1 +1,1 @@
-// test to see if layout adjusts correctly if page.js exists, but no load function
+// test to see if layout adjusts correctly if +page.js exists, but no load function

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -655,7 +655,7 @@ test.describe('SPA mode / no SSR', () => {
 		expect(read_errors('/no-ssr/browser-only-global')).toBe(undefined);
 	});
 
-	test('Can use browser-only global on client-only page through ssr config in layout.js', async ({
+	test('Can use browser-only global on client-only page through ssr config in +layout.js', async ({
 		page,
 		read_errors
 	}) => {
@@ -664,7 +664,7 @@ test.describe('SPA mode / no SSR', () => {
 		expect(read_errors('/no-ssr/ssr-page-config')).toBe(undefined);
 	});
 
-	test('Can use browser-only global on client-only page through ssr config in page.js', async ({
+	test('Can use browser-only global on client-only page through ssr config in +page.js', async ({
 		page,
 		read_errors
 	}) => {
@@ -673,7 +673,7 @@ test.describe('SPA mode / no SSR', () => {
 		expect(read_errors('/no-ssr/ssr-page-config/layout/inherit')).toBe(undefined);
 	});
 
-	test('Cannot use browser-only global on page because of ssr config in page.js', async ({
+	test('Cannot use browser-only global on page because of ssr config in +page.js', async ({
 		page
 	}) => {
 		await page.goto('/no-ssr/ssr-page-config/layout/overwrite');


### PR DESCRIPTION
There are mentiones of `page.js` and `layout.js` where instead `+page.js` and `+layout.js` should be mentioned.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
