### PR TITLE
use prerendered endpoint to get content for search

### DIFF
--- a/sites/kit.svelte.dev/src/routes/search/+page.server.js
+++ b/sites/kit.svelte.dev/src/routes/search/+page.server.js
@@ -10,7 +10,6 @@ export async function load({ url, fetch }) {
 		init(blocks);
 	}
 
-
 	const query = url.searchParams.get('q');
 
 	const results = query ? search(query) : [];

--- a/sites/kit.svelte.dev/src/routes/search/+page.server.js
+++ b/sites/kit.svelte.dev/src/routes/search/+page.server.js
@@ -1,11 +1,15 @@
-import { content } from '$lib/search/content.server.js';
 import { init, inited, search } from '$lib/search/search.js';
 
 /** @type {import('./$types').PageServerLoad} */
 export async function load({ url }) {
 	if (!inited) {
-		init(content());
+		const res = await fetch('/content.json');
+		if (!res.ok) throw new Error("Couldn't fetch content");
+
+		const blocks = (await res.json()).blocks;
+		init(blocks);
 	}
+
 
 	const query = url.searchParams.get('q');
 

--- a/sites/kit.svelte.dev/src/routes/search/+page.server.js
+++ b/sites/kit.svelte.dev/src/routes/search/+page.server.js
@@ -1,7 +1,7 @@
 import { init, inited, search } from '$lib/search/search.js';
 
 /** @type {import('./$types').PageServerLoad} */
-export async function load({ url }) {
+export async function load({ url, fetch }) {
 	if (!inited) {
 		const res = await fetch('/content.json');
 		if (!res.ok) throw new Error("Couldn't fetch content");


### PR DESCRIPTION
closes #8165 

A better solution might be something like a custom vite plugin for the docs, so that all the files are resolved by the bundler instead of a prerender call.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
