### PR TITLE
serve prerendered non-page files when running preview

### DIFF
--- a/.changeset/cold-monkeys-relate.md
+++ b/.changeset/cold-monkeys-relate.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Serve prerendered non-page files when running preview

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -100,27 +100,24 @@ export async function preview(vite, vite_config, svelte_config) {
 
 				const { pathname } = new URL(/** @type {string} */ (req.url), 'http://dummy');
 
-				// only treat this as a page if it doesn't include an extension
-				if (pathname === '/' || /\/[^./]+\/?$/.test(pathname)) {
-					const file = join(
-						svelte_config.kit.outDir,
-						'output/prerendered/pages' +
-							pathname +
-							(pathname.endsWith('/') ? 'index.html' : '.html')
-					);
+				let filename = join(svelte_config.kit.outDir, 'output/prerendered/pages' + pathname);
+				let prerendered = is_file(filename);
 
-					if (fs.existsSync(file)) {
-						res.writeHead(200, {
-							'content-type': 'text/html',
-							etag
-						});
-
-						fs.createReadStream(file).pipe(res);
-						return;
-					}
+				if (!prerendered) {
+					filename += filename.endsWith('/') ? 'index.html' : '.html';
+					prerendered = is_file(filename);
 				}
 
-				next();
+				if (prerendered) {
+					res.writeHead(200, {
+						'content-type': 'text/html',
+						etag
+					});
+
+					fs.createReadStream(filename).pipe(res);
+				} else {
+					next();
+				}
 			})
 		);
 
@@ -186,4 +183,9 @@ function scoped(scope, handler) {
 			next();
 		}
 	};
+}
+
+/** @param {string} path */
+function is_file(path) {
+	return fs.existsSync(path) && !fs.statSync(path).isDirectory();
 }


### PR DESCRIPTION
Noticed that https://kit.svelte.dev/content.json isn't being served when running `preview` locally due to some faulty logic

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
