### PR TITLE
fix: don't load ambient worker types

### DIFF
--- a/.changeset/eleven-rules-sleep.md
+++ b/.changeset/eleven-rules-sleep.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+'@sveltejs/adapter-cloudflare-workers': patch
+---
+
+fix: don't load ambient worker types

--- a/packages/adapter-cloudflare-workers/ambient.d.ts
+++ b/packages/adapter-cloudflare-workers/ambient.d.ts
@@ -1,10 +1,12 @@
-/// <reference types="@cloudflare/workers-types" />
+import { Cache, CacheStorage } from '@cloudflare/workers-types';
 
-declare namespace App {
-	export interface Platform {
-		context?: {
-			waitUntil(promise: Promise<any>): void;
-		};
-		caches?: CacheStorage & { default: Cache };
+declare global {
+	namespace App {
+		export interface Platform {
+			context?: {
+				waitUntil(promise: Promise<any>): void;
+			};
+			caches?: CacheStorage & { default: Cache };
+		}
 	}
 }

--- a/packages/adapter-cloudflare/ambient.d.ts
+++ b/packages/adapter-cloudflare/ambient.d.ts
@@ -1,10 +1,12 @@
-/// <reference types="@cloudflare/workers-types" />
+import { Cache, CacheStorage } from '@cloudflare/workers-types';
 
-declare namespace App {
-	export interface Platform {
-		context?: {
-			waitUntil(promise: Promise<any>): void;
-		};
-		caches?: CacheStorage & { default: Cache };
+declare global {
+	namespace App {
+		export interface Platform {
+			context?: {
+				waitUntil(promise: Promise<any>): void;
+			};
+			caches?: CacheStorage & { default: Cache };
+		}
 	}
 }


### PR DESCRIPTION
fixes #8268

Theoretically someone could have relied on us auto-loading the ambient types previously, but I doubt it because it means that `adapter-cloudflare` would have been imported somewhere where our `tsconfig.json`'s `include` includes it (the `svelte.config.js` isn't), _and_ you'd need to access cloudflare-specific things outside of `platform`. Getting the behavior back as a user is as easy as slapping `/// <reference types="@cloudflare/workers-types" />` at the top of `src/app.d.ts`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
