### PR TITLE
[fix] fetch cache control with body

### DIFF
--- a/.changeset/curvy-years-sin.md
+++ b/.changeset/curvy-years-sin.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] caching takes now into account the body payload

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -593,8 +593,8 @@ export function create_client({ target, base, trailing_slash }) {
 
 					// prerendered pages may be served from any origin, so `initial_fetch` urls shouldn't be resolved
 					return started
-						? subsequent_fetch(resolved, init)
-						: initial_fetch(requested, resolved, init);
+						? subsequent_fetch(requested, resolved, init)
+						: initial_fetch(requested, init);
 				},
 				setHeaders: () => {}, // noop
 				depends,

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-cache-control/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-cache-control/+page.svelte
@@ -1,0 +1,1 @@
+<a href="/load/fetch-cache-control/load-data">load-data</a>

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-cache-control/load-data/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-cache-control/load-data/+page.js
@@ -1,0 +1,24 @@
+export async function load(event) {
+	const url = '/load/fetch-cache-control/load-data';
+
+	const res_fr = await event.fetch(url, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify({ lang: `fr` })
+	});
+	const fr = await res_fr.json();
+
+	const res_hu = await event.fetch(url, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify({ lang: `hu` })
+	});
+
+	const hu = await res_hu.json();
+
+	return { fr, hu };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-cache-control/load-data/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-cache-control/load-data/+page.svelte
@@ -1,0 +1,16 @@
+<script>
+	export let data;
+	$: ({ fr, hu } = data);
+</script>
+
+<a href="/load/fetch-cache-control">fetch-cache-control</a>
+
+<h2>fr</h2>
+<div id="fr">
+	{JSON.stringify(fr)}
+</div>
+
+<h2>hu</h2>
+<div id="hu">
+	{JSON.stringify(hu)}
+</div>

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-cache-control/load-data/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-cache-control/load-data/+server.js
@@ -1,0 +1,20 @@
+import { json } from '@sveltejs/kit';
+
+/** @type {import('./$types').RequestHandler} */
+export async function POST({ request, setHeaders }) {
+	setHeaders({
+		'cache-control': 'public, max-age=7'
+	});
+
+	try {
+		const { lang } = await request.json();
+		if (lang === 'fr') {
+			return json({ hi: 'bonjour' });
+		} else if (lang === 'hu') {
+			return json({ hi: 'szia' });
+		}
+	} catch (error) {}
+
+	// default to english
+	return json({ hi: 'hello' });
+}

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -467,6 +467,23 @@ test.describe('Load', () => {
 		expect(response.headers()['cache-control']).toBe('private, no-store');
 	});
 
+	test('cache with body hash', async ({ page, clicknav }) => {
+		// 1/ go to the page (first load, we expect the right data)
+		await page.goto('/load/fetch-cache-control/load-data');
+		expect(await page.textContent('div#fr')).toBe(JSON.stringify({ hi: 'bonjour' }));
+		expect(await page.textContent('div#hu')).toBe(JSON.stringify({ hi: 'szia' }));
+
+		// 2/ change to another route (client side)
+		await clicknav('a');
+
+		// 3/ come back to the original page (client side)
+		await clicknav('a');
+
+		// 4/ data should still be the same (and cached!)
+		expect(await page.textContent('div#fr')).toBe(JSON.stringify({ hi: 'bonjour' }));
+		expect(await page.textContent('div#hu')).toBe(JSON.stringify({ hi: 'szia' }));
+	});
+
 	if (process.env.DEV) {
 		test('using window.fetch causes a warning', async ({ page }) => {
 			const port = 5173;


### PR DESCRIPTION
- Linked issue: #7545
- This PR adds a `hash` of the body to the fetch cache.
- a test was added here: `packages/kit/test/apps/basics/src/routes/load/fetch-origin-external` (failing first, then fixed with the PR)

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
