### PR TITLE
fix flexsearch usage

### DIFF
--- a/sites/kit.svelte.dev/src/lib/search/search.js
+++ b/sites/kit.svelte.dev/src/lib/search/search.js
@@ -17,10 +17,7 @@ export function init(blocks) {
 	// we have multiple indexes, so we can rank sections (migration guide comes last)
 	const max_rank = Math.max(...blocks.map((block) => block.rank ?? 0));
 
-	indexes = Array.from(
-		{ length: max_rank + 1 },
-		() => new flexsearch.Index({ tokenize: 'forward' })
-	);
+	indexes = Array.from({ length: max_rank + 1 }, () => new flexsearch({ tokenize: 'forward' }));
 
 	for (const block of blocks) {
 		const title = block.breadcrumbs[block.breadcrumbs.length - 1];


### PR DESCRIPTION
According to https://github.com/nextapps-de/flexsearch/blob/9abb781357f04e7db8529654c6941009771f4bf1/src/index.js#L106, `Index` is now the default export.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
