### PR TITLE
Defer client hooks import to allow using env in them

### DIFF
--- a/packages/kit/src/core/sync/write_client_manifest.js
+++ b/packages/kit/src/core/sync/write_client_manifest.js
@@ -110,8 +110,6 @@ export function write_client_manifest(kit, manifest_data, output, metadata) {
 	write_if_changed(
 		`${output}/manifest.js`,
 		trim(`
-			${hooks_file ? `import * as client_hooks from '${relative_path(output, hooks_file)}';` : ''}
-
 			export { matchers } from './matchers.js';
 
 			export const nodes = [${nodes}];
@@ -119,7 +117,13 @@ export function write_client_manifest(kit, manifest_data, output, metadata) {
 			export const server_loads = [${[...layouts_with_server_load].join(',')}];
 
 			export const dictionary = ${dictionary};
+		`)
+	);
 
+	write_if_changed(
+		`${output}/hooks.js`,
+		trim(`
+			${hooks_file ? `import * as client_hooks from '${relative_path(output, hooks_file)}';` : ''}
 			export const hooks = {
 				handleError: ${
 					hooks_file ? 'client_hooks.handleError || ' : ''

--- a/packages/kit/src/runtime/client/ambient.d.ts
+++ b/packages/kit/src/runtime/client/ambient.d.ts
@@ -1,5 +1,5 @@
 declare module '__CLIENT__/manifest.js' {
-	import { CSRPageNodeLoader, ClientHooks, ParamMatcher } from 'types';
+	import { CSRPageNodeLoader, ParamMatcher } from 'types';
 
 	/**
 	 * A list of all the error/layout/page nodes used in the app
@@ -21,6 +21,10 @@ declare module '__CLIENT__/manifest.js' {
 	export const dictionary: Record<string, [leaf: number, layouts: number[], errors?: number[]]>;
 
 	export const matchers: Record<string, ParamMatcher>;
+}
+
+declare module '__CLIENT__/hooks.js' {
+	import { ClientHooks } from 'types';
 
 	export const hooks: ClientHooks;
 }

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -38,10 +38,8 @@ const routes = parse(nodes, server_loads, dictionary, matchers);
 
 /** @type {import('types').ClientHooks} */
 let hooks;
-/** @param {typeof hooks} _hooks */
-export function set_hooks(_hooks) {
-	console.log(_hooks);
-	hooks = _hooks;
+export async function load_client_hooks() {
+	({ hooks } = await import('__CLIENT__/hooks.js'));
 }
 
 const default_layout_loader = nodes[0];

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -25,7 +25,7 @@ import {
 import { parse } from './parse.js';
 
 import Root from '__GENERATED__/root.svelte';
-import { nodes, server_loads, dictionary, matchers, hooks } from '__CLIENT__/manifest.js';
+import { nodes, server_loads, dictionary, matchers } from '__CLIENT__/manifest.js';
 import { HttpError, Redirect } from '../control.js';
 import { stores } from './singletons.js';
 import { unwrap_promises } from '../../utils/promises.js';
@@ -35,6 +35,14 @@ import { validate_common_exports } from '../../utils/exports.js';
 import { compact } from '../../utils/array.js';
 
 const routes = parse(nodes, server_loads, dictionary, matchers);
+
+/** @type {import('types').ClientHooks} */
+let hooks;
+/** @param {typeof hooks} _hooks */
+export function set_hooks(_hooks) {
+	console.log(_hooks);
+	hooks = _hooks;
+}
 
 const default_layout_loader = nodes[0];
 const default_error_loader = nodes[1];

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -1,5 +1,5 @@
 import { DEV } from 'esm-env';
-import { create_client } from './client.js';
+import { create_client, set_hooks } from './client.js';
 import { init } from './singletons.js';
 import { set_paths, set_version, set_public_env } from '../shared.js';
 
@@ -25,6 +25,8 @@ export async function start({ env, hydrate, paths, target, version }) {
 			`Placing %sveltekit.body% directly inside <body> is not recommended, as your app may break for users who have certain browser extensions installed.\n\nConsider wrapping it in an element:\n\n<div style="display: contents">\n  %sveltekit.body%\n</div>`
 		);
 	}
+
+	set_hooks((await import('__CLIENT__/hooks.js')).hooks);
 
 	const client = create_client({
 		target,

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -26,14 +26,14 @@ export async function start({ env, hydrate, paths, target, version }) {
 		);
 	}
 
-	await load_client_hooks();
-
 	const client = create_client({
 		target,
 		base: paths.base
 	});
 
 	init({ client });
+
+	await load_client_hooks();
 
 	if (hydrate) {
 		await client._hydrate(hydrate);

--- a/packages/kit/src/runtime/client/start.js
+++ b/packages/kit/src/runtime/client/start.js
@@ -1,5 +1,5 @@
 import { DEV } from 'esm-env';
-import { create_client, set_hooks } from './client.js';
+import { create_client, load_client_hooks } from './client.js';
 import { init } from './singletons.js';
 import { set_paths, set_version, set_public_env } from '../shared.js';
 
@@ -26,7 +26,7 @@ export async function start({ env, hydrate, paths, target, version }) {
 		);
 	}
 
-	set_hooks((await import('__CLIENT__/hooks.js')).hooks);
+	await load_client_hooks();
 
 	const client = create_client({
 		target,


### PR DESCRIPTION
ref #8464 

Need some insight on [this commit](https://github.com/sveltejs/kit/commit/0e1ab812ba531eb39ee9cab237eb975d417334c5), without it, all the tests start failing at random because it can't find the selector that's set on hydration, no matter what the timeout is. Although it seems like the wrong location to put it in.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
