### PR TITLE
[feat] enable caching for __data.json requests

### DIFF
--- a/.changeset/clean-sheep-run.md
+++ b/.changeset/clean-sheep-run.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-[feat] enable caching for \_\_data.json requests
+[feat] enable caching for `__data.json` requests

--- a/.changeset/clean-sheep-run.md
+++ b/.changeset/clean-sheep-run.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[feat] enable caching for \_\_data.json requests

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -5,6 +5,8 @@ import { load_server_data } from '../page/load_data.js';
 import { clarify_devalue_error, handle_error_and_jsonify, serialize_data_node } from '../utils.js';
 import { normalize_path, strip_data_suffix } from '../../../utils/url.js';
 
+export const INVALIDATED_HEADER = 'x-sveltekit-invalidated';
+
 /**
  * @param {import('types').RequestEvent} event
  * @param {import('types').SSRRoute} route
@@ -24,7 +26,7 @@ export async function render_data(event, route, options, state) {
 		const node_ids = [...route.page.layouts, route.page.leaf];
 
 		const invalidated =
-			event.request.headers.get('x-sveltekit-invalidated')?.split(',').map(Boolean) ??
+			event.request.headers.get(INVALIDATED_HEADER)?.split(',').map(Boolean) ??
 			node_ids.map(() => true);
 
 		let aborted = false;

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -307,7 +307,7 @@ export async function respond(request, options, state) {
 						// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary
 						const vary = response.headers.get('Vary');
 						if (vary !== '*') {
-							response.headers.set('Vary', `${vary ? `${vary}, ` : ''}${INVALIDATED_HEADER}`);
+							response.headers.append('Vary', INVALIDATED_HEADER);
 						}
 					}
 

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -1,7 +1,8 @@
 import { disable_search, make_trackable } from '../../../utils/url.js';
 import { unwrap_promises } from '../../../utils/promises.js';
+
 /**
- * Calls the user's `load` function.
+ * Calls the user's server `load` function.
  * @param {{
  *   event: import('types').RequestEvent;
  *   state: import('types').SSRState;

--- a/packages/kit/test/apps/basics/src/routes/caching/server-data/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/caching/server-data/+page.server.js
@@ -1,0 +1,6 @@
+/** @type {import('./$types').PageServerLoad} */
+export async function load({ setHeaders }) {
+	setHeaders({
+		'cache-control': 'public, max-age=30'
+	});
+}

--- a/packages/kit/test/apps/basics/src/routes/caching/server-data/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/caching/server-data/+page.svelte
@@ -1,0 +1,1 @@
+<h1>this page's __data.json will be cached for 30 seconds</h1>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -7,6 +7,18 @@ test.skip(({ javaScriptEnabled }) => !javaScriptEnabled);
 
 test.describe.configure({ mode: 'parallel' });
 
+test.describe('Caching', () => {
+	test('caches __data.json requests with Vary header', async ({ page, app }) => {
+		await page.goto('/');
+		const [, response] = await Promise.all([
+			app.goto('/caching/server-data'),
+			page.waitForResponse((request) => request.url().endsWith('server-data/__data.json'))
+		]);
+		expect(response.headers()['cache-control']).toBe('public, max-age=30');
+		expect(response.headers()['vary']).toBe('x-sveltekit-invalidated');
+	});
+});
+
 test.describe('beforeNavigate', () => {
 	test('prevents navigation triggered by link click', async ({ page, baseURL }) => {
 		await page.goto('/before-navigate/prevent-navigation');


### PR DESCRIPTION
...using the Vary header, which allows one cached response for each variation of the x-sveltekit-invalidated header, ensuring we cache matching responses for all invalidation scenarios
Closes #6477

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
