### PR TITLE
Removed getStaticDirectory() 

### DIFF
--- a/.changeset/grumpy-maps-complain.md
+++ b/.changeset/grumpy-maps-complain.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+[breaking] remove `getStaticDirectory()` from builder API

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -126,10 +126,6 @@ export function create_builder({ config, build_data, routes, prerendered, log })
 			return `${config.kit.outDir}/output/server`;
 		},
 
-		getStaticDirectory() {
-			return config.kit.files.assets;
-		},
-
 		getAppPath() {
 			return build_data.app_path;
 		},

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -77,7 +77,6 @@ export interface Builder {
 	getBuildDirectory(name: string): string;
 	getClientDirectory(): string;
 	getServerDirectory(): string;
-	getStaticDirectory(): string;
 	/** The application path including any configured base path */
 	getAppPath(): string;
 


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

Removes getStaticDirectory() because of no more usage, as stated in #7800.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
