### PR TITLE
[fix] add optional Promise return type to `enhance` action

### DIFF
--- a/.changeset/honest-eyes-thank.md
+++ b/.changeset/honest-eyes-thank.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] add Promise return type to the `enhance` action

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -95,6 +95,20 @@ declare module '$app/environment' {
 declare module '$app/forms' {
 	import type { ActionResult } from '@sveltejs/kit';
 
+	export type ActionCallback<
+		Success extends Record<string, unknown> | undefined = Record<string, any>,
+		Invalid extends Record<string, unknown> | undefined = Record<string, any>
+	> = (opts: {
+		form: HTMLFormElement;
+		action: URL;
+		result: ActionResult<Success, Invalid>;
+		/**
+		 * Call this to get the default behavior of a form submission response.
+		 * @param options Set `reset: false` if you don't want the `<form>` values to be reset after a successful submission.
+		 */
+		update(options?: { reset: boolean }): Promise<void>;
+	}) => void;
+
 	export type SubmitFunction<
 		Success extends Record<string, unknown> | undefined = Record<string, any>,
 		Invalid extends Record<string, unknown> | undefined = Record<string, any>
@@ -104,18 +118,7 @@ declare module '$app/forms' {
 		form: HTMLFormElement;
 		controller: AbortController;
 		cancel(): void;
-	}) =>
-		| void
-		| ((opts: {
-				form: HTMLFormElement;
-				action: URL;
-				result: ActionResult<Success, Invalid>;
-				/**
-				 * Call this to get the default behavior of a form submission response.
-				 * @param options Set `reset: false` if you don't want the `<form>` values to be reset after a successful submission.
-				 */
-				update(options?: { reset: boolean }): Promise<void>;
-		  }) => void);
+	}) => void | ActionCallback<Success, Invalid> | Promise<void | ActionCallback<Success, Invalid>>;
 
 	/**
 	 * This action enhances a `<form>` element that otherwise would work without JavaScript.


### PR DESCRIPTION
fixes #7628

My bad for forgetting to update the type!

Not sure if this is the best way to update it to optionally return a Promise.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
