### PR TITLE
Error hint for invalid exports

### DIFF
--- a/.changeset/bright-lizards-deny.md
+++ b/.changeset/bright-lizards-deny.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: richer error message for invalid exports

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -106,8 +106,8 @@ async function analyse({ manifest_path, env }) {
 
 			for (const layout of layouts) {
 				if (layout) {
-					validate_common_exports(layout.server, route.id);
-					validate_common_exports(layout.universal, route.id);
+					validate_common_exports(layout.server, layout.server_id);
+					validate_common_exports(layout.universal, layout.universal_id);
 				}
 			}
 
@@ -115,8 +115,8 @@ async function analyse({ manifest_path, env }) {
 				methods.add('GET');
 				if (page.server?.actions) methods.add('POST');
 
-				validate_page_server_exports(page.server, route.id);
-				validate_common_exports(page.universal, route.id);
+				validate_page_server_exports(page.server, page.server_id);
+				validate_common_exports(page.universal, page.universal_id);
 			}
 
 			const should_prerender = get_option(nodes, 'prerender');

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -73,11 +73,13 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 
 			imports.push(`import * as universal from '../${server_manifest[node.universal].file}';`);
 			exports.push(`export { universal };`);
+			exports.push(`export const universal_id = ${s(node.universal)};`);
 		}
 
 		if (node.server) {
 			imports.push(`import * as server from '../${server_manifest[node.server].file}';`);
 			exports.push(`export { server };`);
+			exports.push(`export const server_id = ${s(node.server)};`);
 		}
 
 		exports.push(

--- a/packages/kit/src/utils/exports.js
+++ b/packages/kit/src/utils/exports.js
@@ -15,7 +15,7 @@ function validator(expected) {
 			if (key[0] === '_' || set.has(key)) continue; // key is valid in this module
 
 			const hint =
-				hint_for_supported_files(key, file?.slice(file.lastIndexOf('.'))) ||
+				hint_for_supported_files(key, file?.slice(file.lastIndexOf('.'))) ??
 				`valid exports are ${expected.join(', ')}, or anything with a '_' prefix`;
 
 			throw new Error(`Invalid export '${key}'${file ? ` in ${file}` : ''} (${hint})`);
@@ -28,7 +28,7 @@ function validator(expected) {
 /**
  * @param {string} key
  * @param {string} ext
- * @returns {string | undefined} undefined, if no supported file is found
+ * @returns {string | void}
  */
 function hint_for_supported_files(key, ext = '.js') {
 	let supported_files = [];
@@ -48,8 +48,6 @@ function hint_for_supported_files(key, ext = '.js') {
 	if (supported_files.length > 0) {
 		return `'${key}' is a valid export in ${supported_files.join(` or `)}`;
 	}
-
-	return undefined;
 }
 
 const valid_common_exports = ['load', 'prerender', 'csr', 'ssr', 'trailingSlash', 'config'];

--- a/packages/kit/src/utils/exports.js
+++ b/packages/kit/src/utils/exports.js
@@ -6,19 +6,19 @@ function validator(expected) {
 
 	/**
 	 * @param {any} module
-	 * @param {string} [route_id]
+	 * @param {string} [file]
 	 */
-	function validate(module, route_id) {
+	function validate(module, file) {
 		if (!module) return;
 
 		for (const key in module) {
 			if (key[0] === '_' || set.has(key)) continue; // key is valid in this module
 
 			const hint =
-				hint_for_supported_files(key) ||
+				hint_for_supported_files(key, file?.slice(file.lastIndexOf('.'))) ||
 				`valid exports are ${expected.join(', ')}, or anything with a '_' prefix`;
 
-			throw new Error(`Invalid export '${key}'${route_id ? ` in ${route_id}` : ''} (${hint})`);
+			throw new Error(`Invalid export '${key}'${file ? ` in ${file}` : ''} (${hint})`);
 		}
 	}
 
@@ -27,25 +27,26 @@ function validator(expected) {
 
 /**
  * @param {string} key
+ * @param {string} ext
  * @returns {string | undefined} undefined, if no supported file is found
  */
-function hint_for_supported_files(key) {
+function hint_for_supported_files(key, ext = '.js') {
 	let supported_files = [];
 
 	if (valid_common_exports.includes(key)) {
-		supported_files.push('+page.js');
+		supported_files.push(`+page${ext}`);
 	}
 
 	if (valid_page_server_exports.includes(key)) {
-		supported_files.push('+page.server.js');
+		supported_files.push(`+page.server${ext}`);
 	}
 
 	if (valid_server_exports.includes(key)) {
-		supported_files.push('+server.js');
+		supported_files.push(`+server${ext}`);
 	}
 
 	if (supported_files.length > 0) {
-		return `'${key}' is a valid export in '${supported_files.join(`' or '`)}'`;
+		return `'${key}' is a valid export in ${supported_files.join(` or `)}`;
 	}
 
 	return undefined;

--- a/packages/kit/src/utils/exports.js
+++ b/packages/kit/src/utils/exports.js
@@ -34,26 +34,26 @@ function validator(expected) {
 	return validate;
 }
 
-const valid_common_exports = ['trailingSlash', 'config', 'prerender', 'csr', 'ssr', 'load'];
+const valid_common_exports = ['load', 'prerender', 'csr', 'ssr', 'trailingSlash', 'config'];
 const valid_page_server_exports = [
-	'trailingSlash',
-	'config',
+	'load',
 	'prerender',
 	'csr',
 	'ssr',
-	'load',
-	'actions'
+	'actions',
+	'trailingSlash',
+	'config'
 ];
 const valid_server_exports = [
-	'trailingSlash',
-	'config',
-	'prerender',
 	'GET',
 	'POST',
 	'PATCH',
 	'PUT',
 	'DELETE',
-	'OPTIONS'
+	'OPTIONS',
+	'prerender',
+	'trailingSlash',
+	'config'
 ];
 
 export const validate_common_exports = validator(valid_common_exports);

--- a/packages/kit/src/utils/exports.js
+++ b/packages/kit/src/utils/exports.js
@@ -12,26 +12,43 @@ function validator(expected) {
 		if (!module) return;
 
 		for (const key in module) {
-			if (key[0] === '_' || set.has(key)) {
-				continue; // valid
-			}
+			if (key[0] === '_' || set.has(key)) continue; // key is valid in this module
 
-			const valid = expected.join(', ');
-			let error_hint = `(valid exports are ${valid}, or anything with a '_' prefix)`;
+			const hint =
+				hint_for_supported_files(key) ||
+				`valid exports are ${expected.join(', ')}, or anything with a '_' prefix`;
 
-			if (valid_page_server_exports.includes(key)) {
-				error_hint = `('${key}' is available in '+page.server.js')`;
-			}
-
-			if (valid_server_exports.includes(key)) {
-				error_hint = `('${key}' is available in '+server.js')`;
-			}
-
-			throw new Error(`Invalid export '${key}'${route_id ? ` in ${route_id}` : ''} ${error_hint}`);
+			throw new Error(`Invalid export '${key}'${route_id ? ` in ${route_id}` : ''} (${hint})`);
 		}
 	}
 
 	return validate;
+}
+
+/**
+ * @param {string} key
+ * @returns {string | undefined} undefined, if no supported file is found
+ */
+function hint_for_supported_files(key) {
+	let supported_files = [];
+
+	if (valid_common_exports.includes(key)) {
+		supported_files.push('+page.js');
+	}
+
+	if (valid_page_server_exports.includes(key)) {
+		supported_files.push('+page.server.js');
+	}
+
+	if (valid_server_exports.includes(key)) {
+		supported_files.push('+server.js');
+	}
+
+	if (supported_files.length > 0) {
+		return `'${key}' is a valid export in '${supported_files.join(`' or '`)}'`;
+	}
+
+	return undefined;
 }
 
 const valid_common_exports = ['load', 'prerender', 'csr', 'ssr', 'trailingSlash', 'config'];

--- a/packages/kit/src/utils/exports.js
+++ b/packages/kit/src/utils/exports.js
@@ -12,47 +12,50 @@ function validator(expected) {
 		if (!module) return;
 
 		for (const key in module) {
-			if (key[0] !== '_' && !set.has(key)) {
-				const valid = expected.join(', ');
-				throw new Error(
-					`Invalid export '${key}'${
-						route_id ? ` in ${route_id}` : ''
-					} (valid exports are ${valid}, or anything with a '_' prefix)`
-				);
+			if (key[0] === '_' || set.has(key)) {
+				continue; // valid
 			}
+
+			const valid = expected.join(', ');
+			let error_hint = `(valid exports are ${valid}, or anything with a '_' prefix)`;
+
+			if (valid_page_server_exports.includes(key)) {
+				error_hint = `('${key}' is available in '+page.server.js')`;
+			}
+
+			if (valid_server_exports.includes(key)) {
+				error_hint = `('${key}' is available in '+server.js')`;
+			}
+
+			throw new Error(`Invalid export '${key}'${route_id ? ` in ${route_id}` : ''} ${error_hint}`);
 		}
 	}
 
 	return validate;
 }
 
-export const validate_common_exports = validator([
-	'load',
+const valid_common_exports = ['trailingSlash', 'config', 'prerender', 'csr', 'ssr', 'load'];
+const valid_page_server_exports = [
+	'trailingSlash',
+	'config',
 	'prerender',
 	'csr',
 	'ssr',
-	'trailingSlash',
-	'config'
-]);
-
-export const validate_page_server_exports = validator([
 	'load',
-	'prerender',
-	'csr',
-	'ssr',
-	'actions',
+	'actions'
+];
+const valid_server_exports = [
 	'trailingSlash',
-	'config'
-]);
-
-export const validate_server_exports = validator([
+	'config',
+	'prerender',
 	'GET',
 	'POST',
 	'PATCH',
 	'PUT',
 	'DELETE',
-	'OPTIONS',
-	'prerender',
-	'trailingSlash',
-	'config'
-]);
+	'OPTIONS'
+];
+
+export const validate_common_exports = validator(valid_common_exports);
+export const validate_page_server_exports = validator(valid_page_server_exports);
+export const validate_server_exports = validator(valid_server_exports);

--- a/packages/kit/src/utils/exports.spec.js
+++ b/packages/kit/src/utils/exports.spec.js
@@ -25,13 +25,13 @@ test('validates +layout.server.js, +layout.js, +page.js', () => {
 		validate_common_exports({
 			actions: {}
 		});
-	}, /Invalid export 'actions' \('actions' is available in '\+page\.server\.js'\)/);
+	}, /Invalid export 'actions' \('actions' is a valid export in '\+page\.server\.js'\)/);
 
 	assert.throws(() => {
 		validate_common_exports({
 			GET: {}
 		});
-	}, /Invalid export 'GET' \('GET' is available in '\+server\.js'\)/);
+	}, /Invalid export 'GET' \('GET' is a valid export in '\+server\.js'\)/);
 });
 
 test('validates +page.server.js', () => {
@@ -49,6 +49,12 @@ test('validates +page.server.js', () => {
 			answer: 42
 		});
 	}, /Invalid export 'answer' \(valid exports are load, prerender, csr, ssr, actions, trailingSlash, config, or anything with a '_' prefix\)/);
+
+	assert.throws(() => {
+		validate_page_server_exports({
+			POST: {}
+		});
+	}, /Invalid export 'POST' \('POST' is a valid export in '\+server\.js'\)/);
 });
 
 test('validates +server.js', () => {
@@ -65,6 +71,12 @@ test('validates +server.js', () => {
 			answer: 42
 		});
 	}, /Invalid export 'answer' \(valid exports are GET, POST, PATCH, PUT, DELETE, OPTIONS, prerender, trailingSlash, config, or anything with a '_' prefix\)/);
