### PR TITLE
Revert "[fix] check for private var usage in client code instead of server code"

### DIFF
--- a/.changeset/empty-dryers-applaud.md
+++ b/.changeset/empty-dryers-applaud.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': patch
----
-
-[fix] check for private var usage in client code instead of server code


### PR DESCRIPTION
Reverts sveltejs/kit#7487, which did not fix the issue — it only skips the check the _first_ time the module is imported, but still runs it ever time after that