### PR TITLE
[chore] upgrade marked

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -31,7 +31,7 @@
 		"@types/node": "^16.11.68",
 		"@types/sade": "^1.7.4",
 		"@types/set-cookie-parser": "^2.4.2",
-		"marked": "^4.1.1",
+		"marked": "^4.2.2",
 		"rollup": "^2.79.1",
 		"svelte": "^3.52.0",
 		"svelte-preprocess": "^4.10.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,7 +274,7 @@ importers:
       devalue: ^4.2.0
       kleur: ^4.1.5
       magic-string: ^0.26.7
-      marked: ^4.1.1
+      marked: ^4.2.2
       mime: ^3.0.0
       rollup: ^2.79.1
       sade: ^1.8.1
@@ -710,7 +710,7 @@ importers:
       '@types/node': ^16.11.68
       flexsearch: ^0.7.31
       magic-string: ^0.26.7
-      marked: ^4.1.1
+      marked: ^4.2.2
       prism-svelte: ^0.5.0
       prismjs: ^1.29.0
       shiki-twoslash: ^3.1.0

--- a/sites/kit.svelte.dev/package.json
+++ b/sites/kit.svelte.dev/package.json
@@ -17,7 +17,7 @@
 		"@types/node": "^16.11.68",
 		"flexsearch": "^0.7.31",
 		"magic-string": "^0.26.7",
-		"marked": "^4.1.1",
+		"marked": "^4.2.2",
 		"prism-svelte": "^0.5.0",
 		"prismjs": "^1.29.0",
 		"shiki-twoslash": "^3.1.0",


### PR DESCRIPTION
https://github.com/sveltejs/kit/pull/7657 updated `pnpm-lock.yaml` without touching any `package.json` files. Maybe that's giving the cache difficulty? Upgrade `marked` to touch the `package.json` files and see if it fixes the Vercel deployment issues