+
+	assert.throws(() => {
+		validate_server_exports({
+			csr: false
+		});
+	}, /Invalid export 'csr' \('csr' is a valid export in '\+page\.js' or '\+page\.server\.js'\)/);
 });
 
 test.run();

--- a/packages/kit/src/utils/exports.spec.js
+++ b/packages/kit/src/utils/exports.spec.js
@@ -6,6 +6,22 @@ import {
 	validate_server_exports
 } from './exports.js';
 
+/**
+ * @param {() => void} fn
+ * @param {string} message
+ */
+function check_error(fn, message) {
+	let error;
+
+	try {
+		fn();
+	} catch (e) {
+		error = /** @type {Error} */ (e);
+	}
+
+	assert.equal(error?.message, message);
+}
+
 test('validates +layout.server.js, +layout.js, +page.js', () => {
 	validate_common_exports({
 		load: () => {}
@@ -15,23 +31,26 @@ test('validates +layout.server.js, +layout.js, +page.js', () => {
 		_unknown: () => {}
 	});
 
-	assert.throws(() => {
+	check_error(() => {
 		validate_common_exports({
 			answer: 42
 		});
-	}, /Invalid export 'answer' \(valid exports are load, prerender, csr, ssr, trailingSlash, config, or anything with a '_' prefix\)/);
+	}, `Invalid export 'answer' (valid exports are load, prerender, csr, ssr, trailingSlash, config, or anything with a '_' prefix)`);
 
-	assert.throws(() => {
-		validate_common_exports({
-			actions: {}
-		});
-	}, /Invalid export 'actions' \('actions' is a valid export in '\+page\.server\.js'\)/);
+	check_error(() => {
+		validate_common_exports(
+			{
+				actions: {}
+			},
+			'src/routes/foo/+page.ts'
+		);
+	}, `Invalid export 'actions' in src/routes/foo/+page.ts ('actions' is a valid export in +page.server.ts)`);
 
-	assert.throws(() => {
+	check_error(() => {
 		validate_common_exports({
 			GET: {}
 		});
-	}, /Invalid export 'GET' \('GET' is a valid export in '\+server\.js'\)/);
+	}, `Invalid export 'GET' ('GET' is a valid export in +server.js)`);
 });
 
 test('validates +page.server.js', () => {
@@ -44,17 +63,17 @@ test('validates +page.server.js', () => {
 		_unknown: () => {}
 	});
 
-	assert.throws(() => {
+	check_error(() => {
 		validate_page_server_exports({
 			answer: 42
 		});
-	}, /Invalid export 'answer' \(valid exports are load, prerender, csr, ssr, actions, trailingSlash, config, or anything with a '_' prefix\)/);
+	}, `Invalid export 'answer' (valid exports are load, prerender, csr, ssr, actions, trailingSlash, config, or anything with a '_' prefix)`);
 
-	assert.throws(() => {
+	check_error(() => {
 		validate_page_server_exports({
 			POST: {}
 		});
-	}, /Invalid export 'POST' \('POST' is a valid export in '\+server\.js'\)/);
+	}, `Invalid export 'POST' ('POST' is a valid export in +server.js)`);
 });
 
 test('validates +server.js', () => {
@@ -66,17 +85,17 @@ test('validates +server.js', () => {
 		_unknown: () => {}
 	});
 
-	assert.throws(() => {
+	check_error(() => {
 		validate_server_exports({
 			answer: 42
 		});
-	}, /Invalid export 'answer' \(valid exports are GET, POST, PATCH, PUT, DELETE, OPTIONS, prerender, trailingSlash, config, or anything with a '_' prefix\)/);
+	}, `Invalid export 'answer' (valid exports are GET, POST, PATCH, PUT, DELETE, OPTIONS, prerender, trailingSlash, config, or anything with a '_' prefix)`);
 
-	assert.throws(() => {
+	check_error(() => {
 		validate_server_exports({
 			csr: false
 		});
-	}, /Invalid export 'csr' \('csr' is a valid export in '\+page\.js' or '\+page\.server\.js'\)/);
+	}, `Invalid export 'csr' ('csr' is a valid export in +page.js or +page.server.js)`);
 });
 
 test.run();

--- a/packages/kit/src/utils/exports.spec.js
+++ b/packages/kit/src/utils/exports.spec.js
@@ -17,16 +17,21 @@ test('validates +layout.server.js, +layout.js, +page.js', () => {
 
 	assert.throws(() => {
 		validate_common_exports({
+			answer: 42
+		});
+	}, /Invalid export 'answer' \(valid exports are load, prerender, csr, ssr, trailingSlash, config, or anything with a '_' prefix\)/);
+
+	assert.throws(() => {
+		validate_common_exports({
 			actions: {}
 		});
 	}, /Invalid export 'actions' \('actions' is available in '\+page\.server\.js'\)/);
-	
+
 	assert.throws(() => {
 		validate_common_exports({
 			GET: {}
 		});
 	}, /Invalid export 'GET' \('GET' is available in '\+server\.js'\)/);
-
 });
 
 test('validates +page.server.js', () => {

--- a/packages/kit/src/utils/exports.spec.js
+++ b/packages/kit/src/utils/exports.spec.js
@@ -19,7 +19,14 @@ test('validates +layout.server.js, +layout.js, +page.js', () => {
 		validate_common_exports({
 			actions: {}
 		});
-	}, /Invalid export 'actions' \(valid exports are load, prerender, csr, ssr, trailingSlash, config, or anything with a '_' prefix\)/);
+	}, /Invalid export 'actions' \('actions' is available in '\+page\.server\.js'\)/);
+	
+	assert.throws(() => {
+		validate_common_exports({
+			GET: {}
+		});
+	}, /Invalid export 'GET' \('GET' is available in '\+server\.js'\)/);
+
 });
 
 test('validates +page.server.js', () => {

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -293,9 +293,8 @@ export interface SSRNode {
 		config?: any;
 	};
 
-	// store this in dev so we can print serialization errors
-	universal_id?: string;
-	server_id?: string;
+	universal_id: string;
+	server_id: string;
 }
 
 export type SSRNodeLoader = () => Promise<SSRNode>;


### PR DESCRIPTION
- closes #9034 

This adds a more helpful error message around "Invalid export" (module export validation) to help steer users who are using a named export in the wrong file that is supported elsewhere.

I used a relatively simple approach with hard coded file names because I didn't want to overengineer it too much. If we want a more flexible solution I'm open to suggestions.

I'm not sure if this is a "change that should be noted in one or more packages' changelogs", so please tell me if you want a changeset for this. If yes, would it be a feature?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
