### PR TITLE
Revert "Improved example code"

### DIFF
--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -90,7 +90,7 @@ export async function load() {
 </script>
 
 <main>
-	<!-- +page.svelte is rendered here -->
+	<!-- +page.svelte is rendered in this <slot> -->
 	<slot />
 </main>
 

--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -90,9 +90,8 @@ export async function load() {
 </script>
 
 <main>
-	<slot>
-		<!-- +page.svelte is rendered here -->
-	</slot>
+	<!-- +page.svelte is rendered here -->
+	<slot />
 </main>
 
 <aside>


### PR DESCRIPTION
Reverts sveltejs/kit#8194. I disagree with that change — in SvelteKit layouts, slots are 'void' in that they can't have fallback content. This change makes it look like you _can_ put stuff inside slots, and almost looks like you're _expected_ to put something there.