### PR TITLE
fix: correct undefined reference to global var with Vitest

### DIFF
--- a/.changeset/chilled-rivers-learn.md
+++ b/.changeset/chilled-rivers-learn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correct undefined reference to global var with Vitest

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -334,7 +334,7 @@ function kit({ svelte_config }) {
 
 		async load(id, options) {
 			const browser = !options?.ssr;
-			const global = `__sveltekit_${version_hash}`;
+			const global = `globalThis.__sveltekit_${version_hash}`;
 
 			if (options?.ssr === false && process.env.TEST !== 'true') {
 				const normalized_cwd = vite.normalizePath(cwd);


### PR DESCRIPTION
Closes https://github.com/sveltejs/kit/issues/9162

We should really add tests for this...