### PR TITLE
fix: required parameters placed after missing optional parameters are no longer skipped

### DIFF
--- a/.changeset/loud-ghosts-worry.md
+++ b/.changeset/loud-ghosts-worry.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': fix
 ---
 
-fix: required parameters placed after missing optional parameters are no longer skipped
+fix: don't skip required parameters after missing optional parameters

--- a/.changeset/loud-ghosts-worry.md
+++ b/.changeset/loud-ghosts-worry.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': fix
+---
+
+fix: required parameters placed after missing optional parameters are no longer skipped

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -157,7 +157,7 @@ export function exec(match, params, matchers) {
 			// and the next value is defined, otherwise the buffer will cause us to skip values
 			const next_param = params[i + 1];
 			const next_value = values[i + 1];
-			if (next_param && !next_param.rest && next_value) {
+			if (next_param && !next_param.rest && next_param.optional && next_value) {
 				buffered = 0;
 			}
 			continue;

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -197,6 +197,11 @@ const exec_tests = [
 		route: '/[[slug1=doesntmatch]]/[[slug2=matches]]/constant/[[slug3=matches]]',
 		path: '/b/constant/c',
 		expected: { slug2: 'b', slug3: 'c' }
+	},
+	{
+		route: '/[[slug1=doesntmatch]]/[slug2=matches]/[slug3]',
+		path: '/a/b/c',
+		expected: undefined
 	}
 ];
 


### PR DESCRIPTION
Due to multiple matching routes, exec is called for [[param1=required]]/[param2=param2]/[param3] even though we’ve provided 3 parameters which should correlate to the /[param2=param2]/[param3]/[param4] route.

The code flow was finishing with a buffer size of 0, which was incorrectly telling Kit that the route was a match. As such it wasn't attempting to parse other routes to check for a match, despite the fact there was still a required parameter that hadn't been matched.

This situation doesn’t appear to be covered under current unit tests as the tests load one route at a time. I've added a new Playwright test to cover this scenario.

Fixes https://github.com/sveltejs/kit/issues/9304


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
