### PR TITLE
[fix] ensure that editing app.html reloads open dev page

### DIFF
--- a/.changeset/hot-news-bake.md
+++ b/.changeset/hot-news-bake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+reload dev page on change of app.html

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -235,6 +235,18 @@ export async function dev(vite, vite_config, svelte_config) {
 		sync.update(svelte_config, manifest_data, file);
 	});
 
+	const { appTemplate } = svelte_config.kit.files;
+	// vite client only executes a full reload if the triggering html file path is index.html
+	// kit defaults to src/app.html, so unless user changed that to index.html
+	// send the vite client a full-reload event without path being set
+	if (appTemplate !== 'index.html') {
+		vite.watcher.on('change', (file) => {
+			if (file === appTemplate) {
+				vite.ws.send({ type: 'full-reload' });
+			}
+		});
+	}
+
 	const assets = svelte_config.kit.paths.assets ? SVELTE_KIT_ASSETS : svelte_config.kit.paths.base;
 	const asset_server = sirv(svelte_config.kit.files.assets, {
 		dev: true,


### PR DESCRIPTION
fixes #7942 

the vite client assumes that changes to html files should only trigger a full reload if they are named index.html and the path to the file matches the browser path. kit uses `src/app.html` by default which fails that check.

so we send another full-reload event to the client without a path - this forces it's hand.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
