### PR TITLE
[docs] fix double scrolling on mobile site

### DIFF
--- a/.changeset/wild-mangos-develop.md
+++ b/.changeset/wild-mangos-develop.md
@@ -1,0 +1,5 @@
+---
+'kit.svelte.dev': patch
+---
+
+fix mobile site inconsistent scrolling

--- a/.changeset/wild-mangos-develop.md
+++ b/.changeset/wild-mangos-develop.md
@@ -1,5 +1,0 @@
----
-'kit.svelte.dev': patch
----
-
-fix mobile site inconsistent scrolling

--- a/sites/kit.svelte.dev/src/routes/+layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/+layout.svelte
@@ -49,11 +49,11 @@
 
 <main id="main">
 	<slot />
-</main>
 
-{#if browser}
-	<SearchBox />
-{/if}
+  {#if browser}
+		<SearchBox />
+	{/if}
+</main>
 
 <style>
 	main {

--- a/sites/kit.svelte.dev/src/routes/+layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/+layout.svelte
@@ -49,19 +49,18 @@
 
 <main id="main">
 	<slot />
-
-	{#if browser}
-		<SearchBox />
-	{/if}
 </main>
+
+{#if browser}
+	<SearchBox />
+{/if}
 
 <style>
 	main {
 		position: relative;
 		margin: 0 auto;
 		padding-top: var(--sk-nav-height);
-		overflow: auto;
-		overflow-x: hidden;
+		overflow: hidden;
 	}
 
 	.small {

--- a/sites/kit.svelte.dev/src/routes/+layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/+layout.svelte
@@ -50,7 +50,7 @@
 <main id="main">
 	<slot />
 
-  {#if browser}
+	{#if browser}
 		<SearchBox />
 	{/if}
 </main>


### PR DESCRIPTION
fixes #7954 

Changes the `<main>` element `overflow-y` from `auto` to `hidden`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
