### PR TITLE
[docs] Fixed filename in promise unwrapping section

### DIFF
--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -421,7 +421,7 @@ export function load({ locals }) {
 Top-level promises will be awaited, which makes it easy to return multiple promises without creating a waterfall:
 
 ```js
-/// file: src/routes/+page.server.js
+/// file: src/routes/+page.js
 /** @type {import('./$types').PageServerLoad} */
 export function load() {
 	return {


### PR DESCRIPTION
Returning a promise (`c.value`) is not possible in `+*.server.js` files.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
