### PR TITLE
generate TS with `satisfies`

### DIFF
--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -271,7 +271,7 @@ export async function load({ cookies }) {
 Both server-only and shared `load` functions have access to a `setHeaders` function that, when running on the server, can set headers for the response. (When running in the browser, `setHeaders` has no effect.) This is useful if you want the page to be cached, for example:
 
 ```js
-// @errors: 2322
+// @errors: 2322 1360
 /// file: src/routes/products/+page.js
 /** @type {import('./$types').PageLoad} */
 export async function load({ fetch, setHeaders }) {

--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -157,7 +157,7 @@ declare namespace App {
 
 ```js
 /// file: src/hooks.server.js
-// @errors: 2322 2571 2339
+// @errors: 2322 1360 2571 2339
 // @filename: ambient.d.ts
 const Sentry: any;
 
@@ -177,7 +177,7 @@ export function handleError({ error, event }) {
 
 ```js
 /// file: src/hooks.client.js
-// @errors: 2322 2571 2339
+// @errors: 2322 1360 2571 2339
 // @filename: ambient.d.ts
 const Sentry: any;
 

--- a/documentation/docs/30-advanced/25-errors.md
+++ b/documentation/docs/30-advanced/25-errors.md
@@ -81,7 +81,7 @@ Unexpected errors will go through the [`handleError`](/docs/hooks#shared-hooks-h
 
 ```js
 /// file: src/hooks.server.js
-// @errors: 2322 2571 2339
+// @errors: 2322 1360 2571 2339
 // @filename: ambient.d.ts
 const Sentry: any;
 

--- a/documentation/docs/50-reference/40-types.md
+++ b/documentation/docs/50-reference/40-types.md
@@ -20,7 +20,7 @@ The `RequestHandler` and `Load` types both accept a `Params` argument allowing y
 
 ```js
 /// file: src/routes/[foo]/[bar]/[baz]/+page.server.js
-// @errors: 2355 2322
+// @errors: 2355 2322 1360
 /** @type {import('@sveltejs/kit').RequestHandler<{
  *   foo: string;
  *   bar: string;

--- a/sites/kit.svelte.dev/src/lib/docs/server/index.js
+++ b/sites/kit.svelte.dev/src/lib/docs/server/index.js
@@ -463,12 +463,12 @@ function convert_to_ts(js_code, indent = '', offset = '') {
 							code.overwrite(
 								node.getStart(),
 								node.name.getEnd(),
-								`${is_export ? 'export ' : ''}const ${node.name.getText()} = ${
+								`${is_export ? 'export ' : ''}const ${node.name.getText()} = (${
 									is_async ? 'async ' : ''
 								}`
 							);
 							code.appendLeft(node.body.getStart(), '=> ');
-							code.appendLeft(node.body.getEnd(), ` satisfies ${name};`);
+							code.appendLeft(node.body.getEnd(), `) satisfies ${name};`);
 
 							modified = true;
 						} else if (

--- a/sites/kit.svelte.dev/src/lib/docs/server/index.js
+++ b/sites/kit.svelte.dev/src/lib/docs/server/index.js
@@ -463,11 +463,12 @@ function convert_to_ts(js_code, indent = '', offset = '') {
 							code.overwrite(
 								node.getStart(),
 								node.name.getEnd(),
-								`${is_export ? 'export ' : ''}const ${node.name.getText()}: ${name} = ${
+								`${is_export ? 'export ' : ''}const ${node.name.getText()} = ${
 									is_async ? 'async ' : ''
 								}`
 							);
 							code.appendLeft(node.body.getStart(), '=> ');
+							code.appendLeft(node.body.getEnd(), ` satisfies ${name};`);
 
 							modified = true;
 						} else if (

--- a/sites/kit.svelte.dev/src/lib/docs/server/index.spec.js
+++ b/sites/kit.svelte.dev/src/lib/docs/server/index.spec.js
@@ -59,10 +59,10 @@ export function GET(event) {
 \`\`\`generated-ts
 // @errors: 2461
 /// file: src/routes/what-is-my-user-agent/+server.ts
-import type { RequestHandler } from './$types';
 import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = (event) => {
+export const GET = (event) => {
 	// log all headers
 	console.log(...event.request.headers);
 
@@ -70,7 +70,7 @@ export const GET: RequestHandler = (event) => {
 		// retrieve a specific header
 		userAgent: event.request.headers.get('user-agent')
 	});
-}
+} satisfies RequestHandler;
 \`\`\`
 
 etc etc

--- a/sites/kit.svelte.dev/src/lib/docs/server/index.spec.js
+++ b/sites/kit.svelte.dev/src/lib/docs/server/index.spec.js
@@ -62,7 +62,7 @@ export function GET(event) {
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
-export const GET = (event) => {
+export const GET = ((event) => {
 	// log all headers
 	console.log(...event.request.headers);
 
@@ -70,7 +70,7 @@ export const GET = (event) => {
 		// retrieve a specific header
 		userAgent: event.request.headers.get('user-agent')
 	});
-} satisfies RequestHandler;
+}) satisfies RequestHandler;
 \`\`\`
 
 etc etc


### PR DESCRIPTION
would be nice to get this change in as it reduces the need for proxy types. the site won't build though, because (I think) shiki-twoslash is using an older TypeScript and doesn't know how to deal with the newfangled syntax. A cursory glance didn't show me how to fix it so I'm just going to leave this here for a moment