### PR TITLE
Upgrade dependencies in templates

### DIFF
--- a/.changeset/lazy-islands-deny.md
+++ b/.changeset/lazy-islands-deny.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Upgrade dependencies in templates

--- a/packages/create-svelte/shared/+checkjs/package.json
+++ b/packages/create-svelte/shared/+checkjs/package.json
@@ -4,7 +4,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch"
 	},
 	"devDependencies": {
-		"typescript": "^4.7.4",
-		"svelte-check": "^2.7.1"
+		"typescript": "^4.9.3",
+		"svelte-check": "^2.9.2"
 	}
 }

--- a/packages/create-svelte/shared/+eslint+prettier/package.json
+++ b/packages/create-svelte/shared/+eslint+prettier/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"eslint-config-prettier": "^8.3.0"
+		"eslint-config-prettier": "^8.5.0"
 	},
 	"scripts": {
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",

--- a/packages/create-svelte/shared/+eslint+typescript/package.json
+++ b/packages/create-svelte/shared/+eslint+typescript/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"@typescript-eslint/eslint-plugin": "^5.27.0",
-		"@typescript-eslint/parser": "^5.27.0"
+		"@typescript-eslint/eslint-plugin": "^5.45.0",
+		"@typescript-eslint/parser": "^5.45.0"
 	}
 }

--- a/packages/create-svelte/shared/+eslint/package.json
+++ b/packages/create-svelte/shared/+eslint/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"eslint": "^8.16.0",
+		"eslint": "^8.28.0",
 		"eslint-plugin-svelte3": "^4.0.0"
 	}
 }

--- a/packages/create-svelte/shared/+playwright/package.json
+++ b/packages/create-svelte/shared/+playwright/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"@playwright/test": "1.25.0"
+		"@playwright/test": "^1.28.1"
 	},
 	"scripts": {
 		"test": "playwright test"

--- a/packages/create-svelte/shared/+prettier/package.json
+++ b/packages/create-svelte/shared/+prettier/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"prettier": "^2.6.2",
-		"prettier-plugin-svelte": "^2.7.0"
+		"prettier": "^2.8.0",
+		"prettier-plugin-svelte": "^2.8.1"
 	}
 }

--- a/packages/create-svelte/shared/+typescript/package.json
+++ b/packages/create-svelte/shared/+typescript/package.json
@@ -4,9 +4,9 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
-		"typescript": "^4.7.4",
-		"tslib": "^2.3.1",
-		"svelte-check": "^2.7.1",
-		"svelte-preprocess": "^4.10.6"
+		"typescript": "^4.9.3",
+		"tslib": "^2.4.1",
+		"svelte-check": "^2.9.2",
+		"svelte-preprocess": "^4.10.7"
 	}
 }

--- a/packages/create-svelte/shared/+vitest/package.json
+++ b/packages/create-svelte/shared/+vitest/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"vitest": "^0.23.4"
+		"vitest": "^0.25.3"
 	},
 	"scripts": {
 		"test:unit": "vitest"


### PR DESCRIPTION
I overlooked these files when upgrading dependencies earlier. It's important to bump these as Playwright is currently pinned and this will unpin it. It will also bump the versions of dependencies to a minimum version which supports TypeScript's `satisfies` operator