### PR TITLE
fix: correctly serialize request url when using load `fetch`

### DIFF
--- a/.changeset/silent-icons-guess.md
+++ b/.changeset/silent-icons-guess.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: correctly check serialized data when fetching from absolute URL
+fix: correctly serialize request url when using load `fetch`

--- a/.changeset/silent-icons-guess.md
+++ b/.changeset/silent-icons-guess.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly check serialized data when fetching from absolute URL

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -594,12 +594,17 @@ export function create_client({ target }) {
 					}
 
 					// we must fixup relative urls so they are resolved from the target page
-					const resolved = new URL(requested, url).href;
-					depends(resolved);
+					const resolved = new URL(requested, url);
+					depends(resolved.href);
+
+					// match ssr serialized data url
+					if (resolved.origin === url.origin) {
+						requested = resolved.href.slice(url.origin.length);
+					}
 
 					// prerendered pages may be served from any origin, so `initial_fetch` urls shouldn't be resolved
 					return started
-						? subsequent_fetch(requested, resolved, init)
+						? subsequent_fetch(requested, resolved.href, init)
 						: initial_fetch(requested, init);
 				},
 				setHeaders: () => {}, // noop

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -597,7 +597,7 @@ export function create_client({ target }) {
 					const resolved = new URL(requested, url);
 					depends(resolved.href);
 
-					// match ssr serialized data url
+					// match ssr serialized data url, which is important to find cached responses
 					if (resolved.origin === url.origin) {
 						requested = resolved.href.slice(url.origin.length);
 					}

--- a/packages/kit/test/apps/basics/src/routes/load/serialization/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization/+page.js
@@ -1,8 +1,8 @@
 /** @type {import('./$types').PageLoad} */
-export async function load({ fetch, data }) {
+export async function load({ fetch, data, url }) {
 	const { a } = data;
 
-	const res = await fetch('/load/serialization/fetched-from-shared.json');
+	const res = await fetch(new URL('/load/serialization/fetched-from-shared.json', url.origin));
 	const { b } = await res.json();
 
 	return { a, b, c: a + b };

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -211,7 +211,9 @@ test.describe('Load', () => {
 
 		if (!javaScriptEnabled) {
 			// by the time JS has run, hydration will have nuked these scripts
-			const script_contents = await page.innerHTML('script[data-sveltekit-fetched]');
+			const script_contents = await page.innerHTML(
+				'script[data-sveltekit-fetched][data-url="/load/serialization/fetched-from-shared.json"]'
+			);
 
 			const payload = '{"status":200,"statusText":"","headers":{},"body":"{\\"b\\":2}"}';
 


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/8852

Slices the origin from any client fetch request URLs so that they're always similar in format to fetches done on the server.

Also adjusts one of the tests to account for absolute URL fetches in shared load functions.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
