### PR TITLE
chore: improve error message for prefetching invalid url

### DIFF
--- a/.changeset/twenty-monkeys-glow.md
+++ b/.changeset/twenty-monkeys-glow.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Improve error message when prerendering fails
+Improve error message when prefetching fails

--- a/.changeset/twenty-monkeys-glow.md
+++ b/.changeset/twenty-monkeys-glow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Improve error message when prerendering fails

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -199,9 +199,7 @@ export function create_client({ target, base, trailing_slash }) {
 		const intent = get_navigation_intent(url, false);
 
 		if (!intent) {
-			throw new Error(
-				`Attempted to prefetch "${url}", a URL that does not belong to this app. To disable prefetching add data-sveltekit-prefetch="off" to a parent. See https://kit.svelte.dev/docs/link-options#data-sveltekit-prefetch for more information.`
-			);
+			throw new Error(`Attempted to prefetch a URL that does not belong to this app: ${url}`);
 		}
 
 		load_cache = { id: intent.id, promise: load_route(intent) };

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -199,7 +199,9 @@ export function create_client({ target, base, trailing_slash }) {
 		const intent = get_navigation_intent(url, false);
 
 		if (!intent) {
-			throw new Error('Attempted to prefetch a URL that does not belong to this app');
+			throw new Error(
+				`Attempted to prefetch "${url}", a URL that does not belong to this app. To disable prefetching add data-sveltekit-prefetch="off" to a parent. See https://kit.svelte.dev/docs/link-options#data-sveltekit-prefetch for more information.`
+			);
 		}
 
 		load_cache = { id: intent.id, promise: load_route(intent) };


### PR DESCRIPTION
Happened to come across `Uncaught (in promise) Error: Attempted to prefetch a URL that does not belong to this app ` in an app today and didn't immediately find the cause.

The url in the message can help finding where in the application it happened, also added some guidance and docs link for good measure.

In my case it was a link to a page that hadn't been created yet. If thats the only way to reach this error, maybe the url is enough to not confuse users into disabling prefetching too eagerly?


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
