### PR TITLE
Make vitePreprocess vs svelte-preprocess difference a bit clearer

### DIFF
--- a/documentation/docs/60-appendix/05-integrations.md
+++ b/documentation/docs/60-appendix/05-integrations.md
@@ -21,7 +21,9 @@ export default {
 
 ### `svelte-preprocess`
 
-[`svelte-preprocess`](https://github.com/sveltejs/svelte-preprocess) automatically transforms the code in your Svelte templates to provide support for TypeScript, PostCSS, scss/sass, Less, and many other technologies (except CoffeeScript which is [not supported](https://github.com/sveltejs/kit/issues/2920#issuecomment-996469815) by SvelteKit). `vitePreprocess` may be faster and require less configuration, so it is used by default. However, `svelte-preprocess` has some additional functionality not found in `vitePreprocess`. The first step of setting it up is to add `svelte-preprocess` to your [`svelte.config.js`](/docs/configuration). After that, you will often only need to install the corresponding library such as `npm install -D sass` or `npm install -D less`. See the [`svelte-preprocess`](https://github.com/sveltejs/svelte-preprocess) docs for more details.
+[`svelte-preprocess`](https://github.com/sveltejs/svelte-preprocess) automatically transforms the code in your Svelte templates to provide support for TypeScript, PostCSS, scss/sass, Less, and many other technologies (except CoffeeScript which is [not supported](https://github.com/sveltejs/kit/issues/2920#issuecomment-996469815) by SvelteKit). The first step of setting it up is to add `svelte-preprocess` to your [`svelte.config.js`](/docs/configuration). After that, you will often only need to install the corresponding library such as `npm install -D sass` or `npm install -D less`. See the [`svelte-preprocess`](https://github.com/sveltejs/svelte-preprocess) docs for more details.
+
+`vitePreprocess` can be faster and require less configuration, so it is used by default. However, `svelte-preprocess` does provide extra functionalities not available, such as [template tag](https://github.com/sveltejs/svelte-preprocess#template-tag), [external files](https://github.com/sveltejs/svelte-preprocess#external-files), and [global styles](https://github.com/sveltejs/svelte-preprocess#global-style). 
 
 ## Adders
 


### PR DESCRIPTION
As commented on Discord, if we are specifying that there are two maintained official preprocessors, maybe we could provide an explanation about when to use one or the other. This uses `vite-plugin-svelte` docs as a reference and moves the differentiation part to after both preprocessors
![image](https://user-images.githubusercontent.com/12702016/206865288-91b67421-bc94-4cde-a4e1-b378b44435ed.png)
