### PR TITLE
fix: don't include prerendered routes in default generateManifest

### DIFF
--- a/.changeset/old-teachers-shout.md
+++ b/.changeset/old-teachers-shout.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't include prerendered routes in default generateManifest

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -162,7 +162,7 @@ export function create_builder({
 				relative_path: relativePath,
 				routes: subset
 					? subset.map((route) => /** @type {import('types').RouteData} */ (lookup.get(route)))
-					: route_data
+					: route_data.filter((route) => prerender_map.get(route.id) !== true)
 			});
 		},
 


### PR DESCRIPTION
fixes #9463
bug was introduced in #8740

I see this as a bug fix, I don't think anyone relies on `generateManifest` generating a manifest that is only usable for SvelteKit which includes prerendered routes.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
