### PR TITLE
[fix] handle locked readable stream when reading body

### DIFF
--- a/.changeset/funny-planes-judge.md
+++ b/.changeset/funny-planes-judge.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] handle locked readable stream when reading body

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -122,6 +122,15 @@ export async function setResponse(res, response) {
 		return;
 	}
 
+	if (response.body.locked) {
+		res.write(
+			'Fatal error: Response body is locked. ' +
+				`This can happen when the response was already read (for example through 'response.json()' or 'response.text()').`
+		);
+		res.end();
+		return;
+	}
+
 	const reader = response.body.getReader();
 
 	if (res.destroyed) {


### PR DESCRIPTION
We can't recover from it, but we shouldn't crash
Fixes #7560

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a rxason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
