### PR TITLE
fix: await finalise hook and run it only once

### DIFF
--- a/.changeset/honest-geckos-jog.md
+++ b/.changeset/honest-geckos-jog.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: await finalise hook and run it only once

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -176,8 +176,8 @@ function kit({ svelte_config }) {
 	/** @type {{ public: Record<string, string>; private: Record<string, string> }} */
 	let env;
 
-	/** @type {(() => Promise<void>) | null} */
-	let finalise = null;
+	/** @type {() => Promise<void>} */
+	let finalise;
 
 	const service_worker_entry_file = resolve_entry(kit.files.serviceWorker);
 
@@ -537,9 +537,6 @@ function kit({ svelte_config }) {
 		buildStart() {
 			if (secondary_build) return;
 
-			// reset (here, not in `config`, because `build --watch` skips `config`)
-			finalise = null;
-
 			if (is_build) {
 				if (!vite_config.build.watch) {
 					rimraf(out);
@@ -723,7 +720,8 @@ function kit({ svelte_config }) {
 		closeBundle: {
 			sequential: true,
 			async handler() {
-				finalise?.();
+				if (secondary_build) return;
+				await finalise();
 			}
 		}
 	};


### PR DESCRIPTION
regression reported in https://github.com/vite-pwa/sveltekit/issues/21

I don't think the reset would do anything. `buildStart` will be run for both the server and client builds before `closeBundle` is run for either