### PR TITLE
fix: allow relative fetch to endpoint outside app from within handle

### DIFF
--- a/.changeset/good-bikes-cross.md
+++ b/.changeset/good-bikes-cross.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: allow relative fetch to enpoint outside app from within handle
+fix: allow relative fetch to endpoint outside app from within `handle`

--- a/.changeset/good-bikes-cross.md
+++ b/.changeset/good-bikes-cross.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow relative fetch to enpoint outside app from within handle

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -38,8 +38,6 @@ export async function render_data(
 		});
 	}
 
-	state.initiator = route;
-
 	try {
 		const node_ids = [...route.page.layouts, route.page.leaf];
 		const invalidated = invalidated_data_nodes ?? node_ids.map(() => true);

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -28,7 +28,7 @@ export async function render_endpoint(event, mod, state) {
 	}
 
 	if (state.prerendering && !prerender) {
-		if (state.initiator) {
+		if (state.depth > 0) {
 			// if request came from a prerendered page, bail
 			throw new Error(`${event.route.id} is not prerenderable`);
 		} else {

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -39,8 +39,6 @@ export async function render_endpoint(event, route, mod, state) {
 		}
 	}
 
-	state.initiator = route;
-
 	try {
 		const response = await handler(
 			/** @type {import('types').RequestEvent<Record<string, any>>} */ (event)

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -4,12 +4,11 @@ import { method_not_allowed } from './utils.js';
 
 /**
  * @param {import('types').RequestEvent} event
- * @param {import('types').SSRRoute} route
  * @param {import('types').SSREndpoint} mod
  * @param {import('types').SSRState} state
  * @returns {Promise<Response>}
  */
-export async function render_endpoint(event, route, mod, state) {
+export async function render_endpoint(event, mod, state) {
 	const method = /** @type {import('types').HttpMethod} */ (event.request.method);
 
 	let handler = mod[method];

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -131,7 +131,7 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 					);
 				}
 
-				state.initiator = request.url;
+				state.initiator = event.request.url;
 				response = await respond(request, options, manifest, state);
 
 				const set_cookie = response.headers.get('set-cookie');

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -131,6 +131,7 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 					);
 				}
 
+				state.initiator = request.url;
 				response = await respond(request, options, manifest, state);
 
 				const set_cookie = response.headers.get('set-cookie');

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -5,6 +5,7 @@ import * as paths from '__sveltekit/paths';
 /**
  * @param {{
  *   event: import('types').RequestEvent;
+ *   route: import('types').SSRRoute | null;
  *   options: import('types').SSROptions;
  *   manifest: import('types').SSRManifest;
  *   state: import('types').SSRState;
@@ -12,7 +13,7 @@ import * as paths from '__sveltekit/paths';
  * }} opts
  * @returns {typeof fetch}
  */
-export function create_fetch({ event, options, manifest, state, get_cookie_header }) {
+export function create_fetch({ event, route, options, manifest, state, get_cookie_header }) {
 	return async (info, init) => {
 		const original_request = normalize_fetch_input(info, init, event.url);
 
@@ -131,7 +132,10 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 					);
 				}
 
-				state.initiator = event.request.url;
+				if (!state.initiator && route) {
+					state.initiator = route;
+				}
+
 				response = await respond(request, options, manifest, state);
 
 				const set_cookie = response.headers.get('set-cookie');

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -5,7 +5,6 @@ import * as paths from '__sveltekit/paths';
 /**
  * @param {{
  *   event: import('types').RequestEvent;
- *   route: import('types').SSRRoute | null;
  *   options: import('types').SSROptions;
  *   manifest: import('types').SSRManifest;
  *   state: import('types').SSRState;
@@ -13,7 +12,7 @@ import * as paths from '__sveltekit/paths';
  * }} opts
  * @returns {typeof fetch}
  */
-export function create_fetch({ event, route, options, manifest, state, get_cookie_header }) {
+export function create_fetch({ event, options, manifest, state, get_cookie_header }) {
 	return async (info, init) => {
 		const original_request = normalize_fetch_input(info, init, event.url);
 
@@ -132,11 +131,10 @@ export function create_fetch({ event, route, options, manifest, state, get_cooki
 					);
 				}
 
-				if (!state.initiator && route) {
-					state.initiator = route;
-				}
-
-				response = await respond(request, options, manifest, state);
+				response = await respond(request, options, manifest, {
+					...state,
+					depth: state.depth + 1
+				});
 
 				const set_cookie = response.headers.get('set-cookie');
 				if (set_cookie) {

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -58,6 +58,10 @@ export class Server {
 			);
 		}
 
-		return respond(request, this.#options, this.#manifest, options);
+		return respond(request, this.#options, this.#manifest, {
+			...options,
+			error: false,
+			depth: 0
+		});
 	}
 }

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -18,6 +18,7 @@ import { get_data_json } from '../data/index.js';
 
 /**
  * @param {import('types').RequestEvent} event
+ * @param {import('types').SSRRoute} route
  * @param {import('types').PageNodeIndexes} page
  * @param {import('types').SSROptions} options
  * @param {import('types').SSRManifest} manifest
@@ -25,8 +26,8 @@ import { get_data_json } from '../data/index.js';
  * @param {import('types').RequiredResolveOptions} resolve_opts
  * @returns {Promise<Response>}
  */
-export async function render_page(event, page, options, manifest, state, resolve_opts) {
-	if (state.initiator === event.request.url) {
+export async function render_page(event, route, page, options, manifest, state, resolve_opts) {
+	if (state.initiator === route) {
 		// infinite request cycle detected
 		return text(`Not found: ${event.url.pathname}`, {
 			status: 404

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -18,7 +18,6 @@ import { get_data_json } from '../data/index.js';
 
 /**
  * @param {import('types').RequestEvent} event
- * @param {import('types').SSRRoute} route
  * @param {import('types').PageNodeIndexes} page
  * @param {import('types').SSROptions} options
  * @param {import('types').SSRManifest} manifest
@@ -26,15 +25,13 @@ import { get_data_json } from '../data/index.js';
  * @param {import('types').RequiredResolveOptions} resolve_opts
  * @returns {Promise<Response>}
  */
-export async function render_page(event, route, page, options, manifest, state, resolve_opts) {
-	if (state.initiator === route) {
+export async function render_page(event, page, options, manifest, state, resolve_opts) {
+	if (state.initiator === event.request.url) {
 		// infinite request cycle detected
 		return text(`Not found: ${event.url.pathname}`, {
 			status: 404
 		});
 	}
-
-	state.initiator = route;
 
 	if (is_action_json_request(event)) {
 		const node = await manifest._.nodes[page.leaf]();

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -17,8 +17,12 @@ import { get_option } from '../../../utils/options.js';
 import { get_data_json } from '../data/index.js';
 
 /**
+ * The maximum request depth permitted before assuming we're stuck in an infinite loop
+ */
+const MAX_DEPTH = 10;
+
+/**
  * @param {import('types').RequestEvent} event
- * @param {import('types').SSRRoute} route
  * @param {import('types').PageNodeIndexes} page
  * @param {import('types').SSROptions} options
  * @param {import('types').SSRManifest} manifest
@@ -26,11 +30,11 @@ import { get_data_json } from '../data/index.js';
  * @param {import('types').RequiredResolveOptions} resolve_opts
  * @returns {Promise<Response>}
  */
-export async function render_page(event, route, page, options, manifest, state, resolve_opts) {
-	if (state.initiator === route) {
+export async function render_page(event, page, options, manifest, state, resolve_opts) {
+	if (state.depth > MAX_DEPTH) {
 		// infinite request cycle detected
 		return text(`Not found: ${event.url.pathname}`, {
-			status: 404
+			status: 404 // TODO in some cases this should be 500. not sure how to differentiate
 		});
 	}
 

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -320,7 +320,7 @@ export async function render_page(event, route, page, options, manifest, state, 
 			fetched
 		});
 	} catch (e) {
-		// if we end up here, it means the data loaded successfull
+		// if we end up here, it means the data loaded successfully
 		// but the page failed to render, or that a prerendering error occurred
 		return await respond_with_error({
 			event,

--- a/packages/kit/src/runtime/server/page/load_data.spec.js
+++ b/packages/kit/src/runtime/server/page/load_data.spec.js
@@ -14,7 +14,7 @@ function create_fetch(event) {
 		/** @type {Pick<import('types').RequestEvent, 'fetch' | 'url' | 'request' | 'route'>} */ (
 			event
 		),
-		{ getClientAddress: () => '' },
+		{ getClientAddress: () => '', error: false, depth: 0 },
 		[],
 		true,
 		{

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -1,11 +1,6 @@
 import { render_response } from './render.js';
 import { load_data, load_server_data } from './load_data.js';
-import {
-	handle_error_and_jsonify,
-	static_error_page,
-	redirect_response,
-	GENERIC_ERROR
-} from '../utils.js';
+import { handle_error_and_jsonify, static_error_page, redirect_response } from '../utils.js';
 import { get_option } from '../../../utils/options.js';
 import { HttpError, Redirect } from '../../control.js';
 
@@ -43,7 +38,7 @@ export async function respond_with_error({
 		const csr = get_option([default_layout], 'csr') ?? true;
 
 		if (ssr) {
-			state.initiator = GENERIC_ERROR;
+			state.error = true;
 
 			const server_data_promise = load_server_data({
 				event,

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -5,7 +5,7 @@ import { render_page } from './page/index.js';
 import { render_response } from './page/render.js';
 import { respond_with_error } from './page/respond_with_error.js';
 import { is_form_content_type } from '../../utils/http.js';
-import { GENERIC_ERROR, handle_fatal_error, redirect_response } from './utils.js';
+import { handle_fatal_error, redirect_response } from './utils.js';
 import {
 	decode_pathname,
 	decode_params,
@@ -233,7 +233,7 @@ export async function respond(request, options, manifest, state) {
 
 		cookies_to_add = new_cookies;
 		event.cookies = cookies;
-		event.fetch = create_fetch({ event, route, options, manifest, state, get_cookie_header });
+		event.fetch = create_fetch({ event, options, manifest, state, get_cookie_header });
 
 		if (state.prerendering && !state.prerendering.fallback) disable_search(url);
 
@@ -366,15 +366,7 @@ export async function respond(request, options, manifest, state) {
 				} else if (route.endpoint && (!route.page || is_endpoint_request(event))) {
 					response = await render_endpoint(event, await route.endpoint(), state);
 				} else if (route.page) {
-					response = await render_page(
-						event,
-						route,
-						route.page,
-						options,
-						manifest,
-						state,
-						resolve_opts
-					);
+					response = await render_page(event, route.page, options, manifest, state, resolve_opts);
 				} else {
 					// a route will always have a page or an endpoint, but TypeScript
 					// doesn't know that
@@ -384,7 +376,7 @@ export async function respond(request, options, manifest, state) {
 				return response;
 			}
 
-			if (state.initiator === GENERIC_ERROR) {
+			if (state.error) {
 				return text('Internal Server Error', {
 					status: 500
 				});
@@ -392,7 +384,7 @@ export async function respond(request, options, manifest, state) {
 
 			// if this request came direct from the user, rather than
 			// via our own `fetch`, render a 404 page
-			if (!state.initiator) {
+			if (state.depth === 0) {
 				return await respond_with_error({
 					event,
 					options,

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -233,7 +233,7 @@ export async function respond(request, options, manifest, state) {
 
 		cookies_to_add = new_cookies;
 		event.cookies = cookies;
-		event.fetch = create_fetch({ event, options, manifest, state, get_cookie_header });
+		event.fetch = create_fetch({ event, route, options, manifest, state, get_cookie_header });
 
 		if (state.prerendering && !state.prerendering.fallback) disable_search(url);
 
@@ -366,7 +366,15 @@ export async function respond(request, options, manifest, state) {
 				} else if (route.endpoint && (!route.page || is_endpoint_request(event))) {
 					response = await render_endpoint(event, await route.endpoint(), state);
 				} else if (route.page) {
-					response = await render_page(event, route.page, options, manifest, state, resolve_opts);
+					response = await render_page(
+						event,
+						route,
+						route.page,
+						options,
+						manifest,
+						state,
+						resolve_opts
+					);
 				} else {
 					// a route will always have a page or an endpoint, but TypeScript
 					// doesn't know that

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -364,7 +364,7 @@ export async function respond(request, options, manifest, state) {
 						trailing_slash ?? 'never'
 					);
 				} else if (route.endpoint && (!route.page || is_endpoint_request(event))) {
-					response = await render_endpoint(event, route, await route.endpoint(), state);
+					response = await render_endpoint(event, await route.endpoint(), state);
 				} else if (route.page) {
 					response = await render_page(event, route.page, options, manifest, state, resolve_opts);
 				} else {

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -16,10 +16,7 @@ export function is_pojo(body) {
 	return true;
 }
 
-/** @type {import('types').SSRErrorPage} */
-export const GENERIC_ERROR = {
-	id: '__error'
-};
+export const GENERIC_ERROR = 'GENERIC_ERROR';
 
 /**
  * @param {Partial<Record<import('types').HttpMethod, any>>} mod

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -16,8 +16,6 @@ export function is_pojo(body) {
 	return true;
 }
 
-export const GENERIC_ERROR = 'GENERIC_ERROR';
-
 /**
  * @param {Partial<Record<import('types').HttpMethod, any>>} mod
  * @param {import('types').HttpMethod} method

--- a/packages/kit/test/apps/basics/src/hooks.server.js
+++ b/packages/kit/test/apps/basics/src/hooks.server.js
@@ -106,6 +106,13 @@ export const handle = sequence(
 		}
 
 		return resolve(event);
+	},
+	async ({ event, resolve }) => {
+		if (event.url.pathname === '/prerendering/prerendered-endpoint/from-handle-hook') {
+			return event.fetch('/prerendering/prerendered-endpoint/api');
+		}
+
+		return resolve(event);
 	}
 );
 

--- a/packages/kit/test/apps/basics/src/routes/prerendering/prerendered-endpoint/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/prerendering/prerendered-endpoint/+page.svelte
@@ -1,0 +1,1 @@
+<a href="/prerendering/prerendered-endpoint/from-handle-hook">through handle hook</a>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -496,6 +496,22 @@ test.describe('Load', () => {
 			'Im prerendered and called from a non-prerendered +page.server.js'
 		);
 	});
+
+	test('Prerendered +server.js called from a non-prerendered handle hook works', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		if (javaScriptEnabled) {
+			await page.goto('/prerendering/prerendered-endpoint');
+			await page.click('a', { noWaitAfter: true });
+		} else {
+			await page.goto('/prerendering/prerendered-endpoint/from-handle-hook');
+		}
+
+		expect(await page.textContent('html')).toBe(
+			'{"message":"Im prerendered and called from a non-prerendered +page.server.js"}'
+		);
+	});
 });
 
 test.describe('Nested layouts', () => {

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -157,15 +157,6 @@ export type RecursiveRequired<T> = {
 
 export type RequiredResolveOptions = Required<ResolveOptions>;
 
-export interface Respond {
-	(
-		request: Request,
-		options: SSROptions,
-		manifest: SSRManifest,
-		state: SSRState
-	): Promise<Response>;
-}
-
 export interface RouteParam {
 	name: string;
 	matcher: string;
@@ -352,10 +343,6 @@ export interface SSROptions {
 	version_hash: string;
 }
 
-export interface SSRErrorPage {
-	id: '__error';
-}
-
 export interface PageNodeIndexes {
 	errors: Array<number | undefined>;
 	layouts: Array<number | undefined>;
@@ -380,7 +367,7 @@ export interface SSRRoute {
 export interface SSRState {
 	fallback?: string;
 	getClientAddress(): string;
-	initiator?: SSRRoute | SSRErrorPage;
+	initiator?: 'GENERIC_ERROR' | (string & {});
 	platform?: any;
 	prerendering?: PrerenderOptions;
 	/**

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -367,6 +367,11 @@ export interface SSRRoute {
 export interface SSRState {
 	fallback?: string;
 	getClientAddress(): string;
+	/**
+	 * Tracks which route was responsible for the request, in the case where it
+	 * originates from `event.fetch`. This prevents infinite loops from occuring
+	 * when, for example, a root layout fetches a non-existent route
+	 */
 	initiator?: 'GENERIC_ERROR' | SSRRoute;
 	platform?: any;
 	prerendering?: PrerenderOptions;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -368,11 +368,13 @@ export interface SSRState {
 	fallback?: string;
 	getClientAddress(): string;
 	/**
-	 * Tracks which route was responsible for the request, in the case where it
-	 * originates from `event.fetch`. This prevents infinite loops from occuring
-	 * when, for example, a root layout fetches a non-existent route
+	 * True if we're currently attempting to render an error page
 	 */
-	initiator?: 'GENERIC_ERROR' | SSRRoute;
+	error: boolean;
+	/**
+	 * Allows us to prevent `event.fetch` from making infinitely looping internal requests
+	 */
+	depth: number;
 	platform?: any;
 	prerendering?: PrerenderOptions;
 	/**

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -367,7 +367,7 @@ export interface SSRRoute {
 export interface SSRState {
 	fallback?: string;
 	getClientAddress(): string;
-	initiator?: 'GENERIC_ERROR' | (string & {});
+	initiator?: 'GENERIC_ERROR' | SSRRoute;
 	platform?: any;
 	prerendering?: PrerenderOptions;
 	/**


### PR DESCRIPTION
fixes #9183
also consolidates usage of state.initiator across the server, only setting it in one place now where it's correct, prior to calling the internal fetch function. this means it now compares by url string, not matched route

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
