### PR TITLE
Fix sverdle form reset

### DIFF
--- a/.changeset/yellow-kids-marry.md
+++ b/.changeset/yellow-kids-marry.md
@@ -1,5 +1,5 @@
 ---
-'create-svelte': minor
+'create-svelte': patch
 ---
 
 fix sverdle guesses incorrectly cleared by form `enhance`

--- a/.changeset/yellow-kids-marry.md
+++ b/.changeset/yellow-kids-marry.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': minor
+---
+
+fix sverdle guesses incorrectly cleared by form `enhance`

--- a/packages/create-svelte/templates/default/src/routes/sverdle/+page.svelte
+++ b/packages/create-svelte/templates/default/src/routes/sverdle/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { confetti } from '@neoconfetti/svelte';
-	import { enhance } from '$app/forms';
+	import { applyAction, enhance } from '$app/forms';
 	import type { PageData, ActionData } from './$types';
+	import { invalidateAll } from '$app/navigation';
 
 	/** @type {import('./$types').PageData} */
 	export let data: PageData;
@@ -78,7 +79,19 @@
 
 <svelte:window on:keydown={keydown} />
 
-<form method="POST" action="?/enter" use:enhance>
+<form
+	method="POST"
+	action="?/enter"
+	use:enhance={() => {
+		// prevent default callback from resetting the form
+		return async ({ result }) => {
+			if (result.type === 'success') {
+				await invalidateAll();
+			}
+			await applyAction(result);
+		};
+	}}
+>
 	<a class="how-to-play" href="/sverdle/how-to-play">How to play</a>
 
 	<div class="grid" class:playing={!won} class:bad-guess={form?.badGuess}>


### PR DESCRIPTION
fixes #7238
provides a custom form `enhance` callback for the demo app `/sverdle` to prevent `form.reset()` being called by the default callback.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
