### PR TITLE
Add alternative prefix for actions

### DIFF
--- a/documentation/docs/06-form-actions.md
+++ b/documentation/docs/06-form-actions.md
@@ -63,7 +63,7 @@ export const actions = {
 };
 ```
 
-To invoke a named action, add a query parameter with the name prefixed by a `/` character:
+To invoke a named action, add a query parameter with the name prefixed by a `/` or `.` character:
 
 ```svelte
 /// file: src/routes/login/+page.svelte

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -165,9 +165,9 @@ export async function call_action(event, actions) {
 	const url = new URL(event.request.url);
 
 	let name = 'default';
-	for (const param of url.searchParams) {
-		if (param[0].startsWith('/')) {
-			name = param[0].slice(1);
+	for (const param of url.searchParams.keys()) {
+		if (param[0] === '/' || param[0] === '.') {
+			name = param.slice(1);
 			if (name === 'default') {
 				throw new Error('Cannot use reserved action name "default"');
 			}

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.svelte
@@ -16,6 +16,7 @@
 <form method="post" action="?/login" use:enhance>
 	<input name="username" type="text" />
 	<button class="form1">Submit</button>
+	<button class="form1-prefix" formAction="?.login">Submit</button>
 	<button class="form1-register" formAction="?/register">Submit</button>
 	<button class="form1-submitter" formAction="?/submitter" name="submitter" value="foo">Submit</button>
 </form>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1894,6 +1894,20 @@ test.describe('Actions', () => {
 		);
 	});
 
+	test('use:enhance with alternative prefix', async ({ page }) => {
+		await page.goto('/actions/enhance');
+
+		expect(await page.textContent('pre.formdata1')).toBe(JSON.stringify(null));
+
+		await page.type('input[name="username"]', 'bar');
+		await Promise.all([
+			page.waitForRequest((request) => request.url().includes('/actions/enhance')),
+			page.click('button.form1-prefix')
+		]);
+
+		await expect(page.locator('pre.formdata1')).toHaveText(JSON.stringify({ result: 'bar' }));
+	});
+
 	test('use:enhance button with name', async ({ page, app }) => {
 		await page.goto('/actions/enhance');
 


### PR DESCRIPTION
Closes #7098 

I propose to use a second alternative prefix character  `.` for actions along with `/`
`.` is not on the reserved list of legacy [rfc2396](https://www.ietf.org/rfc/rfc2396.html#section-3.4)
there are no special notes for it in [rfc3986](https://www.ietf.org/rfc/rfc3986.html#section-3.4) and does not require escaping
 It also looks like an [optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) `action="?.login"`

```js
// '.login='
new URLSearchParams({'.login': ''}).toString();

// '%2Flogin='
new URLSearchParams({'/login': ''}).toString();
```

An alternative would be to specify the prefix in the configuration, but that seems a bit redundant.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
