### PR TITLE
Make console.warn named function

### DIFF
--- a/.changeset/itchy-beers-suffer.md
+++ b/.changeset/itchy-beers-suffer.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Make console.warn wrapper named rather than anonymous

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1718,7 +1718,7 @@ function reset_focus() {
 if (__SVELTEKIT_DEV__) {
 	// Nasty hack to silence harmless warnings the user can do nothing about
 	const warn = console.warn;
-	console.warn = (...args) => {
+	console.warn = function warn(...args) {
 		if (
 			args.length === 1 &&
 			/<(Layout|Page)(_[\w$]+)?> was created (with unknown|without expected) prop '(data|form)'/.test(

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1717,7 +1717,7 @@ function reset_focus() {
 
 if (__SVELTEKIT_DEV__) {
 	// Nasty hack to silence harmless warnings the user can do nothing about
-	const original_warn = console.warn;
+	const console_warn = console.warn;
 	console.warn = function warn(...args) {
 		if (
 			args.length === 1 &&
@@ -1727,6 +1727,6 @@ if (__SVELTEKIT_DEV__) {
 		) {
 			return;
 		}
-		original_warn(...args);
+		console_warn(...args);
 	};
 }

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1717,7 +1717,7 @@ function reset_focus() {
 
 if (__SVELTEKIT_DEV__) {
 	// Nasty hack to silence harmless warnings the user can do nothing about
-	const warn = console.warn;
+	const original_warn = console.warn;
 	console.warn = function warn(...args) {
 		if (
 			args.length === 1 &&
@@ -1727,6 +1727,6 @@ if (__SVELTEKIT_DEV__) {
 		) {
 			return;
 		}
-		warn(...args);
+		original_warn(...args);
 	};
 }


### PR DESCRIPTION
We have some code that relies on introspecting the `name` of `console.warn`— some metaprogramming to provide dev-only logs. This update to make `console.warn` an anonymous function means it no longer has a name, which breaks that assumption.

Normally:
```js
console.warn.name
> 'warn'
```
In SvelteKit dev:
```js
console.warn.name
> ''
```