### PR TITLE
[Fix] Add prerendered assets to Vercel config

### DIFF
--- a/.changeset/healthy-singers-stare.md
+++ b/.changeset/healthy-singers-stare.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+[fix] only apply immutable cache-control headers to immutable assets

--- a/.changeset/old-chicken-cough.md
+++ b/.changeset/old-chicken-cough.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-static': patch
 ---
 
-Match `adapter-vercel` logic for serving prerendered content
+[fix] match `adapter-vercel` logic for serving prerendered content

--- a/.changeset/old-chicken-cough.md
+++ b/.changeset/old-chicken-cough.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/adapter-static': patch
+'@sveltejs/adapter-vercel': patch
+---
+
+Add prerendered assets to Vercel config

--- a/.changeset/old-chicken-cough.md
+++ b/.changeset/old-chicken-cough.md
@@ -1,6 +1,5 @@
 ---
 '@sveltejs/adapter-static': patch
-'@sveltejs/adapter-vercel': patch
 ---
 
-Add prerendered assets to Vercel config
+Match `adapter-vercel` logic for serving prerendered content

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -71,9 +71,7 @@ See https://kit.svelte.dev/docs/page-options#prerender for more details`
 				assets = pages,
 				fallback,
 				precompress
-			} = options ??
-			platform?.defaults(builder.config) ??
-			/** @type {import('./index').AdapterOptions} */ ({});
+			} = options ?? platform?.defaults ?? /** @type {import('./index').AdapterOptions} */ ({});
 
 			builder.rimraf(assets);
 			builder.rimraf(pages);

--- a/packages/adapter-static/platforms.js
+++ b/packages/adapter-static/platforms.js
@@ -40,6 +40,14 @@ function vercel_routes(builder) {
 		});
 	}
 
+	// prerendered assets (data.json and other non-html pages)
+	for (const [src] of builder.prerendered.assets) {
+		routes.push({
+			src,
+			dest: `${builder.config.kit.appDir}/prerendered/${src}`
+		});
+	}
+
 	// implicit redirects (trailing slashes)
 	for (const [src] of builder.prerendered.pages) {
 		if (src !== '/') {

--- a/packages/adapter-static/platforms.js
+++ b/packages/adapter-static/platforms.js
@@ -4,7 +4,7 @@ import fs from 'fs';
  * @typedef {{
  *   name: string;
  *   test: () => boolean;
- *   defaults: (config: any) => import('./index').AdapterOptions; // TODO
+ *   defaults: import('./index').AdapterOptions;
  *   done: (builder: import('@sveltejs/kit').Builder) => void;
  * }}
  * Platform */
@@ -64,9 +64,9 @@ export const platforms = [
 	{
 		name: 'Vercel',
 		test: () => !!process.env.VERCEL,
-		defaults: () => ({
+		defaults: {
 			pages: '.vercel/output/static'
-		}),
+		},
 		done: (builder) => {
 			const config = static_vercel_config(builder);
 			fs.writeFileSync('.vercel/output/config.json', JSON.stringify(config, null, '  '));

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -54,6 +54,14 @@ const plugin = function ({ external = [], edge, split } = {}) {
 				}
 			}
 
+			// prerendered assets (data.json and other non-html pages)
+			for (const [src] of builder.prerendered.assets) {
+				prerendered_redirects.push({
+					src,
+					dest: `${builder.config.kit.appDir}/prerendered/${src}`
+				});
+			}
+
 			/** @type {any[]} */
 			const routes = [
 				...prerendered_redirects,


### PR DESCRIPTION
Hello! 
Solves https://github.com/sveltejs/kit/issues/8331

Before prerendered data.json or other non-html pages weren't included in Vercel config. It correctly adds them to it.

I monkey patched the change to my private project and it correctly worked. While fixing I found that it's also applicable to adapter Vercel. However, I'm not familiar with the codebase and the adapters system, so I'm not sure about the correctness of my approach. I'm also not sure about the test for the change but can provide one if given some advice and it's needed 😀

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
