### PR TITLE
fix(adapter-node): only send cache header when static resource is 200

### DIFF
--- a/.changeset/khaki-schools-invent.md
+++ b/.changeset/khaki-schools-invent.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Only send cache header when static resource is 200

--- a/.changeset/khaki-schools-invent.md
+++ b/.changeset/khaki-schools-invent.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-node': patch
 ---
 
-Only send cache header when static resource is 200
+fix: only send cache header when static resource is 200

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -37,7 +37,7 @@ function serve(path, client = false) {
 				client &&
 				((res, pathname) => {
 					// only apply to build directory, not e.g. version.json
-					if (pathname.startsWith(`/${manifest.appPath}/immutable/`)) {
+					if (pathname.startsWith(`/${manifest.appPath}/immutable/`) && res.statusCode === 200) {
 						res.setHeader('cache-control', 'public,max-age=31536000,immutable');
 					}
 				})
@@ -93,8 +93,7 @@ const ssr = async (req, res) => {
 
 	if (address_header && !(address_header in req.headers)) {
 		throw new Error(
-			`Address header was specified with ${
-				ENV_PREFIX + 'ADDRESS_HEADER'
+			`Address header was specified with ${ENV_PREFIX + 'ADDRESS_HEADER'
 			}=${address_header} but is absent from request`
 		);
 	}
@@ -116,8 +115,7 @@ const ssr = async (req, res) => {
 
 						if (xff_depth > addresses.length) {
 							throw new Error(
-								`${ENV_PREFIX + 'XFF_DEPTH'} is ${xff_depth}, but only found ${
-									addresses.length
+								`${ENV_PREFIX + 'XFF_DEPTH'} is ${xff_depth}, but only found ${addresses.length
 								} addresses`
 							);
 						}

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -93,7 +93,8 @@ const ssr = async (req, res) => {
 
 	if (address_header && !(address_header in req.headers)) {
 		throw new Error(
-			`Address header was specified with ${ENV_PREFIX + 'ADDRESS_HEADER'
+			`Address header was specified with ${
+				ENV_PREFIX + 'ADDRESS_HEADER'
 			}=${address_header} but is absent from request`
 		);
 	}
@@ -115,7 +116,8 @@ const ssr = async (req, res) => {
 
 						if (xff_depth > addresses.length) {
 							throw new Error(
-								`${ENV_PREFIX + 'XFF_DEPTH'} is ${xff_depth}, but only found ${addresses.length
+								`${ENV_PREFIX + 'XFF_DEPTH'} is ${xff_depth}, but only found ${
+									addresses.length
 								} addresses`
 							);
 						}


### PR DESCRIPTION
Fixes #9393

During gradual deployment of an app with multiple instances, it is possible to load the main page from one server and the second request for static content goes to a server that has the old code deployed on it.

The old server, with the old code, does not yet have the new file, therefore it returns 404. So far, so good.

The problem arises, that with the return of 404, it also sends cache-control header with a high max-age and immutable. The browser and intermediate CDNs cache this response as much as they can.

Therefore even after the new server gets the new app, the CDNs and the browser need to force cache clear in order to be able to get the new static files.

It would make sense that unless the response is `200`, the cache header is not sent

I have not managed to write a test for this use case, if someone could help I would be really grateful. I am also not sure if I managed to do the changeset correctly.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. https://github.com/sveltejs/kit/issues/9393
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
