### PR TITLE
don't print search params error when prerendering fallback page

### DIFF
--- a/.changeset/cyan-beds-smoke.md
+++ b/.changeset/cyan-beds-smoke.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Don't print search params error when prerendering fallback page

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -102,7 +102,7 @@ export async function respond(request, options, state) {
 
 	const { cookies, new_cookies, get_cookie_header } = get_cookies(request, url, options);
 
-	if (state.prerendering) disable_search(url);
+	if (state.prerendering && !state.prerendering.fallback) disable_search(url);
 
 	/** @type {import('types').RequestEvent} */
 	const event = {


### PR DESCRIPTION
closes #7458. the bug and the fix are both trivial enough that I didn't bother adding a test for this

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
