### PR TITLE
use `node` export condition when bundling

### DIFF
--- a/.changeset/tough-seals-attend.md
+++ b/.changeset/tough-seals-attend.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+fix: use `node` export condition when bundling

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -57,7 +57,14 @@ export default function (opts = {}) {
 					// dependencies could have deep exports, so we need a regex
 					...Object.keys(pkg.dependencies || {}).map((d) => new RegExp(`^${d}(\\/.*)?$`))
 				],
-				plugins: [nodeResolve({ preferBuiltins: true }), commonjs({ strictRequires: true }), json()]
+				plugins: [
+					nodeResolve({
+						preferBuiltins: true,
+						exportConditions: ['node']
+					}),
+					commonjs({ strictRequires: true }),
+					json()
+				]
 			});
 
 			await bundle.write({


### PR DESCRIPTION
closes #9264. The issue was that the dependency in question, `vidstack`, has a bunch of different exports for different conditions; the `node` condition points at a module that is capable of running on the server.

When running in `dev` and `preview`, the module was loaded through Node, and so naturally the `node` condition was used. But `adapter-node` bundles the dependency using the `default` condition, which points at a production browser build.

This PR fixes it by using the `node` export condition for resolution when bundling dependencies.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
