### PR TITLE
DRY out data suffix handling

### DIFF
--- a/packages/kit/src/constants.js
+++ b/packages/kit/src/constants.js
@@ -3,5 +3,3 @@
 export const SVELTE_KIT_ASSETS = '/_svelte_kit_assets';
 
 export const GENERATED_COMMENT = '// this file is generated — do not edit it\n';
-
-export const DATA_SUFFIX = '/__data.json';

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1,5 +1,5 @@
 import { onMount, tick } from 'svelte';
-import { make_trackable, decode_params, normalize_path } from '../../utils/url.js';
+import { make_trackable, decode_params, normalize_path, add_data_suffix } from '../../utils/url.js';
 import { find_anchor, get_base_uri, scroll_state } from './utils.js';
 import {
 	lock_fetch,
@@ -14,7 +14,6 @@ import Root from '__GENERATED__/root.svelte';
 import { nodes, server_loads, dictionary, matchers, hooks } from '__GENERATED__/client-manifest.js';
 import { HttpError, Redirect } from '../control.js';
 import { stores } from './singletons.js';
-import { DATA_SUFFIX } from '../../constants.js';
 import { unwrap_promises } from '../../utils/promises.js';
 import * as devalue from 'devalue';
 
@@ -1511,7 +1510,7 @@ export function create_client({ target, base, trailing_slash }) {
  */
 async function load_data(url, invalid) {
 	const data_url = new URL(url);
-	data_url.pathname = url.pathname.replace(/\/$/, '') + DATA_SUFFIX;
+	data_url.pathname = add_data_suffix(url.pathname);
 
 	const res = await native_fetch(data_url.href, {
 		headers: {

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -1,6 +1,5 @@
 import { parse, serialize } from 'cookie';
-import { DATA_SUFFIX } from '../../constants.js';
-import { normalize_path } from '../../utils/url.js';
+import { has_data_suffix, normalize_path, strip_data_suffix } from '../../utils/url.js';
 
 /**
  * Tracks all cookies set during dev mode so we can emit warnings
@@ -76,9 +75,7 @@ export function get_cookies(request, url, options) {
 				const normalized = normalize_path(
 					// Remove suffix: 'foo/__data.json' would mean the cookie path is '/foo',
 					// whereas a direct hit of /foo would mean the cookie path is '/'
-					url.pathname.endsWith(DATA_SUFFIX)
-						? url.pathname.slice(0, -DATA_SUFFIX.length)
-						: url.pathname,
+					has_data_suffix(url.pathname) ? strip_data_suffix(url.pathname) : url.pathname,
 					options.trailing_slash
 				);
 				// Emulate browser-behavior: if the cookie is set at '/foo/bar', its path is '/foo'

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -3,8 +3,7 @@ import { normalize_error } from '../../../utils/error.js';
 import { once } from '../../../utils/functions.js';
 import { load_server_data } from '../page/load_data.js';
 import { data_response, handle_error_and_jsonify } from '../utils.js';
-import { normalize_path } from '../../../utils/url.js';
-import { DATA_SUFFIX } from '../../../constants.js';
+import { normalize_path, strip_data_suffix } from '../../../utils/url.js';
 
 /**
  * @param {import('types').RequestEvent} event
@@ -31,10 +30,7 @@ export async function render_data(event, route, options, state) {
 		let aborted = false;
 
 		const url = new URL(event.url);
-		url.pathname = normalize_path(
-			url.pathname.slice(0, -DATA_SUFFIX.length),
-			options.trailing_slash
-		);
+		url.pathname = normalize_path(strip_data_suffix(url.pathname), options.trailing_slash);
 
 		const new_event = { ...event, url };
 

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -5,10 +5,15 @@ import { respond_with_error } from './page/respond_with_error.js';
 import { coalesce_to_error } from '../../utils/error.js';
 import { is_form_content_type } from '../../utils/http.js';
 import { GENERIC_ERROR, handle_fatal_error } from './utils.js';
-import { decode_params, disable_search, normalize_path } from '../../utils/url.js';
+import {
+	decode_params,
+	disable_search,
+	has_data_suffix,
+	normalize_path,
+	strip_data_suffix
+} from '../../utils/url.js';
 import { exec } from '../../utils/routing.js';
 import { render_data } from './data/index.js';
-import { DATA_SUFFIX } from '../../constants.js';
 import { add_cookies_to_headers, get_cookies } from './cookie.js';
 import { HttpError } from '../control.js';
 import { create_fetch } from './fetch.js';
@@ -57,8 +62,8 @@ export async function respond(request, options, state) {
 		decoded = decoded.slice(options.paths.base.length) || '/';
 	}
 
-	const is_data_request = decoded.endsWith(DATA_SUFFIX);
-	if (is_data_request) decoded = decoded.slice(0, -DATA_SUFFIX.length) || '/';
+	const is_data_request = has_data_suffix(decoded);
+	if (is_data_request) decoded = strip_data_suffix(decoded);
 
 	if (!state.prerendering?.fallback) {
 		const matchers = await options.manifest._.matchers();

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -1,7 +1,7 @@
 import * as devalue from 'devalue';
-import { DATA_SUFFIX } from '../../../constants.js';
 import { compact } from '../../../utils/array.js';
 import { normalize_error } from '../../../utils/error.js';
+import { add_data_suffix } from '../../../utils/url.js';
 import { HttpError, Redirect } from '../../control.js';
 import {
 	get_option,
@@ -76,7 +76,7 @@ export async function render_page(event, route, page, options, state, resolve_op
 		}
 
 		const should_prerender_data = nodes.some((node) => node?.server);
-		const data_pathname = event.url.pathname.replace(/\/$/, '') + DATA_SUFFIX;
+		const data_pathname = add_data_suffix(event.url.pathname);
 
 		// it's crucial that we do this before returning the non-SSR response, otherwise
 		// SvelteKit will erroneously believe that the path has been prerendered,

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -1,6 +1,6 @@
 import * as devalue from 'devalue';
-import { DATA_SUFFIX } from '../../constants.js';
 import { negotiate } from '../../utils/http.js';
+import { has_data_suffix } from '../../utils/url.js';
 import { HttpError } from '../control.js';
 
 /** @param {any} body */
@@ -144,7 +144,7 @@ export function handle_fatal_error(event, options, error) {
 		'text/html'
 	]);
 
-	if (event.url.pathname.endsWith(DATA_SUFFIX) || type === 'application/json') {
+	if (has_data_suffix(event.url.pathname) || type === 'application/json') {
 		return new Response(JSON.stringify(body), {
 			status,
 			headers: { 'content-type': 'application/json; charset=utf-8' }

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -142,3 +142,20 @@ export function disable_search(url) {
 		});
 	}
 }
+
+const DATA_SUFFIX = '/__data.json';
+
+/** @param {string} pathname */
+export function has_data_suffix(pathname) {
+	return pathname.endsWith(DATA_SUFFIX);
+}
+
+/** @param {string} pathname */
+export function add_data_suffix(pathname) {
+	return pathname.replace(/\/$/, '') + DATA_SUFFIX;
+}
+
+/** @param {string} pathname */
+export function strip_data_suffix(pathname) {
+	return pathname.slice(0, -DATA_SUFFIX.length);
+}


### PR DESCRIPTION
A thought I had while reviewing #7416 — our data suffix handling is a bit raggedy, and would maybe be nicer if we encapsulated the repetitious logic into helper functions.

No changeset or tests needed for this change

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
