### PR TITLE
[create-svelte] Fix playwright filter

### DIFF
--- a/.changeset/honest-peas-cry.md
+++ b/.changeset/honest-peas-cry.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+fix playwright glob filter

--- a/packages/create-svelte/shared/+playwright+typescript/playwright.config.ts
+++ b/packages/create-svelte/shared/+playwright+typescript/playwright.config.ts
@@ -5,7 +5,7 @@ const config: PlaywrightTestConfig = {
 		command: 'npm run build && npm run preview',
 		port: 4173
 	},
-	testMatch: 'tests/**/.*(test|spec).(js|ts)'
+	testDir: 'tests'
 };
 
 export default config;

--- a/packages/create-svelte/shared/+playwright-typescript/playwright.config.js
+++ b/packages/create-svelte/shared/+playwright-typescript/playwright.config.js
@@ -4,7 +4,7 @@ const config = {
 		command: 'npm run build && npm run preview',
 		port: 4173
 	},
-	testMatch: 'tests/**/.*(test|spec).(js|ts)'
+	testDir: 'tests'
 };
 
 export default config;


### PR DESCRIPTION
closes #7825 

The globs weren't matching, playwright has a [default testMatch](https://playwright.dev/docs/test-configuration#testing-options) that works pretty well as long as we contain it with testDir and it's nice to have fewer moving parts so did away with globs altogether

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
