### PR TITLE
[fix] take into account Request input when serializing fetch data

### DIFF
--- a/.changeset/strange-walls-carry.md
+++ b/.changeset/strange-walls-carry.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] take into account Request input when serializing fetch data

--- a/packages/kit/test/apps/basics/src/routes/load/serialization-post-request/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization-post-request/+page.js
@@ -1,0 +1,20 @@
+/** @type {import('@sveltejs/kit').Load} */
+export async function load({ url, fetch }) {
+	/** @param {string} body */
+	async function post(body) {
+		const request = new Request(url.origin + '/load/serialization-post.json', {
+			method: 'POST',
+			headers: {
+				'content-type': 'text/plain'
+			},
+			body
+		});
+		const res = await fetch(request);
+
+		return await res.text();
+	}
+	const a = await post('x');
+	const b = await post('y');
+
+	return { a, b };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/serialization-post-request/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization-post-request/+page.svelte
@@ -1,0 +1,7 @@
+<script>
+	/** @type {import('./$types').PageData} */
+	export let data;
+</script>
+
+<h1>a: {data.a}</h1>
+<h2>b: {data.b}</h2>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -700,15 +700,13 @@ test.describe('Load', () => {
 		expect(await page.textContent('h1')).toBe('a: X');
 		expect(await page.textContent('h2')).toBe('b: Y');
 
-		const payload_a = '{"status":200,"statusText":"","headers":{},"body":"X"}';
-		const payload_b = '{"status":200,"statusText":"","headers":{},"body":"Y"}';
-
 		if (!javaScriptEnabled) {
+			const payload_a = '{"status":200,"statusText":"","headers":{},"body":"X"}';
+			const payload_b = '{"status":200,"statusText":"","headers":{},"body":"Y"}';
 			// by the time JS has run, hydration will have nuked these scripts
 			const script_contents_a = await page.innerHTML(
 				'script[data-sveltekit-fetched][data-url="/load/serialization-post.json"][data-hash="3t25"]'
 			);
-
 			const script_contents_b = await page.innerHTML(
 				'script[data-sveltekit-fetched][data-url="/load/serialization-post.json"][data-hash="3t24"]'
 			);
@@ -718,6 +716,31 @@ test.describe('Load', () => {
 		}
 
 		expect(requests.some((r) => r.endsWith('/load/serialization.json'))).toBe(false);
+	});
+
+	test.only('POST fetches with Request init are serialized', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		await page.goto('/load/serialization-post-request');
+
+		expect(await page.textContent('h1')).toBe('a: X');
+		expect(await page.textContent('h2')).toBe('b: Y');
+
+		if (!javaScriptEnabled) {
+			const payload_a = '{"status":200,"statusText":"","headers":{},"body":"X"}';
+			const payload_b = '{"status":200,"statusText":"","headers":{},"body":"Y"}';
+			// by the time JS has run, hydration will have nuked these scripts
+			const script_contents_a = await page.innerHTML(
+				'script[data-sveltekit-fetched][data-url="/load/serialization-post.json"][data-hash="3t25"]'
+			);
+			const script_contents_b = await page.innerHTML(
+				'script[data-sveltekit-fetched][data-url="/load/serialization-post.json"][data-hash="3t24"]'
+			);
+
+			expect(script_contents_a).toBe(payload_a);
+			expect(script_contents_b).toBe(payload_b);
+		}
 	});
 
 	test('json string is returned', async ({ page }) => {


### PR DESCRIPTION
Fixes #7514

I'm not sure if this is the best approach. I'm a little nervous because cloning the whole Request body might become costly, and since we can't read the body only when absolutely needed (because the ReadableStream is already consumed by then) we have to do it unconditionally. I would hope though that people calling fetch like this are in the minority.

A different solution would be to somehow give the request another kind of ID, like a call index, but that could be messed up if the user does something with `if (browser) fetch(..)`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
