### PR TITLE
Fix prettier-plugin-svelte path

### DIFF
--- a/.changeset/smart-carrots-pull.md
+++ b/.changeset/smart-carrots-pull.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+fix: Prettier formatting in VSCode

--- a/packages/create-svelte/shared/+prettier/.prettierrc
+++ b/packages/create-svelte/shared/+prettier/.prettierrc
@@ -3,7 +3,7 @@
 	"singleQuote": true,
 	"trailingComma": "none",
 	"printWidth": 100,
-	"plugins": ["prettier-plugin-svelte"],
+	"plugins": ["./node_modules/prettier-plugin-svelte"],
 	"pluginSearchDirs": ["."],
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }


### PR DESCRIPTION
Fixes #7582 according to https://github.com/prettier/prettier-vscode/issues/1261#issuecomment-626821072

> The issue is you have an invalid value set in “plugins”. It’s not a list of plugins, it’s a file path to the plugin. Set the value to ./directory/plugin and it will work.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
