### PR TITLE
create `<svelte-announcer>` custom element

### DIFF
--- a/.changeset/rich-monkeys-listen.md
+++ b/.changeset/rich-monkeys-listen.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': minor
 ---
 
-feat: Moved the styles of svelte router announcer into shadow DOM.
+feat: Moved the styles of svelte route announcer into shadow DOM.

--- a/.changeset/rich-monkeys-listen.md
+++ b/.changeset/rich-monkeys-listen.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+Moved the styles of svelte router announcer into shadow DOM.

--- a/.changeset/rich-monkeys-listen.md
+++ b/.changeset/rich-monkeys-listen.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': minor
 ---
 
-Moved the styles of svelte router announcer into shadow DOM.
+feat: Moved the styles of svelte router announcer into shadow DOM.

--- a/packages/kit/src/core/sync/write_root.js
+++ b/packages/kit/src/core/sync/write_root.js
@@ -93,10 +93,13 @@ export function write_root(manifest_data, output) {
 										white-space: nowrap; 
 									}		
 								</style>
-								<slot></slot>
+								<span>
+									<slot></slot>
+								</span>
 							\`;
-							this.setAttribute('aria-live', 'assertive');
-							this.setAttribute('aria-atomic', 'true');
+							const span = shadow.querySelector("span");
+							span.setAttribute("aria-live", "assertive");
+							span.setAttribute("aria-atomic", "true");
 						}
 					});
 				}

--- a/packages/kit/src/core/sync/write_root.js
+++ b/packages/kit/src/core/sync/write_root.js
@@ -84,13 +84,13 @@ export function write_root(manifest_data, output) {
 							const shadow = this.attachShadow({ mode: 'open' });
 							shadow.innerHTML = \`
 								<style>
-									:host {
-										position: absolute;
-										clip-path: inset(50%);
-										height: 1px;
-										width: 1px;
-										overflow: hidden;
-										white-space: nowrap; 
+									:host, span {
+										position: absolute !important;
+										clip-path: inset(50%) !important;
+										height: 1px !important;
+										width: 1px !important;
+										overflow: hidden !important;
+										white-space: nowrap !important; 
 									}		
 								</style>
 								<span aria-live="assertive" aria-atomic="true">

--- a/packages/kit/src/core/sync/write_root.js
+++ b/packages/kit/src/core/sync/write_root.js
@@ -76,16 +76,37 @@ export function write_root(manifest_data, output) {
 					mounted = true;
 					return unsubscribe;
 				});
+				
+				customElements.define('svelte-announcer', class extends HTMLElement {
+					constructor() {
+						const shadow = this.attachShadow({ mode: "open" });
+						shadow.innerHTML = /*html*/ `
+				 			<style>
+				 				:host {
+  								position: absolute;
+				   				clip-path: inset(50%);
+  								height: 1px;
+  								width: 1px;
+  								overflow: hidden;
+  								white-space: nowrap; 
+				 				}		
+				 			</style>
+				 			<slot></slot>
+				 		`;
+						this.setAttribute('aria-live', 'assertive');
+						this.setAttribute('aria-atomic', 'true');
+					}
+				});
 			</script>
 
 			${pyramid.replace(/\n/g, '\n\t\t\t')}
 
 			{#if mounted}
-				<div id="svelte-announcer" aria-live="assertive" aria-atomic="true" style="position: absolute; left: 0; top: 0; clip: rect(0 0 0 0); clip-path: inset(50%); overflow: hidden; white-space: nowrap; width: 1px; height: 1px">
+				<svelte-announcer>
 					{#if navigated}
 						{title}
 					{/if}
-				</div>
+				</svelte-announcer>
 			{/if}
 		`)
 	);

