### PR TITLE
[fix] service-worker builder constant replacement

### DIFF
--- a/.changeset/chilled-suns-travel.md
+++ b/.changeset/chilled-suns-travel.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Apply define config to service worker

--- a/documentation/docs/10-service-workers.md
+++ b/documentation/docs/10-service-workers.md
@@ -8,6 +8,6 @@ In SvelteKit, if you have a `src/service-worker.js` file (or `src/service-worker
 
 > You can change the [location of your service worker](/docs/configuration#files) and [disable automatic registration](/docs/configuration#serviceworker) in your project configuration.
 
-Inside the service worker you have access to the [`$service-worker` module](/docs/modules#$service-worker).
+Inside the service worker you have access to the [`$service-worker` module](/docs/modules#$service-worker). If your Vite config specifies `define`, this will be applied to service workers as well as your server/client builds.
 
 Because it needs to be bundled (since browsers don't yet support `import` in this context), and depends on the client-side app's build manifest, **service workers only work in the production build, not in development**. To test it locally, use `vite preview`.

--- a/packages/kit/src/exports/vite/build/build_service_worker.js
+++ b/packages/kit/src/exports/vite/build/build_service_worker.js
@@ -16,7 +16,7 @@ import { assets_base } from './utils.js';
  * @param {import('vite').Manifest} client_manifest
  */
 export async function build_service_worker(
-	{ config, manifest_data, output_dir, service_worker_entry_file },
+	{ config, vite_config, manifest_data, output_dir, service_worker_entry_file },
 	prerendered,
 	client_manifest
 ) {
@@ -79,6 +79,7 @@ export async function build_service_worker(
 			outDir: `${output_dir}/client`,
 			emptyOutDir: false
 		},
+		define: vite_config.define,
 		configFile: false,
 		resolve: {
 			alias: {

--- a/packages/kit/test/prerendering/basics/src/service-worker.js
+++ b/packages/kit/test/prerendering/basics/src/service-worker.js
@@ -1,0 +1,3 @@
+if (process.env.MY_ENV === 'MY_ENV DEFINED') {
+	console.log(process.env.MY_ENV);
+}

--- a/packages/kit/test/prerendering/basics/test/test.js
+++ b/packages/kit/test/prerendering/basics/test/test.js
@@ -230,4 +230,9 @@ test('injects relative service worker', () => {
 	assert.ok(content.includes(`navigator.serviceWorker.register('./service-worker.js')`));
 });
 
+test('define service worker variables', () => {
+	const content = read('service-worker.js');
+	assert.ok(content.includes(`MY_ENV DEFINED`));
+});
+
 test.run();

--- a/packages/kit/test/prerendering/basics/vite.config.js
+++ b/packages/kit/test/prerendering/basics/vite.config.js
@@ -13,6 +13,10 @@ const config = {
 
 	plugins: [sveltekit()],
 
+	define: {
+		'process.env.MY_ENV': '"MY_ENV DEFINED"'
+	},
+
 	server: {
 		fs: {
 			allow: [path.resolve('../../../src')]


### PR DESCRIPTION
Closes https://github.com/sveltejs/kit/issues/6329 and https://github.com/sveltejs/kit/issues/5682.

Implements Option 1 proposed by @Rich-Harris in https://github.com/sveltejs/kit/issues/6329#issuecomment-1229207997

Vite constant replacement using define only applies to service-worker builder.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
