### PR TITLE
feat(adapters): Add back adapter.esbuild to allow configuration of bundling step

### DIFF
--- a/.changeset/yellow-clouds-kick.md
+++ b/.changeset/yellow-clouds-kick.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/adapter-cloudflare': minor
+'@sveltejs/adapter-netlify': minor
+'@sveltejs/adapter-vercel': minor
+---
+
+feat: Add back esbuild argument to adapter configuration

--- a/packages/adapter-cloudflare/index.d.ts
+++ b/packages/adapter-cloudflare/index.d.ts
@@ -1,7 +1,24 @@
 import { Adapter } from '@sveltejs/kit';
+import { BuildOptions } from 'esbuild';
 import './ambient.js';
 
 export default function plugin(options?: AdapterOptions): Adapter;
+
+interface DefaultEsbuildOptions {
+	platform: 'browser';
+	conditions: ['worker', 'browser'];
+	sourcemap: 'linked';
+	target: 'es2022';
+	entryPoints: [string];
+	outfile: string;
+	allowOverwrite: true;
+	format: 'esm';
+	bundle: true;
+}
+
+type esbuild = (
+	defaultOptions: DefaultEsbuildOptions
+) => Required<Pick<BuildOptions, keyof DefaultEsbuildOptions>> & Partial<BuildOptions>;
 
 export interface AdapterOptions {
 	/**
@@ -30,6 +47,8 @@ export interface AdapterOptions {
 		 */
 		exclude?: string[];
 	};
+
+	esbuild?: esbuild;
 }
 
 export interface RoutesJSONSpec {

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -45,7 +45,8 @@ export default function (options = {}) {
 				}
 			});
 
-			await esbuild.build({
+			/** @type { import('.').DefaultEsbuildOptions } */
+			const default_bundler_props = {
 				platform: 'browser',
 				conditions: ['worker', 'browser'],
 				sourcemap: 'linked',
@@ -55,7 +56,13 @@ export default function (options = {}) {
 				allowOverwrite: true,
 				format: 'esm',
 				bundle: true
-			});
+			};
+
+			const bundler_props = options['esbuild']
+				? options['esbuild'](default_bundler_props)
+				: default_bundler_props;
+
+			await esbuild.build(bundler_props);
 		}
 	};
 }

--- a/packages/adapter-netlify/index.d.ts
+++ b/packages/adapter-netlify/index.d.ts
@@ -1,4 +1,23 @@
 import { Adapter } from '@sveltejs/kit';
+import { BuildOptions } from 'esbuild';
 import './ambient.js';
 
-export default function plugin(opts?: { split?: boolean; edge?: boolean }): Adapter;
+interface DefaultEsbuildOptions {
+	entryPoints: [string];
+	outfile: '.netlify/edge-functions/render.js';
+	bundle: true;
+	format: 'esm';
+	platform: 'browser';
+	sourcemap: 'linked';
+	target: 'es2020';
+}
+
+type esbuild = (
+	defaultOptions: DefaultEsbuildOptions
+) => Required<Pick<BuildOptions, keyof DefaultEsbuildOptions>> & Partial<BuildOptions>;
+
+export default function plugin(opts?: {
+	split?: boolean;
+	edge?: boolean;
+	esbuild?: esbuild;
+}): Adapter;

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -1,4 +1,5 @@
 import { Adapter } from '@sveltejs/kit';
+import { BuildOptions } from 'esbuild';
 import './ambient.js';
 
 export default function plugin(config?: Config): Adapter;
@@ -51,6 +52,22 @@ export interface ServerlessConfig {
 	};
 }
 
+interface DefaultEsbuildOptions {
+	entryPoints: [string];
+	outfile: string;
+	target: 'es2020';
+	bundle: true;
+	platform: 'browser';
+	format: 'esm';
+	external?: string[];
+	sourcemap: 'linked';
+	banner: { js: 'globalThis.global = globalThis;' };
+}
+
+type esbuild = (
+	defaultOptions: DefaultEsbuildOptions
+) => Required<Pick<BuildOptions, keyof DefaultEsbuildOptions>> & Partial<BuildOptions>;
+
 export interface EdgeConfig {
 	/**
 	 * Whether to use [Edge Functions](https://vercel.com/docs/concepts/functions/edge-functions) or [Serverless Functions](https://vercel.com/docs/concepts/functions/serverless-functions)
@@ -75,6 +92,12 @@ export interface EdgeConfig {
 	 * If `true`, this route will always be deployed as its own separate function
 	 */
 	split?: boolean;
+
+	/**
+	 * Advanced. Modify the bundling step's config
+	 * @see https://esbuild.github.io/api/#build
+	 */
+	esbuild?: esbuild;
 }
 
 export type Config = EdgeConfig | ServerlessConfig;


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

---

Hey there! I am opening this PR to solve my own issue.

> This is my first PR to svelte/ any big oss project, all feedback or comments welcomed

# The problem:

Essentially the lack of configuration prevents us from modifying key configuration of the bundling step which cannot be accessed in any other way. Related issues/ PRs: #3733 #1914

In my particular case: `platform: neutral` prevents certain modules that require node modules from bundling as edge functions (in particular `@google-cloud/storage` but I heavily suspect many other packages may have the same issue  #3733). I cannot find any workarounds to get the packages to bundle other than modifying the adapter (be it hard coding or creating a configurable one)

It appears from #1914 this was a feature at one point but has silently been dropped. If there is a reason for this to be the case, I would be glad to hear.

# This PR’s proposed solution

This PR adds an argument `esbuild` of type `function` which gets called inside the adapter with the default options as only parameter. I adhered to what’s described in the adapters’ [(older) read mes](https://www.npmjs.com/package/@sveltejs/adapter-netlify/v/1.0.0-next.33) as much as possible.

# Changes:

This PR does **not** change the default `platform` nor should have any effect on projects that do not pass the esbuild argument to the adapter in their `svelte.config.js` files

This PR **does** affect sites that pass an `esbuild` argument to the adapter in their configs. It takes the output of `esbuild` and uses it in place of the default options

I am not fully aware platforms other than Netlify would support `platform: node` but I still believe being able to access this and other key configuration options for `esbuild` should be permitted as a power-feature.

> I have tested the Netlify adapter on my website overwriting the npm package with a local hot-fixed copy and it does work.

Packages affected:
- `adapter-netlify`
- `adapter-vercel`
- `adapter-cloudflare`

Thank you for considering this PR, and thank you to all maintainers for the hard work you put in, Svelte/Kit is awesome! 
