### PR TITLE
Whitespace in docs code snippets

### DIFF
--- a/packages/kit/scripts/extract-types.js
+++ b/packages/kit/scripts/extract-types.js
@@ -56,13 +56,15 @@ function get_types(code, statements) {
 				const i = code.indexOf('export', start);
 				start = i + 6;
 
-				const snippet = prettier.format(code.slice(start, statement.end).trim(), {
-					parser: 'typescript',
-					printWidth: 80,
-					useTabs: true,
-					singleQuote: true,
-					trailingComma: 'none'
-				});
+				const snippet = prettier
+					.format(code.slice(start, statement.end), {
+						parser: 'typescript',
+						printWidth: 80,
+						useTabs: true,
+						singleQuote: true,
+						trailingComma: 'none'
+					})
+					.trim();
 
 				const collection =
 					ts.isVariableStatement(statement) || ts.isFunctionDeclaration(statement)


### PR DESCRIPTION
Fixes #7330

Fixes whitespace for Modules and Types code snippets.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
