### PR TITLE
Add nonce placeholder to CSP docs

### DIFF
--- a/documentation/docs/50-api-reference/10-configuration.md
+++ b/documentation/docs/50-api-reference/10-configuration.md
@@ -157,6 +157,8 @@ export default config;
 
 ...would prevent scripts loading from external sites. SvelteKit will augment the specified directives with nonces or hashes (depending on `mode`) for any inline styles and scripts it generates.
 
+To add nonce on a specific script, you may use the placeholder `%sveltekit.nonce%` as `<script nonce="%sveltekit.nonce%">` on scripts loaded in app.html.
+
 When pages are prerendered, the CSP header is added via a `<meta http-equiv>` tag (note that in this case, `frame-ancestors`, `report-uri` and `sandbox` directives will be ignored).
 
 > When `mode` is `'auto'`, SvelteKit will use nonces for dynamically rendered pages and hashes for prerendered pages. Using nonces with prerendered pages is insecure and therefore forbidden.

--- a/documentation/docs/50-api-reference/10-configuration.md
+++ b/documentation/docs/50-api-reference/10-configuration.md
@@ -157,7 +157,7 @@ export default config;
 
 ...would prevent scripts loading from external sites. SvelteKit will augment the specified directives with nonces or hashes (depending on `mode`) for any inline styles and scripts it generates.
 
-To add nonce on a specific script, you may use the placeholder `%sveltekit.nonce%` as `<script nonce="%sveltekit.nonce%">` on scripts loaded in app.html.
+To add a nonce for scripts and links manually included in `app.html`, you may use the placeholder `%sveltekit.nonce%` (for example `<script nonce="%sveltekit.nonce%">`).
 
 When pages are prerendered, the CSP header is added via a `<meta http-equiv>` tag (note that in this case, `frame-ancestors`, `report-uri` and `sandbox` directives will be ignored).
 


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

<hr>
Might solve #4440

Adds placeholder for nonce in the CSP section of the configuration part of the API reference docs