### PR TITLE
[fix] prerendering path and layout fixes

### DIFF
--- a/.changeset/curly-suits-lay.md
+++ b/.changeset/curly-suits-lay.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] prerendering path and layout fixes

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -19,9 +19,11 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 	 */
 	const reindexed = new Map();
 	/**
-	 * @type {Set<any>} All nodes actually used in the routes definition (prerendered routes are omitted)
+	 * All nodes actually used in the routes definition (prerendered routes are omitted).
+	 * Root layout/error is always included as they are needed for 404 and root errors.
+	 * @type {Set<any>}
 	 */
-	const used_nodes = new Set();
+	const used_nodes = new Set([0, 1]);
 
 	for (const route of routes) {
 		if (route.page) {

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -5,7 +5,7 @@ import { pathToFileURL } from 'url';
 import { getRequest, setResponse } from '../../../exports/node/index.js';
 import { installPolyfills } from '../../../exports/node/polyfills.js';
 import { SVELTE_KIT_ASSETS } from '../../../constants.js';
-import { loadEnv } from 'vite';
+import { loadEnv, normalizePath } from 'vite';
 
 /** @typedef {import('http').IncomingMessage} Req */
 /** @typedef {import('http').ServerResponse} Res */
@@ -100,7 +100,9 @@ export async function preview(vite, vite_config, svelte_config) {
 
 				const { pathname } = new URL(/** @type {string} */ (req.url), 'http://dummy');
 
-				let filename = join(svelte_config.kit.outDir, 'output/prerendered/pages' + pathname);
+				let filename = normalizePath(
+					join(svelte_config.kit.outDir, 'output/prerendered/pages' + pathname)
+				);
 				let prerendered = is_file(filename);
 
 				if (!prerendered) {


### PR DESCRIPTION
Fixes #7618 - root layout/error should always be included
Fixes #7633 - windows path conversion

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
