### PR TITLE
Direct user to publish `./package/` directory instead of `./`

### DIFF
--- a/.changeset/wild-bags-cheat.md
+++ b/.changeset/wild-bags-cheat.md
@@ -1,0 +1,9 @@
+---
+'create-svelte': patch
+---
+
+After running `svelte-package` (via `create-svelte`), the user is supposed to
+run: `npm publish package/`. However, I keep accidentally running `npm publish`
+(the wrong directory) out of habit, instead.
+With this change, when the user accidentally tries to publish the `./`
+directory, they will be directed to publish the `./package/` directory instead.

--- a/.changeset/wild-bags-cheat.md
+++ b/.changeset/wild-bags-cheat.md
@@ -3,7 +3,7 @@
 ---
 
 After running `svelte-package` (via `create-svelte`), the user is supposed to
-run: `npm publish package/`. However, I keep accidentally running `npm publish`
-(the wrong directory) out of habit, instead.
-With this change, when the user accidentally tries to publish the `./`
-directory, they will be directed to publish the `./package/` directory instead.
+run: `npm publish package/`. However, it is easy to accidentally run 
+`npm publish` on the wrong directory out of habit. With this change, 
+when the user accidentally tries to publish the `./` directory, they will be 
+directed to publish the `./package/` directory instead.

--- a/.changeset/wild-bags-cheat.md
+++ b/.changeset/wild-bags-cheat.md
@@ -2,8 +2,4 @@
 'create-svelte': patch
 ---
 
-After running `svelte-package` (via `create-svelte`), the user is supposed to
-run: `npm publish package/`. However, it is easy to accidentally run 
-`npm publish` on the wrong directory out of habit. With this change, 
-when the user accidentally tries to publish the `./` directory, they will be 
-directed to publish the `./package/` directory instead.
+Warn user when they accidentally try to publish the `./` directory

--- a/packages/create-svelte/templates/skeletonlib/package.template.json
+++ b/packages/create-svelte/templates/skeletonlib/package.template.json
@@ -3,7 +3,8 @@
 	"version": "0.0.1",
 	"scripts": {
 		"dev": "vite dev",
-		"build": "svelte-kit sync && svelte-package"
+		"build": "svelte-kit sync && svelte-package",
+		"prepublishOnly": "echo 'Did you mean to publish `./package/`, instead of `./`?\n' && exit 1"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "workspace:*",

--- a/packages/create-svelte/templates/skeletonlib/package.template.json
+++ b/packages/create-svelte/templates/skeletonlib/package.template.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"dev": "vite dev",
 		"build": "svelte-kit sync && svelte-package",
-		"prepublishOnly": "echo 'Did you mean to publish `./package/`, instead of `./`?\n' && exit 1"
+		"prepublishOnly": "echo 'Did you mean to publish `./package/`, instead of `./`?' && exit 1"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "workspace:*",


### PR DESCRIPTION
After running `svelte-package` (via `create-svelte`), the user is supposed to
run: `npm publish package/`. However, it is easy to accidentally run 
`npm publish` on the wrong directory out of habit. With this change, 
when the user accidentally tries to publish the `./` directory, they will be 
directed to publish the `./package/` directory instead.

In case it is useful, thanks.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
