### PR TITLE
fix: properly convert absolute paths to relative

### DIFF
--- a/.changeset/ten-pets-tease.md
+++ b/.changeset/ten-pets-tease.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Properly resolve absolute paths to relative on server build

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -354,7 +354,9 @@ function get_methods(cwd, output, manifest_data) {
 	const lookup = {};
 	output.forEach((chunk) => {
 		if (!chunk.facadeModuleId) return;
-		const id = chunk.facadeModuleId.slice(cwd.length + 1);
+		const relative = path.relative(cwd, chunk.facadeModuleId);
+        // in case it's on windows - replace backslash with forward slash
+		const id = relative.replace(/\\/g, '/');
 		lookup[id] = chunk.exports;
 	});
 

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -354,9 +354,7 @@ function get_methods(cwd, output, manifest_data) {
 	const lookup = {};
 	output.forEach((chunk) => {
 		if (!chunk.facadeModuleId) return;
-		const relative = path.relative(cwd, chunk.facadeModuleId);
-		// in case it's on windows - replace backslash with forward slash
-		const id = relative.replace(/\\/g, '/');
+		const id = posixify(path.relative(cwd, chunk.facadeModuleId));
 		lookup[id] = chunk.exports;
 	});
 

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -355,7 +355,7 @@ function get_methods(cwd, output, manifest_data) {
 	output.forEach((chunk) => {
 		if (!chunk.facadeModuleId) return;
 		const relative = path.relative(cwd, chunk.facadeModuleId);
-        // in case it's on windows - replace backslash with forward slash
+		// in case it's on windows - replace backslash with forward slash
 		const id = relative.replace(/\\/g, '/');
 		lookup[id] = chunk.exports;
 	});


### PR DESCRIPTION
fixes: #7166

Continuation, because I've noticed that it does not correctly resolve absolute paths to relative - if routes are relative paths outside of `cmd`  Also I think it's more robust  way to get relative path rather than using splice.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
