### PR TITLE
 omit file protocol for create-svelte tests outside CI

### DIFF
--- a/packages/create-svelte/test/check.js
+++ b/packages/create-svelte/test/check.js
@@ -21,8 +21,10 @@ const overrides = { ...existing_workspace_overrides };
 	await glob(fileURLToPath(new URL('../../../packages', import.meta.url)) + '/*/package.json')
 ).forEach((pkgPath) => {
 	const name = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).name;
-	// use `file:` protocol for opting into stricter resolve logic which catches more bugs
-	overrides[name] = `file:${path.dirname(path.resolve(pkgPath))}`;
+	// use `file:` protocol for opting into stricter resolve logic which catches more bugs,
+	// but only on CI because it doesn't work locally for some reason
+	const protocol = process.env.CI ? 'file:' : '';
+	overrides[name] = `${protocol}${path.dirname(path.resolve(pkgPath))}`;
 });
 
 try {


### PR DESCRIPTION
Ever since #9052, `create-svelte` tests fail for me locally. I haven't been able to figure out why, so I figured I'd just do this for now