### PR TITLE
Update 90-adapter-vercel.md

### DIFF
--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -25,7 +25,9 @@ export default {
 			edge: false,
 
 			// an array of dependencies that esbuild should treat
-			// as external when bundling functions
+			// as external when bundling functions. this only applies
+			// to edge functions, and should only be used to exclude
+			// optional dependencies that will not run outside Node
 			external: [],
 
 			// if true, will split your app into multiple functions


### PR DESCRIPTION
clarifies that `external` only applies to edge functions. closes #8814 