### PR TITLE
chore: run github CI on latest windows image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       matrix:
         include:
           - node-version: 16
-            os: windows-2019 # slowness reported on newer versions https://github.com/actions/runner-images/issues/5166
+            os: windows-latest
             e2e-browser: 'firefox'
           - node-version: 16
             os: macOS-latest


### PR DESCRIPTION
I'm curious if this is any faster?