### PR TITLE
Added BODY_SIZE_LIMIT to the env variables recognized by the node adapter

### DIFF
--- a/packages/adapter-node/src/env.js
+++ b/packages/adapter-node/src/env.js
@@ -8,7 +8,8 @@ const expected = new Set([
 	'XFF_DEPTH',
 	'ADDRESS_HEADER',
 	'PROTOCOL_HEADER',
-	'HOST_HEADER'
+	'HOST_HEADER',
+	'BODY_SIZE_LIMIT'
 ]);
 
 if (ENV_PREFIX) {


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.



When you prefix the node adapters env variables, it checks whether the used variable with the prefix is actually an env variable used by the adapter. The BODY_SIZE_LIMIT variable is at this point not included in this list.