### PR TITLE
Allow extending multiple other tsconfig in tsconfigs, typescript 5.0

### DIFF
--- a/.changeset/metal-pugs-wink.md
+++ b/.changeset/metal-pugs-wink.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+allow tsconfig to extend multiple other tsconfigs

--- a/.changeset/metal-pugs-wink.md
+++ b/.changeset/metal-pugs-wink.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-allow tsconfig to extend multiple other tsconfigs
+fix: allow tsconfig to extend multiple other tsconfigs

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -176,7 +176,19 @@ function load_user_tsconfig(cwd) {
 function validate_user_config(kit, cwd, out, config) {
 	// we need to check that the user's tsconfig extends the framework config
 	const extend = config.options.extends;
-	const extends_framework_config = extend && path.resolve(cwd, extend) === out;
+	const extends_framework_config = (() => {
+		if (!extend) return false;
+		if (typeof extend === 'string') return path.resolve(cwd, extend) === out;
+		if (Array.isArray(extend)) return extend.some((e) => path.resolve(cwd, e) === out);
+		console.warn(
+			colors
+				.bold()
+				.yellow(
+					`Your extends field in ${config.kind} should be a string or an array of strings.`
+				)
+		);
+		return false;
+	})();
 
 	const options = config.options.compilerOptions || {};
 

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -183,9 +183,7 @@ function validate_user_config(kit, cwd, out, config) {
 		console.warn(
 			colors
 				.bold()
-				.yellow(
-					`Your extends field in ${config.kind} should be a string or an array of strings.`
-				)
+				.yellow(`Your extends field in ${config.kind} should be a string or an array of strings.`)
 		);
 		return false;
 	})();

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -176,17 +176,12 @@ function load_user_tsconfig(cwd) {
 function validate_user_config(kit, cwd, out, config) {
 	// we need to check that the user's tsconfig extends the framework config
 	const extend = config.options.extends;
-	const extends_framework_config = (() => {
-		if (!extend) return false;
-		if (typeof extend === 'string') return path.resolve(cwd, extend) === out;
-		if (Array.isArray(extend)) return extend.some((e) => path.resolve(cwd, e) === out);
-		console.warn(
-			colors
-				.bold()
-				.yellow(`Your extends field in ${config.kind} should be a string or an array of strings.`)
-		);
-		return false;
-	})();
+	const extends_framework_config =
+		typeof extend === 'string'
+			? path.resolve(cwd, extend) === out
+			: Array.isArray(extend)
+			? extend.some((e) => path.resolve(cwd, e) === out)
+			: false;
 
 	const options = config.options.compilerOptions || {};
 


### PR DESCRIPTION
closes #9412  

Extending multiple tsconfigs in a tsconfig would previously result in a crash, now that works here, vite also needs changes though https://github.com/vitejs/vite/issues/12380 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
