### PR TITLE
[fix] don't run matchers for empty optional params

### DIFF
--- a/.changeset/three-meals-vanish.md
+++ b/.changeset/three-meals-vanish.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] don't run matchers for empty optional params

--- a/packages/kit/src/runtime/client/parse.js
+++ b/packages/kit/src/runtime/client/parse.js
@@ -18,7 +18,7 @@ export function parse(nodes, server_loads, dictionary, matchers) {
 			/** @param {string} path */
 			exec: (path) => {
 				const match = pattern.exec(path);
-				if (match) return exec(match, names, types, matchers);
+				if (match) return exec(match, id, names, types, matchers);
 			},
 			errors: [1, ...(errors || [])].map((n) => nodes[n]),
 			layouts: [0, ...(layouts || [])].map(create_layout_loader),

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -67,7 +67,7 @@ export async function respond(request, options, state) {
 			const match = candidate.pattern.exec(decoded);
 			if (!match) continue;
 
-			const matched = exec(match, candidate.names, candidate.types, matchers);
+			const matched = exec(match, candidate.id, candidate.names, candidate.types, matchers);
 			if (matched) {
 				route = candidate;
 				params = decode_params(matched);

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -104,13 +104,15 @@ export function affects_path(segment) {
 
 /**
  * @param {RegExpMatchArray} match
+ * @param {string} routeId
  * @param {string[]} names
  * @param {string[]} types
  * @param {Record<string, import('types').ParamMatcher>} matchers
  */
-export function exec(match, names, types, matchers) {
+export function exec(match, routeId, names, types, matchers) {
 	/** @type {Record<string, string>} */
 	const params = {};
+	let last_type_idx = -1;
 
 	for (let i = 0; i < names.length; i += 1) {
 		const name = names[i];
@@ -121,7 +123,12 @@ export function exec(match, names, types, matchers) {
 			const matcher = matchers[type];
 			if (!matcher) throw new Error(`Missing "${type}" param matcher`); // TODO do this ahead of time?
 
-			if (!matcher(value)) return;
+			last_type_idx = routeId.indexOf(`=${type}`, last_type_idx + 1);
+			const is_empty_optional_param =
+				!value &&
+				// a param without a value can only be an optional or rest param
+				routeId.lastIndexOf('[[', last_type_idx) > routeId.lastIndexOf('[...', last_type_idx);
+			if (!is_empty_optional_param && !matcher(value)) return;
 		}
 
 		params[name] = value;

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -135,15 +135,48 @@ const exec_tests = [
 		route: '/[[slug1]]/[[slug2]]',
 		path: '/slug1',
 		expected: { slug1: 'slug1', slug2: '' }
+	},
+	{
+		route: '/[[slug1=matches]]',
+		path: '/',
+		expected: { slug1: '' }
+	},
+	{
+		route: '/[[slug1=doesntmatch]]',
+		path: '/',
+		expected: { slug1: '' }
+	},
+	{
+		route: '/[[slug1=matches]]/[[slug2=doesntmatch]]',
+		path: '/foo',
+		expected: { slug1: 'foo', slug2: '' }
+	},
+	{
+		route: '/[[slug1=doesntmatch]]/[[slug2=doesntmatch]]',
+		path: '/foo',
+		expected: undefined
+	},
+	{
+		route: '/[...slug1=matches]',
+		path: '/',
+		expected: { slug1: '' }
+	},
+	{
+		route: '/[...slug1=doesntmatch]',
+		path: '/',
+		expected: undefined
 	}
 ];
 
 for (const { path, route, expected } of exec_tests) {
-	test(`exec extracts params correctly for ${path}`, () => {
+	test(`exec extracts params correctly for ${path} from ${route}`, () => {
 		const { pattern, names, types } = parse_route_id(route);
 		const match = pattern.exec(path);
 		if (!match) throw new Error(`Failed to match ${path}`);
-		const actual = exec(match, names, types, {});
+		const actual = exec(match, route, names, types, {
+			matches: () => true,
+			doesntmatch: () => false
+		});
 		assert.equal(actual, expected);
 	});
 }


### PR DESCRIPTION
Fixes #7344

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
