### PR TITLE
external fetch calls: ensure serialized cookie values are url-encoded

### DIFF
--- a/.changeset/empty-fireants-fetch.md
+++ b/.changeset/empty-fireants-fetch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+external fetch calls: ensure serialized cookie values are url-encoded [#7736]

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -186,7 +186,7 @@ export function get_cookies(request, url, options) {
 		}
 
 		return Object.entries(combined_cookies)
-			.map(([name, value]) => `${name}=${value}`)
+			.map(([name, value]) => `${name}=${encodeURIComponent(value)}`)
 			.join('; ');
 	}
 

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -42,12 +42,13 @@ paths.negative.forEach(([path, constraint]) => {
 	});
 });
 
-/** @param {string} href */
-const cookies_setup = (href = 'https://example.com') => {
-	const url = new URL(href);
+/** @param {{ href?: string, headers?: Record<string, string> }} href */
+const cookies_setup = ({ href, headers } = {}) => {
+	const url = new URL(href || 'https://example.com');
 	const request = new Request(url, {
 		headers: new Headers({
-			cookie: 'a=b;'
+			cookie: 'a=b;',
+			...headers
 		})
 	});
 	return get_cookies(request, url, { dev: false, trailing_slash: 'ignore' });
@@ -72,7 +73,7 @@ test('default values when set is called', () => {
 });
 
 test('default values when set is called on sub path', () => {
-	const { cookies, new_cookies } = cookies_setup('https://example.com/foo/bar');
+	const { cookies, new_cookies } = cookies_setup({ href: 'https://example.com/foo/bar' });
 	cookies.set('a', 'b');
 	const opts = new_cookies['a']?.options;
 	assert.equal(opts?.secure, true);
@@ -82,7 +83,7 @@ test('default values when set is called on sub path', () => {
 });
 
 test('default values when on localhost', () => {
-	const { cookies, new_cookies } = cookies_setup('http://localhost:1234');
+	const { cookies, new_cookies } = cookies_setup({ href: 'http://localhost:1234' });
 	cookies.set('a', 'b');
 	const opts = new_cookies['a']?.options;
 	assert.equal(opts?.secure, false);
@@ -144,6 +145,20 @@ test('cookie names are case sensitive', () => {
 	const entryA = new_cookies['A'];
 	assert.equal(entrya?.value, 'foo');
 	assert.equal(entryA?.value, 'bar');
+});
+
+test('serialized cookie header should be url-encoded', () => {
+	const href = 'https://example.com';
+	const { cookies, get_cookie_header } = cookies_setup({
+		href,
+		headers: {
+			cookie: 'a=f%C3%BC' // a=fü
+		}
+	});
+	// not that one should do this, but we follow the spec...
+	cookies.set('b', 'fö');
+	const header = get_cookie_header(new URL(href), 'c=f%C3%A4');
+	assert.equal(header, 'a=f%C3%BC; b=f%C3%B6; c=f%C3%A4');
 });
 
 test.run();

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -155,10 +155,10 @@ test('serialized cookie header should be url-encoded', () => {
 			cookie: 'a=f%C3%BC' // a=fü
 		}
 	});
-	// not that one should do this, but we follow the spec...
-	cookies.set('b', 'fö');
-	const header = get_cookie_header(new URL(href), 'c=f%C3%A4');
-	assert.equal(header, 'a=f%C3%BC; b=f%C3%B6; c=f%C3%A4');
+	cookies.set('b', 'fö'); // should use default encoding
+	cookies.set('c', 'fö', { encode: () => 'öf' }); // should respect `encode`
+	const header = get_cookie_header(new URL(href), 'd=f%C3%A4');
+	assert.equal(header, 'a=f%C3%BC; b=f%C3%B6; c=öf; d=f%C3%A4');
 });
 
 test.run();


### PR DESCRIPTION
### TLDR

before: external fetch cookie was sent plain

```
browser
     |
(request with url-encoded cookie) (cookie=foo%2Bbar)
     |
     v
sveltekit node app
     |
(external fetch request made with url-DEcoded cookie) (cookie=foo+bar)
     |
     v
backend service
```

after: external fetch cookie is url-encoded

```
browser
     |
(request with url-encoded cookie) (cookie=foo%2Bbar)
     |
     v
sveltekit node app
     |
(external fetch request made with url-ENcoded cookie) (cookie=foo%2Bbar)
     |
     v
backend service
```

### Description

My kit app was making external `fetch` requests with cookies that were different from the the cookies that were part of the original request to the app.

My request coming from the browser had a session cookie that was url-encoded. My sveltekit server code would then use the kit-`fetch` to make a request to a backend api server that uses that same session token in the cookie. But when the request to the api left the kit app, the cookie was not url-encoded anymore. This caused problems in my api server because it would parse the
cookies by doing a url-decode on the values. Given my session token could contain characters that could further url-decode, it would get garbled when it was url-decoded by the api, because it was not url-encoded anymore.

From my superficial web readings, there seems to be no hard standard on the encoding of cookies. But the industry trend seems to be to url-encode cookie values.

### Conclusion

Given that:

1. The industry trend seems to be to url-encode cookie values. 
2. This cookie.js code already url-decodes cookies on the way in. 
3. "Forwarded" input cookies are different on the way out than on the way in

I assumed the attached fix is reasonable, that cookies should just always be url-encoded.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
