### PR TITLE
fix: Prevent crawling empty urls from <img src="">

### DIFF
--- a/.changeset/lucky-tables-jam.md
+++ b/.changeset/lucky-tables-jam.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Prevent crawling empty urls <img src="">
+fix: prevent crawling empty urls (`<img src="">`)

--- a/.changeset/lucky-tables-jam.md
+++ b/.changeset/lucky-tables-jam.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Prevent crawling empty urls <img src="">

--- a/packages/kit/src/core/postbuild/crawl.js
+++ b/packages/kit/src/core/postbuild/crawl.js
@@ -165,7 +165,7 @@ export function crawl(html) {
 							} else if (name === 'rel') {
 								rel = value;
 							} else if (name === 'src') {
-								hrefs.push(value);
+								if (value) hrefs.push(value);
 							} else if (name === 'srcset') {
 								const candidates = [];
 								let insideURL = true;
@@ -183,7 +183,7 @@ export function crawl(html) {
 								candidates.push(value);
 								for (const candidate of candidates) {
 									const src = candidate.split(WHITESPACE)[0];
-									hrefs.push(src);
+									if (src) hrefs.push(src);
 								}
 							}
 						} else {

--- a/packages/kit/src/core/postbuild/fixtures/basic-src/input.html
+++ b/packages/kit/src/core/postbuild/fixtures/basic-src/input.html
@@ -3,5 +3,6 @@
 	<head></head>
 	<body>
 		<img alt="A potato" src="/potato.jpg" />
+		<img alt="empty" src="" />
 	</body>
 </html>


### PR DESCRIPTION
The empty src was crawled as a relative url.
On `/page/about` this would route to `/page/` which could 404

Demo: https://stackblitz.com/edit/sveltejs-kit-template-default-ccvbsj?file=src/routes/page/about/+page.svelte

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
