### PR TITLE
Made `config.kit.outDir` able to be located in `node_modules`

### DIFF
--- a/.changeset/thirty-seahorses-leave.md
+++ b/.changeset/thirty-seahorses-leave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Made `config.kit.outDir` able to be located in `node_modules`

--- a/packages/kit/src/core/sync/utils.js
+++ b/packages/kit/src/core/sync/utils.js
@@ -34,7 +34,7 @@ export function trim(str) {
 
 /**
  * This function generates relative paths, whoose `from` argument can safely reside
- * inside of `node_modules`. Otherwise paths returned by `path.relative` would be interpreted
+ * inside of `node_modules`. Otherwise paths returned by `path.relative` could be interpreted
  * as package paths.
  *
  * @param { string } from

--- a/packages/kit/src/core/sync/utils.js
+++ b/packages/kit/src/core/sync/utils.js
@@ -31,3 +31,16 @@ export function trim(str) {
 	const pattern = new RegExp(`^${indentation}`, 'gm');
 	return str.replace(pattern, '').trim();
 }
+
+/**
+ * This function generates relative paths, whoose `from` argument can safely reside
+ * inside of `node_modules`. Otherwise paths returned by `path.relative` would be interpreted
+ * as package paths.
+ *
+ * @param { string } from
+ * @param { string } to
+ * @returns { string }
+ */
+export function relative_path(from, to) {
+	return `.${path.sep}${path.relative(from, to)}`;
+}

--- a/packages/kit/src/core/sync/write_client_manifest.js
+++ b/packages/kit/src/core/sync/write_client_manifest.js
@@ -1,7 +1,6 @@
-import { relative } from 'path';
 import { posixify, resolve_entry } from '../../utils/filesystem.js';
 import { s } from '../../utils/misc.js';
-import { trim, write_if_changed } from './utils.js';
+import { relative_path, trim, write_if_changed } from './utils.js';
 
 /**
  * Writes the client manifest to disk. The manifest is used to power the router. It contains the
@@ -20,14 +19,16 @@ export function write_client_manifest(config, manifest_data, output) {
 
 		if (node.shared) {
 			declarations.push(
-				`import * as shared from ${s(relative(`${output}/nodes`, node.shared))};`,
+				`import * as shared from ${s(relative_path(`${output}/nodes`, node.shared))};`,
 				`export { shared };`
 			);
 		}
 
 		if (node.component) {
 			declarations.push(
-				`export { default as component } from ${s(relative(`${output}/nodes`, node.component))};`
+				`export { default as component } from ${s(
+					relative_path(`${output}/nodes`, node.component)
+				)};`
 			);
 		}
 
@@ -86,7 +87,11 @@ export function write_client_manifest(config, manifest_data, output) {
 	write_if_changed(
 		`${output}/client-manifest.js`,
 		trim(`
-			${hooks_file ? `import * as client_hooks from '${posixify(relative(output, hooks_file))}';` : ''}
+			${
+				hooks_file
+					? `import * as client_hooks from '${posixify(relative_path(output, hooks_file))}';`
+					: ''
+			}
 
 			export { matchers } from './client-matchers.js';
 

--- a/packages/kit/src/core/sync/write_matchers.js
+++ b/packages/kit/src/core/sync/write_matchers.js
@@ -1,6 +1,5 @@
-import path from 'path';
 import { s } from '../../utils/misc.js';
-import { write_if_changed } from './utils.js';
+import { relative_path, write_if_changed } from './utils.js';
 
 /**
  * @param {import('types').ManifestData} manifest_data
@@ -13,7 +12,7 @@ export function write_matchers(manifest_data, output) {
 	for (const key in manifest_data.matchers) {
 		const src = manifest_data.matchers[key];
 
-		imports.push(`import { match as ${key} } from ${s(path.relative(output, src))};`);
+		imports.push(`import { match as ${key} } from ${s(relative_path(output, src))};`);
 		matchers.push(key);
 	}
 


### PR DESCRIPTION
Previously, if someone tried to make `config.kit.outDir` something like `./node_modules/.svelte-kit`, build and dev processes would execute, but they would quickly start to error like this:
```
X [ERROR] Could not resolve "..\\..\\..\\@sveltejs\\kit\\src\\runtime\\components\\layout.svelte"

    node_modules/.kit/generated/nodes/0.js:1:37:
      1 │ export { default as component } from "..\\..\\..\\@sveltejs\\kit\\src\\runtime\\components\\layout.svelte";
        │                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        ╵                                      "./..\\..\\..\\@sveltejs\\kit\\src\\runtime\\components\\layout.svelte"

  Use the relative path "./..\\..\\..\\@sveltejs\\kit\\src\\runtime\\components\\layout.svelte" to
  reference the file "node_modules/@sveltejs/kit/src/runtime/components/layout.svelte". Without the
  leading "./", the path "..\\..\\..\\@sveltejs\\kit\\src\\runtime\\components\\layout.svelte" is
  being interpreted as a package path instead.
```
The error message already explains the underlying issue: Certain imports are being wrongly interpreted. To combat this I've added a `relative_path` function, which fixes this behaviour.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
