### PR TITLE
[fix] make `<p> <code>` elements in docs scrollable

### DIFF
--- a/sites/site-kit/src/lib/styles/text.css
+++ b/sites/site-kit/src/lib/styles/text.css
@@ -56,6 +56,14 @@
 	background: transparent;
 }
 
+.text p code {
+	max-width: 100%;
+	display: inline-flex;
+	overflow-x: auto;
+	padding-top: 0;
+	padding-bottom: 0;
+}
+
 .text .code-block .filename {
 	content: attr(data-file);
 	display: block;


### PR DESCRIPTION
This is a continuation of #8034

Basically I found another thing that did not sidescroll, here:
https://kit.svelte.dev/docs/advanced-routing

Can be seen on both mobile and desktop:
<img width="400" alt="Screenshot 2022-12-10 at 07 57 00" src="https://user-images.githubusercontent.com/6213424/206836532-e8bedac7-5b20-429f-8fea-a4049c3de665.png">

Instead of doing an issue like before (#8032) I thought I would give it a go to fix it myself this time.

note:
The inline-flex and padding is to give the scrollable element the same appearance as before. I have tested my change on desktop chrome (osx) and on mobile safari (iphone ios) to great success.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
