### PR TITLE
`sizes` needs to be on the `source`-tag

### DIFF
--- a/sites/kit.svelte.dev/src/routes/home/Hero.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Hero.svelte
@@ -11,9 +11,10 @@
 			<a class="cta" href="/docs/introduction">read the docs</a>
 		</div>
 
-		<picture class="hero-image" sizes="(min-width: 480px) 800px, (min-width: 1024px) 480px, 600px">
+		<picture class="hero-image">
 			{#each Object.entries(background.sources) as [format, images]}
 				<source
+					sizes="(min-width: 480px) 800px, (min-width: 1024px) 480px, 600px"
 					srcset={images.map((i) => `${i.src} ${i.w}w`).join(', ')}
 					type={'image/' + format}
 				/>


### PR DESCRIPTION
The `sizes` attribute needs to be on the `source`-tag.
See [source](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source#attr-sizes) vs [picture](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture#attributes) attributes.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
