### PR TITLE
sync: account for relative route path

### DIFF
--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -66,7 +66,7 @@ export async function write_all_types(config, manifest_data) {
 	for (const route of manifest_data.routes) {
 		if (!route.leaf && !route.layout && !route.endpoint) continue; // nothing to do
 
-		const outdir = path.join(config.kit.outDir, 'types', routes_dir, route.id);
+		const outdir = path.join(config.kit.outDir, 'types', routes_dir.replace(/\.\.\//g, ''), route.id);
 
 		// check if the types are out of date
 		/** @type {string[]} */
@@ -180,7 +180,7 @@ function create_routes_map(manifest_data) {
  */
 function update_types(config, routes, route, to_delete = new Set()) {
 	const routes_dir = posixify(path.relative('.', config.kit.files.routes));
-	const outdir = path.join(config.kit.outDir, 'types', routes_dir, route.id);
+	const outdir = path.join(config.kit.outDir, 'types', routes_dir.replace(/\.\.\//g, ''), route.id);
 
 	// now generate new types
 	const imports = [`import type * as Kit from '@sveltejs/kit';`];


### PR DESCRIPTION
Currently when using relative route path in `config.kit.files.routes` e.g. `../../project/src/routes` sync fails because it generates types outside of `.svelte-kit/types`  It should account for relative paths and generate them inside `.svelte-kit/types`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
