### PR TITLE
[fix] postinstall working on node 14

### DIFF
--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -617,7 +617,9 @@ export function tweak_types(content, is_server) {
 					}
 				}
 			}
-			modified ||= _modified;
+			if (!modified) {
+				modified = _modified;
+			}
 			return _modified;
 		}
 

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -617,9 +617,7 @@ export function tweak_types(content, is_server) {
 					}
 				}
 			}
-			if (!modified) {
-				modified = _modified;
-			}
+			modified = modified || _modified;
 			return _modified;
 		}
 


### PR DESCRIPTION
Fixes: #7201

Updating the syntax of sveltekit postinstall script so that in a library handling node 14 nothing is complaining.
This PR is not meant to support node 14 in SvelteKit, it's just to pass postinstall script for libs supporting node 14 is other environements.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
