### PR TITLE
add dark mode styles to default error page

### DIFF
--- a/.changeset/tasty-comics-give.md
+++ b/.changeset/tasty-comics-give.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: add dark mode styles to default error page

--- a/packages/kit/src/core/config/default-error.html
+++ b/packages/kit/src/core/config/default-error.html
@@ -6,6 +6,11 @@
 
 		<style>
 			body {
+				--bg: white;
+				--fg: #222;
+				--divider: #ccc;
+				background: var(--bg);
+				color: var(--fg);
 				font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
 					Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 				display: flex;
@@ -30,7 +35,7 @@
 			}
 
 			.message {
-				border-left: 1px solid #ccc;
+				border-left: 1px solid var(--divider);
 				padding: 0 0 0 1rem;
 				margin: 0 0 0 1rem;
 				min-height: 2.5rem;
@@ -42,6 +47,14 @@
 				font-weight: 400;
 				font-size: 1em;
 				margin: 0;
+			}
+
+			@media (prefers-color-scheme: dark) {
+				body {
+					--bg: #222;
+					--fg: #ddd;
+					--divider: #666;
+				}
 			}
 		</style>
 	</head>


### PR DESCRIPTION
closes https://github.com/sveltejs/learn.svelte.dev/issues/261.

current error page, whether light or dark mode:

<img width="319" alt="image" src="https://user-images.githubusercontent.com/1162160/226412768-fca8648b-403d-497e-8809-8bdf5b93e771.png">

new error page with dark mode:

<img width="326" alt="image" src="https://user-images.githubusercontent.com/1162160/226412809-5a786d6c-6674-4a4a-bfc3-47b970d7b878.png">


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
