### PR TITLE
expose stronger typed `SubmitFunction`

### DIFF
--- a/.changeset/stupid-trains-push.md
+++ b/.changeset/stupid-trains-push.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/kit': patch
+'@sveltejs/kit': minor
 ---
 
-expose stronger typed `SubmitFunction`
+feat: expose stronger typed `SubmitFunction` through `./$types`

--- a/.changeset/stupid-trains-push.md
+++ b/.changeset/stupid-trains-push.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+expose stronger typed `SubmitFunction`

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -396,9 +396,13 @@ function process_node(node, outdir, is_page, proxies, all_pages_have_load = true
 				const from = proxy.modified
 					? `./proxy${replace_ext_with_js(basename)}`
 					: path_to_original(outdir, node.server);
-				
-				exports.push(`type AwaitedActions = Expand<Kit.AwaitedActions<typeof import('${from}').actions>>`);
-				exports.push(`export type SubmitFunction = Kit.SubmitFunction<AwaitedActions, AwaitedActions>`);
+
+				exports.push(
+					`type AwaitedActions = Expand<Kit.AwaitedActions<typeof import('${from}').actions>>`
+				);
+				exports.push(
+					`export type SubmitFunction = Kit.SubmitFunction<AwaitedActions, AwaitedActions>`
+				);
 
 				type = `AwaitedActions | null`;
 			}

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -399,7 +399,7 @@ function process_node(node, outdir, is_page, proxies, all_pages_have_load = true
 
 				exports.push(
 					`type ActionsExport = typeof import('${from}').actions`,
-					`export type SubmitFunction = Kit.SubmitFunction<Expand<Kit.ActionsSuccess<ActionsExport>>, Expand<Kit.ActionsInvalid<ActionsExport>>>`
+					`export type SubmitFunction = Kit.SubmitFunction<Expand<Kit.ActionsSuccess<ActionsExport>>, Expand<Kit.ActionsFailure<ActionsExport>>>`
 				);
 
 				type = `Expand<Kit.AwaitedActions<ActionsExport>> | null`;

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -398,8 +398,12 @@ function process_node(node, outdir, is_page, proxies, all_pages_have_load = true
 					: path_to_original(outdir, node.server);
 
 				exports.push(
+					`type ExcludeActionFailure<T> = T extends Kit.ActionFailure<any> ? never : T extends void ? never : T;`,
+					`type ActionsSuccess<T extends Record<string, (...args: any) => any>> = { [Key in keyof T]: ExcludeActionFailure<Awaited<ReturnType<T[Key]>>>; }[keyof T];`,
+					`type ExtractActionFailure<T> = T extends Kit.ActionFailure<infer X>	? X extends void ? never : X : never;`,
+					`type ActionsFailure<T extends Record<string, (...args: any) => any>> = { [Key in keyof T]: Exclude<ExtractActionFailure<Awaited<ReturnType<T[Key]>>>, void>; }[keyof T];`,
 					`type ActionsExport = typeof import('${from}').actions`,
-					`export type SubmitFunction = Kit.SubmitFunction<Expand<Kit.ActionsSuccess<ActionsExport>>, Expand<Kit.ActionsFailure<ActionsExport>>>`
+					`export type SubmitFunction = Kit.SubmitFunction<Expand<ActionsSuccess<ActionsExport>>, Expand<ActionsFailure<ActionsExport>>>`
 				);
 
 				type = `Expand<Kit.AwaitedActions<ActionsExport>> | null`;

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -390,16 +390,17 @@ function process_node(node, outdir, is_page, proxies, all_pages_have_load = true
 
 		if (is_page) {
 			let type = 'unknown';
-			if (proxy) {
-				if (proxy.exports.includes('actions')) {
-					// If the file wasn't tweaked, we can use the return type of the original file.
-					// The advantage is that type updates are reflected without saving.
-					const from = proxy.modified
-						? `./proxy${replace_ext_with_js(basename)}`
-						: path_to_original(outdir, node.server);
+			if (proxy && proxy.exports.includes('actions')) {
+				// If the file wasn't tweaked, we can use the return type of the original file.
+				// The advantage is that type updates are reflected without saving.
+				const from = proxy.modified
+					? `./proxy${replace_ext_with_js(basename)}`
+					: path_to_original(outdir, node.server);
+				
+				exports.push(`type AwaitedActions = Expand<Kit.AwaitedActions<typeof import('${from}').actions>>`);
+				exports.push(`export type SubmitFunction = Kit.SubmitFunction<AwaitedActions, AwaitedActions>`);
 
-					type = `Expand<Kit.AwaitedActions<typeof import('${from}').actions>> | null`;
-				}
+				type = `AwaitedActions | null`;
 			}
 			exports.push(`export type ActionData = ${type};`);
 		}

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -398,13 +398,11 @@ function process_node(node, outdir, is_page, proxies, all_pages_have_load = true
 					: path_to_original(outdir, node.server);
 
 				exports.push(
-					`type AwaitedActions = Expand<Kit.AwaitedActions<typeof import('${from}').actions>>`
-				);
-				exports.push(
-					`export type SubmitFunction = Kit.SubmitFunction<AwaitedActions, AwaitedActions>`
+					`type ActionsExport = typeof import('${from}').actions`,
+					`export type SubmitFunction = Kit.SubmitFunction<Expand<Kit.ActionsSuccess<ActionsExport>>, Expand<Kit.ActionsInvalid<ActionsExport>>>`
 				);
 
-				type = `AwaitedActions | null`;
+				type = `Expand<Kit.AwaitedActions<ActionsExport>> | null`;
 			}
 			exports.push(`export type ActionData = ${type};`);
 		}

--- a/packages/kit/src/core/sync/write_types/index.spec.js
+++ b/packages/kit/src/core/sync/write_types/index.spec.js
@@ -33,6 +33,7 @@ test('Creates correct $types', async () => {
 	// To safe us from creating a real SvelteKit project for each of the tests,
 	// we first run the type generation directly for each test case, and then
 	// call `tsc` to check that the generated types are valid.
+	await run_test('actions');
 	await run_test('simple-page-shared-only');
 	await run_test('simple-page-server-only');
 	await run_test('simple-page-server-and-shared');

--- a/packages/kit/src/core/sync/write_types/test/actions/+page.server.js
+++ b/packages/kit/src/core/sync/write_types/test/actions/+page.server.js
@@ -1,0 +1,35 @@
+import { fail } from '../../../../../../types/internal.js'
+
+let condition = false
+
+export const actions = {
+	default: () => {
+		if (condition) {
+			return fail(400, { fail: 'oops' })
+		}
+
+		return {
+			success: true,
+		}
+	}
+}
+
+/** @type {import('./.svelte-kit/types/src/core/sync/write_types/test/actions/$types').SubmitFunction} */
+const submit = () => {
+	return ({ result }) => {
+		if (result.type === 'success') {
+			result.data?.success === true
+			// @ts-expect-error should be of type `boolean`
+			result.data?.success === 'success'
+			// @ts-expect-error unknown property
+			result.data?.something
+		}
+		if (result.type === 'failure') {
+			result.data?.fail === ''
+			// @ts-expect-error should be of type `string`
+			result.data?.fail === 1
+			// @ts-expect-error unknown property
+			result.data?.unknown
+		}
+	}
+}

--- a/packages/kit/src/core/sync/write_types/test/actions/+page.server.js
+++ b/packages/kit/src/core/sync/write_types/test/actions/+page.server.js
@@ -5,12 +5,34 @@ let condition = false;
 export const actions = {
 	default: () => {
 		if (condition) {
-			return fail(400, { fail: 'oops' });
+			return fail(400, {
+				fail: 'oops'
+			});
 		}
 
 		return {
 			success: true
 		};
+	},
+	successWithPayload: () => {
+		return {
+			id: 42,
+			username: 'John Doe',
+			profession: 'Svelte specialist'
+		};
+	},
+	successWithoutPayload: () => {},
+	failWithPayload: () => {
+		return fail(400, {
+			reason: {
+				error: {
+					code: /** @type {const} */ ('VALIDATION_FAILED')
+				}
+			}
+		});
+	},
+	failWithoutPayload: () => {
+		return fail(400);
 	}
 };
 
@@ -18,18 +40,48 @@ export const actions = {
 const submit = () => {
 	return ({ result }) => {
 		if (result.type === 'success') {
-			result.data?.success === true;
-			// @ts-expect-error should be of type `boolean`
-			result.data?.success === 'success';
+			// @ts-expect-error does only exist on `failure` result
+			result.data?.fail;
 			// @ts-expect-error unknown property
 			result.data?.something;
+
+			if (result.data && 'success' in result.data) {
+				result.data.success === true;
+				// @ts-expect-error should be of type `boolean`
+				result.data.success === 'success';
+				// @ts-expect-error does not exist in this branch
+				result.data.id;
+			}
+
+			if (result.data && 'id' in result.data) {
+				result.data.id === 42;
+				// @ts-expect-error should be of type `number`
+				result.data.id === 'John';
+				// @ts-expect-error does not exist in this branch
+				result.data.success;
+			}
 		}
+
 		if (result.type === 'failure') {
-			result.data?.fail === '';
-			// @ts-expect-error should be of type `string`
-			result.data?.fail === 1;
+			result.data;
+			// @ts-expect-error does only exist on `success` result
+			result.data.success;
 			// @ts-expect-error unknown property
-			result.data?.unknown;
+			result.data.unknown;
+
+			if (result.data && 'fail' in result.data) {
+				result.data.fail === '';
+				// @ts-expect-error does not exist in this branch
+				result.data.reason;
+			}
+
+			if (result.data && 'reason' in result.data) {
+				result.data.reason.error.code === 'VALIDATION_FAILED';
+				// @ts-expect-error should be a const
+				result.data.reason.error.code === '';
+				// @ts-expect-error does not exist in this branch
+				result.data.fail;
+			}
 		}
 	};
 };

--- a/packages/kit/src/core/sync/write_types/test/actions/+page.server.js
+++ b/packages/kit/src/core/sync/write_types/test/actions/+page.server.js
@@ -1,35 +1,35 @@
-import { fail } from '../../../../../../types/internal.js'
+import { fail } from '../../../../../../types/internal.js';
 
-let condition = false
+let condition = false;
 
 export const actions = {
 	default: () => {
 		if (condition) {
-			return fail(400, { fail: 'oops' })
+			return fail(400, { fail: 'oops' });
 		}
 
 		return {
-			success: true,
-		}
+			success: true
+		};
 	}
-}
+};
 
 /** @type {import('./.svelte-kit/types/src/core/sync/write_types/test/actions/$types').SubmitFunction} */
 const submit = () => {
 	return ({ result }) => {
 		if (result.type === 'success') {
-			result.data?.success === true
+			result.data?.success === true;
 			// @ts-expect-error should be of type `boolean`
-			result.data?.success === 'success'
+			result.data?.success === 'success';
 			// @ts-expect-error unknown property
-			result.data?.something
+			result.data?.something;
 		}
 		if (result.type === 'failure') {
-			result.data?.fail === ''
+			result.data?.fail === '';
 			// @ts-expect-error should be of type `string`
-			result.data?.fail === 1
+			result.data?.fail === 1;
 			// @ts-expect-error unknown property
-			result.data?.unknown
+			result.data?.unknown;
 		}
-	}
-}
+	};
+};

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -71,6 +71,22 @@ type UnpackValidationError<T> = T extends ActionFailure<infer X>
 	? undefined // needs to be undefined, because void will corrupt union type
 	: T;
 
+export type ActionsSuccess<T extends Record<string, (...args: any) => any>> = {
+	[Key in keyof T]: ExcludeValidationError<Awaited<ReturnType<T[Key]>>>;
+}[keyof T];
+
+type ExcludeValidationError<T> = T extends ActionFailure<any> ? never : T extends void ? never : T;
+
+export type ActionsInvalid<T extends Record<string, (...args: any) => any>> = {
+	[Key in keyof T]: Exclude<ExtractValidationError<Awaited<ReturnType<T[Key]>>>, void>;
+}[keyof T];
+
+type ExtractValidationError<T> = T extends ActionFailure<infer X>
+	? X extends void
+		? never
+		: X
+	: never;
+
 /**
  * This object is passed to the `adapt` function of adapters.
  * It contains various methods and properties that are useful for adapting the app.
@@ -1188,7 +1204,7 @@ export function text(body: string, init?: ResponseInit): Response;
  * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
  * @param data Data associated with the failure (e.g. validation errors)
  */
-export function fail<T extends Record<string, unknown> | undefined>(
+export function fail<T extends Record<string, unknown> | undefined = undefined>(
 	status: number,
 	data?: T
 ): ActionFailure<T>;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1219,7 +1219,7 @@ export interface SubmitFunction<
 		| ((opts: {
 				form: HTMLFormElement;
 				action: URL;
-			result: ActionResult<Success, Failure>;
+				result: ActionResult<Success, Failure>;
 				/**
 				 * Call this to get the default behavior of a form submission response.
 				 * @param options Set `reset: false` if you don't want the `<form>` values to be reset after a successful submission.

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1132,10 +1132,10 @@ export type Actions<
  */
 export type ActionResult<
 	Success extends Record<string, unknown> | undefined = Record<string, any>,
-	Invalid extends Record<string, unknown> | undefined = Record<string, any>
+	Failure extends Record<string, unknown> | undefined = Record<string, any>
 > =
 	| { type: 'success'; status: number; data?: Success }
-	| { type: 'failure'; status: number; data?: Invalid }
+	| { type: 'failure'; status: number; data?: Failure }
 	| { type: 'redirect'; status: number; location: string }
 	| { type: 'error'; status?: number; error: any };
 
@@ -1222,7 +1222,7 @@ export interface ActionFailure<T extends Record<string, unknown> | undefined = u
 
 export interface SubmitFunction<
 	Success extends Record<string, unknown> | undefined = Record<string, any>,
-	Invalid extends Record<string, unknown> | undefined = Record<string, any>
+	Failure extends Record<string, unknown> | undefined = Record<string, any>
 > {
 	(input: {
 		action: URL;
@@ -1235,8 +1235,8 @@ export interface SubmitFunction<
 		| ((opts: {
 				form: HTMLFormElement;
 				action: URL;
-				result: ActionResult<Success, Invalid>;
-				/**
+			result: ActionResult<Success, Failure>;
+				/**D
 				 * Call this to get the default behavior of a form submission response.
 				 * @param options Set `reset: false` if you don't want the `<form>` values to be reset after a successful submission.
 				 */

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -72,16 +72,16 @@ type UnpackValidationError<T> = T extends ActionFailure<infer X>
 	: T;
 
 export type ActionsSuccess<T extends Record<string, (...args: any) => any>> = {
-	[Key in keyof T]: ExcludeValidationError<Awaited<ReturnType<T[Key]>>>;
+	[Key in keyof T]: ExcludeActionFailure<Awaited<ReturnType<T[Key]>>>;
 }[keyof T];
 
-type ExcludeValidationError<T> = T extends ActionFailure<any> ? never : T extends void ? never : T;
+type ExcludeActionFailure<T> = T extends ActionFailure<any> ? never : T extends void ? never : T;
 
-export type ActionsInvalid<T extends Record<string, (...args: any) => any>> = {
-	[Key in keyof T]: Exclude<ExtractValidationError<Awaited<ReturnType<T[Key]>>>, void>;
+export type ActionsFailure<T extends Record<string, (...args: any) => any>> = {
+	[Key in keyof T]: Exclude<ExtractActionFailure<Awaited<ReturnType<T[Key]>>>, void>;
 }[keyof T];
 
-type ExtractValidationError<T> = T extends ActionFailure<infer X>
+type ExtractActionFailure<T> = T extends ActionFailure<infer X>
 	? X extends void
 		? never
 		: X
@@ -1236,7 +1236,7 @@ export interface SubmitFunction<
 				form: HTMLFormElement;
 				action: URL;
 			result: ActionResult<Success, Failure>;
-				/**D
+				/**
 				 * Call this to get the default behavior of a form submission response.
 				 * @param options Set `reset: false` if you don't want the `<form>` values to be reset after a successful submission.
 				 */

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -71,22 +71,6 @@ type UnpackValidationError<T> = T extends ActionFailure<infer X>
 	? undefined // needs to be undefined, because void will corrupt union type
 	: T;
 
-export type ActionsSuccess<T extends Record<string, (...args: any) => any>> = {
-	[Key in keyof T]: ExcludeActionFailure<Awaited<ReturnType<T[Key]>>>;
-}[keyof T];
-
-type ExcludeActionFailure<T> = T extends ActionFailure<any> ? never : T extends void ? never : T;
-
-export type ActionsFailure<T extends Record<string, (...args: any) => any>> = {
-	[Key in keyof T]: Exclude<ExtractActionFailure<Awaited<ReturnType<T[Key]>>>, void>;
-}[keyof T];
-
-type ExtractActionFailure<T> = T extends ActionFailure<infer X>
-	? X extends void
-		? never
-		: X
-	: never;
-
 /**
  * This object is passed to the `adapt` function of adapters.
  * It contains various methods and properties that are useful for adapting the app.


### PR DESCRIPTION
partially implements #7161

This PR adds stronger type definitions for `SubmitFunction` to the types genereted inside `$types.d.ts`. Unfortunately it is currently not possible to distinguish between `Success` and `Invalid` with the current `Kit` helper types. This could be implemented in a future version.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
