### PR TITLE
[fix] restart on config change

### DIFF
--- a/.changeset/brave-numbers-destroy.md
+++ b/.changeset/brave-numbers-destroy.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+restart vite dev-server on svelte config change

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -250,13 +250,13 @@ export async function dev(vite, vite_config, svelte_config) {
 	// changing the svelte config requires restarting the dev server
 	// the config is only read on start and passed on to vite-plugin-svelte
 	// which needs up-to-date values to operate correctly
-	vite.watcher.on('change',(file)=> {
-		if(path.basename(file) === 'svelte.config.js'){
+	vite.watcher.on('change', (file) => {
+		if (path.basename(file) === 'svelte.config.js') {
 			console.log(`svelte config changed, restarting vite dev-server. changed file: ${file}`);
 			restarting = true;
 			vite.restart();
 		}
-	})
+	});
 
 	const assets = svelte_config.kit.paths.assets ? SVELTE_KIT_ASSETS : svelte_config.kit.paths.base;
 	const asset_server = sirv(svelte_config.kit.files.assets, {

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -221,13 +221,16 @@ export async function dev(vite, vite_config, svelte_config) {
 		}, 100);
 	};
 
+	// flag to skip watchers if server is already restarting
+	let restarting = false;
+
 	// Debounce add/unlink events because in case of folder deletion or moves
 	// they fire in rapid succession, causing needless invocations.
 	watch('add', () => debounce(update_manifest));
 	watch('unlink', () => debounce(update_manifest));
 	watch('change', (file) => {
 		// Don't run for a single file if the whole manifest is about to get updated
-		if (timeout) return;
+		if (timeout || restarting) return;
 
 		sync.update(svelte_config, manifest_data, file);
 	});
@@ -238,11 +241,22 @@ export async function dev(vite, vite_config, svelte_config) {
 	// send the vite client a full-reload event without path being set
 	if (appTemplate !== 'index.html') {
 		vite.watcher.on('change', (file) => {
-			if (file === appTemplate) {
+			if (file === appTemplate && !restarting) {
 				vite.ws.send({ type: 'full-reload' });
 			}
 		});
 	}
+
+	// changing the svelte config requires restarting the dev server
+	// the config is only read on start and passed on to vite-plugin-svelte
+	// which needs up-to-date values to operate correctly
+	vite.watcher.on('change',(file)=> {
+		if(path.basename(file) === 'svelte.config.js'){
+			console.log(`svelte config changed, restarting vite dev-server. changed file: ${file}`);
+			restarting = true;
+			vite.restart();
+		}
+	})
 
 	const assets = svelte_config.kit.paths.assets ? SVELTE_KIT_ASSETS : svelte_config.kit.paths.base;
 	const asset_server = sirv(svelte_config.kit.files.assets, {


### PR DESCRIPTION
recently sveltekit changed to passing the svelte config inline to vite-plugin-svelte. With this way, vite-plugin-svelte does not watch svelte.config.js for changes to restart the vite devserver, as configFile: false indicates it should not use it.

this PR sets up a watcher in kits dev plugin that does the same. Restarting the server is absolutely required in this case.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
