### PR TITLE
fix(test): use file: protocol for overrides in create-svelte tests for stricter resolve

### DIFF
--- a/packages/create-svelte/test/check.js
+++ b/packages/create-svelte/test/check.js
@@ -21,6 +21,7 @@ const overrides = { ...existing_workspace_overrides };
 	await glob(fileURLToPath(new URL('../../../packages', import.meta.url)) + '/*/package.json')
 ).forEach((pkgPath) => {
 	const name = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).name;
+	// use `file:` protocol for opting into stricter resolve logic which catches more bugs
 	overrides[name] = `file:${path.dirname(path.resolve(pkgPath))}`;
 });
 

--- a/packages/create-svelte/test/check.js
+++ b/packages/create-svelte/test/check.js
@@ -21,7 +21,7 @@ const overrides = { ...existing_workspace_overrides };
 	await glob(fileURLToPath(new URL('../../../packages', import.meta.url)) + '/*/package.json')
 ).forEach((pkgPath) => {
 	const name = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).name;
-	overrides[name] = path.dirname(path.resolve(pkgPath));
+	overrides[name] = `file:${path.dirname(path.resolve(pkgPath))}`
 });
 
 try {

--- a/packages/create-svelte/test/check.js
+++ b/packages/create-svelte/test/check.js
@@ -21,7 +21,7 @@ const overrides = { ...existing_workspace_overrides };
 	await glob(fileURLToPath(new URL('../../../packages', import.meta.url)) + '/*/package.json')
 ).forEach((pkgPath) => {
 	const name = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).name;
-	overrides[name] = `file:${path.dirname(path.resolve(pkgPath))}`
+	overrides[name] = `file:${path.dirname(path.resolve(pkgPath))}`;
 });
 
 try {


### PR DESCRIPTION
see #9047  which was not caught even though  create-svelte tests do run `build` in a project created with local `create-svelte`.

for some reason absolute path overrides without `file:` protocol are treated differently, adding it made the test fail with when using `@sveltejs/kit/paths` instead of `__sveltekit_paths` as internal virtual module.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
