### PR TITLE
Added `SubmitFunction` type to use:enhance docs

### DIFF
--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -324,7 +324,7 @@ Without an argument, `use:enhance` will emulate the browser-native behaviour, ju
 - call `goto` on a redirect response
 - render the nearest `+error` boundary if an error occurs
 
-To customise the behaviour, you can provide a function that runs immediately before the form is submitted, and (optionally) returns a callback that runs with the `ActionResult`. Note that if you return a callback, the default behavior mentioned above is not triggered. To get it back, call `update`.
+To customise the behaviour, you can provide a `SubmitFunction` that runs immediately before the form is submitted, and (optionally) returns a callback that runs with the `ActionResult`. Note that if you return a callback, the default behavior mentioned above is not triggered. To get it back, call `update`.
 
 ```svelte
 <form


### PR DESCRIPTION
The type of the function passed to the `use:enhance` action should be specified in the docs. This makes it easier for developers working in TS to get type checking and intellisense within custom `enhance` functions.

As far as I can tell a manual link isn't needed for the type, but if it is the correct page appears to be [here](https://kit.svelte.dev/docs/types#public-types-submitfunction). Credit to [ShadowMobX on discord](https://discord.com/channels/457912077277855764/1050623304312045618/1050625506594271274) for the insight.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

As this is a simple doc update, I don't see a reason to open an issue/discussion or implement tests for it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

n/a, simple doc change