### PR TITLE
docs: state management part 2

### DIFF
--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -6,9 +6,9 @@ If you're used to building client-only apps, state management in an app that spa
 
 ## Avoid shared state on the server
 
-While browsers are _stateful_ (state is stored in memory as the user interacts with the application), servers are _stateless_ (the content of the response is determined entirely by the content of the request) — conceptually, at least.
+Browsers are _stateful_ — state is stored in memory as the user interacts with the application. Servers, on the other hand, are _stateless_ — the content of the response is determined entirely by the content of the request.
 
-In reality, servers are often long-lived and shared by multiple users. For that reason it's important not to store data in shared variables. For example, consider this code:
+Conceptually, that is. In reality, servers are often long-lived and shared by multiple users. For that reason it's important not to store data in shared variables. For example, consider this code:
 
 ```js
 // @errors: 7034 7005

--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -82,7 +82,7 @@ export async function load({ fetch }) {
 You might wonder how we're able to use `$page.data` and other [app stores](/docs/modules#$app-stores) if we can't use our own stores. The answer is that app stores on the server use Svelte's [context API](https://learn.svelte.dev/tutorial/context-api) — the store is attached to the component tree with `setContext`, and when you subscribe you retrieve it with `getContext`. We can do the same thing with our own stores:
 
 ```svelte
-/// file: +layout.svelte
+/// file: src/routes/+layout.svelte
 <script>
 	import { setContext } from 'svelte';
 	import { writable } from 'svelte/store';
@@ -100,7 +100,7 @@ You might wonder how we're able to use `$page.data` and other [app stores](/docs
 ```
 
 ```svelte
-/// file: +src/user/+page.svelte
+/// file: src/routes/user/+page.svelte
 <script>
 	import { getContext } from 'svelte';
 

--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -113,6 +113,8 @@ You might wonder how we're able to use `$page.data` and other [app stores](/docs
 <p>Welcome {$user.name}</p>
 ```
 
+If you're not using SSR (and can guarantee that you won't need to use SSR in future) then you can safely keep state in a shared module, without using the context API.
+
 ## Component state is preserved
 
 When you navigate around your application, SvelteKit reuses existing layout and page components. For example, if you have a route like this...

--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -77,6 +77,8 @@ export async function load({ fetch }) {
 
 ...and pass it around to the components that need it, or use [`$page.data`](/docs/load#$page-data).
 
+If you're not using SSR, then there's no risk of accidentally exposing one user's data to another. But you should still avoid side-effects in your `load` functions — your application will be much easier to reason about without them.
+
 ## Using stores with context
 
 You might wonder how we're able to use `$page.data` and other [app stores](/docs/modules#$app-stores) if we can't use our own stores. The answer is that app stores on the server use Svelte's [context API](https://learn.svelte.dev/tutorial/context-api) — the store is attached to the component tree with `setContext`, and when you subscribe you retrieve it with `getContext`. We can do the same thing with our own stores:

--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -163,7 +163,7 @@ Reusing components like this means that things like sidebar scroll state are pre
 
 ## Storing state in the URL
 
-If you have state that should survive a reload and/or affect SSR, such as filters or sorting rules on a table, URL search parameters (like `?sort=price&order=ascending`) are a good place to put them. These can be accessed inside `load` functions via the `url` parameter, and inside components via `$page.url.searchParams`.
+If you have state that should survive a reload and/or affect SSR, such as filters or sorting rules on a table, URL search parameters (like `?sort=price&order=ascending`) are a good place to put them. You can put them in `<a href="...">` or `<form action="...">` attributes, or set them programmatically via `goto('?key=value')`. They can be accessed inside `load` functions via the `url` parameter, and inside components via `$page.url.searchParams`.
 
 ## Storing ephemeral state in snapshots
 

--- a/packages/kit/src/runtime/app/stores.js
+++ b/packages/kit/src/runtime/app/stores.js
@@ -67,7 +67,7 @@ function get_store(name) {
 	} catch (e) {
 		throw new Error(
 			`Cannot subscribe to '${name}' store on the server outside of a Svelte component, as it is bound to the current request via component context. This prevents state from leaking between users.` +
-				'For more information, see https://kit.svelte.dev/docs/state-management#avoid-global-state-in-ssr'
+				'For more information, see https://kit.svelte.dev/docs/state-management#avoid-shared-state-on-the-server'
 		);
 	}
 }


### PR DESCRIPTION
builds on #8547:

* focuses on how to prevent shared state on the server rather than saying 'you don't need to worry about this if you build an SPA', because that will unduly encourage people to build SPAs
* separate section for stores+context
* explanation of component state preservation
* mention snapshots
* remove form stuff