### PR TITLE
docs: apply generics to typescript example

### DIFF
--- a/sites/kit.svelte.dev/src/lib/docs/server/index.js
+++ b/sites/kit.svelte.dev/src/lib/docs/server/index.js
@@ -570,7 +570,7 @@ function convert_to_ts(js_code, indent = '', offset = '') {
 		const type_text = tag.typeExpression.getText();
 		let name = type_text.slice(1, -1); // remove { }
 
-		const import_match = /import\('(.+?)'\)\.(\w+)(<{[\n\* \w:;]+}>)?/.exec(type_text);
+		const import_match = /import\('(.+?)'\)\.(\w+)(<{?[\n\* \w:;,]+}?>)?/.exec(type_text);
 		if (import_match) {
 			const [, from, _name, generics] = import_match;
 			name = _name;


### PR DESCRIPTION
Closes #7854. Extracts generics along with the name to establish extra information when converting to typescript.

I would absolutely love a suggestion on this, as the current trick to un-indent the closing brace in generics is a bit hacky and may not work in different use cases.