### PR TITLE
[fix] correct Vite config merging with force option

### DIFF
--- a/.changeset/thin-pillows-work.md
+++ b/.changeset/thin-pillows-work.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] correct Vite config merging with force option

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -1,7 +1,8 @@
 import fs from 'fs';
 import path from 'path';
+import { mergeConfig } from 'vite';
 import { mkdirp, posixify, resolve_entry } from '../../../utils/filesystem.js';
-import { get_vite_config, merge_vite_configs } from '../utils.js';
+import { get_vite_config } from '../utils.js';
 import { load_error_page, load_template } from '../../../core/config/index.js';
 import { runtime_directory } from '../../../core/utils.js';
 import {
@@ -240,7 +241,7 @@ export async function build_server(options, client) {
 		})
 	);
 
-	const merged_config = merge_vite_configs(
+	const merged_config = mergeConfig(
 		get_default_build_config({ config, input, ssr: true, outDir: `${output_dir}/server` }),
 		await get_vite_config(vite_config, vite_config_env)
 	);

--- a/packages/kit/src/exports/vite/utils.js
+++ b/packages/kit/src/exports/vite/utils.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import { loadConfigFromFile, loadEnv } from 'vite';
+import { loadConfigFromFile, loadEnv, mergeConfig } from 'vite';
 import { runtime_directory } from '../../core/utils.js';
 import { posixify } from '../../utils/filesystem.js';
 
@@ -19,30 +19,13 @@ export async function get_vite_config(config, config_env) {
 	if (!loaded) {
 		throw new Error('Could not load Vite config');
 	}
-	return {
-		...loaded.config,
+	return mergeConfig(loaded.config, {
 		// CLI opts
 		mode: config_env.mode,
 		logLevel: config.logLevel,
 		clearScreen: config.clearScreen,
 		optimizeDeps: { force: config.optimizeDeps.force }
-	};
-}
-
-/**
- * @param {...import('vite').UserConfig} configs
- * @returns {import('vite').UserConfig}
- */
-export function merge_vite_configs(...configs) {
-	return deep_merge(
-		...configs.map((config) => ({
-			...config,
-			resolve: {
-				...config.resolve,
-				alias: normalize_alias(config.resolve?.alias || {})
-			}
-		}))
-	);
+	});
 }
 
 /**
@@ -59,16 +42,6 @@ export function deep_merge(...objects) {
 	/** @type {string[]} */
 	objects.forEach((o) => merge_into(result, o));
 	return result;
-}
-
-/**
- * normalize kit.vite.resolve.alias as an array
- * @param {import('vite').AliasOptions} o
- * @returns {import('vite').Alias[]}
- */
-function normalize_alias(o) {
-	if (Array.isArray(o)) return o;
-	return Object.entries(o).map(([find, replacement]) => ({ find, replacement }));
 }
 
 /**

--- a/packages/kit/src/exports/vite/utils.spec.js
+++ b/packages/kit/src/exports/vite/utils.spec.js
@@ -3,7 +3,7 @@ import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { validate_config } from '../../core/config/index.js';
 import { posixify } from '../../utils/filesystem.js';
-import { deep_merge, get_app_aliases, get_config_aliases, merge_vite_configs } from './utils.js';
+import { deep_merge, get_app_aliases, get_config_aliases } from './utils.js';
 
 test('basic test no conflicts', async () => {
 	const merged = deep_merge(
@@ -171,31 +171,6 @@ test('merge including toString', () => {
 		}
 	);
 	assert.equal(Object.keys(merged), ['toString', 'constructor', 'y']);
-});
-
-test('merge resolve.alias', () => {
-	const merged = merge_vite_configs(
-		{
-			resolve: {
-				alias: [{ find: /foo/, replacement: 'bar' }]
-			}
-		},
-		{
-			resolve: {
-				alias: {
-					alpha: 'beta'
-				}
-			}
-		}
-	);
-	assert.equal(merged, {
-		resolve: {
-			alias: [
-				{ find: /foo/, replacement: 'bar' },
-				{ find: 'alpha', replacement: 'beta' }
-			]
-		}
-	});
 });
 
 test('transform kit.alias to resolve.alias', () => {


### PR DESCRIPTION
two suggestions from @dominikg:
- code was broken when `force` was used as we'd drop the other `optimizeDeps` options
- we don't need our own config merge function as Vite has one that's exported