### PR TITLE
fix: add prerendered redirect for non-trailing slash routes with the Vercel adapter

### DIFF
--- a/.changeset/purple-starfishes-sip.md
+++ b/.changeset/purple-starfishes-sip.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-vercel': patch
 ---
 
-fix: prerendered trailing slash redirect for Vercel adapter
+fix: add trailing slash -> no trailing slash redirect for prerendered pages

--- a/.changeset/purple-starfishes-sip.md
+++ b/.changeset/purple-starfishes-sip.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+fix: prerendered trailing slash redirect for Vercel adapter

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -193,16 +193,24 @@ function static_vercel_config(builder) {
 	}
 
 	for (const [path, page] of builder.prerendered.pages) {
-		if (path.endsWith('/') && path !== '/') {
-			prerendered_redirects.push(
-				{ src: path, dest: path.slice(0, -1) },
-				{ src: path.slice(0, -1), status: 308, headers: { Location: path } }
-			);
+		let overrides_path = path.slice(1);
 
-			overrides[page.file] = { path: path.slice(1, -1) };
-		} else {
-			overrides[page.file] = { path: path.slice(1) };
+		if (path !== '/') {
+			/** @type {string | undefined} */
+			let counterpart_route = path + '/';
+
+			if (path.endsWith('/')) {
+				counterpart_route = path.slice(0, -1);
+				overrides_path = path.slice(1, -1);
+			}
+
+			prerendered_redirects.push(
+				{ src: path, dest: counterpart_route },
+				{ src: counterpart_route, status: 308, headers: { Location: path } }
+			);
 		}
+
+		overrides[page.file] = { path: overrides_path };
 	}
 
 	return {


### PR DESCRIPTION
fixes #8755

Adds a redirect for prerendered non-trailing slash routes to `adapter-vercel`.
Previously, only prerendered trailing slash routes would be added to the redirects list in the vercel config file.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
