### PR TITLE
chore: make some test retries possible to succeed

### DIFF
--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -552,36 +552,39 @@ test.describe('Load', () => {
 		expect(await page.textContent('p')).toBe('This text comes from the server load function');
 	});
 
-	test('load does not call fetch if max-age allows it', async ({ page }) => {
+	test('load does not call fetch if max-age allows it', async ({ page }, testInfo) => {
 		page.addInitScript(`
 			window.now = 0;
 			window.performance.now = () => now;
 		`);
 
 		await page.goto('/load/cache-control/default');
-		await expect(page.getByText('Count is 0')).toBeVisible();
+		// we do not have a reset function, so if this is retried, it would never pass
+		await expect(page.getByText('Count is ' + testInfo.retry)).toBeVisible();
 		await page.locator('button').click();
 		await page.waitForLoadState('networkidle');
-		await expect(page.getByText('Count is 0')).toBeVisible();
+		await expect(page.getByText('Count is ' + testInfo.retry)).toBeVisible();
 
 		await page.evaluate(() => (window.now = 2500));
 
 		await page.locator('button').click();
-		await expect(page.getByText('Count is 2')).toBeVisible();
+		await expect(page.getByText('Count is ' + (testInfo.retry + 2))).toBeVisible();
 	});
 
-	test('load does ignore ttl if fetch cache options says so', async ({ page }) => {
+	test('load does ignore ttl if fetch cache options says so', async ({ page }, testInfo) => {
 		await page.goto('/load/cache-control/force');
-		await expect(page.getByText('Count is 0')).toBeVisible();
+		// we do not have a reset function, so if this is retried, it would never pass
+		await expect(page.getByText('Count is ' + testInfo.retry)).toBeVisible();
 		await page.locator('button').click();
-		await expect(page.getByText('Count is 1')).toBeVisible();
+		await expect(page.getByText('Count is ' + (testInfo.retry + 1))).toBeVisible();
 	});
 
-	test('load busts cache if non-GET request to resource is made', async ({ page }) => {
+	test('load busts cache if non-GET request to resource is made', async ({ page }, testInfo) => {
 		await page.goto('/load/cache-control/bust');
-		await expect(page.getByText('Count is 0')).toBeVisible();
+		// we do not have a reset function, so if this is retried, it would never pass
+		await expect(page.getByText('Count is ' + testInfo.retry)).toBeVisible();
 		await page.locator('button').click();
-		await expect(page.getByText('Count is 1')).toBeVisible();
+		await expect(page.getByText('Count is ' + (testInfo.retry + 1))).toBeVisible();
 	});
 
 	test('__data.json has cache-control: private, no-store', async ({ page, clicknav }) => {


### PR DESCRIPTION
We do not have a reset function on those, and they sometimes fail for mysterious reason even if the count _is_ updated, but playwright somehow doesn't notice. This makes it possible for retries to succeed in that case.

Alternative would be to have a reset function on all of them, but I'm not sure if this then has the "fetch goes into the abyss" problem.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
