### PR TITLE
[chore] simplify test for external link

### DIFF
--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -789,19 +789,14 @@ test.describe('Routing', () => {
 	});
 
 	test('does not normalize external path', async ({ page }) => {
-		/** @type {Array<string|undefined>} */
-		const urls = [];
-
 		const { port, close } = await start_server((req, res) => {
-			if (req.url !== '/favicon.ico') urls.push(req.url);
 			res.end('ok');
 		});
 
 		try {
 			await page.goto(`/routing/slashes?port=${port}`);
 			await page.locator(`a[href="http://localhost:${port}/with-slash/"]`).click();
-
-			expect(urls).toEqual(['/with-slash/']);
+			expect(await page.content()).toBe('ok');
 		} finally {
 			await close();
 		}

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -797,6 +797,7 @@ test.describe('Routing', () => {
 			await page.goto(`/routing/slashes?port=${port}`);
 			await page.locator(`a[href="http://localhost:${port}/with-slash/"]`).click();
 			expect(await page.content()).toBe('<html><head></head><body>ok</body></html>');
+			expect(page.url()).toBe(`http://localhost:${port}/with-slash/`);
 		} finally {
 			await close();
 		}

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -789,14 +789,14 @@ test.describe('Routing', () => {
 	});
 
 	test('does not normalize external path', async ({ page }) => {
-		const { port, close } = await start_server((req, res) => {
-			res.end('ok');
+		const { port, close } = await start_server((_req, res) => {
+			res.end('<html><head></head><body>ok</body></html>');
 		});
 
 		try {
 			await page.goto(`/routing/slashes?port=${port}`);
 			await page.locator(`a[href="http://localhost:${port}/with-slash/"]`).click();
-			expect(await page.content()).toBe('ok');
+			expect(await page.content()).toBe('<html><head></head><body>ok</body></html>');
 		} finally {
 			await close();
 		}


### PR DESCRIPTION
This test was flaking (https://github.com/sveltejs/kit/actions/runs/3877364096/jobs/6612302810) and I can't tell why. It hit the tests's timeout limit of 45s, but as far as I can tell there wasn't anything that went wrong. Possibly this code simplification will fix it, but even if not it seemed like a good thing to do regardless