### PR TITLE
[chore] vite-imagetools improvements

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -705,7 +705,7 @@ importers:
       typescript: ^4.9.4
       uvu: ^0.5.6
       vite: ^4.0.0
-      vite-imagetools: ^4.0.11
+      vite-imagetools: ^4.0.13
     dependencies:
       d3-geo: 3.0.1
       d3-geo-projection: 4.0.0
@@ -729,7 +729,7 @@ importers:
       typescript: 4.9.4
       uvu: 0.5.6
       vite: 4.0.0_@types+node@16.18.6
-      vite-imagetools: 4.0.11
+      vite-imagetools: 4.0.13
 
 packages:
 
@@ -2618,7 +2618,7 @@ packages:
     resolution: {integrity: sha512-YbZhedg/zja34yV6iRDhfo4cmAYSwxaErkuzc/RpMMAELgszpDKf3MLH6VlsR+QkenPUEGkGAVpJAM2GbUls9Q==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      sharp: 0.31.2
+      sharp: 0.31.3
     dev: true
 
   /import-fresh/3.3.0:
@@ -3176,8 +3176,8 @@ packages:
       tslib: 2.4.1
     dev: false
 
-  /node-abi/3.28.0:
-    resolution: {integrity: sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==}
+  /node-abi/3.30.0:
+    resolution: {integrity: sha512-qWO5l3SCqbwQavymOmtTVuCWZE23++S+rxyoHjXqUmPyzRcaoI4lA2gO55/drddGnedAyjA7sk76SfQ5lfUMnw==}
     engines: {node: '>=10'}
     dependencies:
       semver: 7.3.8
@@ -3501,7 +3501,7 @@ packages:
       minimist: 1.2.7
       mkdirp-classic: 0.5.3
       napi-build-utils: 1.0.2
-      node-abi: 3.28.0
+      node-abi: 3.30.0
       pump: 3.0.0
       rc: 1.2.8
       simple-get: 4.0.1
@@ -3821,8 +3821,8 @@ packages:
     resolution: {integrity: sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==}
     dev: false
 
-  /sharp/0.31.2:
-    resolution: {integrity: sha512-DUdNVEXgS5A97cTagSLIIp8dUZ/lZtk78iNVZgHdHbx1qnQR7JAHY0BnXnwwH39Iw+VKhO08CTYhIg0p98vQ5Q==}
+  /sharp/0.31.3:
+    resolution: {integrity: sha512-XcR4+FCLBFKw1bdB+GEhnUNXNXvnt0tDo4WsBsraKymuo/IAuPuCBVAL2wIkUw2r/dwFW5Q5+g66Kwl2dgDFVg==}
     engines: {node: '>=14.15.0'}
     requiresBuild: true
     dependencies:
@@ -4588,8 +4588,8 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite-imagetools/4.0.11:
-    resolution: {integrity: sha512-S6+vzsd/6kSBdPIdjJFGeZ4+UV/aIK09V7oLb/Z9soV3jNwKh60WBi6jF+RnKtY7F9FMU3W6xPbln+VPHI0icA==}
+  /vite-imagetools/4.0.13:
+    resolution: {integrity: sha512-DeMAhDwvWATzBa5Qu9Fv6rtOuHZFONrv5Z5a95jd/oBDDCdyTKYVqxIurS5ox9A/sH8bhVF7r++Yww0DKpjKFQ==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@rollup/pluginutils': 5.0.2

--- a/sites/kit.svelte.dev/package.json
+++ b/sites/kit.svelte.dev/package.json
@@ -28,7 +28,7 @@
 		"typescript": "^4.9.4",
 		"uvu": "^0.5.6",
 		"vite": "^4.0.0",
-		"vite-imagetools": "^4.0.11"
+		"vite-imagetools": "^4.0.13"
 	},
 	"type": "module",
 	"dependencies": {

--- a/sites/kit.svelte.dev/src/lib/Image.svelte
+++ b/sites/kit.svelte.dev/src/lib/Image.svelte
@@ -1,5 +1,5 @@
 <script>
-	/* @type {string | import('vite-imagetools').Picture} */
+	/** @type {string | import('vite-imagetools').Picture} */
 	export let src;
 
 	/** @type {string} */

--- a/sites/kit.svelte.dev/vite.config.js
+++ b/sites/kit.svelte.dev/vite.config.js
@@ -16,7 +16,7 @@ const config = {
 				const extension = path.extname(url.pathname);
 				if (supportedExtensions.includes(extension)) {
 					return new URLSearchParams({
-						format: 'avif;webp;' + extension,
+						format: 'avif;webp;' + extension.slice(1),
 						picture: true
 					});
 				}


### PR DESCRIPTION
Upgrade to 4.0.13 which exports the `Picture` type so that we can properly type our `Image` component

Also, remove leading `.` in the config
