### PR TITLE
[docs] improve visibility of permalink in dark mode

### DIFF
--- a/sites/site-kit/src/lib/icons/link-white.svg
+++ b/sites/site-kit/src/lib/icons/link-white.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="width:24px;height:24px" viewBox="0 0 24 24">
+	<g fill="none" stroke="#CCC">
+		<path d="M9,7L6,7A2 2 0 0 0 6,17L9,17"/>
+		<path d="M15,7L18,7A2 2 0 0 1 18,17L15,17"/>
+		<path d="M7,12L17,12"/>
+	</g>
+</svg>

--- a/sites/site-kit/src/lib/styles/text.css
+++ b/sites/site-kit/src/lib/styles/text.css
@@ -212,6 +212,12 @@
 	bottom: 0.25em;
 }
 
+@media (prefers-color-scheme: dark) {
+	.text a.permalink {
+		background: url(@sveltejs/site-kit/icons/link-white.svg) 0 50% no-repeat;
+	}
+}
+
 @media (min-width: 768px) {
 	.text a.permalink:focus,
 	.text h2:hover a.permalink,


### PR DESCRIPTION
The permalink in the kit website doesn't have a good contrast while in dark mode. This changes that by adding a light coloured version of the `link.svg` graphic.

Before:
<img width="540" alt="poor permalink visibility" src="https://user-images.githubusercontent.com/54401897/206798788-e78e63e5-a388-4c0d-b264-209ffdc9c5ef.png">

After:
<img width="533" alt="CleanShot 2022-12-10 at 05 31 48@2x" src="https://user-images.githubusercontent.com/54401897/206799484-42bbf3f5-5f66-4098-b570-d76ce1f9ef2c.png">

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
