### PR TITLE
[docs] fix route example in 10-advanced-routing.md

### DIFF
--- a/documentation/docs/30-advanced/10-advanced-routing.md
+++ b/documentation/docs/30-advanced/10-advanced-routing.md
@@ -98,7 +98,7 @@ It's possible for multiple routes to match a given path. For example each of the
 
 ```bash
 src/routes/[...catchall]/+page.svelte
-src/routes/[[a=string]]/+page.svelte
+src/routes/[[a=x]]/+page.svelte
 src/routes/[b]/+page.svelte
 src/routes/foo-[c]/+page.svelte
 src/routes/foo-abc/+page.svelte
@@ -116,7 +116,7 @@ SvelteKit needs to know which route is being requested. To do so, it sorts them 
 ```bash
 src/routes/foo-abc/+page.svelte
 src/routes/foo-[c]/+page.svelte
-src/routes/[[a=string]]/+page.svelte
+src/routes/[[a=x]]/+page.svelte
 src/routes/[b]/+page.svelte
 src/routes/[...catchall]/+page.svelte
 ```

--- a/documentation/docs/30-advanced/10-advanced-routing.md
+++ b/documentation/docs/30-advanced/10-advanced-routing.md
@@ -98,7 +98,7 @@ It's possible for multiple routes to match a given path. For example each of the
 
 ```bash
 src/routes/[...catchall]/+page.svelte
-src/routes/[[a]]/foo/+page.svelte
+src/routes/[[a=string]]/+page.svelte
 src/routes/[b]/+page.svelte
 src/routes/foo-[c]/+page.svelte
 src/routes/foo-abc/+page.svelte
@@ -116,7 +116,7 @@ SvelteKit needs to know which route is being requested. To do so, it sorts them 
 ```bash
 src/routes/foo-abc/+page.svelte
 src/routes/foo-[c]/+page.svelte
-src/routes/[[a]]/foo/+page.svelte
+src/routes/[[a=string]]/+page.svelte
 src/routes/[b]/+page.svelte
 src/routes/[...catchall]/+page.svelte
 ```


### PR DESCRIPTION
`src/routes/[[a]]/foo/+page.svelte` doesn't match the route `/foo-abc` , and there aren't any cases with parameter matcher, so I propose using `src/routes/[[a=string]]/+page.svelte` instead.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
