### PR TITLE
fix: prerendered endpoint callable from non-prerendered endpoint

### DIFF
--- a/.changeset/slimy-donkeys-itch.md
+++ b/.changeset/slimy-donkeys-itch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prerendered endpoint callable from non-prerendered endpoint

--- a/.changeset/slimy-donkeys-itch.md
+++ b/.changeset/slimy-donkeys-itch.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: prerendered endpoint callable from non-prerendered endpoint
+fix: ensure endpoints can fetch endpoints on the same host but not part of the application

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -4,11 +4,12 @@ import { method_not_allowed } from './utils.js';
 
 /**
  * @param {import('types').RequestEvent} event
+ * @param {import('types').SSRRoute} route
  * @param {import('types').SSREndpoint} mod
  * @param {import('types').SSRState} state
  * @returns {Promise<Response>}
  */
-export async function render_endpoint(event, mod, state) {
+export async function render_endpoint(event, route, mod, state) {
 	const method = /** @type {import('types').HttpMethod} */ (event.request.method);
 
 	let handler = mod[method];
@@ -37,6 +38,8 @@ export async function render_endpoint(event, mod, state) {
 			return new Response(undefined, { status: 204 });
 		}
 	}
+
+	state.initiator = route;
 
 	try {
 		const response = await handler(

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -358,7 +358,7 @@ export async function respond(request, options, manifest, state) {
 						trailing_slash ?? 'never'
 					);
 				} else if (route.endpoint && (!route.page || is_endpoint_request(event))) {
-					response = await render_endpoint(event, await route.endpoint(), state);
+					response = await render_endpoint(event, route, await route.endpoint(), state);
 				} else if (route.page) {
 					response = await render_page(
 						event,

--- a/packages/kit/test/apps/basics/src/routes/prerendering/prerendered-endpoint/proxy/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/prerendering/prerendered-endpoint/proxy/+server.js
@@ -1,0 +1,3 @@
+export async function GET({ fetch }) {
+	return await fetch('/prerendering/prerendered-endpoint/api');
+}

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -97,6 +97,17 @@ test.describe('Endpoints', () => {
 		expect(headers.head).toEqual(headers.get);
 	});
 
+	test('Prerendered +server.js called from a non-prerendered +server.js works', async ({
+		baseURL
+	}) => {
+		const res = await fetch(`${baseURL}/prerendering/prerendered-endpoint/proxy`);
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toStrictEqual({
+			message: 'Im prerendered and called from a non-prerendered +page.server.js'
+		});
+	});
+
 	// TODO all the remaining tests in this section are really only testing
 	// setResponse, since we're not otherwise changing anything on the response.
 	// might be worth making these unit tests instead


### PR DESCRIPTION
fixes #8851

adds `state.initiator` in `endpoint.js#render_endpoint` similar to https://github.com/sveltejs/kit/pull/8453 as suggested by Simon (dummdidumm)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
