### PR TITLE
Avoid FOUC when using CSS modules in dev

### DIFF
--- a/.changeset/lemon-beers-yawn.md
+++ b/.changeset/lemon-beers-yawn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: avoid FOUC when using CSS modules in dev

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -175,15 +175,20 @@ export async function dev(vite, vite_config, svelte_config) {
 							const styles = {};
 
 							for (const dep of deps) {
-								const parsed = new URL(dep.url, 'http://localhost/');
-								const query = parsed.searchParams;
+								const url = new URL(dep.url, 'http://localhost/');
+								const query = url.searchParams;
 
 								if (
 									isCSSRequest(dep.file) ||
 									(query.has('svelte') && query.get('type') === 'style')
 								) {
+									// setting `?inline` to load CSS modules as css string
+									query.set('inline', '');
+
 									try {
-										const mod = await loud_ssr_load_module(dep.url);
+										const mod = await loud_ssr_load_module(
+											`${url.pathname}${url.search}${url.hash}`
+										);
 										styles[dep.url] = mod.default;
 									} catch {
 										// this can happen with dynamically imported modules, I think


### PR DESCRIPTION
Fixes #5019

Importing CSS modules causes flash of unstyled content, as an object is returned from Vite causing it to be injected as `[object Object]` inside the style tag.
Importing with `?inline`, allows Vite to returns the CSS  as string which can be used inside the style tag.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
