### PR TITLE
docs: adjust project structure

### DIFF
--- a/documentation/docs/10-getting-started/30-project-structure.md
+++ b/documentation/docs/10-getting-started/30-project-structure.md
@@ -54,7 +54,7 @@ Any static assets that should be served as-is, like `robots.txt` or `favicon.png
 
 ### tests
 
-If you added [Playwright](https://playwright.dev/) for browser testing when you set up your project, the tests will live in this directory.
+If you added [Playwright](https://playwright.dev/) for browser testing when you set up your project, the tests will live in this directory. This directory is optional.
 
 ### package.json
 
@@ -69,6 +69,8 @@ This file contains your Svelte and SvelteKit [configuration](/docs/configuration
 ### tsconfig.json
 
 This file (or `jsconfig.json`, if you prefer type-checked `.js` files over `.ts` files) configures TypeScript, if you added typechecking during `npm create svelte@latest`. Since SvelteKit relies on certain configuration being set a specific way, it generates its own `.svelte-kit/tsconfig.json` file which your own config `extends`.
+
+Although optional, it's highly recommended to keep this in your project in order for [generated types](/docs/types#generated-types) to provide helpful type inferences for data passed between pages and back-end code as well as path alias autocomplete for `$lib` and [custom path aliases](/docs/configuration#alias) defined in `svelte.config.js`.
 
 ### vite.config.js
 

--- a/documentation/docs/10-getting-started/30-project-structure.md
+++ b/documentation/docs/10-getting-started/30-project-structure.md
@@ -4,27 +4,31 @@ title: Project structure
 
 A typical SvelteKit project looks like this:
 
+> Directories surrounded in brackets `[]` indicate they are optional and can be
+> added after starting a project.
+
 ```bash
 my-project/
 ├ src/
 │ ├ lib/
-│ │ ├ server/
+│ │ ├ [server]/
 │ │ │ └ [your server-only lib files]
 │ │ └ [your lib files]
-│ ├ params/
+│ ├ [params]/
 │ │ └ [your param matchers]
 │ ├ routes/
 │ │ └ [your routes]
 │ ├ app.html
-│ ├ error.html
-│ └ hooks.js
+│ ├ [error.html]
+│ └ [hooks.client.js]
+│ └ [hooks.server.js]
 ├ static/
 │ └ [your static assets]
-├ tests/
+├ [tests]/
 │ └ [your tests]
 ├ package.json
 ├ svelte.config.js
-├ tsconfig.json
+├ tsconfig.json [or jsconfig.json]
 └ vite.config.js
 ```
 
@@ -49,7 +53,7 @@ The `src` directory contains the meat of your project.
 - `error.html` (optional) is the page that is rendered when everything else fails. It can contain the following placeholders:
   - `%sveltekit.status%` — the HTTP status
   - `%sveltekit.error.message%` — the error message
-- `hooks.js` (optional) contains your application's [hooks](/docs/hooks)
+- `hooks.server.js` (or `hooks.client.js`) contains your application's [hooks](/docs/hooks)
 - `service-worker.js` (optional) contains your [service worker](/docs/service-workers)
 
 You can use `.ts` files instead of `.js` files, if using TypeScript.

--- a/documentation/docs/10-getting-started/30-project-structure.md
+++ b/documentation/docs/10-getting-started/30-project-structure.md
@@ -2,30 +2,18 @@
 title: Project structure
 ---
 
-A typical SvelteKit project looks like this:
-
-> Directories surrounded in brackets `[]` indicate they are optional and can be
-> added after starting a project.
+A SvelteKit project requires the following files and directories at minimum in order to build a site:
 
 ```bash
 my-project/
 ├ src/
 │ ├ lib/
-│ │ ├ [server]/
-│ │ │ └ [your server-only lib files]
 │ │ └ [your lib files]
-│ ├ [params]/
-│ │ └ [your param matchers]
 │ ├ routes/
 │ │ └ [your routes]
 │ ├ app.html
-│ ├ [error.html]
-│ └ [hooks.client.js]
-│ └ [hooks.server.js]
 ├ static/
 │ └ [your static assets]
