### PR TITLE
docs: add relevant variables to form example

### DIFF
--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -178,8 +178,17 @@ export const actions = {
 
 ```diff
 /// file: src/routes/login/+page.svelte
+<script>
+	import { page } from '$app/stores'
+
+	export let form
+</script>
+
 <form method="POST" action="?/login">
 -	<input name="email" type="email">
++	{#if form?.missing || form?.incorrect}
++		<p>{$page.status} There are errors in your form submission. See below</p>
++	{/if}
 +	{#if form?.missing}<p class="error">The email field is required</p>{/if}
 +	{#if form?.incorrect}<p class="error">Invalid credentials!</p>{/if}
 +	<input name="email" type="email" value={form?.email ?? ''}>

--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -181,13 +181,16 @@ export const actions = {
 <script>
 	import { page } from '$app/stores'
 
+	/** @type {import('./$types').ActionData} */
 	export let form
 </script>
 
 <form method="POST" action="?/login">
 -	<input name="email" type="email">
-+	{#if form?.missing || form?.incorrect}
-+		<p>{$page.status} There are errors in your form submission. See below</p>
++	{#if form?.incorrect && $page.status === 400}
++		<p>There are errors in your form submission. See below</p>
++	{:else if form?.incorrect && $page.status === 409}
++		<p>Account already exists, please log in or register with a different email.</p>
 +	{/if}
 +	{#if form?.missing}<p class="error">The email field is required</p>{/if}
 +	{#if form?.incorrect}<p class="error">Invalid credentials!</p>{/if}

--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -140,7 +140,7 @@ export const actions = {
 
 #### Validation errors
 
-If the request couldn't be processed because of invalid data, you can return validation errors — along with the previously submitted form values — back to the user so that they can try again. The `invalid` function lets you return an HTTP status code (typically 400 or 422, in the case of validation errors) along with the data:
+If the request couldn't be processed because of invalid data, you can return validation errors — along with the previously submitted form values — back to the user so that they can try again. The `invalid` function lets you return an HTTP status code in `$page.status` (typically 400 or 422, in the case of validation errors) along with the data in `form`:
 
 ```diff
 // @errors: 2339 2304
@@ -178,20 +178,8 @@ export const actions = {
 
 ```diff
 /// file: src/routes/login/+page.svelte
-<script>
-	import { page } from '$app/stores'
-
-	/** @type {import('./$types').ActionData} */
-	export let form
-</script>
-
 <form method="POST" action="?/login">
 -	<input name="email" type="email">
-+	{#if form?.incorrect && $page.status === 400}
-+		<p>There are errors in your form submission. See below</p>
-+	{:else if form?.incorrect && $page.status === 409}
-+		<p>Account already exists, please log in or register with a different email.</p>
-+	{/if}
 +	{#if form?.missing}<p class="error">The email field is required</p>{/if}
 +	{#if form?.incorrect}<p class="error">Invalid credentials!</p>{/if}
 +	<input name="email" type="email" value={form?.email ?? ''}>

--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -140,7 +140,7 @@ export const actions = {
 
 #### Validation errors
 
-If the request couldn't be processed because of invalid data, you can return validation errors — along with the previously submitted form values — back to the user so that they can try again. The `invalid` function lets you return an HTTP status code in `$page.status` (typically 400 or 422, in the case of validation errors) along with the data in `form`:
+If the request couldn't be processed because of invalid data, you can return validation errors — along with the previously submitted form values — back to the user so that they can try again. The `invalid` function lets you return an HTTP status code (typically 400 or 422, in the case of validation errors) along with the data. The status code is available through `$page.status`, and the data through `form`:
 
 ```diff
 // @errors: 2339 2304

--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -140,7 +140,7 @@ export const actions = {
 
 #### Validation errors
 
-If the request couldn't be processed because of invalid data, you can return validation errors — along with the previously submitted form values — back to the user so that they can try again. The `invalid` function lets you return an HTTP status code (typically 400 or 422, in the case of validation errors) along with the data. The status code is available through `$page.status`, and the data through `form`:
+If the request couldn't be processed because of invalid data, you can return validation errors — along with the previously submitted form values — back to the user so that they can try again. The `invalid` function lets you return an HTTP status code (typically 400 or 422, in the case of validation errors) along with the data. The status code is available through `$page.status` and the data through `form`:
 
 ```diff
 // @errors: 2339 2304


### PR DESCRIPTION
* Show `$page` store and `form` variable in invalid form example. 

I was a bit stumped by how to to display the status code passed into `return invalid()`, so I hyper-focused on the "Validation errors" section on this page and couldn't find information despite it being mentioned:

> The invalid function lets you return an <ins>HTTP status code</ins> (typically 400 or 422, in the case of validation errors) along with the data

`$page` and `$page.status` are mentioned several times on that document already, so hopefully this small change to the example will help others.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
