### PR TITLE
Clarify requirement to specify `ORIGIN` in `adapter-node`

### DIFF
--- a/.changeset/fresh-geese-flow.md
+++ b/.changeset/fresh-geese-flow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Update docs

--- a/packages/adapter-node/README.md
+++ b/packages/adapter-node/README.md
@@ -43,6 +43,10 @@ PROTOCOL_HEADER=x-forwarded-proto HOST_HEADER=x-forwarded-host node build
 
 > [`x-forwarded-proto`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto) and [`x-forwarded-host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host) are de facto standard headers that forward the original protocol and host if you're using a reverse proxy (think load balancers and CDNs). You should only set these variables if your server is behind a trusted reverse proxy; otherwise, it'd be possible for clients to spoof these headers.
 
+If `adapter-node` can't correctly determine the URL of your deployment, you may experience this error when using [form actions](https://kit.svelte.dev/docs/form-actions):
+
+> Cross-site POST form submissions are forbidden
+
 ### `ADDRESS_HEADER` and `XFF_DEPTH`
 
 The [RequestEvent](https://kit.svelte.dev/docs/types#sveltejs-kit-requestevent) object passed to hooks and endpoints includes an `event.clientAddress` property representing the client's IP address. By default this is the connecting `remoteAddress`. If your server is behind one or more proxies (such as a load balancer), this value will contain the innermost proxy's IP address rather than the client's, so we need to specify an `ADDRESS_HEADER` to read the address from:


### PR DESCRIPTION
Supersedes #7693, closes #7042. We'll have to see if this is enough