### PR TITLE
fix: add scrollable area check and scrollable area attribute

### DIFF
--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -76,39 +76,40 @@ function is_scrollable(element) {
 const SCROLLABLE_AREA_ATTRIBUTE = 'data-sveltekit-main-scrollable';
 
 function get_scrollable_area() {
-	const html_is_scrollable = getComputedStyle(document.documentElement).overflowY !== 'hidden';
-	const scrollable_area = html_is_scrollable
+	const is_default_scrollable = getComputedStyle(document.documentElement).overflowY !== 'hidden';
+	const scrollable_area = is_default_scrollable
 		? document.documentElement
 		: is_scrollable(document.body);
 
-	const custom_scrollable_areas = document.querySelectorAll(`*[${SCROLLABLE_AREA_ATTRIBUTE}]`);
+	const custom_scrollable_area = document.querySelector(`*[${SCROLLABLE_AREA_ATTRIBUTE}]`);
 
 	if (DEV) {
-		if (scrollable_area && custom_scrollable_areas.length > 0) {
+		if (scrollable_area && custom_scrollable_area) {
 			console.warn(
 				`<${scrollable_area.tagName.toLowerCase()}> is already scrollable but '${SCROLLABLE_AREA_ATTRIBUTE}' was found on an element. Only use '${SCROLLABLE_AREA_ATTRIBUTE}' if <html> or <body> are not the main scrollable areas`,
-				custom_scrollable_areas
+				custom_scrollable_area
 			);
-		} else if (custom_scrollable_areas?.[0] && !is_scrollable(custom_scrollable_areas[0])) {
+		} else if (custom_scrollable_area && !is_scrollable(custom_scrollable_area)) {
 			console.error(
 				`Invalid main scrollable area. Ensure that the overflow style is set to 'auto' or 'scroll', and the element height is less than its content`,
-				custom_scrollable_areas[0]
+				custom_scrollable_area
 			);
-		} else if (!scrollable_area && !custom_scrollable_areas[0]) {
+		} else if (!scrollable_area && !custom_scrollable_area) {
 			throw new Error(
-				`No scrollable area found. Please identify the main scrolling area with '${SCROLLABLE_AREA_ATTRIBUTE}' to ensure navigation functions correctly`
+				`No scrollable area found. Identify the main scrolling area with '${SCROLLABLE_AREA_ATTRIBUTE}' to ensure navigation functions correctly`
 			);
 		}
 
+		const custom_scrollable_areas = document.querySelectorAll(`*[${SCROLLABLE_AREA_ATTRIBUTE}]`);
 		if (custom_scrollable_areas.length > 1) {
 			console.warn(
-				`More than one '${SCROLLABLE_AREA_ATTRIBUTE}' found. Please only specify a single main scrolling area`,
+				`More than one '${SCROLLABLE_AREA_ATTRIBUTE}' found. Only one main scrolling area is allowed`,
 				custom_scrollable_areas
 			);
 		}
 	}
 
-	return scrollable_area ?? custom_scrollable_areas[0];
+	return scrollable_area ?? custom_scrollable_area;
 }
 
 /***
@@ -116,7 +117,7 @@ function get_scrollable_area() {
  * @param {number} y
  */
 function scroll_to(x, y) {
-	get_scrollable_area().scrollTo(x, y);
+	get_scrollable_area()?.scrollTo(x, y);
 }
 
 /**

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -294,7 +294,7 @@ export function create_client({ target, base }) {
 	 * @param {import('./types').NavigationIntent | undefined} intent
 	 * @param {URL} url
 	 * @param {string[]} redirect_chain
-	 * @param {{scroll: { x: number, y: number } | null, keepfocus: boolean, details: { replaceState: boolean, state: any } | null}} [opts]
+	 * @param {{hash?: string, scroll: { x: number, y: number } | null, keepfocus: boolean, details: { replaceState: boolean, state: any } | null}} [opts]
 	 * @param {{}} [nav_token] To distinguish between different navigation events and determine the latest. Needed for example for redirects to keep the original token
 	 * @param {() => void} [callback]
 	 */


### PR DESCRIPTION
fixes #2733

Adds a check to see if `html` or `body` is scrollable.
Otherwise, it looks for an element with the attribute `data-sveltekit-main-scrollable` to determine which element to scroll during navigation.

Looking for feedback as this solution still feels quite rough. @dummdidumm 

#### TODO
- [ ] add tests
- [ ] docs
- [ ] changeset

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