--- a/packages/kit/src/core/sync/write_root.js
+++ b/packages/kit/src/core/sync/write_root.js
@@ -81,7 +81,7 @@ export function write_root(manifest_data, output) {
 					customElements.define('svelte-announcer', class extends HTMLElement {
 						constructor() {
 							super();
-							const shadow = this.attachShadow({ mode: "open" });
+							const shadow = this.attachShadow({ mode: 'open' });
 							shadow.innerHTML = \`
 								<style>
 									:host {
@@ -93,13 +93,10 @@ export function write_root(manifest_data, output) {
 										white-space: nowrap; 
 									}		
 								</style>
-								<span>
+								<span aria-live="assertive" aria-atomic="true">
 									<slot></slot>
 								</span>
 							\`;
-							const span = shadow.querySelector("span");
-							span.setAttribute("aria-live", "assertive");
-							span.setAttribute("aria-atomic", "true");
 						}
 					});
 				}

--- a/packages/kit/src/core/sync/write_root.js
+++ b/packages/kit/src/core/sync/write_root.js
@@ -76,12 +76,12 @@ export function write_root(manifest_data, output) {
 					mounted = true;
 					return unsubscribe;
 				});
-				
+
 				customElements.define('svelte-announcer', class extends HTMLElement {
 					constructor() {
 						super();
 						const shadow = this.attachShadow({ mode: "open" });
-						shadow.innerHTML = /*html*/ `
+						shadow.innerHTML = \`
 				 			<style>
 				 				:host {
   								position: absolute;
@@ -93,7 +93,7 @@ export function write_root(manifest_data, output) {
 				 				}		
 				 			</style>
 				 			<slot></slot>
-				 		`;
+				 		\`;
 						this.setAttribute('aria-live', 'assertive');
 						this.setAttribute('aria-atomic', 'true');
 					}

--- a/packages/kit/src/core/sync/write_root.js
+++ b/packages/kit/src/core/sync/write_root.js
@@ -77,27 +77,29 @@ export function write_root(manifest_data, output) {
 					return unsubscribe;
 				});
 
-				customElements.define('svelte-announcer', class extends HTMLElement {
-					constructor() {
-						super();
-						const shadow = this.attachShadow({ mode: "open" });
-						shadow.innerHTML = \`
-				 			<style>
-				 				:host {
-  								position: absolute;
-				   				clip-path: inset(50%);
-  								height: 1px;
-  								width: 1px;
-  								overflow: hidden;
-  								white-space: nowrap; 
-				 				}		
-				 			</style>
-				 			<slot></slot>
-				 		\`;
-						this.setAttribute('aria-live', 'assertive');
-						this.setAttribute('aria-atomic', 'true');
-					}
-				});
+				if (browser) {
+					customElements.define('svelte-announcer', class extends HTMLElement {
+						constructor() {
+							super();
+							const shadow = this.attachShadow({ mode: "open" });
+							shadow.innerHTML = \`
+								<style>
+									:host {
+										position: absolute;
+										clip-path: inset(50%);
+										height: 1px;
+										width: 1px;
+										overflow: hidden;
+										white-space: nowrap; 
+									}		
+								</style>
+								<slot></slot>
+							\`;
+							this.setAttribute('aria-live', 'assertive');
+							this.setAttribute('aria-atomic', 'true');
+						}
+					});
+				}
 			</script>
 
 			${pyramid.replace(/\n/g, '\n\t\t\t')}

--- a/packages/kit/src/core/sync/write_root.js
+++ b/packages/kit/src/core/sync/write_root.js
@@ -79,6 +79,7 @@ export function write_root(manifest_data, output) {
 				
 				customElements.define('svelte-announcer', class extends HTMLElement {
 					constructor() {
+						super();
 						const shadow = this.attachShadow({ mode: "open" });
 						shadow.innerHTML = /*html*/ `
 				 			<style>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -287,7 +287,7 @@ test.describe('Page options', () => {
 
 		expect(
 			await page.evaluate(() => {
-				const el = document.querySelector('#svelte-announcer');
+				const el = document.querySelector('svelte-announcer');
 				return el && getComputedStyle(el).position;
 			})
 		).toBe('absolute');

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -49,10 +49,10 @@ test.describe('a11y', () => {
 			expect(has_announcer).toBeTruthy();
 
 			// live region should exist, but be empty
-			expect(await page.innerHTML('[svelte-announcer]')).toBe('');
+			expect(await page.innerHTML('svelte-announcer')).toBe('');
 
 			await clicknav('[href="/accessibility/b"]');
-			expect(await page.innerHTML('[svelte-announcer]')).toBe('b'); // TODO i18n
+			expect(await page.innerHTML('svelte-announcer')).toBe('b'); // TODO i18n
 		} else {
 			expect(has_announcer).toBeFalsy();
 		}

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -408,7 +408,7 @@ test.describe('CSS', () => {
 
 		expect(
 			await page.evaluate(() => {
-				const el = document.querySelector('#svelte-announcer');
+				const el = document.querySelector('svelte-announcer');
 				return el && getComputedStyle(el).position;
 			})
 		).toBe('absolute');

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -43,18 +43,18 @@ test.describe('a11y', () => {
 	test('announces client-side navigation', async ({ page, clicknav, javaScriptEnabled }) => {
 		await page.goto('/accessibility/a');
 
-		const has_live_region = (await page.innerHTML('body')).includes('aria-live');
+		const has_announcer = (await page.innerHTML('body')).includes('svelte-announcer');
 
 		if (javaScriptEnabled) {
-			expect(has_live_region).toBeTruthy();
+			expect(has_announcer).toBeTruthy();
 
 			// live region should exist, but be empty
-			expect(await page.innerHTML('[aria-live]')).toBe('');
+			expect(await page.innerHTML('[svelte-announcer]')).toBe('');
 
 			await clicknav('[href="/accessibility/b"]');
-			expect(await page.innerHTML('[aria-live]')).toBe('b'); // TODO i18n
+			expect(await page.innerHTML('[svelte-announcer]')).toBe('b'); // TODO i18n
 		} else {
-			expect(has_live_region).toBeFalsy();
+			expect(has_announcer).toBeFalsy();
 		}
 	});
 


### PR DESCRIPTION
Closes #9081. See issue description for more details.

I just inlined the custom element in the script. There might be a better approach to this (perhaps using a svelte component to create the custom element?). Feedback welcome.

### Checklist:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

*I was getting all sorts of errors when running tests \:(*

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
