### PR TITLE
chore: skip form action tests on webkit build

### DIFF
--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1797,6 +1797,10 @@ test.describe('XSS', () => {
 });
 
 test.describe('Actions', () => {
+	// fetch requests sometimes for unknown reasons go into the abyss and never fire off,
+	// most commonly on webkit during build mode - therefore disable tests there
+	test.skip(({ browserName }) => browserName === 'webkit' && !process.env.DEV);
+
 	test('Error props are returned', async ({ page, javaScriptEnabled }) => {
 		await page.goto('/actions/form-errors');
 		await page.click('button');


### PR DESCRIPTION
fetch requests sometimes for unknown reasons go into the abyss and never fire off, most commonly on webkit during build mode - therefore disable tests there

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
