### PR TITLE
fix: bundle SvelteKit when using Vitest

### DIFF
--- a/.changeset/lazy-olives-mix.md
+++ b/.changeset/lazy-olives-mix.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't force externalize SvelteKit

--- a/.changeset/lazy-olives-mix.md
+++ b/.changeset/lazy-olives-mix.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: bundle SvelteKit for better Vitest support
+fix: bundle SvelteKit when using Vitest

--- a/.changeset/lazy-olives-mix.md
+++ b/.changeset/lazy-olives-mix.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: don't force externalize SvelteKit
+fix: bundle SvelteKit for better Vitest support

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -257,6 +257,7 @@ function kit({ svelte_config }) {
 
 			// Vitest will only call resolveId for packages that are being bundled
 			// Without this it will not be able to load our virtual modules
+			// See https://vitest.dev/config/#deps-registernodeloader
 			const noExternal = process.env.TEST ? ['@sveltejs/kit'] : [];
 
 			if (is_build) {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -289,14 +289,6 @@ function kit({ svelte_config }) {
 					__SVELTEKIT_DEV__: 'true',
 					__SVELTEKIT_EMBEDDED__: kit.embedded ? 'true' : 'false'
 				};
-
-				new_config.ssr = {
-					// Without this, Vite will treat `@sveltejs/kit` as noExternal if it's
-					// a linked dependency, and that causes modules to be imported twice
-					// under different IDs, which breaks a bunch of stuff
-					// https://github.com/vitejs/vite/pull/9296
-					external: ['@sveltejs/kit', 'cookie', 'set-cookie-parser']
-				};
 			}
 
 			warn_overridden_config(config, new_config);

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -225,9 +225,10 @@ function kit({ svelte_config }) {
 			// because they for example use esbuild.build with `platform: 'browser'`
 			const noExternal = ['esm-env'];
 
-			// Vitest bypasses Vite when loading external modules, so when it is
-			// detected we take a tiny performance hit to preserve correctness.
+			// Vitest bypasses Vite when loading external modules, so we bundle
+			// when it is detected to keep our virtual modules working.
 			// See https://github.com/sveltejs/kit/pull/9172
+			// and https://vitest.dev/config/#deps-registernodeloader
 			if (process.env.TEST) {
 				noExternal.push('@sveltejs/kit');
 			}

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -252,7 +252,7 @@ function kit({ svelte_config }) {
 						'$app',
 						'$env'
 					]
-				},
+				}
 			};
 
 			// Vitest will only call resolveId for packages that are being bundled

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -218,6 +218,20 @@ function kit({ svelte_config }) {
 
 			const generated = path.posix.join(kit.outDir, 'generated');
 
+			// This ensures that esm-env is inlined into the server output with the
+			// export conditions resolved correctly through Vite. This prevents adapters
+			// that bundle later on from resolving the export conditions incorrectly
+			// and for example include browser-only code in the server output
+			// because they for example use esbuild.build with `platform: 'browser'`
+			const noExternal = ['esm-env'];
+
+			// Vitest bypasses Vite when loading external modules, so when it is
+			// detected we take a tiny performance hit to preserve correctness.
+			// See https://github.com/sveltejs/kit/pull/9172
+			if (process.env.TEST) {
+				noExternal.push('@sveltejs/kit');
+			}
+
 			// dev and preview config can be shared
 			/** @type {import('vite').UserConfig} */
 			const new_config = {
@@ -254,12 +268,7 @@ function kit({ svelte_config }) {
 					]
 				},
 				ssr: {
-					// This ensures that esm-env is inlined into the server output with the
-					// export conditions resolved correctly through Vite. This prevents adapters
-					// that bundle later on from resolving the export conditions incorrectly
-					// and for example include browser-only code in the server output
-					// because they for example use esbuild.build with `platform: 'browser'`
-					noExternal: ['esm-env']
+					noExternal
 				}
 			};
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -252,13 +252,16 @@ function kit({ svelte_config }) {
 						'$app',
 						'$env'
 					]
+				},
+				ssr: {
+					// This ensures that esm-env is inlined into the server output with the
+					// export conditions resolved correctly through Vite. This prevents adapters
+					// that bundle later on from resolving the export conditions incorrectly
+					// and for example include browser-only code in the server output
+					// because they for example use esbuild.build with `platform: 'browser'`
+					noExternal: ['esm-env']
 				}
 			};
-
-			// Vitest will only call resolveId for packages that are being bundled
-			// Without this it will not be able to load our virtual modules
-			// See https://vitest.dev/config/#deps-registernodeloader
-			const noExternal = process.env.TEST ? ['@sveltejs/kit'] : [];
 
 			if (is_build) {
 				if (!new_config.build) new_config.build = {};
@@ -272,13 +275,6 @@ function kit({ svelte_config }) {
 					__SVELTEKIT_EMBEDDED__: kit.embedded ? 'true' : 'false'
 				};
 
-				// This ensures that esm-env is inlined into the server output with the
-				// export conditions resolved correctly through Vite. This prevents adapters
-				// that bundle later on to resolve the export conditions incorrectly
-				// and for example include browser-only code in the server output
-				// because they for example use esbuild.build with `platform: 'browser'`
-				noExternal.push('esm-env');
-
 				if (!secondary_build_started) {
 					manifest_data = (await sync.all(svelte_config, config_env.mode)).manifest_data;
 				}
@@ -288,11 +284,14 @@ function kit({ svelte_config }) {
 					__SVELTEKIT_DEV__: 'true',
 					__SVELTEKIT_EMBEDDED__: kit.embedded ? 'true' : 'false'
 				};
-			}
 
-			new_config.ssr = {
-				noExternal
-			};
+				// These Kit dependencies are packaged as CommonJS, which means they must always be externalized.
+				// Without this, the tests will still pass but `pnpm dev` will fail in projects that link `@sveltejs/kit`.
+				/** @type {NonNullable<import('vite').UserConfig['ssr']>} */ (new_config.ssr).external = [
+					'cookie',
+					'set-cookie-parser'
+				];
+			}
 
 			warn_overridden_config(config, new_config);
 


### PR DESCRIPTION
We had added SvelteKit to `external` in https://github.com/sveltejs/kit/pull/5861 to make the tests pass as it was needed for Vite 3. It appears to no longer be necessary with Vite 4

This partially addresses https://github.com/sveltejs/kit/issues/9162. There's still another issue I'll need to fix