### PR TITLE
[docs] fix iOS search box hidden by nav

### DIFF
--- a/.changeset/modern-radios-develop.md
+++ b/.changeset/modern-radios-develop.md
@@ -1,0 +1,5 @@
+---
+'kit.svelte.dev': patch
+---
+
+fix iOS site searchbar overlapping nav

--- a/.changeset/modern-radios-develop.md
+++ b/.changeset/modern-radios-develop.md
@@ -1,5 +1,0 @@
----
-'kit.svelte.dev': patch
----
-
-fix iOS site searchbar overlapping nav

--- a/sites/kit.svelte.dev/src/routes/+layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/+layout.svelte
@@ -49,11 +49,11 @@
 
 <main id="main">
 	<slot />
-
-	{#if browser}
-		<SearchBox />
-	{/if}
 </main>
+
+{#if browser}
+	<SearchBox />
+{/if}
 
 <style>
 	main {


### PR DESCRIPTION
fixes #7947 
Moves the `<SearchBox>` component out of the `<main>` element because iOS has an issue with `z-index`.
The `<nav>` had a higher z-index than the container of the SearchBox so the search box gets hidden. It ignores the z-index of the search box.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
