### PR TITLE
Use `justify-content: flex-start;` on Sverdle CSS to avoid compatibility issues

### DIFF
--- a/.changeset/sixty-rats-divide.md
+++ b/.changeset/sixty-rats-divide.md
@@ -1,0 +1,5 @@
+---
+'default-template': patch
+---
+
+Use `justify-content: flex-start;` on Sverdle CSS to avoid compatibility issues

--- a/.changeset/sixty-rats-divide.md
+++ b/.changeset/sixty-rats-divide.md
@@ -1,5 +1,5 @@
 ---
-'default-template': patch
+'create-svelte': patch
 ---
 
 Use `justify-content: flex-start;` on Sverdle CSS to avoid compatibility issues

--- a/packages/create-svelte/templates/default/src/routes/sverdle/+page.svelte
+++ b/packages/create-svelte/templates/default/src/routes/sverdle/+page.svelte
@@ -210,7 +210,7 @@
 		height: 100%;
 		display: flex;
 		flex-direction: column;
-		justify-content: start;
+		justify-content: flex-start;
 	}
 
 	.grid .row {

--- a/packages/create-svelte/templates/default/src/routes/sverdle/how-to-play/+page.svelte
+++ b/packages/create-svelte/templates/default/src/routes/sverdle/how-to-play/+page.svelte
@@ -70,7 +70,7 @@
 
 	.example {
 		display: flex;
-		justify-content: start;
+		justify-content: flex-start;
 		margin: 1rem 0;
 		gap: 0.2rem;
 	}


### PR DESCRIPTION
This also eliminates the Vite warnings:
[vite:css] start value has mixed support, consider using flex-start instead

Using `justify-content: flex-start;` has here the same result as `justify-content: start;` (they are different only if the flex direction is opposite to the natural), and it has a wider compatibility (see [caniuseit](https://caniuse.com/mdn-css_properties_justify-content_flex_context_start_end)).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
