### PR TITLE
exclude Node 17.x as supported version

### DIFF
--- a/.changeset/nervous-lamps-pay.md
+++ b/.changeset/nervous-lamps-pay.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/kit': patch
+'@sveltejs/package': patch
+---
+
+Explicitly mark Node 17.x as not supported

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -87,6 +87,6 @@
 	},
 	"types": "types/index.d.ts",
 	"engines": {
-		"node": ">=16.14"
+		"node": "^16.14 || >=18"
 	}
 }

--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -47,6 +47,6 @@
 	},
 	"types": "types/index.d.ts",
 	"engines": {
-		"node": ">=16.14"
+		"node": "^16.14 || >=18"
 	}
 }


### PR DESCRIPTION
Closes #8173. The `>=16.14` range also includes Node 17, which (apparently at least in some versions) doesn't support the three-argument version of `util.inspect.custom`. People shouldn't be using Node 17 anyway. I think we can make this change as a fix rather than as a breaking change.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
