### PR TITLE
fix: Ensure we have fallback for host for every request

### DIFF
--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -17,7 +17,7 @@ const origin = env('ORIGIN', undefined);
 const xff_depth = parseInt(env('XFF_DEPTH', '1'));
 const address_header = env('ADDRESS_HEADER', '').toLowerCase();
 const protocol_header = env('PROTOCOL_HEADER', '').toLowerCase();
-const host_header = env('HOST_HEADER', 'host').toLowerCase();
+const host_header = env('HOST_HEADER', '').toLowerCase();
 const body_size_limit = parseInt(env('BODY_SIZE_LIMIT', '524288'));
 
 const dir = path.dirname(fileURLToPath(import.meta.url));
@@ -162,7 +162,7 @@ function sequence(handlers) {
  */
 function get_origin(headers) {
 	const protocol = (protocol_header && headers[protocol_header]) || 'https';
-	const host = headers[host_header];
+	const host = (host_header && headers[host_header]) || headers.host;
 	return `${protocol}://${host}`;
 }
 


### PR DESCRIPTION
This fixes a major issue in `adapter-node`.

The Default use case:

https://github.com/sveltejs/kit/blob/master/packages/adapter-node/src/handler.js#L165 always uses
`headers.host` for generating the final `request origin`. So the default behavior is using `headers.host`

HOST_HEADER use case:
Now, there are cases especially on production apps, there is a DNS / traffic server in front of k8s container or something similar setup. `adapter-node` provides a way to resolve to the correct host by setting `HOST_HEADER` env variable.
So basically we can do something like

HOST_HEADER=x-foo-host

And then send a `headers['x-foo-host'] = example.com`, which would be used to resolve to correct origin for CORS requests. Great, we got the request to work when it comes from the Traffic server / user front facing server which sends down that `x-foo-host` header.

But the problem is there might be some requests which we directly make from node itself, with some node proxy for things like monitoring/client certs, MTLS, etc. In that case, the header which we were relying on `x-foo-host` is not set because it was set by the front facing traffic server. So, in this case our `request origin` becomes `https://` which is not what we want.

The line https://github.com/sveltejs/kit/blob/master/packages/adapter-node/src/handler.js#L20 here tries to default to host header, but it only evaluates for the availability of env variable, not on a per request basis. We have this kind of fallback for protocol https://github.com/sveltejs/kit/blob/master/packages/adapter-node/src/handler.js#L164 for per request.

This change defaults to using `host` header per request as it works in the default use case so its perfectly safe to use.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.




