### PR TITLE
Add polyfill option to adapter-node

### DIFF
--- a/.changeset/strange-sheep-grab.md
+++ b/.changeset/strange-sheep-grab.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': minor
+---
+
+add polyfill option

--- a/documentation/docs/25-build-and-deploy/40-adapter-node.md
+++ b/documentation/docs/25-build-and-deploy/40-adapter-node.md
@@ -123,7 +123,7 @@ export default {
 			out: 'build',
 			precompress: false,
 			envPrefix: '',
-			polyfill: false
+			polyfill: true
 		})
 	}
 };

--- a/documentation/docs/25-build-and-deploy/40-adapter-node.md
+++ b/documentation/docs/25-build-and-deploy/40-adapter-node.md
@@ -122,7 +122,8 @@ export default {
 			// default options are shown
 			out: 'build',
 			precompress: false,
-			envPrefix: ''
+			envPrefix: '',
+			polyfill: false
 		})
 	}
 };
@@ -139,6 +140,10 @@ Enables precompressing using gzip and brotli for assets and prerendered pages. I
 ### envPrefix
 
 If you need to change the name of the environment variables used to configure the deployment (for example, to deconflict with environment variables you don't control), you can specify a prefix:
+
+### polyfill
+
+Controlls whether your build will load polyfills for missing modules. It defaults to `true`, and should only be disabled when using Node 18.11 or greater.
 
 ```js
 envPrefix: 'MY_CUSTOM_';

--- a/packages/adapter-node/index.d.ts
+++ b/packages/adapter-node/index.d.ts
@@ -9,6 +9,7 @@ interface AdapterOptions {
 	out?: string;
 	precompress?: boolean;
 	envPrefix?: string;
+	polyfill?: boolean;
 }
 
 export default function plugin(options?: AdapterOptions): Adapter;

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -9,7 +9,7 @@ const files = fileURLToPath(new URL('./files', import.meta.url).href);
 
 /** @type {import('.').default} */
 export default function (opts = {}) {
-	const { out = 'build', precompress, envPrefix = '' } = opts;
+	const { out = 'build', precompress, envPrefix = '', polyfill = true } = opts;
 
 	return {
 		name: '@sveltejs/adapter-node',
@@ -72,10 +72,16 @@ export default function (opts = {}) {
 					ENV: './env.js',
 					HANDLER: './handler.js',
 					MANIFEST: './server/manifest.js',
-					SERVER: `./server/index.js`,
+					SERVER: './server/index.js',
+					SHIMS: './shims.js',
 					ENV_PREFIX: JSON.stringify(envPrefix)
 				}
 			});
+
+			// If polyfills aren't wanted then clear the file
+			if (!polyfill) {
+				writeFileSync(`${out}/shims.js`, '', 'utf-8');
+			}
 		}
 	};
 }

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -30,6 +30,15 @@ export default [
 			inlineDynamicImports: true
 		},
 		plugins: [nodeResolve(), commonjs(), json()],
-		external: ['ENV', 'MANIFEST', 'SERVER', ...builtinModules]
+		external: ['ENV', 'MANIFEST', 'SERVER', 'SHIMS', ...builtinModules]
+	},
+	{
+		input: 'src/shims.js',
+		output: {
+			file: 'files/shims.js',
+			format: 'esm'
+		},
+		plugins: [nodeResolve(), commonjs()],
+		external: builtinModules
 	}
 ];

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -1,4 +1,4 @@
-import './shims';
+import 'SHIMS';
 import fs from 'node:fs';
 import path from 'node:path';
 import sirv from 'sirv';


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

This would close #7374 - I wasn't sure the best way to go about this but settled on this solution. Instead of building the polyfills into the `handle.js` before publishing `adapter-node` it will build a `shims.js` file which `handle.js` imports. If the `polyfill` option is `false` when the adapter code runs then it will empty the local copy of `shims.js` so it won't end up loading any polyfills