### PR TITLE
remove --force from test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "monorepo for @sveltejs/kit and friends",
 	"private": true,
 	"scripts": {
-		"test": "turbo run test --filter=./packages/* --force",
+		"test": "turbo run test --filter=./packages/*",
 		"check": "turbo run check",
 		"lint": "turbo run lint",
 		"format": "turbo run format",


### PR DESCRIPTION
I know we've run into sticky caches before, but at the moment we're not using Turborepo at all. For things like docs changes we're causing CI to take waaaay longer than it needs to. I think we should remove `--force` and deal with caching bugs as they arise