### PR TITLE
fix: successive optional route parameters can now be empty

### DIFF
--- a/.changeset/nasty-guests-sing.md
+++ b/.changeset/nasty-guests-sing.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: Chained optional parameters can now be excluded

--- a/.changeset/nasty-guests-sing.md
+++ b/.changeset/nasty-guests-sing.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: Chained optional parameters can now be excluded
+fix: successive optional route parameters can now be empty

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -152,6 +152,14 @@ export function exec(match, params, matchers) {
 
 		if (!param.matcher || matchers[param.matcher](value)) {
 			result[param.name] = value;
+
+			// Now that the params match, reset the buffer if the next param isn't the [...rest]
+			// and the next value is defined, otherwise the buffer will cause us to skip values
+			const next_param = params[i + 1];
+			const next_value = values[i + 1];
+			if (next_param && !next_param.rest && next_value) {
+				buffered = 0;
+			}
 			continue;
 		}
 

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -187,6 +187,16 @@ const exec_tests = [
 		route: '/[[a=doesntmatch]]/[[b=matches]]/c',
 		path: '/a/b/c',
 		expected: undefined
+	},
+	{
+		route: '/[[slug1=matches]]/[[slug2=matches]]/constant/[[slug3=matches]]',
+		path: '/a/b/constant/c',
+		expected: { slug1: 'a', slug2: 'b', slug3: 'c' }
+	},
+	{
+		route: '/[[slug1=doesntmatch]]/[[slug2=matches]]/constant/[[slug3=matches]]',
+		path: '/b/constant/c',
+		expected: { slug2: 'b', slug3: 'c' }
 	}
 ];
 


### PR DESCRIPTION
Closes https://github.com/sveltejs/kit/issues/9261

In the scenario outlined in the linked issue, with 2 chained optional parameters, skipping the first optional parameter would result in a 404.
When the first optional parameter was detected as being missing, a buffer variable was incremented to allow the 2nd parameter to be correctly assigned. However this buffer was never reset (except in the case of a [...rest] parameter being present). This was triggering the `if(buffered) return;`  check, resulting in a 404.

This change resets the buffer back to 0 in the appropriate circumstance.
The check verifies that the next parameter is not a [...rest] parameter. If it is, we don't reset the buffer in order to trigger the coalescing of remaining values into [...rest].
If it's _not_ a rest parameter, and the next value is defined, then we should reset the buffer to prevent any data loss. This scenario is tested in the following existing test:

```
{
	route: '/[[slug1=doesntmatch]]/[[slug2=matches]]/[[slug3=doesntmatch]]/[...rest].json',
	path: '/foo/bar/baz.json',
	expected: { slug2: 'foo', rest: 'bar/baz' }
},
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
