### PR TITLE
fix: prevent `_headers` and `_redirects` files from being included in Cloudflare `_routes.json`

### DIFF
--- a/.changeset/clever-books-study.md
+++ b/.changeset/clever-books-study.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+fix: exclude `_headers` and `_redirects` files from Cloudflare Pages static request list

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -1,6 +1,6 @@
-import { writeFileSync } from 'fs';
-import { posix } from 'path';
-import { fileURLToPath } from 'url';
+import { writeFileSync } from 'node:fs';
+import { posix } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import * as esbuild from 'esbuild';
 
 /** @type {import('.').default} */
@@ -70,7 +70,14 @@ function get_routes_json(builder, assets) {
 	const exclude = [
 		`/${builder.config.kit.appDir}/*`,
 		...assets
-			.filter((file) => !file.startsWith(`${builder.config.kit.appDir}/`))
+			.filter(
+				(file) =>
+					!(
+						file.startsWith(`${builder.config.kit.appDir}/`) ||
+						file === '_headers' ||
+						file === '_redirects'
+					)
+			)
 			.map((file) => `/${file}`)
 	];
 


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/9041

Checks for the `_headers` and `_redirects` filenames when filtering assets to add to the `exclude` list in the `_routes.json` file.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
