### PR TITLE
Ignore Vite timestamp files by default in `create-svelte` templates (added to `.gitignore`)

### DIFF
--- a/.changeset/clean-grapes-think.md
+++ b/.changeset/clean-grapes-think.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Ignore Vite timestamp files by default in `create-svelte` templates (added to `.gitignore`)

--- a/packages/create-svelte/templates/default/.gitignore
+++ b/packages/create-svelte/templates/default/.gitignore
@@ -8,3 +8,5 @@ node_modules
 !.env.example
 .vercel
 .output
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*

--- a/packages/create-svelte/templates/skeleton/.gitignore
+++ b/packages/create-svelte/templates/skeleton/.gitignore
@@ -6,3 +6,5 @@ node_modules
 .env
 .env.*
 !.env.example
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*

--- a/packages/create-svelte/templates/skeletonlib/.gitignore
+++ b/packages/create-svelte/templates/skeletonlib/.gitignore
@@ -6,3 +6,5 @@ node_modules
 .env
 .env.*
 !.env.example
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*


### PR DESCRIPTION
Because why new SvelteKit users need to figure this out by themselves?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
