### PR TITLE
fix: allow importing assets while using base path

### DIFF
--- a/.changeset/cold-students-repair.md
+++ b/.changeset/cold-students-repair.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow importing assets while using base path

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -364,10 +364,13 @@ export async function dev(vite, vite_config, svelte_config) {
 				/** @type {function} */ (middleware.handle).name === 'viteServeStaticMiddleware'
 		);
 
+		// Vite will give a 403 on URLs like /test, /static, and /package.json preventing us from
+		// serving routes with those names. See https://github.com/vitejs/vite/issues/7363
 		remove_static_middlewares(vite.middlewares);
 
 		vite.middlewares.use(async (req, res) => {
 			// Vite's base middleware strips out the base path. Restore it
+			const original_url = req.url;
 			req.url = req.originalUrl;
 			try {
 				const base = `${vite.config.server.https ? 'https' : 'http'}://${
@@ -375,13 +378,14 @@ export async function dev(vite, vite_config, svelte_config) {
 				}`;
 
 				const decoded = decodeURI(new URL(base + req.url).pathname);
-				const file = posixify(path.resolve(decoded.slice(1)));
+				const file = posixify(path.resolve(decoded.slice(svelte_config.kit.paths.base.length + 1)));
 				const is_file = fs.existsSync(file) && !fs.statSync(file).isDirectory();
 				const allowed =
 					!vite_config.server.fs.strict ||
 					vite_config.server.fs.allow.some((dir) => file.startsWith(dir));
 
 				if (is_file && allowed) {
+					req.url = original_url;
 					// @ts-expect-error
 					serve_static_middleware.handle(req, res);
 					return;

--- a/packages/kit/test/apps/options/source/pages/test.txt
+++ b/packages/kit/test/apps/options/source/pages/test.txt
@@ -1,0 +1,1 @@
+hello there world

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -32,6 +32,16 @@ test.describe('base path', () => {
 		);
 	});
 
+	if (process.env.DEV) {
+		test('serves files in source directory', async ({ request, javaScriptEnabled }) => {
+			if (!javaScriptEnabled) return;
+
+			const response = await request.get('/path-base/source/pages/test.txt');
+			expect(response.ok()).toBe(true);
+			expect(await response.text()).toBe('hello there world\n');
+		});
+	}
+
 	test('sets_paths', async ({ page }) => {
 		await page.goto('/path-base/base/');
 		expect(await page.textContent('[data-source="base"]')).toBe('/path-base');
@@ -234,14 +244,14 @@ test.describe('trailingSlash', () => {
 	});
 });
 
-test.describe('serviceWorker', () => {
-	if (process.env.DEV) return;
-
-	test('does not register service worker if none created', async ({ page }) => {
-		await page.goto('/path-base/');
-		expect(await page.content()).not.toMatch('navigator.serviceWorker');
+if (!process.env.DEV) {
+	test.describe('serviceWorker', () => {
+		test('does not register service worker if none created', async ({ page }) => {
+			await page.goto('/path-base/');
+			expect(await page.content()).not.toMatch('navigator.serviceWorker');
+		});
 	});
-});
+}
 
 test.describe('Vite options', () => {
 	test('Respects --mode', async ({ page }) => {


### PR DESCRIPTION
[Importing an asset](https://kit.svelte.dev/docs/assets) would not work if you'd set `paths.base` because we were not stripping off the base path before checking for the asset on the file system