### PR TITLE
a11y improvements to kit.svelte.dev

### DIFF
--- a/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
+++ b/sites/kit.svelte.dev/src/lib/docs/Contents.svelte
@@ -5,7 +5,7 @@
 	export let contents = [];
 </script>
 
-<nav>
+<nav aria-label="Docs">
 	<ul class="sidebar">
 		{#each contents as section}
 			<li>

--- a/sites/kit.svelte.dev/src/lib/docs/TSToggle.svelte
+++ b/sites/kit.svelte.dev/src/lib/docs/TSToggle.svelte
@@ -1,5 +1,5 @@
 <script>
-	import Checkbox from './Checkbox.svelte';
+	import ToggleButton from './ToggleButton.svelte';
 
 	let checked = prefers_ts();
 	$: toggle(checked);
@@ -22,10 +22,9 @@
 	}
 </script>
 
-<!-- svelte-ignore a11y-label-has-associated-control -->
-<label class="input-output-toggle">
-	JavaScript <Checkbox bind:checked /> TypeScript
-</label>
+<div class="input-output-toggle">
+	<span aria-hidden="true">JavaScript</span> <ToggleButton bind:pressed={checked} label="TypeScript code examples" /> <span aria-hidden="true">TypeScript</span>
+</div>
 
 <style>
 	.input-output-toggle {

--- a/sites/kit.svelte.dev/src/lib/docs/ToggleButton.svelte
+++ b/sites/kit.svelte.dev/src/lib/docs/ToggleButton.svelte
@@ -1,12 +1,15 @@
 <script>
-	export let checked;
+	export let pressed;
+	export let label;
 </script>
 
-<input type="checkbox" bind:checked />
+<button aria-pressed={pressed ? "true" : "false" } on:click={ () => pressed = !pressed}>
+	<span class="visually-hidden">{label}</span>
+</button>
 
 <style>
-	input[type='checkbox'] {
-		--size: 1.2em;
+	button {
+		--size: 1em;
 		--bg: var(--sk-theme-2);
 		--fg: white;
 		--bg-active: var(--bg);
@@ -19,11 +22,11 @@
 		border-radius: 0.5em;
 		-webkit-appearance: none;
 		appearance: none;
-		outline: none;
+		outline-offset: 2px;
 		border: transparent;
 	}
 
-	input[type='checkbox']::before {
+	button::before {
 		content: '';
 		position: absolute;
 		display: block;
@@ -37,11 +40,11 @@
 		box-sizing: border-box;
 	}
 
-	input[type='checkbox']:checked::before {
+	button[aria-pressed="true"]::before {
 		background: var(--bg-active);
 	}
 
-	input[type='checkbox']::after {
+	button::after {
 		content: '';
 		position: absolute;
 		display: block;
@@ -56,7 +59,7 @@
 		transition: background 0.2s ease-out, left 0.2s ease-out;
 	}
 
-	input[type='checkbox']:checked::after {
+	button[aria-pressed="true"]::after {
 		background: var(--fg-active);
 		left: calc(100% - var(--size) + 2px);
 	}

--- a/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
+++ b/sites/kit.svelte.dev/src/lib/search/SearchBox.svelte
@@ -148,6 +148,7 @@
 				value={$query}
 				placeholder="Search"
 				aria-describedby="search-description"
+				aria-label="Search"
 				spellcheck="false"
 			/>
 

--- a/sites/kit.svelte.dev/src/routes/search/+page.svelte
+++ b/sites/kit.svelte.dev/src/routes/search/+page.svelte
@@ -10,6 +10,7 @@
 </svelte:head>
 
 <main>
+	<h1>Search</h1>
 	<form>
 		<input name="q" value={data.query} placeholder="Search" spellcheck="false" />
 	</form>

--- a/sites/site-kit/src/lib/components/Nav.svelte
+++ b/sites/site-kit/src/lib/components/Nav.svelte
@@ -49,7 +49,7 @@
 	<div class="modal-background hide-if-desktop" on:click={() => (open = false)} />
 {/if}
 
-<nav class:visible={visible || open} class:open bind:this={nav}>
+<nav class:visible={visible || open} class:open bind:this={nav} aria-label="Primary">
 	<a href="/" class="nav-spot home" title={home_title} style="background-image: url({logo})">
 		{home}
 	</a>


### PR DESCRIPTION
Some minor a11y improvements to the docs. 

The largest change was fixing the accessibility of the JS/TS toggle. Instead of a checkbox, I refactored it to use `<button aria-pressed>` instead. Using a checkbox isn't inaccessible, but a [button is a better fit for this usecase](https://adrianroselli.com/2019/08/under-engineered-toggles-too.html#Button):

>  If flipping the toggle immediately performs an action on the page (such as updating a setting), then a `<button>` is a better fit. Unlike a checkbox, which only changes its state, a `<button>` conveys to a user that something will happen. 

The label on the control also wasn't clear (it was "JavaScript TypeScript"), so I instead gave it the label "TypeScript code examples" (visually hidden). Combined with the state of `aria-pressed`, it will convey whether TS examples are on or off.

I also removed the `outline: none` so we have focus styles.

<img width="250" alt="screenshot of toggle focus styles" src="https://user-images.githubusercontent.com/4992896/205452252-d0ce0f8a-669d-46e4-82f1-bd5daa40cccf.png">


Other changes:
- Give each `<nav>` a unique label (resolves [landmarks are unique](https://dequeuniversity.com/rules/axe/4.4/landmark-unique) Axe issue)
- Label search input
- Add `<h1>` to search page

With these changes, the only automated axe issues left are related to color contrast.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
