### PR TITLE
feat: add preprocessor warning about common mistakes

### DIFF
--- a/.changeset/nine-pets-join.md
+++ b/.changeset/nine-pets-join.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: warn when usage of page options in `.svelte` files is detected

--- a/.changeset/nine-pets-join.md
+++ b/.changeset/nine-pets-join.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': minor
 ---
 
-feat: warn when usage of page options in `.svelte` files is detected
+feat: warn when usage of page options in `.svelte` files or missing `<slot />` in layout is detected

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -86,6 +86,21 @@ const warning_preprocessor = {
 				);
 			}
 		}
+	},
+	markup: ({ content, filename }) => {
+		if (!filename) {
+			return;
+		}
+		const basename = path.basename(filename);
+		if (basename.startsWith('+layout.') && !content.includes('<slot')) {
+			console.log(
+				colors.yellow(
+					`${colors.bold('<slot />')} element is missing in ${colors.bold(
+						filename
+					)}, inner content will not be rendered.`
+				)
+			);
+		}
 	}
 };
 


### PR DESCRIPTION
Uses a preprocessor to check the script contents of Svelte files for "export const prerender/csr/ssr/trailingsSlash =" or a missing `<slot />` in case of a layout file
closes #7411
closes #7773

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
