### PR TITLE
chore: add ignore list to changesets config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,5 +5,6 @@
 	"linked": [],
 	"access": "public",
 	"baseBranch": "master",
-	"bumpVersionsWithWorkspaceProtocolOnly": true
+	"bumpVersionsWithWorkspaceProtocolOnly": true,
+	"ignore": ["!(@sveltejs/*|create-svelte|svelte-migrate)"]
 }


### PR DESCRIPTION
uses a negated micromatch pattern to only include @sveltejs packages and published non-org packages.

This skips over the plethora of test apps and other non-published things like the templates.

Con: adding new non-org packages does require extending the negated pattern
Pro: adding new test apps or other non-published packages does not require changes

As the second case is arguably happening more often and first publish of a new package is something we have to plan for either way, i prefer this approach over a positive pattern

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
