### PR TITLE
warn if recommended env vars are missing

### DIFF
--- a/.changeset/chilled-toes-report.md
+++ b/.changeset/chilled-toes-report.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Warn if ORIGIN/PROTOCOL_HEADER/HOST_HEADER are unset

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -21,6 +21,12 @@ const body_size_limit = parseInt(env('BODY_SIZE_LIMIT', '524288'));
 
 const dir = path.dirname(fileURLToPath(import.meta.url));
 
+if (!origin && (!address_header || !host_header)) {
+	console.warn(
+		`You should specify either ${ENV_PREFIX}ORIGIN or both ${ENV_PREFIX}PROTOCOL_HEADER and ${ENV_PREFIX}HOST_HEADER so that adapter-node can reliably determine the request URL. See https://github.com/sveltejs/kit/tree/master/packages/adapter-node#environment-variables for more information`
+	);
+}
+
 /**
  * @param {string} path
  * @param {boolean} client


### PR DESCRIPTION
#7042. When using `adapter-node`, if the `ORIGIN` header is missing, and `PROTOCOL_HEADER` and `HOST_HEADER` aren't both set, then request URLs are very likely to be incorrect. That will result in the CSRF check misfiring, for example.

I don't 100% know if this solution is appropriate but it's the best I've got

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
