### PR TITLE
[fix] avoid decoding %25 in path segments

### DIFF
--- a/.changeset/proud-parrots-hang.md
+++ b/.changeset/proud-parrots-hang.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] avoid decoding %25 in path segments

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -21,7 +21,8 @@ export function parse_route_id(id) {
 			: new RegExp(
 					`^${get_route_segments(id)
 						.map((segment, i, segments) => {
-							const decoded_segment = decodeURIComponent(segment);
+							// exclude %25 from decoding to match decoding of url.pathname
+							const decoded_segment = segment.split('%25').map(decodeURIComponent).join('%25');
 							// special case — /[...rest]/ could contain zero segments
 							const rest_match = /^\[\.\.\.(\w+)(?:=(\w+))?\]$/.exec(decoded_segment);
 							if (rest_match) {

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -68,8 +68,8 @@ const tests = {
 		names: ['id'],
 		types: [undefined]
 	},
-	'/%255bdoubly-encoded': {
-		pattern: /^\/%5bdoubly-encoded\/?$/,
+	'/%25-not-encoded': {
+		pattern: /^\/%25-not-encoded\/?$/,
 		names: [],
 		types: []
 	}

--- a/packages/kit/test/apps/basics/src/routes/encoded/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/encoded/+page.svelte
@@ -8,3 +8,4 @@
 <a href="/encoded/test%252fme">test%2fme</a>
 <a href="/encoded/AC%2fDC">AC/DC</a>
 <a href="/encoded/%5b">[</a>
+<a href="/encoded/99%25">99%</a>

--- a/packages/kit/test/apps/basics/src/routes/encoded/[percent]%25/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/encoded/[percent]%25/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { page } from '$app/stores';
+</script>
+
+<h1>{$page.params.percent}%</h1>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -402,6 +402,12 @@ test.describe('Encoded paths', () => {
 		expect(await page.textContent('h1')).toBe('$SVLT');
 	});
 
+	test('allows %-encoded percent character in directory names', async ({ page, clicknav }) => {
+		await page.goto('/encoded');
+		await clicknav('[href="/encoded/99%25"]');
+		expect(await page.textContent('h1')).toBe('99%');
+	});
+
 	test('allows %-encoded characters in filenames', async ({ page, clicknav }) => {
 		await page.goto('/encoded');
 		await clicknav('[href="/encoded/@svelte"]');


### PR DESCRIPTION
Closes #7554

This is a draft because new test causes 500 error on hydration step.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
