### PR TITLE
Amend the "nasty hack to silence harmless warnings"...

### DIFF
--- a/.changeset/tender-melons-train.md
+++ b/.changeset/tender-melons-train.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: squelch unknown prop warning for `+error.svelte` components

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1737,7 +1737,7 @@ if (DEV) {
 	console.warn = function warn(...args) {
 		if (
 			args.length === 1 &&
-			/<(Layout|Page)(_[\w$]+)?> was created (with unknown|without expected) prop '(data|form)'/.test(
+			/<(Layout|Page|Error)(_[\w$]+)?> was created (with unknown|without expected) prop '(data|form)'/.test(
 				args[0]
 			)
 		) {


### PR DESCRIPTION
...to include Error pages too, because when throwing 404s (etc), `args[0]` can also be:

```
"<Error> was created with unknown prop 'data'"
```

And this is not caught by the current regex. Instead, the regex only captures strings containing `<Layout>` or `<Page>`.

This is an extremely minor edit, and I anticipate no problems, alas I have not run tests.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
