### PR TITLE
[fix] fetch erroring on Cloudflare

### DIFF
--- a/.changeset/tidy-tables-think.md
+++ b/.changeset/tidy-tables-think.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] fetch erroring on Cloudflare

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -34,7 +34,8 @@ export function create_fetch({ event, options, state, get_cookie_header }) {
 				// Remove Origin, according to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin#description
 				if (
 					(request.method === 'GET' || request.method === 'HEAD') &&
-					((request.mode === 'no-cors' && url.origin !== event.url.origin) ||
+					((('cf' in request ? 'cors' : request.mode) === 'no-cors' &&
+						url.origin !== event.url.origin) ||
 						url.origin === event.url.origin)
 				) {
 					request.headers.delete('origin');
@@ -51,7 +52,7 @@ export function create_fetch({ event, options, state, get_cookie_header }) {
 					// leading dot prevents mydomain.com matching domain.com
 					if (
 						`.${url.hostname}`.endsWith(`.${event.url.hostname}`) &&
-						request.credentials !== 'omit'
+						('cf' in request ? 'same-origin' : request.credentials) !== 'omit'
 					) {
 						const cookie = get_cookie_header(url, request.headers.get('cookie'));
 						if (cookie) request.headers.set('cookie', cookie);
@@ -59,7 +60,7 @@ export function create_fetch({ event, options, state, get_cookie_header }) {
 
 					let response = await fetch(request);
 
-					if (request.mode === 'no-cors') {
+					if (('cf' in request ? 'cors' : request.mode) === 'no-cors') {
 						response = new Response('', {
 							status: response.status,
 							statusText: response.statusText,
@@ -112,7 +113,7 @@ export function create_fetch({ event, options, state, get_cookie_header }) {
 					return await fetch(request);
 				}
 
-				if (request.credentials !== 'omit') {
+				if (('cf' in request ? 'same-origin' : request.credentials) !== 'omit') {
 					const cookie = get_cookie_header(url, request.headers.get('cookie'));
 					if (cookie) {
 						request.headers.set('cookie', cookie);


### PR DESCRIPTION
Fixes #6739

Ever since #6565 calling `fetch` in a load function fails on Cloudflare (Pages+Workers). This solution checks for the unique `cf` object that Cloudflare sets to bypass properties Cloudflare does not provide, assuming reasonable defaults.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
