### PR TITLE
fix: publish missing files

### DIFF
--- a/.changeset/purple-poets-approve.md
+++ b/.changeset/purple-poets-approve.md
@@ -1,0 +1,10 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-static': patch
+'@sveltejs/adapter-vercel': patch
+'@sveltejs/amp': patch
+---
+
+fix: publish missing files

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -20,6 +20,7 @@
 	"files": [
 		"ambient.d.ts",
 		"files",
+		"index.js",
 		"index.d.ts"
 	],
 	"scripts": {

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -19,6 +19,7 @@
 	"types": "index.d.ts",
 	"files": [
 		"files",
+		"index.js",
 		"index.d.ts"
 	],
 	"scripts": {

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -19,6 +19,7 @@
 	"types": "index.d.ts",
 	"files": [
 		"files",
+		"index.js",
 		"index.d.ts"
 	],
 	"scripts": {

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -19,7 +19,8 @@
 	"types": "index.d.ts",
 	"files": [
 		"index.js",
-		"index.d.ts"
+		"index.d.ts",
+		"platforms.js"
 	],
 	"scripts": {
 		"lint": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -17,6 +17,10 @@
 		"./package.json": "./package.json"
 	},
 	"types": "index.d.ts",
+	"files": [
+		"index.js",
+		"index.d.ts"
+	],
 	"scripts": {
 		"lint": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"check": "tsc",

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -19,6 +19,7 @@
 	"types": "index.d.ts",
 	"files": [
 		"files",
+		"index.js",
 		"index.d.ts"
 	],
 	"scripts": {

--- a/packages/amp/package.json
+++ b/packages/amp/package.json
@@ -18,7 +18,8 @@
 	},
 	"types": "index.d.ts",
 	"files": [
-		"index.js"
+		"index.js",
+		"index.d.ts"
 	],
 	"scripts": {
 		"lint": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",


### PR DESCRIPTION
Fix https://github.com/sveltejs/kit/issues/8530

npm and pnpm includes the file in `pkg.main` to publish by default. Since https://github.com/sveltejs/kit/pull/8519 removed the `pkg.main` field, we forgot to add the `index.js` file to the `pkg.files` field, causing it to be missing after publish.

This PR updates the `pkg.files` field

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
