### PR TITLE
fix: correctly compare routes when splitting functions

### DIFF
--- a/.changeset/rich-chefs-refuse.md
+++ b/.changeset/rich-chefs-refuse.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+fix: correctly compare routes when generating split functions

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -244,10 +244,11 @@ async function generate_lambda_functions({ builder, publish, split }) {
 
 			// figure out which lower priority routes should be considered fallbacks
 			for (let j = i + 1; j < builder.routes.length; j += 1) {
-				if (routes[j].prerender === true) continue;
+				const other = builder.routes[j];
+				if (other.prerender === true) continue;
 
-				if (matches(route.segments, routes[j].segments)) {
-					routes.push(builder.routes[j]);
+				if (matches(route.segments, other.segments)) {
+					routes.push(other);
 				}
 			}
 


### PR DESCRIPTION
no issue, i saw this while looking at something else