### PR TITLE
add type declaration for vitePreprocess reexport

### DIFF
--- a/.changeset/violet-donuts-share.md
+++ b/.changeset/violet-donuts-share.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+add declaration for vitePreprocess reexport

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -434,4 +434,5 @@ declare module '@sveltejs/kit/vite' {
 	 * Returns the SvelteKit Vite plugins.
 	 */
 	export function sveltekit(): Promise<Plugin[]>;
+	export { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 }


### PR DESCRIPTION
aside: Using 'declare module' for these exports kind of feels like a hack to me, unless it's needed for the docs we should maybe be using "exports.types" alongside the js files listed in package.json but out of scope for this PR.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
