### PR TITLE
[fix] use searchParams for x-sveltekit-invalidated

### DIFF
--- a/.changeset/heavy-forks-search.md
+++ b/.changeset/heavy-forks-search.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] use searchParams for x-sveltekit-invalidated

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1700,12 +1700,15 @@ export function create_client({ target, base }) {
 async function load_data(url, invalid) {
 	const data_url = new URL(url);
 	data_url.pathname = add_data_suffix(url.pathname);
+	if (__SVELTEKIT_DEV__ && url.searchParams.has('x-sveltekit-invalidated')) {
+		throw new Error('Cannot used reserved query parameter "x-sveltekit-invalidated"');
+	}
+	data_url.searchParams.append(
+		'x-sveltekit-invalidated',
+		invalid.map((x) => (x ? '1' : '')).join('_')
+	);
 
-	const res = await native_fetch(data_url.href, {
-		headers: {
-			'x-sveltekit-invalidated': invalid.map((x) => (x ? '1' : '')).join(',')
-		}
-	});
+	const res = await native_fetch(data_url.href);
 	const data = await res.json();
 
 	if (!res.ok) {

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -27,8 +27,9 @@ export async function render_data(event, route, options, state, trailing_slash) 
 		const node_ids = [...route.page.layouts, route.page.leaf];
 
 		const invalidated =
-			event.request.headers.get(INVALIDATED_HEADER)?.split(',').map(Boolean) ??
+			event.url.searchParams.get(INVALIDATED_HEADER)?.split('_').map(Boolean) ??
 			node_ids.map(() => true);
+		event.url.searchParams.delete(INVALIDATED_HEADER);
 
 		let aborted = false;
 

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -13,7 +13,7 @@ import {
 	strip_data_suffix
 } from '../../utils/url.js';
 import { exec } from '../../utils/routing.js';
-import { INVALIDATED_HEADER, redirect_json_response, render_data } from './data/index.js';
+import { redirect_json_response, render_data } from './data/index.js';
 import { add_cookies_to_headers, get_cookies } from './cookie.js';
 import { create_fetch } from './fetch.js';
 import { Redirect } from '../control.js';
@@ -228,16 +228,6 @@ export async function respond(request, options, state) {
 					for (const key in headers) {
 						const value = headers[key];
 						response.headers.set(key, /** @type {string} */ (value));
-					}
-
-					if (is_data_request) {
-						// set the Vary header on __data.json requests to ensure we don't cache
-						// incomplete responses with skipped data loads
-						// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary
-						const vary = response.headers.get('Vary');
-						if (vary !== '*') {
-							response.headers.append('Vary', INVALIDATED_HEADER);
-						}
 					}
 
 					add_cookies_to_headers(response.headers, Object.values(new_cookies));

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -101,14 +101,15 @@ test.describe('a11y', () => {
 });
 
 test.describe('Caching', () => {
-	test('caches __data.json requests with Vary header', async ({ page, app }) => {
+	test('caches __data.json requests with invalidated search param', async ({ page, app }) => {
 		await page.goto('/');
 		const [, response] = await Promise.all([
 			app.goto('/caching/server-data'),
-			page.waitForResponse((request) => request.url().endsWith('server-data/__data.json'))
+			page.waitForResponse((request) =>
+				request.url().endsWith('server-data/__data.json?x-sveltekit-invalidated=_1')
+			)
 		]);
 		expect(response.headers()['cache-control']).toBe('public, max-age=30');
-		expect(response.headers()['vary']).toBe('x-sveltekit-invalidated');
 	});
 });
 


### PR DESCRIPTION
..instead of Vary, because that header is not supported on all CDNs/platforms, leading to wrong cache behavior

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
