### PR TITLE
[docs] add `@sentry/svelte` import for clarity

### DIFF
--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -164,6 +164,7 @@ const Sentry: any;
 
 // @filename: index.js
 // ---cut---
+import * as Sentry from '@sentry/svelte';
 import crypto from 'crypto';
 
 /** @type {import('@sveltejs/kit').HandleServerError} */
@@ -187,6 +188,8 @@ const Sentry: any;
 
 // @filename: index.js
 // ---cut---
+import * as Sentry from '@sentry/svelte';
+
 /** @type {import('@sveltejs/kit').HandleClientError} */
 export function handleError({ error, event }) {
 	const errorId = crypto.randomUUID();

--- a/documentation/docs/30-advanced/25-errors.md
+++ b/documentation/docs/30-advanced/25-errors.md
@@ -87,6 +87,8 @@ const Sentry: any;
 
 // @filename: index.js
 // ---cut---
+import * as Sentry from '@sentry/svelte';
+
 /** @type {import('@sveltejs/kit').HandleServerError} */
 export function handleError({ error, event }) {
 	// example integration with https://sentry.io/


### PR DESCRIPTION
This addition makes it easier to see that Sentry is providing Svelte SDK.