### PR TITLE
Revert "only apply polyfills where necessary"

### DIFF
--- a/.changeset/many-rivers-hide.md
+++ b/.changeset/many-rivers-hide.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': patch
----
-
-Only apply polyfills where necessary

--- a/packages/kit/src/exports/node/polyfills.js
+++ b/packages/kit/src/exports/node/polyfills.js
@@ -18,8 +18,6 @@ const globals = {
 // exported for dev/preview and node environments
 export function installPolyfills() {
 	for (const name in globals) {
-		if (name in globalThis) continue;
-
 		Object.defineProperty(globalThis, name, {
 			enumerable: true,
 			configurable: true,


### PR DESCRIPTION
Reverts sveltejs/kit#7668, as it caused #7673 (since Node 18 apparently has an old version of undici)