### PR TITLE
fix: change Vite config type to work with Vitest options

### DIFF
--- a/.changeset/rotten-windows-wonder.md
+++ b/.changeset/rotten-windows-wonder.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+fix: adjust vite config type to work with vitest options

--- a/packages/create-svelte/shared/+vitest/vite.config.ts
+++ b/packages/create-svelte/shared/+vitest/vite.config.ts
@@ -1,12 +1,9 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import type { UserConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
-/** @type {import('vite').UserConfig} */
-const config: UserConfig = {
+export default defineConfig({
 	plugins: [sveltekit()],
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}']
 	}
-};
-
-export default config;
+});

--- a/packages/create-svelte/shared/vite.config.ts
+++ b/packages/create-svelte/shared/vite.config.ts
@@ -1,9 +1,6 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import type { UserConfig } from 'vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('vite').UserConfig} */
-const config: UserConfig = {
+export default defineConfig({
 	plugins: [sveltekit()]
-};
-
-export default config;
+});

--- a/packages/create-svelte/templates/default/vite.config.js
+++ b/packages/create-svelte/templates/default/vite.config.js
@@ -1,8 +1,8 @@
 import path from 'path';
 import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('vite').UserConfig} */
-const config = {
+export default defineConfig({
 	plugins: [sveltekit()],
 
 	server: {
@@ -10,6 +10,4 @@ const config = {
 			allow: [path.resolve('../../../kit')]
 		}
 	}
-};
-
-export default config;
+});

--- a/packages/create-svelte/templates/skeleton/vite.config.js
+++ b/packages/create-svelte/templates/skeleton/vite.config.js
@@ -1,8 +1,6 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('vite').UserConfig} */
-const config = {
+export default defineConfig({
 	plugins: [sveltekit()]
-};
-
-export default config;
+});

--- a/packages/create-svelte/templates/skeletonlib/vite.config.js
+++ b/packages/create-svelte/templates/skeletonlib/vite.config.js
@@ -1,8 +1,6 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('vite').UserConfig} */
-const config = {
+export default defineConfig({
 	plugins: [sveltekit()]
-};
-
-export default config;
+});


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/8768

As suggested by Rich and Dominik, this changes all `vite.config` templates to:
* use `defineConfig` instead of type annotations.
* import `defineConfig` from `vitest` if the project includes vitest.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
