### PR TITLE
make options object optional

### DIFF
--- a/.changeset/chilled-students-unite.md
+++ b/.changeset/chilled-students-unite.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-static': patch
+---
+
+Make options object optional

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -24,7 +24,7 @@ export default function (options) {
 					};
 				});
 
-				if (dynamic_routes.length > 0 && options.strict) {
+				if (dynamic_routes.length > 0 && options?.strict !== false) {
 					const prefix = path.relative('.', builder.config.kit.files.routes);
 					const has_param_routes = dynamic_routes.some((route) => route.includes('['));
 					const config_option =


### PR DESCRIPTION
Fixes #7340.

We missed a bug in https://github.com/sveltejs/kit/pull/7264 — `strict` should be assumed to be `true`, and the `options` object should be optional

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
