### PR TITLE
persist DOM state on beforeunload

### DIFF
--- a/.changeset/gorgeous-dolphins-join.md
+++ b/.changeset/gorgeous-dolphins-join.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: persist DOM state on beforeunload

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -177,6 +177,14 @@ export function create_client(app, target) {
 		});
 	}
 
+	function persist_state() {
+		update_scroll_positions(current_history_index);
+		storage.set(SCROLL_KEY, scroll_positions);
+
+		capture_snapshot(current_history_index);
+		storage.set(SNAPSHOT_KEY, snapshots);
+	}
+
 	/**
 	 * @param {string | URL} url
 	 * @param {{ noScroll?: boolean; replaceState?: boolean; keepFocus?: boolean; state?: any; invalidateAll?: boolean }} opts
@@ -1438,6 +1446,8 @@ export function create_client(app, target) {
 			addEventListener('beforeunload', (e) => {
 				let should_block = false;
 
+				persist_state();
+
 				if (!navigating) {
 					// If we're navigating, beforeNavigate was already called. If we end up in here during navigation,
 					// it's due to an external or full-page-reload link, for which we don't want to call the hook again.
@@ -1467,11 +1477,7 @@ export function create_client(app, target) {
 
 			addEventListener('visibilitychange', () => {
 				if (document.visibilityState === 'hidden') {
-					update_scroll_positions(current_history_index);
-					storage.set(SCROLL_KEY, scroll_positions);
-
-					capture_snapshot(current_history_index);
-					storage.set(SNAPSHOT_KEY, snapshots);
+					persist_state();
 				}
 			});
 


### PR DESCRIPTION
closes #9098. Since we're already using `beforeunload`, there's no real reason not to persist state there as well. This _does_ mean that non-Firefox browsers will persist the state twice, but... that's probably fine?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
