### PR TITLE
Update routing docs so `+server` code example route has file extension.

### DIFF
--- a/documentation/docs/03-routing.md
+++ b/documentation/docs/03-routing.md
@@ -240,10 +240,10 @@ Like `+layout.js`, `+layout.server.js` can export [page options](/docs/page-opti
 
 As well as pages, you can define routes with a `+server.js` file (sometimes referred to as an 'API route' or an 'endpoint'), which gives you full control over the response. Your `+server.js` file (or `+server.ts`) exports functions corresponding to HTTP verbs like `GET`, `POST`, `PATCH`, `PUT` and `DELETE` that take a `RequestEvent` argument and return a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) object.
 
-For example we could create an `/api/random-number` route with a `GET` handler:
+For example we could create an `/api/random-number.xml` route with a `GET` handler:
 
 ```js
-/// file: src/routes/api/random-number/+server.js
+/// file: src/routes/api/random-number.xml/+server.js
 import { error } from '@sveltejs/kit';
 
 /** @type {import('./$types').RequestHandler} */
@@ -257,9 +257,12 @@ export function GET({ url }) {
 		throw error(400, 'min and max must be numbers, and min must be less than max');
 	}
 
-	const random = min + Math.random() * d;
+	const random = String(min + Math.random() * d);
 
-	return new Response(String(random));
+	return new Response(
+		`<?xml version="1.0" encoding="UTF-8"?><number>${random}</number>`,
+		{ headers: { 'Content-Type': 'application/xml' }}
+	);
 }
 ```
 


### PR DESCRIPTION
Update routing docs so `+server` code example route has file extension.
Route now has a file with extension (`.xml`), instead of bare. It took me a while to figure this out, I don't think there are any other docs about it.
In case it's helpful, thanks.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
