### PR TITLE
docs: clarify Vercel `api` functions

### DIFF
--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -69,7 +69,7 @@ Since all of these variables are unchanged between build time and run time when 
 
 ### Vercel functions
 
-Vercel functions contained in the `/api` directory at the project's root will _not_ be included in the deployment — these should be implemented as [server endpoints](https://kit.svelte.dev/docs/routing#server) in your SvelteKit app.
+If you have Vercel functions contained in the `api` directory at the project's root, any requests for `/api/*` will _not_ be handled by SvelteKit. You should implement these as [API routes](https://kit.svelte.dev/docs/routing#server) in your SvelteKit app instead, unless you need to use a non-JavaScript language in which case you will need to ensure that you don't have any `/api/*` routes in your SvelteKit app.
 
 ### Node version
 


### PR DESCRIPTION
In a Vercel deployment, you can create API routes like so:

```js
// project/api/hello.js
export default function handler(request, response) {
  response.status(200).json({
    body: 'hello'
  });
}
```

If you have an `api` directory, Vercel will inject a route into your configuration that matches all `/api/*` requests. This means that any `project/src/routes/api/*` routes will never be invoked.

Currently, the documentation says Vercel `api` functions are ignored, which is incorrect. This PR fixes it.