### PR TITLE
fix: set headers when throwing redirect in handle

### DIFF
--- a/.changeset/gorgeous-bulldogs-talk.md
+++ b/.changeset/gorgeous-bulldogs-talk.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: set headers when throwing redirect in handle

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -4,7 +4,7 @@ import { render_page } from './page/index.js';
 import { render_response } from './page/render.js';
 import { respond_with_error } from './page/respond_with_error.js';
 import { is_form_content_type } from '../../utils/http.js';
-import { GENERIC_ERROR, get_option, handle_fatal_error } from './utils.js';
+import { GENERIC_ERROR, get_option, handle_fatal_error, redirect_response } from './utils.js';
 import {
 	decode_pathname,
 	decode_params,
@@ -297,19 +297,11 @@ export async function respond(request, options, manifest, state) {
 		return response;
 	} catch (e) {
 		if (e instanceof Redirect) {
-			if (is_data_request) {
-				return redirect_json_response(e);
-			} else {
-				const response = new Response(undefined, {
-					status: e.status,
-					headers
-				});
-				response.headers.set('location', e.location);
-
-				add_cookies_to_headers(response.headers, Object.values(cookies_to_add));
-
-				return response;
-			}
+			const response = is_data_request
+				? redirect_json_response(e)
+				: redirect_response(e.status, e.location);
+			add_cookies_to_headers(response.headers, Object.values(cookies_to_add));
+			return response;
 		}
 		return await handle_fatal_error(event, options, e);
 	}

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -111,7 +111,7 @@ export async function respond(request, options, manifest, state) {
 	const headers = {};
 
 	/** @type {Record<string, import('./page/types').Cookie>} */
-	let new_cookies = {};
+	let cookies_to_add = {};
 
 	/** @type {import('types').RequestEvent} */
 	const event = {
@@ -224,7 +224,7 @@ export async function respond(request, options, manifest, state) {
 			trailing_slash ?? 'never'
 		);
 
-		this.new_cookies = new_cookies;
+		cookies_to_add = new_cookies;
 		event.cookies = cookies;
 		event.fetch = create_fetch({ event, options, manifest, state, get_cookie_header });
 
@@ -241,7 +241,7 @@ export async function respond(request, options, manifest, state) {
 						response.headers.set(key, /** @type {string} */ (value));
 					}
 
-					add_cookies_to_headers(response.headers, Object.values(new_cookies));
+					add_cookies_to_headers(response.headers, Object.values(cookies_to_add));
 
 					if (state.prerendering && event.route.id !== null) {
 						response.headers.set('x-sveltekit-routeid', encodeURI(event.route.id));
@@ -306,7 +306,7 @@ export async function respond(request, options, manifest, state) {
 				});
 				response.headers.set('location', e.location);
 
-				add_cookies_to_headers(response.headers, Object.values(new_cookies));
+				add_cookies_to_headers(response.headers, Object.values(cookies_to_add));
 
 				return response;
 			}

--- a/packages/kit/test/apps/basics/src/hooks.server.js
+++ b/packages/kit/test/apps/basics/src/hooks.server.js
@@ -98,7 +98,7 @@ export const handle = sequence(
 			if (event.url.search === '?throw') {
 				throw redirect(307, event.url.origin + '/redirect/c');
 			} else if (event.url.search === '?throw&headers') {
-				event.cookies.delete(COOKIE_NAME);
+				event.cookies.delete(COOKIE_NAME, { path: '/cookies' });
 				throw redirect(307, event.url.origin + '/cookies');
 			} else {
 				return new Response(undefined, { status: 307, headers: { location: '/redirect/c' } });

--- a/packages/kit/test/apps/basics/src/hooks.server.js
+++ b/packages/kit/test/apps/basics/src/hooks.server.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import { sequence } from '@sveltejs/kit/hooks';
 import { HttpError } from '../../../../src/runtime/control';
 import { error, redirect } from '@sveltejs/kit';
+import { COOKIE_NAME } from './routes/cookies/shared';
 
 /**
  * Transform an error into a POJO, by copying its `name`, `message`
@@ -96,6 +97,9 @@ export const handle = sequence(
 		if (event.url.pathname.includes('/redirect/in-handle')) {
 			if (event.url.search === '?throw') {
 				throw redirect(307, event.url.origin + '/redirect/c');
+			} else if (event.url.search === '?throw&headers') {
+				event.cookies.delete(COOKIE_NAME);
+				throw redirect(307, event.url.origin + '/cookies');
 			} else {
 				return new Response(undefined, { status: 307, headers: { location: '/redirect/c' } });
 			}

--- a/packages/kit/test/apps/basics/src/hooks.server.js
+++ b/packages/kit/test/apps/basics/src/hooks.server.js
@@ -97,7 +97,7 @@ export const handle = sequence(
 		if (event.url.pathname.includes('/redirect/in-handle')) {
 			if (event.url.search === '?throw') {
 				throw redirect(307, event.url.origin + '/redirect/c');
-			} else if (event.url.search === '?throw&headers') {
+			} else if (event.url.search.includes('cookies')) {
 				event.cookies.delete(COOKIE_NAME, { path: '/cookies' });
 				throw redirect(307, event.url.origin + '/cookies');
 			} else {

--- a/packages/kit/test/apps/basics/test/cross-platform/test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/test.js
@@ -582,11 +582,22 @@ test.describe('Redirects', () => {
 		expect(page.url()).toBe(`${baseURL}/redirect`);
 	});
 
-	test('redirect thrown in handle sets headers', async ({ page }) => {
+	test('sets cookies when throw redirect in handle hook', async ({ page, app, javaScriptEnabled }) => {
 		await page.goto('/cookies/set');
 		let span = page.locator('#cookie-value');
 		expect(await span.innerText()).toContain('teapot');
-		await page.goto('/redirect/in-handle?throw&headers');
+
+		if (javaScriptEnabled) {
+			const [, response] = await Promise.all([
+				app.goto('/redirect/in-handle?throw&cookies'),
+				page.waitForResponse((request) =>
+					request.url().endsWith('in-handle/__data.json?throw=&cookies=&x-sveltekit-invalidated=_1')
+				)
+			]);
+			expect((await response.allHeaders())['set-cookie']).toBeDefined();
+		}
+
+		await page.goto('/redirect/in-handle?throw&cookies');
 		span = page.locator('#cookie-value');
 		expect(await span.innerText()).toContain('undefined');
 	});

--- a/packages/kit/test/apps/basics/test/cross-platform/test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/test.js
@@ -581,6 +581,15 @@ test.describe('Redirects', () => {
 		await page.goBack();
 		expect(page.url()).toBe(`${baseURL}/redirect`);
 	});
+
+	test('redirect thrown in handle sets headers', async ({ page }) => {
+		await page.goto('/cookies/set');
+		let span = page.locator('#cookie-value');
+		expect(await span.innerText()).toContain('teapot');
+		await page.goto('/redirect/in-handle?throw&headers');
+		span = page.locator('#cookie-value');
+		expect(await span.innerText()).toContain('undefined');
+	});
 });
 
 test.describe('Routing', () => {

--- a/packages/kit/test/apps/basics/test/cross-platform/test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/test.js
@@ -582,7 +582,11 @@ test.describe('Redirects', () => {
 		expect(page.url()).toBe(`${baseURL}/redirect`);
 	});
 
-	test('sets cookies when throw redirect in handle hook', async ({ page, app, javaScriptEnabled }) => {
+	test('sets cookies when throw redirect in handle hook', async ({
+		page,
+		app,
+		javaScriptEnabled
+	}) => {
 		await page.goto('/cookies/set');
 		let span = page.locator('#cookie-value');
 		expect(await span.innerText()).toContain('teapot');


### PR DESCRIPTION
fixes #8643

Adds headers and cookies to the response when using `throw redirect` in `handle` so that it behaves similarly to returning a new redirect `Response` in `handle`.

I'm sure there's a more elegant approach to this fix and the test, but I can't quite figure it out (this is my first time writing a test). Would appreciate any suggested changes.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