-├ [tests]/
-│ └ [your tests]
 ├ package.json
 ├ svelte.config.js
 ├ tsconfig.json [or jsconfig.json]
@@ -38,11 +26,11 @@ You'll also find common files like `.gitignore` and `.npmrc` (and `.prettierrc` 
 
 ### src
 
-The `src` directory contains the meat of your project.
+The `src` directory contains your project files. All necessary and optional files and directories include:
 
 - `lib` contains your library code (utilities and components), which can be imported via the [`$lib`](/docs/modules#$lib) alias, or packaged up for distribution using [`svelte-package`](/docs/packaging)
-  - `server` contains your server-only library code. It can be imported by using the [`$lib/server`](/docs/server-only-modules) alias. SvelteKit will prevent you from importing these in client code.
-- `params` contains any [param matchers](/docs/advanced-routing#matching) your app needs
+  - `server` (optional) contains your server-only library code. Files in this directory can be imported by using the [`$lib/server`](/docs/server-only-modules) alias. SvelteKit will prevent you from importing these in client code.
+- `params` (optional) contains any [param matchers](/docs/advanced-routing#matching) your app needs
 - `routes` contains the [routes](/docs/routing) of your application. You can also colocate other components that are only used within a single route here
 - `app.html` is your page template — an HTML document containing the following placeholders:
   - `%sveltekit.head%` — `<link>` and `<script>` elements needed by the app, plus any `<svelte:head>` content
@@ -53,7 +41,7 @@ The `src` directory contains the meat of your project.
 - `error.html` (optional) is the page that is rendered when everything else fails. It can contain the following placeholders:
   - `%sveltekit.status%` — the HTTP status
   - `%sveltekit.error.message%` — the error message
-- `hooks.server.js` (or `hooks.client.js`) contains your application's [hooks](/docs/hooks)
+- `hooks.server.js` or `hooks.client.js` (optional) contains your application's [hooks](/docs/hooks)
 - `service-worker.js` (optional) contains your [service worker](/docs/service-workers)
 
 You can use `.ts` files instead of `.js` files, if using TypeScript.

--- a/documentation/docs/10-getting-started/30-project-structure.md
+++ b/documentation/docs/10-getting-started/30-project-structure.md
@@ -2,7 +2,7 @@
 title: Project structure
 ---
 
-A SvelteKit project requires the following files and directories at minimum in order to build a site:
+A typical SvelteKit project contains the following files and directories:
 
 ```bash
 my-project/
@@ -28,7 +28,7 @@ You'll also find common files like `.gitignore` and `.npmrc` (and `.prettierrc` 
 
 The `src` directory contains your project files. All necessary and optional files and directories include:
 
-- `lib` contains your library code (utilities and components), which can be imported via the [`$lib`](/docs/modules#$lib) alias, or packaged up for distribution using [`svelte-package`](/docs/packaging)
+- `lib` (optional) contains your library code (utilities and components), which can be imported via the [`$lib`](/docs/modules#$lib) alias, or packaged up for distribution using [`svelte-package`](/docs/packaging)
   - `server` (optional) contains your server-only library code. Files in this directory can be imported by using the [`$lib/server`](/docs/server-only-modules) alias. SvelteKit will prevent you from importing these in client code.
 - `params` (optional) contains any [param matchers](/docs/advanced-routing#matching) your app needs
 - `routes` contains the [routes](/docs/routing) of your application. You can also colocate other components that are only used within a single route here
@@ -50,7 +50,7 @@ If you added [Vitest](https://vitest.dev) when you set up your project, your uni
 
 ### static
 
-Any static assets that should be served as-is, like `robots.txt` or `favicon.png`, go in here.
+Any static assets that should be served as-is, like `robots.txt` or `favicon.png`, go in here. This directory is optional.
 
 ### tests
 


### PR DESCRIPTION
(no related tickets)

This adjusts the 'project structure' page in the docs to explicitly call out optional directories to aid newcomers when comparing projects started with `npm create svelte` and the provided 'project structure' docs.

- Indicate which directories are optional
- Replace `hooks.js` with `hooks.{server|client}.js`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
