### PR TITLE
[fix] don't pass second arg to `generateManifest`

### DIFF
--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -188,8 +188,7 @@ async function generate_lambda_functions({ builder, publish, split }) {
 				filter: (other) => matches(route.segments, other.segments),
 				complete: (entry) => {
 					const manifest = entry.generateManifest({
-						relativePath: '../server',
-						format: 'esm'
+						relativePath: '../server'
 					});
 
 					const fn = `import { init } from '../serverless.js';\n\nexport const handler = init(${manifest});\n`;
@@ -206,8 +205,7 @@ async function generate_lambda_functions({ builder, publish, split }) {
 		builder.log.minor('Generating serverless functions...');
 
 		const manifest = builder.generateManifest({
-			relativePath: '../server',
-			format: 'esm'
+			relativePath: '../server'
 		});
 
 		const fn = `import { init } from '../serverless.js';\n\nexport const handler = init(${manifest});\n`;


### PR DESCRIPTION
This was removed in https://github.com/sveltejs/kit/pull/7820 and is causing lint to fail. It didn't fail on that PR because Turbo is a giant steaming pile of shit. Here is the Turbo output from that PR:

>@sveltejs/adapter-netlify:check: cache hit, suppressing output 98cf59e7443a315b
@sveltejs/adapter-netlify:lint: cache hit, suppressing output e148ef9617701497

No changeset necessary since it's only a lint fix and won't impact users