### PR TITLE
add custom error message for `throw invalid()` in actions

### DIFF
--- a/.changeset/pretty-scissors-march.md
+++ b/.changeset/pretty-scissors-march.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+add helpful error message for `throw invalid()` in form actions

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -62,10 +62,6 @@ export async function handle_action_json_request(event, options, server) {
 			});
 		}
 
-		if (!(error instanceof HttpError)) {
-			options.handle_error(error, event);
-		}
-
 		return action_json(
 			{
 				type: 'error',

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -69,19 +69,22 @@ export async function handle_action_json_request(event, options, server) {
 		return action_json(
 			{
 				type: 'error',
-				error: handle_error_and_jsonify(
-					event,
-					options,
-					error instanceof ValidationError
-						? new Error(`Cannot "throw invalid()". Use "return invalid()"`)
-						: error
-				)
+				error: handle_error_and_jsonify(event, options, check_incorrect_invalid_use(error))
 			},
 			{
 				status: error instanceof HttpError ? error.status : 500
 			}
 		);
 	}
+}
+
+/**
+ * @param {HttpError | Error} error
+ */
+function check_incorrect_invalid_use(error) {
+	return error instanceof ValidationError
+		? new Error(`Cannot "throw invalid()". Use "return invalid()"`)
+		: error;
 }
 
 /**
@@ -149,10 +152,7 @@ export async function handle_action_request(event, server) {
 
 		return {
 			type: 'error',
-			error:
-				error instanceof ValidationError
-					? new Error(`Cannot "throw invalid()". Use "return invalid()"`)
-					: error
+			error: check_incorrect_invalid_use(error)
 		};
 	}
 }

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -133,6 +133,10 @@ export async function handle_action_request(event, server) {
 	} catch (e) {
 		const error = normalize_error(e);
 
+		if (error instanceof ValidationError) {
+			throw new Error(`Cannot "throw invalid()". Use "return invalid()"`);
+		}
+
 		if (error instanceof Redirect) {
 			return {
 				type: 'redirect',

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -54,10 +54,6 @@ export async function handle_action_json_request(event, options, server) {
 	} catch (e) {
 		const error = normalize_error(e);
 
-		if (error instanceof ValidationError) {
-			throw new Error(`Cannot "throw invalid()". Use "return invalid()"`);
-		}
-
 		if (error instanceof Redirect) {
 			return action_json({
 				type: 'redirect',
@@ -73,7 +69,13 @@ export async function handle_action_json_request(event, options, server) {
 		return action_json(
 			{
 				type: 'error',
-				error: handle_error_and_jsonify(event, options, error)
+				error: handle_error_and_jsonify(
+					event,
+					options,
+					error instanceof ValidationError
+						? new Error(`Cannot "throw invalid()". Use "return invalid()"`)
+						: error
+				)
 			},
 			{
 				status: error instanceof HttpError ? error.status : 500
@@ -137,10 +139,6 @@ export async function handle_action_request(event, server) {
 	} catch (e) {
 		const error = normalize_error(e);
 
-		if (error instanceof ValidationError) {
-			throw new Error(`Cannot "throw invalid()". Use "return invalid()"`);
-		}
-
 		if (error instanceof Redirect) {
 			return {
 				type: 'redirect',
@@ -149,7 +147,13 @@ export async function handle_action_request(event, server) {
 			};
 		}
 
-		return { type: 'error', error };
+		return {
+			type: 'error',
+			error:
+				error instanceof ValidationError
+					? new Error(`Cannot "throw invalid()". Use "return invalid()"`)
+					: error
+		};
 	}
 }
 

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -54,6 +54,10 @@ export async function handle_action_json_request(event, options, server) {
 	} catch (e) {
 		const error = normalize_error(e);
 
+		if (error instanceof ValidationError) {
+			throw new Error(`Cannot "throw invalid()". Use "return invalid()"`);
+		}
+
 		if (error instanceof Redirect) {
 			return action_json({
 				type: 'redirect',


### PR DESCRIPTION
fixes #7224 
Throws an error that suggests a fix instead of displaying `[object Object]`.

The new error message:
`Cannot "throw invalid()". Use "return invalid()"`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
