### PR TITLE
chore: move `start_server` util in tests into a fixture

### DIFF
--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { start_server, test } from '../../../utils.js';
+import { test } from '../../../utils.js';
 
 /** @typedef {import('@playwright/test').Response} Response */
 
@@ -788,20 +788,16 @@ test.describe('Routing', () => {
 		await expect(page.locator('#page-url-hash')).toHaveText('');
 	});
 
-	test('does not normalize external path', async ({ page, context }) => {
-		const { port, close } = await start_server((_req, res) => {
-			res.end('<html><head></head><body>ok</body></html>');
+	test('does not normalize external path', async ({ page, start_server }) => {
+		const html_ok = '<html><head></head><body>ok</body></html>';
+		const { port } = await start_server((_req, res) => {
+			res.end(html_ok);
 		});
 
-		try {
-			await page.goto(`/routing/slashes?port=${port}`);
-			await page.locator(`a[href="http://localhost:${port}/with-slash/"]`).click();
-			expect(await page.content()).toBe('<html><head></head><body>ok</body></html>');
-			expect(page.url()).toBe(`http://localhost:${port}/with-slash/`);
-		} finally {
-			await context.close();
-			await close();
-		}
+		await page.goto(`/routing/slashes?port=${port}`);
+		await page.locator(`a[href="http://localhost:${port}/with-slash/"]`).click();
+		expect(await page.content()).toBe(html_ok);
+		expect(page.url()).toBe(`http://localhost:${port}/with-slash/`);
 	});
 
 	test('ignores popstate events from outside the router', async ({ page }) => {

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { start_server, test } from '../../../utils.js';
+import { test } from '../../../utils.js';
 import { fetch } from 'undici';
 import { createHash, randomBytes } from 'node:crypto';
 
@@ -24,8 +24,8 @@ test.describe('Content-Type', () => {
 });
 
 test.describe('Cookies', () => {
-	test('does not forward cookies from external domains', async ({ request }) => {
-		const { close, port } = await start_server(async (req, res) => {
+	test('does not forward cookies from external domains', async ({ request, start_server }) => {
+		const { port } = await start_server(async (req, res) => {
 			if (req.url === '/') {
 				res.writeHead(200, {
 					'set-cookie': 'external=true',
@@ -39,12 +39,8 @@ test.describe('Cookies', () => {
 			}
 		});
 
-		try {
-			const response = await request.get(`/load/fetch-external-no-cookies?port=${port}`);
-			expect(response.headers()['set-cookie']).not.toContain('external=true');
-		} finally {
-			close();
-		}
+		const response = await request.get(`/load/fetch-external-no-cookies?port=${port}`);
+		expect(response.headers()['set-cookie']).not.toContain('external=true');
 	});
 });
 
@@ -311,8 +307,8 @@ test.describe('Load', () => {
 		expect(await page.textContent('h1')).toBe(`origin: ${new URL(baseURL).origin}`);
 	});
 
-	test('includes origin header on external request', async ({ page, baseURL, context }) => {
-		const { port, close } = await start_server((req, res) => {
+	test('includes origin header on external request', async ({ page, baseURL, start_server }) => {
+		const { port } = await start_server((req, res) => {
 			if (req.url === '/') {
 				res.writeHead(200, {
 					'content-type': 'application/json',
@@ -326,13 +322,8 @@ test.describe('Load', () => {
 			}
 		});
 
-		try {
-			await page.goto(`/load/fetch-origin-external?port=${port}`);
-			expect(await page.textContent('h1')).toBe(`origin: ${new URL(baseURL).origin}`);
-		} finally {
-			await context.close();
-			close();
-		}
+		await page.goto(`/load/fetch-origin-external?port=${port}`);
+		expect(await page.textContent('h1')).toBe(`origin: ${new URL(baseURL).origin}`);
 	});
 });
 

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { start_server, test } from '../../../utils.js';
+import { test } from '../../../utils.js';
 
 /** @typedef {import('@playwright/test').Response} Response */
 
@@ -793,11 +793,11 @@ test.describe('Load', () => {
 		expect(await page.textContent('h1')).toBe('text.length is 5000000');
 	});
 
-	test('handles external api', async ({ page, context }) => {
+	test('handles external api', async ({ page, start_server }) => {
 		/** @type {string[]} */
 		const requested_urls = [];
 
-		const { port, close } = await start_server(async (req, res) => {
+		const { port } = await start_server(async (req, res) => {
 			requested_urls.push(req.url);
 
 			if (req.url === '/server-fetch-request-modified.json') {
@@ -813,15 +813,10 @@ test.describe('Load', () => {
 			}
 		});
 
-		try {
-			await page.goto(`/load/server-fetch-request?port=${port}`);
+		await page.goto(`/load/server-fetch-request?port=${port}`);
 
-			expect(requested_urls).toEqual(['/server-fetch-request-modified.json']);
-			expect(await page.textContent('h1')).toBe('the answer is 42');
-		} finally {
-			await context.close();
-			await close();
-		}
+		expect(requested_urls).toEqual(['/server-fetch-request-modified.json']);
+		expect(await page.textContent('h1')).toBe('the answer is 42');
 	});
 
 	test('makes credentialed fetches to endpoints by default', async ({
@@ -1574,20 +1569,15 @@ test.describe('Routing', () => {
 		expect(await page.textContent('h2')).toBe('y-z');
 	});
 
-	test('ignores navigation to URLs the app does not own', async ({ page, context }) => {
-		const { port, close } = await start_server((req, res) => res.end('ok'));
+	test('ignores navigation to URLs the app does not own', async ({ page, start_server }) => {
+		const { port } = await start_server((req, res) => res.end('ok'));
 
-		try {
-			await page.goto(`/routing?port=${port}`);
-			await Promise.all([
-				page.click(`[href="http://localhost:${port}"]`),
-				// assert that the app can visit a URL not owned by the app without crashing
-				page.waitForURL(`http://localhost:${port}/`)
-			]);
-		} finally {
-			await context.close();
-			await close();
-		}
+		await page.goto(`/routing?port=${port}`);
+		await Promise.all([
+			page.click(`[href="http://localhost:${port}"]`),
+			// assert that the app can visit a URL not owned by the app without crashing
+			page.waitForURL(`http://localhost:${port}/`)
+		]);
 	});
 
 	test('navigates to ...rest', async ({ page, clicknav }) => {

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { start_server, test } from '../../../utils.js';
+import { test } from '../../../utils.js';
 
 /** @typedef {import('@playwright/test').Response} Response */
 
@@ -105,8 +105,8 @@ test.describe('assets path', () => {
 });
 
 test.describe('CSP', () => {
-	test('blocks script from external site', async ({ page, context }) => {
-		const { port, close } = await start_server((req, res) => {
+	test('blocks script from external site', async ({ page, start_server }) => {
+		const { port } = await start_server((req, res) => {
 			if (req.url === '/blocked.js') {
 				res.writeHead(200, {
 					'content-type': 'text/javascript'
@@ -118,13 +118,8 @@ test.describe('CSP', () => {
 			}
 		});
 
-		try {
-			await page.goto(`/path-base/csp?port=${port}`);
-			expect(await page.evaluate('window.pwned')).toBe(undefined);
-		} finally {
-			await context.close();
-			await close();
-		}
+		await page.goto(`/path-base/csp?port=${port}`);
+		expect(await page.evaluate('window.pwned')).toBe(undefined);
 	});
 
 	test("quotes 'script'", async ({ page }) => {

--- a/packages/kit/test/utils.d.ts
+++ b/packages/kit/test/utils.d.ts
@@ -6,7 +6,7 @@ import {
 	PlaywrightWorkerOptions,
 	TestType
 } from '@playwright/test';
-import http, { IncomingMessage, ServerResponse } from 'http';
+import { IncomingMessage, ServerResponse } from 'http';
 import { Plugin } from 'vite';
 
 export const test: TestType<
@@ -27,7 +27,7 @@ export const test: TestType<
 			 */
 			read_errors(href: string): Record<string, any>;
 			start_server(
-				handler: (req: http.IncomingMessage, res: http.ServerResponse) => void
+				handler: (req: IncomingMessage, res: ServerResponse) => void
 			): Promise<{ port: number }>;
 			page: PlaywrightTestArgs['page'] & {
 				goto: (

--- a/packages/kit/test/utils.d.ts
+++ b/packages/kit/test/utils.d.ts
@@ -6,7 +6,7 @@ import {
 	PlaywrightWorkerOptions,
 	TestType
 } from '@playwright/test';
-import { IncomingMessage, ServerResponse } from 'http';
+import http, { IncomingMessage, ServerResponse } from 'http';
 import { Plugin } from 'vite';
 
 export const test: TestType<
@@ -26,6 +26,9 @@ export const test: TestType<
 			 * `handleError` defines the shape
 			 */
 			read_errors(href: string): Record<string, any>;
+			start_server(
+				handler: (req: http.IncomingMessage, res: http.ServerResponse) => void
+			): Promise<{ port: number }>;
 			page: PlaywrightTestArgs['page'] & {
 				goto: (
 					url: string,
@@ -37,13 +40,5 @@ export const test: TestType<
 >;
 
 export const config: PlaywrightTestConfig;
-
-export const start_server: (
-	handler: (req: IncomingMessage, res: ServerResponse) => void,
-	start?: number
-) => Promise<{
-	port: number;
-	close(): Promise<void>;
-}>;
 
 export const plugin: () => Plugin;

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -154,6 +154,19 @@ export const test = base.extend({
 				});
 			});
 		}
+	},
+
+	// make sure context fixture depends on start server, so setup/teardown order is
+	// setup start_server
+	// setup context
+	// teardown context
+	// teardown start_server
+	context: function ({ context, start_server }, use) {
+		// just here make sure start_server is referenced, don't call
+		if (!start_server) {
+			throw new Error('start_server fixture not present');
+		}
+		use(context);
 	}
 });
 

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -100,7 +100,7 @@ export const test = base.extend({
 		await use(page);
 	},
 
-	read_errors: async ({}, use) => {
+	read_errors: ({}, use) => {
 		/** @param {string} path */
 		function read_errors(path) {
 			const errors =


### PR DESCRIPTION
so we don't have to try/finally inside the tests and leave playwright created contexrt alone

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. All changesets should be `patch` until SvelteKit 1.0
