### PR TITLE
cache code snippets

### DIFF
--- a/sites/kit.svelte.dev/.gitignore
+++ b/sites/kit.svelte.dev/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .env
 /.svelte-kit/
+/.snippets
 /build/
 /functions/

--- a/sites/kit.svelte.dev/src/lib/docs/server/index.js
+++ b/sites/kit.svelte.dev/src/lib/docs/server/index.js
@@ -12,6 +12,13 @@ import { render_modules } from './modules.js';
 import { parse_route_id } from '../../../../../../packages/kit/src/utils/routing.js';
 import ts from 'typescript';
 import MagicString from 'magic-string';
+import { fileURLToPath } from 'url';
+import { createHash } from 'crypto';
+
+const snippet_cache = fileURLToPath(new URL('../../../../.snippets', import.meta.url));
+if (!fs.existsSync(snippet_cache)) {
+	fs.mkdirSync(snippet_cache, { recursive: true });
+}
 
 const languages = {
 	bash: 'bash',
@@ -54,8 +61,6 @@ export async function read_file(file) {
 	const match = /\d{2}-(.+)\.md/.exec(file.split(path.sep).pop());
 	if (!match) return null;
 
-	const slug = match[1];
-
 	const markdown = fs
 		.readFileSync(`${base}/${file}`, 'utf-8')
 		.replace('**TYPES**', () => render_modules('types'))
@@ -68,8 +73,15 @@ export async function read_file(file) {
 	const { content, sections } = parse({
 		body: generate_ts_from_js(body),
 		file,
-		slug,
 		code: (source, language, current) => {
+			const hash = createHash('sha256');
+			hash.update(source + language + current);
+			const digest = hash.digest().toString('base64').replace(/\//g, '-');
+
+			if (fs.existsSync(`${snippet_cache}/${digest}.html`)) {
+				return fs.readFileSync(`${snippet_cache}/${digest}.html`, 'utf-8');
+			}
+
 			/** @type {Record<string, string>} */
 			const options = {};
 
@@ -213,7 +225,7 @@ export async function read_file(file) {
 
 			type_regex.lastIndex = 0;
 
-			return html
+			html = html
 				.replace(type_regex, (match, prefix, name) => {
 					if (options.link === 'false' || name === current) {
 						// we don't want e.g. RequestHandler to link to RequestHandler
@@ -240,6 +252,9 @@ export async function read_file(file) {
 							.join('');
 					}
 				);
+
+			fs.writeFileSync(`${snippet_cache}/${digest}.html`, html);
+			return html;
 		},
 		codespan: (text) => {
 			return (
@@ -266,12 +281,11 @@ export async function read_file(file) {
  * @param {{
  *   body: string;
  *   file: string;
- *   slug: string;
  *   code: (source: string, language: string, current: string) => string;
  *   codespan: (source: string) => string;
  * }} opts
  */
-function parse({ body, file, slug, code, codespan }) {
+function parse({ body, file, code, codespan }) {
 	const headings = [];
 
 	/** @type {import('./types').Section[]} */


### PR DESCRIPTION
When developing the site locally, it takes forever to load a page that includes a lot of code snippets, because they have to be processed by shiki-twoslash which is quite expensive. It's very annoying.

This adds a simple cache that makes it essentially instant to see changes. It also speeds up builds by a massive amount, if the cache is already populated. In future we could conceivably wire this up to Turborepo's remote cache to speed up deploys across the board, though I'm not doing that here because there's probably lots of gotchas around type changes in SvelteKit being respected, or version changes invalidating caches.