### PR TITLE
Undefined optional params

### DIFF
--- a/.changeset/fair-seas-clean.md
+++ b/.changeset/fair-seas-clean.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] optional params can be undefined

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -66,6 +66,7 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 					pattern: ${route.pattern},
 					names: ${s(route.names)},
 					types: ${s(route.types)},
+					optional: ${s(route.optional)},
 					page: ${route.page ? `{ layouts: ${get_nodes(route.page.layouts)}, errors: ${get_nodes(route.page.errors)}, leaf: ${route.page.leaf} }` : 'null'},
 					endpoint: ${route.endpoint ? loader(`${relative_path}/${resolve_symlinks(build_data.server.vite_manifest, route.endpoint.file).chunk.file}`) : 'null'}
 				}`;

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -121,7 +121,7 @@ function create_routes_and_nodes(cwd, config, fallback) {
 				);
 			}
 
-			const { pattern, names, types } = parse_route_id(id);
+			const { pattern, names, types, optional } = parse_route_id(id);
 
 			/** @type {import('types').RouteData} */
 			const route = {
@@ -132,6 +132,7 @@ function create_routes_and_nodes(cwd, config, fallback) {
 				pattern,
 				names,
 				types,
+				optional,
 
 				layout: null,
 				error: null,
@@ -228,6 +229,7 @@ function create_routes_and_nodes(cwd, config, fallback) {
 			pattern: /^$/,
 			names: [],
 			types: [],
+			optional: [],
 			parent: null,
 			layout: null,
 			error: null,

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -195,7 +195,9 @@ function update_types(config, routes, route, to_delete = new Set()) {
 	// Makes sure a type is "repackaged" and therefore more readable
 	declarations.push('type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;');
 	declarations.push(
-		`type RouteParams = { ${route.names.map((param) => `${param}: string`).join('; ')} }`
+		`type RouteParams = { ${route.names
+			.map((param, idx) => `${param}${route.optional[idx] ? '?' : ''}: string`)
+			.join('; ')} }`
 	);
 
 	// These could also be placed in our public types, but it would bloat them unnecessarily and we may want to change these in the future

--- a/packages/kit/src/core/sync/write_types/index.spec.js
+++ b/packages/kit/src/core/sync/write_types/index.spec.js
@@ -12,6 +12,19 @@ import { tweak_types, write_all_types } from './index.js';
 
 const cwd = fileURLToPath(new URL('./test', import.meta.url));
 
+function format_dts(file) {
+	// format with the same settings we use in this monorepo so
+	// the output is the same as visible when opening the $types.d.ts
+	// files in the editor
+	return format(fs.readFileSync(file, 'utf-8'), {
+		parser: 'typescript',
+		useTabs: true,
+		singleQuote: true,
+		trailingComma: 'none',
+		printWidth: 100
+	});
+}
+
 /**
  * @param {string} dir
  * @param {(code: string) => string} [prepare_expected]
@@ -49,12 +62,8 @@ async function run_test(dir, prepare_expected = (code) => code) {
 			continue;
 		}
 
-		const expected = format(fs.readFileSync(expected_file, 'utf-8'), {
-			parser: 'typescript'
-		});
-		const actual = format(fs.readFileSync(actual_file, 'utf-8'), {
-			parser: 'typescript'
-		});
+		const expected = format_dts(expected_file);
+		const actual = format_dts(actual_file);
 		const err_msg = `Expected equal file contents for ${file} in ${dir}`;
 		assert.fixture(actual, prepare_expected(expected), err_msg);
 	}

--- a/packages/kit/src/core/sync/write_types/test/slugs/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs/_expected/$types.d.ts
@@ -12,7 +12,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Record<string, any>
 >;
 type EnsureDefined<T> = T extends null | undefined ? {} : T;
-type LayoutParams = RouteParams & { rest?: string; slug?: string; optional?: string | void };
+type LayoutParams = RouteParams & { optional?: string; rest?: string; slug?: string };
 type LayoutParentData = EnsureDefined<{}>;
 
 export type LayoutServerData = null;

--- a/packages/kit/src/core/sync/write_types/test/slugs/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs/_expected/$types.d.ts
@@ -12,7 +12,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Record<string, any>
 >;
 type EnsureDefined<T> = T extends null | undefined ? {} : T;
-type LayoutParams = RouteParams & { optional?: string; rest?: string; slug?: string };
+type LayoutParams = RouteParams & { rest?: string; slug?: string; optional?: string };
 type LayoutParentData = EnsureDefined<{}>;
 
 export type LayoutServerData = null;

--- a/packages/kit/src/core/sync/write_types/test/slugs/_expected/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs/_expected/$types.d.ts
@@ -12,7 +12,7 @@ type OutputDataShape<T> = MaybeWithVoid<
 		Record<string, any>
 >;
 type EnsureDefined<T> = T extends null | undefined ? {} : T;
-type LayoutParams = RouteParams & { rest?: string; slug?: string };
+type LayoutParams = RouteParams & { rest?: string; slug?: string; optional?: string | void };
 type LayoutParentData = EnsureDefined<{}>;
 
 export type LayoutServerData = null;

--- a/packages/kit/src/core/sync/write_types/test/slugs/_expected/x/[[optional]]/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs/_expected/x/[[optional]]/$types.d.ts
@@ -1,14 +1,38 @@
 import type * as Kit from '@sveltejs/kit';
 
 type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
-type RouteParams = { optional: string | void }
+type RouteParams = { optional?: string };
 type MaybeWithVoid<T> = {} extends T ? T | void : T;
-export type RequiredKeys<T> = { [K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K; }[keyof T];
-type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>
+export type RequiredKeys<T> = {
+	[K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K;
+}[keyof T];
+type OutputDataShape<T> = MaybeWithVoid<
+	Omit<App.PageData, RequiredKeys<T>> &
+		Partial<Pick<App.PageData, keyof T & keyof App.PageData>> &
+		Record<string, any>
+>;
 type EnsureDefined<T> = T extends null | undefined ? {} : T;
 type PageParentData = EnsureDefined<import('../../$types.js').LayoutData>;
 
 export type PageServerData = null;
-export type PageLoad<OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>> = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
+export type PageLoad<
+	OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>
+> = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
 export type PageLoadEvent = Parameters<PageLoad>[0];
-export type PageData = Expand<Omit<PageParentData, keyof Kit.AwaitedProperties<Awaited<ReturnType<typeof import('../../../../../../x/[[optional]]/+page.js').load>>>> & EnsureDefined<Kit.AwaitedProperties<Awaited<ReturnType<typeof import('../../../../../../x/[[optional]]/+page.js').load>>>>>;
+export type PageData = Expand<
+	Omit<
+		PageParentData,
+		keyof Kit.AwaitedProperties<
+			Awaited<
+				ReturnType<typeof import('../../../../../../../../../../x/[[optional]]/+page.js').load>
+			>
+		>
+	> &
+		EnsureDefined<
+			Kit.AwaitedProperties<
+				Awaited<
+					ReturnType<typeof import('../../../../../../../../../../x/[[optional]]/+page.js').load>
+				>
+			>
+		>
+>;

--- a/packages/kit/src/core/sync/write_types/test/slugs/_expected/x/[[optional]]/$types.d.ts
+++ b/packages/kit/src/core/sync/write_types/test/slugs/_expected/x/[[optional]]/$types.d.ts
@@ -1,0 +1,14 @@
+import type * as Kit from '@sveltejs/kit';
+
+type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+type RouteParams = { optional: string | void }
+type MaybeWithVoid<T> = {} extends T ? T | void : T;
+export type RequiredKeys<T> = { [K in keyof T]-?: {} extends { [P in K]: T[K] } ? never : K; }[keyof T];
+type OutputDataShape<T> = MaybeWithVoid<Omit<App.PageData, RequiredKeys<T>> & Partial<Pick<App.PageData, keyof T & keyof App.PageData>> & Record<string, any>>
+type EnsureDefined<T> = T extends null | undefined ? {} : T;
+type PageParentData = EnsureDefined<import('../../$types.js').LayoutData>;
+
+export type PageServerData = null;
+export type PageLoad<OutputData extends OutputDataShape<PageParentData> = OutputDataShape<PageParentData>> = Kit.Load<RouteParams, PageServerData, PageParentData, OutputData>;
+export type PageLoadEvent = Parameters<PageLoad>[0];
+export type PageData = Expand<Omit<PageParentData, keyof Kit.AwaitedProperties<Awaited<ReturnType<typeof import('../../../../../../x/[[optional]]/+page.js').load>>>> & EnsureDefined<Kit.AwaitedProperties<Awaited<ReturnType<typeof import('../../../../../../x/[[optional]]/+page.js').load>>>>>;

--- a/packages/kit/src/core/sync/write_types/test/slugs/x/[[optional]]/+page.js
+++ b/packages/kit/src/core/sync/write_types/test/slugs/x/[[optional]]/+page.js
@@ -1,0 +1,3 @@
+export function load() {
+	return { optional: 'optional' };
+}

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -172,6 +172,7 @@ export async function dev(vite, vite_config, svelte_config) {
 							pattern: route.pattern,
 							names: route.names,
 							types: route.types,
+							optional: route.optional,
 							page: route.page,
 							endpoint: endpoint
 								? async () => {

--- a/packages/kit/src/runtime/client/parse.js
+++ b/packages/kit/src/runtime/client/parse.js
@@ -11,14 +11,14 @@ export function parse(nodes, server_loads, dictionary, matchers) {
 	const layouts_with_server_load = new Set(server_loads);
 
 	return Object.entries(dictionary).map(([id, [leaf, layouts, errors]]) => {
-		const { pattern, names, types } = parse_route_id(id);
+		const { pattern, names, types, optional } = parse_route_id(id);
 
 		const route = {
 			id,
 			/** @param {string} path */
 			exec: (path) => {
 				const match = pattern.exec(path);
-				if (match) return exec(match, id, names, types, matchers);
+				if (match) return exec(match, { names, types, optional }, matchers);
 			},
 			errors: [1, ...(errors || [])].map((n) => nodes[n]),
 			layouts: [0, ...(layouts || [])].map(create_layout_loader),

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -67,7 +67,7 @@ export async function respond(request, options, state) {
 			const match = candidate.pattern.exec(decoded);
 			if (!match) continue;
 
-			const matched = exec(match, candidate.id, candidate.names, candidate.types, matchers);
+			const matched = exec(match, candidate, matchers);
 			if (matched) {
 				route = candidate;
 				params = decode_params(matched);

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -84,12 +84,12 @@ const exec_tests = [
 	{
 		route: '/blog/[[slug]]/sub[[param]]',
 		path: '/blog/sub',
-		expected: { slug: '', param: '' }
+		expected: {}
 	},
 	{
 		route: '/blog/[[slug]]/sub[[param]]',
 		path: '/blog/slug/sub',
-		expected: { slug: 'slug', param: '' }
+		expected: { slug: 'slug' }
 	},
 	{
 		route: '/blog/[[slug]]/sub[[param]]',
@@ -99,7 +99,7 @@ const exec_tests = [
 	{
 		route: '/blog/[[slug]]/sub[[param]]',
 		path: '/blog/subparam',
-		expected: { slug: '', param: 'param' }
+		expected: { param: 'param' }
 	},
 	{
 		route: '/[[slug]]/[...rest]',
@@ -119,7 +119,7 @@ const exec_tests = [
 	{
 		route: '/[[slug]]/[...rest]',
 		path: '/',
-		expected: { slug: '', rest: '' }
+		expected: { rest: '' }
 	},
 	{
 		route: '/[...rest]/path',
@@ -134,22 +134,22 @@ const exec_tests = [
 	{
 		route: '/[[slug1]]/[[slug2]]',
 		path: '/slug1',
-		expected: { slug1: 'slug1', slug2: '' }
+		expected: { slug1: 'slug1' }
 	},
 	{
 		route: '/[[slug1=matches]]',
 		path: '/',
-		expected: { slug1: '' }
+		expected: {}
 	},
 	{
 		route: '/[[slug1=doesntmatch]]',
 		path: '/',
-		expected: { slug1: '' }
+		expected: {}
 	},
 	{
 		route: '/[[slug1=matches]]/[[slug2=doesntmatch]]',
 		path: '/foo',
-		expected: { slug1: 'foo', slug2: '' }
+		expected: { slug1: 'foo' }
 	},
 	{
 		route: '/[[slug1=doesntmatch]]/[[slug2=doesntmatch]]',
@@ -170,13 +170,17 @@ const exec_tests = [
 
 for (const { path, route, expected } of exec_tests) {
 	test(`exec extracts params correctly for ${path} from ${route}`, () => {
-		const { pattern, names, types } = parse_route_id(route);
+		const { pattern, names, types, optional } = parse_route_id(route);
 		const match = pattern.exec(path);
 		if (!match) throw new Error(`Failed to match ${path}`);
-		const actual = exec(match, route, names, types, {
-			matches: () => true,
-			doesntmatch: () => false
-		});
+		const actual = exec(
+			match,
+			{ names, types, optional },
+			{
+				matches: () => true,
+				doesntmatch: () => false
+			}
+		);
 		assert.equal(actual, expected);
 	});
 }

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -169,6 +169,7 @@ export interface RouteData {
 	pattern: RegExp;
 	names: string[];
 	types: string[];
+	optional: boolean[];
 
 	layout: PageNode | null;
 	error: PageNode | null;
@@ -335,6 +336,7 @@ export interface SSRRoute {
 	pattern: RegExp;
 	names: string[];
 	types: string[];
+	optional: boolean[];
 
 	page: PageNodeIndexes | null;
 


### PR DESCRIPTION
Follow-up to #7346 — if `/x/[[y]]` matches `/x`, then `params.y` should be undefined.

I haven't updated the generated types yet, I just added a failing test

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
