### PR TITLE
fix: use non-existent package name for virtual module

### DIFF
--- a/.changeset/selfish-doors-watch.md
+++ b/.changeset/selfish-doors-watch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: use non-existent package name for virtual module

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -324,7 +324,7 @@ function kit({ svelte_config }) {
 
 		async resolveId(id) {
 			// treat $env/static/[public|private] as virtual
-			if (id.startsWith('$env/') || id === '@sveltejs/kit/paths' || id === '$service-worker') {
+			if (id.startsWith('$env/') || id === '@sveltejs/virtual/paths' || id === '$service-worker') {
 				return `\0${id}`;
 			}
 		},
@@ -364,7 +364,7 @@ function kit({ svelte_config }) {
 					return create_service_worker_module(svelte_config);
 				// for internal use only. it's published as $app/paths externally
 				// we use this alias so that we won't collide with user aliases
-				case '\0@sveltejs/kit/paths':
+				case '\0@sveltejs/virtual/paths':
 					const { assets, base } = svelte_config.kit.paths;
 					return `export const base = ${s(base)};
 export let assets = ${assets ? s(assets) : 'base'};

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -324,7 +324,7 @@ function kit({ svelte_config }) {
 
 		async resolveId(id) {
 			// treat $env/static/[public|private] as virtual
-			if (id.startsWith('$env/') || id === '@sveltejs/virtual/paths' || id === '$service-worker') {
+			if (id.startsWith('$env/') || id === '__sveltekit/paths' || id === '$service-worker') {
 				return `\0${id}`;
 			}
 		},
@@ -364,7 +364,7 @@ function kit({ svelte_config }) {
 					return create_service_worker_module(svelte_config);
 				// for internal use only. it's published as $app/paths externally
 				// we use this alias so that we won't collide with user aliases
-				case '\0@sveltejs/virtual/paths':
+				case '\0__sveltekit/paths':
 					const { assets, base } = svelte_config.kit.paths;
 					return `export const base = ${s(base)};
 export let assets = ${assets ? s(assets) : 'base'};

--- a/packages/kit/src/internal.d.ts
+++ b/packages/kit/src/internal.d.ts
@@ -1,5 +1,5 @@
 /** Internal version of $app/paths */
-declare module '@sveltejs/kit/paths' {
+declare module '@sveltejs/virtual/paths' {
 	export const base: `/${string}`;
 	export let assets: `https://${string}` | `http://${string}`;
 	export function set_assets(path: string): void;

--- a/packages/kit/src/internal.d.ts
+++ b/packages/kit/src/internal.d.ts
@@ -1,5 +1,5 @@
 /** Internal version of $app/paths */
-declare module '@sveltejs/virtual/paths' {
+declare module '__sveltekit/paths' {
 	export const base: `/${string}`;
 	export let assets: `https://${string}` | `http://${string}`;
 	export function set_assets(path: string): void;

--- a/packages/kit/src/runtime/app/paths.js
+++ b/packages/kit/src/runtime/app/paths.js
@@ -1,1 +1,1 @@
-export { base, assets } from '@sveltejs/kit/paths';
+export { base, assets } from '@sveltejs/virtual/paths';

--- a/packages/kit/src/runtime/app/paths.js
+++ b/packages/kit/src/runtime/app/paths.js
@@ -1,1 +1,1 @@
-export { base, assets } from '@sveltejs/virtual/paths';
+export { base, assets } from '__sveltekit/paths';

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -27,7 +27,7 @@ import { parse } from './parse.js';
 
 import Root from '__GENERATED__/root.svelte';
 import { nodes, server_loads, dictionary, matchers, hooks } from '__CLIENT__/manifest.js';
-import { base } from '@sveltejs/virtual/paths';
+import { base } from '__sveltekit/paths';
 import { HttpError, Redirect } from '../control.js';
 import { stores } from './singletons.js';
 import { unwrap_promises } from '../../utils/promises.js';

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -27,7 +27,7 @@ import { parse } from './parse.js';
 
 import Root from '__GENERATED__/root.svelte';
 import { nodes, server_loads, dictionary, matchers, hooks } from '__CLIENT__/manifest.js';
-import { base } from '@sveltejs/kit/paths';
+import { base } from '@sveltejs/virtual/paths';
 import { HttpError, Redirect } from '../control.js';
 import { stores } from './singletons.js';
 import { unwrap_promises } from '../../utils/promises.js';

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -1,6 +1,6 @@
 import { BROWSER, DEV } from 'esm-env';
 import { writable } from 'svelte/store';
-import { assets } from '@sveltejs/virtual/paths';
+import { assets } from '__sveltekit/paths';
 import { version } from '../shared.js';
 import { PRELOAD_PRIORITIES } from './constants.js';
 

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -1,6 +1,6 @@
 import { BROWSER, DEV } from 'esm-env';
 import { writable } from 'svelte/store';
-import { assets } from '@sveltejs/kit/paths';
+import { assets } from '@sveltejs/virtual/paths';
 import { version } from '../shared.js';
 import { PRELOAD_PRIORITIES } from './constants.js';
 

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -1,6 +1,6 @@
 import * as set_cookie_parser from 'set-cookie-parser';
 import { respond } from './respond.js';
-import * as paths from '@sveltejs/virtual/paths';
+import * as paths from '__sveltekit/paths';
 
 /**
  * @param {{

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -1,6 +1,6 @@
 import * as set_cookie_parser from 'set-cookie-parser';
 import { respond } from './respond.js';
-import * as paths from '@sveltejs/kit/paths';
+import * as paths from '@sveltejs/virtual/paths';
 
 /**
  * @param {{

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -1,7 +1,7 @@
 import * as devalue from 'devalue';
 import { readable, writable } from 'svelte/store';
 import { DEV } from 'esm-env';
-import { assets, base } from '@sveltejs/kit/paths';
+import { assets, base } from '@sveltejs/virtual/paths';
 import { hash } from '../../hash.js';
 import { serialize_data } from './serialize_data.js';
 import { s } from '../../../utils/misc.js';

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -1,7 +1,7 @@
 import * as devalue from 'devalue';
 import { readable, writable } from 'svelte/store';
 import { DEV } from 'esm-env';
-import { assets, base } from '@sveltejs/virtual/paths';
+import { assets, base } from '__sveltekit/paths';
 import { hash } from '../../hash.js';
 import { serialize_data } from './serialize_data.js';
 import { s } from '../../../utils/misc.js';

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -1,5 +1,5 @@
 import { DEV } from 'esm-env';
-import { base } from '@sveltejs/virtual/paths';
+import { base } from '__sveltekit/paths';
 import { is_endpoint_request, render_endpoint } from './endpoint.js';
 import { render_page } from './page/index.js';
 import { render_response } from './page/render.js';

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -1,5 +1,5 @@
 import { DEV } from 'esm-env';
-import { base } from '@sveltejs/kit/paths';
+import { base } from '@sveltejs/virtual/paths';
 import { is_endpoint_request, render_endpoint } from './endpoint.js';
 import { render_page } from './page/index.js';
 import { render_response } from './page/render.js';

--- a/packages/kit/src/runtime/shared.js
+++ b/packages/kit/src/runtime/shared.js
@@ -1,4 +1,4 @@
-export { set_assets } from '@sveltejs/virtual/paths';
+export { set_assets } from '__sveltekit/paths';
 
 export let building = false;
 export let version = '';

--- a/packages/kit/src/runtime/shared.js
+++ b/packages/kit/src/runtime/shared.js
@@ -1,4 +1,4 @@
-export { set_assets } from '@sveltejs/kit/paths';
+export { set_assets } from '@sveltejs/virtual/paths';
 
 export let building = false;
 export let version = '';


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/9047

closes #9049 

We mess around with `@sveltejs/kit` in `optimizeDeps` and `ssr.external`/`ssr.noExternal`. Use a different package name to avoid that. That's probably also related to why the tests didn't catch this - Vite automatically handles pnpm linked packages differently