### PR TITLE
pass asset list to adapters

### DIFF
--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -41,7 +41,7 @@ export default function () {
 
 			writeFileSync(
 				`${dest}/_routes.json`,
-				JSON.stringify(get_routes_json(builder.config.kit.appDir, written_files))
+				JSON.stringify(get_routes_json(builder.config.kit.appDir, written_files)) // TODO involve builder.assets here
 			);
 
 			writeFileSync(`${dest}/_headers`, generate_headers(builder.config.kit.appDir));

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -12,6 +12,7 @@ const pipe = promisify(pipeline);
 /**
  * Creates the Builder which is passed to adapters for building the application.
  * @param {{
+ *   assets: import('types').Asset[];
  *   config: import('types').ValidatedConfig;
  *   build_data: import('types').BuildData;
  *   routes: import('types').RouteData[];
@@ -20,13 +21,14 @@ const pipe = promisify(pipeline);
  * }} opts
  * @returns {import('types').Builder}
  */
-export function create_builder({ config, build_data, routes, prerendered, log }) {
+export function create_builder({ assets, config, build_data, routes, prerendered, log }) {
 	return {
 		log,
 		rimraf,
 		mkdirp,
 		copy,
 
+		assets,
 		config,
 		prerendered,
 

--- a/packages/kit/src/core/adapt/index.js
+++ b/packages/kit/src/core/adapt/index.js
@@ -14,6 +14,7 @@ export async function adapt(config, build_data, prerendered, prerender_map, { lo
 	console.log(colors.bold().cyan(`\n> Using ${name}`));
 
 	const builder = create_builder({
+		assets: build_data.manifest_data.assets,
 		config,
 		build_data,
 		routes: build_data.manifest_data.routes.filter((route) => {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -17,7 +17,7 @@ import {
 	TrailingSlash,
 	UniqueInterface
 } from './private.js';
-import { SSRNodeLoader, SSRRoute, ValidatedConfig } from './internal.js';
+import { Asset, SSRNodeLoader, SSRRoute, ValidatedConfig } from './internal.js';
 import { HttpError, Redirect } from '../src/runtime/control.js';
 
 export { PrerenderOption } from './private.js';
@@ -71,6 +71,7 @@ export interface Builder {
 	rimraf(dir: string): void;
 	mkdirp(dir: string): void;
 
+	assets: Asset[];
 	config: ValidatedConfig;
 	prerendered: Prerendered;
 


### PR DESCRIPTION
had a quick look at #7640 to see if there's anything needed from the framework itself. i'm a little unclear on why requests are 404ing — it seems that the worker should be able to serve the assets, even if doing so is wasteful.

regardless, if we're not going to add all of `written_files` to the `exclude` array, then we probably need to pass the `assets` list (which contains all the files in the `static` folder) so that we can figure out which files were generated? not sure about any of this, so just going to leave this here in draft form for now