### PR TITLE
[fix] handle redirects in handle hook while processing data request

### DIFF
--- a/.changeset/calm-peaches-enjoy.md
+++ b/.changeset/calm-peaches-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] handle redirects in handle hook while processing data request

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -117,12 +117,7 @@ export async function render_data(event, route, options, state, trailing_slash) 
 		const error = normalize_error(e);
 
 		if (error instanceof Redirect) {
-			return json_response(
-				JSON.stringify({
-					type: 'redirect',
-					location: error.location
-				})
-			);
+			return redirect_json_response(error);
 		} else {
 			// TODO make it clearer that this was an unexpected error
 			return json_response(JSON.stringify(handle_error_and_jsonify(event, options, error)));
@@ -142,4 +137,16 @@ function json_response(json, status = 200) {
 			'cache-control': 'private, no-store'
 		}
 	});
+}
+
+/**
+ * @param {Redirect} redirect
+ */
+export function redirect_json_response(redirect) {
+	return json_response(
+		JSON.stringify({
+			type: 'redirect',
+			location: redirect.location
+		})
+	);
 }

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -291,7 +291,7 @@ export async function respond(request, options, state) {
 
 		// Edge case: If user does `return Response(30x)` in handle hook while processing a data request,
 		// we need to transform the redirect response to a corresponding JSON response.
-		if (is_data_request && response.status >= 300 && response.status < 309) {
+		if (is_data_request && response.status >= 300 && response.status <= 308) {
 			const location = response.headers.get('location');
 			if (location) {
 				return redirect_json_response(new Redirect(/** @type {any} */ (response.status), location));

--- a/packages/kit/test/apps/basics/src/hooks.server.js
+++ b/packages/kit/test/apps/basics/src/hooks.server.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { sequence } from '@sveltejs/kit/hooks';
 import { HttpError } from '../../../../src/runtime/control';
-import { error } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
 
 /**
  * Transform an error into a POJO, by copying its `name`, `message`
@@ -80,6 +80,17 @@ export const handle = sequence(
 		} catch {}
 
 		return response;
+	},
+	async ({ event, resolve }) => {
+		if (event.url.pathname.includes('/redirect/in-handle')) {
+			if (event.url.search === '?throw') {
+				throw redirect(307, event.url.origin + '/redirect/c');
+			} else {
+				return new Response(undefined, { status: 307, headers: { location: '/redirect/c' } });
+			}
+		}
+
+		return resolve(event);
 	}
 );
 

--- a/packages/kit/test/apps/basics/src/routes/redirect/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/redirect/+page.svelte
@@ -7,3 +7,6 @@
 
 <a href="/redirect/missing-status/a">a (missing-status)</a>
 <a href="/redirect/missing-status/b">b (missing-status)</a>
+
+<a href="/redirect/in-handle?throw">in-handle (throw redirect)</a>
+<a href="/redirect/in-handle?response">in-handle (return Response)</a>

--- a/packages/kit/test/apps/basics/src/routes/redirect/in-handle/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/redirect/in-handle/+page.server.js
@@ -1,0 +1,1 @@
+export function load() {}

--- a/packages/kit/test/apps/basics/src/routes/redirect/in-handle/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/redirect/in-handle/+page.svelte
@@ -1,0 +1,1 @@
+<h1>in-handle</h1>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1337,6 +1337,32 @@ test.describe('Redirects', () => {
 			expect(await page.textContent('h1')).toBe('Hazaa!');
 		}
 	});
+
+	test('redirect response in handle hook', async ({ baseURL, clicknav, page }) => {
+		await page.goto('/redirect');
+
+		await clicknav('[href="/redirect/in-handle?response"]');
+
+		await page.waitForURL('/redirect/c');
+		expect(await page.textContent('h1')).toBe('c');
+		expect(page.url()).toBe(`${baseURL}/redirect/c`);
+
+		await page.goBack();
+		expect(page.url()).toBe(`${baseURL}/redirect`);
+	});
+
+	test('throw redirect in handle hook', async ({ baseURL, clicknav, page }) => {
+		await page.goto('/redirect');
+
+		await clicknav('[href="/redirect/in-handle?throw"]');
+
+		await page.waitForURL('/redirect/c');
+		expect(await page.textContent('h1')).toBe('c');
+		expect(page.url()).toBe(`${baseURL}/redirect/c`);
+
+		await page.goBack();
+		expect(page.url()).toBe(`${baseURL}/redirect`);
+	});
 });
 
 test.describe('Routing', () => {


### PR DESCRIPTION
Fixes #7787

During fixing this, I wondered why the tests also pass without the fix, and discovered that this specific behavior will only occur if there's no root `+layout.server.js` (because then it wouldn't try to rerequest the data, failing again, resulting in a fallback to the server where the redirect would be handled correctly), which we have in the tests. I'm not sure if it's worth creating another test suite for this, so I left it like this.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
