### PR TITLE
chore: use `fill` in test one more place

### DIFF
--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -370,7 +370,7 @@ test.describe('a11y', () => {
 		await page.goto('/keepfocus');
 
 		await Promise.all([
-			page.type('#input', 'bar'),
+			page.locator('#input').fill('bar'),
 			page.waitForFunction(() => window.location.search === '?foo=bar')
 		]);
 		await expect(page.locator('#input')).toBeFocused();


### PR DESCRIPTION
https://github.com/sveltejs/kit/pull/8545 switched to using `locator` and `fill` which is probably better practice, but forgot to update `client.test.js`