### PR TITLE
feat: Validate Vercel cron paths

### DIFF
--- a/.changeset/tiny-deers-complain.md
+++ b/.changeset/tiny-deers-complain.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': minor
+---
+
+feat: Validate that Vercel cron paths match an API path

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -546,10 +546,14 @@ function validate_vercel_json(builder, vercel_config) {
 	}
 
 	builder.log.warn(
-		`The following paths are not matched by any route:\n  - ${unmatched_paths.join(
-			'\n  - '
-		)}\nIf these paths are handled in your \`handle\` hook, you can safely ignore this warning.`
+		`\nvercel.json defines cron tasks that use paths that do not correspond to an API route with a GET handler (ignore this if the request is handled in your \`handle\` hook):`
 	);
+
+	for (const path of unmatched_paths) {
+		console.log(`    - ${path}`);
+	}
+
+	console.log('');
 }
 
 export default plugin;

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -40,11 +40,13 @@ const plugin = function (defaults = {}) {
 			builder.rimraf(tmp);
 
 			if (fs.existsSync('./vercel.json')) {
-				const vercelFile = fs.readFileSync('./vercel.json', 'utf-8');
-				const vercelConfig = JSON.parse(vercelFile);
+				const vercel_file = fs.readFileSync('./vercel.json', 'utf-8');
+				const vercel_config = JSON.parse(vercel_file);
 				const crons = /** @type {Array<unknown>} */ (
-					Array.isArray(vercelConfig?.crons) ? vercelConfig.crons : []
+					Array.isArray(vercel_config?.crons) ? vercel_config.crons : []
 				);
+				const GET_routes = builder.routes.filter((route) => route.methods.includes('GET'));
+
 				crons.forEach((cron) => {
 					if (!(typeof cron === 'object' && cron !== null && 'path' in cron)) {
 						return;
@@ -55,15 +57,13 @@ const plugin = function (defaults = {}) {
 						return;
 					}
 
-					if (!builder.routes.some((route) => route.pattern.test(path))) {
+					if (!GET_routes.some((route) => route.pattern.test(path))) {
 						builder.log.warn(
 							`Cron job path ${path} does not match any routes. If this path is handled in your \`handle\` hook, you can ignore this warning.`
 						);
 					}
 				});
 			}
-
-			builder.routes.some((route) => route.pattern.test());
 
 			const files = fileURLToPath(new URL('./files', import.meta.url).href);
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -45,8 +45,9 @@ const plugin = function (defaults = {}) {
 				const crons = /** @type {Array<unknown>} */ (
 					Array.isArray(vercel_config?.crons) ? vercel_config.crons : []
 				);
+				// This will false-positive on pages that have endpoints other than `GET`
 				const GET_routes = builder.routes.filter(
-					(route) => route.type === 'endpoint' && route.methods.includes('GET')
+					(route) => route.hasEndpoint && route.methods.includes('GET')
 				);
 				/** @type {Array<string>} */
 				const unmatched_paths = [];

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -45,7 +45,9 @@ const plugin = function (defaults = {}) {
 				const crons = /** @type {Array<unknown>} */ (
 					Array.isArray(vercel_config?.crons) ? vercel_config.crons : []
 				);
-				const GET_routes = builder.routes.filter((route) => route.methods.includes('GET'));
+				const GET_routes = builder.routes.filter(
+					(route) => route.type === 'endpoint' && route.methods.includes('GET')
+				);
 				/** @type {Array<string>} */
 				const unmatched_paths = [];
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -509,9 +509,9 @@ async function create_function_bundle(builder, entry, dir, config) {
  * @param {any} vercel_config
  */
 function validate_vercel_json(builder, vercel_config) {
-	if (builder.routes.length > 0 && !builder.routes[0].endpoint) {
+	if (builder.routes.length > 0 && !builder.routes[0].api) {
 		// bail — we're on an older SvelteKit version that doesn't
-		// populate `route.endpoint.methods`, so we can't check
+		// populate `route.api.methods`, so we can't check
 		// to see if cron paths are valid
 		return;
 	}
@@ -521,7 +521,7 @@ function validate_vercel_json(builder, vercel_config) {
 	);
 
 	/** For a route to be considered 'valid', it must be an API route with a GET handler */
-	const valid_routes = builder.routes.filter((route) => route.endpoint.methods.includes('GET'));
+	const valid_routes = builder.routes.filter((route) => route.api.methods.includes('GET'));
 
 	/** @type {Array<string>} */
 	const unmatched_paths = [];

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -45,9 +45,8 @@ const plugin = function (defaults = {}) {
 				const crons = /** @type {Array<unknown>} */ (
 					Array.isArray(vercel_config?.crons) ? vercel_config.crons : []
 				);
-				// This will false-positive on pages that have endpoints other than `GET`
-				const GET_routes = builder.routes.filter(
-					(route) => route.hasEndpoint && route.methods.includes('GET')
+				const GET_endpoints = builder.routes.filter((route) =>
+					route?.endpoint?.methods?.includes('GET')
 				);
 				/** @type {Array<string>} */
 				const unmatched_paths = [];
@@ -62,7 +61,7 @@ const plugin = function (defaults = {}) {
 						continue;
 					}
 
-					if (!GET_routes.some((route) => route.pattern.test(path))) {
+					if (!GET_endpoints.some((route) => route.pattern.test(path))) {
 						unmatched_paths.push(path);
 					}
 				}

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -43,16 +43,23 @@ export function create_builder({
 	 * we expose a stable type that adapters can use to group/filter routes
 	 */
 	const routes = route_data.map((route) => {
-		const methods =
-			/** @type {import('types').HttpMethod[]} */
-			(server_metadata.routes.get(route.id)?.methods);
+		const { methods, pageMethods, endpointMethods } =
+			/** @type {NonNullable<ReturnType<typeof server_metadata['routes']['get']>>} */ (
+				server_metadata.routes.get(route.id)
+			);
 		const config = server_metadata.routes.get(route.id)?.config;
+
+		server_metadata.routes.get(route.id)?.methods;
 
 		/** @type {import('types').RouteDefinition} */
 		const facade = {
 			id: route.id,
-			hasEndpoint: !!route.endpoint,
-			hasPage: !!route.page,
+			endpoint: {
+				methods: endpointMethods
+			},
+			page: {
+				methods: pageMethods
+			},
 			segments: get_route_segments(route.id).map((segment) => ({
 				dynamic: segment.includes('['),
 				rest: segment.includes('[...'),

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -43,14 +43,14 @@ export function create_builder({
 	 * we expose a stable type that adapters can use to group/filter routes
 	 */
 	const routes = route_data.map((route) => {
-		const { config, methods, page, endpoint } = /** @type {import('types').ServerMetadataRoute} */ (
+		const { config, methods, page, api } = /** @type {import('types').ServerMetadataRoute} */ (
 			server_metadata.routes.get(route.id)
 		);
 
 		/** @type {import('types').RouteDefinition} */
 		const facade = {
 			id: route.id,
-			endpoint,
+			api,
 			page,
 			segments: get_route_segments(route.id).map((segment) => ({
 				dynamic: segment.includes('['),

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -43,21 +43,15 @@ export function create_builder({
 	 * we expose a stable type that adapters can use to group/filter routes
 	 */
 	const routes = route_data.map((route) => {
-		const { methods, pageMethods, endpointMethods } =
-			/** @type {import('types').ServerMetadataRoute} */ (server_metadata.routes.get(route.id));
-		const config = server_metadata.routes.get(route.id)?.config;
-
-		server_metadata.routes.get(route.id)?.methods;
+		const { config, methods, page, endpoint } = /** @type {import('types').ServerMetadataRoute} */ (
+			server_metadata.routes.get(route.id)
+		);
 
 		/** @type {import('types').RouteDefinition} */
 		const facade = {
 			id: route.id,
-			endpoint: {
-				methods: endpointMethods
-			},
-			page: {
-				methods: pageMethods
-			},
+			endpoint,
+			page,
 			segments: get_route_segments(route.id).map((segment) => ({
 				dynamic: segment.includes('['),
 				rest: segment.includes('[...'),

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -44,9 +44,7 @@ export function create_builder({
 	 */
 	const routes = route_data.map((route) => {
 		const { methods, pageMethods, endpointMethods } =
-			/** @type {NonNullable<ReturnType<typeof server_metadata['routes']['get']>>} */ (
-				server_metadata.routes.get(route.id)
-			);
+			/** @type {import('types').ServerMetadataRoute} */ (server_metadata.routes.get(route.id));
 		const config = server_metadata.routes.get(route.id)?.config;
 
 		server_metadata.routes.get(route.id)?.methods;

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -51,7 +51,8 @@ export function create_builder({
 		/** @type {import('types').RouteDefinition} */
 		const facade = {
 			id: route.id,
-			type: route.endpoint ? 'endpoint' : 'page',
+			hasEndpoint: !!route.endpoint,
+			hasPage: !!route.page,
 			segments: get_route_segments(route.id).map((segment) => ({
 				dynamic: segment.includes('['),
 				rest: segment.includes('[...'),

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -51,6 +51,7 @@ export function create_builder({
 		/** @type {import('types').RouteDefinition} */
 		const facade = {
 			id: route.id,
+			type: route.endpoint ? 'endpoint' : 'page',
 			segments: get_route_segments(route.id).map((segment) => ({
 				dynamic: segment.includes('['),
 				rest: segment.includes('[...'),

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -138,11 +138,15 @@ async function analyse({ manifest_path, env }) {
 		const endpointMethods = Array.from(endpointMethodsSet);
 		const methods = [...pageMethods, ...endpointMethods];
 		metadata.routes.set(route.id, {
-			prerender,
 			config,
-			pageMethods,
-			endpointMethods,
-			methods
+			methods,
+			page: {
+				methods: Array.from(pageMethodsSet)
+			},
+			endpoint: {
+				methods: Array.from(endpointMethodsSet)
+			},
+			prerender
 		});
 	}
 

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -66,7 +66,7 @@ async function analyse({ manifest_path, env }) {
 		const page_methods = [];
 
 		/** @type {import('types').HttpMethod[]} */
-		const endpoint_methods = [];
+		const api_methods = [];
 
 		/** @type {import('types').PrerenderOption | undefined} */
 		let prerender = undefined;
@@ -87,12 +87,12 @@ async function analyse({ manifest_path, env }) {
 				prerender = mod.prerender;
 			}
 
-			if (mod.GET) endpoint_methods.push('GET');
-			if (mod.POST) endpoint_methods.push('POST');
-			if (mod.PUT) endpoint_methods.push('PUT');
-			if (mod.PATCH) endpoint_methods.push('PATCH');
-			if (mod.DELETE) endpoint_methods.push('DELETE');
-			if (mod.OPTIONS) endpoint_methods.push('OPTIONS');
+			if (mod.GET) api_methods.push('GET');
+			if (mod.POST) api_methods.push('POST');
+			if (mod.PUT) api_methods.push('PUT');
+			if (mod.PATCH) api_methods.push('PATCH');
+			if (mod.DELETE) api_methods.push('DELETE');
+			if (mod.OPTIONS) api_methods.push('OPTIONS');
 
 			config = mod.config;
 		}
@@ -137,12 +137,12 @@ async function analyse({ manifest_path, env }) {
 
 		metadata.routes.set(route.id, {
 			config,
-			methods: Array.from(new Set([...page_methods, ...endpoint_methods])),
+			methods: Array.from(new Set([...page_methods, ...api_methods])),
 			page: {
 				methods: page_methods
 			},
-			endpoint: {
-				methods: endpoint_methods
+			api: {
+				methods: api_methods
 			},
 			prerender
 		});

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -983,7 +983,8 @@ export interface ResolveOptions {
 
 export interface RouteDefinition<Config = any> {
 	id: string;
-	type: 'endpoint' | 'page';
+	hasEndpoint: boolean;
+	hasPage: boolean;
 	pattern: RegExp;
 	prerender: PrerenderOption;
 	segments: RouteSegment[];

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -983,8 +983,12 @@ export interface ResolveOptions {
 
 export interface RouteDefinition<Config = any> {
 	id: string;
-	hasEndpoint: boolean;
-	hasPage: boolean;
+	endpoint: {
+		methods: HttpMethod[];
+	};
+	page: {
+		methods: Extract<HttpMethod, 'GET' | 'POST'>[];
+	};
 	pattern: RegExp;
 	prerender: PrerenderOption;
 	segments: RouteSegment[];

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -983,6 +983,7 @@ export interface ResolveOptions {
 
 export interface RouteDefinition<Config = any> {
 	id: string;
+	type: 'endpoint' | 'page';
 	pattern: RegExp;
 	prerender: PrerenderOption;
 	segments: RouteSegment[];

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -892,7 +892,7 @@ export interface RequestEvent<
 	 */
 	locals: App.Locals;
 	/**
-	 * The parameters of the current page or endpoint - e.g. for a route like `/blog/[slug]`, a `{ slug: string }` object
+	 * The parameters of the current route - e.g. for a route like `/blog/[slug]`, a `{ slug: string }` object
 	 */
 	params: Params;
 	/**
@@ -936,7 +936,7 @@ export interface RequestEvent<
 	 */
 	setHeaders(headers: Record<string, string>): void;
 	/**
-	 * The URL of the current page or endpoint.
+	 * The requested URL.
 	 */
 	url: URL;
 	/**
@@ -983,7 +983,7 @@ export interface ResolveOptions {
 
 export interface RouteDefinition<Config = any> {
 	id: string;
-	endpoint: {
+	api: {
 		methods: HttpMethod[];
 	};
 	page: {

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -265,7 +265,7 @@ export interface ServerErrorNode {
 
 export interface ServerMetadataRoute {
 	config: any;
-	endpoint: {
+	api: {
 		methods: HttpMethod[];
 	};
 	page: {

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -263,18 +263,17 @@ export interface ServerErrorNode {
 	status?: number;
 }
 
+export interface ServerMetadataRoute {
+	prerender: PrerenderOption | undefined;
+	endpointMethods: HttpMethod[];
+	pageMethods: Extract<HttpMethod, 'GET' | 'POST'>[];
+	methods: HttpMethod[];
+	config: any;
+}
+
 export interface ServerMetadata {
 	nodes: Array<{ has_server_load: boolean }>;
-	routes: Map<
-		string,
-		{
-			prerender: PrerenderOption | undefined;
-			endpointMethods: HttpMethod[];
-			pageMethods: Extract<HttpMethod, 'GET' | 'POST'>[];
-			methods: HttpMethod[];
-			config: any;
-		}
-	>;
+	routes: Map<string, ServerMetadataRoute>;
 }
 
 export interface SSRComponent {

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -269,6 +269,8 @@ export interface ServerMetadata {
 		string,
 		{
 			prerender: PrerenderOption | undefined;
+			endpointMethods: HttpMethod[];
+			pageMethods: Extract<HttpMethod, 'GET' | 'POST'>[];
 			methods: HttpMethod[];
 			config: any;
 		}

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -264,11 +264,15 @@ export interface ServerErrorNode {
 }
 
 export interface ServerMetadataRoute {
-	prerender: PrerenderOption | undefined;
-	endpointMethods: HttpMethod[];
-	pageMethods: Extract<HttpMethod, 'GET' | 'POST'>[];
-	methods: HttpMethod[];
 	config: any;
+	endpoint: {
+		methods: HttpMethod[];
+	};
+	page: {
+		methods: Array<'GET' | 'POST'>;
+	};
+	methods: HttpMethod[];
+	prerender: PrerenderOption | undefined;
 }
 
 export interface ServerMetadata {


### PR DESCRIPTION
Vercel Cron Jobs are launching. Thanks to their API, we don't actually have to make any changes to support them.  However, as a courtesy to our users, we _can_ make sure that a SvelteKit app exports a `GET` API handler that matches the path for each cron job. We can't do more than warn here, as users could handle these requests in `handle`, but I think the normal usecase would be to define a `+server.ts` endpoint.

- [ ] Is there a way to test this?
- [ ] Do we want to enable suppression of these warnings via a config option?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
