### PR TITLE
[chore] fix console warnings in tests

### DIFF
--- a/packages/kit/test/apps/amp/src/app.html
+++ b/packages/kit/test/apps/amp/src/app.html
@@ -7,6 +7,6 @@
 		%sveltekit.head%
 	</head>
 	<body>
-		<div style="display:contents">%sveltekit.body%</div>
+		<div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/packages/kit/test/apps/amp/src/app.html
+++ b/packages/kit/test/apps/amp/src/app.html
@@ -7,6 +7,8 @@
 		%sveltekit.head%
 	</head>
 	<body>
-		%sveltekit.body%
+		<div style="display:contents">
+			%sveltekit.body%
+		</div>
 	</body>
 </html>

--- a/packages/kit/test/apps/amp/src/app.html
+++ b/packages/kit/test/apps/amp/src/app.html
@@ -7,8 +7,6 @@
 		%sveltekit.head%
 	</head>
 	<body>
-		<div style="display:contents">
-			%sveltekit.body%
-		</div>
+		<div style="display:contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/packages/kit/test/apps/options-2/src/app.html
+++ b/packages/kit/test/apps/options-2/src/app.html
@@ -6,6 +6,8 @@
 		%sveltekit.head%
 	</head>
 	<body>
-		%sveltekit.body%
+		<div style="display:contents">
+			%sveltekit.body%
+		</div>
 	</body>
 </html>

--- a/packages/kit/test/apps/options-2/src/app.html
+++ b/packages/kit/test/apps/options-2/src/app.html
@@ -6,8 +6,6 @@
 		%sveltekit.head%
 	</head>
 	<body>
-		<div style="display:contents">
-			%sveltekit.body%
-		</div>
+		<div style="display:contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/packages/kit/test/apps/options-2/src/app.html
+++ b/packages/kit/test/apps/options-2/src/app.html
@@ -6,6 +6,6 @@
 		%sveltekit.head%
 	</head>
 	<body>
-		<div style="display:contents">%sveltekit.body%</div>
+		<div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/packages/kit/test/apps/writes/src/app.html
+++ b/packages/kit/test/apps/writes/src/app.html
@@ -7,6 +7,6 @@
 		%sveltekit.head%
 	</head>
 	<body>
-		<div style="display:contents">%sveltekit.body%</div>
+		<div style="display: contents">%sveltekit.body%</div>
 	</body>
 </html>

--- a/packages/kit/test/apps/writes/src/app.html
+++ b/packages/kit/test/apps/writes/src/app.html
@@ -7,6 +7,8 @@
 		%sveltekit.head%
 	</head>
 	<body>
-		%sveltekit.body%
+		<div style="display:contents">
+			%sveltekit.body%
+		</div>
 	</body>
 </html>

--- a/packages/kit/test/apps/writes/src/app.html
+++ b/packages/kit/test/apps/writes/src/app.html
@@ -7,8 +7,6 @@
 		%sveltekit.head%
 	</head>
 	<body>
-		<div style="display:contents">
-			%sveltekit.body%
-		</div>
+		<div style="display:contents">%sveltekit.body%</div>
 	</body>
 </html>


### PR DESCRIPTION
It's printing a warning that `%sveltekit.body%` needs to be contained within another element, which is cluttering up the console