### PR TITLE
remove non-browser code from browser builds

### DIFF
--- a/.changeset/real-taxis-march.md
+++ b/.changeset/real-taxis-march.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Enable removal of non-browser code from client builds

--- a/packages/kit/src/exports/vite/build/utils.js
+++ b/packages/kit/src/exports/vite/build/utils.js
@@ -136,6 +136,7 @@ export function get_default_build_config({ config, input, ssr, outDir }) {
 			__SVELTEKIT_APP_VERSION__: JSON.stringify(config.kit.version.name),
 			__SVELTEKIT_APP_VERSION_FILE__: JSON.stringify(`${config.kit.appDir}/version.json`),
 			__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: JSON.stringify(config.kit.version.pollInterval),
+			__SVELTEKIT_BROWSER__: ssr ? 'false' : 'true',
 			__SVELTEKIT_DEV__: 'false'
 		},
 		publicDir: ssr ? false : config.kit.files.assets,

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -30,6 +30,9 @@ const cwd = process.cwd();
 export async function dev(vite, vite_config, svelte_config) {
 	installPolyfills();
 
+	// @ts-expect-error
+	globalThis.__SVELTEKIT_BROWSER__ = false;
+
 	sync.init(svelte_config, vite_config.mode);
 
 	/** @type {import('types').Respond} */

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -249,8 +249,9 @@ function kit() {
 					}
 				},
 				define: {
-					__SVELTEKIT_DEV__: 'true',
-					__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: '0'
+					__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: '0',
+					__SVELTEKIT_BROWSER__: !config_env.ssrBuild,
+					__SVELTEKIT_DEV__: 'true'
 				},
 				publicDir: svelte_config.kit.files.assets,
 				resolve: {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -250,7 +250,7 @@ function kit() {
 				},
 				define: {
 					__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: '0',
-					__SVELTEKIT_BROWSER__: !config_env.ssrBuild,
+					__SVELTEKIT_BROWSER__: config_env.ssrBuild ? 'false' : 'true',
 					__SVELTEKIT_DEV__: 'true'
 				},
 				publicDir: svelte_config.kit.files.assets,

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -103,10 +103,12 @@ export function make_trackable(url, callback) {
 		});
 	}
 
-	// @ts-ignore
-	tracked[Symbol.for('nodejs.util.inspect.custom')] = (depth, opts, inspect) => {
-		return inspect(url, opts);
-	};
+	if (!__SVELTEKIT_BROWSER__) {
+		// @ts-ignore
+		tracked[Symbol.for('nodejs.util.inspect.custom')] = (depth, opts, inspect) => {
+			return inspect(url, opts);
+		};
+	}
 
 	disable_hash(tracked);
 

--- a/packages/kit/src/utils/url.spec.js
+++ b/packages/kit/src/utils/url.spec.js
@@ -2,7 +2,7 @@ import * as assert from 'uvu/assert';
 import { describe } from './unit_test.js';
 import { resolve, normalize_path, make_trackable, disable_search } from './url.js';
 
-// define global required in url.js
+// @ts-expect-error define global required in url.js
 globalThis.__SVELTEKIT_BROWSER__ = false;
 
 describe('resolve', (test) => {

--- a/packages/kit/src/utils/url.spec.js
+++ b/packages/kit/src/utils/url.spec.js
@@ -2,6 +2,9 @@ import * as assert from 'uvu/assert';
 import { describe } from './unit_test.js';
 import { resolve, normalize_path, make_trackable, disable_search } from './url.js';
 
+// define global required in url.js
+globalThis.__SVELTEKIT_BROWSER__ = false;
+
 describe('resolve', (test) => {
 	test('resolves a root-relative path', () => {
 		assert.equal(resolve('/a/b/c', '/x/y/z'), '/x/y/z');

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -375,5 +375,6 @@ declare global {
 	const __SVELTEKIT_APP_VERSION__: string;
 	const __SVELTEKIT_APP_VERSION_FILE__: string;
 	const __SVELTEKIT_APP_VERSION_POLL_INTERVAL__: number;
+	const __SVELTEKIT_BROWSER__: boolean;
 	const __SVELTEKIT_DEV__: boolean;
 }


### PR DESCRIPTION
This is a small thing but I noticed we're including this code in production client builds, quite unnecessarily. There might be other cases, and after this PR we can just wrap them in a `if (!__SVELTEKIT_BROWSER__)` block to remove them from client builds.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
