### PR TITLE
[docs] add missing declare

### DIFF
--- a/documentation/docs/30-advanced/25-errors.md
+++ b/documentation/docs/30-advanced/25-errors.md
@@ -132,7 +132,7 @@ If you're using TypeScript and need to customize the shape of errors, you can do
 
 ```ts
 /// file: src/app.d.ts
-namespace App {
+declare namespace App {
 	interface Error {
 		code: string;
 		id: string;


### PR DESCRIPTION
The generated template has a `declare` as does `20-hooks.md`