### PR TITLE
Try inputting text using `fill` to reduce test flakiness

### DIFF
--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1831,10 +1831,7 @@ test.describe('Actions', () => {
 		expect(await page.textContent('pre')).toBe(JSON.stringify(null));
 
 		await page.locator('input[name="username"]').fill('foo');
-		await Promise.all([
-			page.waitForRequest((request) => request.url().includes('/actions/success-data')),
-			page.click('button[formenctype="multipart/form-data"]')
-		]);
+		await page.locator('button[formenctype="multipart/form-data"]').click();
 
 		await expect(page.locator('pre')).toHaveText(JSON.stringify({ result: 'foo' }));
 	});
@@ -1845,10 +1842,7 @@ test.describe('Actions', () => {
 		expect(await page.textContent('pre')).toBe(JSON.stringify(null));
 
 		await page.locator('input[name="username"]').fill('bar');
-		await Promise.all([
-			page.waitForRequest((request) => request.url().includes('/actions/success-data')),
-			page.click('button[formenctype="application/x-www-form-urlencoded"]')
-		]);
+		await page.locator('button[formenctype="application/x-www-form-urlencoded"]').click();
 
 		await expect(page.locator('pre')).toHaveText(JSON.stringify({ result: 'bar' }));
 	});
@@ -1918,10 +1912,7 @@ test.describe('Actions', () => {
 		expect(await page.textContent('pre.formdata2')).toBe(JSON.stringify(null));
 
 		await page.locator('input[name="username"]').fill('foo');
-		await Promise.all([
-			page.waitForRequest((request) => request.url().includes('/actions/enhance')),
-			page.click('button.form1')
-		]);
+		await page.locator('button.form1').click();
 
 		await expect(page.locator('pre.formdata1')).toHaveText(JSON.stringify({ result: 'foo' }));
 		await expect(page.locator('pre.formdata2')).toHaveText(JSON.stringify({ result: 'foo' }));

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1808,8 +1808,8 @@ test.describe('Actions', () => {
 
 	test('Form fields are persisted', async ({ page, javaScriptEnabled }) => {
 		await page.goto('/actions/form-errors-persist-fields');
-		await page.type('input[name="username"]', 'foo');
-		await page.type('input[name="password"]', 'bar');
+		await page.locator('input[name="username"]').fill('foo');
+		await page.locator('input[name="password"]').fill('bar');
 		await Promise.all([
 			page.waitForRequest((request) =>
 				request.url().includes('/actions/form-errors-persist-fields')
@@ -1830,7 +1830,7 @@ test.describe('Actions', () => {
 
 		expect(await page.textContent('pre')).toBe(JSON.stringify(null));
 
-		await page.type('input[name="username"]', 'foo');
+		await page.locator('input[name="username"]').fill('foo');
 		await Promise.all([
 			page.waitForRequest((request) => request.url().includes('/actions/success-data')),
 			page.click('button[formenctype="multipart/form-data"]')
@@ -1844,7 +1844,7 @@ test.describe('Actions', () => {
 
 		expect(await page.textContent('pre')).toBe(JSON.stringify(null));
 
-		await page.type('input[name="username"]', 'bar');
+		await page.locator('input[name="username"]').fill('bar');
 		await Promise.all([
 			page.waitForRequest((request) => request.url().includes('/actions/success-data')),
 			page.click('button[formenctype="application/x-www-form-urlencoded"]')
@@ -1917,7 +1917,7 @@ test.describe('Actions', () => {
 		expect(await page.textContent('pre.formdata1')).toBe(JSON.stringify(null));
 		expect(await page.textContent('pre.formdata2')).toBe(JSON.stringify(null));
 
-		await page.type('input[name="username"]', 'foo');
+		await page.locator('input[name="username"]').fill('foo');
 		await Promise.all([
 			page.waitForRequest((request) => request.url().includes('/actions/enhance')),
 			page.click('button.form1')
@@ -1950,7 +1950,7 @@ test.describe('Actions', () => {
 
 		expect(await page.textContent('pre.formdata1')).toBe(JSON.stringify(null));
 
-		await page.type('input[name="username"]', 'foo');
+		await page.locator('input[name="username"]').fill('foo');
 		await Promise.all([
 			page.waitForRequest((request) => request.url().includes('/actions/enhance')),
 			page.click('button.form1-register')

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1942,10 +1942,7 @@ test.describe('Actions', () => {
 		expect(await page.textContent('pre.formdata1')).toBe(JSON.stringify(null));
 
 		await page.locator('input[name="username"]').fill('foo');
-		await Promise.all([
-			page.waitForRequest((request) => request.url().includes('/actions/enhance')),
-			page.click('button.form1-register')
-		]);
+		await page.locator('button.form1-register').click();
 
 		await expect(page.locator('pre.formdata1')).toHaveText(
 			JSON.stringify({ result: 'register: foo' })


### PR DESCRIPTION
Another attempt of https://github.com/sveltejs/kit/pull/8440

A few of the flaky tests use [`type`](https://playwright.dev/docs/api/class-page#page-type) to input text. This PR updates them to use [`fill`](https://playwright.dev/docs/api/class-locator#locator-fill) instead, which is more reliable.

There is a slight difference in behavior between `type` and `fill`. Fill seems more robust because it carries out a [few](https://playwright.dev/docs/actionability) more extra checks before interacting with the element.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
