### PR TITLE
chore(create-svelte): address flakiness in playwright test

### DIFF
--- a/.changeset/rare-frogs-crash.md
+++ b/.changeset/rare-frogs-crash.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+[fix] address flakiness in playwright test

--- a/packages/create-svelte/shared/+playwright+default/tests/test.ts
+++ b/packages/create-svelte/shared/+playwright+default/tests/test.ts
@@ -2,5 +2,5 @@ import { expect, test } from '@playwright/test';
 
 test('about page has expected h1', async ({ page }) => {
 	await page.goto('/about');
-	expect(await page.textContent('h1')).toBe('About this app');
+	await expect(page.locator('h1')).toHaveText('About this app');
 });


### PR DESCRIPTION
Congrats to the version release! Before no web-first assertion was used for the assertion, which means that it did not retry and just failed when the text was not matching. Now its using [toHaveText](https://playwright.dev/docs/test-assertions#locator-assertions-to-have-text) which is recommended and not flaky.

There were more such places inside the sveltekit codebase, seems not related, since its not customer facing, but might still be worth updating.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0

