### PR TITLE
[fix] add $types to includes for better DX

### DIFF
--- a/.changeset/spotty-kangaroos-peel.md
+++ b/.changeset/spotty-kangaroos-peel.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] add \$types to includes for better DX

--- a/.changeset/spotty-kangaroos-peel.md
+++ b/.changeset/spotty-kangaroos-peel.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-[fix] add \$types to includes for better DX
+[fix] add `$types` to includes for better DX

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -46,7 +46,7 @@ export function write_tsconfig(config, cwd = process.cwd()) {
 	/** @param {string} file */
 	const config_relative = (file) => posixify(path.relative(config.outDir, file));
 
-	const include = ['ambient.d.ts', config_relative('vite.config.ts')];
+	const include = ['ambient.d.ts', './types/**/$types.d.ts', config_relative('vite.config.ts')];
 	for (const dir of [config.files.routes, config.files.lib]) {
 		const relative = project_relative(path.dirname(dir));
 		include.push(config_relative(`${relative}/**/*.js`));


### PR DESCRIPTION
$types.d.ts files not referenced in user code were not loaded on startup in the IDE, because the includes list did not contain references to them. This resulted in suboptimal DX because they're not part of autocompletion suggestions or even unrecognized then.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
