### PR TITLE
fix: return correct list of client files from `builder.writeClient()`

### DIFF
--- a/.changeset/ninety-waves-cheer.md
+++ b/.changeset/ninety-waves-cheer.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: return correct list of client files from `builder.writeClient()`

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -187,7 +187,7 @@ export function create_builder({
 				join(dest, config.kit.appDir, 'immutable/assets')
 			);
 			const client_assets = copy(`${config.kit.outDir}/output/client`, dest);
-			return Array.from(new Set(...server_assets, ...client_assets));
+			return Array.from(new Set([...server_assets, ...client_assets]));
 		},
 
 		// @ts-expect-error

--- a/packages/kit/src/core/adapt/builder.spec.js
+++ b/packages/kit/src/core/adapt/builder.spec.js
@@ -45,7 +45,9 @@ test('copy files', () => {
 	const dest = join(__dirname, 'output');
 
 	rmSync(dest, { recursive: true, force: true });
-	builder.writeClient(dest);
+	const clientPaths = builder.writeClient(dest);
+
+	assert.equal(clientPaths, glob('**', { cwd: dest, dot: true, filesOnly: true }));
 
 	assert.equal(
 		glob('**', { cwd: `${outDir}/output/client`, dot: true }),
@@ -53,7 +55,9 @@ test('copy files', () => {
 	);
 
 	rmSync(dest, { recursive: true, force: true });
-	builder.writeServer(dest);
+	const serverPaths = builder.writeServer(dest);
+
+	assert.equal(serverPaths, glob('**', { cwd: dest, dot: true, filesOnly: true }));
 
 	assert.equal(
 		glob('**', { cwd: `${outDir}/output/server`, dot: true }),


### PR DESCRIPTION
#9073 introduced a bug, resulting in invalid array of files from writeClient. 

Adding tests to catch the error. Before the change, the test resulted in following error: 

```
  ··[
        Actual:
        --··"r",
        --··"o",
        --··"u",
        --··"t",
        --··"e",
        --··"s",
        --··"/",
        --··"i",
        --··"n",
        --··"d",
        --··"x",
        --··".",
        --··"j",
        Expected:
        ++··"routes/index.js",
        ··]
```

Fixes #9093

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
