### PR TITLE
reload after error

### DIFF
--- a/.changeset/lucky-paws-work.md
+++ b/.changeset/lucky-paws-work.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: recover from errors during dev by reloading

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1326,13 +1326,15 @@ export function create_client(app, target) {
 	 * @returns {import('types').MaybePromise<App.Error>}
 	 */
 	function handle_error(error, event) {
-		if (DEV) {
-			errored = true;
-		}
-
 		if (error instanceof HttpError) {
 			return error.body;
 		}
+
+		if (DEV) {
+			errored = true;
+			console.warn('The next HMR update will cause the page to reload');
+		}
+
 		return (
 			app.hooks.handleError({ error, event }) ??
 			/** @type {any} */ ({ message: event.route.id != null ? 'Internal Error' : 'Not Found' })


### PR DESCRIPTION
It's quite hard to get SvelteKit into an unrecoverably broken state during dev — to the extent that I can't reliably reproduce it — but it's not impossible. learn.svelte.dev seems particularly prone to it, due to some quirk of the setup, though I've seen it happen in a normal project too.

This seems like a pretty comprehensive fix: if something causes an unexpected error, reload the page on the next HMR event. learn.svelte.dev is noticeably more reliable with this change.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
