### PR TITLE
[fix] prevent usage of unsafe encoded characters in path segments

### DIFF
--- a/.changeset/ninety-dogs-learn.md
+++ b/.changeset/ninety-dogs-learn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] prevent usage of unsafe encoded characters in path segments

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -67,11 +67,6 @@ const tests = {
 		pattern: /^\/@at-encoded\/([^/]+?)\/?$/,
 		names: ['id'],
 		types: [undefined]
-	},
-	'/%255bdoubly-encoded': {
-		pattern: /^\/%5bdoubly-encoded\/?$/,
-		names: [],
-		types: []
 	}
 };
 
@@ -193,6 +188,12 @@ for (const { path, route, expected } of exec_tests) {
 test('errors on bad param name', () => {
 	assert.throws(() => parse_route_id('abc/[b-c]'), /Invalid param: b-c/);
 	assert.throws(() => parse_route_id('abc/[bc=d-e]'), /Invalid param: bc=d-e/);
+});
+
+test('errors on bad encoded characters', () => {
+	assert.throws(() => parse_route_id('abc/%25'), /unprocessable encoded character %25/);
+	assert.throws(() => parse_route_id('abc/%40%5b/def'), /unprocessable encoded character %5B/);
+	assert.throws(() => parse_route_id('abc/%c2%b5/def'), /unprocessable encoded character %C2%B5/);
 });
 
 test.run();


### PR DESCRIPTION
Closes #7567
Closes #7554
Closes #7570

This PR prevents using path segments (folder names) to contain uri-decodable characters like `[]%` and so on.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
