### PR TITLE
[chore] consistently await server close

### DIFF
--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -43,7 +43,7 @@ test.describe('Cookies', () => {
 			const response = await request.get(`/load/fetch-external-no-cookies?port=${port}`);
 			expect(response.headers()['set-cookie']).not.toContain('external=true');
 		} finally {
-			close();
+			await close();
 		}
 	});
 });
@@ -331,7 +331,7 @@ test.describe('Load', () => {
 			expect(await page.textContent('h1')).toBe(`origin: ${new URL(baseURL).origin}`);
 		} finally {
 			await context.close();
-			close();
+			await close();
 		}
 	});
 });


### PR DESCRIPTION
@dominikg noticed everywhere else we do `await close()`, but not here. It probably makes sense to be consistent