### PR TITLE
bump devalue version

### DIFF
--- a/.changeset/long-ghosts-act.md
+++ b/.changeset/long-ghosts-act.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Bump devalue version

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -13,7 +13,7 @@
 		"@sveltejs/vite-plugin-svelte": "^1.1.0",
 		"@types/cookie": "^0.5.1",
 		"cookie": "^0.5.0",
-		"devalue": "^4.0.1",
+		"devalue": "^4.1.0",
 		"kleur": "^4.1.5",
 		"magic-string": "^0.26.7",
 		"mime": "^3.0.0",

--- a/packages/kit/src/core/prerender/prerender.js
+++ b/packages/kit/src/core/prerender/prerender.js
@@ -413,10 +413,11 @@ export async function prerender() {
 		const path = key.slice(0, index);
 		const id = key.slice(index + 1);
 
+		const hashlinks = actual_hashlinks.get(path);
 		// ignore fragment links to pages that were not prerendered
-		if (!actual_hashlinks.has(path)) continue;
+		if (!hashlinks) continue;
 
-		if (!actual_hashlinks.get(path).includes(id)) {
+		if (!hashlinks.includes(id)) {
 			handle_missing_id({ id, path, referrers: Array.from(referrers) });
 		}
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,7 +275,7 @@ importers:
       '@types/sade': ^1.7.4
       '@types/set-cookie-parser': ^2.4.2
       cookie: ^0.5.0
-      devalue: ^4.0.1
+      devalue: ^4.1.0
       kleur: ^4.1.5
       magic-string: ^0.26.7
       marked: ^4.1.1
@@ -295,7 +295,7 @@ importers:
       '@sveltejs/vite-plugin-svelte': 1.1.0_svelte@3.52.0+vite@3.2.1
       '@types/cookie': 0.5.1
       cookie: 0.5.0
-      devalue: 4.0.1
+      devalue: 4.1.0
       kleur: 4.1.5
       magic-string: 0.26.7
       mime: 3.0.0
@@ -1916,8 +1916,8 @@ packages:
     resolution: {integrity: sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==}
     engines: {node: '>=8'}
 
-  /devalue/4.0.1:
-    resolution: {integrity: sha512-Oksbel8g2rv5ivcCyImF1RXEU2FcS1OtCwVs4tJCCeVws/Dp9EE15fUbEsNr/xLD3ZxsQURBCDf56Lk1CgwCpg==}
+  /devalue/4.1.0:
+    resolution: {integrity: sha512-glzE77YSRp97HdNQ8EKTYJQ3tS/7DaY+c7/NjsTrJsNexqYIEANww4qyjhxsJqvpDpoqxgRqjwDNrOq8WS8NFQ==}
     dev: false
 
   /diff/5.1.0:


### PR DESCRIPTION
The newest version of `devalue` only de-duplicates non-primitives. That means that a value like `[null, null]` is serialized sensibly:

```diff
<script type="module" data-sveltekit-hydrate="1vcz4c4">
  import { start } from "./_app/immutable/start-050325ff.js";

  start({
    env: {},
    hydrate: {
      status: 200,
      error: null,
      node_ids: [0, 3],
      params: {},
      routeId: "/",
-      data: (function(a){return [a,a]}(null)),
+      data: [null,null],
      form: null
    },
    paths: {"base":"","assets":""},
    target: document.querySelector('[data-sveltekit-hydrate="1vcz4c4"]').parentNode,
    trailing_slash: "never"
  });
</script>
```

It also makes it _much_ less likely that you'd end up with an IIFE with too many arguments. Between that and the fact that we now use `devalue.stringify` rather than `devalue.uneval`, we can close #6672.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
