### PR TITLE
chore: prettier caching

### DIFF
--- a/.changeset/thick-mails-punch.md
+++ b/.changeset/thick-mails-punch.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+chore: speed up formatting and linting when using Prettier

--- a/packages/adapter-auto/package.json
+++ b/packages/adapter-auto/package.json
@@ -24,7 +24,7 @@
 		"adapters.js"
 	],
 	"scripts": {
-		"lint": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
+		"lint": "prettier --cache --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"format": "pnpm lint --write",
 		"check": "tsc"
 	},

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -24,7 +24,7 @@
 		"index.d.ts"
 	],
 	"scripts": {
-		"lint": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
+		"lint": "prettier --cache --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"format": "pnpm lint --write",
 		"check": "tsc"
 	},

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -25,7 +25,7 @@
 	],
 	"scripts": {
 		"build": "esbuild src/worker.js --bundle --outfile=files/worker.js --external:SERVER --external:MANIFEST --format=esm",
-		"lint": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
+		"lint": "prettier --cache --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"format": "pnpm lint --write",
 		"check": "tsc --skipLibCheck",
 		"prepublishOnly": "pnpm build"

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -27,7 +27,7 @@
 		"build": "rimraf files && rollup -c && cp src/edge.js files/edge.js",
 		"test": "uvu src \"(spec\\.js|test[\\\\/]index\\.js)\"",
 		"check": "tsc",
-		"lint": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
+		"lint": "prettier --cache --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"format": "pnpm lint --write",
 		"prepublishOnly": "pnpm build"
 	},

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -27,7 +27,7 @@
 		"build": "rimraf files && rollup -c",
 		"test": "echo \"tests temporarily disabled\" # c8 uvu tests",
 		"check": "tsc",
-		"lint": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
+		"lint": "prettier --cache --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"format": "pnpm lint --write",
 		"prepublishOnly": "pnpm build"
 	},

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -23,7 +23,7 @@
 		"platforms.js"
 	],
 	"scripts": {
-		"lint": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
+		"lint": "prettier --cache --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"check": "tsc",
 		"format": "pnpm lint --write",
 		"test": "uvu test test.js"

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -23,7 +23,7 @@
 		"index.d.ts"
 	],
 	"scripts": {
-		"lint": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
+		"lint": "prettier --cache --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"format": "pnpm lint --write",
 		"check": "tsc"
 	},

--- a/packages/amp/package.json
+++ b/packages/amp/package.json
@@ -22,7 +22,7 @@
 		"index.d.ts"
 	],
 	"scripts": {
-		"lint": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
+		"lint": "prettier --cache --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"format": "pnpm lint --write"
 	},
 	"peerDependencies": {

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -31,7 +31,7 @@
 		"build": "node scripts/build-templates",
 		"test": "pnpm build && uvu test",
 		"check": "tsc",
-		"lint": "prettier --check . --config ../../.prettierrc --ignore-path ../../.gitignore --ignore-path .gitignore --plugin prettier-plugin-svelte --plugin-search-dir=.",
+		"lint": "prettier --cache --check . --config ../../.prettierrc --ignore-path ../../.gitignore --ignore-path .gitignore --plugin prettier-plugin-svelte --plugin-search-dir=.",
 		"format": "pnpm lint --write",
 		"prepublishOnly": "pnpm build",
 		"postpublish": "echo \"Updating template repo\" && bash ./scripts/update-template-repo.sh"

--- a/packages/create-svelte/shared/+eslint+prettier/package.json
+++ b/packages/create-svelte/shared/+eslint+prettier/package.json
@@ -3,7 +3,7 @@
 		"eslint-config-prettier": "^8.5.0"
 	},
 	"scripts": {
-		"lint": "prettier --plugin-search-dir . --check . && eslint .",
-		"format": "prettier --plugin-search-dir . --write ."
+		"lint": "prettier --cache --plugin-search-dir . --check . && eslint .",
+		"format": "prettier --cache --plugin-search-dir . --write ."
 	}
 }

--- a/packages/create-svelte/shared/-eslint+prettier/package.json
+++ b/packages/create-svelte/shared/-eslint+prettier/package.json
@@ -1,6 +1,6 @@
 {
 	"scripts": {
-		"lint": "prettier --plugin-search-dir . --check .",
-		"format": "prettier --plugin-search-dir . --write ."
+		"lint": "prettier --cache --plugin-search-dir . --check .",
+		"format": "prettier --cache --plugin-search-dir . --write ."
 	}
 }

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -57,7 +57,7 @@
 		"postinstall.js"
 	],
 	"scripts": {
-		"lint": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
+		"lint": "prettier --cache --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"check": "tsc",
 		"check:all": "tsc && pnpm -r --filter=\"./**\" check",
 		"format": "prettier --write . --config ../../.prettierrc --ignore-path .gitignore",

--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -33,7 +33,7 @@
 		"types"
 	],
 	"scripts": {
-		"lint": "prettier --check . --config ../../.prettierrc --ignore-path .gitignore",
+		"lint": "prettier --cache --check . --config ../../.prettierrc --ignore-path .gitignore",
 		"check": "tsc",
 		"check:all": "tsc && pnpm -r --filter=\"./**\" check",
 		"format": "pnpm lint --write",


### PR DESCRIPTION
### Problem

Prettier formatting and linting can get pretty slow, especially when a SvelteKit project gets bigger and there is transpilation/compilation (eg TypeScript) involved.

### Solution

Prettier v2.7 introduced a `--cache` CLI-option, which can "dramatically improve CLI performance":

* https://prettier.io/blog/2022/06/14/2.7.0.html
* https://prettier.io/docs/en/cli.html#--cache

Since prettier was updated to v2.8 in https://github.com/sveltejs/kit/commit/581c43e1884d7d79e4ae6d41ed8f77a1e0b1732f, this change should just work.

> I also added the `--cache`-flag to "internal" CI checks as a separate commit.

### Discussion

* Caching might not be desired when running prettier in a CI environment, since caches are generally not persisted in CI
* It is possible to set a different `--cache-strategy`, which may makes sense for some use-cases (https://prettier.io/docs/en/cli.html#--cache-strategy)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
