### PR TITLE
fix: properly purge server load cache

### DIFF
--- a/.changeset/fast-rules-exercise.md
+++ b/.changeset/fast-rules-exercise.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: purge server load cache when no server load function for page

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -804,7 +804,7 @@ export function create_client({ target }) {
 					// server_data_node is undefined if it wasn't reloaded from the server;
 					// and if current loader uses server data, we want to reuse previous data.
 					server_data_node === undefined && loader[0] ? { type: 'skip' } : server_data_node ?? null,
-					previous?.server
+					loader[0] ? previous?.server : undefined
 				)
 			});
 		});


### PR DESCRIPTION
fixes #8272

When going from a page with server load to a page without server load, the cache wasn't purged properly

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

---

You can check out a repo with the bug here: https://github.com/coyotte508/sveltekit-load-bug/