### PR TITLE
Set correct `$page.status` when using `enhance` and result is of type `'error'`

### DIFF
--- a/.changeset/dry-snails-own.md
+++ b/.changeset/dry-snails-own.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/kit': minor
+'@sveltejs/kit': patch
 ---
 
 Set correct `$page.status` when using `enhance` and result is of type `'error'`

--- a/.changeset/dry-snails-own.md
+++ b/.changeset/dry-snails-own.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+Set correct `$page.status` when using `enhance` and result is of type `'error'`

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -107,6 +107,7 @@ export function enhance(form, submit = () => {}) {
 			});
 
 			result = deserialize(await response.text());
+			if (result.type === 'error') result.status = response.status;
 		} catch (error) {
 			if (/** @type {any} */ (error)?.name === 'AbortError') return;
 			result = { type: 'error', error };

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1387,7 +1387,7 @@ export function create_client({ target, base }) {
 						url,
 						params: current.params,
 						branch: branch.slice(0, error_load.idx).concat(error_load.node),
-						status: 500, // TODO might not be 500?
+						status: result.status || 500,
 						error: result.error,
 						route
 					});

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1387,7 +1387,7 @@ export function create_client({ target, base }) {
 						url,
 						params: current.params,
 						branch: branch.slice(0, error_load.idx).concat(error_load.node),
-						status: result.status || 500,
+						status: result.status ?? 500,
 						error: result.error,
 						route
 					});

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.server.js
@@ -1,3 +1,5 @@
+import { error } from '@sveltejs/kit';
+
 /** @type {import('./$types').PageServerLoad} */
 export function load() {
 	return {
@@ -27,5 +29,8 @@ export const actions = {
 		return {
 			result: 'submitter: ' + fields.get('submitter')
 		};
+	},
+	error: () => {
+		throw error(400, 'error');
 	}
 };

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.svelte
@@ -20,6 +20,7 @@
 	<button class="form1">Submit</button>
 	<button class="form1-register" formAction="?/register">Submit</button>
 	<button class="form1-submitter" formAction="?/submitter" name="submitter" value="foo">Submit</button>
+	<button class="form1-error" formAction="?/error">Submit</button>
 </form>
 
 <span class="count">{count}</span>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -2019,6 +2019,17 @@ test.describe('Actions', () => {
 
 		expect(page.url()).toContain('/actions/enhance');
 	});
+
+	test.only('$page.status reflects error status', async ({ page, app }) => {
+		await page.goto('/actions/enhance');
+
+		await Promise.all([
+			page.waitForRequest((request) => request.url().includes('/actions/enhance')),
+			page.click('button.form1-error')
+		]);
+
+		await expect(page.locator('h1')).toHaveText('400');
+	});
 });
 
 // Run in serial to not pollute the log with (correct) cookie warnings

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -2020,7 +2020,7 @@ test.describe('Actions', () => {
 		expect(page.url()).toContain('/actions/enhance');
 	});
 
-	test.only('$page.status reflects error status', async ({ page, app }) => {
+	test('$page.status reflects error status', async ({ page, app }) => {
 		await page.goto('/actions/enhance');
 
 		await Promise.all([

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1074,7 +1074,7 @@ export type ActionResult<
 	| { type: 'success'; status: number; data?: Success }
 	| { type: 'failure'; status: number; data?: Invalid }
 	| { type: 'redirect'; status: number; location: string }
-	| { type: 'error'; error: any };
+	| { type: 'error'; status?: number; error: any };
 
 /**
  * Creates an `HttpError` object with an HTTP status code and an optional message.


### PR DESCRIPTION
Fixes #8072 

I wanted to create a `+error.svelte` in `test/apps/basic/src/routes/actions/enhance` for this test, but somehow it is not mounted in the "js"-test. I also tried to put it in `test/apps/basic/src/routes/actions`, that also didn't work.
Furthermore, I've tried to debug with playwright debug, but couldn't find any reason why it does not work.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
