### PR TITLE
[chore] remove unnecessary Request pseudo-header removal

### DIFF
--- a/.changeset/early-kiwis-raise.md
+++ b/.changeset/early-kiwis-raise.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[chore] Skip removing HTTP/2 pseudo-headers, which is no longer necessary with undici

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -94,21 +94,9 @@ function get_raw_body(req, body_size_limit) {
 
 /** @type {import('@sveltejs/kit/node').getRequest} */
 export async function getRequest({ request, base, bodySizeLimit }) {
-	let headers = /** @type {Record<string, string>} */ (request.headers);
-	if (request.httpVersionMajor === 2) {
-		// we need to strip out the HTTP/2 pseudo-headers because node-fetch's
-		// Request implementation doesn't like them
-		// TODO is this still true with Node 18
-		headers = Object.assign({}, headers);
-		delete headers[':method'];
-		delete headers[':path'];
-		delete headers[':authority'];
-		delete headers[':scheme'];
-	}
-
 	return new Request(base + request.url, {
 		method: request.method,
-		headers,
+		headers: /** @type {Record<string, string>} */ (request.headers),
 		body: get_raw_body(request, bodySizeLimit)
 	});
 }


### PR DESCRIPTION
In #3572 to fix #3566 we started stripping HTTP/2 pseudo-headers from the incoming requests because `node-fetch`'s `Request` implementation couldn't handle them. This may or may not have been possible to revert when we switched to `undici` and were only using `node-fetch` for its multipart formdata handle - but it should certainly be possible now that we're not using `node-fetch` at all.

My understanding is that there's currently something else amiss with Vite's `--https` mode, so I tested this with the Node adapter and a custom entrypoint defining an HTTP/2 server, as described in #3566, and things seemed to work fine.

This change _does_ mean that `event.request.headers` will start having these HTTP/2 pseudo-headers present when an HTTP/2 server is being used, but this is probably safe - especially since we're no longer automatically copying incoming request headers into outgoing request headers for server-side `fetch`es.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
