### PR TITLE
fix: exclude service worker from tsconfig

### DIFF
--- a/.changeset/tidy-tools-suffer.md
+++ b/.changeset/tidy-tools-suffer.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: exclude service worker from tsconfig

--- a/documentation/docs/30-advanced/40-service-workers.md
+++ b/documentation/docs/30-advanced/40-service-workers.md
@@ -112,17 +112,17 @@ Setting up proper types for service workers requires some manual setup. Inside y
 /// <reference lib="esnext" />
 /// <reference lib="webworker" />
 
-const ws = /** @type {ServiceWorkerGlobalScope} */ (/** @type {unknown} */ (self));
+const sw = /** @type {ServiceWorkerGlobalScope} */ (/** @type {unknown} */ (self));
 ```
 ```generated-ts
 /// <reference no-default-lib="true"/>
 /// <reference lib="esnext" />
 /// <reference lib="webworker" />
 
-const ws = self as unknown as ServiceWorkerGlobalScope;
+const sw = self as unknown as ServiceWorkerGlobalScope;
 ```
 
-This disables access to DOM typings like `HTMLElement` which are not available inside a service worker and instantiates the correct globals. The reassignment of `self` to `ws` allows you to type cast it in the process (there are a couple of ways to do this, but the easiest that requires no additional files). Use `ws` instead of `self` in the rest of the file.
+This disables access to DOM typings like `HTMLElement` which are not available inside a service worker and instantiates the correct globals. The reassignment of `self` to `sw` allows you to type cast it in the process (there are a couple of ways to do this, but the easiest that requires no additional files). Use `sw` instead of `self` in the rest of the file.
 
 ## Other solutions
 

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -60,6 +60,15 @@ export function write_tsconfig(config, cwd = process.cwd()) {
 	include.push(config_relative(`${test_folder}/**/*.ts`));
 	include.push(config_relative(`${test_folder}/**/*.svelte`));
 
+	const exclude = [config_relative('node_modules/**'), './[!ambient.d.ts]**'];
+	if (path.extname(config.files.serviceWorker)) {
+		exclude.push(config_relative(config.files.serviceWorker));
+	} else {
+		exclude.push(config_relative(`${config.files.serviceWorker}.js`));
+		exclude.push(config_relative(`${config.files.serviceWorker}.ts`));
+		exclude.push(config_relative(`${config.files.serviceWorker}.d.ts`));
+	}
+
 	write_if_changed(
 		out,
 		JSON.stringify(
@@ -88,7 +97,7 @@ export function write_tsconfig(config, cwd = process.cwd()) {
 					target: 'esnext'
 				},
 				include,
-				exclude: [config_relative('node_modules/**'), './[!ambient.d.ts]**']
+				exclude
 			},
 			null,
 			'\t'


### PR DESCRIPTION
This is necessary so the recommended way to get sw types doesn't remove the globals from other files in the project.
Also document how to get types working inside the file closes #8127

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
