### PR TITLE
Fixing the Skeleton Template's svelte.config.js

### DIFF
--- a/packages/create-svelte/templates/skeleton/svelte.config.js
+++ b/packages/create-svelte/templates/skeleton/svelte.config.js
@@ -1,11 +1,11 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapters from '@sveltejs/adapter-auto';
 
 // This config is ignored and replaced with one of the configs in the shared folder when a project is created.
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter()
+		adapter: adapters()
 	}
 };
 


### PR DESCRIPTION
There isn't an issue opened for this issue, I just noticed it when I created a new Svelte Project. 

When I created the project, and opened it in VSCode, it gave me an error saying that svelte.config.js couldn't find the `adapter` variable. I went and checked the node module for `@sveltejs/adapter-auto` and sure enough, the exported variable is `adapters` not `adapter` so, I updated the import on the config file, and the error went away. 

Not a super big issue, but just something I noticed. 
