### PR TITLE
add trailing slash redirect middleware to adapter-node

### DIFF
--- a/.changeset/warm-bananas-sneeze.md
+++ b/.changeset/warm-bananas-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+fix: correctly redirect trailing slashes for `adapter-node`

--- a/packages/adapter-node/ambient.d.ts
+++ b/packages/adapter-node/ambient.d.ts
@@ -8,7 +8,9 @@ declare module 'HANDLER' {
 
 declare module 'MANIFEST' {
 	import { SSRManifest } from '@sveltejs/kit';
+
 	export const manifest: SSRManifest;
+	export const prerendered: Set<string>;
 }
 
 declare module 'SERVER' {

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -1,5 +1,5 @@
-import { readFileSync, writeFileSync } from 'fs';
-import { fileURLToPath } from 'url';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { rollup } from 'rollup';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
@@ -39,7 +39,8 @@ export default function (opts = {}) {
 
 			writeFileSync(
 				`${tmp}/manifest.js`,
-				`export const manifest = ${builder.generateManifest({ relativePath: './' })};`
+				`export const manifest = ${builder.generateManifest({ relativePath: './' })};\n\n` +
+					`export const prerendered = new Set(${JSON.stringify(builder.prerendered.paths)});\n`
 			);
 
 			const pkg = JSON.parse(readFileSync('package.json', 'utf8'));

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -62,11 +62,11 @@ function serve_prerendered() {
 			return handler(req, res, next);
 		}
 
-		// redirect to counterpart
-		const counterpart_route = pathname.at(-1) === '/' ? pathname.slice(0, -1) : pathname + '/';
-		if (counterpart_route && prerendered.has(counterpart_route)) {
+		// remove or add trailing slash as appropriate
+		let location = pathname.at(-1) === '/' ? pathname.slice(0, -1) : pathname + '/';
+		if (prerendered.has(location)) {
 			const search = req.url.split('?')[1];
-			const location = `${counterpart_route}${search ? `?${search}` : ''}`;
+			if (search) location += `?${search}`;
 			res.writeHead(308, { location }).end();
 		} else {
 			next();

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -65,7 +65,8 @@ function serve_prerendered() {
 		// redirect to counterpart
 		const counterpart_route = pathname.at(-1) === '/' ? pathname.slice(0, -1) : pathname + '/';
 		if (counterpart_route && prerendered.has(counterpart_route)) {
-			const location = `${counterpart_route}?${new URLSearchParams(req.query)}`;
+			const search = req.url.split('?')[1];
+			const location = `${counterpart_route}${search ? `?${search}` : ''}`;
 			res.writeHead(308, { location }).end();
 		} else {
 			next();


### PR DESCRIPTION
fixes #8755

Adds prerendered pages to the manifest so that a middleware can check if a counterpart route exists, and redirect to it.

I'm not too experienced with Express / Polka and writing middleware for them, so I'm sure this can be fixed up a bit.

Specifically, I'm sure there's a way to skip the middleware for serving prerendered routes and go straight to ssr.
We should do this since we already check if it's prerendered or not.

Also, I'm not sure if there are any penalties for including the prerendered routes list in the manifest.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
