### PR TITLE
encode streamed chunks

### DIFF
--- a/.changeset/chilly-rats-glow.md
+++ b/.changeset/chilly-rats-glow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: encode streamed chunks

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -10,6 +10,8 @@ import { create_async_iterator } from '../../../utils/streaming.js';
 
 export const INVALIDATED_PARAM = 'x-sveltekit-invalidated';
 
+const encoder = new TextEncoder();
+
 /**
  * @param {import('types').RequestEvent} event
  * @param {import('types').SSRRoute} route
@@ -128,12 +130,14 @@ export async function render_data(
 		return new Response(
 			new ReadableStream({
 				async start(controller) {
-					controller.enqueue(data);
+					controller.enqueue(encoder.encode(data));
 					for await (const chunk of chunks) {
-						controller.enqueue(chunk);
+						controller.enqueue(encoder.encode(chunk));
 					}
 					controller.close();
-				}
+				},
+
+				type: 'bytes'
 			}),
 			{
 				headers: {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -19,6 +19,8 @@ const updated = {
 	check: () => false
 };
 
+const encoder = new TextEncoder();
+
 /**
  * Creates the HTML response.
  * @param {{
@@ -458,12 +460,14 @@ export async function render_response({
 		: new Response(
 				new ReadableStream({
 					async start(controller) {
-						controller.enqueue(transformed);
+						controller.enqueue(encoder.encode(transformed));
 						for await (const chunk of chunks) {
-							controller.enqueue(chunk);
+							controller.enqueue(encoder.encode(chunk));
 						}
 						controller.close();
-					}
+					},
+
+					type: 'bytes'
 				}),
 				{
 					headers: {


### PR DESCRIPTION
It turns out that if `response.body` is a `ReadableStream`, it must be a `ReadableStream<Uint8Array>`. This escaped notice before, because Node does its own thing, quelle surprise

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
