### PR TITLE
[fix] reestablish prerender.enabled option

### DIFF
--- a/.changeset/olive-ears-suffer.md
+++ b/.changeset/olive-ears-suffer.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] reestablish prerender.enabled option

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -113,7 +113,7 @@ const get_defaults = (prefix = '') => ({
 			crawl: true,
 			createIndexFiles: undefined,
 			default: undefined,
-			enabled: undefined,
+			enabled: true,
 			entries: ['*'],
 			force: undefined,
 			handleHttpError: 'fail',

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -238,10 +238,7 @@ const options = object(
 					(keypath) =>
 						`${keypath} has been removed. You can set it inside the top level +layout.js instead. See the PR for more information: https://github.com/sveltejs/kit/pull/6197`
 				),
-				enabled: error(
-					(keypath) =>
-						`${keypath} has been removed. You can wrap any code that should not be executed during build in a \`if (!building) {...}\` block. See the discussion for more information: https://github.com/sveltejs/kit/discussions/7716`
-				),
+				enabled: boolean(true),
 				entries: validate(['*'], (input, keypath) => {
 					if (!Array.isArray(input) || !input.every((page) => typeof page === 'string')) {
 						throw new Error(`${keypath} must be an array of strings`);

--- a/packages/kit/src/core/prerender/prerender.js
+++ b/packages/kit/src/core/prerender/prerender.js
@@ -77,6 +77,11 @@ export async function prerender() {
 	/** @type {import('types').ValidatedKitConfig} */
 	const config = (await load_config()).kit;
 
+	if (!config.prerender.enabled) {
+		output_and_exit({ prerendered, prerender_map });
+		return;
+	}
+
 	/** @type {import('types').Logger} */
 	const log = logger({
 		verbose: verbose === 'true'

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -436,6 +436,11 @@ export interface KitConfig {
 		 */
 		crawl?: boolean;
 		/**
+		 * Set this to `false` to disable prerendering altogether
+		 * @default true
+		 */
+		enabled?: boolean;
+		/**
 		 * An array of pages to prerender, or start crawling from (if `crawl: true`). The `*` string includes all non-dynamic routes (i.e. pages with no `[parameters]`, because SvelteKit doesn't know what value the parameters should have).
 		 * @default ["*"]
 		 */


### PR DESCRIPTION
fixes #7899
I figured this is the easiest and most straightforward fix to the issue. That option still makes sense to have even after the prerendering->building change, which is somewhat orthogonal. We still reserve the right to load the files at build time and look at a potential `config` option, we just added back the additional granularity of disabling prerendering altogether.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
