### PR TITLE
[breaking] add embedded option, turned off by default

### DIFF
--- a/.changeset/popular-crabs-shop.md
+++ b/.changeset/popular-crabs-shop.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] add embedded option, turned off by default

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -76,6 +76,7 @@ const get_defaults = (prefix = '') => ({
 			checkOrigin: true
 		},
 		endpointExtensions: undefined,
+		embedded: false,
 		env: {
 			dir: process.cwd(),
 			publicPrefix: 'PUBLIC_'

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -129,6 +129,8 @@ const options = object(
 				checkOrigin: boolean(true)
 			}),
 
+			embedded: boolean(false),
+
 			// TODO: remove this for the 1.0 release
 			endpointExtensions: error(
 				(keypath) => `${keypath} has been renamed to config.kit.moduleExtensions`

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -66,6 +66,7 @@ export class Server {
 				check_origin: ${s(config.kit.csrf.checkOrigin)},
 			},
 			dev: false,
+			embedded: ${config.kit.embedded},
 			handle_error: (error, event) => {
 				return this.options.hooks.handleError({
 					error,

--- a/packages/kit/src/exports/vite/build/utils.js
+++ b/packages/kit/src/exports/vite/build/utils.js
@@ -147,7 +147,8 @@ export function get_default_build_config({ config, input, ssr, outDir }) {
 			__SVELTEKIT_APP_VERSION_FILE__: JSON.stringify(`${config.kit.appDir}/version.json`),
 			__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: JSON.stringify(config.kit.version.pollInterval),
 			__SVELTEKIT_BROWSER__: ssr ? 'false' : 'true',
-			__SVELTEKIT_DEV__: 'false'
+			__SVELTEKIT_DEV__: 'false',
+			__SVELTEKIT_EMBEDDED__: config.kit.embedded ? 'true' : 'false'
 		},
 		publicDir: ssr ? false : config.kit.files.assets,
 		resolve: {

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -444,6 +444,7 @@ export async function dev(vite, vite_config, svelte_config) {
 							check_origin: svelte_config.kit.csrf.checkOrigin
 						},
 						dev: true,
+						embedded: svelte_config.kit.embedded,
 						handle_error: async (error, event) => {
 							const error_object = await hooks.handleError({
 								error: new Proxy(error, {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -248,7 +248,8 @@ function kit() {
 				define: {
 					__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: '0',
 					__SVELTEKIT_BROWSER__: config_env.ssrBuild ? 'false' : 'true',
-					__SVELTEKIT_DEV__: 'true'
+					__SVELTEKIT_DEV__: 'true',
+					__SVELTEKIT_EMBEDDED__: svelte_config.kit.embedded ? 'true' : 'false'
 				},
 				publicDir: svelte_config.kit.files.assets,
 				resolve: {

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1635,7 +1635,15 @@ export function create_client({ target, base }) {
 			});
 		},
 
-		_hydrate: async ({ status, error, node_ids, params, route, data: server_data_nodes, form }) => {
+		_hydrate: async ({
+			status = 200,
+			error,
+			node_ids,
+			params,
+			route,
+			data: server_data_nodes,
+			form
+		}) => {
 			hydrated = true;
 
 			const url = new URL(location.href);
@@ -1643,7 +1651,7 @@ export function create_client({ target, base }) {
 			if (!__SVELTEKIT_EMBEDDED__) {
 				// See https://github.com/sveltejs/kit/pull/4935#issuecomment-1328093358 for one motivation
 				// of determining the params on the client side.
-				params = get_navigation_intent(url, false)?.params || {};
+				({ params = {}, route = { id: null } } = get_navigation_intent(url, false) || {});
 			}
 
 			/** @type {import('./types').NavigationFinished | undefined} */

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -88,6 +88,7 @@ function check_for_removed_attributes() {
  * @returns {import('./types').Client}
  */
 export function create_client({ target, base }) {
+	const container = __SVELTEKIT_EMBEDDED__ ? target : document.documentElement;
 	/** @type {Array<((url: URL) => boolean)>} */
 	const invalidated = [];
 
@@ -1194,7 +1195,7 @@ export function create_client({ target, base }) {
 		/** @type {NodeJS.Timeout} */
 		let mousemove_timeout;
 
-		target.addEventListener('mousemove', (event) => {
+		container.addEventListener('mousemove', (event) => {
 			const target = /** @type {Element} */ (event.target);
 
 			clearTimeout(mousemove_timeout);
@@ -1208,8 +1209,8 @@ export function create_client({ target, base }) {
 			preload(/** @type {Element} */ (event.composedPath()[0]), 1);
 		}
 
-		target.addEventListener('mousedown', tap);
-		target.addEventListener('touchstart', tap, { passive: true });
+		container.addEventListener('mousedown', tap);
+		container.addEventListener('touchstart', tap, { passive: true });
 
 		const observer = new IntersectionObserver(
 			(entries) => {
@@ -1228,7 +1229,7 @@ export function create_client({ target, base }) {
 		 * @param {number} priority
 		 */
 		function preload(element, priority) {
-			const a = find_anchor(element, target);
+			const a = find_anchor(element, container);
 			if (!a) return;
 
 			const { url, external } = get_link_info(a, base);
@@ -1248,7 +1249,7 @@ export function create_client({ target, base }) {
 		function after_navigate() {
 			observer.disconnect();
 
-			for (const a of target.querySelectorAll('a')) {
+			for (const a of container.querySelectorAll('a')) {
 				const { url, external } = get_link_info(a, base);
 				if (external) continue;
 
@@ -1452,14 +1453,14 @@ export function create_client({ target, base }) {
 			}
 
 			/** @param {MouseEvent} event */
-			target.addEventListener('click', (event) => {
+			container.addEventListener('click', (event) => {
 				// Adapted from https://github.com/visionmedia/page.js
 				// MIT license https://github.com/visionmedia/page.js#license
 				if (event.button || event.which !== 1) return;
 				if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
 				if (event.defaultPrevented) return;
 
-				const a = find_anchor(/** @type {Element} */ (event.composedPath()[0]), target);
+				const a = find_anchor(/** @type {Element} */ (event.composedPath()[0]), container);
 				if (!a) return;
 
 				const { url, external, has } = get_link_info(a, base);
@@ -1529,7 +1530,7 @@ export function create_client({ target, base }) {
 				});
 			});
 
-			target.addEventListener('submit', (event) => {
+			container.addEventListener('submit', (event) => {
 				if (event.defaultPrevented) return;
 
 				const form = /** @type {HTMLFormElement} */ (

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1640,6 +1640,12 @@ export function create_client({ target, base }) {
 
 			const url = new URL(location.href);
 
+			if (!__SVELTEKIT_EMBEDDED__) {
+				// See https://github.com/sveltejs/kit/pull/4935#issuecomment-1328093358 for one motivation
+				// of determining the params on the client side.
+				params = get_navigation_intent(url, false)?.params || {};
+			}
+
 			/** @type {import('./types').NavigationFinished | undefined} */
 			let result;
 

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -809,11 +809,11 @@ test.describe('Routing', () => {
 		expect(await page.textContent('h1')).toBe('hello');
 	});
 
-	test('ignores clicks outside the app target', async ({ page }) => {
+	test('recognizes clicks outside the app target', async ({ page }) => {
 		await page.goto('/routing/link-outside-app-target/source');
 
 		await page.click('[href="/routing/link-outside-app-target/target"]');
-		expect(await page.textContent('h1')).toBe('target: 0');
+		await expect(page.locator('h1')).toHaveText('target: 1');
 	});
 
 	test('responds to <form method="GET"> submission without reload', async ({ page }) => {

--- a/packages/kit/test/apps/options/source/pages/routing/link-outside-app-target/source/+page.svelte
+++ b/packages/kit/test/apps/options/source/pages/routing/link-outside-app-target/source/+page.svelte
@@ -1,0 +1,8 @@
+<script>
+	import { onMount } from 'svelte';
+	import { increment, count } from '../state.js';
+
+	onMount(increment);
+</script>
+
+<h2>source: {count}</h2>

--- a/packages/kit/test/apps/options/source/pages/routing/link-outside-app-target/state.js
+++ b/packages/kit/test/apps/options/source/pages/routing/link-outside-app-target/state.js
@@ -1,0 +1,5 @@
+export let count = 0;
+
+export function increment() {
+	count += 1;
+}

--- a/packages/kit/test/apps/options/source/pages/routing/link-outside-app-target/target/+page.svelte
+++ b/packages/kit/test/apps/options/source/pages/routing/link-outside-app-target/target/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { count } from '../state.js';
+</script>
+
+<h2>target: {count}</h2>

--- a/packages/kit/test/apps/options/source/template.html
+++ b/packages/kit/test/apps/options/source/template.html
@@ -8,5 +8,6 @@
 	<body>
 		<h1>I am in the template</h1>
 		<div>%sveltekit.body%</div>
+		<a href="/path-base/routing/link-outside-app-target/target">outside app target</a>
 	</body>
 </html>

--- a/packages/kit/test/apps/options/svelte.config.js
+++ b/packages/kit/test/apps/options/svelte.config.js
@@ -2,6 +2,7 @@
 const config = {
 	extensions: ['.jesuslivesineveryone', '.whokilledthemuffinman', '.svelte.md', '.svelte'],
 	kit: {
+		embedded: true,
 		csp: {
 			directives: {
 				'script-src': ['self']

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -229,3 +229,12 @@ test.describe('Vite options', () => {
 		expect(await page.textContent('h2')).toBe(`${mode} === ${mode} === ${mode}`);
 	});
 });
+
+test.describe('Routing', () => {
+	test('ignores clicks outside the app target', async ({ page }) => {
+		await page.goto('/path-base/routing/link-outside-app-target/source');
+
+		await page.click('[href="/path-base/routing/link-outside-app-target/target"]');
+		await expect(page.locator('h2')).toHaveText('target: 0');
+	});
+});

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -326,7 +326,7 @@ export interface KitConfig {
 		checkOrigin?: boolean;
 	};
 	/**
-	 * Whether or not the app is embedded inside a larger app. If `true`, SvelteKit will add its event listeners related to navigation etc on the parent of `%sveltekit.body%` instead of `window`.
+	 * Whether or not the app is embedded inside a larger app. If `true`, SvelteKit will add its event listeners related to navigation etc on the parent of `%sveltekit.body%` instead of `window`, and will pass `params` from the server rather than inferring them from `location.pathname`.
 	 * @default false
 	 */
 	embedded?: boolean;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -326,6 +326,11 @@ export interface KitConfig {
 		checkOrigin?: boolean;
 	};
 	/**
+	 * Whether or not the app is embedded inside a larger app. If `true`, SvelteKit will add its event listeners related to navigation etc on the parent of `%sveltekit.body%` instead of `window`.
+	 * @default false
+	 */
+	embedded?: boolean;
+	/**
 	 * Environment variable configuration
 	 */
 	env?: {

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -385,4 +385,5 @@ declare global {
 	const __SVELTEKIT_APP_VERSION_POLL_INTERVAL__: number;
 	const __SVELTEKIT_BROWSER__: boolean;
 	const __SVELTEKIT_DEV__: boolean;
+	const __SVELTEKIT_EMBEDDED__: boolean;
 }

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -298,6 +298,7 @@ export interface SSROptions {
 		check_origin: boolean;
 	};
 	dev: boolean;
+	embedded: boolean;
 	handle_error(error: Error & { frame?: string }, event: RequestEvent): MaybePromise<App.Error>;
 	hooks: ServerHooks;
 	manifest: SSRManifest;


### PR DESCRIPTION
## Migration

If you relied on the new behavior introduced in #7766, you can get that back by adding `embedded: true` to your `svelte.config.js`:

```diff
export default {
  kit: {
+    embedded: true
  }
}
```

## PR description

Closes #7940
Closes #4935
Adds a new option which defaults to false. If true, events related to navigation etc are listened to on the target element rather the html root

~Open questions~ solved: 
- ~approach sensible? I figured using the `define` feature for this is the most straightforward and treeshakes nicely~ it is
- ~using `data-sveltekit-root` instead (as discussed in the issue)? Advantage: no config option, more control ("I use popper.js with embedded Kit, and it adds itself to some tag higher than the target). Disadvantage: feels clunky, a little more startup code that might not be as reliable.~ option is the way to go

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
