### PR TITLE
always add trailing slash to base path

### DIFF
--- a/.changeset/great-stingrays-flash.md
+++ b/.changeset/great-stingrays-flash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: use correct relative paths when rendering base path

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -95,13 +95,9 @@ export async function render_response({
 
 	// if appropriate, use relative paths for greater portability
 	if (paths.relative !== false && !state.prerendering?.fallback) {
-		const segments = event.url.pathname.slice(paths.base.length).split('/');
+		const segments = event.url.pathname.slice(paths.base.length).split('/').slice(2);
 
-		base =
-			segments
-				.slice(2)
-				.map(() => '..')
-				.join('/') || '.';
+		base = segments.map(() => '..').join('/') || '.';
 
 		// resolve e.g. '../..' against current location, then remove trailing slash
 		base_expression = `new URL(${s(base)}, location).pathname.slice(0, -1)`;

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -97,21 +97,14 @@ export async function render_response({
 	if (paths.relative !== false && !state.prerendering?.fallback) {
 		const segments = event.url.pathname.slice(paths.base.length).split('/');
 
-		if (segments.length === 1 && paths.base !== '') {
-			// if we're on `/my-base-path`, relative links need to start `./my-base-path` rather than `.`
-			base = `./${paths.base.split('/').at(-1)}`;
+		base =
+			segments
+				.slice(2)
+				.map(() => '..')
+				.join('/') || '.';
 
-			base_expression = `new URL(${s(base)}, location).pathname`;
-		} else {
-			base =
-				segments
-					.slice(2)
-					.map(() => '..')
-					.join('/') || '.';
-
-			// resolve e.g. '../..' against current location, then remove trailing slash
-			base_expression = `new URL(${s(base)}, location).pathname.slice(0, -1)`;
-		}
+		// resolve e.g. '../..' against current location, then remove trailing slash
+		base_expression = `new URL(${s(base)}, location).pathname.slice(0, -1)`;
 
 		if (!paths.assets || (paths.assets[0] === '/' && paths.assets !== SVELTE_KIT_ASSETS)) {
 			assets = base;

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -172,6 +172,8 @@ export async function respond(request, options, manifest, state) {
 	try {
 		// determine whether we need to redirect to add/remove a trailing slash
 		if (route && !is_data_request) {
+			// if `paths.base === '/a/b/c`, then the root route is `/a/b/c/`,
+			// regardless of the `trailingSlash` route option
 			if (url.pathname === base || url.pathname === base + '/') {
 				trailing_slash = 'always';
 			} else if (route.page) {

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -172,7 +172,9 @@ export async function respond(request, options, manifest, state) {
 	try {
 		// determine whether we need to redirect to add/remove a trailing slash
 		if (route && !is_data_request) {
-			if (route.page) {
+			if (url.pathname === base || url.pathname === base + '/') {
+				trailing_slash = 'always';
+			} else if (route.page) {
 				const nodes = await Promise.all([
 					// we use == here rather than === because [undefined] serializes as "[null]"
 					...route.page.layouts.map((n) => (n == undefined ? n : manifest._.nodes[n]())),

--- a/packages/kit/test/apps/options-2/test/test.js
+++ b/packages/kit/test/apps/options-2/test/test.js
@@ -27,7 +27,7 @@ test.describe('paths', () => {
 	test('uses relative paths during SSR', async ({ page, javaScriptEnabled }) => {
 		await page.goto('/basepath');
 
-		let base = javaScriptEnabled ? '/basepath' : './basepath';
+		let base = javaScriptEnabled ? '/basepath' : '.';
 		expect(await page.textContent('[data-testid="base"]')).toBe(`base: ${base}`);
 		expect(await page.textContent('[data-testid="assets"]')).toBe(`assets: ${base}`);
 


### PR DESCRIPTION
fixes #9341.

In #9220, we changed the logic for resolving asset paths to accommodate the `relative: true` option, and included [special handling](https://github.com/sveltejs/kit/pull/9220/files#r1120243235) for the case where you're rendering the root page when `base` is set — if the base path is `/a/b/c` and you render `/a/b/c`, then the relative path (somewhat counter-intuitively) needs to be `./c` for links to work.

Turns out that was a mistake, because the root should always end with a trailing slash — if you prerender that page, it will be output as `<output>/index.html`, and relative paths will thus be incorrectly converted to `<output>/c/...`.

The fix is to remove the special case handling, and ensure that `/a/b/c` always redirects to `/a/b/c/`. This is much simpler and more correct. It arguably falls into the semver gray zone where someone somewhere might be relying on the buggy behaviour, but I think it's vanishingly unlikely, and in any case the worst that will happen is a URL that used to render something gets turned into a redirect.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
