### PR TITLE
feat: use @clack/prompts

### DIFF
--- a/.changeset/mighty-cars-wave.md
+++ b/.changeset/mighty-cars-wave.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': major
+---
+
+feat: use `@clack/prompts`

--- a/.changeset/mighty-cars-wave.md
+++ b/.changeset/mighty-cars-wave.md
@@ -1,5 +1,5 @@
 ---
-'create-svelte': major
+'create-svelte': minor
 ---
 
 feat: use `@clack/prompts`

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -1,187 +1,167 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
-import { bold, cyan, gray, green, yellow } from 'kleur/colors';
-import prompts from 'prompts';
+import * as p from '@clack/prompts';
+import { bold, cyan, grey, yellow } from 'kleur/colors';
 import { create } from './index.js';
 import { dist } from './utils.js';
 
-// prettier-ignore
-const disclaimer = `
-${bold(cyan('Welcome to SvelteKit!'))}
-`;
-
 const { version } = JSON.parse(fs.readFileSync(new URL('package.json', import.meta.url), 'utf-8'));
+let cwd = process.argv[2] || '.';
 
-async function main() {
-	console.log(gray(`\ncreate-svelte version ${version}`));
-	console.log(disclaimer);
+console.log(`
+${grey(`create-svelte version ${version}`)}
+`);
 
-	let cwd = process.argv[2] || '.';
+p.intro('Welcome to SvelteKit!');
 
-	if (cwd === '.') {
-		const opts = await prompts([
-			{
-				type: 'text',
-				name: 'dir',
-				message: 'Where should we create your project?\n  (leave blank to use current directory)'
-			}
-		]);
+if (cwd === '.') {
+	const dir = await p.text({
+		message: 'Where should we create your project?',
+		placeholder: '  (hit Enter to use current directory)'
+	});
 
-		if (opts.dir) {
-			cwd = opts.dir;
-		}
+	if (p.isCancel(dir)) process.exit(1);
+
+	if (dir) {
+		cwd = /** @type {string} */ (dir);
 	}
-
-	if (fs.existsSync(cwd)) {
-		if (fs.readdirSync(cwd).length > 0) {
-			const response = await prompts({
-				type: 'confirm',
-				name: 'value',
-				message: 'Directory not empty. Continue?',
-				initial: false
-			});
-
-			if (!response.value) {
-				process.exit(1);
-			}
-		}
-	}
-
-	const options = /** @type {import('./types/internal').Options} */ (
-		await prompts(
-			[
-				{
-					type: 'select',
-					name: 'template',
-					message: 'Which Svelte app template?',
-					choices: fs.readdirSync(dist('templates')).map((dir) => {
-						const meta_file = dist(`templates/${dir}/meta.json`);
-						const { title, description } = JSON.parse(fs.readFileSync(meta_file, 'utf8'));
-
-						return {
-							title,
-							description,
-							value: dir
-						};
-					})
-				},
-				{
-					type: 'select',
-					name: 'types',
-					message: 'Add type checking with TypeScript?',
-					initial: false,
-					choices: [
-						{
-							title: 'Yes, using JavaScript with JSDoc comments',
-							value: 'checkjs'
-						},
-						{
-							title: 'Yes, using TypeScript syntax',
-							value: 'typescript'
-						},
-						{ title: 'No', value: null }
-					]
-				},
-				{
-					type: 'toggle',
-					name: 'eslint',
-					message: 'Add ESLint for code linting?',
-					initial: false,
-					active: 'Yes',
-					inactive: 'No'
-				},
-				{
-					type: 'toggle',
-					name: 'prettier',
-					message: 'Add Prettier for code formatting?',
-					initial: false,
-					active: 'Yes',
-					inactive: 'No'
-				},
-				{
-					type: 'toggle',
-					name: 'playwright',
-					message: 'Add Playwright for browser testing?',
-					initial: false,
-					active: 'Yes',
-					inactive: 'No'
-				},
-				{
-					type: 'toggle',
-					name: 'vitest',
-					message: 'Add Vitest for unit testing?',
-					initial: false,
-					active: 'Yes',
-					inactive: 'No'
-				}
-			],
-			{
-				onCancel: () => {
-					process.exit(1);
-				}
-			}
-		)
-	);
-
-	options.name = path.basename(path.resolve(cwd));
-
-	await create(cwd, options);
-
-	console.log(bold(green('\nYour project is ready!')));
-
-	if (options.types === 'typescript') {
-		console.log(bold('✔ Typescript'));
-		console.log('  Inside Svelte components, use <script lang="ts">');
-	} else if (options.types === 'checkjs') {
-		console.log(bold('✔ Type-checked JavaScript'));
-		console.log('  https://www.typescriptlang.org/tsconfig#checkJs');
-	} else if (options.template === 'skeletonlib') {
-		const warning = yellow('▲');
-		console.log(
-			`${warning} You chose to not add type checking, but TypeScript will still be installed in order to generate type definitions when building the library`
-		);
-	}
-
-	if (options.eslint) {
-		console.log(bold('✔ ESLint'));
-		console.log(cyan('  https://github.com/sveltejs/eslint-plugin-svelte3'));
-	}
-
-	if (options.prettier) {
-		console.log(bold('✔ Prettier'));
-		console.log(cyan('  https://prettier.io/docs/en/options.html'));
-		console.log(cyan('  https://github.com/sveltejs/prettier-plugin-svelte#options'));
-	}
-
-	if (options.playwright) {
-		console.log(bold('✔ Playwright'));
-		console.log(cyan('  https://playwright.dev'));
-	}
-
-	if (options.vitest) {
-		console.log(bold('✔ Vitest'));
-		console.log(cyan('  https://vitest.dev'));
-	}
-
-	console.log('\nInstall community-maintained integrations:');
-	console.log(cyan('  https://github.com/svelte-add/svelte-add'));
-
-	console.log('\nNext steps:');
-	let i = 1;
-
-	const relative = path.relative(process.cwd(), cwd);
-	if (relative !== '') {
-		console.log(`  ${i++}: ${bold(cyan(`cd ${relative}`))}`);
-	}
-
-	console.log(`  ${i++}: ${bold(cyan('npm install'))} (or pnpm install, etc)`);
-	// prettier-ignore
-	console.log(`  ${i++}: ${bold(cyan('git init && git add -A && git commit -m "Initial commit"'))} (optional)`);
-	console.log(`  ${i++}: ${bold(cyan('npm run dev -- --open'))}`);
-
-	console.log(`\nTo close the dev server, hit ${bold(cyan('Ctrl-C'))}`);
-	console.log(`\nStuck? Visit us at ${cyan('https://svelte.dev/chat')}`);
 }
 
-main();
+if (fs.existsSync(cwd)) {
+	if (fs.readdirSync(cwd).length > 0) {
+		const force = await p.confirm({
+			message: 'Directory not empty. Continue?',
+			initialValue: false
+		});
+
+		if (force !== true) {
+			process.exit(1);
+		}
+	}
+}
+
+const options = await p.group(
+	{
+		template: () =>
+			p.select({
+				message: 'Which Svelte app template?',
+				options: fs.readdirSync(dist('templates')).map((dir) => {
+					const meta_file = dist(`templates/${dir}/meta.json`);
+					const { title, description } = JSON.parse(fs.readFileSync(meta_file, 'utf8'));
+
+					return {
+						label: title,
+						hint: description,
+						value: dir
+					};
+				})
+			}),
+
+		types: () =>
+			p.select({
+				message: 'Add type checking with TypeScript?',
+				options: [
+					{
+						label: 'Yes, using JavaScript with JSDoc comments',
+						value: 'checkjs'
+					},
+					{
+						label: 'Yes, using TypeScript syntax',
+						value: 'typescript'
+					},
+					{ label: 'No', value: null }
+				]
+			}),
+
+		features: () =>
+			p.multiselect({
+				message: 'Select additional options',
+				required: false,
+				options: [
+					{
+						value: 'eslint',
+						label: 'Add ESLint for code linting'
+					},
+					{
+						value: 'prettier',
+						label: 'Add Prettier for code formatting'
+					},
+					{
+						value: 'playwright',
+						label: 'Add Playwright for browser testing'
+					},
+					{
+						value: 'vitest',
+						label: 'Add Vitest for unit testing'
+					}
+				]
+			})
+	},
+	{ onCancel: () => process.exit(1) }
+);
+
+await create(cwd, {
+	name: path.basename(path.resolve(cwd)),
+	template: /** @type {'default' | 'skeleton' | 'skeletonlib'} */ (options.template),
+	types: options.types,
+	prettier: options.features.includes('prettier'),
+	eslint: options.features.includes('eslint'),
+	playwright: options.features.includes('playwright'),
+	vitest: options.features.includes('vitest')
+});
+
+p.outro(`Your project is ready!`);
+
+if (options.types === 'typescript') {
+	console.log(bold('✔ Typescript'));
+	console.log('  Inside Svelte components, use <script lang="ts">\n');
+} else if (options.types === 'checkjs') {
+	console.log(bold('✔ Type-checked JavaScript'));
+	console.log(cyan('  https://www.typescriptlang.org/tsconfig#checkJs\n'));
+} else if (options.template === 'skeletonlib') {
+	const warning = yellow('▲');
+	console.log(
+		`${warning} You chose to not add type checking, but TypeScript will still be installed in order to generate type definitions when building the library\n`
+	);
+}
+
+if (options.features.includes('eslint')) {
+	console.log(bold('✔ ESLint'));
+	console.log(cyan('  https://github.com/sveltejs/eslint-plugin-svelte3\n'));
+}
+
+if (options.features.includes('prettier')) {
+	console.log(bold('✔ Prettier'));
+	console.log(cyan('  https://prettier.io/docs/en/options.html'));
+	console.log(cyan('  https://github.com/sveltejs/prettier-plugin-svelte#options\n'));
+}
+
+if (options.features.includes('playwright')) {
+	console.log(bold('✔ Playwright'));
+	console.log(cyan('  https://playwright.dev\n'));
+}
+
+if (options.features.includes('vitest')) {
+	console.log(bold('✔ Vitest'));
+	console.log(cyan('  https://vitest.dev\n'));
+}
+
+console.log('Install community-maintained integrations:');
+console.log(cyan('  https://github.com/svelte-add/svelte-add'));
+
+console.log('\nNext steps:');
+let i = 1;
+
+const relative = path.relative(process.cwd(), cwd);
+if (relative !== '') {
+	console.log(`  ${i++}: ${bold(cyan(`cd ${relative}`))}`);
+}
+
+console.log(`  ${i++}: ${bold(cyan('npm install'))} (or pnpm install, etc)`);
+// prettier-ignore
+console.log(`  ${i++}: ${bold(cyan('git init && git add -A && git commit -m "Initial commit"'))} (optional)`);
+console.log(`  ${i++}: ${bold(cyan('npm run dev -- --open'))}`);
+
+console.log(`\nTo close the dev server, hit ${bold(cyan('Ctrl-C'))}`);
+console.log(`\nStuck? Visit us at ${cyan('https://svelte.dev/chat')}`);

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -35,6 +35,7 @@ if (fs.existsSync(cwd)) {
 			initialValue: false
 		});
 
+		// bail if `force` is `false` or the user cancelled with Ctrl-C
 		if (force !== true) {
 			process.exit(1);
 		}

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -11,8 +11,8 @@
 	"bin": "./bin.js",
 	"main": "./index.js",
 	"dependencies": {
-		"kleur": "^4.1.5",
-		"prompts": "^2.4.2"
+		"@clack/prompts": "^0.6.0",
+		"kleur": "^4.1.5"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.28.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,7 @@ importers:
 
   packages/create-svelte:
     specifiers:
+      '@clack/prompts': ^0.6.0
       '@playwright/test': ^1.28.1
       '@types/gitignore-parser': ^0.0.0
       '@types/prettier': ^2.7.1
@@ -215,14 +216,13 @@ importers:
       kleur: ^4.1.5
       prettier: ^2.8.0
       prettier-plugin-svelte: ^2.8.1
-      prompts: ^2.4.2
       sucrase: ^3.29.0
       svelte: ^3.55.1
       tiny-glob: ^0.2.9
       uvu: ^0.5.6
     dependencies:
+      '@clack/prompts': 0.6.0
       kleur: 4.1.5
-      prompts: 2.4.2
     devDependencies:
       '@playwright/test': 1.29.2
       '@types/gitignore-parser': 0.0.0
@@ -972,6 +972,23 @@ packages:
       human-id: 1.0.2
       prettier: 2.8.0
     dev: true
+
+  /@clack/core/0.3.0:
+    resolution: {integrity: sha512-ujw1888RciTArxUvwLOf24XSygRX7F4qiCPI7WLH3zCTZJuqKPMcTS7Wqjz0x/AuMpwGPlzhKln4+sCuQqYxzA==}
+    dependencies:
+      picocolors: 1.0.0
+      sisteransi: 1.0.5
+    dev: false
+
+  /@clack/prompts/0.6.0:
+    resolution: {integrity: sha512-lNg3MFPLA2rrMAZ6R2QFg+jGo2Pt3ACJERDbPgxjPU9QJwVFB3D2v3x7SzzVoS6schggcMN0tDJ4zSdcI+kqJg==}
+    dependencies:
+      '@clack/core': 0.3.0
+      picocolors: 1.0.0
+      sisteransi: 1.0.5
+    dev: false
+    bundledDependencies:
+      - is-unicode-supported
 
   /@cloudflare/kv-asset-handler/0.3.0:
     resolution: {integrity: sha512-9CB/MKf/wdvbfkUdfrj+OkEwZ5b7rws0eogJ4293h+7b6KX5toPwym+VQKmILafNB9YiehqY0DlNrDcDhdWHSQ==}


### PR DESCRIPTION
Thought I'd have a go at using [`@clack/prompts`](https://twitter.com/n_moore/status/1624951793829519362) to make the `create-svelte` experience slightly more polished.

Before:

<img width="909" alt="image" src="https://user-images.githubusercontent.com/1162160/221389854-5de4d379-23c2-4e57-afc1-312ebe9da2c6.png">

After:

<img width="816" alt="image" src="https://user-images.githubusercontent.com/1162160/221389829-e9abc419-b1f3-4d3a-a4ab-1b3510f55870.png">