### PR TITLE
guarantee that $page.route has the correct shape

### DIFF
--- a/.changeset/quiet-feet-compare.md
+++ b/.changeset/quiet-feet-compare.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Guarantee that $page.route has the correct shape
+Guarantee that `$page.route` has the correct shape

--- a/.changeset/quiet-feet-compare.md
+++ b/.changeset/quiet-feet-compare.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Guarantee that $page.route has the correct shape

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -471,8 +471,7 @@ export function create_client({ target, base }) {
 			data_changed;
 
 		if (page_changed) {
-			/** @type {import('types').Page} */
-			const new_page = {
+			result.props.page = {
 				error,
 				params,
 				route: {
@@ -484,8 +483,6 @@ export function create_client({ target, base }) {
 				// The whole page store is updated, but this way the object reference stays the same
 				data: data_changed ? data : page.data
 			};
-
-			result.props.page = new_page;
 		}
 
 		return result;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -286,7 +286,7 @@ export function create_client({ target, base }) {
 				);
 				return false;
 			}
-		} else if (navigation_result.props?.page?.status >= 400) {
+		} else if (/** @type {number} */ (navigation_result.props?.page?.status) >= 400) {
 			const updated = await stores.updated.check();
 			if (updated) {
 				await native_navigation(url);
@@ -369,7 +369,7 @@ export function create_client({ target, base }) {
 		const style = document.querySelector('style[data-sveltekit]');
 		if (style) style.remove();
 
-		page = result.props.page;
+		page = /** @type {import('types').Page} */ (result.props.page);
 
 		root = new Root({
 			target,
@@ -435,6 +435,7 @@ export function create_client({ target, base }) {
 				route
 			},
 			props: {
+				// @ts-ignore Somehow it's getting SvelteComponent and SvelteComponentDev mixed up
 				components: filtered.map((branch_node) => branch_node.node.component)
 			}
 		};
@@ -470,16 +471,21 @@ export function create_client({ target, base }) {
 			data_changed;
 
 		if (page_changed) {
-			result.props.page = {
+			/** @type {import('types').Page} */
+			const new_page = {
 				error,
 				params,
-				route,
+				route: {
+					id: route?.id ?? null
+				},
 				status,
 				url: new URL(url),
 				form: form ?? null,
 				// The whole page store is updated, but this way the object reference stays the same
 				data: data_changed ? data : page.data
 			};
+
+			result.props.page = new_page;
 		}
 
 		return result;

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -8,7 +8,8 @@ import {
 	preloadCode,
 	preloadData
 } from '$app/navigation';
-import { CSRPageNode, CSRPageNodeLoader, CSRRoute, TrailingSlash, Uses } from 'types';
+import { SvelteComponent } from 'svelte';
+import { CSRPageNode, CSRPageNodeLoader, CSRRoute, Page, TrailingSlash, Uses } from 'types';
 
 export interface Client {
 	// public API, exposed via $app/navigation
@@ -58,7 +59,12 @@ export type NavigationRedirect = {
 export type NavigationFinished = {
 	type: 'loaded';
 	state: NavigationState;
-	props: Record<string, any>;
+	props: {
+		components: Array<typeof SvelteComponent>;
+		page?: Page;
+		form?: Record<string, any> | null;
+		[key: `data_${number}`]: Record<string, any>;
+	};
 };
 
 export type BranchNode = {


### PR DESCRIPTION
fixes #8351. This bug was made possible by lazy typing, so rather than add a new test (since we really need to figure out a way to reduce our reliance on e2e tests) I made the types stricter instead.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
