### PR TITLE
chore: mark all renovate changes as chore

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
 		"github>whitesource/merge-confidence:beta",
 		"config:base",
 		":preserveSemverRanges",
-		"group:allNonMajor"
+		"group:allNonMajor",
+		":semanticCommitTypeAll(chore)"
 	],
 	"pin": {
 		"enabled": false


### PR DESCRIPTION
Renovate is calling upgrades of devDeps chore and deps fix. If we're upgrading because of renovate then it's usually not because there's some specific issue we're trying to address, so I think chore is more appropriate 