### PR TITLE
docs: add satisfies for actions

### DIFF
--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -56,7 +56,6 @@ Instead of one `default` action, a page can have as many named actions as it nee
 
 ```diff
 /// file: src/routes/login/+page.server.js
-
 /** @type {import('./$types').Actions} */
 export const actions = {
 -	default: async (event) => {
@@ -107,7 +106,7 @@ As well as the `action` attribute, we can use the `formaction` attribute on a bu
 Each action receives a `RequestEvent` object, allowing you to read the data with `request.formData()`. After processing the request (for example, logging the user in by setting a cookie), the action can respond with data that will be available through the `form` property on the corresponding page and through `$page.form` app-wide until the next update.
 
 ```js
-// @errors: 2339 2304
+// @errors: 2304
 /// file: src/routes/login/+page.server.js
 /** @type {import('./$types').PageServerLoad} */
 export async function load({ cookies }) {
@@ -155,7 +154,6 @@ export const actions = {
 If the request couldn't be processed because of invalid data, you can return validation errors — along with the previously submitted form values — back to the user so that they can try again. The `fail` function lets you return an HTTP status code (typically 400 or 422, in the case of validation errors) along with the data. The status code is available through `$page.status` and the data through `form`:
 
 ```diff
-// @errors: 2339 2304
 /// file: src/routes/login/+page.server.js
 +import { fail } from '@sveltejs/kit';
 
@@ -214,7 +212,6 @@ The returned data must be serializable as JSON. Beyond that, the structure is en
 Redirects (and errors) work exactly the same as in [`load`](/docs/load#redirects):
 
 ```diff
-// @errors: 2339 2304
 /// file: src/routes/login/+page.server.js
 +import { fail, redirect } from '@sveltejs/kit';
 

--- a/sites/kit.svelte.dev/src/lib/docs/server/index.js
+++ b/sites/kit.svelte.dev/src/lib/docs/server/index.js
@@ -505,16 +505,14 @@ function convert_to_ts(js_code, indent = '', offset = '') {
 							node.declarationList.declarations.length === 1
 						) {
 							const variable_statement = node.declarationList.declarations[0];
-							
+
 							if (variable_statement.name.getText() === 'actions') {
 								const is_export = node.modifiers?.some(
 									(modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
 								)
 									? 'export '
 									: '';
-								const is_async = node.modifiers?.some(
-									(modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword
-								);
+
 								code.overwrite(
 									node.getStart(),
 									variable_statement.name.getEnd(),

--- a/sites/kit.svelte.dev/src/lib/docs/server/index.js
+++ b/sites/kit.svelte.dev/src/lib/docs/server/index.js
@@ -507,18 +507,6 @@ function convert_to_ts(js_code, indent = '', offset = '') {
 							const variable_statement = node.declarationList.declarations[0];
 
 							if (variable_statement.name.getText() === 'actions') {
-								const is_export = node.modifiers?.some(
-									(modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
-								)
-									? 'export '
-									: '';
-
-								code.overwrite(
-									node.getStart(),
-									variable_statement.name.getEnd(),
-									`${is_export ? 'export ' : ''}const ${variable_statement.name.getText()}`
-								);
-
 								code.appendLeft(variable_statement.getEnd(), ` satisfies ${name}`);
 							} else {
 								code.appendLeft(variable_statement.name.getEnd(), `: ${name}`);

--- a/sites/kit.svelte.dev/src/lib/docs/server/index.js
+++ b/sites/kit.svelte.dev/src/lib/docs/server/index.js
@@ -504,7 +504,27 @@ function convert_to_ts(js_code, indent = '', offset = '') {
 							ts.isVariableStatement(node) &&
 							node.declarationList.declarations.length === 1
 						) {
-							code.appendLeft(node.declarationList.declarations[0].name.getEnd(), `: ${name}`);
+							const variable_statement = node.declarationList.declarations[0];
+							
+							if (variable_statement.name.getText() === 'actions') {
+								const is_export = node.modifiers?.some(
+									(modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
+								)
+									? 'export '
+									: '';
+								const is_async = node.modifiers?.some(
+									(modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword
+								);
+								code.overwrite(
+									node.getStart(),
+									variable_statement.name.getEnd(),
+									`${is_export ? 'export ' : ''}const ${variable_statement.name.getText()}`
+								);
+								code.appendLeft(variable_statement.initializer.getStart(), '(');
+								code.appendLeft(variable_statement.getEnd(), `) satisfies ${name}`);
+							} else {
+								code.appendLeft(variable_statement.name.getEnd(), `: ${name}`);
+							}
 
 							modified = true;
 						} else {

--- a/sites/kit.svelte.dev/src/lib/docs/server/index.js
+++ b/sites/kit.svelte.dev/src/lib/docs/server/index.js
@@ -518,8 +518,8 @@ function convert_to_ts(js_code, indent = '', offset = '') {
 									variable_statement.name.getEnd(),
 									`${is_export ? 'export ' : ''}const ${variable_statement.name.getText()}`
 								);
-								code.appendLeft(variable_statement.initializer.getStart(), '(');
-								code.appendLeft(variable_statement.getEnd(), `) satisfies ${name}`);
+
+								code.appendLeft(variable_statement.getEnd(), ` satisfies ${name}`);
 							} else {
 								code.appendLeft(variable_statement.name.getEnd(), `: ${name}`);
 							}


### PR DESCRIPTION
Changes the Form actions documentation section TS examples to use `satisfies`.
They are currently using the old `export const actions: Actions = {`
https://kit.svelte.dev/docs/form-actions

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
