### PR TITLE
write redirects for prerendered pages with trailing slashes

### DIFF
--- a/.changeset/quick-weeks-explode.md
+++ b/.changeset/quick-weeks-explode.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+[fix] Write redirects for prerendered pages with trailing slashes

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -182,18 +182,6 @@ export default function ({ external = [], edge, split } = {}) {
 
 			builder.log.minor('Writing routes...');
 
-			console.log(
-				JSON.stringify(
-					{
-						version: 3,
-						routes,
-						overrides
-					},
-					null,
-					'  '
-				)
-			);
-
 			write(
 				`${dir}/config.json`,
 				JSON.stringify(

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -180,13 +180,29 @@ export default function ({ external = [], edge, split } = {}) {
 
 			builder.log.minor('Writing routes...');
 
+			console.log(
+				JSON.stringify(
+					{
+						version: 3,
+						routes,
+						overrides
+					},
+					null,
+					'  '
+				)
+			);
+
 			write(
 				`${dir}/config.json`,
-				JSON.stringify({
-					version: 3,
-					routes,
-					overrides
-				})
+				JSON.stringify(
+					{
+						version: 3,
+						routes,
+						overrides
+					},
+					null,
+					'  '
+				)
 			);
 		}
 	};

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -33,9 +33,11 @@ export default function ({ external = [], edge, split } = {}) {
 
 			for (const [src, redirect] of builder.prerendered.redirects) {
 				prerendered_redirects.push({
-					source: src,
-					destination: redirect,
-					permanent: true
+					src,
+					headers: {
+						Location: redirect.location
+					},
+					status: redirect.status
 				});
 			}
 


### PR DESCRIPTION
fixes #7725. The prerendered page wasn't being served because the `overrides` config in `.vercel/output/config.json` can't have a `path` value with a trailing slash. To get the correct behaviour we have to remove the trailing slash, and also add two entries to the `routes` config for each prerendered page:

```json
{ "src": "/the-path/", "dest": "/the-path" },
{ "src": "/the-path", "status": 308, "headers": { "Location": "/the-path/" } }
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
