### PR TITLE
[fix] handle missing server file for an action request

### DIFF
--- a/.changeset/witty-spies-occur.md
+++ b/.changeset/witty-spies-occur.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix `enhance` error message when form action doesn't exist
+fix `enhance` error message when form action doesn't exist or csrf is enabled

--- a/.changeset/witty-spies-occur.md
+++ b/.changeset/witty-spies-occur.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix `enhance` error message when form action doesn't exist

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -1,4 +1,5 @@
 import * as devalue from 'devalue';
+import { error } from '../../exports/index.js';
 import { client } from '../client/singletons.js';
 import { invalidateAll } from './navigation.js';
 
@@ -103,7 +104,13 @@ export function enhance(form, submit = () => {}) {
 				signal: controller.signal
 			});
 
-			result = deserialize(await response.text());
+			const response_text = await response.text();
+
+			if (response.headers.get('content-type') !== 'application/json') {
+				throw error(response.status, response_text);
+			}
+
+			result = deserialize(response_text);
 		} catch (error) {
 			if (/** @type {any} */ (error)?.name === 'AbortError') return;
 			result = { type: 'error', error };

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -104,13 +104,7 @@ export function enhance(form, submit = () => {}) {
 				signal: controller.signal
 			});
 
-			const response_text = await response.text();
-
-			if (response.headers.get('content-type') !== 'application/json') {
-				throw error(response.status, response_text);
-			}
-
-			result = deserialize(response_text);
+			result = deserialize(await response.text());
 		} catch (error) {
 			if (/** @type {any} */ (error)?.name === 'AbortError') return;
 			result = { type: 'error', error };

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -1,5 +1,4 @@
 import * as devalue from 'devalue';
-import { error } from '../../exports/index.js';
 import { client } from '../client/singletons.js';
 import { invalidateAll } from './navigation.js';
 

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -17,6 +17,7 @@ import { redirect_json_response, render_data } from './data/index.js';
 import { add_cookies_to_headers, get_cookies } from './cookie.js';
 import { create_fetch } from './fetch.js';
 import { Redirect } from '../control.js';
+import { error, json } from '../../exports/index.js';
 
 /* global __SVELTEKIT_ADAPTER_NAME__ */
 
@@ -40,9 +41,11 @@ export async function respond(request, options, state) {
 			is_form_content_type(request);
 
 		if (forbidden) {
-			return new Response(`Cross-site ${request.method} form submissions are forbidden`, {
-				status: 403
-			});
+			const csrf_error = error(403, `Cross-site ${request.method} form submissions are forbidden`);
+			if (request.headers.get('accept') === 'application/json') {
+				return json(csrf_error.body, { status: csrf_error.status });
+			}
+			return new Response(csrf_error.body.message, { status: csrf_error.status });
 		}
 	}
 

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -17,6 +17,7 @@ import { redirect_json_response, render_data } from './data/index.js';
 import { add_cookies_to_headers, get_cookies } from './cookie.js';
 import { create_fetch } from './fetch.js';
 import { Redirect } from '../control.js';
+import { json } from '../../exports/index.js';
 
 /* global __SVELTEKIT_ADAPTER_NAME__ */
 
@@ -40,9 +41,12 @@ export async function respond(request, options, state) {
 			is_form_content_type(request);
 
 		if (forbidden) {
-			return new Response(`Cross-site ${request.method} form submissions are forbidden`, {
-				status: 403
-			});
+			return json(
+				{ message: `Cross-site ${request.method} form submissions are forbidden` },
+				{
+					status: 403
+				}
+			);
 		}
 	}
 

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -17,7 +17,6 @@ import { redirect_json_response, render_data } from './data/index.js';
 import { add_cookies_to_headers, get_cookies } from './cookie.js';
 import { create_fetch } from './fetch.js';
 import { Redirect } from '../control.js';
-import { json } from '../../exports/index.js';
 
 /* global __SVELTEKIT_ADAPTER_NAME__ */
 
@@ -41,12 +40,9 @@ export async function respond(request, options, state) {
 			is_form_content_type(request);
 
 		if (forbidden) {
-			return json(
-				{ message: `Cross-site ${request.method} form submissions are forbidden` },
-				{
-					status: 403
-				}
-			);
+			return new Response(`Cross-site ${request.method} form submissions are forbidden`, {
+				status: 403
+			});
 		}
 	}
 

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -28,17 +28,14 @@ export async function handle_action_json_request(event, options, server) {
 			maybe_throw_migration_error(server);
 		}
 		// TODO should this be a different error altogether?
-		return json(
-			{ message: 'POST method not allowed. No actions exist for this page' },
-			{
-				status: 405,
-				headers: {
-					// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405
-					// "The server must generate an Allow header field in a 405 status code response"
-					allow: 'GET'
-				}
+		return new Response('POST method not allowed. No actions exist for this page', {
+			status: 405,
+			headers: {
+				// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405
+				// "The server must generate an Allow header field in a 405 status code response"
+				allow: 'GET'
 			}
-		);
+		});
 	}
 
 	check_named_default_separate(actions);

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -18,16 +18,18 @@ export function is_action_json_request(event) {
 /**
  * @param {import('types').RequestEvent} event
  * @param {import('types').SSROptions} options
- * @param {import('types').SSRNode['server']} server
+ * @param {import('types').SSRNode['server'] | undefined} server
  */
 export async function handle_action_json_request(event, options, server) {
-	const actions = server.actions;
+	const actions = server?.actions;
 
 	if (!actions) {
-		maybe_throw_migration_error(server);
+		if (server) {
+			maybe_throw_migration_error(server);
+		}
 		// TODO should this be a different error altogether?
-		return new Response(
-			JSON.stringify({ message: 'POST method not allowed. No actions exist for this page' }),
+		return json(
+			{ message: 'POST method not allowed. No actions exist for this page' },
 			{
 				status: 405,
 				headers: {

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -26,14 +26,17 @@ export async function handle_action_json_request(event, options, server) {
 	if (!actions) {
 		maybe_throw_migration_error(server);
 		// TODO should this be a different error altogether?
-		return new Response('POST method not allowed. No actions exist for this page', {
-			status: 405,
-			headers: {
-				// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405
-				// "The server must generate an Allow header field in a 405 status code response"
-				allow: 'GET'
+		return new Response(
+			JSON.stringify({ message: 'POST method not allowed. No actions exist for this page' }),
+			{
+				status: 405,
+				headers: {
+					// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405
+					// "The server must generate an Allow header field in a 405 status code response"
+					allow: 'GET'
+				}
 			}
-		});
+		);
 	}
 
 	check_named_default_separate(actions);

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -28,14 +28,21 @@ export async function handle_action_json_request(event, options, server) {
 			maybe_throw_migration_error(server);
 		}
 		// TODO should this be a different error altogether?
-		return new Response('POST method not allowed. No actions exist for this page', {
-			status: 405,
-			headers: {
-				// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405
-				// "The server must generate an Allow header field in a 405 status code response"
-				allow: 'GET'
+		const no_actions_error = error(405, 'POST method not allowed. No actions exist for this page');
+		return action_json(
+			{
+				type: 'error',
+				error: await handle_error_and_jsonify(event, options, no_actions_error)
+			},
+			{
+				status: no_actions_error.status,
+				headers: {
+					// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405
+					// "The server must generate an Allow header field in a 405 status code response"
+					allow: 'GET'
+				}
 			}
-		});
+		);
 	}
 
 	check_named_default_separate(actions);

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -1,3 +1,4 @@
+import { json } from '../../../exports/index.js';
 import { compact } from '../../../utils/array.js';
 import { normalize_error } from '../../../utils/error.js';
 import { add_data_suffix } from '../../../utils/url.js';
@@ -40,9 +41,7 @@ export async function render_page(event, route, page, options, state, resolve_op
 
 	if (is_action_json_request(event)) {
 		const node = await options.manifest._.nodes[page.leaf]();
-		if (node.server) {
-			return handle_action_json_request(event, options, node.server);
-		}
+		return handle_action_json_request(event, options, node?.server);
 	}
 
 	try {

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -1,4 +1,3 @@
-import { json } from '../../../exports/index.js';
 import { compact } from '../../../utils/array.js';
 import { normalize_error } from '../../../utils/error.js';
 import { add_data_suffix } from '../../../utils/url.js';


### PR DESCRIPTION
fixes #7965 
fixes #7957 

* Returns a `405` response for an action request when no server file exists for a page.
* Adds a JSON body for the "cross-origin POST" and "no actions exist" error responses.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
