### PR TITLE
[chore] close page before closing server

### DIFF
--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -799,6 +799,7 @@ test.describe('Routing', () => {
 			expect(await page.content()).toBe('<html><head></head><body>ok</body></html>');
 			expect(page.url()).toBe(`http://localhost:${port}/with-slash/`);
 		} finally {
+			await page.close();
 			await close();
 		}
 	});

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -788,7 +788,7 @@ test.describe('Routing', () => {
 		await expect(page.locator('#page-url-hash')).toHaveText('');
 	});
 
-	test('does not normalize external path', async ({ page }) => {
+	test('does not normalize external path', async ({ page, context }) => {
 		const { port, close } = await start_server((_req, res) => {
 			res.end('<html><head></head><body>ok</body></html>');
 		});
@@ -799,7 +799,7 @@ test.describe('Routing', () => {
 			expect(await page.content()).toBe('<html><head></head><body>ok</body></html>');
 			expect(page.url()).toBe(`http://localhost:${port}/with-slash/`);
 		} finally {
-			await page.close();
+			await context.close();
 			await close();
 		}
 	});

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -311,7 +311,7 @@ test.describe('Load', () => {
 		expect(await page.textContent('h1')).toBe(`origin: ${new URL(baseURL).origin}`);
 	});
 
-	test('includes origin header on external request', async ({ page, baseURL }) => {
+	test('includes origin header on external request', async ({ page, baseURL, context }) => {
 		const { port, close } = await start_server((req, res) => {
 			if (req.url === '/') {
 				res.writeHead(200, {
@@ -330,7 +330,7 @@ test.describe('Load', () => {
 			await page.goto(`/load/fetch-origin-external?port=${port}`);
 			expect(await page.textContent('h1')).toBe(`origin: ${new URL(baseURL).origin}`);
 		} finally {
-			await page.close();
+			await context.close();
 			close();
 		}
 	});

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -39,10 +39,12 @@ test.describe('Cookies', () => {
 			}
 		});
 
-		const response = await request.get(`/load/fetch-external-no-cookies?port=${port}`);
-		expect(response.headers()['set-cookie']).not.toContain('external=true');
-
-		close();
+		try {
+			const response = await request.get(`/load/fetch-external-no-cookies?port=${port}`);
+			expect(response.headers()['set-cookie']).not.toContain('external=true');
+		} finally {
+			close();
+		}
 	});
 });
 
@@ -324,10 +326,13 @@ test.describe('Load', () => {
 			}
 		});
 
-		await page.goto(`/load/fetch-origin-external?port=${port}`);
-		expect(await page.textContent('h1')).toBe(`origin: ${new URL(baseURL).origin}`);
-
-		close();
+		try {
+			await page.goto(`/load/fetch-origin-external?port=${port}`);
+			expect(await page.textContent('h1')).toBe(`origin: ${new URL(baseURL).origin}`);
+		} finally {
+			await page.close();
+			close();
+		}
 	});
 });
 

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -819,6 +819,7 @@ test.describe('Load', () => {
 			expect(requested_urls).toEqual(['/server-fetch-request-modified.json']);
 			expect(await page.textContent('h1')).toBe('the answer is 42');
 		} finally {
+			await page.close();
 			await close();
 		}
 	});
@@ -1584,6 +1585,7 @@ test.describe('Routing', () => {
 				page.waitForURL(`http://localhost:${port}/`)
 			]);
 		} finally {
+			await page.close();
 			await close();
 		}
 	});

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -793,7 +793,7 @@ test.describe('Load', () => {
 		expect(await page.textContent('h1')).toBe('text.length is 5000000');
 	});
 
-	test('handles external api', async ({ page }) => {
+	test('handles external api', async ({ page, context }) => {
 		/** @type {string[]} */
 		const requested_urls = [];
 
@@ -819,7 +819,7 @@ test.describe('Load', () => {
 			expect(requested_urls).toEqual(['/server-fetch-request-modified.json']);
 			expect(await page.textContent('h1')).toBe('the answer is 42');
 		} finally {
-			await page.close();
+			await context.close();
 			await close();
 		}
 	});
@@ -1574,7 +1574,7 @@ test.describe('Routing', () => {
 		expect(await page.textContent('h2')).toBe('y-z');
 	});
 
-	test('ignores navigation to URLs the app does not own', async ({ page }) => {
+	test('ignores navigation to URLs the app does not own', async ({ page, context }) => {
 		const { port, close } = await start_server((req, res) => res.end('ok'));
 
 		try {
@@ -1585,7 +1585,7 @@ test.describe('Routing', () => {
 				page.waitForURL(`http://localhost:${port}/`)
 			]);
 		} finally {
-			await page.close();
+			await context.close();
 			await close();
 		}
 	});

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -118,11 +118,13 @@ test.describe('CSP', () => {
 			}
 		});
 
-		await page.goto(`/path-base/csp?port=${port}`);
-
-		expect(await page.evaluate('window.pwned')).toBe(undefined);
-
-		await close();
+		try {
+			await page.goto(`/path-base/csp?port=${port}`);
+			expect(await page.evaluate('window.pwned')).toBe(undefined);
+		} finally {
+			await page.close();
+			await close();
+		}
 	});
 
 	test("quotes 'script'", async ({ page }) => {

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -105,7 +105,7 @@ test.describe('assets path', () => {
 });
 
 test.describe('CSP', () => {
-	test('blocks script from external site', async ({ page }) => {
+	test('blocks script from external site', async ({ page, context }) => {
 		const { port, close } = await start_server((req, res) => {
 			if (req.url === '/blocked.js') {
 				res.writeHead(200, {
@@ -122,7 +122,7 @@ test.describe('CSP', () => {
 			await page.goto(`/path-base/csp?port=${port}`);
 			expect(await page.evaluate('window.pwned')).toBe(undefined);
 		} finally {
-			await page.close();
+			await context.close();
 			await close();
 		}
 	});


### PR DESCRIPTION
It seems the server may not be closing. The docs for `server.close` say "the server is finally closed when all connections are ended". Try doing `context.close()` first to see if it kills any dangling connections.