### PR TITLE
[fix] don't clean build and output directories when using `--watch`

### DIFF
--- a/.changeset/large-starfishes-relate.md
+++ b/.changeset/large-starfishes-relate.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': minor
 ---
 
-Avoid cleaning build_dir and output_dir when using --watch
+[fix] don't clean build and output directories when using `--watch`

--- a/.changeset/large-starfishes-relate.md
+++ b/.changeset/large-starfishes-relate.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+Avoid cleaning build_dir and output_dir when using --watch

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -330,10 +330,10 @@ function kit() {
 			completed_build = false;
 
 			if (is_build) {
-        if (!vite_config.build.watch) {
-				  rimraf(paths.build_dir);
-				  rimraf(paths.output_dir);
-        }
+					if (!vite_config.build.watch) {
+						rimraf(paths.build_dir);
+						rimraf(paths.output_dir);
+					}
 				mkdirp(paths.build_dir);
 				mkdirp(paths.output_dir);
 			}

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -330,10 +330,11 @@ function kit() {
 			completed_build = false;
 
 			if (is_build) {
-				rimraf(paths.build_dir);
+        if (!vite_config.build.watch) {
+				  rimraf(paths.build_dir);
+				  rimraf(paths.output_dir);
+        }
 				mkdirp(paths.build_dir);
-
-				rimraf(paths.output_dir);
 				mkdirp(paths.output_dir);
 			}
 		},

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -330,10 +330,10 @@ function kit() {
 			completed_build = false;
 
 			if (is_build) {
-					if (!vite_config.build.watch) {
-						rimraf(paths.build_dir);
-						rimraf(paths.output_dir);
-					}
+				if (!vite_config.build.watch) {
+					rimraf(paths.build_dir);
+					rimraf(paths.output_dir);
+				}
 				mkdirp(paths.build_dir);
 				mkdirp(paths.output_dir);
 			}


### PR DESCRIPTION
When watching, static directory is missing on outDir because the vite svelte-kit plugin clean them

How to reproduce:

Create a clean svelte-kit project (choose skeleton and no to all questions)
- npm create svelte@latest watch_bug
- cd watch_bug
- npm install
- touch static/file.txt
- npx vite build -w
- Check files on .svelte-kit/output/client/, is missing file.txt and favicon.png

Couldn't devote too much time to do a better solution, so my PR only avoid cleaning directories when using --watch

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
