### PR TITLE
[site] fix homepage dark mode strong text colour

### DIFF
--- a/sites/kit.svelte.dev/src/routes/home/Svelte.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Svelte.svelte
@@ -28,9 +28,7 @@
 			<p>
 				SvelteKit is built on Svelte, a UI framework that uses a compiler to let you write
 				breathtakingly concise components that do minimal work in the browser, using languages you
-				already know — HTML, CSS and JavaScript. <strong style="color: var(--sk-theme-2)"
-					>It's a love letter to web development.</strong
-				>
+				already know — HTML, CSS and JavaScript. <strong>It's a love letter to web development.</strong>
 			</p>
 
 			<p>


### PR DESCRIPTION
The emphasised text "It's a love letter to web development" in the video section of the kit site home page has a poor contrast in dark mode. This removes the inline style `color: --sk-theme-2;` from that text to make it more visible.

Before:
<img width="652" alt="emphasised text has poor contrast in dark mode" src="https://user-images.githubusercontent.com/54401897/208224138-428dc651-689e-48e8-af21-fd1fd399c1e9.png">

After:
<img width="656" alt="emphasised text uses default dark mode text colour" src="https://user-images.githubusercontent.com/54401897/208224171-661c22e7-0f98-4406-b7eb-9815716f1166.png">


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
