### PR TITLE
[fix] prerendered endpoint callable from non-prerendered server load

### DIFF
--- a/.changeset/angry-ways-divide.md
+++ b/.changeset/angry-ways-divide.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] prerendered endpoint callable from non-prerendered server load

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -31,6 +31,8 @@ export async function render_data(
 		});
 	}
 
+	state.initiator = route;
+
 	try {
 		const node_ids = [...route.page.layouts, route.page.leaf];
 		const invalidated = invalidated_data_nodes ?? node_ids.map(() => true);

--- a/packages/kit/test/apps/basics/src/routes/prerendering/prerendered-endpoint/api/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/prerendering/prerendered-endpoint/api/+server.js
@@ -1,0 +1,7 @@
+import { json } from '@sveltejs/kit';
+
+export const prerender = true;
+
+export function GET() {
+	return json({ message: 'Im prerendered and called from a non-prerendered +page.server.js' });
+}

--- a/packages/kit/test/apps/basics/src/routes/prerendering/prerendered-endpoint/page/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/prerendering/prerendered-endpoint/page/+page.server.js
@@ -1,0 +1,6 @@
+/** @type {import('./$types').PageServerLoad} */
+export async function load({ fetch }) {
+	const res = await fetch('/prerendering/prerendered-endpoint/api');
+	const json = await res.json();
+	return json;
+}

--- a/packages/kit/test/apps/basics/src/routes/prerendering/prerendered-endpoint/page/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/prerendering/prerendered-endpoint/page/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let data;
+</script>
+
+<h1>{data.message}</h1>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -940,6 +940,23 @@ test.describe('Load', () => {
 
 		expect(await page.textContent('h1')).toBe('true');
 	});
+
+	test('Prerendered +server.js called from a non-prerendered +page.server.js works', async ({
+		page,
+		app,
+		javaScriptEnabled
+	}) => {
+		if (javaScriptEnabled) {
+			await page.goto('/');
+			await app.goto('/prerendering/prerendered-endpoint/page');
+		} else {
+			await page.goto('/prerendering/prerendered-endpoint/page');
+		}
+
+		expect(await page.textContent('h1')).toBe(
+			'Im prerendered and called from a non-prerendered +page.server.js'
+		);
+	});
 });
 
 test.describe('Nested layouts', () => {


### PR DESCRIPTION
Fixes #8341

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
