### PR TITLE
Always avoid caching form submission on enhanced forms

### DIFF
--- a/.changeset/smart-dolphins-mix.md
+++ b/.changeset/smart-dolphins-mix.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Always avoid caching form submission on enhanced forms

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -86,6 +86,7 @@ export function enhance(form, submit = () => {}) {
 					accept: 'application/json',
 					'x-sveltekit-action': 'true'
 				},
+				cache: 'no-cache',
 				body: data,
 				signal: controller.signal
 			});

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -86,7 +86,7 @@ export function enhance(form, submit = () => {}) {
 					accept: 'application/json',
 					'x-sveltekit-action': 'true'
 				},
-				cache: 'no-cache',
+				cache: 'no-store',
 				body: data,
 				signal: controller.signal
 			});


### PR DESCRIPTION
Due to the return of regular JSON requests of #7177, issue #6357 is relevant back again. Although now I couldn't reproduce the behavior, it stills problematic and needed to be fixed.

Clearly, when you simulate regular form submission, you should check that the browser never used a cached result of previous POST request.

It is unclear how browsers choose to handle this situation, see [this stackoverflow question](https://webmasters.stackexchange.com/questions/111298/what-happens-if-you-dont-set-cache-control-header).
Since browsers seems to be more careful on programically `fetch` POST requests, I couldn't catch a browser really use caching for this "no cache-control header" responses.

Currently on form submission from enhanced forms, there is no cache control header from the server, no cache guideline on the `fetch` function, so I think that the best solution is to guide the browser in the `fetch` method of the submission, to not use previously cached results.

fixes #6357 (in some sense)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
