### PR TITLE
fix: client build minification

### DIFF
--- a/.changeset/eleven-buckets-hammer.md
+++ b/.changeset/eleven-buckets-hammer.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: ssr defaults preventing minification for client build

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -164,7 +164,11 @@ function kit({ svelte_config }) {
 	const { kit } = svelte_config;
 	const out = `${kit.outDir}/output`;
 
-	/** @type {import('vite').ResolvedConfig} */
+	/**
+	 * @typedef {import('vite').ResolvedConfig} ResolvedConfig
+	 */
+
+	/** @type {ResolvedConfig} */
 	let vite_config;
 
 	/** @type {import('vite').ConfigEnv} */
@@ -179,6 +183,15 @@ function kit({ svelte_config }) {
 	/** @type {() => Promise<void>} */
 	let finalise;
 
+	/**
+	 * Store parts of the config that may have different defaults based on config.build.ssr
+	 * so that we don't get overridden values later for the client build.
+	 * @type {{
+	 * 		minify?: ResolvedConfig['build']['minify'];
+	 * }}
+	 */
+	let cli_opts = {};
+
 	const service_worker_entry_file = resolve_entry(kit.files.serviceWorker);
 
 	/** @type {import('vite').Plugin} */
@@ -192,6 +205,8 @@ function kit({ svelte_config }) {
 		async config(config, config_env) {
 			vite_config_env = config_env;
 			is_build = config_env.command === 'build';
+
+			cli_opts.minify = config.build?.minify;
 
 			env = get_env(kit.env, vite_config_env.mode);
 
@@ -634,7 +649,7 @@ export function set_assets(path) {
 						logLevel: vite_config.logLevel,
 						clearScreen: vite_config.clearScreen,
 						build: {
-							minify: vite_config.build.minify,
+							minify: cli_opts.minify,
 							assetsInlineLimit: vite_config.build.assetsInlineLimit,
 							sourcemap: vite_config.build.sourcemap
 						},

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -164,11 +164,7 @@ function kit({ svelte_config }) {
 	const { kit } = svelte_config;
 	const out = `${kit.outDir}/output`;
 
-	/**
-	 * @typedef {import('vite').ResolvedConfig} ResolvedConfig
-	 */
-
-	/** @type {ResolvedConfig} */
+	/** @type {import('vite').ResolvedConfig} */
 	let vite_config;
 
 	/** @type {import('vite').ConfigEnv} */
@@ -183,14 +179,8 @@ function kit({ svelte_config }) {
 	/** @type {() => Promise<void>} */
 	let finalise;
 
-	/**
-	 * Store parts of the config that may have different defaults based on config.build.ssr
-	 * so that we don't get overridden values later for the client build.
-	 * @type {{
-	 * 		minify?: ResolvedConfig['build']['minify'];
-	 * }}
-	 */
-	let cli_opts = {};
+	/** @type {import('vite').UserConfig} */
+	let initial_config;
 
 	const service_worker_entry_file = resolve_entry(kit.files.serviceWorker);
 
@@ -203,10 +193,9 @@ function kit({ svelte_config }) {
 		 * @see https://vitejs.dev/guide/api-plugin.html#config
 		 */
 		async config(config, config_env) {
+			initial_config = config;
 			vite_config_env = config_env;
 			is_build = config_env.command === 'build';
-
-			cli_opts.minify = config.build?.minify;
 
 			env = get_env(kit.env, vite_config_env.mode);
 
@@ -649,7 +638,7 @@ export function set_assets(path) {
 						logLevel: vite_config.logLevel,
 						clearScreen: vite_config.clearScreen,
 						build: {
-							minify: cli_opts.minify,
+							minify: initial_config.build?.minify,
 							assetsInlineLimit: vite_config.build.assetsInlineLimit,
 							sourcemap: vite_config.build.sourcemap
 						},


### PR DESCRIPTION
This fixes a regression from #8977 where vite_config is the resolved config so build.minify is defaulted to `false` for ssr builds if the user doesn't specify an option manually.

I *think* `minify` is the only relevant inline option that's [overriden](https://github.com/vitejs/vite/blob/5364c901dca31d4a16dac288bcb55305949d10ae/packages/vite/src/node/build.ts#L324), so this should be the only one that needs special handling.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
