### PR TITLE
Create package.json in the adapter-node build

### DIFF
--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -75,6 +75,11 @@ export default function (opts = {}) {
 					ENV_PREFIX: JSON.stringify(envPrefix)
 				}
 			});
+
+			writeFileSync(
+				`${out}/package.json`,
+				JSON.stringify({type: 'module'})
+			);
 		}
 	};
 }


### PR DESCRIPTION
Currently `adapter-node` produces a build that does not include any `package.json` file. As long as the build is kept inside the project directory, there is no problem (node reads the package.json higher up the file tree). But once the build dir is copied elsewhere (or just the build target is placed somewhere outside the project dir), it does not work. Instead `node server.js` returns the following error:

```js
(node:13771) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
/path/to/build/index.js:1
import { handler } from './handler.js';
^^^^^^

SyntaxError: Cannot use import statement outside a module
```

The solution is to create a `package.json` inside the build dir.

I'm not very familiar with the project and best practices. Currently in this PR I am just writing the minimal `{"type":"module"}` content that allows node to run. I'll be happy if anyone more knowledgable helps with a better `package.json` or a more proper way to create the file.

Fixes #8339. Also [this](https://www.reddit.com/r/sveltejs/comments/108ayfb/sveltekit_adapternode_deploy/) report and some discord threads like [this one](https://discord.com/channels/457912077277855764/1023340103071965194/threads/1060883830078185472). Seems like a fairly common issue.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
