### PR TITLE
chore: use `declare global` instead of ambient declarations

### DIFF
--- a/documentation/docs/25-build-and-deploy/60-adapter-cloudflare.md
+++ b/documentation/docs/25-build-and-deploy/60-adapter-cloudflare.md
@@ -59,14 +59,18 @@ To make these types available to your app, reference them in your `src/app.d.ts`
 
 ```diff
 /// file: src/app.d.ts
-declare namespace App {
-	interface Platform {
-+		env?: {
-+			YOUR_KV_NAMESPACE: KVNamespace;
-+			YOUR_DURABLE_OBJECT_NAMESPACE: DurableObjectNamespace;
-+		};
+declare global {
+	namespace App {
+		interface Platform {
++			env?: {
++				YOUR_KV_NAMESPACE: KVNamespace;
++				YOUR_DURABLE_OBJECT_NAMESPACE: DurableObjectNamespace;
++			};
+		}
 	}
 }
+
+export {};
 ```
 
 > `platform.env` is only available in the production build. Use [wrangler](https://developers.cloudflare.com/workers/cli-wrangler) to test it locally

--- a/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
+++ b/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
@@ -94,14 +94,18 @@ To make these types available to your app, reference them in your `src/app.d.ts`
 
 ```diff
 /// file: src/app.d.ts
-declare namespace App {
-	interface Platform {
-+		env?: {
-+			YOUR_KV_NAMESPACE: KVNamespace;
-+			YOUR_DURABLE_OBJECT_NAMESPACE: DurableObjectNamespace;
-+		};
+declare global {
+	namespace App {
+		interface Platform {
++			env?: {
++				YOUR_KV_NAMESPACE: KVNamespace;
++				YOUR_DURABLE_OBJECT_NAMESPACE: DurableObjectNamespace;
++			};
+		}
 	}
 }
+
+export {};
 ```
 
 > `platform.env` is only available in the production build. Use [wrangler](https://developers.cloudflare.com/workers/cli-wrangler) to test it locally

--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -148,12 +148,16 @@ The following code shows an example of typing the error shape as `{ message: str
 
 ```ts
 /// file: src/app.d.ts
-declare namespace App {
-	interface Error {
-		message: string;
-		errorId: string;
+declare global {
+	namespace App {
+		interface Error {
+			message: string;
+			errorId: string;
+		}
 	}
 }
+
+export {};
 ```
 
 ```js

--- a/documentation/docs/30-advanced/25-errors.md
+++ b/documentation/docs/30-advanced/25-errors.md
@@ -139,7 +139,7 @@ The exception is when the error occurs inside the root `+layout.js` or `+layout.
 
 If you're using TypeScript and need to customize the shape of errors, you can do so by declaring an `App.Error` interface in your app (by convention, in `src/app.d.ts`, though it can live anywhere that TypeScript can 'see'):
 
-```ts
+```diff
 /// file: src/app.d.ts
 declare global {
 	namespace App {

--- a/documentation/docs/30-advanced/25-errors.md
+++ b/documentation/docs/30-advanced/25-errors.md
@@ -141,12 +141,16 @@ If you're using TypeScript and need to customize the shape of errors, you can do
 
 ```ts
 /// file: src/app.d.ts
-declare namespace App {
-	interface Error {
-		code: string;
-		id: string;
+declare global {
+	namespace App {
+		interface Error {
++			code: string;
++			id: string;
+		}
 	}
 }
+
+export {};
 ```
 
 This interface always includes a `message: string` property.

--- a/packages/adapter-static/test/apps/spa/src/app.d.ts
+++ b/packages/adapter-static/test/apps/spa/src/app.d.ts
@@ -1,5 +1,0 @@
-declare global {
-	namespace App {}
-}
-
-export {};

--- a/packages/adapter-static/test/apps/spa/src/app.d.ts
+++ b/packages/adapter-static/test/apps/spa/src/app.d.ts
@@ -1,3 +1,5 @@
-/// <reference types="@sveltejs/kit" />
+declare global {
+	namespace App {}
+}
 
-declare namespace App {}
+export {};

--- a/packages/kit/test/apps/basics/src/app.d.ts
+++ b/packages/kit/test/apps/basics/src/app.d.ts
@@ -1,10 +1,14 @@
-declare namespace App {
-	interface Locals {
-		answer: number;
-		name?: string;
-		key: string;
-		params: Record<string, string>;
-	}
+declare global {
+	namespace App {
+		interface Locals {
+			answer: number;
+			name?: string;
+			key: string;
+			params: Record<string, string>;
+		}
 
-	interface Platform {}
+		interface Platform {}
+	}
 }
+
+export {};

--- a/packages/kit/test/apps/options-2/src/app.d.ts
+++ b/packages/kit/test/apps/options-2/src/app.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@sveltejs/kit" />

--- a/packages/kit/test/apps/options/source/app.d.ts
+++ b/packages/kit/test/apps/options/source/app.d.ts
@@ -1,9 +1,0 @@
-declare global {
-	namespace App {
-		interface Locals {}
-
-		interface Platform {}
-	}
-}
-
-export {};

--- a/packages/kit/test/apps/options/source/app.d.ts
+++ b/packages/kit/test/apps/options/source/app.d.ts
@@ -1,7 +1,9 @@
-/// <reference types="@sveltejs/kit" />
+declare global {
+	namespace App {
+		interface Locals {}
 
-declare namespace App {
-	interface Locals {}
-
-	interface Platform {}
+		interface Platform {}
+	}
 }
+
+export {};

--- a/packages/kit/test/apps/writes/src/app.d.ts
+++ b/packages/kit/test/apps/writes/src/app.d.ts
@@ -1,9 +1,0 @@
-declare global {
-	namespace App {
-		interface Locals {}
-
-		interface Platform {}
-	}
-}
-
-export {};

--- a/packages/kit/test/apps/writes/src/app.d.ts
+++ b/packages/kit/test/apps/writes/src/app.d.ts
@@ -1,7 +1,9 @@
-/// <reference types="@sveltejs/kit" />
+declare global {
+	namespace App {
+		interface Locals {}
 
-declare namespace App {
-	interface Locals {}
-
-	interface Platform {}
+		interface Platform {}
+	}
 }
+
+export {};

--- a/packages/kit/test/build-errors/apps/private-dynamic-env-dynamic-import/src/app.d.ts
+++ b/packages/kit/test/build-errors/apps/private-dynamic-env-dynamic-import/src/app.d.ts
@@ -1,7 +1,0 @@
-// See https://kit.svelte.dev/docs/types#app
-// for information about these interfaces
-// and what to do when importing types
-declare namespace App {
-	// interface Locals {}
-	// interface Platform {}
-}

--- a/packages/kit/test/build-errors/apps/private-dynamic-env/src/app.d.ts
+++ b/packages/kit/test/build-errors/apps/private-dynamic-env/src/app.d.ts
@@ -1,7 +1,0 @@
-// See https://kit.svelte.dev/docs/types#app
-// for information about these interfaces
-// and what to do when importing types
-declare namespace App {
-	// interface Locals {}
-	// interface Platform {}
-}

--- a/packages/kit/test/build-errors/apps/private-static-env-dynamic-import/src/app.d.ts
+++ b/packages/kit/test/build-errors/apps/private-static-env-dynamic-import/src/app.d.ts
@@ -1,7 +1,0 @@
-// See https://kit.svelte.dev/docs/types#app
-// for information about these interfaces
-// and what to do when importing types
-declare namespace App {
-	// interface Locals {}
-	// interface Platform {}
-}

--- a/packages/kit/test/build-errors/apps/private-static-env/src/app.d.ts
+++ b/packages/kit/test/build-errors/apps/private-static-env/src/app.d.ts
@@ -1,7 +1,0 @@
-// See https://kit.svelte.dev/docs/types#app
-// for information about these interfaces
-// and what to do when importing types
-declare namespace App {
-	// interface Locals {}
-	// interface Platform {}
-}

--- a/packages/kit/test/build-errors/apps/server-only-folder-dynamic-import/src/app.d.ts
+++ b/packages/kit/test/build-errors/apps/server-only-folder-dynamic-import/src/app.d.ts
@@ -1,7 +1,0 @@
-// See https://kit.svelte.dev/docs/types#app
-// for information about these interfaces
-// and what to do when importing types
-declare namespace App {
-	// interface Locals {}
-	// interface Platform {}
-}

--- a/packages/kit/test/build-errors/apps/server-only-folder/src/app.d.ts
+++ b/packages/kit/test/build-errors/apps/server-only-folder/src/app.d.ts
@@ -1,7 +1,0 @@
-// See https://kit.svelte.dev/docs/types#app
-// for information about these interfaces
-// and what to do when importing types
-declare namespace App {
-	// interface Locals {}
-	// interface Platform {}
-}

--- a/packages/kit/test/build-errors/apps/server-only-module-dynamic-import/src/app.d.ts
+++ b/packages/kit/test/build-errors/apps/server-only-module-dynamic-import/src/app.d.ts
@@ -1,7 +1,0 @@
-// See https://kit.svelte.dev/docs/types#app
-// for information about these interfaces
-// and what to do when importing types
-declare namespace App {
-	// interface Locals {}
-	// interface Platform {}
-}

--- a/packages/kit/test/build-errors/apps/server-only-module/src/app.d.ts
+++ b/packages/kit/test/build-errors/apps/server-only-module/src/app.d.ts
@@ -1,7 +1,0 @@
-// See https://kit.svelte.dev/docs/types#app
-// for information about these interfaces
-// and what to do when importing types
-declare namespace App {
-	// interface Locals {}
-	// interface Platform {}
-}


### PR DESCRIPTION
updates docs to use the preferred form of `App` declaration. closes #8587 