### PR TITLE
Service worker config aliases (#7496)

### DIFF
--- a/.changeset/ten-hairs-drum.md
+++ b/.changeset/ten-hairs-drum.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+custom aliases resolved in service worker builds

--- a/packages/kit/src/exports/vite/build/build_service_worker.js
+++ b/packages/kit/src/exports/vite/build/build_service_worker.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import * as vite from 'vite';
 import { s } from '../../../utils/misc.js';
+import { get_config_aliases } from '../utils.js';
 import { assets_base } from './utils.js';
 
 /**
@@ -82,10 +83,10 @@ export async function build_service_worker(
 		define: vite_config.define,
 		configFile: false,
 		resolve: {
-			alias: {
-				'$service-worker': service_worker,
-				$lib: config.kit.files.lib
-			}
+			alias: [
+				...get_config_aliases(config.kit),
+				{ find: '$service-worker', replacement: service_worker }
+			]
 		}
 	});
 }

--- a/packages/kit/src/exports/vite/build/utils.js
+++ b/packages/kit/src/exports/vite/build/utils.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import * as vite from 'vite';
-import { get_aliases } from '../utils.js';
+import { get_config_aliases, get_app_aliases } from '../utils.js';
 
 /**
  * @typedef {import('rollup').RollupOutput} RollupOutput
@@ -143,7 +143,7 @@ export function get_default_build_config({ config, input, ssr, outDir }) {
 		},
 		publicDir: ssr ? false : config.kit.files.assets,
 		resolve: {
-			alias: get_aliases(config.kit)
+			alias: [...get_app_aliases(config.kit), ...get_config_aliases(config.kit)]
 		},
 		optimizeDeps: {
 			exclude: ['@sveltejs/kit']

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -14,7 +14,7 @@ import { generate_manifest } from '../../core/generate_manifest/index.js';
 import { runtime_directory, logger } from '../../core/utils.js';
 import { find_deps, get_default_build_config } from './build/utils.js';
 import { preview } from './preview/index.js';
-import { get_aliases, get_env } from './utils.js';
+import { get_config_aliases, get_app_aliases, get_env } from './utils.js';
 import { prevent_illegal_rollup_imports } from './graph_analysis/index.js';
 import { fileURLToPath } from 'node:url';
 import { create_static_module, create_dynamic_module } from '../../core/env.js';
@@ -257,7 +257,7 @@ function kit() {
 				},
 				publicDir: svelte_config.kit.files.assets,
 				resolve: {
-					alias: get_aliases(svelte_config.kit)
+					alias: [...get_app_aliases(svelte_config.kit), ...get_config_aliases(svelte_config.kit)]
 				},
 				root: cwd,
 				server: {

--- a/packages/kit/src/exports/vite/utils.js
+++ b/packages/kit/src/exports/vite/utils.js
@@ -96,15 +96,14 @@ function merge_into(a, b) {
 
 /**
  * Transforms kit.alias to a valid vite.resolve.alias array.
+ *
  * Related to tsconfig path alias creation.
  *
  * @param {import('types').ValidatedKitConfig} config
  * */
-export function get_aliases(config) {
+export function get_config_aliases(config) {
 	/** @type {import('vite').Alias[]} */
 	const alias = [
-		{ find: '__GENERATED__', replacement: path.posix.join(config.outDir, 'generated') },
-		{ find: '$app', replacement: `${runtime_directory}/app` },
 		// For now, we handle `$lib` specially here rather than make it a default value for
 		// `config.kit.alias` since it has special meaning for packaging, etc.
 		{ find: '$lib', replacement: config.files.lib }
@@ -131,6 +130,21 @@ export function get_aliases(config) {
 			alias.push({ find: key, replacement: path.resolve(value) });
 		}
 	}
+
+	return alias;
+}
+
+/**
+ * Returns Vite aliases for generated and runtime files.
+ *
+ * @param {import('types').ValidatedKitConfig} config
+ * */
+export function get_app_aliases(config) {
+	/** @type {import('vite').Alias[]} */
+	const alias = [
+		{ find: '__GENERATED__', replacement: path.posix.join(config.outDir, 'generated') },
+		{ find: '$app', replacement: `${runtime_directory}/app` }
+	];
 
 	return alias;
 }

--- a/packages/kit/src/exports/vite/utils.spec.js
+++ b/packages/kit/src/exports/vite/utils.spec.js
@@ -3,7 +3,7 @@ import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { validate_config } from '../../core/config/index.js';
 import { posixify } from '../../utils/filesystem.js';
-import { deep_merge, get_aliases, merge_vite_configs } from './utils.js';
+import { deep_merge, get_app_aliases, get_config_aliases, merge_vite_configs } from './utils.js';
 
 test('basic test no conflicts', async () => {
 	const merged = deep_merge(
@@ -211,7 +211,10 @@ test('transform kit.alias to resolve.alias', () => {
 		}
 	});
 
-	const transformed = get_aliases(config.kit).map((entry) => {
+	// combine aliases from config with generated and runtime aliases
+	const aliases = [...get_app_aliases(config.kit), ...get_config_aliases(config.kit)];
+
+	const transformed = aliases.map((entry) => {
 		const replacement = posixify(path.relative('.', entry.replacement));
 
 		return {


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

### Fixes #7496  

This PR splits the `get_aliases` function into two. One that returns aliases that are consumer-configurable, another that returns the 'stock' aliases (`__GENERATED__` and `$app`).

With this refactor, this PR also involves the config aliases in service worker builds, meaning service workers can import modules using custom aliases defined in `svelte.config.js`.