### PR TITLE
chore: run publint only once in prepublish script

### DIFF
--- a/.changeset/quick-cats-jam.md
+++ b/.changeset/quick-cats-jam.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+chore: avoid running publint twice in prepublish

--- a/packages/create-svelte/templates/skeletonlib/package.template.json
+++ b/packages/create-svelte/templates/skeletonlib/package.template.json
@@ -6,7 +6,7 @@
 		"build": "vite build && npm run package",
 		"preview": "vite preview",
 		"package": "svelte-kit sync && svelte-package && publint",
-		"prepublishOnly": "npm run package && publint"
+		"prepublishOnly": "npm run package"
 	},
 	"exports": {
 		".": {


### PR DESCRIPTION
publint is called by the package script above. This doesn't really "fix" anything so labelled it as a chore but still needs a changeset.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
