### PR TITLE
append newline to trigger script evaluation

### DIFF
--- a/.changeset/smart-fishes-boil.md
+++ b/.changeset/smart-fishes-boil.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: append newline to trigger script evaluation

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -460,7 +460,7 @@ export async function render_response({
 		: new Response(
 				new ReadableStream({
 					async start(controller) {
-						controller.enqueue(encoder.encode(transformed));
+						controller.enqueue(encoder.encode(transformed + '\n'));
 						for await (const chunk of chunks) {
 							controller.enqueue(encoder.encode(chunk));
 						}
@@ -525,7 +525,7 @@ function get_data(event, options, nodes, global) {
 							str = devalue.uneval({ id, data, error }, replacer);
 						}
 
-						push(`\n<script>${global}.resolve(${str})</script>`);
+						push(`<script>${global}.resolve(${str})</script>\n`);
 						if (count === 0) done();
 					}
 				);


### PR DESCRIPTION
The newline needs to come _after_ the `<script>`, not before, so that it evaluates immediately

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
