### PR TITLE
fix: pin adapter versions in adapter-auto

### DIFF
--- a/.changeset/cyan-ladybugs-divide.md
+++ b/.changeset/cyan-ladybugs-divide.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-auto': patch
+---
+
+fix: pin adapter versions

--- a/packages/adapter-auto/adapters.js
+++ b/packages/adapter-auto/adapters.js
@@ -1,22 +1,28 @@
+// List of adapters to check for. `version` is used to pin the installed adapter version and should point
+// to the latest version of the adapter that is compatible with adapter-auto's current peerDependency version of SvelteKit.
 export const adapters = [
 	{
 		name: 'Vercel',
 		test: () => !!process.env.VERCEL,
-		module: '@sveltejs/adapter-vercel'
+		module: '@sveltejs/adapter-vercel',
+		version: '1'
 	},
 	{
 		name: 'Cloudflare Pages',
 		test: () => !!process.env.CF_PAGES,
-		module: '@sveltejs/adapter-cloudflare'
+		module: '@sveltejs/adapter-cloudflare',
+		version: '2'
 	},
 	{
 		name: 'Netlify',
 		test: () => !!process.env.NETLIFY,
-		module: '@sveltejs/adapter-netlify'
+		module: '@sveltejs/adapter-netlify',
+		version: '1'
 	},
 	{
 		name: 'Azure Static Web Apps',
 		test: () => process.env.GITHUB_ACTION_REPOSITORY === 'Azure/static-web-apps-deploy',
-		module: 'svelte-adapter-azure-swa'
+		module: 'svelte-adapter-azure-swa',
+		version: '0.13'
 	}
 ];

--- a/packages/adapter-auto/index.js
+++ b/packages/adapter-auto/index.js
@@ -5,11 +5,11 @@ import { adapters } from './adapters.js';
 import { dirname, join } from 'path';
 import { existsSync } from 'fs';
 
-/** @type {Record<string, (name: string) => string>} */
+/** @type {Record<string, (name: string, version: string) => string>} */
 const commands = {
-	npm: (name) => `npm install -D ${name}`,
-	pnpm: (name) => `pnpm add -D ${name}`,
-	yarn: (name) => `yarn add -D ${name}`
+	npm: (name, version) => `npm install -D ${name}@${version}`,
+	pnpm: (name, version) => `pnpm add -D ${name}@${version}`,
+	yarn: (name, version) => `yarn add -D ${name}@${version}`
 };
 
 function detect_lockfile() {
@@ -64,7 +64,7 @@ async function get_adapter() {
 			error.message.startsWith(`Cannot find package '${match.module}'`)
 		) {
 			const package_manager = detect_package_manager();
-			const command = commands[package_manager](match.module);
+			const command = commands[package_manager](match.module, match.version);
 
 			try {
 				console.log(`Installing ${match.module}...`);


### PR DESCRIPTION
MUST be released before #8740 is merged

`version` is used to pin the installed adapter version and should point to the latest version of the adapter that is compatible with adapter-auto's current peerDependency version of SvelteKit. Will prevent adapter-auto from accidentally installing adapter versions that are possibly incompatible with the user's SvelteKit version.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
