### PR TITLE
chore: split dev and build cross-browser tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           path: test-results.tar.gz
   Cross-browser-test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -78,12 +78,27 @@ jobs:
           - node-version: 16
             os: windows-2019 # slowness reported on newer versions https://github.com/actions/runner-images/issues/5166
             e2e-browser: 'chromium'
+            mode: 'dev'
           - node-version: 16
             os: ubuntu-latest
             e2e-browser: 'firefox'
+            mode: 'dev'
           - node-version: 16
             os: macOS-latest
             e2e-browser: 'webkit'
+            mode: 'dev'
+          - node-version: 16
+            os: windows-2019 # slowness reported on newer versions https://github.com/actions/runner-images/issues/5166
+            e2e-browser: 'chromium'
+            mode: 'build'
+          - node-version: 16
+            os: ubuntu-latest
+            e2e-browser: 'firefox'
+            mode: 'build'
+          - node-version: 16
+            os: macOS-latest
+            e2e-browser: 'webkit'
+            mode: 'build'
     env:
       KIT_E2E_BROWSER: ${{matrix.e2e-browser}}
     steps:
@@ -96,15 +111,15 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm playwright install ${{ matrix.e2e-browser }}
-      - run: pnpm test:cross-platform
+      - run: pnpm test:cross-platform:${{ matrix.mode }}
       - name: Archive test results
         if: failure()
         shell: bash
-        run: find packages -type d -name test-results -not -empty | tar -czf test-results-cross-platform.tar.gz --files-from=-
+        run: find packages -type d -name test-results -not -empty | tar -czf test-results-cross-platform-${{ matrix.mode }}.tar.gz --files-from=-
       - name: Upload test results
         if: failure()
         uses: actions/upload-artifact@v3
         with:
           retention-days: 3
-          name: test-failure-cross-platform-${{ github.run_id }}-${{ matrix.os }}-${{ matrix.node-version }}-${{ matrix.e2e-browser }}
-          path: test-results-cross-platform.tar.gz
+          name: test-failure-cross-platform-${{ matrix.mode }}-${{ github.run_id }}-${{ matrix.os }}-${{ matrix.node-version }}-${{ matrix.e2e-browser }}
+          path: test-results-cross-platform-${{ matrix.mode }}.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
         include:
           - node-version: 16
             os: windows-2019 # slowness reported on newer versions https://github.com/actions/runner-images/issues/5166
+            e2e-browser: 'chromium'
+          - node-version: 16
+            os: ubuntu-latest
             e2e-browser: 'firefox'
           - node-version: 16
             os: macOS-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           path: test-results.tar.gz
   Cross-browser-test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"private": true,
 	"scripts": {
 		"test": "pnpm test -r --filter=./packages/*",
-		"test:cross-platform": "pnpm -r test:cross-platform --filter=./packages/*",
+		"test:cross-platform:dev": "pnpm -r test:cross-platform:dev --filter=./packages/*",
+		"test:cross-platform:build": "pnpm -r test:cross-platform:build --filter=./packages/*",
 		"test:vite-ecosystem-ci": "pnpm test --dir packages/kit",
 		"check": "pnpm -r check",
 		"lint": "pnpm -r lint",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
 	"private": true,
 	"scripts": {
 		"test": "pnpm test -r --filter=./packages/*",
-		"test:cross-platform:dev": "pnpm -r test:cross-platform:dev --filter=./packages/*",
-		"test:cross-platform:build": "pnpm -r test:cross-platform:build --filter=./packages/*",
+		"test:cross-platform:dev": "pnpm test:cross-platform:dev --dir packages/kit",
+		"test:cross-platform:build": "pnpm test:cross-platform:build --dir packages/kit",
 		"test:vite-ecosystem-ci": "pnpm test --dir packages/kit",
 		"check": "pnpm -r check",
 		"lint": "pnpm -r lint",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
 	"private": true,
 	"scripts": {
 		"test": "pnpm test -r --filter=./packages/*",
-		"test:cross-platform:dev": "pnpm test:cross-platform:dev --dir packages/kit",
-		"test:cross-platform:build": "pnpm test:cross-platform:build --dir packages/kit",
+		"test:cross-platform:dev": "pnpm run --dir packages/kit test:cross-platform:dev",
+		"test:cross-platform:build": "pnpm run --dir packages/kit test:cross-platform:build",
 		"test:vite-ecosystem-ci": "pnpm test --dir packages/kit",
 		"check": "pnpm -r check",
 		"lint": "pnpm -r lint",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -65,7 +65,8 @@
 		"format": "pnpm lint --write",
 		"test": "pnpm test:unit && pnpm test:integration",
 		"test:integration": "pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test",
-		"test:cross-platform": "pnpm test:unit && pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:cross-platform",
+		"test:cross-platform:dev": "pnpm test:unit && pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:cross-platform:dev",
+		"test:cross-platform:build": "pnpm test:unit && pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:cross-platform:build",
 		"test:unit": "uvu src \"(spec\\.js|test[\\\\/]index\\.js)\"",
 		"postinstall": "node postinstall.js"
 	},

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -65,7 +65,7 @@
 		"format": "pnpm lint --write",
 		"test": "pnpm test:unit && pnpm test:integration",
 		"test:integration": "pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test",
-		"test:cross-platform:dev": "pnpm test:unit && pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:cross-platform:dev",
+		"test:cross-platform:dev": "pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:cross-platform:dev",
 		"test:cross-platform:build": "pnpm test:unit && pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:cross-platform:build",
 		"test:unit": "uvu src \"(spec\\.js|test[\\\\/]index\\.js)\"",
 		"postinstall": "node postinstall.js"

--- a/packages/kit/test/apps/basics/package.json
+++ b/packages/kit/test/apps/basics/package.json
@@ -10,7 +10,6 @@
 		"test": "node test/setup.js && pnpm test:dev && pnpm test:build",
 		"test:dev": "rimraf test/errors.json && cross-env DEV=true playwright test",
 		"test:build": "rimraf test/errors.json && playwright test",
-		"test:cross-platform": "npm run test:cross-platform:dev && npm run test:cross-platform:build",
 		"test:cross-platform:dev": "node test/setup.js && rimraf test/errors.json && cross-env DEV=true playwright test test/cross-platform/",
 		"test:cross-platform:build": "node test/setup.js && rimraf test/errors.json && playwright test test/cross-platform/"
 	},

--- a/packages/kit/test/build-errors/package.json
+++ b/packages/kit/test/build-errors/package.json
@@ -4,7 +4,7 @@
 	"version": "0.0.0-next.0",
 	"scripts": {
 		"test": "uvu . \"(spec\\.js|test[\\\\/]index\\.js)\"",
-		"test:cross-platform": "uvu . \"(spec\\.js|test[\\\\/]index\\.js)\""
+		"test:cross-platform:build": "uvu . \"(spec\\.js|test[\\\\/]index\\.js)\""
 	},
 	"type": "module",
 	"devDependencies": {


### PR DESCRIPTION
Firefox takes twice as long to run as Chrome. By splitting dev and build into two jobs we can run them in parallel and finish twice as fast soling our timeout issues

I also moved the Firefox tests to Ubuntu. Eventhough this means we test an additional variant it reduces our billing because Windows is billed at a higher rate