### PR TITLE
improve fetch response recording and serialization

### DIFF
--- a/.changeset/thin-cheetahs-rescue.md
+++ b/.changeset/thin-cheetahs-rescue.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add support for using all .body methods in universal load functions

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -77,7 +77,7 @@ export function initial_fetch(resource, opts) {
 		const ttl = script.getAttribute('data-ttl');
 		if (ttl) cache.set(selector, { body, init, ttl: 1000 * Number(ttl) });
 
-		return Promise.resolve(new Response(body, init));
+		return Promise.resolve(new Response(atob(body), init));
 	}
 
 	return native_fetch(resource, opts);


### PR DESCRIPTION
 Previously, calling the sveltekit supplied fetch method would return a proxy around fetch that overrode certain methods. Accessing these methods would push the response into the fetched array which would then be used on the client side to avoid re-fetching data. This method required overriding every method on fetch that could read the body and could leave developers stumped if they happened to read .body from a different method. This commit opts to attach a transformer to the responses original body and pushes into fetched once the body has been completely read. This ensures that all methods of consuming .body will be appropriately recorded.

Notably, this strategy requires encoding the body as a base64'd array of bytes rather than raw text which introduces a minor overhead for serialization and deserialization.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
