### PR TITLE
remove unused elements from default error component

### DIFF
--- a/.changeset/old-peas-grin.md
+++ b/.changeset/old-peas-grin.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] remove unused elements from default error component

--- a/packages/kit/src/runtime/components/error.svelte
+++ b/packages/kit/src/runtime/components/error.svelte
@@ -3,14 +3,4 @@
 </script>
 
 <h1>{$page.status}</h1>
-
-<pre>{$page.error.message}</pre>
-
-<!-- TODO figure out what to do with frames/stacktraces in prod -->
-<!-- frame is populated by Svelte in its CompileError and is a Rollup/Vite convention -->
-{#if $page.error.frame}
-	<pre>{$page.error.frame}</pre>
-{/if}
-{#if $page.error.stack}
-	<pre>{$page.error.stack}</pre>
-{/if}
+<p>{$page.error?.message}</p>


### PR DESCRIPTION
The default `+error.svelte` component is rather out of date. `$page.error.frame` and `$page.error.stack` haven't been a thing in forever, and there's no reason to put `$page.error.message` inside a `<pre>`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
