### PR TITLE
fix: End responses that are not streams

### DIFF
--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -150,6 +150,10 @@ export async function setResponse(res, response) {
 
 	res.on('close', cancel);
 	res.on('error', cancel);
+	
+	// If the body is intended to be a readable stream then leave the 
+	// connection open, else end the response after all bytes sent
+  const isReadableStream = headers['content-type'] === 'application/octet-stream';
 
 	next();
 	async function next() {
@@ -161,7 +165,8 @@ export async function setResponse(res, response) {
 
 				if (!res.write(value)) {
 					res.once('drain', next);
-					return;
+					if(isReadableStream){ return; }
+					break; 
 				}
 			}
 			res.end();


### PR DESCRIPTION
This is so a SvelteKit  RequestHandle can do "return json({});"

 I'm really not liking this fix because I can't seem to wrap my head around what is really happening.  
I believe the failing test "[chromium-build] › test/server.test.js:131:2 › Endpoints › body can be a binary ReadableStream" is written correctly. 

Maybe the problem is really somewhere else?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
