### PR TITLE
Ignore param matchers that match .{spec,test}.{js,ts}

### DIFF
--- a/.changeset/healthy-lizards-drum.md
+++ b/.changeset/healthy-lizards-drum.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Ignore `*.test.js` and `*.spec.js` files in `params` directory

--- a/documentation/docs/30-advanced/10-advanced-routing.md
+++ b/documentation/docs/30-advanced/10-advanced-routing.md
@@ -90,6 +90,8 @@ export function match(param) {
 
 If the pathname doesn't match, SvelteKit will try to match other routes (using the sort order specified below), before eventually returning a 404.
 
+Each module in the `params` directory corresponds to a matcher, with the exception of `*.test.js` and `*.spec.js` files which may be used to unit test your matchers.
+
 > Matchers run both on the server and in the browser.
 
 ## Sorting

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -76,6 +76,9 @@ function create_matchers(config, cwd) {
 					matchers[type] = matcher_file;
 				}
 			} else {
+				// Allow for matcher test collocation
+				if (type.endsWith('.test') || type.endsWith('.spec')) continue;
+
 				throw new Error(
 					`Matcher names can only have underscores and alphanumeric characters — "${file}" is invalid`
 				);


### PR DESCRIPTION
This allows for param matcher tests to be collocated with their matchers

fixes #7583

Collocation of tests is a common practice, and the current param matcher scanning will throw an error if there are `.{test,spec}.{js,ts}` files in the `src/params` directory, as it sees them as malformed param names.

This is a simple change that just skips over those files instead of throwing an exception.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
