### PR TITLE
chore: remove superfluous fields from package.json

### DIFF
--- a/.changeset/breezy-vans-prove.md
+++ b/.changeset/breezy-vans-prove.md
@@ -9,4 +9,4 @@
 '@sveltejs/amp': patch
 ---
 
-"chore: remove superfluous fields from package.json"
+chore: remove superfluous main field from package.json

--- a/.changeset/breezy-vans-prove.md
+++ b/.changeset/breezy-vans-prove.md
@@ -1,0 +1,12 @@
+---
+'@sveltejs/adapter-auto': patch
+'@sveltejs/adapter-cloudflare': patch
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-static': patch
+'@sveltejs/adapter-vercel': patch
+'@sveltejs/amp': patch
+---
+
+"chore: remove superfluous fields from package.json"

--- a/packages/adapter-auto/package.json
+++ b/packages/adapter-auto/package.json
@@ -16,7 +16,6 @@
 		},
 		"./package.json": "./package.json"
 	},
-	"main": "index.js",
 	"types": "index.d.ts",
 	"files": [
 		"files",

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -16,7 +16,6 @@
 		},
 		"./package.json": "./package.json"
 	},
-	"main": "index.js",
 	"types": "index.d.ts",
 	"files": [
 		"ambient.d.ts",

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -23,7 +23,6 @@
 		"index.d.ts",
 		"ambient.d.ts"
 	],
-	"main": "index.js",
 	"scripts": {
 		"build": "esbuild src/worker.js --bundle --outfile=files/worker.js --external:SERVER --external:MANIFEST --format=esm",
 		"lint": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -16,7 +16,6 @@
 		},
 		"./package.json": "./package.json"
 	},
-	"main": "index.js",
 	"types": "index.d.ts",
 	"files": [
 		"files",

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -16,7 +16,6 @@
 		},
 		"./package.json": "./package.json"
 	},
-	"main": "index.js",
 	"types": "index.d.ts",
 	"files": [
 		"files",

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -9,7 +9,6 @@
 	"license": "MIT",
 	"homepage": "https://kit.svelte.dev",
 	"type": "module",
-	"main": "index.js",
 	"exports": {
 		".": {
 			"types": "./index.d.ts",

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -16,7 +16,6 @@
 		},
 		"./package.json": "./package.json"
 	},
-	"main": "index.js",
 	"types": "index.d.ts",
 	"files": [
 		"files",

--- a/packages/amp/package.json
+++ b/packages/amp/package.json
@@ -16,7 +16,6 @@
 		},
 		"./package.json": "./package.json"
 	},
-	"main": "index.js",
 	"types": "index.d.ts",
 	"files": [
 		"index.js"


### PR DESCRIPTION
These are already in `exports` and are causing publint warnings for me