### PR TITLE
[fix] disable Vite's modulePreload

### DIFF
--- a/.changeset/rude-buttons-bathe.md
+++ b/.changeset/rude-buttons-bathe.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] disable Vite's modulePreload

--- a/packages/kit/src/exports/vite/build/utils.js
+++ b/packages/kit/src/exports/vite/build/utils.js
@@ -127,9 +127,7 @@ export function get_default_build_config({ config, input, ssr, outDir }) {
 			cssCodeSplit: true,
 			// don't use the default name to avoid collisions with 'static/manifest.json'
 			manifest: 'vite-manifest.json',
-			modulePreload: {
-				polyfill: false
-			},
+			modulePreload: false,
 			outDir,
 			rollupOptions: {
 				input,

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -35,9 +35,6 @@ const enforced_config = {
 			formats: true
 		},
 		manifest: true,
-		modulePreload: {
-			polyfill: true
-		},
 		outDir: true,
 		rollupOptions: {
 			input: true,


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/7557

see https://github.com/sveltejs/kit/issues/7557#issuecomment-1324143161 for an explanation

I removed it from `enforced_config` so users can turn it back on if they want. For some apps it may be a desirable behavior, but I think disabled is a better default