### PR TITLE
fix undefined comparison

### DIFF
--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -98,7 +98,7 @@ export function find_anchor(element, base) {
 	/** @type {typeof valid_link_options['reload'][number] | null} */
 	let reload = null;
 
-	while (element !== document.documentElement) {
+	while (element && element !== document.documentElement) {
 		if (!a && element.nodeName.toUpperCase() === 'A') {
 			// SVG <a> elements have a lowercase name
 			a = /** @type {HTMLAnchorElement | SVGAElement} */ (element);
@@ -115,7 +115,7 @@ export function find_anchor(element, base) {
 		element = element.assignedSlot ?? element.parentNode;
 
 		// @ts-expect-error handle shadow roots
-		if (element.nodeType === 11) element = element.host;
+		if (element?.nodeType === 11) element = element.host;
 	}
 
 	/** @type {URL | undefined} */


### PR DESCRIPTION
I tested it in version 1.0.0-next.560 and 1.0.0-next.567 and there is an error in comparison with undefined.
In version 1.0.0-next.559 this does not happen.

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0


https://user-images.githubusercontent.com/527641/204590283-eb608052-e927-4368-a82b-99b0229fdc71.mp4

