### PR TITLE
feat: Full layout reset (ignore the root layout)

### DIFF
--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -362,7 +362,7 @@ function create_routes_and_nodes(cwd, config, fallback) {
 			current_route = current_route.parent;
 		}
 
-		if (parent_id !== undefined) {
+		if (parent_id !== undefined && parent_id !== '@') {
 			throw new Error(`${current_node.component} references missing segment "${parent_id}"`);
 		}
 	}


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

---

Hello,

I found a way to resolve my issue : https://github.com/sveltejs/kit/issues/9455
And in fact it's pretty simple !


The goal is to allow a page or layout to break all layout, even the root layout, to an empty one.
In order to do that, it use a new special syntax : a double **@@** like `+page@@.svelte` or `+layout@@.svelte` that means "reset to an empty layout".





Note : `pnpm lint` and `pnpm check` are OK, but `pnpm test` fail with this error :
```
  1 failed
    [chromium-dev-no-js] › test\server.test.js:464:2 › Static files › Serves symlinked asset =======
  152 skipped
  483 passed (2m)
 ELIFECYCLE  Command failed with exit code 1.
 ```
 
 I don't understand why, and it fail even without my code modification...
 
 I also don't know how to write a test for this PR. :/
