### PR TITLE
make `$page.url` resilient against mutations

### DIFF
--- a/.changeset/rude-actors-serve.md
+++ b/.changeset/rude-actors-serve.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Make `$page.url` resilient against mutations

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -474,7 +474,7 @@ export function create_client({ target, base }) {
 				params,
 				route,
 				status,
-				url,
+				url: new URL(url),
 				form,
 				// The whole page store is updated, but this way the object reference stays the same
 				data: data_changed ? data : page.data

--- a/packages/kit/test/apps/basics/src/routes/load/mutated-url/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/mutated-url/+page.js
@@ -1,0 +1,6 @@
+/** @type {import('./$types').PageLoad} */
+export function load({ url }) {
+	return {
+		q: url.searchParams.get('q')
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/mutated-url/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/mutated-url/+page.svelte
@@ -1,0 +1,15 @@
+<script>
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
+
+	/** @type {import('./$types').PageData} */
+	export let data;
+
+	function update_q() {
+		$page.url.searchParams.set('q', 'updated');
+		goto($page.url);
+	}
+</script>
+
+<h1>{data.q}</h1>
+<button on:click={update_q}>update q</button>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1046,6 +1046,14 @@ test.describe.serial('Invalidation', () => {
 		await clicknav('[href="/load/invalidation/route/shared/b"]');
 		expect(await page.textContent('h1')).toBe('route.id: /load/invalidation/route/shared/b');
 	});
+
+	test('$page.url can safely be mutated', async ({ page }) => {
+		await page.goto('/load/mutated-url?q=initial');
+		expect(await page.textContent('h1')).toBe('initial');
+
+		await page.click('button');
+		expect(await page.textContent('h1')).toBe('updated');
+	});
 });
 
 test.describe('data-sveltekit attributes', () => {


### PR DESCRIPTION
Turns out if you mutate `$page.url`, e.g. to update a search param, SvelteKit mistakenly thinks no navigation is necessary

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
