### PR TITLE
docs: Updates RequestHandler Type to be RequestEvent in +server docs

### DIFF
--- a/documentation/docs/20-core-concepts/10-routing.md
+++ b/documentation/docs/20-core-concepts/10-routing.md
@@ -252,7 +252,7 @@ For example we could create an `/api/random-number` route with a `GET` handler:
 /// file: src/routes/api/random-number/+server.js
 import { error } from '@sveltejs/kit';
 
-/** @type {import('./$types').RequestHandler} */
+/** @type {import('./$types').RequestEvent} */
 export function GET({ url }) {
 	const min = Number(url.searchParams.get('min') ?? '0');
 	const max = Number(url.searchParams.get('max') ?? '1');
@@ -310,7 +310,7 @@ By exporting `POST`/`PUT`/`PATCH`/`DELETE` handlers, `+server.js` files can be u
 /// file: src/routes/api/add/+server.js
 import { json } from '@sveltejs/kit';
 
-/** @type {import('./$types').RequestHandler} */
+/** @type {import('./$types').RequestEvent} */
 export async function POST({ request }) {
 	const { a, b } = await request.json();
 	return json(a + b);


### PR DESCRIPTION
While working in +server.ts files, I noticed TS errors with the suggested RequestHandler type. I'm pretty sure this should be RequestEvent as that's what includes the properties that are available within requests in +server.js files. 

This is a small change only to the docs, so no tests needed. 