### PR TITLE
[fix] clear out build directory when running `adapter-netlify`

### DIFF
--- a/.changeset/sharp-lies-grin.md
+++ b/.changeset/sharp-lies-grin.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-netlify": patch
+---
+
+[fix] clear out build directory when running `adapter-netlify`

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -45,6 +45,7 @@ export default function ({ split = false, edge = edge_set_in_env_var } = {}) {
 			const publish = get_publish_directory(netlify_config, builder) || 'build';
 
 			// empty out existing build directories
+			builder.rimraf(publish);
 			builder.rimraf('.netlify/edge-functions');
 			builder.rimraf('.netlify/functions-internal');
 			builder.rimraf('.netlify/server');


### PR DESCRIPTION
We used to do this and somehow lost it, which has been causing me frustration. I'm pretty sure we do it in the other adapters though I didn't confirm that