### PR TITLE
Failing test for encoded underscore prefix in route path (https://github.com/sveltejs/kit/issues/7570)

### DIFF
--- a/packages/kit/test/apps/basics/src/routes/encoded/%5Funderscore-prefix/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/encoded/%5Funderscore-prefix/+page.svelte
@@ -1,1 +1,1 @@
-_underscore-prefix
+<h1>_underscore-prefix</h1>

--- a/packages/kit/test/apps/basics/src/routes/encoded/%5Funderscore-prefix/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/encoded/%5Funderscore-prefix/+page.svelte
@@ -1,0 +1,1 @@
+_underscore-prefix

--- a/packages/kit/test/apps/basics/src/routes/encoded/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/encoded/+page.svelte
@@ -4,6 +4,7 @@
 <a href="/encoded/redirect">Redirect</a>
 <a href="/encoded/@svelte">@svelte</a>
 <a href="/encoded/$SVLT">$SVLT</a>
+<a href="/encoded/_underscore-prefix">_underscore-prefix</a>
 <a href="/encoded/test%2520me">test%20me</a>
 <a href="/encoded/test%252fme">test%2fme</a>
 <a href="/encoded/AC%2fDC">AC/DC</a>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -407,6 +407,12 @@ test.describe('Encoded paths', () => {
 		await clicknav('[href="/encoded/@svelte"]');
 		expect(await page.textContent('h1')).toBe('@svelte');
 	});
+
+	test('allows %-encoded underscores in directory names', async ({ page, clicknav }) => {
+		await page.goto('/encoded');
+		await clicknav('[href="/encoded/_underscore-prefix"]');
+		expect(await page.textContent('h1')).toBe('_underscore-prefix');
+	});
 });
 
 test.describe('$env', () => {


### PR DESCRIPTION
This PR is currently just a failing test for https://github.com/sveltejs/kit/issues/7570. I've not yet looked into a fix.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
