### PR TITLE
FormData or URLSearchParams as body in fetch in load function

### DIFF
--- a/.changeset/fuzzy-buses-call.md
+++ b/.changeset/fuzzy-buses-call.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Allow formdata and urlsearchparams as body for fetch in load functions.

--- a/packages/kit/src/runtime/hash.js
+++ b/packages/kit/src/runtime/hash.js
@@ -12,8 +12,19 @@ export function hash(value) {
 		const buffer = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
 		let i = buffer.length;
 		while (i) hash = (hash * 33) ^ buffer[--i];
+	} else if (value instanceof FormData) {
+		let i, entry_str;
+		for (const entry of value.entries()) {
+			entry_str = entry.toString();
+			i = entry_str.length;
+			while (i) hash = (hash * 33) ^ entry_str.charCodeAt(--i);
+		}
+	} else if (value instanceof URLSearchParams) {
+		const search_str = value.toString();
+		let i = search_str.length;
+		while (i) hash = (hash * 33) ^ search_str.charCodeAt(--i);
 	} else {
-		throw new TypeError('value must be a string or TypedArray');
+		throw new TypeError('value must be a string, TypedArray, FormData or URLSearchParams');
 	}
 
 	return (hash >>> 0).toString(36);

--- a/packages/kit/test/apps/basics/src/routes/load/[dynamic].json/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/[dynamic].json/+server.js
@@ -6,3 +6,10 @@ export function GET({ params }) {
 		name: params.dynamic
 	});
 }
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export function POST({ params }) {
+	return json({
+		name: params.dynamic
+	});
+}

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-formdata/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-formdata/+page.js
@@ -1,0 +1,15 @@
+import { browser } from '$app/environment';
+
+/** @type {import('@sveltejs/kit').Load} */
+export async function load({ fetch }) {
+	const url = '/load/fetch-request.json';
+
+	// this is contrived, but saves us faffing about with node-fetch here
+	const resource = browser ? new Request(url) : url;
+	const formData = new FormData();
+	formData.set('Test', 'Test');
+
+	const res = await fetch(resource, { body: formData, method: 'POST' });
+
+	return { answer: 'ok' };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-formdata/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-formdata/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	/** @type {import('./$types').PageData} */
+	export let data;
+</script>
+
+<h1>the answer is {data.answer}</h1>

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-urlsearchparams/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-urlsearchparams/+page.js
@@ -1,0 +1,15 @@
+import { browser } from '$app/environment';
+
+/** @type {import('@sveltejs/kit').Load} */
+export async function load({ fetch }) {
+	const url = '/load/fetch-request.json';
+
+	// this is contrived, but saves us faffing about with node-fetch here
+	const resource = browser ? new Request(url) : url;
+
+	const url_search_params = new URLSearchParams({ foo: 'bar', baz: 'bar' });
+
+	const res = await fetch(resource, { body: url_search_params, method: 'POST' });
+
+	return { answer: 'ok' };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-urlsearchparams/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-urlsearchparams/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	/** @type {import('./$types').PageData} */
+	export let data;
+</script>
+
+<h1>the answer is {data.answer}</h1>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -551,6 +551,14 @@ test.describe('Load', () => {
 		expect(await page.textContent('p')).toBe('This text comes from the server load function');
 	});
 
+	test('formdata or urlsearchparams allowed as body for post request in load function', async ({
+		page,
+		request
+	}) => {
+		await page.goto('load/fetch-formdata');
+		await page.goto('load/fetch-urlsearchparams');
+	});
+
 	test('load does not call fetch if max-age allows it', async ({ page, request }) => {
 		await request.get('/load/cache-control/reset');
 

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -361,7 +361,7 @@ export interface SSRState {
 	prerender_default?: PrerenderOption;
 }
 
-export type StrictBody = string | ArrayBufferView;
+export type StrictBody = string | ArrayBufferView | FormData | URLSearchParams;
 
 export interface Uses {
 	dependencies: Set<string>;


### PR DESCRIPTION
At the moment the only blocker for supporting FormData or URLSearchParams as the body of a fetch request, is the hashing function. This updates the hashing function to create a hash for these types of bodies. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
