### PR TITLE
[fix] check for private var usage in client code instead of server code

### DIFF
--- a/.changeset/empty-dryers-applaud.md
+++ b/.changeset/empty-dryers-applaud.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[chore] separate module resolving and loading

--- a/.changeset/empty-dryers-applaud.md
+++ b/.changeset/empty-dryers-applaud.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-[chore] separate module resolving and loading
+[fix] check for private var usage in client code instead of server code

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -117,6 +117,7 @@ export async function dev(vite, vite_config, svelte_config) {
 								extensions
 							);
 
+							// wait to load the module until after we check for illegal imports
 							result.shared = await vite.ssrLoadModule(url);
 						}
 

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -49,6 +49,7 @@ export async function dev(vite, vite_config, svelte_config) {
 	async function resolve(id) {
 		const url = id.startsWith('..') ? `/@fs${path.posix.resolve(id)}` : `/${id}`;
 
+		await vite.moduleGraph.ensureEntryFromUrl(url);
 		const module_node = await vite.moduleGraph.getModuleByUrl(url);
 		if (!module_node) throw new Error(`Could not find node for ${url}`);
 

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -49,6 +49,8 @@ export async function dev(vite, vite_config, svelte_config) {
 	async function resolve(id) {
 		const url = id.startsWith('..') ? `/@fs${path.posix.resolve(id)}` : `/${id}`;
 
+		// need to ensure the entry is in the module graph before we can get it
+		// we leave the ssr parameter undefined because we care about the client-side code here
 		await vite.moduleGraph.ensureEntryFromUrl(url);
 		const module_node = await vite.moduleGraph.getModuleByUrl(url);
 		if (!module_node) throw new Error(`Could not find node for ${url}`);
@@ -98,6 +100,7 @@ export async function dev(vite, vite_config, svelte_config) {
 									extensions
 								);
 
+								// wait to load the module until after we check for illegal imports
 								const module = await vite.ssrLoadModule(url);
 								return module.default;
 							};


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/pull/7288

Don't put the module into the graph with `ssrLoadModule` which will add the server-side code, but instead use `ensureEntryFromUrl` leaving the `ssr` parameter `undefined`