### PR TITLE
[fix] avoid unnecessary $page store updates

### DIFF
--- a/.changeset/wise-otters-swim.md
+++ b/.changeset/wise-otters-swim.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+[fix] avoid unnecessary $page store updates

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -467,7 +467,7 @@ export function create_client({ target, base }) {
 			!current.url ||
 			url.href !== current.url.href ||
 			current.error !== error ||
-			form !== undefined ||
+			(form !== undefined && form !== page.form) ||
 			data_changed;
 
 		if (page_changed) {

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -26,7 +26,7 @@ export interface Client {
 	// private API
 	_hydrate(opts: {
 		status: number;
-		error: App.Error;
+		error: App.Error | null;
 		node_ids: number[];
 		params: Record<string, string>;
 		route: { id: string | null };

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -157,7 +157,7 @@ export async function render_response({
 	/** @param {string} path */
 	const prefixed = (path) => (path.startsWith('/') ? path : `${assets}/${path}`);
 
-	const serialized = { data: '', form: 'null' };
+	const serialized = { data: '', form: 'null', error: 'null' };
 
 	try {
 		serialized.data = `[${branch
@@ -193,6 +193,10 @@ export async function render_response({
 
 	if (form_value) {
 		serialized.form = uneval_action_response(form_value, /** @type {string} */ (event.route.id));
+	}
+
+	if (error) {
+		serialized.error = devalue.uneval(error);
 	}
 
 	if (inline_styles.size > 0) {
@@ -255,15 +259,12 @@ export async function render_response({
 			const hydrate = [
 				`node_ids: [${branch.map(({ node }) => node.index).join(', ')}]`,
 				`data: ${serialized.data}`,
-				`form: ${serialized.form}`
+				`form: ${serialized.form}`,
+				`error: ${serialized.error}`
 			];
 
 			if (status !== 200) {
 				hydrate.push(`status: ${status}`);
-			}
-
-			if (error) {
-				hydrate.push(`error: ${devalue.uneval(error)}`);
 			}
 
 			if (options.embedded) {


### PR DESCRIPTION
Clicking a page link and staying on the same page with nothing changing still changed the $page.store, because
- form was always !== undefined (it's null)
- $page.error was set to undefined after hydration, but it should be null

No test because it's super silly to e2e test this - we really need `client.js` to be unit-testable.
Discovered while investigating another issue which is no longer reproducible.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
