### PR TITLE
respect `<base>` when crawling

### DIFF
--- a/.changeset/nasty-elephants-grab.md
+++ b/.changeset/nasty-elephants-grab.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: respect `<base>` when crawling

--- a/packages/kit/src/core/postbuild/crawl.js
+++ b/packages/kit/src/core/postbuild/crawl.js
@@ -1,3 +1,4 @@
+import { resolve } from '../../utils/url.js';
 import { decode } from './entities.js';
 
 const DOCTYPE = 'DOCTYPE';
@@ -12,8 +13,11 @@ const ATTRIBUTE_NAME = /[^\t\n\f />"'=]/;
 
 const WHITESPACE = /[\s\n\r]/;
 
-/** @param {string} html */
-export function crawl(html) {
+/**
+ * @param {string} html
+ * @param {string} base
+ */
+export function crawl(html, base) {
 	/** @type {string[]} */
 	const ids = [];
 
@@ -157,7 +161,11 @@ export function crawl(html) {
 							value = decode(value);
 
 							if (name === 'href') {
-								href = value;
+								if (tag === 'BASE') {
+									base = resolve(base, value);
+								} else {
+									href = resolve(base, value);
+								}
 							} else if (name === 'id') {
 								ids.push(value);
 							} else if (name === 'name') {
@@ -165,7 +173,7 @@ export function crawl(html) {
 							} else if (name === 'rel') {
 								rel = value;
 							} else if (name === 'src') {
-								if (value) hrefs.push(value);
+								if (value) hrefs.push(resolve(base, value));
 							} else if (name === 'srcset') {
 								const candidates = [];
 								let insideURL = true;
@@ -183,7 +191,7 @@ export function crawl(html) {
 								candidates.push(value);
 								for (const candidate of candidates) {
 									const src = candidate.split(WHITESPACE)[0];
-									if (src) hrefs.push(src);
+									if (src) hrefs.push(resolve(base, src));
 								}
 							}
 						} else {
@@ -195,7 +203,7 @@ export function crawl(html) {
 				}
 
 				if (href && !/\bexternal\b/i.test(rel)) {
-					hrefs.push(href);
+					hrefs.push(resolve(base, href));
 				}
 			}
 		}

--- a/packages/kit/src/core/postbuild/crawl.spec.js
+++ b/packages/kit/src/core/postbuild/crawl.spec.js
@@ -13,7 +13,7 @@ for (const fixture of fs.readdirSync(fixtures)) {
 
 		// const start = Date.now();
 
-		const output = crawl(input);
+		const output = crawl(input, '/');
 
 		// uncomment to see how long it took
 		// console.error(fixture, Date.now() - start);

--- a/packages/kit/src/core/postbuild/fixtures/base/input.html
+++ b/packages/kit/src/core/postbuild/fixtures/base/input.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<base href="/base-path/" />
+		<link rel="stylesheet" href="styles.css" />
+		<link rel="icon" href="favicon.png" />
+	</head>
+	<body>
+		<a href="https://external.com">https://external.com</a>
+		<a href="wheee">/wheee</a>
+		<a data-sveltekit-prefetch href="wheee2">/wheee</a>
+		<a href="wheee3" data-sveltekit-prefetch>/wheee</a>
+		<a href="wheee4">/wheee</a>
+	</body>
+</html>

--- a/packages/kit/src/core/postbuild/fixtures/base/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/base/output.json
@@ -1,0 +1,12 @@
+{
+	"hrefs": [
+		"/base-path/styles.css",
+		"/base-path/favicon.png",
+		"https://external.com",
+		"/base-path/wheee",
+		"/base-path/wheee2",
+		"/base-path/wheee3",
+		"/base-path/wheee4"
+	],
+	"ids": []
+}

--- a/packages/kit/src/core/postbuild/fixtures/basic-srcset/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/basic-srcset/output.json
@@ -1,11 +1,11 @@
 {
 	"hrefs": [
-		"header.png",
+		"/header.png",
 		"https://example.com/w_200,q_100/header.png",
-		"header640.png",
-		"header960.png",
-		"header1024.png",
-		"header.png"
+		"/header640.png",
+		"/header960.png",
+		"/header1024.png",
+		"/header.png"
 	],
 	"ids": []
 }

--- a/packages/kit/src/core/postbuild/fixtures/ids/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/ids/output.json
@@ -1,4 +1,4 @@
 {
-	"hrefs": ["#encöded"],
+	"hrefs": ["/#encöded"],
 	"ids": ["before", "after", "encöded"]
 }

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -240,17 +240,14 @@ async function prerender({ out, manifest_path, metadata, verbose, env }) {
 		const headers = Object.fromEntries(response.headers);
 
 		if (config.prerender.crawl && headers['content-type'] === 'text/html') {
-			const { ids, hrefs } = crawl(body.toString());
+			const { ids, hrefs } = crawl(body.toString(), decoded);
 
 			actual_hashlinks.set(decoded, ids);
 
 			for (const href of hrefs) {
-				if (href.startsWith('data:')) continue;
+				if (!is_root_relative(href)) continue;
 
-				const resolved = resolve(encoded, href);
-				if (!is_root_relative(resolved)) continue;
-
-				const { pathname, search, hash } = new URL(resolved, 'http://localhost');
+				const { pathname, search, hash } = new URL(href, 'http://localhost');
 
 				if (search) {
 					// TODO warn that query strings have no effect on statically-exported pages

--- a/packages/kit/src/utils/url.spec.js
+++ b/packages/kit/src/utils/url.spec.js
@@ -54,6 +54,10 @@ describe('resolve', (test) => {
 	test('resolves a fragment link', () => {
 		assert.equal(resolve('/a/b/c', '#foo'), '/a/b/c#foo');
 	});
+
+	test('resolves data: urls', () => {
+		assert.equal(resolve('/a/b/c', 'data:text/plain,hello'), 'data:text/plain,hello');
+	});
 });
 
 describe('normalize_path', (test) => {

--- a/packages/kit/test/prerendering/paths-base/src/app.html
+++ b/packages/kit/test/prerendering/paths-base/src/app.html
@@ -3,7 +3,8 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<base href="/path-base/" />
+		<link rel="icon" href="favicon.png" />
 		%sveltekit.head%
 	</head>
 	<body>

--- a/packages/kit/test/prerendering/paths-base/src/routes/+page.svelte
+++ b/packages/kit/test/prerendering/paths-base/src/routes/+page.svelte
@@ -1,8 +1,4 @@
-<script>
-	import { base } from '$app/paths'
-</script>
-
 <div>
 	<h1>Main Page</h1>
-	<a href="{base}/nested">Nested Link</a>
+	<a href="nested">Nested Link</a>
 </div>

--- a/packages/kit/test/prerendering/paths-base/src/routes/a/b/c/+page.svelte
+++ b/packages/kit/test/prerendering/paths-base/src/routes/a/b/c/+page.svelte
@@ -1,0 +1,1 @@
+<a href="a/b/d">a/b/d</a>

--- a/packages/kit/test/prerendering/paths-base/src/routes/a/b/d/+page.svelte
+++ b/packages/kit/test/prerendering/paths-base/src/routes/a/b/d/+page.svelte
@@ -1,0 +1,1 @@
+<a href="a/b/c">a/b/c</a>

--- a/packages/kit/test/prerendering/paths-base/svelte.config.js
+++ b/packages/kit/test/prerendering/paths-base/svelte.config.js
@@ -6,7 +6,8 @@ const config = {
 		adapter: adapter(),
 
 		paths: {
-			base: '/path-base'
+			base: '/path-base',
+			relative: false
 		}
 	}
 };

--- a/packages/kit/test/prerendering/paths-base/test/test.js
+++ b/packages/kit/test/prerendering/paths-base/test/test.js
@@ -10,7 +10,7 @@ const read = (file) => fs.readFileSync(`${build}/${file}`, 'utf-8');
 
 test('prerenders /path-base', () => {
 	const content = read('index.html');
-	assert.ok(content.includes('/path-base/favicon.png') && content.includes('/path-base/nested'));
+	assert.ok(content.includes('favicon.png') && content.includes('nested'));
 });
 
 test('prerenders /path-base/redirect', () => {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -452,6 +452,8 @@ export interface KitConfig {
 		 *
 		 * If `true`, `base` and `assets` imported from `$app/paths` will be replaced with relative asset paths during server-side rendering, resulting in portable HTML.
 		 * If `false`, `%sveltekit.assets%` and references to build artifacts will always be root-relative paths, unless `paths.assets` is an external URL
+		 *
+		 * If your app uses a `<base>` element, you should set this to `false`, otherwise asset URLs will incorrectly be resolved against the `<base>` URL rather than the current page.
 		 * @default undefined
 		 */
 		relative?: boolean | undefined;


### PR DESCRIPTION
closes #8559. Note that in order to use `<base>` successfully, you must use `config.kit.paths.relative: false`, otherwise SvelteKit will attempt to load JavaScript modules relative to the base rather than to the current page.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
