### PR TITLE
remove `format` option from `generateManifest(...)`

### DIFF
--- a/.changeset/shy-queens-wash.md
+++ b/.changeset/shy-queens-wash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] remove `format` option from `generateManifest(...)`

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -11,10 +11,9 @@ import { join_relative } from '../../utils/filesystem.js';
  *   build_data: import('types').BuildData;
  *   relative_path: string;
  *   routes: import('types').RouteData[];
- *   format?: 'esm' | 'cjs'
  * }} opts
  */
-export function generate_manifest({ build_data, relative_path, routes, format = 'esm' }) {
+export function generate_manifest({ build_data, relative_path, routes }) {
 	/**
 	 * @type {Map<any, number>} The new index of each node in the filtered nodes array
 	 */
@@ -55,13 +54,7 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 	});
 
 	/** @type {(path: string) => string} */
-	const load =
-		format === 'esm'
-			? (path) => `import('${path}')`
-			: (path) => `Promise.resolve().then(() => require('${path}'))`;
-
-	/** @type {(path: string) => string} */
-	const loader = (path) => `() => ${load(path)}`;
+	const loader = (path) => `() => import('${path}')`;
 
 	const assets = build_data.manifest_data.assets.map((asset) => asset.file);
 	if (build_data.service_worker) {
@@ -115,7 +108,7 @@ export function generate_manifest({ build_data, relative_path, routes, format = 
 				}).filter(Boolean).join(',\n\t\t\t\t')}
 			],
 			matchers: async () => {
-				${Array.from(matchers).map(type => `const { match: ${type} } = await ${load(join_relative(relative_path, `/entries/matchers/${type}.js`))}`).join('\n\t\t\t\t')}
+				${Array.from(matchers).map(type => `const { match: ${type} } = await import ('${(join_relative(relative_path, `/entries/matchers/${type}.js`))}')`).join('\n\t\t\t\t')}
 				return { ${Array.from(matchers).join(', ')} };
 			}
 		}

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -72,7 +72,7 @@ export interface Builder {
 	 */
 	createEntries(fn: (route: RouteDefinition) => AdapterEntry): Promise<void>;
 
-	generateManifest(opts: { relativePath: string; format?: 'esm' | 'cjs' }): string;
+	generateManifest(opts: { relativePath: string }): string;
 
 	getBuildDirectory(name: string): string;
 	getClientDirectory(): string;

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -21,9 +21,7 @@ export interface AdapterEntry {
 	 * A function that is invoked once the entry has been created. This is where you
 	 * should write the function to the filesystem and generate redirect manifests.
 	 */
-	complete(entry: {
-		generateManifest(opts: { relativePath: string; format?: 'esm' | 'cjs' }): string;
-	}): MaybePromise<void>;
+	complete(entry: { generateManifest(opts: { relativePath: string }): string }): MaybePromise<void>;
 }
 
 // Based on https://github.com/josh-hemphill/csp-typed-directives/blob/latest/src/csp.types.ts


### PR DESCRIPTION
closes #7798. I haven't yet checked community adapters to make sure no-one is using this

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
