### PR TITLE
Update request type definitions to make platform possibly undefined

### DIFF
--- a/.changeset/shy-monkeys-raise.md
+++ b/.changeset/shy-monkeys-raise.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Update typings of event.platform to be possibly undefined
+Update typings of `event.platform` to be possibly undefined

--- a/.changeset/shy-monkeys-raise.md
+++ b/.changeset/shy-monkeys-raise.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-event.platform falls back to empty object when not defined
+Update typings of event.platform to be possibly undefined

--- a/.changeset/shy-monkeys-raise.md
+++ b/.changeset/shy-monkeys-raise.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+event.platform falls back to empty object when not defined

--- a/.changeset/shy-monkeys-raise.md
+++ b/.changeset/shy-monkeys-raise.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/kit': minor
+'@sveltejs/kit': patch
 ---
 
 event.platform falls back to empty object when not defined

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -124,7 +124,7 @@ export async function respond(request, options, state) {
 			}),
 		locals: {},
 		params,
-		platform: state.platform,
+		platform: state.platform ?? {},
 		request,
 		route: { id: route?.id ?? null },
 		setHeaders: (new_headers) => {

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -124,7 +124,7 @@ export async function respond(request, options, state) {
 			}),
 		locals: {},
 		params,
-		platform: state.platform ?? {},
+		platform: state.platform,
 		request,
 		route: { id: route?.id ?? null },
 		setHeaders: (new_headers) => {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -865,7 +865,7 @@ export interface RequestEvent<
 	/**
 	 * Additional data made available through the adapter.
 	 */
-	platform: Readonly<App.Platform>;
+	platform: Readonly<App.Platform> | undefined;
 	/**
 	 * The original request object
 	 */

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -865,7 +865,7 @@ export interface RequestEvent<
 	/**
 	 * Additional data made available through the adapter.
 	 */
-	platform: Readonly<App.Platform> | undefined;
+	platform: Readonly<App.Platform> | void;
 	/**
 	 * The original request object
 	 */

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -865,7 +865,7 @@ export interface RequestEvent<
 	/**
 	 * Additional data made available through the adapter.
 	 */
-	platform: Readonly<App.Platform> | void;
+	platform: Readonly<App.Platform> | undefined;
 	/**
 	 * The original request object
 	 */


### PR DESCRIPTION
This PR is to resolve issue https://github.com/sveltejs/kit/issues/8230 in which the platform object does not match it's types.

`event.platform` is typed as an empty object by default so I am changing the server response to fallback to this rather than allowing it to be undefined.

An alternative could be to update the types to make platform optional within event.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
