### PR TITLE
[chore] don't hardcode port in test

### DIFF
--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -608,8 +608,6 @@ test.describe('Load', () => {
 
 	if (process.env.DEV) {
 		test('using window.fetch causes a warning', async ({ page }) => {
-			const port = 5173;
-
 			/** @type {string[]} */
 			const warnings = [];
 
@@ -622,8 +620,9 @@ test.describe('Load', () => {
 			await page.goto('/load/window-fetch/incorrect');
 			expect(await page.textContent('h1')).toBe('42');
 
+			const { origin } = new URL(page.url());
 			expect(warnings).toContain(
-				`Loading http://localhost:${port}/load/window-fetch/data.json using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/load#making-fetch-requests`
+				`Loading ${origin}/load/window-fetch/data.json using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/load#making-fetch-requests`
 			);
 
 			warnings.length = 0;
@@ -632,7 +631,7 @@ test.describe('Load', () => {
 			expect(await page.textContent('h1')).toBe('42');
 
 			expect(warnings).not.toContain(
-				`Loading http://localhost:${port}/load/window-fetch/data.json using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/load#making-fetch-requests`
+				`Loading ${origin}/load/window-fetch/data.json using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/load#making-fetch-requests`
 			);
 		});
 	}

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -607,7 +607,7 @@ test.describe('Load', () => {
 	});
 
 	if (process.env.DEV) {
-		test('using window.fetch causes a warning', async ({ page }) => {
+		test('using window.fetch causes a warning', async ({ page, baseURL }) => {
 			/** @type {string[]} */
 			const warnings = [];
 
@@ -620,9 +620,8 @@ test.describe('Load', () => {
 			await page.goto('/load/window-fetch/incorrect');
 			expect(await page.textContent('h1')).toBe('42');
 
-			const { origin } = new URL(page.url());
 			expect(warnings).toContain(
-				`Loading ${origin}/load/window-fetch/data.json using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/load#making-fetch-requests`
+				`Loading ${baseURL}/load/window-fetch/data.json using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/load#making-fetch-requests`
 			);
 
 			warnings.length = 0;
@@ -631,7 +630,7 @@ test.describe('Load', () => {
 			expect(await page.textContent('h1')).toBe('42');
 
 			expect(warnings).not.toContain(
-				`Loading ${origin}/load/window-fetch/data.json using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/load#making-fetch-requests`
+				`Loading ${baseURL}/load/window-fetch/data.json using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/load#making-fetch-requests`
 			);
 		});
 	}


### PR DESCRIPTION
just a minor cleanup I noticed while looking at the test that's failing the latest Playwright version