### PR TITLE
[breaking] strip __data.json from url

### DIFF
--- a/.changeset/stupid-panthers-learn.md
+++ b/.changeset/stupid-panthers-learn.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-[breaking] strip \_\_data.json from url
+[breaking] strip `__data.json` from url

--- a/.changeset/stupid-panthers-learn.md
+++ b/.changeset/stupid-panthers-learn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[breaking] strip \_\_data.json from url

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -1,5 +1,5 @@
 import { parse, serialize } from 'cookie';
-import { has_data_suffix, normalize_path, strip_data_suffix } from '../../utils/url.js';
+import { normalize_path } from '../../utils/url.js';
 
 /**
  * Tracks all cookies set during dev mode so we can emit warnings
@@ -22,12 +22,7 @@ export function get_cookies(request, url, dev, trailing_slash) {
 	const header = request.headers.get('cookie') ?? '';
 	const initial_cookies = parse(header, { decode });
 
-	const normalized_url = normalize_path(
-		// Remove suffix: 'foo/__data.json' would mean the cookie path is '/foo',
-		// whereas a direct hit of /foo would mean the cookie path is '/'
-		has_data_suffix(url.pathname) ? strip_data_suffix(url.pathname) : url.pathname,
-		trailing_slash
-	);
+	const normalized_url = normalize_path(url.pathname, trailing_slash);
 	// Emulate browser-behavior: if the cookie is set at '/foo/bar', its path is '/foo'
 	const default_path = normalized_url.split('/').slice(0, -1).join('/') || '/';
 

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -13,7 +13,7 @@ import {
 	strip_data_suffix
 } from '../../utils/url.js';
 import { exec } from '../../utils/routing.js';
-import { redirect_json_response, render_data } from './data/index.js';
+import { INVALIDATED_PARAM, redirect_json_response, render_data } from './data/index.js';
 import { add_cookies_to_headers, get_cookies } from './cookie.js';
 import { create_fetch } from './fetch.js';
 import { Redirect } from '../control.js';
@@ -32,6 +32,7 @@ const default_preload = ({ type }) => type === 'js' || type === 'css';
 
 /** @type {import('types').Respond} */
 export async function respond(request, options, state) {
+	/** URL but stripped from the potential `/__data.json` suffix and its search param  */
 	let url = new URL(request.url);
 
 	if (options.csrf.check_origin) {
@@ -70,7 +71,14 @@ export async function respond(request, options, state) {
 	}
 
 	const is_data_request = has_data_suffix(decoded);
-	if (is_data_request) decoded = strip_data_suffix(decoded) || '/';
+	/** @type {boolean[] | undefined} */
+	let invalidated_data_nodes;
+	if (is_data_request) {
+		decoded = strip_data_suffix(decoded) || '/';
+		url.pathname = strip_data_suffix(url.pathname) || '/';
+		invalidated_data_nodes = url.searchParams.get(INVALIDATED_PARAM)?.split('_').map(Boolean);
+		url.searchParams.delete(INVALIDATED_PARAM);
+	}
 
 	if (!state.prerendering?.fallback) {
 		// TODO this could theoretically break — should probably be inside a try-catch
@@ -133,7 +141,8 @@ export async function respond(request, options, state) {
 				}
 			}
 		},
-		url
+		url,
+		isDataRequest: is_data_request
 	};
 
 	// TODO remove this for 1.0
@@ -350,7 +359,14 @@ export async function respond(request, options, state) {
 				let response;
 
 				if (is_data_request) {
-					response = await render_data(event, route, options, state, trailing_slash ?? 'never');
+					response = await render_data(
+						event,
+						route,
+						options,
+						state,
+						invalidated_data_nodes,
+						trailing_slash ?? 'never'
+					);
 				} else if (route.endpoint && (!route.page || is_endpoint_request(event))) {
 					response = await render_endpoint(event, await route.endpoint(), state);
 				} else if (route.page) {

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -124,7 +124,7 @@ export async function handle_fatal_error(event, options, error) {
 		'text/html'
 	]);
 
-	if (has_data_suffix(event.url.pathname) || type === 'application/json') {
+	if (has_data_suffix(new URL(event.request.url).pathname) || type === 'application/json') {
 		return new Response(JSON.stringify(body), {
 			status,
 			headers: { 'content-type': 'application/json; charset=utf-8' }

--- a/packages/kit/test/apps/basics/src/hooks.server.js
+++ b/packages/kit/test/apps/basics/src/hooks.server.js
@@ -45,6 +45,17 @@ export const handle = sequence(
 		return resolve(event);
 	},
 	({ event, resolve }) => {
+		if (
+			event.request.url.includes('__data.json') &&
+			(event.url.pathname.endsWith('__data.json') || !event.isDataRequest)
+		) {
+			throw new Error(
+				'__data.json requests should have the suffix stripped from the URL and isDataRequest set to true'
+			);
+		}
+		return resolve(event);
+	},
+	({ event, resolve }) => {
 		if (event.url.pathname.includes('fetch-credentialed')) {
 			// Only get the cookie at the test where we know it's set to avoid polluting our logs with (correct) warnings
 			event.locals.name = /** @type {string} */ (event.cookies.get('name'));

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -536,7 +536,7 @@ test.describe('Errors', () => {
 		);
 
 		const { status, name, message, stack, fancy } = read_errors(
-			'/errors/page-endpoint/get-implicit/__data.json'
+			'/errors/page-endpoint/get-implicit'
 		);
 		expect(status).toBe(undefined);
 		expect(name).toBe('FancyError');

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -900,9 +900,14 @@ export interface RequestEvent<
 	 */
 	setHeaders(headers: Record<string, string>): void;
 	/**
-	 * The URL of the current page or endpoint
+	 * The URL of the current page or endpoint.
 	 */
 	url: URL;
+	/**
+	 * `true` if the request comes from the client asking for `+page/layout.server.js` data. The `url` property will be stripped of the internal information
+	 * related to the data request in this case. Use this property instead if the distinction is important to you.
+	 */
+	isDataRequest: boolean;
 }
 
 /**


### PR DESCRIPTION
This is breaking change for people who relied on the `__data.json` suffix being present on `event.url` which is now no longer the case. Use the new `isDataRequest` boolean instead.

```diff
export function handle({ event, resolve }) {
-  if (event.url.pathname.endsWith('__data.json') {
+  if (event.isDataRequest) {
    // ..
  }
  return resolve(event);
}
```

closes #7926

Open question: Should we also remove those things from the original `request` object? I vote for "no".

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
