### PR TITLE
Route level config alt

### DIFF
--- a/documentation/docs/20-core-concepts/40-page-options.md
+++ b/documentation/docs/20-core-concepts/40-page-options.md
@@ -139,11 +139,11 @@ declare module 'some-adapter' {
 }
 
 // @filename: index.js
----cut---
+// ---cut---
 /// file: src/routes/+page.js
 /** @type {import('some-adapter').Config} */
-export const config: Config = {
-	runtime: 'edge';
+export const config = {
+	runtime: 'edge'
 };
 ```
 

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -8,25 +8,9 @@ export default function (options) {
 
 		async adapt(builder) {
 			if (!options?.fallback) {
-				/** @type {string[]} */
-				const dynamic_routes = [];
-
-				// this is a bit of a hack — it allows us to know whether there are dynamic
-				// (i.e. prerender = false/'auto') routes without having dedicated API
-				// surface area for it
-				builder.createEntries((route) => {
-					dynamic_routes.push(route.id);
-
-					return {
-						id: '',
-						filter: () => false,
-						complete: () => {}
-					};
-				});
-
-				if (dynamic_routes.length > 0 && options?.strict !== false) {
+				if (builder.routes.length > 0 && options?.strict !== false) {
 					const prefix = path.relative('.', builder.config.kit.files.routes);
-					const has_param_routes = dynamic_routes.some((route) => route.includes('['));
+					const has_param_routes = builder.routes.some((route) => route.id.includes('['));
 					const config_option =
 						has_param_routes || JSON.stringify(builder.config.kit.prerender.entries) !== '["*"]'
 							? `  - adjust the \`prerender.entries\` config option ${
@@ -38,7 +22,7 @@ export default function (options) {
 
 					builder.log.error(
 						`@sveltejs/adapter-static: all routes must be fully prerenderable, but found the following routes that are dynamic:
-${dynamic_routes.map((id) => `  - ${path.posix.join(prefix, id)}`).join('\n')}
+${builder.routes.map((route) => `  - ${path.posix.join(prefix, route.id)}`).join('\n')}
 
 You have the following options:
   - set the \`fallback\` option — see https://github.com/sveltejs/kit/tree/master/packages/adapter-static#spa-mode for more info.

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -203,6 +203,8 @@ const plugin = function ({ external = [], edge, split, ...default_config } = {})
 					src = '^/?';
 				}
 
+				src += '(?:/__data.json)?$';
+
 				const name = functions.get(pattern);
 				if (name) {
 					static_config.routes.push({ src, dest: `/${name}` });

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -230,39 +230,6 @@ function hash_config(config) {
 }
 
 /**
- * @param {import('.').Config | undefined} config_a
- * @param {import('.').Config | undefined} config_b
- */
-function can_group(config_a, config_b) {
-	if (config_a === config_b) return true;
-	if (!config_a || !config_b) return false;
-
-	if (config_a.runtime !== config_b.runtime) return false;
-	if (config_a.maxDuration !== config_b.maxDuration) return false;
-	if (config_a.memory !== config_b.memory) return false;
-	if (arrays_different(config_a.envVarsInUse, config_b.envVarsInUse)) return false;
-
-	const regions_a = config_a.regions === 'all' ? ['all'] : config_a.regions;
-	const regions_b = config_b.regions === 'all' ? ['all'] : config_b.regions;
-	if (arrays_different(regions_a, regions_b)) return false;
-
-	return true;
-}
-
-/**
- *
- * @param {any[] | undefined} a
- * @param {any[] | undefined} b
- * @returns
- */
-function arrays_different(a, b) {
-	if (a === b) return false;
-	if (!a || !b) return true;
-	if (a.length !== b.length) return true;
-	return a.every((e) => b.includes(e));
-}
-
-/**
  * @param {string} file
  * @param {string} data
  */

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -39,7 +39,7 @@ const plugin = function ({ external = [], edge, split, ...default_config } = {})
 			/**
 			 * @param {string} name
 			 * @param {import('.').Config} config
-			 * @param {typeof builder.routes} routes
+			 * @param {import('@sveltejs/kit').RouteDefinition<import('.').Config>[]} routes
 			 */
 			async function generate_serverless_function(name, config, routes) {
 				const relativePath = path.posix.relative(tmp, builder.getServerDirectory());
@@ -68,7 +68,7 @@ const plugin = function ({ external = [], edge, split, ...default_config } = {})
 			/**
 			 * @param {string} name
 			 * @param {import('.').Config} config
-			 * @param {typeof builder.routes} routes
+			 * @param {import('@sveltejs/kit').RouteDefinition<import('.').Config>[]} routes
 			 */
 			async function generate_edge_function(name, config, routes) {
 				const tmp = builder.getBuildDirectory(`vercel-tmp/${name}`);
@@ -115,7 +115,7 @@ const plugin = function ({ external = [], edge, split, ...default_config } = {})
 				);
 			}
 
-			/** @type {Map<string, { i: number, config: import('.').Config, routes: typeof builder.routes }>} */
+			/** @type {Map<string, { i: number, config: import('.').Config, routes: import('@sveltejs/kit').RouteDefinition<import('.').Config>[] }>} */
 			const groups = new Map();
 
 			/** @type {Map<string, { hash: string, route_id: string }>} */
@@ -158,7 +158,7 @@ const plugin = function ({ external = [], edge, split, ...default_config } = {})
 
 				if (split) {
 					// generate individual functions
-					/** @type {Map<string, typeof builder.routes>} */
+					/** @type {Map<string, import('@sveltejs/kit').RouteDefinition<import('.').Config>[]>} */
 					const merged = new Map();
 
 					for (const route of group.routes) {

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -5,7 +5,7 @@ import { nodeFileTrace } from '@vercel/nft';
 import esbuild from 'esbuild';
 
 const DEFAULTS = {
-	runtime: 'node18.x',
+	runtime: 'nodejs18.x',
 	regions: ['iad1'],
 	memory: 128,
 	maxDuration: 30 // TODO check what the defaults actually are

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -18,13 +18,51 @@ const pipe = promisify(pipeline);
  *   config: import('types').ValidatedConfig;
  *   build_data: import('types').BuildData;
  *   server_metadata: import('types').ServerMetadata;
- *   routes: import('types').RouteData[];
+ *   route_data: import('types').RouteData[];
  *   prerendered: import('types').Prerendered;
  *   log: import('types').Logger;
  * }} opts
  * @returns {import('types').Builder}
  */
-export function create_builder({ config, build_data, server_metadata, routes, prerendered, log }) {
+export function create_builder({
+	config,
+	build_data,
+	server_metadata,
+	route_data,
+	prerendered,
+	log
+}) {
+	/** @type {Map<import('types').RouteDefinition, import('types').RouteData>} */
+	const lookup = new Map();
+
+	/**
+	 * Rather than exposing the internal `RouteData` type, which is subject to change,
+	 * we expose a stable type that adapters can use to group/filter routes
+	 */
+	const routes = route_data.map((route) => {
+		const methods =
+			/** @type {import('types').HttpMethod[]} */
+			(server_metadata.routes.get(route.id)?.methods);
+		const config = server_metadata.routes.get(route.id)?.config;
+
+		/** @type {import('types').RouteDefinition} */
+		const facade = {
+			id: route.id,
+			segments: get_route_segments(route.id).map((segment) => ({
+				dynamic: segment.includes('['),
+				rest: segment.includes('[...'),
+				content: segment
+			})),
+			pattern: route.pattern,
+			methods,
+			config
+		};
+
+		lookup.set(facade, route);
+
+		return facade;
+	});
+
 	return {
 		log,
 		rimraf,
@@ -33,6 +71,8 @@ export function create_builder({ config, build_data, server_metadata, routes, pr
 
 		config,
 		prerendered,
+		routes,
+
 		hasRouteLevelConfig:
 			!!server_metadata.routes &&
 			!![...server_metadata.routes.values()].some((route) => route.config),
@@ -55,31 +95,11 @@ export function create_builder({ config, build_data, server_metadata, routes, pr
 		},
 
 		async createEntries(fn) {
-			/** @type {import('types').RouteDefinition[]} */
-			const facades = routes.map((route) => {
-				const methods =
-					/** @type {import('types').HttpMethod[]} */
-					(server_metadata.routes.get(route.id)?.methods);
-				const config = server_metadata.routes.get(route.id)?.config;
-
-				return {
-					id: route.id,
-					segments: get_route_segments(route.id).map((segment) => ({
-						dynamic: segment.includes('['),
-						rest: segment.includes('[...'),
-						content: segment
-					})),
-					pattern: route.pattern,
-					methods,
-					config
-				};
-			});
-
 			const seen = new Set();
 
-			for (let i = 0; i < routes.length; i += 1) {
-				const route = routes[i];
-				const { id, filter, complete } = fn(facades[i]);
+			for (let i = 0; i < route_data.length; i += 1) {
+				const route = route_data[i];
+				const { id, filter, complete } = fn(routes[i]);
 
 				if (seen.has(id)) continue;
 				seen.add(id);
@@ -87,9 +107,9 @@ export function create_builder({ config, build_data, server_metadata, routes, pr
 				const group = [route];
 
 				// figure out which lower priority routes should be considered fallbacks
-				for (let j = i + 1; j < routes.length; j += 1) {
-					if (filter(facades[j])) {
-						group.push(routes[j]);
+				for (let j = i + 1; j < route_data.length; j += 1) {
+					if (filter(routes[j])) {
+						group.push(route_data[j]);
 					}
 				}
 
@@ -100,7 +120,7 @@ export function create_builder({ config, build_data, server_metadata, routes, pr
 				// TODO is this still necessary, given the new way of doing things?
 				filtered.forEach((route) => {
 					if (route.page) {
-						const endpoint = routes.find((candidate) => candidate.id === route.id + '.json');
+						const endpoint = route_data.find((candidate) => candidate.id === route.id + '.json');
 
 						if (endpoint) {
 							filtered.add(endpoint);
@@ -148,11 +168,13 @@ export function create_builder({ config, build_data, server_metadata, routes, pr
 			});
 		},
 
-		generateManifest: ({ relativePath }) => {
+		generateManifest: ({ relativePath, routes: subset }) => {
 			return generate_manifest({
 				build_data,
 				relative_path: relativePath,
-				routes
+				routes: subset
+					? subset.map((route) => /** @type {import('types').RouteData} */ (lookup.get(route)))
+					: route_data
 			});
 		},
 

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -73,10 +73,6 @@ export function create_builder({
 		prerendered,
 		routes,
 
-		hasRouteLevelConfig:
-			!!server_metadata.routes &&
-			!![...server_metadata.routes.values()].some((route) => route.config),
-
 		async compress(directory) {
 			if (!existsSync(directory)) {
 				return;

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -76,57 +76,40 @@ export function create_builder({ config, build_data, server_metadata, routes, pr
 			});
 
 			const seen = new Set();
-			const grouped = new Set();
-			let ungrouped = facades.map((f, i) => ({ r: routes[i], f }));
 
 			for (let i = 0; i < routes.length; i += 1) {
 				const route = routes[i];
-				const { id, filter, complete, group } = fn(facades[i]);
+				const { id, filter, complete } = fn(facades[i]);
 
-				if (seen.has(id) || grouped.has(route)) continue;
+				if (seen.has(id)) continue;
 				seen.add(id);
 
-				const filtered = new Set([route]);
-				const route_definitions = new Set([facades[i]]);
-
-				if (group) {
-					ungrouped = ungrouped.filter((candidate) => {
-						if (group(candidate.f)) {
-							filtered.add(candidate.r);
-							route_definitions.add(candidate.f);
-							grouped.add(candidate.r);
-							return false;
-						}
-						return true;
-					});
-				}
+				const group = [route];
 
 				// figure out which lower priority routes should be considered fallbacks
 				for (let j = i + 1; j < routes.length; j += 1) {
-					if (!group && filter(facades[j])) {
-						filtered.add(routes[j]);
-						route_definitions.add(facades[j]);
+					if (filter(facades[j])) {
+						group.push(routes[j]);
 					}
 				}
+
+				const filtered = new Set(group);
 
 				// heuristic: if /foo/[bar] is included, /foo/[bar].json should
 				// also be included, since the page likely needs the endpoint
 				// TODO is this still necessary, given the new way of doing things?
 				filtered.forEach((route) => {
 					if (route.page) {
-						const idx = routes.findIndex((candidate) => candidate.id === route.id + '.json');
-						const endpoint = routes[idx];
+						const endpoint = routes.find((candidate) => candidate.id === route.id + '.json');
 
 						if (endpoint) {
 							filtered.add(endpoint);
-							route_definitions.add(facades[idx]);
 						}
 					}
 				});
 
 				if (filtered.size > 0) {
 					await complete({
-						routes: Array.from(route_definitions),
 						generateManifest: ({ relativePath }) =>
 							generate_manifest({
 								build_data,

--- a/packages/kit/src/core/adapt/builder.spec.js
+++ b/packages/kit/src/core/adapt/builder.spec.js
@@ -31,7 +31,7 @@ test('copy files', () => {
 		build_data: {},
 		// @ts-expect-error
 		server_metadata: {},
-		routes: [],
+		route_data: [],
 		// @ts-expect-error
 		prerendered: {
 			paths: []

--- a/packages/kit/src/core/adapt/index.js
+++ b/packages/kit/src/core/adapt/index.js
@@ -18,7 +18,7 @@ export async function adapt(config, build_data, server_metadata, prerendered, pr
 		config,
 		build_data,
 		server_metadata,
-		routes: build_data.manifest_data.routes.filter((route) => {
+		route_data: build_data.manifest_data.routes.filter((route) => {
 			if (!route.page && !route.endpoint) return false;
 
 			const prerender = prerender_map.get(route.id);

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -83,12 +83,16 @@ export interface Builder {
 	config: ValidatedConfig;
 	/** Information about prerendered pages and assets, if any. */
 	prerendered: Prerendered;
+	/** An array of dynamic (not prerendered) routes */
+	routes: RouteDefinition[];
+
 	/** `true` if one or more routes have `export const config = ..` in it */
 	hasRouteLevelConfig: boolean;
 
 	/**
 	 * Create separate functions that map to one or more routes of your app.
 	 * @param fn A function that groups a set of routes into an entry point
+	 * @deprecated Use `builder.routes` instead
 	 */
 	createEntries(fn: (route: RouteDefinition) => AdapterEntry): Promise<void>;
 
@@ -101,7 +105,7 @@ export interface Builder {
 	 * Generate a server-side manifest to initialise the SvelteKit [server](https://kit.svelte.dev/docs/types#public-types-server) with.
 	 * @param opts a relative path to the base directory of the app and optionally in which format (esm or cjs) the manifest should be generated
 	 */
-	generateManifest(opts: { relativePath: string }): string;
+	generateManifest(opts: { relativePath: string; routes?: RouteDefinition[] }): string;
 
 	/**
 	 * Resolve a path to the `name` directory inside `outDir`, e.g. `/path/to/.svelte-kit/my-adapter`.

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -7,13 +7,14 @@ import { CompileOptions } from 'svelte/types/compiler/interfaces';
 import {
 	AdapterEntry,
 	CspDirectives,
+	HttpMethod,
 	Logger,
 	MaybePromise,
 	Prerendered,
 	PrerenderHttpErrorHandlerValue,
 	PrerenderMissingIdHandlerValue,
 	RequestOptions,
-	RouteDefinition,
+	RouteSegment,
 	UniqueInterface
 } from './private.js';
 import { SSRNodeLoader, SSRRoute, ValidatedConfig } from './internal.js';
@@ -957,6 +958,14 @@ export interface ResolveOptions {
 	 * @param input the type of the file and its path
 	 */
 	preload?(input: { type: 'font' | 'css' | 'js' | 'asset'; path: string }): boolean;
+}
+
+export interface RouteDefinition<Config = any> {
+	id: string;
+	pattern: RegExp;
+	segments: RouteSegment[];
+	methods: HttpMethod[];
+	config: Config;
 }
 
 export class Server {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -86,9 +86,6 @@ export interface Builder {
 	/** An array of dynamic (not prerendered) routes */
 	routes: RouteDefinition[];
 
-	/** `true` if one or more routes have `export const config = ..` in it */
-	hasRouteLevelConfig: boolean;
-
 	/**
 	 * Create separate functions that map to one or more routes of your app.
 	 * @param fn A function that groups a set of routes into an entry point

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -2,6 +2,8 @@
 // but which cannot be imported from `@sveltejs/kit`. Care should
 // be taken to avoid breaking changes when editing this file
 
+import { RouteDefinition } from './index.js';
+
 export interface AdapterEntry {
 	/**
 	 * A string that uniquely identifies an HTTP service (e.g. serverless function) and is used for deduplication.
@@ -213,14 +215,6 @@ export type PrerenderMap = Map<string, PrerenderOption>;
 export interface RequestOptions {
 	getClientAddress(): string;
 	platform?: App.Platform;
-}
-
-export interface RouteDefinition<Config = any> {
-	id: string;
-	pattern: RegExp;
-	segments: RouteSegment[];
-	methods: HttpMethod[];
-	config: Config;
 }
 
 export interface RouteSegment {

--- a/packages/kit/types/private.d.ts
+++ b/packages/kit/types/private.d.ts
@@ -11,32 +11,20 @@ export interface AdapterEntry {
 	id: string;
 
 	/**
-	 * A function that compares the lower candidate route with the current route to determine
-	 * if it should be grouped with the current route. Has no effect when `group` is set.
+	 * A function that compares the candidate route with the current route to determine
+	 * if it should be grouped with the current route.
 	 *
 	 * Use cases:
 	 * - Fallback pages: `/foo/[c]` is a fallback for `/foo/a-[b]`, and `/[...catchall]` is a fallback for all routes
-	 */
-	filter(route: RouteDefinition): boolean;
-
-	/**
-	 * A function that compares the candidate route with the current route to determine
-	 * if it should be grouped with the current route. In contrast to `filter`, this
-	 * results in the other route not being invoked by `createEntries` again, if grouped.
-	 *
-	 * Use cases:
 	 * - Grouping routes that share a common `config`: `/foo` should be deployed to the edge, `/bar` and `/baz` should be deployed to a serverless function
 	 */
-	group?(route: RouteDefinition): boolean;
+	filter(route: RouteDefinition): boolean;
 
 	/**
 	 * A function that is invoked once the entry has been created. This is where you
 	 * should write the function to the filesystem and generate redirect manifests.
 	 */
-	complete(entry: {
-		routes: RouteDefinition[];
-		generateManifest(opts: { relativePath: string }): string;
-	}): MaybePromise<void>;
+	complete(entry: { generateManifest(opts: { relativePath: string }): string }): MaybePromise<void>;
 }
 
 // Based on https://github.com/josh-hemphill/csp-typed-directives/blob/latest/src/csp.types.ts


### PR DESCRIPTION
Follow-up to https://github.com/sveltejs/kit/pull/8740#issuecomment-1414088396. It's increasingly apparent that `builder.createEntries` is the wrong API — it tries to make it simple to merge routes into a single function, but the result is anything but.

The approach here is much simpler — just expose the `RouteDefinition` objects to the builder directly, and let it do whatever it wants.

WIP — need to kick the tyres a bit more before committing

* [x] validate `runtime` and other options
* [x] default to `all` region for edge functions, not `iad1`