### PR TITLE
remove root build script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm turbo run build --filter="./packages/*"
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # SvelteKit Contributing Guide
 
-## Building and Running
+## Preparing
 
 This is a monorepo, meaning the repo holds multiple packages. It requires the use of [pnpm](https://pnpm.js.org/en/). You can [install pnpm](https://pnpm.io/installation) with:
 
@@ -8,13 +8,12 @@ This is a monorepo, meaning the repo holds multiple packages. It requires the us
 npm i -g pnpm
 ```
 
-`pnpm` commands run in the project's root directory will run on all sub-projects. You can checkout the code and build all sub-projects with:
+`pnpm` commands run in the project's root directory will run on all sub-projects. You can checkout the code and install the dependencies with:
 
 ```bash
 git clone git@github.com:sveltejs/kit.git
 cd kit
 pnpm install
-pnpm build
 ```
 
 You can now run SvelteKit by linking it into your project with [pnpm `overrides`](https://pnpm.io/package_json#pnpmoverrides) as demonstrated in the [sandbox example](https://github.com/sveltejs/kit-sandbox) or by running one of the test projects as described in [the testing section](#testing) below.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
 	"description": "monorepo for @sveltejs/kit and friends",
 	"private": true,
 	"scripts": {
-		"build": "turbo run build --filter=./packages/*",
 		"test": "turbo run test --filter=./packages/* --force",
 		"check": "turbo run check",
 		"lint": "turbo run lint",


### PR DESCRIPTION
We're building 0 packages now

```sh
> pnpm turbo run build --filter="./packages/*"
• Packages in scope: 
• Running build in 0 packages

 Tasks:    0 successful, 0 total
Cached:    0 cached, 0 total
  Time:    183ms
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
