### PR TITLE
fix: always add `@sveltejs/kit` to `noExternal` for ssr build

### DIFF
--- a/.changeset/gold-fireants-talk.md
+++ b/.changeset/gold-fireants-talk.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: always add `@sveltejs/kit` to `noExternal` for ssr build

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -218,21 +218,6 @@ function kit({ svelte_config }) {
 
 			const generated = path.posix.join(kit.outDir, 'generated');
 
-			// This ensures that esm-env is inlined into the server output with the
-			// export conditions resolved correctly through Vite. This prevents adapters
-			// that bundle later on from resolving the export conditions incorrectly
-			// and for example include browser-only code in the server output
-			// because they for example use esbuild.build with `platform: 'browser'`
-			const noExternal = ['esm-env'];
-
-			// Vitest bypasses Vite when loading external modules, so we bundle
-			// when it is detected to keep our virtual modules working.
-			// See https://github.com/sveltejs/kit/pull/9172
-			// and https://vitest.dev/config/#deps-registernodeloader
-			if (process.env.TEST) {
-				noExternal.push('@sveltejs/kit');
-			}
-
 			// dev and preview config can be shared
 			/** @type {import('vite').UserConfig} */
 			const new_config = {
@@ -269,7 +254,23 @@ function kit({ svelte_config }) {
 					]
 				},
 				ssr: {
-					noExternal
+					noExternal: [
+						// This ensures that esm-env is inlined into the server output with the
+						// export conditions resolved correctly through Vite. This prevents adapters
+						// that bundle later on from resolving the export conditions incorrectly
+						// and for example include browser-only code in the server output
+						// because they for example use esbuild.build with `platform: 'browser'`
+						'esm-env',
+						// We need this for two reasons:
+						// 1. Without this, `@sveltejs/kit` imports are kept as-is in the server output,
+						//    and that causes modules and therefore classes like `Redirect` to be imported twice
+						//    under different IDs, which breaks a bunch of stuff because of failing instanceof checks.
+						// 2. Vitest bypasses Vite when loading external modules, so we bundle
+						//    when it is detected to keep our virtual modules working.
+						//    See https://github.com/sveltejs/kit/pull/9172
+						//    and https://vitest.dev/config/#deps-registernodeloader
+						'@sveltejs/kit'
+					]
 				}
 			};
 


### PR DESCRIPTION
fixes #9234

FYI @benmccann @Rich-Harris we _always_ need `@sveltejs/kit` to be part of `noExternal`. Else the build output contains something like 
```js
import { redirect } from '@sveltejs/kit';

// some compiled code..
  redirect(307, '..');
```
while the output code _also_ contains the SvelteKit server runtime, including their own definitions for `Redirect` etc classes, which means all instanceof checks fail.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
