### PR TITLE
prevent overflowing headers in search results

### DIFF
--- a/sites/kit.svelte.dev/src/lib/search/SearchResultList.svelte
+++ b/sites/kit.svelte.dev/src/lib/search/SearchResultList.svelte
@@ -103,6 +103,8 @@
 		display: block;
 		white-space: nowrap;
 		line-height: 1;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	a strong {
@@ -113,8 +115,6 @@
 	a span {
 		font-size: 1.2rem;
 		color: #737373;
-		overflow: hidden;
-		text-overflow: ellipsis;
 		margin: 0.4rem 0 0 0;
 	}
 


### PR DESCRIPTION
Fixes this:

<img width="535" alt="image" src="https://user-images.githubusercontent.com/1162160/194904610-1560b480-f0ad-47d4-8065-ac62861a2ac1.png">
