### PR TITLE
chore: throw helpful migration error

### DIFF
--- a/.changeset/large-tables-breathe.md
+++ b/.changeset/large-tables-breathe.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-vercel': patch
+---
+
+chore: throw helpful migration error

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -39,6 +39,13 @@ export default function ({ split = false, edge = edge_set_in_env_var } = {}) {
 		name: '@sveltejs/adapter-netlify',
 
 		async adapt(builder) {
+			if (!builder.routes) {
+				throw new Error(
+					'@sveltejs/adapter-netlify >=2.x (possibly installed through @sveltejs/adapter-auto) requires @sveltejs/kit version 1.5 or higher. ' +
+						'Either downgrade the adapter or upgrade @sveltejs/kit'
+				);
+			}
+
 			const netlify_config = get_netlify_config();
 
 			// "build" is the default publish directory when Netlify detects SvelteKit

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -26,6 +26,13 @@ const plugin = function (defaults = {}) {
 		name: '@sveltejs/adapter-vercel',
 
 		async adapt(builder) {
+			if (!builder.routes) {
+				throw new Error(
+					'@sveltejs/adapter-vercel >=2.x (possibly installed through @sveltejs/adapter-auto) requires @sveltejs/kit version 1.5 or higher. ' +
+						'Either downgrade the adapter or upgrade @sveltejs/kit'
+				);
+			}
+
 			const dir = '.vercel/output';
 			const tmp = builder.getBuildDirectory('vercel-tmp');
 


### PR DESCRIPTION
For the Vercel and Netlify adapters. adapter-auto on earlier versions could install them when it shouldn't
Related to #8911

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
