### PR TITLE
Warn of cookie paths only when applicable

### DIFF
--- a/.changeset/green-foxes-wait.md
+++ b/.changeset/green-foxes-wait.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Prevents cookie not found warning when cookie was removed in browser.

--- a/.changeset/green-foxes-wait.md
+++ b/.changeset/green-foxes-wait.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': patch
----
-
-Prevents cookie not found warning when cookie was removed in browser.

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -58,10 +58,10 @@ export function get_cookies(request, url, options) {
 			}
 
 			// Warn about cookies that are set with other paths in dev mode
-			if (cookie_paths[name]?.has(url.pathname)) {
+			if (cookie_paths[name]?.has('/')) {
 				// Cookie was set on this path, but removed elsewhere
 				// Reflect these changes and remove the path from the set
-				cookie_paths[name].delete(url.pathname);
+				cookie_paths[name].delete('/');
 			} else if (cookie_paths[name]?.size > 0) {
 				// Warn about cookie existence on other paths
 				const paths = `'${Array.from(cookie_paths[name]).join("', '")}'`;

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -57,9 +57,16 @@ export function get_cookies(request, url, options) {
 				return cookie;
 			}
 
-			if (c || cookie_paths[name]?.size > 0) {
+			// Warn about cookies that are set with other paths in dev mode
+			if (cookie_paths[name]?.has(url.pathname)) {
+				// Cookie was set on this path, but removed elsewhere
+				// Reflect these changes and remove the path from the set
+				cookie_paths[name].delete(url.pathname);
+			} else if (cookie_paths[name]?.size > 0) {
+				// Warn about cookie existence on other paths
+				const paths = `'${Array.from(cookie_paths[name]).join("', '")}'`;
 				console.warn(
-					`Cookie with name '${name}' was not found, but a cookie with that name exists at a sub path. Did you mean to set its 'path' to '/'?`
+					`Cookie with name '${name}' was not found at path: '${url.pathname}'. However, it was found at these paths: ${paths}. Did you mean to set its 'path' to '/' instead?`
 				);
 			}
 		},


### PR DESCRIPTION
Fixes #7510 

Replaces the dev mode cookie warning with a more detailed one that doesn't get printed when a cookie was removed on the browser.

Essentially, only prints the warning when the cookie paths didn't include the request path.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
