### PR TITLE
fix: Add support linking to for <a name="hash"> tags.

### DIFF
--- a/.changeset/empty-vans-draw.md
+++ b/.changeset/empty-vans-draw.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add support for linking to <a name="hash"> tags

--- a/packages/kit/src/core/prerender/crawl.js
+++ b/packages/kit/src/core/prerender/crawl.js
@@ -160,6 +160,8 @@ export function crawl(html) {
 								href = value;
 							} else if (name === 'id') {
 								ids.push(value);
+							} else if (name === 'name' && tag === 'A') {
+								ids.push(value);
 							} else if (name === 'rel') {
 								rel = value;
 							} else if (name === 'src') {


### PR DESCRIPTION
Fixes the following error:
```
The following pages contain links to /#hash, but no element with id="hash" exists on /
```
when using `<a name="hash">` anchors.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
