### PR TITLE
fix(create-svelte): add hint when scaffolding

### DIFF
--- a/.changeset/heavy-spiders-invite.md
+++ b/.changeset/heavy-spiders-invite.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+chore: Add hint for toggling additional options during scaffolding flow.

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -77,7 +77,7 @@ const options = await p.group(
 
 		features: () =>
 			p.multiselect({
-				message: 'Select additional options (use arrow keys to navigate and SPACE to toggle options)',
+				message: 'Select additional options (use arrow keys/space bar)',
 				required: false,
 				options: [
 					{

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -77,7 +77,7 @@ const options = await p.group(
 
 		features: () =>
 			p.multiselect({
-				message: 'Select additional options',
+				message: 'Select additional options (use arrow keys to navigate and SPACE to toggle options)',
 				required: false,
 				options: [
 					{


### PR DESCRIPTION
Relates to #9317 

A number of folks on Discord have been asking how to toggle options in the new 'Select additional options' step when running `npm create svelte@latest`. This change aims to provide a hint for this lesser-known prompt experience. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
