### PR TITLE
fix: end response during stream handling

### DIFF
--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -150,7 +150,11 @@ export async function setResponse(res, response) {
 
 	res.on('close', cancel);
 	res.on('error', cancel);
-
+	
+	// If the body is intended to be a readable stream then leave the 
+	// connection open, else end the response after all bytes sent
+  const isReadableStream = headers['content-type'] === 'application/octet-stream';
+	
 	next();
 	async function next() {
 		try {
@@ -161,7 +165,8 @@ export async function setResponse(res, response) {
 
 				if (!res.write(value)) {
 					res.once('drain', next);
-					break;
+					if(isReadableStream){ return; }
+					break; 
 				}
 			}
 			res.end();

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -161,7 +161,7 @@ export async function setResponse(res, response) {
 
 				if (!res.write(value)) {
 					res.once('drain', next);
-					return;
+					break;
 				}
 			}
 			res.end();


### PR DESCRIPTION
Fix bug - exiting a for loop with 'return' instead of 'break'. Using 'break' skips res.end() stream eventually breaking stuff downstream. This took me 3 days to track down.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
