### PR TITLE
docs: Strip decorative HTML from search results

### DIFF
--- a/sites/kit.svelte.dev/src/lib/search/content.server.js
+++ b/sites/kit.svelte.dev/src/lib/search/content.server.js
@@ -1,9 +1,9 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import glob from 'tiny-glob/sync.js';
-import { extract_frontmatter, transform } from '../docs/server/markdown.js';
-import { render, replace_placeholders } from '../docs/server/render.js';
 import { slugify } from '../docs/server';
+import { extract_frontmatter, transform } from '../docs/server/markdown.js';
+import { replace_placeholders } from '../docs/server/render.js';
 
 const categories = [
 	{
@@ -90,9 +90,8 @@ function plaintext(markdown) {
 	return transform(markdown, {
 		code: (source) => source.split('// ---cut---\n').pop(),
 		blockquote: block,
-		html: (html) => {
-			return html;
-		},
+		html: () => '\n',
+		heading: (text) => `${text}\n`,
 		hr: () => '',
 		list: block,
 		listitem: block,


### PR DESCRIPTION
closes #8992

This hook or renderer or whatever marked calls it is only invoked for raw HTML in the markdown files which I doubt there's any we would want to index, and example html inside eg. codeblocks works as intended.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
