### PR TITLE
[docs] add a JSDoc for create_manifest_data

### DIFF
--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -7,6 +7,7 @@ import { parse_route_id } from '../../../utils/routing.js';
 import { sort_routes } from './sort.js';
 
 /**
+ * Generates the manifest data used for the client-side manifest and types generation.
  * @param {{
  *   config: import('types').ValidatedConfig;
  *   fallback?: string;


### PR DESCRIPTION
It looks like we now have three things call manifest :laughing: Adding this doc to help me keep them straight