### PR TITLE
Mention client-side navigation alongside server-side redirect

### DIFF
--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -417,7 +417,7 @@ export function load({ locals }) {
 
 > Make sure you're not catching the thrown redirect, which results in a noop.
 
-To navigate users from the client-side, you'll want to use [`goto`](modules#$app-navigation-goto) from [`$app.navigation`](modules#$app-navigation)
+In the browser, you can also navigate programmatically outside of a `load` function using [`goto`](modules#$app-navigation-goto) from [`$app.navigation`](modules#$app-navigation).
 
 ## Promise unwrapping
 

--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -417,6 +417,8 @@ export function load({ locals }) {
 
 > Make sure you're not catching the thrown redirect, which results in a noop.
 
+To navigate users from the client-side, you'll want to use [`goto`](modules#$app-navigation-goto) from [`$app.navigation`](modules#$app-navigation)
+
 ## Promise unwrapping
 
 Top-level promises will be awaited, which makes it easy to return multiple promises without creating a waterfall:


### PR DESCRIPTION
Newcomers may benefit from this one added line. Especially since if a user accidentally writes something like this client-side:

```js
throw redirect(302, '/somePage');
```

There isn't an any indication of why it fails. So if they head over to the docs, this will point them in the right direction. (It would be great if SvelteKit also had a good error message for throwing a redirect client side, too.)

Forgive me ignoring the checklist, this is merely a proposed doc change.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
