### PR TITLE
[fix] prevent double decoding of path segment

### DIFF
--- a/.changeset/young-geckos-sit.md
+++ b/.changeset/young-geckos-sit.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] prevent double decoding of path segment

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -72,11 +72,6 @@ export function parse_route_id(id) {
 									return (
 										content // allow users to specify characters on the file system in an encoded manner
 											.normalize()
-											// We use [ and ] to denote parameters, so users must encode these on the file
-											// system to match against them. We don't decode all characters since others
-											// can already be epressed and so that '%' can be easily used directly in filenames
-											.replace(/%5[Bb]/g, '[')
-											.replace(/%5[Dd]/g, ']')
 											// '#', '/', and '?' can only appear in URL path segments in an encoded manner.
 											// They will not be touched by decodeURI so need to be encoded here, so
 											// that we can match against them.

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -67,6 +67,11 @@ const tests = {
 		pattern: /^\/@at-encoded\/([^/]+?)\/?$/,
 		names: ['id'],
 		types: [undefined]
+	},
+	'/%255bdoubly-encoded': {
+		pattern: /^\/%5bdoubly-encoded\/?$/,
+		names: [],
+		types: []
 	}
 };
 


### PR DESCRIPTION
Segment is already decoded here, so another decoding is not needed

https://github.com/sveltejs/kit/blob/eab9680966812f8755b6d1fe37a310610ec43777/packages/kit/src/utils/routing.js#L24

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
