### PR TITLE
[fix] no false positive warnings for fetch uses in firefox

### DIFF
--- a/.changeset/shy-readers-help.md
+++ b/.changeset/shy-readers-help.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] no false positive warnings for fetch uses in firefox

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -24,12 +24,20 @@ if (DEV) {
 	check_stack_trace();
 
 	window.fetch = (input, init) => {
+		// Check if fetch was called via load_node. the lock method only checks if it was called at the
+		// same time, but not necessarily if it was called from `load`.
+		// We use just the filename as the method name sometimes does not appear on the CI.
 		const url = input instanceof Request ? input.url : input.toString();
-		const stack = /** @type {string} */ (new Error().stack);
+		const stack_array = /** @type {string} */ (new Error().stack).split('\n');
+		// We need to do some Firefox-specific cutoff because it (impressively) maintains the stack
+		// across events and for example traces a `fetch` call triggered from a button back
+		// to the creation of the event listener and the element creation itself,
+		// where at some point client.js will show up, leading to false positives.
+		const firefox_cutoff = stack_array.findIndex((a) => a.includes('*listen@'));
+		const stack = stack_array
+			.slice(0, firefox_cutoff !== -1 ? firefox_cutoff : undefined)
+			.join('\n');
 
-		// check if fetch was called via load_node. the lock method only checks if it was called at the
-		// same time, but not necessarily if it was called from `load`
-		// we use just the filename as the method name sometimes does not appear on the CI
 		const heuristic = can_inspect_stack_trace
 			? stack.includes('src/runtime/client/client.js')
 			: loading;


### PR DESCRIPTION
fixes #7992

Pretty impressive how Firefox traces things across listeners/async. This is the stack trace for a `<button on:click={() => fetch('/')}>fetch</button>`:

```
window.fetch@http://127.0.0.1:5173/@fs/REDACTED/svelte-kit/packages/kit/src/runtime/client/fetcher.js?t=1673437793682:31:46
click_handler@http://127.0.0.1:5173/src/routes/+page.svelte:303:35
EventListener.handleEvent*listen@http://127.0.0.1:5173/node_modules/.vite/deps/chunk-P54SLY7E.js?v=e5cdb4e8:360:8
listen_dev@http://127.0.0.1:5173/node_modules/.vite/deps/chunk-P54SLY7E.js?v=e5cdb4e8:1891:25
mount@http://127.0.0.1:5173/src/routes/+page.svelte:239:15
createProxiedComponent/instrument/targetCmp.$$.fragment.m@http://127.0.0.1:5173/@fs/REDACTED/svelte-kit/node_modules/.pnpm/svelte-hmr@0.15.1_svelte@3.55.0/node_modules/svelte-hmr/runtime/svelte-hooks.js?v=e5cdb4e8:291:25
mount_component@http://127.0.0.1:5173/node_modules/.vite/deps/chunk-P54SLY7E.js?v=e5cdb4e8:1691:24
mount@http://127.0.0.1:5173/.svelte-kit/generated/root.svelte:252:40
mount@http://127.0.0.1:5173/.svelte-kit/generated/root.svelte:522:40
mount@http://127.0.0.1:5173/src/routes/+layout.svelte:803:18
createProxiedComponent/instrument/targetCmp.$$.fragment.m@http://127.0.0.1:5173/@fs/REDACTED/svelte-kit/node_modules/.pnpm/svelte-hmr@0.15.1_svelte@3.55.0/node_modules/svelte-hmr/runtime/svelte-hooks.js?v=e5cdb4e8:291:25
mount_component@http://127.0.0.1:5173/node_modules/.vite/deps/chunk-P54SLY7E.js?v=e5cdb4e8:1691:24
mount@http://127.0.0.1:5173/.svelte-kit/generated/root.svelte:159:40
mount@http://127.0.0.1:5173/.svelte-kit/generated/root.svelte:718:40
mount_component@http://127.0.0.1:5173/node_modules/.vite/deps/chunk-P54SLY7E.js?v=e5cdb4e8:1691:24
init@http://127.0.0.1:5173/node_modules/.vite/deps/chunk-P54SLY7E.js?v=e5cdb4e8:1770:20
Root@http://127.0.0.1:5173/.svelte-kit/generated/root.svelte:916:7
createProxiedComponent@http://127.0.0.1:5173/@fs/REDACTED/svelte-kit/node_modules/.pnpm/svelte-hmr@0.15.1_svelte@3.55.0/node_modules/svelte-hmr/runtime/svelte-hooks.js?v=e5cdb4e8:341:9
ProxyComponent@http://127.0.0.1:5173/@fs/REDACTED/svelte-kit/node_modules/.pnpm/svelte-hmr@0.15.1_svelte@3.55.0/node_modules/svelte-hmr/runtime/proxy.js?v=e5cdb4e8:242:29
Proxy<Root>@http://127.0.0.1:5173/@fs/REDACTED/svelte-kit/node_modules/.pnpm/svelte-hmr@0.15.1_svelte@3.55.0/node_modules/svelte-hmr/runtime/proxy.js?v=e5cdb4e8:349:11
initialize@http://127.0.0.1:5173/@fs/REDACTED/svelte-kit/packages/kit/src/runtime/client/client.js?t=1673437793682:374:10
_hydrate@http://127.0.0.1:5173/@fs/REDACTED/svelte-kit/packages/kit/src/runtime/client/client.js?t=1673437793682:1630:14
async*start@http://127.0.0.1:5173/@fs/repos/svelte/svelte-kit/packages/kit/src/runtime/client/start.js:39:16
@http://127.0.0.1:5173/:1184:9
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
