### PR TITLE
fix: ISR support for `adapter-vercel`

### DIFF
--- a/.changeset/pretty-kids-camp.md
+++ b/.changeset/pretty-kids-camp.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+fix: get ISR working on Vercel

--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -88,18 +88,14 @@ export const config = {
 		// Setting the value to `false` means it will never expire.
 		expiration: 60,
 
-		// Option group number of the asset. Assets with the same group number will all be re-validated at the same time.
-		group: 1,
-
 		// Random token that can be provided in the URL to bypass the cached version of the asset, by requesting the asset
 		// with a __prerender_bypass=<token> cookie.
 		//
 		// Making a `GET` or `HEAD` request with `x-prerender-revalidate: <token>` will force the asset to be re-validated.
 		bypassToken: BYPASS_TOKEN,
 
-		// List of query string parameter names that will be cached independently.
-		// If an empty array, query values are not considered for caching.
-		// If `undefined` each unique query value is cached independently
+		// List of valid query parameters. Other parameters (such as utm tracking codes) will be ignored,
+		// ensuring that they do not result in content being regenerated unnecessarily
 		allowQuery: ['search']
 	}
 };

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -11,11 +11,25 @@ await server.init({
 	env: /** @type {Record<string, string>} */ (process.env)
 });
 
+const DATA_SUFFIX = '/__data.json';
+
 /**
  * @param {import('http').IncomingMessage} req
  * @param {import('http').ServerResponse} res
  */
 export default async (req, res) => {
+	if (req.url) {
+		const [path, search] = req.url.split('?');
+
+		const params = new URLSearchParams(search);
+		const pathname = params.get('__pathname');
+
+		if (pathname) {
+			params.delete('__pathname');
+			req.url = `${pathname}${path.endsWith(DATA_SUFFIX) ? DATA_SUFFIX : ''}?${params}`;
+		}
+	}
+
 	/** @type {Request} */
 	let request;
 

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -37,10 +37,6 @@ export interface ServerlessConfig {
 		 */
 		expiration: number | false;
 		/**
-		 * Option group number of the asset. Assets with the same group number will all be re-validated at the same time.
-		 */
-		group?: number;
-		/**
 		 * Random token that can be provided in the URL to bypass the cached version of the asset, by requesting the asset
 		 * with a __prerender_bypass=<token> cookie.
 		 *

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -246,7 +246,8 @@ const plugin = function (defaults = {}) {
 
 				const isr = isr_config.get(route);
 				if (isr) {
-					const base = `${dirs.functions}/${route.id.slice(1)}`;
+					const isr_name = route.id.slice(1) || '__root__'; // should we check that __root__ isn't a route?
+					const base = `${dirs.functions}/${isr_name}`;
 					builder.mkdirp(base);
 
 					const target = `${dirs.functions}/${name}.func`;
@@ -273,12 +274,12 @@ const plugin = function (defaults = {}) {
 
 					static_config.routes.push({
 						src: src + '$',
-						dest: `${route.id}${q}`
+						dest: `${isr_name}${q}`
 					});
 
 					static_config.routes.push({
 						src: src + '/__data.json$',
-						dest: `${route.id}/__data.json${q}`
+						dest: `${isr_name}/__data.json${q}`
 					});
 				} else if (!singular) {
 					static_config.routes.push({ src: src + '(?:/__data.json)?$', dest: `/${name}` });

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -147,11 +147,13 @@ const plugin = function (defaults = {}) {
 			let group_id = 0;
 
 			// ensure automatically assigned group ids are unique
+			// by first seeing which ids were explicitly assigned
+			// and therefore shouldn't be used
 			for (const route of builder.routes) {
 				if (route.prerender === true) continue;
 
 				if (route.config?.isr?.group !== undefined) {
-					group_id = route.config.isr.group;
+					group_id = Math.max(group_id, route.config.isr.group);
 				}
 			}
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -251,7 +251,7 @@ const plugin = function (defaults = {}) {
 					const isr = isr_config.get(route);
 					if (isr) {
 						if (isr.allowQuery?.includes('__pathname')) {
-							throw new Error('__pathname is a reserved query parameter');
+							throw new Error('__pathname is a reserved query parameter for isr.allowQuery');
 						}
 
 						const base = `${dirs.functions}/${route.id.slice(1)}`;

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -400,22 +400,21 @@ async function create_function_bundle(builder, entry, dir, config) {
 		}
 	}
 
+	const files = Array.from(traced.fileList);
+
 	// find common ancestor directory
 	/** @type {string[]} */
-	let common_parts = [];
+	let common_parts = files[0]?.split(path.sep) ?? [];
 
-	for (const file of traced.fileList) {
-		if (common_parts) {
-			const parts = file.split(path.sep);
+	for (let i = 1; i < files.length; i += 1) {
+		const file = files[i];
+		const parts = file.split(path.sep);
 
-			for (let i = 0; i < common_parts.length; i += 1) {
-				if (parts[i] !== common_parts[i]) {
-					common_parts = common_parts.slice(0, i);
-					break;
-				}
+		for (let i = 0; i < common_parts.length; i += 1) {
+			if (parts[i] !== common_parts[i]) {
+				common_parts = common_parts.slice(0, i);
+				break;
 			}
-		} else {
-			common_parts = path.dirname(file).split(path.sep);
 		}
 	}
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -302,11 +302,7 @@ function hash_config(config) {
 		config.external ?? '',
 		config.regions ?? '',
 		config.memory ?? '',
-		config.maxDuration ?? '',
-		config.isr?.expiration ?? '',
-		config.isr?.group ?? '',
-		config.isr?.bypassToken ?? '',
-		config.isr?.allowQuery ?? ''
+		config.maxDuration ?? ''
 	].join('/');
 }
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -442,9 +442,9 @@ async function create_function_bundle(builder, entry, dir, config) {
 		const file = files[i];
 		const parts = file.split(path.sep);
 
-		for (let i = 0; i < common_parts.length; i += 1) {
-			if (parts[i] !== common_parts[i]) {
-				common_parts = common_parts.slice(0, i);
+		for (let j = 0; j < common_parts.length; j += 1) {
+			if (parts[j] !== common_parts[j]) {
+				common_parts = common_parts.slice(0, j);
 				break;
 			}
 		}


### PR DESCRIPTION
We shipped incremental static regeneration on Vercel last week, but it was broken. Turns out there were a few extra hoops to jump through.

Brief explanation of the changes:

* every route needs a `group`, so that if you invalidate `/foo` you simultaneously invalidate `/foo/__data.json` — this is assigned automatically
* the pathname is passed to the prerender function as the `__pathname` query parameter. `req.url` is reconstructed by `adapter-vercel` before the request is handed off to SvelteKit
* so that we can know if `/foo` or `/foo/__data.json` is being requested, while still allowing `/foo` and `/foo/__data.json` to be invalidate simultaneously, we need to create two Vercel routes for each SvelteKit route with `isr`. To save space, these are symlinks rather than duplicates

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
