### PR TITLE
Warn if `%sveltekit.body%` is a direct child of `<body>`

### DIFF
--- a/.changeset/purple-apes-whisper.md
+++ b/.changeset/purple-apes-whisper.md
@@ -2,4 +2,4 @@
 'create-svelte': patch
 ---
 
-Add style="display: contents" to wrapper element by default
+Add `style="display: contents"` to wrapper element by default

--- a/.changeset/purple-apes-whisper.md
+++ b/.changeset/purple-apes-whisper.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Add style="display: contents" to wrapper element by default

--- a/.changeset/slimy-laws-argue.md
+++ b/.changeset/slimy-laws-argue.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Warn if %sveltekit.body% is direct child of <body>

--- a/.changeset/slimy-laws-argue.md
+++ b/.changeset/slimy-laws-argue.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Warn if %sveltekit.body% is direct child of <body>
+Warn if `%sveltekit.body%` is direct child of `<body>`

--- a/documentation/docs/10-getting-started/30-project-structure.md
+++ b/documentation/docs/10-getting-started/30-project-structure.md
@@ -42,7 +42,7 @@ The `src` directory contains the meat of your project.
 - `routes` contains the [routes](/docs/routing) of your application
 - `app.html` is your page template — an HTML document containing the following placeholders:
   - `%sveltekit.head%` — `<link>` and `<script>` elements needed by the app, plus any `<svelte:head>` content
-  - `%sveltekit.body%` — the markup for a rendered page. Typically this lives inside a `<div>` or other element, rather than directly inside `<body>`, to prevent bugs caused by browser extensions injecting elements that are then destroyed by the hydration process
+  - `%sveltekit.body%` — the markup for a rendered page. This should live inside a `<div>` or other element, rather than directly inside `<body>`, to prevent bugs caused by browser extensions injecting elements that are then destroyed by the hydration process. SvelteKit will warn you in development if this is not the case
   - `%sveltekit.assets%` — either [`paths.assets`](/docs/configuration#paths), if specified, or a relative path to [`paths.base`](/docs/configuration#paths)
   - `%sveltekit.nonce%` — a [CSP](/docs/configuration#csp) nonce for manually included links and scripts, if used
 - `error.html` (optional) is the page that is rendered when everything else fails. It can contain the following placeholders:

--- a/packages/create-svelte/templates/default/src/app.html
+++ b/packages/create-svelte/templates/default/src/app.html
@@ -7,6 +7,6 @@
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-prefetch>
-		<div>%sveltekit.body%</div>
+		<div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/packages/create-svelte/templates/skeleton/src/app.html
+++ b/packages/create-svelte/templates/skeleton/src/app.html
@@ -7,6 +7,6 @@
 		%sveltekit.head%
 	</head>
 	<body>
-		<div>%sveltekit.body%</div>
+		<div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -19,6 +19,12 @@ export async function start({ env, hydrate, paths, target, trailing_slash }) {
 	set_public_env(env);
 	set_paths(paths);
 
+	if (__SVELTEKIT_DEV__ && target === document.body) {
+		console.warn(
+			`Placing %sveltekit.body% directly inside <body> is not recommended, as your app may break for users who have certain browser extensions installed.\n\nConsider wrapping it in an element:\n\n<div style="display: contents">\n  %sveltekit.body%\n</div>`
+		);
+	}
+
 	const client = create_client({
 		target,
 		base: paths.base,


### PR DESCRIPTION
#7585. In addition to the warning, it adds `display: contents` to the wrapper elements in the template apps

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
