### PR TITLE
fix: allow rest parameters to follow multiple optional - or not - parameters

### DIFF
--- a/.changeset/chatty-forks-press.md
+++ b/.changeset/chatty-forks-press.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+Allows rest parameters to follow multiple optional - or not - parameters

--- a/.changeset/chatty-forks-press.md
+++ b/.changeset/chatty-forks-press.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': minor
----
-
-Allows rest parameters to follow multiple optional - or not - parameters

--- a/.changeset/fast-jokes-sing.md
+++ b/.changeset/fast-jokes-sing.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow rest parameters to follow multiple optional - or not - parameters

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -124,7 +124,6 @@ export function exec(match, params, matchers) {
 	/** @type {Record<string, string>} */
 	const result = {};
 
-	/** @type {Array<string | undefined>} cause it is */
 	const values = match.slice(1);
 
 	let buffered = 0;
@@ -133,17 +132,17 @@ export function exec(match, params, matchers) {
 		const param = params[i];
 		const value = values[i - buffered];
 
+		// in the `[[a=b]]/.../[...rest]` case, if one or more optional parameters
+		// weren't matched, roll the skipped values into the rest
 		if (param.chained && param.rest && buffered) {
-			// in the `[[a=b]]/.../[...rest]` case, if one or more optional parameters
-			// weren't matched, roll the skipped values into the rest
 			const bufferedValues = values.slice(i - buffered, i + 1);
 			result[param.name] = bufferedValues.filter((s) => s).join('/');
 			buffered = 0;
 			continue;
 		}
 
+		// if `value` is undefined, it means this is an optional or rest parameter
 		if (value === undefined) {
-			// if `value` is undefined, it means this is an optional or rest parameter
 			if (param.rest) result[param.name] = '';
 			continue;
 		}

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -135,8 +135,11 @@ export function exec(match, params, matchers) {
 		// in the `[[a=b]]/.../[...rest]` case, if one or more optional parameters
 		// weren't matched, roll the skipped values into the rest
 		if (param.chained && param.rest && buffered) {
-			const bufferedValues = values.slice(i - buffered, i + 1);
-			result[param.name] = bufferedValues.filter((s) => s).join('/');
+			result[param.name] = values
+				.slice(i - buffered, i + 1)
+				.filter((s) => s)
+				.join('/');
+
 			buffered = 0;
 			continue;
 		}

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -154,6 +154,31 @@ const exec_tests = [
 		expected: { rest: 'foo' }
 	},
 	{
+		route: '/[[slug1=doesntmatch]]/[slug2]/[...rest]',
+		path: '/foo/bar/baz',
+		expected: { slug2: 'foo', rest: 'bar/baz' }
+	},
+	{
+		route: '/[[slug1=doesntmatch]]/[slug2]/[...rest]/baz',
+		path: '/foo/bar/baz',
+		expected: { slug2: 'foo', rest: 'bar' }
+	},
+	{
+		route: '/[[a=doesntmatch]]/[[b=doesntmatch]]/[[c=doesntmatch]]/[...d]',
+		path: '/a/b/c/d',
+		expected: { d: 'a/b/c/d' }
+	},
+	{
+		route: '/[[a=doesntmatch]]/[b]/[...c]/[d]/e',
+		path: '/foo/bar/baz/qux/e',
+		expected: { b: 'foo', c: 'bar/baz', d: 'qux' }
+	},
+	{
+		route: '/[[slug1=doesntmatch]]/[[slug2=doesntmatch]]/[...rest]',
+		path: '/foo/bar/baz',
+		expected: { rest: 'foo/bar/baz' }
+	},
+	{
 		route: '/[[slug1=doesntmatch]]/[[slug2=matches]]/[[slug3=doesntmatch]]/[...rest].json',
 		path: '/foo/bar/baz.json',
 		expected: { slug2: 'foo', rest: 'bar/baz' }


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/issues/8601

Actually, managed to clean up the whole thing and make it work with every valid test case I could think of.

~~It's not pretty (it's not *that* bad either), but it works.~~
~~There's still a case it doesn't solve though, but I'm fairly confident we got time before someone actually goes for such thing.~~

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
