### PR TITLE
Revert "[fix] set platform to neutral when calling esbuild"

### DIFF
--- a/.changeset/chilly-pumas-look.md
+++ b/.changeset/chilly-pumas-look.md
@@ -1,8 +1,0 @@
----
-'@sveltejs/adapter-cloudflare': patch
-'@sveltejs/adapter-cloudflare-workers': patch
-'@sveltejs/adapter-netlify': patch
-'@sveltejs/adapter-vercel': patch
----
-
-[fix] set esbuild platform to neutral

--- a/.changeset/chilly-pumas-look.md
+++ b/.changeset/chilly-pumas-look.md
@@ -1,0 +1,8 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-vercel': patch
+---
+
+[fix] set esbuild platform to neutral

--- a/.changeset/smooth-pianos-kiss.md
+++ b/.changeset/smooth-pianos-kiss.md
@@ -1,0 +1,8 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-vercel': patch
+---
+
+[fix] revert platform change from browser to neutral

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -63,6 +63,7 @@ export default function ({ config = 'wrangler.toml' } = {}) {
 
 			await esbuild.build({
 				platform: 'browser',
+				conditions: ['worker', 'browser'],
 				sourcemap: 'linked',
 				target: 'es2020',
 				entryPoints: [`${tmp}/entry.js`],

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -62,15 +62,14 @@ export default function ({ config = 'wrangler.toml' } = {}) {
 			);
 
 			await esbuild.build({
-				platform: 'neutral',
-				mainFields: ['module', 'main'],
-				conditions: ['worker'],
+				platform: 'browser',
 				sourcemap: 'linked',
 				target: 'es2020',
 				entryPoints: [`${tmp}/entry.js`],
 				outfile: main,
 				bundle: true,
-				external: ['__STATIC_CONTENT_MANIFEST']
+				external: ['__STATIC_CONTENT_MANIFEST'],
+				format: 'esm'
 			});
 
 			builder.log.minor('Copying assets...');

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -55,6 +55,7 @@ export default function () {
 
 			await esbuild.build({
 				platform: 'browser',
+				conditions: ['worker', 'browser'],
 				sourcemap: 'linked',
 				target: 'es2020',
 				entryPoints: [`${tmp}/_worker.js`],

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -54,14 +54,13 @@ export default function () {
 			});
 
 			await esbuild.build({
-				platform: 'neutral',
-				mainFields: ['module', 'main'],
-				conditions: ['worker'],
+				platform: 'browser',
 				sourcemap: 'linked',
 				target: 'es2020',
 				entryPoints: [`${tmp}/_worker.js`],
 				outfile: `${dest}/_worker.js`,
 				allowOverwrite: true,
+				format: 'esm',
 				bundle: true
 			});
 		}

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -129,11 +129,11 @@ async function generate_edge_functions({ builder }) {
 	);
 
 	await esbuild.build({
-		platform: 'neutral',
-		mainFields: ['module', 'main'],
 		entryPoints: [`${tmp}/entry.js`],
 		outfile: '.netlify/edge-functions/render.js',
 		bundle: true,
+		format: 'esm',
+		platform: 'browser',
 		sourcemap: 'linked',
 		target: 'es2020'
 	});

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -122,12 +122,12 @@ const plugin = function ({ external = [], edge, split } = {}) {
 				);
 
 				await esbuild.build({
-					platform: 'neutral',
-					mainFields: ['module', 'main'],
 					entryPoints: [`${tmp}/edge.js`],
 					outfile: `${dirs.functions}/${name}.func/index.js`,
 					target: 'es2020', // TODO verify what the edge runtime supports
 					bundle: true,
+					platform: 'browser',
+					format: 'esm',
 					external,
 					sourcemap: 'linked',
 					banner: { js: 'globalThis.global = globalThis;' }


### PR DESCRIPTION
Reverts sveltejs/kit#8083. Turns out this was a mistake, since it breaks packages like `cross-fetch` which assume that if you're not resolving `browser` modules, you want the Node version instead.

Since we bundle `esm-env`, the original reason for #8083 no longer applies.