### PR TITLE
Use `req.originalUrl` for better Vite compatibility

### DIFF
--- a/.changeset/lucky-moles-count.md
+++ b/.changeset/lucky-moles-count.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+Restore `req.url` to `req.originalUrl` in dev and preview

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -94,8 +94,7 @@ function get_raw_body(req, body_size_limit) {
 
 /** @type {import('@sveltejs/kit/node').getRequest} */
 export async function getRequest({ request, base, bodySizeLimit }) {
-	// @ts-expect-error - the request may be a connect request
-	return new Request(base + (request.originalUrl || request.url), {
+	return new Request(base + request.url, {
 		method: request.method,
 		headers: /** @type {Record<string, string>} */ (request.headers),
 		body: get_raw_body(request, bodySizeLimit)

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -94,7 +94,8 @@ function get_raw_body(req, body_size_limit) {
 
 /** @type {import('@sveltejs/kit/node').getRequest} */
 export async function getRequest({ request, base, bodySizeLimit }) {
-	return new Request(base + request.url, {
+	// @ts-expect-error - the request may be a connect request
+	return new Request(base + (request.originalUrl || request.url), {
 		method: request.method,
 		headers: /** @type {Record<string, string>} */ (request.headers),
 		body: get_raw_body(request, bodySizeLimit)

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -258,7 +258,7 @@ export async function dev(vite, vite_config, svelte_config) {
 				req.headers[':authority'] || req.headers.host
 			}`;
 
-			const decoded = decodeURI(new URL(base + req.url).pathname);
+			const decoded = decodeURI(new URL(base + req.originalUrl).pathname);
 
 			if (decoded.startsWith(assets)) {
 				const pathname = decoded.slice(assets.length);
@@ -295,7 +295,7 @@ export async function dev(vite, vite_config, svelte_config) {
 					req.headers[':authority'] || req.headers.host
 				}`;
 
-				const decoded = decodeURI(new URL(base + req.url).pathname);
+				const decoded = decodeURI(new URL(base + req.originalUrl).pathname);
 				const file = posixify(path.resolve(decoded.slice(1)));
 				const is_file = fs.existsSync(file) && !fs.statSync(file).isDirectory();
 				const allowed =
@@ -311,7 +311,7 @@ export async function dev(vite, vite_config, svelte_config) {
 				if (!decoded.startsWith(svelte_config.kit.paths.base)) {
 					return not_found(
 						res,
-						`Not found (did you mean ${svelte_config.kit.paths.base + req.url}?)`
+						`Not found (did you mean ${svelte_config.kit.paths.base + req.originalUrl}?)`
 					);
 				}
 

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -258,7 +258,7 @@ export async function dev(vite, vite_config, svelte_config) {
 				req.headers[':authority'] || req.headers.host
 			}`;
 
-			const decoded = decodeURI(new URL(base + req.originalUrl).pathname);
+			const decoded = decodeURI(new URL(base + req.url).pathname);
 
 			if (decoded.startsWith(assets)) {
 				const pathname = decoded.slice(assets.length);
@@ -295,7 +295,7 @@ export async function dev(vite, vite_config, svelte_config) {
 					req.headers[':authority'] || req.headers.host
 				}`;
 
-				const decoded = decodeURI(new URL(base + req.originalUrl).pathname);
+				const decoded = decodeURI(new URL(base + req.url).pathname);
 				const file = posixify(path.resolve(decoded.slice(1)));
 				const is_file = fs.existsSync(file) && !fs.statSync(file).isDirectory();
 				const allowed =
@@ -311,7 +311,7 @@ export async function dev(vite, vite_config, svelte_config) {
 				if (!decoded.startsWith(svelte_config.kit.paths.base)) {
 					return not_found(
 						res,
-						`Not found (did you mean ${svelte_config.kit.paths.base + req.originalUrl}?)`
+						`Not found (did you mean ${svelte_config.kit.paths.base + req.url}?)`
 					);
 				}
 

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -290,6 +290,8 @@ export async function dev(vite, vite_config, svelte_config) {
 		remove_static_middlewares(vite.middlewares);
 
 		vite.middlewares.use(async (req, res) => {
+			// Vite's base middleware strips out the base path. Restore it
+			req.url = req.originalUrl;
 			try {
 				const base = `${vite.config.server.https ? 'https' : 'http'}://${
 					req.headers[':authority'] || req.headers.host


### PR DESCRIPTION
This gets us pretty darn close to being able to set the `base` option in Vite correctly. Right now we hardcode it to `./`, which isn't correct and I suspect is one of the reasons the highly upvoted https://github.com/sveltejs/kit/issues/2958 doesn't work. There's one more thing we'll need to fix it which is https://github.com/vitejs/vite/issues/9236 and I'm working on getting that in as part of Vite 4

The reason we need this is that Vite rewrites the `url` to strip out the base path, which makes the `url` not what we might expect. I looked into changing that in Vite and discussed with the Vite team. While there's the possibility we might be able to do it, it's not easy and would affect the entire Vite ecosystem, so we'd need to get buy in from all the other frameworks. And actually, what Vite is doing is how the Express ecosystem works and is explicitly what `originalUrl` was provided for, so there's a good argument they shouldn't change anything on their side