### PR TITLE
[fix] show more descriptive error if data returned from `load` is a non-POJO

### DIFF
--- a/.changeset/shiny-eels-brush.md
+++ b/.changeset/shiny-eels-brush.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Show more descriptive error if data returned from `load` is a non-POJO

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -182,6 +182,19 @@ export async function render_response({
 				`Data returned from \`load\` while rendering ${event.routeId} is not serializable: ${error.message} (data.${match[2]})`
 			);
 		}
+
+		const nonPojoError = /pojo/i.exec(error.message);
+
+		if (nonPojoError) {
+			const constructorName = branch[0]?.server_data?.data?.constructor?.name;
+
+			throw new Error(
+				`Data returned from \`load\` must be a plain object${
+					constructorName ? ` rather than ${constructorName} constructor` : ''
+				}`
+			);
+		}
+
 		throw error;
 	}
 

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -186,11 +186,12 @@ export async function render_response({
 		const nonPojoError = /pojo/i.exec(error.message);
 
 		if (nonPojoError) {
-			const constructorName = branch[0]?.server_data?.data?.constructor?.name;
+			const constructorName = branch.find(({ server_data }) => server_data?.data?.constructor?.name)
+				?.server_data?.data?.constructor?.name;
 
 			throw new Error(
-				`Data returned from \`load\` must be a plain object${
-					constructorName ? ` rather than ${constructorName} constructor` : ''
+				`Data returned from \`load\` (while rendering ${event.routeId}) must be a plain object${
+					constructorName ? ` rather than an instance of ${constructorName}` : ''
 				}`
 			);
 		}


### PR DESCRIPTION
Closes #7262

- Tested it out with return `json`

<img width="398" alt="Screenshot 2022-10-25 at 17 44 12" src="https://user-images.githubusercontent.com/64462998/197772126-85ee64db-3feb-45fd-b4dd-7af4d751bb8f.png">
<img width="997" alt="Screenshot 2022-10-25 at 17 42 52" src="https://user-images.githubusercontent.com/64462998/197772172-05d44355-36f0-47bd-a6da-535ba753e456.png">

- with `new Error`

<img width="399" alt="Screenshot 2022-10-25 at 17 43 58" src="https://user-images.githubusercontent.com/64462998/197772190-85467f0b-b1bb-4d80-ae5c-4a46895e5a86.png">
<img width="1018" alt="Screenshot 2022-10-25 at 17 43 15" src="https://user-images.githubusercontent.com/64462998/197772201-e84e83a5-31db-4d61-8918-33845754c1cb.png">



### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
