### PR TITLE
[fix] rebuild manifest when client hooks or param matcher file is added/removed

### DIFF
--- a/.changeset/wet-trainers-perform.md
+++ b/.changeset/wet-trainers-perform.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] rebuild manifest when client hook file is added/removed

--- a/.changeset/wet-trainers-perform.md
+++ b/.changeset/wet-trainers-perform.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-[fix] rebuild manifest when client hook file is added/removed
+[fix] rebuild manifest when client hooks or param matcher file is added/removed

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -150,7 +150,7 @@ export async function write_types(config, manifest_data, file) {
 	const id = '/' + posixify(path.relative(config.kit.files.routes, path.dirname(file)));
 
 	const route = manifest_data.routes.find((route) => route.id === id);
-	if (!route) return; // this shouldn't ever happen
+	if (!route) return;
 	if (!route.leaf && !route.layout && !route.endpoint) return; // nothing to do
 
 	update_types(config, create_routes_map(manifest_data), route);

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -202,7 +202,12 @@ export async function dev(vite, vite_config, svelte_config) {
 	 */
 	const watch = (event, cb) => {
 		vite.watcher.on(event, (file) => {
-			if (file.startsWith(svelte_config.kit.files.routes + path.sep)) {
+			if (
+				file.startsWith(svelte_config.kit.files.routes + path.sep) ||
+				// in contrast to server hooks, client hooks are written to the client manifest
+				// and therefore need rebuilding when they are added/removed
+				file.startsWith(svelte_config.kit.files.hooks.client)
+			) {
 				cb(file);
 			}
 		});

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -204,6 +204,7 @@ export async function dev(vite, vite_config, svelte_config) {
 		vite.watcher.on(event, (file) => {
 			if (
 				file.startsWith(svelte_config.kit.files.routes + path.sep) ||
+				file.startsWith(svelte_config.kit.files.params + path.sep) ||
 				// in contrast to server hooks, client hooks are written to the client manifest
 				// and therefore need rebuilding when they are added/removed
 				file.startsWith(svelte_config.kit.files.hooks.client)


### PR DESCRIPTION
In contrast to server hooks, client hooks are written to the client manifest and therefore need rebuilding when they are added/removed.

I noticed this while working on the tutorial

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
