### PR TITLE
[fix] set Vite base URL

### DIFF
--- a/.changeset/clever-ducks-wave.md
+++ b/.changeset/clever-ducks-wave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] set Vite base URL

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -253,7 +253,7 @@ function kit({ svelte_config }) {
 			/** @type {import('vite').UserConfig} */
 			const result = {
 				appType: 'custom',
-				base: './',
+				base: svelte_config.kit.paths.base,
 				build: {
 					rollupOptions: {
 						// Vite dependency crawler needs an explicit JS entry point

--- a/packages/kit/src/exports/vite/utils.js
+++ b/packages/kit/src/exports/vite/utils.js
@@ -173,8 +173,12 @@ export function not_found(req, res, base) {
 
 	if (type === 'text/html') {
 		res.setHeader('Content-Type', 'text/html');
-		res.end(`Not found (did you mean <a href="${prefixed}">${prefixed}</a>?)`);
+		res.end(
+			`The server is configured with a public base URL of /path-base - did you mean to visit <a href="${prefixed}">${prefixed}</a> instead?`
+		);
 	} else {
-		res.end(`Not found (did you mean ${prefixed}?)`);
+		res.end(
+			`The server is configured with a public base URL of /path-base - did you mean to visit ${prefixed} instead?`
+		);
 	}
 }

--- a/packages/kit/test/apps/options/source/template.html
+++ b/packages/kit/test/apps/options/source/template.html
@@ -9,6 +9,6 @@
 	<body>
 		<h1>I am in the template</h1>
 		<div>%sveltekit.body%</div>
-		<a href="/path-base/routing/link-outside-app-target/target">outside app target</a>
+		<a href="/path-base/routing/link-outside-app-target/target/">outside app target</a>
 	</body>
 </html>

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -9,21 +9,15 @@ test.describe('base path', () => {
 	test('serves a useful 404 when visiting unprefixed path', async ({ request }) => {
 		const html = await request.get('/slash/', { headers: { Accept: 'text/html' } });
 		expect(html.status()).toBe(404);
-		if (process.env.DEV) {
-			// Vite's message
-			expect(await html.text()).toBe(
-				'The server is configured with a public base URL of /path-base - did you mean to visit <a href="/path-base/slash/">/path-base/slash/</a> instead?'
-			);
-		} else {
-			// SvelteKit's message
-			expect(await html.text()).toBe(
-				'Not found (did you mean <a href="/path-base/slash/">/path-base/slash/</a>?)'
-			);
-		}
+		expect(await html.text()).toBe(
+			'The server is configured with a public base URL of /path-base - did you mean to visit <a href="/path-base/slash/">/path-base/slash/</a> instead?'
+		);
 
 		const plain = await request.get('/slash/');
 		expect(plain.status()).toBe(404);
-		expect(await plain.text()).toBe('Not found (did you mean /path-base/slash/?)');
+		expect(await plain.text()).toBe(
+			'The server is configured with a public base URL of /path-base - did you mean to visit /path-base/slash/ instead?'
+		);
 	});
 
 	test('serves /', async ({ page, javaScriptEnabled }) => {

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -9,9 +9,15 @@ test.describe('base path', () => {
 	test('serves a useful 404 when visiting unprefixed path', async ({ request }) => {
 		const html = await request.get('/slash/', { headers: { Accept: 'text/html' } });
 		expect(html.status()).toBe(404);
-		expect(await html.text()).toBe(
-			'Not found (did you mean <a href="/path-base/slash/">/path-base/slash/</a>?)'
-		);
+		if (process.env.DEV) {
+			// Vite's message
+			expect(await html.text()).toBe(
+				'The server is configured with a public base URL of /path-base - did you mean to visit <a href=\"/path-base/slash/\">/path-base/slash/</a> instead?'
+			);
+		} else {
+			// SvelteKit's message
+			expect(await html.text()).toBe('Not found (did you mean <a href=\"/path-base/slash/\">/path-base/slash/</a>?)');
+		}
 
 		const plain = await request.get('/slash/');
 		expect(plain.status()).toBe(404);
@@ -248,9 +254,9 @@ test.describe('Vite options', () => {
 
 test.describe('Routing', () => {
 	test('ignores clicks outside the app target', async ({ page }) => {
-		await page.goto('/path-base/routing/link-outside-app-target/source');
+		await page.goto('/path-base/routing/link-outside-app-target/source/');
 
-		await page.click('[href="/path-base/routing/link-outside-app-target/target"]');
+		await page.click('[href="/path-base/routing/link-outside-app-target/target/"]');
 		await expect(page.locator('h2')).toHaveText('target: 0');
 	});
 });

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -12,11 +12,13 @@ test.describe('base path', () => {
 		if (process.env.DEV) {
 			// Vite's message
 			expect(await html.text()).toBe(
-				'The server is configured with a public base URL of /path-base - did you mean to visit <a href=\"/path-base/slash/\">/path-base/slash/</a> instead?'
+				'The server is configured with a public base URL of /path-base - did you mean to visit <a href="/path-base/slash/">/path-base/slash/</a> instead?'
 			);
 		} else {
 			// SvelteKit's message
-			expect(await html.text()).toBe('Not found (did you mean <a href=\"/path-base/slash/\">/path-base/slash/</a>?)');
+			expect(await html.text()).toBe(
+				'Not found (did you mean <a href="/path-base/slash/">/path-base/slash/</a>?)'
+			);
 		}
 
 		const plain = await request.get('/slash/');


### PR DESCRIPTION
Setting Vite's base URL makes the 404 message a bit different in dev vs prod, but that seems like a very minor issue. Setting it will make a number of things easier like probably allowing us to fix https://github.com/sveltejs/kit/issues/2958, fix Vite PWA trying to read the base path from Vite, etc.

There were a few places I added trailing slashes. This avoids unnecessary redirects and makes the tests run faster and be less flaky. That probably could have been a separate PR, but I found it while working on this, so just crammed them in here