### PR TITLE
[chore] fix some test flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
 
 env:
+  DEBUG: 'true'
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: svelte
   # we call `pnpm playwright install` instead

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -121,7 +121,7 @@ export async function setResponse(res, response, opt_req) {
 
 	res.writeHead(response.status, headers);
 	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-		console.warn('-! wrote headers');
+		console.warn(`-! wrote headers ${JSON.stringify(headers)}`);
 	}
 
 	if (!response.body) {

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -174,10 +174,6 @@ export async function setResponse(res, response, opt_req) {
 	res.on('error', cancel);
 
 	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-		console.warn('-! NO BODY');
-	}
-
-	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
 		console.warn('-! consuming response body');
 	}
 

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -157,6 +157,10 @@ export async function setResponse(res, response, opt_req) {
 	}
 
 	const cancel = (/** @type {Error|undefined} */ error) => {
+		if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
+			console.warn('-! canceling reponse');
+		}
+
 		res.off('close', cancel);
 		res.off('error', cancel);
 

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -106,7 +106,7 @@ export async function getRequest({ request, base, bodySizeLimit }) {
 /** @type {import('@sveltejs/kit/node').setResponse} */
 export async function setResponse(res, response, opt_req) {
 	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-		console.log('setting response');
+		console.log('-! setting response');
 	}
 
 	const headers = Object.fromEntries(response.headers);
@@ -121,12 +121,12 @@ export async function setResponse(res, response, opt_req) {
 
 	res.writeHead(response.status, headers);
 	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-		console.log('wrote headers');
+		console.debug('-! wrote headers');
 	}
 
 	if (!response.body) {
 		if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-			console.log('NO BODY');
+			console.debug('-! NO BODY');
 		}
 
 		res.end();
@@ -135,7 +135,7 @@ export async function setResponse(res, response, opt_req) {
 
 	if (response.body.locked) {
 		if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-			console.log('BODY LOCKED');
+			console.debug('-! BODY LOCKED');
 		}
 
 		res.write(
@@ -150,7 +150,7 @@ export async function setResponse(res, response, opt_req) {
 
 	if (res.destroyed) {
 		if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-			console.log('RESPONSE DESTROYED');
+			console.debug('-! RESPONSE DESTROYED');
 		}
 		reader.cancel();
 		return;
@@ -170,17 +170,17 @@ export async function setResponse(res, response, opt_req) {
 	res.on('error', cancel);
 
 	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-		console.log('NO BODY');
+		console.debug('-! NO BODY');
 	}
 
 	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-		console.log('consuming response body');
+		console.debug('-! consuming response body');
 	}
 
 	next();
 
 	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-		console.log('returning from setResponse');
+		console.debug('-! returning from setResponse');
 	}
 
 	async function next() {
@@ -189,18 +189,18 @@ export async function setResponse(res, response, opt_req) {
 				const { done, value } = await reader.read();
 
 				if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment' && done) {
-					console.log('done consuming response body');
+					console.debug('-! done consuming response body');
 				}
 
 				if (done) break;
 
 				if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-					console.log(`writing ${value}`);
+					console.debug(`-! writing ${value}`);
 				}
 
 				if (!res.write(value)) {
 					if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-						console.log(`stream remaining...`);
+						console.debug(`-! stream remaining...`);
 					}
 
 					res.once('drain', next);

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -105,7 +105,8 @@ export async function getRequest({ request, base, bodySizeLimit }) {
 
 /** @type {import('@sveltejs/kit/node').setResponse} */
 export async function setResponse(res, response, opt_req) {
-	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
+	const DEBUG = (opt_req?.url === '/load/cache-control/count' || opt_req?.url === '/load/cache-control/increment');
+	if (DEBUG) {
 		console.log('-! setting response');
 	}
 
@@ -120,12 +121,12 @@ export async function setResponse(res, response, opt_req) {
 	}
 
 	res.writeHead(response.status, headers);
-	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
+	if (DEBUG) {
 		console.warn(`-! wrote headers ${JSON.stringify(headers)}`);
 	}
 
 	if (!response.body) {
-		if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
+		if (DEBUG) {
 			console.warn('-! NO BODY');
 		}
 
@@ -134,7 +135,7 @@ export async function setResponse(res, response, opt_req) {
 	}
 
 	if (response.body.locked) {
-		if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
+		if (DEBUG) {
 			console.warn('-! BODY LOCKED');
 		}
 
@@ -149,7 +150,7 @@ export async function setResponse(res, response, opt_req) {
 	const reader = response.body.getReader();
 
 	if (res.destroyed) {
-		if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
+		if (DEBUG) {
 			console.warn('-! RESPONSE DESTROYED');
 		}
 		reader.cancel();
@@ -157,7 +158,7 @@ export async function setResponse(res, response, opt_req) {
 	}
 
 	const cancel = (/** @type {Error|undefined} */ error) => {
-		if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
+		if (DEBUG) {
 			console.warn('-! canceling response');
 		}
 
@@ -173,13 +174,13 @@ export async function setResponse(res, response, opt_req) {
 	res.on('close', cancel);
 	res.on('error', cancel);
 
-	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
+	if (DEBUG) {
 		console.warn('-! consuming response body');
 	}
 
 	next();
 
-	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
+	if (DEBUG) {
 		console.warn('-! returning from setResponse');
 	}
 
@@ -188,18 +189,18 @@ export async function setResponse(res, response, opt_req) {
 			for (;;) {
 				const { done, value } = await reader.read();
 
-				if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment' && done) {
+				if (DEBUG && done) {
 					console.warn('-! done consuming response body');
 				}
 
 				if (done) break;
 
-				if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
+				if (DEBUG) {
 					console.warn(`-! writing ${value}`);
 				}
 
 				if (!res.write(value)) {
-					if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
+					if (DEBUG) {
 						console.warn(`-! stream remaining...`);
 					}
 

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -105,7 +105,7 @@ export async function getRequest({ request, base, bodySizeLimit }) {
 
 /** @type {import('@sveltejs/kit/node').setResponse} */
 export async function setResponse(res, response, opt_req) {
-	if (process.env.DEBUG && opt_req.url === '/load/cache-control/increment') {
+	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
 		console.log('setting response');
 	}
 
@@ -120,12 +120,12 @@ export async function setResponse(res, response, opt_req) {
 	}
 
 	res.writeHead(response.status, headers);
-	if (process.env.DEBUG && opt_req.url === '/load/cache-control/increment') {
+	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
 		console.log('wrote headers');
 	}
 
 	if (!response.body) {
-		if (process.env.DEBUG && opt_req.url === '/load/cache-control/increment') {
+		if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
 			console.log('NO BODY');
 		}
 
@@ -134,7 +134,7 @@ export async function setResponse(res, response, opt_req) {
 	}
 
 	if (response.body.locked) {
-		if (process.env.DEBUG && opt_req.url === '/load/cache-control/increment') {
+		if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
 			console.log('BODY LOCKED');
 		}
 
@@ -149,7 +149,7 @@ export async function setResponse(res, response, opt_req) {
 	const reader = response.body.getReader();
 
 	if (res.destroyed) {
-		if (process.env.DEBUG && opt_req.url === '/load/cache-control/increment') {
+		if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
 			console.log('RESPONSE DESTROYED');
 		}
 		reader.cancel();
@@ -169,17 +169,17 @@ export async function setResponse(res, response, opt_req) {
 	res.on('close', cancel);
 	res.on('error', cancel);
 
-	if (process.env.DEBUG && opt_req.url === '/load/cache-control/increment') {
+	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
 		console.log('NO BODY');
 	}
 
-	if (process.env.DEBUG && opt_req.url === '/load/cache-control/increment') {
+	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
 		console.log('consuming response body');
 	}
 
 	next();
 
-	if (process.env.DEBUG && opt_req.url === '/load/cache-control/increment') {
+	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
 		console.log('returning from setResponse');
 	}
 
@@ -188,18 +188,18 @@ export async function setResponse(res, response, opt_req) {
 			for (;;) {
 				const { done, value } = await reader.read();
 
-				if (process.env.DEBUG && opt_req.url === '/load/cache-control/increment' && done) {
+				if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment' && done) {
 					console.log('done consuming response body');
 				}
 
 				if (done) break;
 
-				if (process.env.DEBUG && opt_req.url === '/load/cache-control/increment') {
+				if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
 					console.log(`writing ${value}`);
 				}
 
 				if (!res.write(value)) {
-					if (process.env.DEBUG && opt_req.url === '/load/cache-control/increment') {
+					if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
 						console.log(`stream remaining...`);
 					}
 

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -121,12 +121,12 @@ export async function setResponse(res, response, opt_req) {
 
 	res.writeHead(response.status, headers);
 	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-		console.debug('-! wrote headers');
+		console.warn('-! wrote headers');
 	}
 
 	if (!response.body) {
 		if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-			console.debug('-! NO BODY');
+			console.warn('-! NO BODY');
 		}
 
 		res.end();
@@ -135,7 +135,7 @@ export async function setResponse(res, response, opt_req) {
 
 	if (response.body.locked) {
 		if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-			console.debug('-! BODY LOCKED');
+			console.warn('-! BODY LOCKED');
 		}
 
 		res.write(
@@ -150,7 +150,7 @@ export async function setResponse(res, response, opt_req) {
 
 	if (res.destroyed) {
 		if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-			console.debug('-! RESPONSE DESTROYED');
+			console.warn('-! RESPONSE DESTROYED');
 		}
 		reader.cancel();
 		return;
@@ -170,17 +170,17 @@ export async function setResponse(res, response, opt_req) {
 	res.on('error', cancel);
 
 	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-		console.debug('-! NO BODY');
+		console.warn('-! NO BODY');
 	}
 
 	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-		console.debug('-! consuming response body');
+		console.warn('-! consuming response body');
 	}
 
 	next();
 
 	if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-		console.debug('-! returning from setResponse');
+		console.warn('-! returning from setResponse');
 	}
 
 	async function next() {
@@ -189,18 +189,18 @@ export async function setResponse(res, response, opt_req) {
 				const { done, value } = await reader.read();
 
 				if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment' && done) {
-					console.debug('-! done consuming response body');
+					console.warn('-! done consuming response body');
 				}
 
 				if (done) break;
 
 				if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-					console.debug(`-! writing ${value}`);
+					console.warn(`-! writing ${value}`);
 				}
 
 				if (!res.write(value)) {
 					if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-						console.debug(`-! stream remaining...`);
+						console.warn(`-! stream remaining...`);
 					}
 
 					res.once('drain', next);

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -158,7 +158,7 @@ export async function setResponse(res, response, opt_req) {
 
 	const cancel = (/** @type {Error|undefined} */ error) => {
 		if (process.env.DEBUG && opt_req?.url === '/load/cache-control/increment') {
-			console.warn('-! canceling reponse');
+			console.warn('-! canceling response');
 		}
 
 		res.off('close', cancel);

--- a/packages/kit/src/exports/vite/build/utils.js
+++ b/packages/kit/src/exports/vite/build/utils.js
@@ -185,7 +185,7 @@ export function get_build_compile_config({ config, input, ssr, outDir }) {
 		},
 		esbuild: {
 			// drop from build unless running on CI
-			pure: process.env.CI ? [] : ['console.debug', 'console.trace'],
+			pure: process.env.CI ? [] : ['console.debug', 'console.trace']
 		},
 		publicDir: ssr ? false : config.kit.files.assets,
 		worker: {

--- a/packages/kit/src/exports/vite/build/utils.js
+++ b/packages/kit/src/exports/vite/build/utils.js
@@ -127,6 +127,7 @@ export function get_build_setup_config({ config, ssr }) {
 			__SVELTEKIT_ADAPTER_NAME__: JSON.stringify(config.kit.adapter?.name),
 			__SVELTEKIT_APP_VERSION_FILE__: JSON.stringify(`${config.kit.appDir}/version.json`),
 			__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: JSON.stringify(config.kit.version.pollInterval),
+			__SVELTEKIT_DEBUG__: process.env.DEBUG ? 'true' : 'false',
 			__SVELTEKIT_EMBEDDED__: config.kit.embedded ? 'true' : 'false'
 		},
 		resolve: {
@@ -182,10 +183,6 @@ export function get_build_compile_config({ config, input, ssr, outDir }) {
 				preserveEntrySignatures: 'strict'
 			},
 			target: ssr ? 'node16.14' : undefined
-		},
-		esbuild: {
-			// drop from build unless running on CI
-			pure: process.env.CI ? [] : ['console.debug', 'console.trace']
 		},
 		publicDir: ssr ? false : config.kit.files.assets,
 		worker: {

--- a/packages/kit/src/exports/vite/build/utils.js
+++ b/packages/kit/src/exports/vite/build/utils.js
@@ -183,6 +183,10 @@ export function get_build_compile_config({ config, input, ssr, outDir }) {
 			},
 			target: ssr ? 'node16.14' : undefined
 		},
+		esbuild: {
+			// drop from build unless running on CI
+			pure: process.env.CI ? [] : ['console.debug', 'console.trace'],
+		},
 		publicDir: ssr ? false : config.kit.files.assets,
 		worker: {
 			rollupOptions: {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -254,6 +254,7 @@ function kit({ svelte_config }) {
 			const result = {
 				define: {
 					__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: '0',
+					__SVELTEKIT_DEBUG__: process.env.DEBUG ? 'true' : 'false',
 					__SVELTEKIT_EMBEDDED__: svelte_config.kit.embedded ? 'true' : 'false'
 				},
 				resolve: {

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -70,6 +70,10 @@ export async function preview(vite, vite_config, svelte_config) {
 			const original_url = /** @type {string} */ (req.url);
 			const { pathname } = new URL(original_url, 'http://dummy');
 
+			if (process.env.DEBUG && pathname === '/load/cache-control/increment') {
+				console.log('\n\nPreview middleware got request to /load/cache-control/increment');
+			}
+
 			if (pathname.startsWith(base)) {
 				next();
 			} else {

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -130,8 +130,8 @@ export async function preview(vite, vite_config, svelte_config) {
 
 		// SSR
 		vite.middlewares.use(async (req, res) => {
-			if (process.env.DEBUG && req.url === '/load/cache-control/increment') {
-				console.warn('-! Preview middleware got request to /load/cache-control/increment');
+			if (process.env.DEBUG && (req.url === '/load/cache-control/count' || req.url === '/load/cache-control/increment')) {
+				console.warn(`-! Preview middleware got request to ${req.url}`);
 			}
 
 			const host = req.headers['host'];
@@ -144,7 +144,7 @@ export async function preview(vite, vite_config, svelte_config) {
 					request: req
 				});
 			} catch (/** @type {any} */ err) {
-				if (process.env.DEBUG && req.url === '/load/cache-control/increment') {
+				if (process.env.DEBUG && (req.url === '/load/cache-control/count' || req.url === '/load/cache-control/increment')) {
 					console.warn('-! INVALID REQUEST BODY');
 				}
 				res.statusCode = err.status || 400;
@@ -162,7 +162,7 @@ export async function preview(vite, vite_config, svelte_config) {
 				}),
 				req
 			);
-			if (process.env.DEBUG && req.url === '/load/cache-control/increment') {
+			if (process.env.DEBUG && (req.url === '/load/cache-control/count' || req.url === '/load/cache-control/increment')) {
 				console.warn('-! returning from preview middleware');
 			}
 		});

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -153,16 +153,13 @@ export async function preview(vite, vite_config, svelte_config) {
 
 			setResponse(
 				res,
-				await server.respond(
-					request,
-					{
-						getClientAddress: () => {
-							const { remoteAddress } = req.socket;
-							if (remoteAddress) return remoteAddress;
-							throw new Error('Could not determine clientAddress');
-						}
+				await server.respond(request, {
+					getClientAddress: () => {
+						const { remoteAddress } = req.socket;
+						if (remoteAddress) return remoteAddress;
+						throw new Error('Could not determine clientAddress');
 					}
-				),
+				}),
 				req
 			);
 			if (process.env.DEBUG && req.url === '/load/cache-control/increment') {

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -144,6 +144,9 @@ export async function preview(vite, vite_config, svelte_config) {
 					request: req
 				});
 			} catch (/** @type {any} */ err) {
+				if (process.env.DEBUG && req.url === '/load/cache-control/increment') {
+					console.warn('-! INVALID REQUEST BODY');
+				}
 				res.statusCode = err.status || 400;
 				return res.end('Invalid request body');
 			}
@@ -158,9 +161,9 @@ export async function preview(vite, vite_config, svelte_config) {
 							if (remoteAddress) return remoteAddress;
 							throw new Error('Could not determine clientAddress');
 						}
-					},
-					req
-				)
+					}
+				),
+				req
 			);
 			if (process.env.DEBUG && req.url === '/load/cache-control/increment') {
 				console.warn('-! returning from preview middleware');

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -71,7 +71,7 @@ export async function preview(vite, vite_config, svelte_config) {
 			const { pathname } = new URL(original_url, 'http://dummy');
 
 			if (process.env.DEBUG && pathname === '/load/cache-control/increment') {
-				console.log('\n\nPreview middleware got request to /load/cache-control/increment');
+				console.log('\n\nPreview server got request to /load/cache-control/increment');
 			}
 
 			if (pathname.startsWith(base)) {
@@ -130,6 +130,10 @@ export async function preview(vite, vite_config, svelte_config) {
 
 		// SSR
 		vite.middlewares.use(async (req, res) => {
+			if (process.env.DEBUG && req.url === '/load/cache-control/increment') {
+				console.log('Preview middleware got request to /load/cache-control/increment');
+			}
+
 			const host = req.headers['host'];
 
 			let request;
@@ -146,13 +150,17 @@ export async function preview(vite, vite_config, svelte_config) {
 
 			setResponse(
 				res,
-				await server.respond(request, {
-					getClientAddress: () => {
-						const { remoteAddress } = req.socket;
-						if (remoteAddress) return remoteAddress;
-						throw new Error('Could not determine clientAddress');
-					}
-				})
+				await server.respond(
+					request,
+					{
+						getClientAddress: () => {
+							const { remoteAddress } = req.socket;
+							if (remoteAddress) return remoteAddress;
+							throw new Error('Could not determine clientAddress');
+						}
+					},
+					req
+				)
 			);
 		});
 	};

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -71,7 +71,7 @@ export async function preview(vite, vite_config, svelte_config) {
 			const { pathname } = new URL(original_url, 'http://dummy');
 
 			if (process.env.DEBUG && pathname === '/load/cache-control/increment') {
-				console.log('\n\nPreview server got request to /load/cache-control/increment');
+				console.debug('\n\nPreview server got request to /load/cache-control/increment');
 			}
 
 			if (pathname.startsWith(base)) {
@@ -131,7 +131,7 @@ export async function preview(vite, vite_config, svelte_config) {
 		// SSR
 		vite.middlewares.use(async (req, res) => {
 			if (process.env.DEBUG && req.url === '/load/cache-control/increment') {
-				console.log('Preview middleware got request to /load/cache-control/increment');
+				console.debug('-! Preview middleware got request to /load/cache-control/increment');
 			}
 
 			const host = req.headers['host'];
@@ -162,6 +162,9 @@ export async function preview(vite, vite_config, svelte_config) {
 					req
 				)
 			);
+			if (process.env.DEBUG && req.url === '/load/cache-control/increment') {
+				console.debug('-! returning from preview middleware');
+			}
 		});
 	};
 }

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -71,7 +71,7 @@ export async function preview(vite, vite_config, svelte_config) {
 			const { pathname } = new URL(original_url, 'http://dummy');
 
 			if (process.env.DEBUG && pathname === '/load/cache-control/increment') {
-				console.debug('\n\nPreview server got request to /load/cache-control/increment');
+				console.warn('\n\nPreview server got request to /load/cache-control/increment');
 			}
 
 			if (pathname.startsWith(base)) {
@@ -131,7 +131,7 @@ export async function preview(vite, vite_config, svelte_config) {
 		// SSR
 		vite.middlewares.use(async (req, res) => {
 			if (process.env.DEBUG && req.url === '/load/cache-control/increment') {
-				console.debug('-! Preview middleware got request to /load/cache-control/increment');
+				console.warn('-! Preview middleware got request to /load/cache-control/increment');
 			}
 
 			const host = req.headers['host'];
@@ -163,7 +163,7 @@ export async function preview(vite, vite_config, svelte_config) {
 				)
 			);
 			if (process.env.DEBUG && req.url === '/load/cache-control/increment') {
-				console.debug('-! returning from preview middleware');
+				console.warn('-! returning from preview middleware');
 			}
 		});
 	};

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1254,12 +1254,15 @@ export function create_client({ target, base }) {
 				throw new Error('Can only disable scroll handling during navigation');
 			}
 
+			if (__SVELTEKIT_DEBUG__) console.debug('disabling scroll handling');
+
 			if (updating || !started) {
 				autoscroll = false;
 			}
 		},
 
 		goto: (href, opts = {}) => {
+			if (__SVELTEKIT_DEBUG__) console.debug(`goto ${href}`);
 			return goto(href, opts, []);
 		},
 
@@ -1276,7 +1279,7 @@ export function create_client({ target, base }) {
 		},
 
 		invalidateAll: () => {
-			if (__SVELTEKIT_DEBUG__) console.debug(`invalidating all resources`);
+			if (__SVELTEKIT_DEBUG__) console.debug('invalidating all resources');
 			force_invalidation = true;
 			return invalidate();
 		},

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -713,22 +713,17 @@ export function create_client({ target, base }) {
 
 			const has_server_load = !!loader?.[0];
 			const new_loader = has_server_load && previous?.loader !== loader[1];
+			const parent_changed = acc.some(Boolean);
 			const invalid =
 				has_server_load &&
 				(new_loader ||
-					has_changed(
-						acc.some(Boolean),
-						route_changed,
-						url_changed,
-						previous?.server?.uses,
-						params
-					));
+					has_changed(parent_changed, route_changed, url_changed, previous?.server?.uses, params));
 
 			if (__SVELTEKIT_DEBUG__) {
 				console.debug(
 					`${url} ${i == loaders.length - 1 ? 'leaf' : 'layout ' + i} found ${
 						invalid ? '' : 'not '
-					}to be invalid (has_server_load: ${has_server_load}, new_loader: ${new_loader}, uses: ${JSON.stringify(
+					}to be invalid (has_server_load: ${has_server_load}, new_loader: ${new_loader}, parent_changed: ${parent_changed}, route_changed: ${route_changed}, url_changed: ${url_changed}, uses: ${JSON.stringify(
 						previous?.server?.uses
 					)})`
 				);

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -689,6 +689,7 @@ export function create_client({ target, base }) {
 	 */
 	async function load_route({ id, invalidating, url, params, route }) {
 		if (load_cache?.id === id) {
+			if (__SVELTEKIT_DEBUG__) console.debug(`returning from load_cache when loading ${url}`);
 			return load_cache.promise;
 		}
 
@@ -1263,6 +1264,7 @@ export function create_client({ target, base }) {
 		},
 
 		invalidate: (resource) => {
+			if (__SVELTEKIT_DEBUG__) console.debug(`invalidating ${resource}`);
 			if (typeof resource === 'function') {
 				invalidated.push(resource);
 			} else {
@@ -1274,6 +1276,7 @@ export function create_client({ target, base }) {
 		},
 
 		invalidateAll: () => {
+			if (__SVELTEKIT_DEBUG__) console.debug(`invalidating all resources`);
 			force_invalidation = true;
 			return invalidate();
 		},

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -51,7 +51,7 @@ if (DEV) {
 			cache.delete(selector);
 		}
 
-		if (__SVELTEKIT_DEBUG__) console.debug('delegating to native fetch');
+		if (__SVELTEKIT_DEBUG__) console.debug("delegating to browser's native fetch in dev mode");
 		const response = await native_fetch(input, init);
 		if (__SVELTEKIT_DEBUG__) console.debug('native fetch done');
 		return response;
@@ -71,8 +71,7 @@ if (DEV) {
 		}
 
 		if (__SVELTEKIT_DEBUG__)
-			console.debug(`delegating to native fetch (${input}, ${JSON.stringify(init)})`);
-		if (__SVELTEKIT_DEBUG__) console.debug(`${native_fetch}`);
+			console.debug(`delegating to browser's native fetch in build mode (${input}, ${JSON.stringify(init)})`);
 		const response = await native_fetch(input, init);
 		if (__SVELTEKIT_DEBUG__) console.debug('native fetch done');
 		return response;

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -24,6 +24,8 @@ if (DEV) {
 	check_stack_trace();
 
 	window.fetch = (input, init) => {
+		if (__SVELTEKIT_DEBUG__) console.debug(`fetching ${input} using global fetch`);
+
 		const url = input instanceof Request ? input.url : input.toString();
 		const stack = /** @type {string} */ (new Error().stack);
 
@@ -49,10 +51,13 @@ if (DEV) {
 			cache.delete(selector);
 		}
 
+		if (__SVELTEKIT_DEBUG__) console.debug(`delegating to native fetch`);
 		return native_fetch(input, init);
 	};
 } else {
 	window.fetch = (input, init) => {
+		if (__SVELTEKIT_DEBUG__) console.debug(`fetching ${input} using global fetch`);
+
 		const method = input instanceof Request ? input.method : init?.method || 'GET';
 
 		if (method !== 'GET') {
@@ -63,6 +68,7 @@ if (DEV) {
 			cache.delete(selector);
 		}
 
+		if (__SVELTEKIT_DEBUG__) console.debug(`delegating to native fetch`);
 		return native_fetch(input, init);
 	};
 }

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -23,7 +23,7 @@ if (DEV) {
 
 	check_stack_trace();
 
-	window.fetch = (input, init) => {
+	window.fetch = async (input, init) => {
 		if (__SVELTEKIT_DEBUG__) console.debug(`fetching ${input} using global fetch`);
 
 		const url = input instanceof Request ? input.url : input.toString();
@@ -52,10 +52,12 @@ if (DEV) {
 		}
 
 		if (__SVELTEKIT_DEBUG__) console.debug('delegating to native fetch');
-		return native_fetch(input, init);
+		const response = await native_fetch(input, init);
+		if (__SVELTEKIT_DEBUG__) console.debug('native fetch done');
+		return response;
 	};
 } else {
-	window.fetch = (input, init) => {
+	window.fetch = async (input, init) => {
 		if (__SVELTEKIT_DEBUG__) console.debug(`fetching ${input} using global fetch`);
 
 		const method = input instanceof Request ? input.method : init?.method || 'GET';
@@ -69,7 +71,9 @@ if (DEV) {
 		}
 
 		if (__SVELTEKIT_DEBUG__) console.debug('delegating to native fetch');
-		return native_fetch(input, init);
+		const response = await native_fetch(input, init);
+		if (__SVELTEKIT_DEBUG__) console.debug('native fetch done');
+		return response;
 	};
 }
 

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -42,7 +42,9 @@ if (DEV) {
 		const method = input instanceof Request ? input.method : init?.method || 'GET';
 
 		if (method !== 'GET') {
-			cache.delete(build_selector(input));
+			const selector = build_selector(input);
+			console.debug(`deleting ${selector} from fetch cache due to non-GET request`);
+			cache.delete(selector);
 		}
 
 		return native_fetch(input, init);
@@ -52,7 +54,9 @@ if (DEV) {
 		const method = input instanceof Request ? input.method : init?.method || 'GET';
 
 		if (method !== 'GET') {
-			cache.delete(build_selector(input));
+			const selector = build_selector(input);
+			console.debug(`deleting ${selector} from fetch cache due to non-GET request`);
+			cache.delete(selector);
 		}
 
 		return native_fetch(input, init);
@@ -69,7 +73,7 @@ const cache = new Map();
  */
 export function initial_fetch(resource, opts) {
 	const selector = build_selector(resource, opts);
-
+	console.debug(`doing initial_fetch of ${selector} as part of hydration`);
 	const script = document.querySelector(selector);
 	if (script?.textContent) {
 		const { body, ...init } = JSON.parse(script.textContent);
@@ -99,13 +103,16 @@ export function subsequent_fetch(resource, resolved, opts) {
 				performance.now() < cached.ttl &&
 				['default', 'force-cache', 'only-if-cached', undefined].includes(opts?.cache)
 			) {
+				console.debug(`returning data from fetch cache for ${selector}`);
 				return new Response(cached.body, cached.init);
 			}
 
+			console.debug(`removing ${selector} from fetch cache as expired`);
 			cache.delete(selector);
 		}
 	}
 
+	console.debug(`fetching ${resolved}`);
 	return native_fetch(resolved, opts);
 }
 

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -70,7 +70,8 @@ if (DEV) {
 			cache.delete(selector);
 		}
 
-		if (__SVELTEKIT_DEBUG__) console.debug(`delegating to native fetch (${input}, ${JSON.stringify(init)})`);
+		if (__SVELTEKIT_DEBUG__)
+			console.debug(`delegating to native fetch (${input}, ${JSON.stringify(init)})`);
 		if (__SVELTEKIT_DEBUG__) console.debug(`${native_fetch}`);
 		const response = await native_fetch(input, init);
 		if (__SVELTEKIT_DEBUG__) console.debug('native fetch done');

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -43,7 +43,9 @@ if (DEV) {
 
 		if (method !== 'GET') {
 			const selector = build_selector(input);
-			console.debug(`deleting ${selector} from fetch cache due to non-GET request`);
+			if (__SVELTEKIT_DEBUG__) {
+				console.debug(`deleting ${selector} from fetch cache due to non-GET request`);
+			}
 			cache.delete(selector);
 		}
 
@@ -55,7 +57,9 @@ if (DEV) {
 
 		if (method !== 'GET') {
 			const selector = build_selector(input);
-			console.debug(`deleting ${selector} from fetch cache due to non-GET request`);
+			if (__SVELTEKIT_DEBUG__) {
+				console.debug(`deleting ${selector} from fetch cache due to non-GET request`);
+			}
 			cache.delete(selector);
 		}
 
@@ -73,7 +77,7 @@ const cache = new Map();
  */
 export function initial_fetch(resource, opts) {
 	const selector = build_selector(resource, opts);
-	console.debug(`doing initial_fetch of ${selector} as part of hydration`);
+	if (__SVELTEKIT_DEBUG__) console.debug(`doing initial_fetch of ${selector} as part of hydration`);
 	const script = document.querySelector(selector);
 	if (script?.textContent) {
 		const { body, ...init } = JSON.parse(script.textContent);
@@ -103,16 +107,16 @@ export function subsequent_fetch(resource, resolved, opts) {
 				performance.now() < cached.ttl &&
 				['default', 'force-cache', 'only-if-cached', undefined].includes(opts?.cache)
 			) {
-				console.debug(`returning data from fetch cache for ${selector}`);
+				if (__SVELTEKIT_DEBUG__) console.debug(`returning data from fetch cache for ${selector}`);
 				return new Response(cached.body, cached.init);
 			}
 
-			console.debug(`removing ${selector} from fetch cache as expired`);
+			if (__SVELTEKIT_DEBUG__) console.debug(`removing ${selector} from fetch cache as expired`);
 			cache.delete(selector);
 		}
 	}
 
-	console.debug(`fetching ${resolved}`);
+	if (__SVELTEKIT_DEBUG__) console.debug(`fetching ${resolved}`);
 	return native_fetch(resolved, opts);
 }
 

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -51,7 +51,7 @@ if (DEV) {
 			cache.delete(selector);
 		}
 
-		if (__SVELTEKIT_DEBUG__) console.debug(`delegating to native fetch`);
+		if (__SVELTEKIT_DEBUG__) console.debug('delegating to native fetch');
 		return native_fetch(input, init);
 	};
 } else {
@@ -68,7 +68,7 @@ if (DEV) {
 			cache.delete(selector);
 		}
 
-		if (__SVELTEKIT_DEBUG__) console.debug(`delegating to native fetch`);
+		if (__SVELTEKIT_DEBUG__) console.debug('delegating to native fetch');
 		return native_fetch(input, init);
 	};
 }

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -70,7 +70,8 @@ if (DEV) {
 			cache.delete(selector);
 		}
 
-		if (__SVELTEKIT_DEBUG__) console.debug('delegating to native fetch');
+		if (__SVELTEKIT_DEBUG__) console.debug(`delegating to native fetch (${input}, ${JSON.stringify(init)})`);
+		if (__SVELTEKIT_DEBUG__) console.debug(`${native_fetch}`);
 		const response = await native_fetch(input, init);
 		if (__SVELTEKIT_DEBUG__) console.debug('native fetch done');
 		return response;

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
@@ -11,7 +11,7 @@
 		if (type === 'force') {
 			_force_next_fetch();
 		} else if (type === 'bust') {
-			await fetch('/load/cache-control/count', {method: 'POST'});
+			await fetch('/load/cache-control/count', { method: 'POST' });
 		}
 		await invalidate('/load/cache-control/count');
 	}

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
@@ -7,7 +7,6 @@
 
 	/** @param {'default' | 'force' | 'bust'} type */
 	async function fetch_again(type) {
-		data = undefined;
 		await fetch('/load/cache-control/increment');
 		if (type === 'force') {
 			_force_next_fetch();
@@ -18,9 +17,7 @@
 	}
 </script>
 
-{#if data}
-	<p>Count is {data.count}</p>
-{/if}
+<p>Count is {data.count}</p>
 <button class="default" on:click={() => fetch_again('default')}>Fetch again</button>
 <button class="force" on:click={() => fetch_again('force')}>Fetch again (force reload)</button>
 <button class="bust" on:click={() => fetch_again('bust')}>Fetch again (prior POST request)</button>

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
@@ -10,13 +10,13 @@
 		if (__SVELTEKIT_DEBUG__) console.debug(`fetch_again with type ${type}`);
 
 		const inc_response = await fetch('/load/cache-control/increment');
-		if (__SVELTEKIT_DEBUG__) console.debug(`got increment response of ${inc_response.status}`);
+		if (__SVELTEKIT_DEBUG__) console.debug(`got increment response with status code ${inc_response.status}`);
 
 		if (type === 'force') {
 			_force_next_fetch();
 		} else if (type === 'bust') {
 			const count_response = await fetch('/load/cache-control/count', { method: 'POST' });
-			if (__SVELTEKIT_DEBUG__) console.debug(`got count POST response of ${count_response.status}`);
+			if (__SVELTEKIT_DEBUG__) console.debug(`got count POST response with status code ${count_response.status}`);
 		}
 
 		if (__SVELTEKIT_DEBUG__) console.debug("calling invalidate('/load/cache-control/count')");

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
@@ -7,6 +7,7 @@
 
 	/** @param {'default' | 'force' | 'bust'} type */
 	async function fetch_again(type) {
+		data = undefined;
 		await fetch('/load/cache-control/increment');
 		if (type === 'force') {
 			_force_next_fetch();
@@ -17,8 +18,9 @@
 	}
 </script>
 
-<p>Count is {data.count}</p>
+{#if data}
+	<p>Count is {data.count}</p>
+{/if}
 <button class="default" on:click={() => fetch_again('default')}>Fetch again</button>
 <button class="force" on:click={() => fetch_again('force')}>Fetch again (force reload)</button>
 <button class="bust" on:click={() => fetch_again('bust')}>Fetch again (prior POST request)</button>
-

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
@@ -14,7 +14,7 @@
 		} else if (type === 'bust') {
 			await fetch('/load/cache-control/count', {method: 'POST'});
 		}
-		invalidate('/load/cache-control/count');
+		await invalidate('/load/cache-control/count');
 	}
 </script>
 

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
@@ -7,12 +7,19 @@
 
 	/** @param {'default' | 'force' | 'bust'} type */
 	async function fetch_again(type) {
-		await fetch('/load/cache-control/increment');
+		if (__SVELTEKIT_DEBUG__) console.debug(`fetch_again with type ${type}`);
+
+		const inc_response = await fetch('/load/cache-control/increment');
+		if (__SVELTEKIT_DEBUG__) console.debug(`got increment response of ${inc_response.status}`);
+
 		if (type === 'force') {
 			_force_next_fetch();
 		} else if (type === 'bust') {
-			await fetch('/load/cache-control/count', { method: 'POST' });
+			const count_response = await fetch('/load/cache-control/count', { method: 'POST' });
+			if (__SVELTEKIT_DEBUG__) console.debug(`got count POST response of ${count_response.status}`);
 		}
+
+		if (__SVELTEKIT_DEBUG__) console.debug("calling invalidate('/load/cache-control/count')");
 		await invalidate('/load/cache-control/count');
 	}
 </script>

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
@@ -8,20 +8,26 @@
 
 	/** @param {'default' | 'force' | 'bust'} type */
 	async function fetch_again(type) {
+		const test = $page.url.searchParams.get('test');
+
 		if (__SVELTEKIT_DEBUG__) console.debug(`fetch_again with type ${type}`);
 
-		const inc_response = await fetch('/load/cache-control/increment?test=' + $page.url.searchParams.get('test'));
+		const inc_response = await fetch('/load/cache-control/increment?test=' + test);
 		if (__SVELTEKIT_DEBUG__) console.debug(`got increment response with status code ${inc_response.status}`);
+		await fetch(`/load/cache-control/echo?msg=` + encodeURIComponent(`test ${test} incremented`));
 
 		if (type === 'force') {
 			_force_next_fetch();
+			await fetch(`/load/cache-control/echo?msg=` + encodeURIComponent(`test ${test} forced`));
 		} else if (type === 'bust') {
 			const count_response = await fetch('/load/cache-control/count', { method: 'POST' });
 			if (__SVELTEKIT_DEBUG__) console.debug(`got count POST response with status code ${count_response.status}`);
+			await fetch(`/load/cache-control/echo?msg=` + encodeURIComponent(`test ${test} busted`));
 		}
 
 		if (__SVELTEKIT_DEBUG__) console.debug("calling invalidate('/load/cache-control/count')");
 		await invalidate('/load/cache-control/count');
+		await fetch(`/load/cache-control/echo?msg=` + encodeURIComponent(`test ${test} invalidated`));
 	}
 </script>
 

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
@@ -14,20 +14,21 @@
 
 		const inc_response = await fetch('/load/cache-control/increment?test=' + test);
 		if (__SVELTEKIT_DEBUG__) console.debug(`got increment response with status code ${inc_response.status}`);
-		await fetch(`/load/cache-control/echo?msg=` + encodeURIComponent(`test ${test} incremented`));
+		if (__SVELTEKIT_DEBUG__) await fetch(`/load/cache-control/echo?msg=` + encodeURIComponent(`test ${test} incremented`));
 
 		if (type === 'force') {
 			_force_next_fetch();
-			await fetch(`/load/cache-control/echo?msg=` + encodeURIComponent(`test ${test} forced`));
+			if (__SVELTEKIT_DEBUG__) console.debug(`set next fetch to force`);
+			if (__SVELTEKIT_DEBUG__) await fetch(`/load/cache-control/echo?msg=` + encodeURIComponent(`test ${test} forced`));
 		} else if (type === 'bust') {
 			const count_response = await fetch('/load/cache-control/count', { method: 'POST' });
 			if (__SVELTEKIT_DEBUG__) console.debug(`got count POST response with status code ${count_response.status}`);
-			await fetch(`/load/cache-control/echo?msg=` + encodeURIComponent(`test ${test} busted`));
+			if (__SVELTEKIT_DEBUG__) await fetch(`/load/cache-control/echo?msg=` + encodeURIComponent(`test ${test} busted`));
 		}
 
 		if (__SVELTEKIT_DEBUG__) console.debug("calling invalidate('/load/cache-control/count')");
 		await invalidate('/load/cache-control/count');
-		await fetch(`/load/cache-control/echo?msg=` + encodeURIComponent(`test ${test} invalidated`));
+		if (__SVELTEKIT_DEBUG__) await fetch(`/load/cache-control/echo?msg=` + encodeURIComponent(`test ${test} invalidated`));
 	}
 </script>
 

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/+page.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { invalidate } from '$app/navigation';
+	import { page } from '$app/stores';
 	import { _force_next_fetch } from './+page';
 
 	/** @type {import('./$types').PageData} */
@@ -9,7 +10,7 @@
 	async function fetch_again(type) {
 		if (__SVELTEKIT_DEBUG__) console.debug(`fetch_again with type ${type}`);
 
-		const inc_response = await fetch('/load/cache-control/increment');
+		const inc_response = await fetch('/load/cache-control/increment?test=' + $page.url.searchParams.get('test'));
 		if (__SVELTEKIT_DEBUG__) console.debug(`got increment response with status code ${inc_response.status}`);
 
 		if (type === 'force') {

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/count/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/count/+server.js
@@ -2,8 +2,11 @@ import { json } from '@sveltejs/kit';
 import { count } from '../state.js';
 
 export function GET({ setHeaders }) {
+	if (process.env.DEBUG) console.warn(`\n\nCALLED GET /load/cache-control/count`);
 	setHeaders({ 'cache-control': 'public, max-age=30', age: '26' });
-	return json({ count });
+	const result = json({ count });
+	if (process.env.DEBUG) console.warn('RETURNING FROM GET /load/cache-control/count\n\n');
+	return result;
 }
 
 export function POST() {

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/count/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/count/+server.js
@@ -2,7 +2,7 @@ import { json } from '@sveltejs/kit';
 import { count } from '../state.js';
 
 export function GET({ setHeaders }) {
-	setHeaders({ 'cache-control': 'public, max-age=4', age: '2' });
+	setHeaders({ 'cache-control': 'public, max-age=30', age: '10' });
 	return json({ count });
 }
 

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/count/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/count/+server.js
@@ -10,5 +10,6 @@ export function GET({ setHeaders }) {
 }
 
 export function POST() {
+	if (process.env.DEBUG) console.warn(`POST /load/cache-control/count`);
 	return new Response();
 }

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/count/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/count/+server.js
@@ -2,7 +2,7 @@ import { json } from '@sveltejs/kit';
 import { count } from '../state.js';
 
 export function GET({ setHeaders }) {
-	setHeaders({ 'cache-control': 'public, max-age=30', age: '10' });
+	setHeaders({ 'cache-control': 'public, max-age=30', age: '26' });
 	return json({ count });
 }
 

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/echo/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/echo/+server.js
@@ -1,0 +1,4 @@
+export function GET({ url }) {
+	if (process.env.DEBUG) console.warn(`echo ${url.searchParams.get('msg')}\n\n`);
+	return {};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/increment/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/increment/+server.js
@@ -3,8 +3,8 @@ import { increment } from '../state.js';
 
 export function GET() {
 	if (process.env.DEBUG) console.warn('\n\nCALLED GET /load/cache-control/increment');
-	increment();
-	if (process.env.DEBUG) console.warn('incremented');
+	const value = increment();
+	if (process.env.DEBUG) console.warn(`incremented to ${value}`);
 	const result = json({});
 	if (process.env.DEBUG) console.warn('RETURNING FROM GET /load/cache-control/increment\n\n');
 	return result;

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/increment/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/increment/+server.js
@@ -2,7 +2,9 @@ import { json } from '@sveltejs/kit';
 import { increment } from '../state.js';
 
 export function GET() {
-	console.warn('\n\nCALLED GET /load/cache-control/increment\n\n');
+	if (process.env.DEBUG) console.warn('\n\nCALLED GET /load/cache-control/increment');
 	increment();
-	return json({});
+	const result = json({});
+	if (process.env.DEBUG) console.warn('RETURNING FROM GET /load/cache-control/increment\n\n');
+	return result;
 }

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/increment/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/increment/+server.js
@@ -2,6 +2,7 @@ import { json } from '@sveltejs/kit';
 import { increment } from '../state.js';
 
 export function GET() {
+	console.warn('\n\nCALLED GET /load/cache-control/increment\n\n');
 	increment();
 	return json({});
 }

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/increment/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/increment/+server.js
@@ -4,6 +4,7 @@ import { increment } from '../state.js';
 export function GET() {
 	if (process.env.DEBUG) console.warn('\n\nCALLED GET /load/cache-control/increment');
 	increment();
+	if (process.env.DEBUG) console.warn('incremented');
 	const result = json({});
 	if (process.env.DEBUG) console.warn('RETURNING FROM GET /load/cache-control/increment\n\n');
 	return result;

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/increment/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/increment/+server.js
@@ -1,8 +1,9 @@
 import { json } from '@sveltejs/kit';
 import { increment } from '../state.js';
 
-export function GET() {
-	if (process.env.DEBUG) console.warn('\n\nCALLED GET /load/cache-control/increment');
+/** @type {import('./$types').RequestHandler} */
+export function GET({ url }) {
+	if (process.env.DEBUG) console.warn(`\n\nCALLED GET /load/cache-control/increment from ${url.searchParams.get('test')}`);
 	const value = increment();
 	if (process.env.DEBUG) console.warn(`incremented to ${value}`);
 	const result = json({});

--- a/packages/kit/test/apps/basics/src/routes/load/cache-control/state.js
+++ b/packages/kit/test/apps/basics/src/routes/load/cache-control/state.js
@@ -1,7 +1,7 @@
 export let count = 0;
 
 export function increment() {
-	return count++;
+	return ++count;
 }
 
 export function reset() {

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -562,37 +562,31 @@ test.describe('Load', () => {
 		`);
 
 			await page.goto('/load/cache-control');
-			expect(await page.textContent('p')).toBe('Count is 0');
-			await page.waitForTimeout(500);
+			expect(page.locator('p')).toHaveText('Count is 0');
 			await page.click('button.default');
-			await page.waitForTimeout(500);
-			expect(await page.textContent('p')).toBe('Count is 0');
+			expect(page.locator('p')).toHaveText('Count is 0');
 
 			await page.evaluate(() => (window.now = 2500));
 			await page.click('button.default');
-			await expect(page.locator('p')).toHaveText('Count is 2');
+			expect(page.locator('p')).toHaveText('Count is 2');
 		});
 
 		test('load does ignore ttl if fetch cache options says so', async ({ page, request }) => {
 			await request.get('/load/cache-control/reset');
 
 			await page.goto('/load/cache-control');
-			expect(await page.textContent('p')).toBe('Count is 0');
-			await page.waitForTimeout(500);
+			expect(page.locator('p')).toHaveText('Count is 0');
 			await page.click('button.force');
-			await page.waitForTimeout(500);
-			expect(await page.textContent('p')).toBe('Count is 1');
+			expect(page.locator('p')).toHaveText('Count is 1');
 		});
 
 		test('load busts cache if non-GET request to resource is made', async ({ page, request }) => {
 			await request.get('/load/cache-control/reset');
 
 			await page.goto('/load/cache-control');
-			expect(await page.textContent('p')).toBe('Count is 0');
-			await page.waitForTimeout(500);
+			expect(page.locator('p')).toHaveText('Count is 0');
 			await page.click('button.bust');
-			await page.waitForTimeout(500);
-			expect(await page.textContent('p')).toBe('Count is 1');
+			expect(page.locator('p')).toHaveText('Count is 1');
 		});
 	});
 

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -556,17 +556,15 @@ test.describe('Load', () => {
 		test('load does not call fetch if max-age allows it', async ({ page, request }) => {
 			await request.get('/load/cache-control/reset');
 
-			page.addInitScript(`
-				window.now = 0;
-				window.performance.now = () => now;
-			`);
-
 			await page.goto('/load/cache-control');
 			await expect(page.getByText('Count is 0')).toBeVisible();
 			await page.locator('button.default').click();
 			await expect(page.getByText('Count is 0')).toBeVisible();
 
-			await page.evaluate(() => (window.now = 21000));
+			// use a cache expiration value high enough that we're confident the earlier
+			// portions of the test will complete before the cache expires
+			await page.waitForTimeout(4000);
+
 			await page.locator('button.default').click();
 			await expect(page.getByText('Count is 2')).toBeVisible();
 		});

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -556,7 +556,7 @@ test.describe('Load', () => {
 		test('load does not call fetch if max-age allows it', async ({ page, request }) => {
 			await request.get('/load/cache-control/reset');
 
-			await page.goto('/load/cache-control');
+			await page.goto('/load/cache-control?test=test1');
 			await expect(page.getByText('Count is 0')).toBeVisible();
 			await page.locator('button.default').click();
 			await expect(page.getByText('Count is 0')).toBeVisible();
@@ -572,7 +572,7 @@ test.describe('Load', () => {
 		test('load does ignore ttl if fetch cache options says so', async ({ page, request }) => {
 			await request.get('/load/cache-control/reset');
 
-			await page.goto('/load/cache-control');
+			await page.goto('/load/cache-control?test=test2');
 			await expect(page.getByText('Count is 0')).toBeVisible();
 			await page.locator('button.force').click();
 			await expect(page.getByText('Count is 1')).toBeVisible();
@@ -581,7 +581,7 @@ test.describe('Load', () => {
 		test('load busts cache if non-GET request to resource is made', async ({ page, request }) => {
 			await request.get('/load/cache-control/reset');
 
-			await page.goto('/load/cache-control');
+			await page.goto('/load/cache-control?test=test3');
 			await expect(page.getByText('Count is 0')).toBeVisible();
 			await page.locator('button.bust').click();
 			await expect(page.getByText('Count is 1')).toBeVisible();

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -566,7 +566,7 @@ test.describe('Load', () => {
 			await page.click('button.default');
 			expect(page.locator('p')).toHaveText('Count is 0');
 
-			await page.evaluate(() => (window.now = 2500));
+			await page.evaluate(() => (window.now = 21000));
 			await page.click('button.default');
 			expect(page.locator('p')).toHaveText('Count is 2');
 		});

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1088,10 +1088,10 @@ test.describe.serial('Invalidation', () => {
 
 	test('$page.url can safely be mutated', async ({ page }) => {
 		await page.goto('/load/mutated-url?q=initial');
-		expect(await page.textContent('h1')).toBe('initial');
+		expect(page.getByText('initial')).toBeVisible();
 
 		await page.locator('button').click();
-		expect(await page.textContent('h1')).toBe('updated');
+		expect(page.getByText('updated')).toBeVisible();
 	});
 });
 

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -238,7 +238,7 @@ test.describe('Scrolling', () => {
 
 	test('scroll is restored after hitting the back button', async ({ baseURL, clicknav, page }) => {
 		await page.goto('/anchor');
-		await page.click('#scroll-anchor');
+		await page.locator('#scroll-anchor').click();
 		const originalScrollY = /** @type {number} */ (await page.evaluate(() => scrollY));
 		await clicknav('#routing-page');
 		await page.goBack();
@@ -266,7 +266,7 @@ test.describe('Scrolling', () => {
 		const target_scroll_y = rect.y + rect.height - height;
 		await page.evaluate((y) => scrollTo(0, y), target_scroll_y);
 
-		await page.click('[href="/scroll/cross-document/b"]');
+		await page.locator('[href="/scroll/cross-document/b"]').click();
 		expect(await page.textContent('h1')).toBe('b');
 		await page.waitForSelector('body.started');
 
@@ -394,7 +394,7 @@ test.describe('CSS', () => {
 test.describe('Endpoints', () => {
 	test('calls a delete handler', async ({ page }) => {
 		await page.goto('/delete-route');
-		await page.click('.del');
+		await page.locator('.del').click();
 		expect(await page.innerHTML('h1')).toBe('deleted 42');
 	});
 });
@@ -563,11 +563,11 @@ test.describe('Load', () => {
 
 			await page.goto('/load/cache-control');
 			await expect(page.getByText('Count is 0')).toBeVisible();
-			await page.click('button.default');
+			await page.locator('button.default').click();
 			await expect(page.getByText('Count is 0')).toBeVisible();
 
 			await page.evaluate(() => (window.now = 21000));
-			await page.click('button.default');
+			await page.locator('button.default').click();
 			await expect(page.getByText('Count is 2')).toBeVisible();
 		});
 
@@ -576,7 +576,7 @@ test.describe('Load', () => {
 
 			await page.goto('/load/cache-control');
 			await expect(page.getByText('Count is 0')).toBeVisible();
-			await page.click('button.force');
+			await page.locator('button.force').click();
 			await expect(page.getByText('Count is 1')).toBeVisible();
 		});
 
@@ -585,7 +585,7 @@ test.describe('Load', () => {
 
 			await page.goto('/load/cache-control');
 			await expect(page.getByText('Count is 0')).toBeVisible();
-			await page.click('button.bust');
+			await page.locator('button.bust').click();
 			await expect(page.getByText('Count is 1')).toBeVisible();
 		});
 	});
@@ -786,10 +786,10 @@ test.describe('Routing', () => {
 		await page.goto('/routing/hashes/pagestore');
 		expect(await page.textContent('#window-hash')).toBe('');
 		expect(await page.textContent('#page-url-hash')).toBe('');
-		await page.click('[href="#target"]');
+		await page.locator('[href="#target"]').click();
 		expect(await page.textContent('#window-hash')).toBe('#target');
 		expect(await page.textContent('#page-url-hash')).toBe('#target');
-		await page.click('[href="/routing/hashes/pagestore"]');
+		await page.locator('[href="/routing/hashes/pagestore"]').click();
 		await expect(page.locator('#window-hash')).toHaveText('#target'); // hashchange doesn't fire for these
 		await expect(page.locator('#page-url-hash')).toHaveText('');
 	});
@@ -805,7 +805,7 @@ test.describe('Routing', () => {
 
 		try {
 			await page.goto(`/routing/slashes?port=${port}`);
-			await page.click(`a[href="http://localhost:${port}/with-slash/"]`);
+			await page.locator(`a[href="http://localhost:${port}/with-slash/"]`).click();
 
 			expect(urls).toEqual(['/with-slash/']);
 		} finally {
@@ -817,7 +817,7 @@ test.describe('Routing', () => {
 		await page.goto('/routing/external-popstate');
 		expect(await page.textContent('h1')).toBe('hello');
 
-		await page.click('button');
+		await page.locator('button').click();
 		expect(await page.textContent('h1')).toBe('hello');
 
 		await page.goBack();
@@ -830,7 +830,7 @@ test.describe('Routing', () => {
 	test('recognizes clicks outside the app target', async ({ page }) => {
 		await page.goto('/routing/link-outside-app-target/source');
 
-		await page.click('[href="/routing/link-outside-app-target/target"]');
+		await page.locator('[href="/routing/link-outside-app-target/target"]').click();
 		await expect(page.locator('h1')).toHaveText('target: 1');
 	});
 
@@ -843,7 +843,7 @@ test.describe('Routing', () => {
 		page.on('request', (request) => requests.push(request.url()));
 
 		await page.locator('input').fill('updated');
-		await page.click('button');
+		await page.locator('button').click();
 
 		expect(requests).toEqual([]);
 		expect(await page.textContent('h1')).toBe('updated');
@@ -913,7 +913,7 @@ test.describe('$app/stores', () => {
 	test('can use $app/stores from anywhere on client', async ({ page }) => {
 		await page.goto('/store/client-access');
 		await expect(page.locator('h1')).toHaveText('undefined');
-		await page.click('button');
+		await page.locator('button').click();
 		await expect(page.locator('h1')).toHaveText('/store/client-access');
 	});
 
@@ -1008,19 +1008,19 @@ test.describe.serial('Invalidation', () => {
 		await page.goto('/load/invalidation/multiple');
 		expect(await page.textContent('p')).toBe('layout: 0, page: 0');
 
-		await page.click('button.layout');
-		await page.click('button.layout');
-		await page.click('button.page');
-		await page.click('button.page');
-		await page.click('button.layout');
-		await page.click('button.page');
-		await page.click('button.all');
+		await page.locator('button.layout').click();
+		await page.locator('button.layout').click();
+		await page.locator('button.page').click();
+		await page.locator('button.page').click();
+		await page.locator('button.layout').click();
+		await page.locator('button.page').click();
+		await page.locator('button.all').click();
 		await expect(page.locator('p')).toHaveText('layout: 4, page: 4');
 	});
 
 	test('invalidateAll persists through redirects', async ({ page }) => {
 		await page.goto('/load/invalidation/multiple/redirect');
-		await page.click('button.redirect');
+		await page.locator('button.redirect').click();
 		await expect(page.locator('p.redirect-state')).toHaveText('Redirect state: done');
 	});
 
@@ -1090,7 +1090,7 @@ test.describe.serial('Invalidation', () => {
 		await page.goto('/load/mutated-url?q=initial');
 		expect(await page.textContent('h1')).toBe('initial');
 
-		await page.click('button');
+		await page.locator('button').click();
 		expect(await page.textContent('h1')).toBe('updated');
 	});
 });
@@ -1138,12 +1138,12 @@ test.describe('data-sveltekit attributes', () => {
 		page.on('request', (r) => requests.push(r.url()));
 
 		await page.goto('/data-sveltekit/reload');
-		await page.click('#one');
+		await page.locator('#one').click();
 		expect(requests).toContain(`${baseURL}/data-sveltekit/reload/target`);
 
 		requests.length = 0;
 		await page.goto('/data-sveltekit/reload');
-		await page.click('#two');
+		await page.locator('#two').click();
 		expect(requests).toContain(`${baseURL}/data-sveltekit/reload/target`);
 
 		requests.length = 0;
@@ -1199,7 +1199,7 @@ test.describe('cookies', () => {
 	test('etag forwards cookies', async ({ page }) => {
 		await page.goto('/cookies/forwarded-in-etag');
 		await expect(page.locator('p')).toHaveText('foo=bar');
-		await Promise.all([page.waitForNavigation(), page.click('button')]);
+		await page.locator('button').click();
 		await expect(page.locator('p')).toHaveText('foo=bar');
 	});
 });
@@ -1216,11 +1216,11 @@ test.describe('Interactivity', () => {
 		await page.goto('/interactivity/toggle-element');
 		expect(await page.textContent('button')).toBe('remove');
 
-		await page.click('button');
+		await page.locator('button').click();
 		expect(await page.textContent('button')).toBe('add');
 		expect(await page.textContent('a')).toBe('add');
 
-		await page.click('a');
+		await page.locator('a').filter({ hasText: 'add' }).click();
 		expect(await page.textContent('a')).toBe('remove');
 
 		expect(errored).toBe(false);

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -554,6 +554,7 @@ test.describe('Load', () => {
 
 	test.describe.serial('', () => {
 		test('load does not call fetch if max-age allows it', async ({ page, request }) => {
+			console.warn('starting test1');
 			await request.get('/load/cache-control/reset');
 
 			await page.goto('/load/cache-control?test=test1');
@@ -567,24 +568,29 @@ test.describe('Load', () => {
 
 			await page.locator('button.default').click();
 			await expect(page.getByText('Count is 2')).toBeVisible();
+			console.warn('ending test1');
 		});
 
 		test('load does ignore ttl if fetch cache options says so', async ({ page, request }) => {
+			console.warn('starting test2');
 			await request.get('/load/cache-control/reset');
 
 			await page.goto('/load/cache-control?test=test2');
 			await expect(page.getByText('Count is 0')).toBeVisible();
 			await page.locator('button.force').click();
 			await expect(page.getByText('Count is 1')).toBeVisible();
+			console.warn('ending test2');
 		});
 
 		test('load busts cache if non-GET request to resource is made', async ({ page, request }) => {
+			console.warn('starting test3');
 			await request.get('/load/cache-control/reset');
 
 			await page.goto('/load/cache-control?test=test3');
 			await expect(page.getByText('Count is 0')).toBeVisible();
 			await page.locator('button.bust').click();
 			await expect(page.getByText('Count is 1')).toBeVisible();
+			console.warn('ending test3');
 		});
 	});
 

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -557,9 +557,9 @@ test.describe('Load', () => {
 			await request.get('/load/cache-control/reset');
 
 			page.addInitScript(`
-			window.now = 0;
-			window.performance.now = () => now;
-		`);
+				window.now = 0;
+				window.performance.now = () => now;
+			`);
 
 			await page.goto('/load/cache-control');
 			expect(page.locator('p')).toHaveText('Count is 0');

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -562,31 +562,31 @@ test.describe('Load', () => {
 			`);
 
 			await page.goto('/load/cache-control');
-			await expect(page.locator('p')).toHaveText('Count is 0');
+			await expect(page.getByText('Count is 0')).toBeVisible();
 			await page.click('button.default');
-			await expect(page.locator('p')).toHaveText('Count is 0');
+			await expect(page.getByText('Count is 0')).toBeVisible();
 
 			await page.evaluate(() => (window.now = 21000));
 			await page.click('button.default');
-			await expect(page.locator('p')).toHaveText('Count is 2');
+			await expect(page.getByText('Count is 2')).toBeVisible();
 		});
 
 		test('load does ignore ttl if fetch cache options says so', async ({ page, request }) => {
 			await request.get('/load/cache-control/reset');
 
 			await page.goto('/load/cache-control');
-			await expect(page.locator('p')).toHaveText('Count is 0');
+			await expect(page.getByText('Count is 0')).toBeVisible();
 			await page.click('button.force');
-			await expect(page.locator('p')).toHaveText('Count is 1');
+			await expect(page.getByText('Count is 1')).toBeVisible();
 		});
 
 		test('load busts cache if non-GET request to resource is made', async ({ page, request }) => {
 			await request.get('/load/cache-control/reset');
 
 			await page.goto('/load/cache-control');
-			await expect(page.locator('p')).toHaveText('Count is 0');
+			await expect(page.getByText('Count is 0')).toBeVisible();
 			await page.click('button.bust');
-			await expect(page.locator('p')).toHaveText('Count is 1');
+			await expect(page.getByText('Count is 1')).toBeVisible();
 		});
 	});
 

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -562,31 +562,31 @@ test.describe('Load', () => {
 			`);
 
 			await page.goto('/load/cache-control');
-			expect(page.locator('p')).toHaveText('Count is 0');
+			await expect(page.locator('p')).toHaveText('Count is 0');
 			await page.click('button.default');
-			expect(page.locator('p')).toHaveText('Count is 0');
+			await expect(page.locator('p')).toHaveText('Count is 0');
 
 			await page.evaluate(() => (window.now = 21000));
 			await page.click('button.default');
-			expect(page.locator('p')).toHaveText('Count is 2');
+			await expect(page.locator('p')).toHaveText('Count is 2');
 		});
 
 		test('load does ignore ttl if fetch cache options says so', async ({ page, request }) => {
 			await request.get('/load/cache-control/reset');
 
 			await page.goto('/load/cache-control');
-			expect(page.locator('p')).toHaveText('Count is 0');
+			await expect(page.locator('p')).toHaveText('Count is 0');
 			await page.click('button.force');
-			expect(page.locator('p')).toHaveText('Count is 1');
+			await expect(page.locator('p')).toHaveText('Count is 1');
 		});
 
 		test('load busts cache if non-GET request to resource is made', async ({ page, request }) => {
 			await request.get('/load/cache-control/reset');
 
 			await page.goto('/load/cache-control');
-			expect(page.locator('p')).toHaveText('Count is 0');
+			await expect(page.locator('p')).toHaveText('Count is 0');
 			await page.click('button.bust');
-			expect(page.locator('p')).toHaveText('Count is 1');
+			await expect(page.locator('p')).toHaveText('Count is 1');
 		});
 	});
 

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1006,7 +1006,7 @@ test.describe.serial('Invalidation', () => {
 
 	test('multiple invalidations run concurrently', async ({ page, request }) => {
 		await page.goto('/load/invalidation/multiple');
-		expect(await page.textContent('p')).toBe('layout: 0, page: 0');
+		await expect(page.textContent('layout: 0, page: 0')).toBeVisible();
 
 		await page.locator('button.layout').click();
 		await page.locator('button.layout').click();
@@ -1015,7 +1015,7 @@ test.describe.serial('Invalidation', () => {
 		await page.locator('button.layout').click();
 		await page.locator('button.page').click();
 		await page.locator('button.all').click();
-		await expect(page.locator('p')).toHaveText('layout: 4, page: 4');
+		await expect(page.textContent('layout: 4, page: 4')).toBeVisible();
 	});
 
 	test('invalidateAll persists through redirects', async ({ page }) => {

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1006,13 +1006,13 @@ test.describe.serial('Invalidation', () => {
 		await page.goto('/load/invalidation/multiple');
 		await expect(page.getByText('layout: 0, page: 0')).toBeVisible();
 
-		await page.locator('button.layout').click();
-		await page.locator('button.layout').click();
-		await page.locator('button.page').click();
-		await page.locator('button.page').click();
-		await page.locator('button.layout').click();
-		await page.locator('button.page').click();
-		await page.locator('button.all').click();
+		await page.click('button.layout');
+		await page.click('button.layout');
+		await page.click('button.page');
+		await page.click('button.page');
+		await page.click('button.layout');
+		await page.click('button.page');
+		await page.click('button.all');
 		await expect(page.getByText('layout: 4, page: 4')).toBeVisible();
 	});
 

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1004,7 +1004,7 @@ test.describe.serial('Invalidation', () => {
 
 	test('multiple invalidations run concurrently', async ({ page, request }) => {
 		await page.goto('/load/invalidation/multiple');
-		await expect(page.textContent('layout: 0, page: 0')).toBeVisible();
+		await expect(page.getByText('layout: 0, page: 0')).toBeVisible();
 
 		await page.locator('button.layout').click();
 		await page.locator('button.layout').click();
@@ -1013,7 +1013,7 @@ test.describe.serial('Invalidation', () => {
 		await page.locator('button.layout').click();
 		await page.locator('button.page').click();
 		await page.locator('button.all').click();
-		await expect(page.textContent('layout: 4, page: 4')).toBeVisible();
+		await expect(page.getByText('layout: 4, page: 4')).toBeVisible();
 	});
 
 	test('invalidateAll persists through redirects', async ({ page }) => {

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1297,7 +1297,7 @@ test.describe('Redirects', () => {
 	test('prevents redirect loops', async ({ baseURL, page, javaScriptEnabled, browserName }) => {
 		await page.goto('/redirect');
 
-		await page.click('[href="/redirect/loopy/a"]');
+		await page.locator('[href="/redirect/loopy/a"]').click();
 
 		if (javaScriptEnabled) {
 			await page.waitForSelector('#message');
@@ -1490,8 +1490,7 @@ test.describe('Routing', () => {
 
 	test('does not attempt client-side navigation to server routes', async ({ page }) => {
 		await page.goto('/routing');
-		await page.click('[href="/routing/ambiguous/ok.json"]');
-		await page.waitForLoadState('networkidle');
+		await page.locator('[href="/routing/ambiguous/ok.json"]').click();
 		expect(await page.textContent('body')).toBe('ok');
 	});
 
@@ -1560,7 +1559,7 @@ test.describe('Routing', () => {
 	}) => {
 		await page.goto('/routing/hashes/a');
 
-		await page.click('[href="#hash-target"]');
+		await page.locator('[href="#hash-target"]').click();
 		await clicknav('[href="/routing/hashes/b"]');
 
 		await page.goBack();
@@ -1622,10 +1621,7 @@ test.describe('Routing', () => {
 
 		try {
 			await page.goto(`/routing?port=${port}`);
-			await Promise.all([
-				page.click(`[href="http://localhost:${port}"]`),
-				page.waitForURL(`http://localhost:${port}/`)
-			]);
+			await page.locator(`[href="http://localhost:${port}"]`).click();
 		} finally {
 			await close();
 		}
@@ -1656,7 +1652,7 @@ test.describe('Routing', () => {
 		expect(await page.textContent('h1')).toBe('xyz/abc');
 		expect(await page.textContent('h2')).toBe('xyz/abc');
 
-		await page.click('[href="/routing/rest/xyz/abc/qwe/deep.json"]');
+		await page.locator('[href="/routing/rest/xyz/abc/qwe/deep.json"]').click();
 		expect(await page.textContent('body')).toBe('xyz/abc/qwe');
 	});
 
@@ -1711,7 +1707,7 @@ test.describe('Routing', () => {
 		clicknav
 	}) => {
 		await page.goto('/routing/cancellation');
-		await page.click('[href="/routing/cancellation/a"]');
+		await page.locator('[href="/routing/cancellation/a"]').click();
 		await clicknav('[href="/routing/cancellation/b"]');
 
 		expect(await page.url()).toBe(`${baseURL}/routing/cancellation/b`);
@@ -1892,10 +1888,10 @@ test.describe('Actions', () => {
 		expect(await page.textContent('pre')).toBe(JSON.stringify(null));
 
 		if (javaScriptEnabled) {
-			await page.click('button.increment-success');
+			await page.locator('button.increment-success').click();
 			await expect(page.locator('pre')).toHaveText(JSON.stringify({ count: 0 }));
 
-			await page.click('button.increment-invalid');
+			await page.locator('button.increment-invalid').click();
 			await expect(page.locator('pre')).toHaveText(JSON.stringify({ count: 1 }));
 		}
 	});
@@ -1909,10 +1905,10 @@ test.describe('Actions', () => {
 		expect(await page.textContent('pre')).toBe(JSON.stringify(null));
 
 		if (javaScriptEnabled) {
-			await page.click('button.increment-success');
+			await page.locator('button.increment-success').click();
 			await expect(page.locator('pre')).toHaveText(JSON.stringify({ count: 0 }));
 
-			await page.click('button.invalidateAll');
+			await page.locator('button.invalidateAll').click();
 			await page.waitForTimeout(500);
 			await expect(page.locator('pre')).toHaveText(JSON.stringify({ count: 0 }));
 			await app.goto('/actions/enhance');
@@ -1928,7 +1924,7 @@ test.describe('Actions', () => {
 		expect(await page.textContent('pre')).toBe(JSON.stringify(null));
 
 		if (javaScriptEnabled) {
-			await page.click('button.redirect');
+			await page.locator('button.redirect').click();
 			await expect(page.locator('footer')).toHaveText('Custom layout');
 		}
 	});
@@ -1938,7 +1934,7 @@ test.describe('Actions', () => {
 		expect(await page.textContent('pre')).toBe(JSON.stringify(null));
 
 		if (javaScriptEnabled) {
-			await page.click('button.error');
+			await page.locator('button.error').click();
 			await expect(page.locator('p')).toHaveText(
 				'This is your custom error page saying: "Unexpected Form Error"'
 			);
@@ -2090,11 +2086,11 @@ test.describe.serial('Cookies API', () => {
 		let span = page.locator('#cookie-value');
 		expect(await span.innerText()).toContain('undefined');
 
-		await page.click('button#teapot');
+		await page.locator('button#teapot').click();
 		await expect(page.locator('#cookie-value')).toHaveText('teapot');
 
 		// setting a different value...
-		await page.click('button#janeAusten');
+		await page.locator('button#janeAusten').click();
 		await expect(page.locator('#cookie-value')).toHaveText('Jane Austen');
 	});
 

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1621,7 +1621,11 @@ test.describe('Routing', () => {
 
 		try {
 			await page.goto(`/routing?port=${port}`);
-			await page.locator(`[href="http://localhost:${port}"]`).click();
+			await Promise.all([
+				page.click(`[href="http://localhost:${port}"]`),
+				// assert that the app can visit a URL not owned by the app without crashing
+				page.waitForURL(`http://localhost:${port}/`)
+			]);
 		} finally {
 			await close();
 		}

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -141,6 +141,7 @@ export const config = {
 		command: process.env.DEV ? 'pnpm dev' : 'pnpm build && pnpm preview',
 		port: process.env.DEV ? 5173 : 4173
 	},
+	reporter: process.env.DEBUG ?? 'list',
 	retries: process.env.CI ? 2 : 0,
 	projects: [
 		{

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -92,6 +92,7 @@ export const test = base.extend({
 				const res = await page_fn.call(page, ...args);
 				if (javaScriptEnabled && args[1]?.wait_for_started !== false) {
 					await page.waitForSelector('body.started', { timeout: 5000 });
+					if (__SVELTEKIT_DEBUG__) console.debug(`body.started detected`);
 				}
 				return res;
 			};

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -141,7 +141,7 @@ export const config = {
 		command: process.env.DEV ? 'pnpm dev' : 'pnpm build && pnpm preview',
 		port: process.env.DEV ? 5173 : 4173
 	},
-	reporter: process.env.DEBUG ?? 'list',
+	reporter: process.env.DEBUG ? 'list' : undefined,
 	retries: process.env.CI ? 2 : 0,
 	projects: [
 		{

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -92,9 +92,6 @@ export const test = base.extend({
 				const res = await page_fn.call(page, ...args);
 				if (javaScriptEnabled && args[1]?.wait_for_started !== false) {
 					await page.waitForSelector('body.started', { timeout: 5000 });
-					if (process.env.DEBUG) {
-						await page.evaluate(`console.debug('body.started detected after ${fn}');`);
-					}
 				}
 				return res;
 			};

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -92,7 +92,9 @@ export const test = base.extend({
 				const res = await page_fn.call(page, ...args);
 				if (javaScriptEnabled && args[1]?.wait_for_started !== false) {
 					await page.waitForSelector('body.started', { timeout: 5000 });
-					if (__SVELTEKIT_DEBUG__) console.debug(`body.started detected`);
+					if (process.env.DEBUG) {
+						await page.evaluate(`console.debug('body.started detected after ${fn}');`);
+					}
 				}
 				return res;
 			};

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -388,5 +388,6 @@ declare global {
 	const __SVELTEKIT_APP_VERSION_POLL_INTERVAL__: number;
 	const __SVELTEKIT_BROWSER__: boolean;
 	const __SVELTEKIT_DEV__: boolean;
+	const __SVELTEKIT_DEBUG__: boolean;
 	const __SVELTEKIT_EMBEDDED__: boolean;
 }


### PR DESCRIPTION
`waitForTimeout` is inherently flaky and we should avoid using it as much as possible
`page.textContent` is discouraged: https://playwright.dev/docs/api/class-page#page-text-content
as is `page.click`: https://playwright.dev/docs/api/class-page#page-click

The `window.now` cache invalidation basically didn't work at all. We were just accidentally triggering cache invalidation a lot of the time because the tests ran slowly. If you had a bigger cache invalidation window the test would fail somewhat consistently