### PR TITLE
[fix] load errorTemplate from correct location

### DIFF
--- a/.changeset/four-ligers-help.md
+++ b/.changeset/four-ligers-help.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] load errorTemplate from correct location

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -43,7 +43,14 @@ export function load_template(cwd, config) {
  * @param {import('types').ValidatedConfig} config
  */
 export function load_error_page(config) {
-	const { errorTemplate } = config.kit.files;
+	let { errorTemplate } = config.kit.files;
+
+	// Don't do this inside resolving the config, because that would mean
+	// adding/removing error.html isn't detected and would require a restart.
+	if (!fs.existsSync(config.kit.files.errorTemplate)) {
+		errorTemplate = url.fileURLToPath(new URL('./default-error.html', import.meta.url));
+	}
+
 	return fs.readFileSync(errorTemplate, 'utf-8');
 }
 
@@ -84,12 +91,6 @@ function process_config(config, { cwd = process.cwd() } = {}) {
 			// @ts-expect-error
 			validated.kit.files[key] = path.resolve(cwd, validated.kit.files[key]);
 		}
-	}
-
-	if (!fs.existsSync(validated.kit.files.errorTemplate)) {
-		validated.kit.files.errorTemplate = url.fileURLToPath(
-			new URL('./default-error.html', import.meta.url)
-		);
 	}
 
 	return validated;


### PR DESCRIPTION
The alternative would be to move the "set a fallback error.html path if not set" logic into load_error_page, which @Rich-Harris added [here](https://github.com/sveltejs/kit/pull/6367/commits/d5c986bf28e889dddbcef4ab3af8ca5a8083f508)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
