### PR TITLE
use a proprietary content-type

### DIFF
--- a/.changeset/plenty-pugs-hunt.md
+++ b/.changeset/plenty-pugs-hunt.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: use a proprietary content-type to ensure response is not buffered

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -141,9 +141,9 @@ export async function render_data(
 			}),
 			{
 				headers: {
-					// text/plain isn't strictly correct, but it makes it easier to inspect
-					// the data, and doesn't affect how it is consumed by the client
-					'content-type': 'text/plain',
+					// we use a proprietary content type to prevent buffering.
+					// the `text` prefix makes it inspectable
+					'content-type': 'text/sveltekit-data',
 					'cache-control': 'private, no-store'
 				}
 			}


### PR DESCRIPTION
It turns out that `text/plain` is buffered in some cases. I don't really understand how or why, but using a proprietary content type for streamed `__data.json` files seems to do the trick

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
