### PR TITLE
feat: support for `ServerlessFunctionConfig` and `EdgeFunctionConfig`

### DIFF
--- a/.changeset/wet-hats-listen.md
+++ b/.changeset/wet-hats-listen.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-vercel': minor
 ---
 
-adding support for ServerlessFunctionConfig and EdgeFunctionConfig
+feat: support for `ServerlessFunctionConfig` and `EdgeFunctionConfig`

--- a/.changeset/wet-hats-listen.md
+++ b/.changeset/wet-hats-listen.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': minor
+---
+
+adding support for ServerlessFunctionConfig and EdgeFunctionConfig

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -1,9 +1,16 @@
 import { Adapter } from '@sveltejs/kit';
 
+type ServerlessFunctionConfig = {
+	memory?: number;
+	maxDuration?: number;
+	regions?: string[];
+};
+
 type Options = {
 	edge?: boolean;
 	external?: string[];
 	split?: boolean;
+	serverlessFunctionConfig?: ServerlessFunctionConfig;
 };
 
 export default function plugin(options?: Options): Adapter;

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -6,11 +6,17 @@ type ServerlessFunctionConfig = {
 	regions?: string[];
 };
 
+type EdgeFunctionConfig = {
+	envVarsInUse?: string[];
+	regions?: 'all' | string | string[];
+};
+
 type Options = {
 	edge?: boolean;
 	external?: string[];
 	split?: boolean;
 	serverlessFunctionConfig?: ServerlessFunctionConfig;
+	edgeFunctionConfig?: EdgeFunctionConfig;
 };
 
 export default function plugin(options?: Options): Adapter;

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -10,7 +10,7 @@ const plugin = function ({
 	edge,
 	split,
 	serverlessFunctionConfig,
-	edgeFunctionConfig
+	edgeFunctionConfig: { envVarsInUse, regions }
 } = {}) {
 	return {
 		name: '@sveltejs/adapter-vercel',
@@ -102,9 +102,10 @@ const plugin = function ({
 				write(
 					`${dirs.functions}/${name}.func/.vc-config.json`,
 					JSON.stringify({
-						...edgeFunctionConfig,
 						runtime: 'edge',
-						entrypoint: 'index.js'
+						entrypoint: 'index.js',
+						envVarsInUse,
+						regions
 					})
 				);
 
@@ -237,7 +238,13 @@ function static_vercel_config(builder) {
  * @param {string} runtime
  * @param {import('.').ServerlessFunctionConfig} serverlessFunctionConfig
  */
-async function create_function_bundle(builder, entry, dir, runtime, serverlessFunctionConfig) {
+async function create_function_bundle(
+	builder,
+	entry,
+	dir,
+	runtime,
+	{ memory, maxDuration, regions }
+) {
 	fs.rmSync(dir, { force: true, recursive: true });
 
 	let base = entry;
@@ -331,10 +338,12 @@ async function create_function_bundle(builder, entry, dir, runtime, serverlessFu
 	write(
 		`${dir}/.vc-config.json`,
 		JSON.stringify({
-			...serverlessFunctionConfig,
 			runtime,
 			handler: path.relative(base + ancestor, entry),
-			launcherType: 'Nodejs'
+			launcherType: 'Nodejs',
+			memory,
+			maxDuration,
+			regions
 		})
 	);
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -5,7 +5,13 @@ import { nodeFileTrace } from '@vercel/nft';
 import esbuild from 'esbuild';
 
 /** @type {import('.').default} **/
-const plugin = function ({ external = [], edge, split, serverlessFunctionConfig } = {}) {
+const plugin = function ({
+	external = [],
+	edge,
+	split,
+	serverlessFunctionConfig,
+	edgeFunctionConfig
+} = {}) {
 	return {
 		name: '@sveltejs/adapter-vercel',
 
@@ -96,9 +102,9 @@ const plugin = function ({ external = [], edge, split, serverlessFunctionConfig 
 				write(
 					`${dirs.functions}/${name}.func/.vc-config.json`,
 					JSON.stringify({
+						...edgeFunctionConfig,
 						runtime: 'edge',
 						entrypoint: 'index.js'
-						// TODO expose envVarsInUse
 					})
 				);
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -5,7 +5,7 @@ import { nodeFileTrace } from '@vercel/nft';
 import esbuild from 'esbuild';
 
 /** @type {import('.').default} **/
-const plugin = function ({ external = [], edge, split } = {}) {
+const plugin = function ({ external = [], edge, split, serverlessFunctionConfig } = {}) {
 	return {
 		name: '@sveltejs/adapter-vercel',
 
@@ -53,7 +53,8 @@ const plugin = function ({ external = [], edge, split } = {}) {
 					builder,
 					`${tmp}/index.js`,
 					`${dirs.functions}/${name}.func`,
-					`nodejs${node_version.major}.x`
+					`nodejs${node_version.major}.x`,
+					serverlessFunctionConfig
 				);
 
 				config.routes.push({ src: pattern, dest: `/${name}` });
@@ -228,8 +229,9 @@ function static_vercel_config(builder) {
  * @param {string} entry
  * @param {string} dir
  * @param {string} runtime
+ * @param {import('.').ServerlessFunctionConfig} serverlessFunctionConfig
  */
-async function create_function_bundle(builder, entry, dir, runtime) {
+async function create_function_bundle(builder, entry, dir, runtime, serverlessFunctionConfig) {
 	fs.rmSync(dir, { force: true, recursive: true });
 
 	let base = entry;
@@ -323,6 +325,7 @@ async function create_function_bundle(builder, entry, dir, runtime) {
 	write(
 		`${dir}/.vc-config.json`,
 		JSON.stringify({
+			...serverlessFunctionConfig,
 			runtime,
 			handler: path.relative(base + ancestor, entry),
 			launcherType: 'Nodejs'


### PR DESCRIPTION
Adding support for :
- `memory`, `maxDuration` and `regions` for Serverless Functions
- `envVarsInUse` and `regions` for Edge Functions

I tried to keep the types structure defined here: https://vercel.com/docs/build-output-api/v3 without breaking the current API.

Limitation: settings **cannot** be defined on a by function basis when using `split = true`, they are applied globaly.

Maybe there is a nicer API for this, but for now:
```javascript

import vercel from '@sveltejs/adapter-vercel';

export default {
  kit: {
    adapter: vercel({
      serverlessFunctionConfig: {
          memory: 1024,
          maxDuration: 10,
          regions: ['cdg1']
      },
    })
  }
};
```
and on the edge:
```javascript

import vercel from '@sveltejs/adapter-vercel';

export default {
  kit: {
    adapter: vercel({
      edge: true,
      edgeFunctionConfig: {
          envVarsInUse: ['ENV1'],
          regions: ['cdg1']
      }
    })
  }
};
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
