### PR TITLE
more robust recovery from manifest errors

### DIFF
--- a/.changeset/shy-toys-confess.md
+++ b/.changeset/shy-toys-confess.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+More robust manifest error recovery

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -470,7 +470,9 @@ export async function dev(vite, vite_config, svelte_config) {
 					res.writeHead(500, {
 						'Content-Type': 'text/html; charset=utf-8'
 					});
-					res.end(error_template({ status: 500, message: manifest_error.message ?? 'Invalid routes' }));
+					res.end(
+						error_template({ status: 500, message: manifest_error.message ?? 'Invalid routes' })
+					);
 
 					return;
 				}

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -36,6 +36,9 @@ export async function dev(vite, vite_config, svelte_config) {
 	/** @type {import('types').SSRManifest} */
 	let manifest;
 
+	/** @type {Error | null} */
+	let manifest_error = null;
+
 	/** @param {string} id */
 	async function resolve(id) {
 		const url = id.startsWith('..') ? `/@fs${path.posix.resolve(id)}` : `/${id}`;
@@ -51,18 +54,24 @@ export async function dev(vite, vite_config, svelte_config) {
 	async function update_manifest() {
 		try {
 			({ manifest_data } = await sync.create(svelte_config));
+
+			if (manifest_error) {
+				manifest_error = null;
+				vite.ws.send({ type: 'full-reload' });
+			}
 		} catch (error) {
-			console.error(colors.bold().red('Failed to update manifest'));
+			manifest_error = /** @type {Error} */ (error);
+
+			console.error(colors.bold().red('Invalid routes'));
 			console.error(error);
 			vite.ws.send({
 				type: 'error',
 				err: {
-					message: `Failed to udpate manifest: ${
-						/** @type {Error} */ (error)?.message ?? 'Unknown error'
-					}`,
-					stack: /** @type {Error} */ (error)?.stack ?? ''
+					message: manifest_error?.message ?? 'Invalid routes',
+					stack: ''
 				}
 			});
+
 			return;
 		}
 
@@ -447,6 +456,25 @@ export async function dev(vite, vite_config, svelte_config) {
 				const template = load_template(cwd, svelte_config);
 				const error_page = load_error_page(svelte_config);
 
+				/** @param {{ status: number; message: string }} opts */
+				const error_template = ({ status, message }) => {
+					return error_page
+						.replace(/%sveltekit\.status%/g, String(status))
+						.replace(/%sveltekit\.error\.message%/g, message);
+				};
+
+				if (manifest_error) {
+					console.error(colors.bold().red('Invalid routes'));
+					console.error(manifest_error);
+
+					res.writeHead(500, {
+						'Content-Type': 'text/html; charset=utf-8'
+					});
+					res.end(error_template({ status: 500, message: 'Invalid routes' }));
+
+					return;
+				}
+
 				const rendered = await respond(
 					request,
 					{
@@ -501,11 +529,7 @@ export async function dev(vite, vite_config, svelte_config) {
 							);
 						},
 						app_template_contains_nonce: template.includes('%sveltekit.nonce%'),
-						error_template: ({ status, message }) => {
-							return error_page
-								.replace(/%sveltekit\.status%/g, String(status))
-								.replace(/%sveltekit\.error\.message%/g, message);
-						},
+						error_template,
 						service_worker:
 							svelte_config.kit.serviceWorker.register &&
 							!!resolve_entry(svelte_config.kit.files.serviceWorker),

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -67,7 +67,7 @@ export async function dev(vite, vite_config, svelte_config) {
 			vite.ws.send({
 				type: 'error',
 				err: {
-					message: manifest_error?.message ?? 'Invalid routes',
+					message: manifest_error.message ?? 'Invalid routes',
 					stack: ''
 				}
 			});

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -470,7 +470,7 @@ export async function dev(vite, vite_config, svelte_config) {
 					res.writeHead(500, {
 						'Content-Type': 'text/html; charset=utf-8'
 					});
-					res.end(error_template({ status: 500, message: 'Invalid routes' }));
+					res.end(error_template({ status: 500, message: manifest_error.message ?? 'Invalid routes' }));
 
 					return;
 				}


### PR DESCRIPTION
follow-up to #8093:

* clears the error overlay once the error is fixed (by doing a full page reload — not sure if there's a better way?)
* removes the 'failed to update manifest' message — that's internal jargon we don't really use in a public-facing way
* removes the stack trace — it's all internal stuff that's no help to the user
* responds with an error page if the page is reloaded, instead of a) stumbling along with a stale manifest or b) in the case that the manifest was invalid from the start, failing with a cryptic internal error

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
