### PR TITLE
fix: remove duplicate space in create-svelte templates for TS demo app

### DIFF
--- a/.changeset/early-rockets-impress.md
+++ b/.changeset/early-rockets-impress.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+fix: remove duplicate space around JSDoc comments removed for TypeScript demo app

--- a/packages/create-svelte/scripts/build-templates.js
+++ b/packages/create-svelte/scripts/build-templates.js
@@ -31,7 +31,7 @@ function convert_typescript(content) {
 /** @param {string} content */
 function strip_jsdoc(content) {
 	return content
-		.replace(/\/\*\*\*\//g, '')
+		.replace(/ \/\*\*\*\//g, '')
 		.replace(
 			/\/\*\*([\s\S]+?)(@[\s\S]+?)?\*\/([\s\n]+)/g,
 			(match, description, tags, whitespace) => {


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

This PR solves a minor formatting issue present in TypeScript demo app. The issue is that for `packages/create-svelte/templates/default/src/routes/sverdle/+page.server.ts` [line 59](https://github.com/sveltejs/kit/blob/master/packages/create-svelte/templates/default/src/routes/sverdle/%2Bpage.server.ts#L59) and `packages/create-svelte/templates/default/src/routes/sverdle/game.ts` [line 23](https://github.com/sveltejs/kit/blob/master/packages/create-svelte/templates/default/src/routes/sverdle/game.ts#L23) produced corresponding TypeScript files have double space where closing `/***/` JSDoc comment from original templates was located. I believe the only outcome caused by this PR is that TypeScript demo app in two linked locations has single space instead of a double space.