### PR TITLE
fix: add   and  to optimizeDeps.exclude

### DIFF
--- a/.changeset/healthy-walls-move.md
+++ b/.changeset/healthy-walls-move.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+add $app and $env to optimizeDeps.exclude so that libraries using these work correctly when prebundled

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -274,7 +274,13 @@ function kit() {
 					external: ['@sveltejs/kit']
 				},
 				optimizeDeps: {
-					exclude: ['@sveltejs/kit']
+					exclude: [
+						'@sveltejs/kit',
+						// exclude kit features so that libraries using them work even when they are prebundled
+						// this does not affect app code, just handling of imported libraries that use $app or $env
+						'$app',
+						'$env'
+					]
 				}
 			};
 


### PR DESCRIPTION
 to allow prebundling for libraries using them

see https://discord.com/channels/457912077277855764/1024975960564580383

note that optimizeDeps.exclude automatically excludes subpaths too, implementation in vite looks like this:  `i === exclude || i.startsWith(exclude+'/')`


cc @bluwy @babichjacob 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
