### PR TITLE
Update polyfills.js to include File

### DIFF
--- a/.changeset/famous-hornets-invite.md
+++ b/.changeset/famous-hornets-invite.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: polyfill File from node:buffer

--- a/packages/kit/src/exports/node/polyfills.js
+++ b/packages/kit/src/exports/node/polyfills.js
@@ -1,4 +1,5 @@
 import { ReadableStream, TransformStream, WritableStream } from 'node:stream/web';
+import { File } from 'node:buffer';
 import { webcrypto as crypto } from 'node:crypto';
 import { fetch, Response, Request, Headers, FormData } from 'undici';
 

--- a/packages/kit/src/exports/node/polyfills.js
+++ b/packages/kit/src/exports/node/polyfills.js
@@ -1,7 +1,10 @@
 import { ReadableStream, TransformStream, WritableStream } from 'node:stream/web';
-import { File } from 'node:buffer';
+import buffer from 'node:buffer';
 import { webcrypto as crypto } from 'node:crypto';
-import { fetch, Response, Request, Headers, FormData } from 'undici';
+import { fetch, Response, Request, Headers, FormData, File as UndiciFile } from 'undici';
+
+// @ts-expect-error
+const File = buffer.File ?? UndiciFile;
 
 /** @type {Record<string, any>} */
 const globals = {

--- a/packages/kit/src/exports/node/polyfills.js
+++ b/packages/kit/src/exports/node/polyfills.js
@@ -12,7 +12,8 @@ const globals = {
 	ReadableStream,
 	TransformStream,
 	WritableStream,
-	FormData
+	FormData,
+	File
 };
 
 // exported for dev/preview and node environments


### PR DESCRIPTION
Currently there is no global `File` object available. Usually this is fine, as any "file" returned by `FormData` still has the normal properties and methods available.

The problem became apparent when using `zod-form-data`, a library that relies on the global `File` object.
```javascript
import { zfd } from "zod-form-data";

const schema = zfd.formData({
    pdf: zfd.file(),
});
```
Discussion [here](https://discord.com/channels/457912077277855764/1072401358419935262).

This is a simple fix, just adds another import from `undici` to include `File`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
