### PR TITLE
[docs site] Add color-scheme meta tag

### DIFF
--- a/sites/kit.svelte.dev/src/app.html
+++ b/sites/kit.svelte.dev/src/app.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
 		<meta name="theme-color" content="#ff3e00" />
+		<meta name="color-scheme" content="dark light" />
 
 		<link rel="manifest" href="/manifest.json" />
 		<link rel="icon" type="image/png" href="/favicon.png" />


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/issues/7901

Specifying `color-scheme` will theme the browser native elements that would otherwise not be automatically themed, such as scrollbars. `"dark light"` is a special value that respects the operating system preferences.

Here's what it looks like on Windows 11 with system theme set to dark:
| Before | After |
| --- | --- |
| ![](https://user-images.githubusercontent.com/9084735/206809436-e4ca9979-37b9-4ece-88c1-6ced6e707c35.png) | ![](https://user-images.githubusercontent.com/9084735/206809371-f8d4a436-3bdc-4d24-8994-1fa14cb41c0d.png) |

Note that if in the future a manual theme switcher is added to the site, then this will need to be overridden in CSS using the `color-scheme` property.
```css
html[data-theme="light"] { color-scheme: light; }
html[data-theme="dark"] { color-scheme: dark; }
```

Further reading if curious:
- https://blog.mayank.co/better-scrolling-through-modern-css#heading-theming-scrollbars
- https://web.dev/color-scheme/
---

No change outside docs site, so none of the checklist items apply I hope.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
