### PR TITLE
chore: restore bug reporting section of readme

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
     id: bug-description
     attributes:
       label: Describe the bug
-      description: Please check if bugs related to building are caused by Vite and [file there](https://github.com/vitejs/vite/issues) if appropriate. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      description: Please [check if bugs related to building are caused by Vite](https://github.com/sveltejs/kit#bug-reporting) and [file there](https://github.com/vitejs/vite/issues) if appropriate. If you intend to submit a PR for this issue, tell us in the description. Thanks!
       placeholder: Bug description
     validations:
       required: true

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Web development, streamlined. Read the [documentation](https://kit.svelte.dev/do
 
 ## Bug reporting
 
-Please make sure the issue you're reporting involves SvelteKit. Many issues related to how a project builds originate from [Vite](https://vitejs.dev/), which is used to build a SvelteKit project. It's important to note that new Vite projects don't use SSR by default, and so if you create a new Vite project from scratch, many issues won't reproduce. You should thus start with a project that utilizes SSR, such as `npm create vite-extra@latest -- --template ssr-svelte`.
+Please make sure the issue you're reporting involves SvelteKit. Many issues related to how a project builds originate from [Vite](https://vitejs.dev/), which is used to build a SvelteKit project. You can create a new Vite project with `npm create vite@latest` for client-side only repros and `npm create vite-extra@latest` for SSR or library repros.
 
 If an issue originates from Vite, please report it in the [Vite issue tracker](https://github.com/vitejs/vite/issues).
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Web development, streamlined. Read the [documentation](https://kit.svelte.dev/do
 
 [Additional adapters](<(https://sveltesociety.dev/components#adapters)>) are maintained by the community.
 
+## Bug reporting
+
+Please make sure the issue you're reporting involves SvelteKit. Many issues related to how a project builds originate from [Vite](https://vitejs.dev/), which is used to build a SvelteKit project. It's important to note that new Vite projects don't use SSR by default, and so if you create a new Vite project from scratch, many issues won't reproduce. You should thus start with a project that utilizes SSR, such as `npm create vite-extra@latest -- --template ssr-svelte`.
+
+If an issue originates from Vite, please report it in the [Vite issue tracker](https://github.com/vitejs/vite/issues).
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for information on how to develop SvelteKit locally.


### PR DESCRIPTION
This is basically the only place `ssr-svelte` is documented and bugs won't reproduce if you use the standard template, which means even for advanced users there's no way to understand how to report a bug other than this documentation.

it was accidentally removed in https://github.com/sveltejs/kit/pull/8109

reverts https://github.com/sveltejs/kit/pull/9094