### PR TITLE
[fix] harmonize cookie path and add dev time warnings

### DIFF
--- a/.changeset/eighty-turkeys-exercise.md
+++ b/.changeset/eighty-turkeys-exercise.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] harmonize cookie path and add dev time warnings

--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -266,6 +266,8 @@ export async function load({ cookies }) {
 }
 ```
 
+> When setting cookies, be aware of the `path` property. By default, the `path` of a cookie is the current pathname. If you for example set a cookie at page `admin/user`, the cookie will only be available within the `admin` pages by default. In most cases you likely want to set `path` to `'/'` to make the cookie available throughout your app.
+
 Both server-only and shared `load` functions have access to a `setHeaders` function that, when running on the server, can set headers for the response. (When running in the browser, `setHeaders` has no effect.) This is useful if you want the page to be cached, for example:
 
 ```js

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -1,10 +1,20 @@
 import { parse, serialize } from 'cookie';
+import { DATA_SUFFIX } from '../../constants.js';
+import { normalize_path } from '../../utils/url.js';
+
+/**
+ * Tracks all cookies set during dev mode so we can emit warnings
+ * when we detect that there's likely cookie misusage due to wrong paths
+ *
+ * @type {Record<string, Set<string>>} */
+const cookie_paths = {};
 
 /**
  * @param {Request} request
  * @param {URL} url
+ * @param {Pick<import('types').SSROptions, 'dev' | 'trailing_slash'>} options
  */
-export function get_cookies(request, url) {
+export function get_cookies(request, url, options) {
 	const header = request.headers.get('cookie') ?? '';
 
 	const initial_cookies = parse(header);
@@ -42,7 +52,17 @@ export function get_cookies(request, url) {
 
 			const decode = opts?.decode || decodeURIComponent;
 			const req_cookies = parse(header, { decode });
-			return req_cookies[name]; // the decoded string or undefined
+			const cookie = req_cookies[name]; // the decoded string or undefined
+
+			if (!options.dev || cookie) {
+				return cookie;
+			}
+
+			if (c || cookie_paths[name]?.size > 0) {
+				console.warn(
+					`Cookie with name '${name}' was not found, but a cookie with that name exists at a sub path. Did you mean to set its 'path' to '/'?`
+				);
+			}
 		},
 
 		/**
@@ -51,14 +71,45 @@ export function get_cookies(request, url) {
 		 * @param {import('cookie').CookieSerializeOptions} opts
 		 */
 		set(name, value, opts = {}) {
+			let path = opts.path;
+			if (!path) {
+				const normalized = normalize_path(
+					// Remove suffix: 'foo/__data.json' would mean the cookie path is '/foo',
+					// whereas a direct hit of /foo would mean the cookie path is '/'
+					url.pathname.endsWith(DATA_SUFFIX)
+						? url.pathname.slice(0, -DATA_SUFFIX.length)
+						: url.pathname,
+					options.trailing_slash
+				);
+				// Emulate browser-behavior: if the cookie is set at '/foo/bar', its path is '/foo'
+				path = normalized.split('/').slice(0, -1).join('/') || '/';
+			}
+
 			new_cookies[name] = {
 				name,
 				value,
 				options: {
 					...defaults,
-					...opts
+					...opts,
+					path
 				}
 			};
+
+			if (options.dev) {
+				cookie_paths[name] = cookie_paths[name] || new Set();
+				if (!value) {
+					if (!cookie_paths[name].has(path) && cookie_paths[name].size > 0) {
+						console.warn(
+							`Trying to delete cookie '${name}' at path '${path}', but a cookie with that name only exists at a different path.`
+						);
+					}
+					cookie_paths[name].delete(path);
+				} else {
+					// We could also emit a warning here if the cookie already exists at a different path,
+					// but that's more likely a false positive because it's valid to set the same name at different paths
+					cookie_paths[name].add(path);
+				}
+			}
 		},
 
 		/**
@@ -66,15 +117,10 @@ export function get_cookies(request, url) {
 		 * @param {import('cookie').CookieSerializeOptions} opts
 		 */
 		delete(name, opts = {}) {
-			new_cookies[name] = {
-				name,
-				value: '',
-				options: {
-					...defaults,
-					...opts,
-					maxAge: 0
-				}
-			};
+			cookies.set(name, '', {
+				...opts,
+				maxAge: 0
+			});
 		},
 
 		/**

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -42,15 +42,15 @@ paths.negative.forEach(([path, constraint]) => {
 	});
 });
 
-/** @param {boolean} localhost */
-const cookies_setup = (localhost = false) => {
-	const url = new URL(localhost ? 'http://localhost:1234' : 'https://example.com');
+/** @param {string} href */
+const cookies_setup = (href = 'https://example.com') => {
+	const url = new URL(href);
 	const request = new Request(url, {
 		headers: new Headers({
 			cookie: 'a=b;'
 		})
 	});
-	return get_cookies(request, url);
+	return get_cookies(request, url, { dev: false, trailing_slash: 'ignore' });
 };
 
 test('a cookie should not be present after it is deleted', () => {
@@ -67,12 +67,22 @@ test('default values when set is called', () => {
 	const opts = new_cookies['a']?.options;
 	assert.equal(opts?.secure, true);
 	assert.equal(opts?.httpOnly, true);
-	assert.equal(opts?.path, undefined);
+	assert.equal(opts?.path, '/');
+	assert.equal(opts?.sameSite, 'lax');
+});
+
+test('default values when set is called on sub path', () => {
+	const { cookies, new_cookies } = cookies_setup('https://example.com/foo/bar');
+	cookies.set('a', 'b');
+	const opts = new_cookies['a']?.options;
+	assert.equal(opts?.secure, true);
+	assert.equal(opts?.httpOnly, true);
+	assert.equal(opts?.path, '/foo');
 	assert.equal(opts?.sameSite, 'lax');
 });
 
 test('default values when on localhost', () => {
-	const { cookies, new_cookies } = cookies_setup(true);
+	const { cookies, new_cookies } = cookies_setup('http://localhost:1234');
 	cookies.set('a', 'b');
 	const opts = new_cookies['a']?.options;
 	assert.equal(opts?.secure, false);
@@ -94,7 +104,7 @@ test('default values when delete is called', () => {
 	const opts = new_cookies['a']?.options;
 	assert.equal(opts?.secure, true);
 	assert.equal(opts?.httpOnly, true);
-	assert.equal(opts?.path, undefined);
+	assert.equal(opts?.path, '/');
 	assert.equal(opts?.sameSite, 'lax');
 	assert.equal(opts?.maxAge, 0);
 });

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -96,7 +96,7 @@ export async function respond(request, options, state) {
 	/** @type {Record<string, string>} */
 	const headers = {};
 
-	const { cookies, new_cookies, get_cookie_header } = get_cookies(request, url);
+	const { cookies, new_cookies, get_cookie_header } = get_cookies(request, url, options);
 
 	if (state.prerendering) disable_search(url);
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -161,6 +161,8 @@ export interface Cookies {
 
 	/**
 	 * Deletes a cookie by setting its value to an empty string and setting the expiry date in the past.
+	 *
+	 * By default, the `path` of a cookie is the 'directory' of the current pathname. In most cases you should explicitly set `path: '/'` to make the cookie available throughout your app.
 	 */
 	delete(name: string, opts?: import('cookie').CookieSerializeOptions): void;
 


### PR DESCRIPTION
- Warnings will be logged to the console if it's detected that there's likely misusage of the path parameter.
- More documentation
- Fix mismatch of cookie path between /foo and /foo/__data.json server-load calls by emulating browser behavior of the default path

Fixes #6609

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
