### PR TITLE
ignore elements that are no longer in the document

### DIFF
--- a/.changeset/light-papayas-agree.md
+++ b/.changeset/light-papayas-agree.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Ignore elements that are no longer in the document

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -98,24 +98,26 @@ export function find_anchor(element, base) {
 	/** @type {typeof valid_link_options['reload'][number] | null} */
 	let reload = null;
 
-	while (element !== document.documentElement) {
-		if (!a && element.nodeName.toUpperCase() === 'A') {
-			// SVG <a> elements have a lowercase name
-			a = /** @type {HTMLAnchorElement | SVGAElement} */ (element);
+	if (document.contains(element)) {
+		while (element !== document.documentElement) {
+			if (!a && element.nodeName.toUpperCase() === 'A') {
+				// SVG <a> elements have a lowercase name
+				a = /** @type {HTMLAnchorElement | SVGAElement} */ (element);
+			}
+
+			if (a) {
+				if (preload_code === null) preload_code = link_option(element, 'preload-code');
+				if (preload_data === null) preload_data = link_option(element, 'preload-data');
+				if (noscroll === null) noscroll = link_option(element, 'noscroll');
+				if (reload === null) reload = link_option(element, 'reload');
+			}
+
+			// @ts-expect-error handle shadow roots
+			element = element.assignedSlot ?? element.parentNode;
+
+			// @ts-expect-error handle shadow roots
+			if (element.nodeType === 11) element = element.host;
 		}
-
-		if (a) {
-			if (preload_code === null) preload_code = link_option(element, 'preload-code');
-			if (preload_data === null) preload_data = link_option(element, 'preload-data');
-			if (noscroll === null) noscroll = link_option(element, 'noscroll');
-			if (reload === null) reload = link_option(element, 'reload');
-		}
-
-		// @ts-expect-error handle shadow roots
-		element = element.assignedSlot ?? element.parentNode;
-
-		// @ts-expect-error handle shadow roots
-		if (element.nodeType === 11) element = element.host;
 	}
 
 	/** @type {URL | undefined} */

--- a/packages/kit/test/apps/basics/src/routes/interactivity/toggle-element/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/interactivity/toggle-element/+page.svelte
@@ -1,0 +1,13 @@
+<script>
+	let visible = true;
+
+	function toggle() {
+		visible = !visible;
+	}
+</script>
+
+{#if visible}
+	<button on:click={toggle}>remove</button>
+{:else}
+	<button on:click={toggle}>add</button>
+{/if}

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1168,3 +1168,22 @@ test.describe('cookies', () => {
 		await expect(page.locator('p')).toHaveText('foo=bar');
 	});
 });
+
+test.describe('Interactivity', () => {
+	test('click events on removed elements are ignored', async ({ page }) => {
+		let errored = false;
+
+		page.on('pageerror', (err) => {
+			console.error(err);
+			errored = true;
+		});
+
+		await page.goto('/interactivity/toggle-element');
+		expect(await page.textContent('button')).toBe('remove');
+
+		await page.click('button');
+		expect(await page.textContent('button')).toBe('add');
+
+		expect(errored).toBe(false);
+	});
+});


### PR DESCRIPTION
closes #7876. This is an alternative to #7879 — the issue is that the click handler doesn't run until after Svelte has updated the DOM, meaning in some cases the element no longer exists in the DOM. In those cases it probably makes sense to bail altogether.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
