### PR TITLE
feat: Add Tauri Zero-Config to `adapter-static`

### DIFF
--- a/.changeset/tame-donuts-admire.md
+++ b/.changeset/tame-donuts-admire.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-static': minor
+---
+
+Add Tauri to zero-config, move platform check before fallback check

--- a/.changeset/tame-donuts-admire.md
+++ b/.changeset/tame-donuts-admire.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-static': minor
 ---
 
-Add Tauri to zero-config, move platform check before fallback check
+feat: Add Tauri to zero-config, move platform check before fallback check

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -7,7 +7,25 @@ export default function (options) {
 		name: '@sveltejs/adapter-static',
 
 		async adapt(builder) {
-			if (!options?.fallback) {
+			const platform = platforms.find((platform) => platform.test());
+
+			if (platform) {
+				if (options) {
+					builder.log.warn(
+						`Detected ${platform.name}. Please remove adapter-static options to enable zero-config mode`
+					);
+				} else {
+					builder.log.info(`Detected ${platform.name}, using zero-config mode`);
+				}
+			}
+			const {
+				pages = 'build',
+				assets = pages,
+				fallback,
+				precompress
+			} = options ?? platform?.defaults ?? /** @type {import('./index').AdapterOptions} */ ({});
+
+			if (!fallback) {
 				if (builder.routes.some((route) => route.prerender !== true) && options?.strict !== false) {
 					const prefix = path.relative('.', builder.config.kit.files.routes);
 					const has_param_routes = builder.routes.some((route) => route.id.includes('['));
@@ -37,25 +55,6 @@ See https://kit.svelte.dev/docs/page-options#prerender for more details`
 					throw new Error('Encountered dynamic routes');
 				}
 			}
-
-			const platform = platforms.find((platform) => platform.test());
-
-			if (platform) {
-				if (options) {
-					builder.log.warn(
-						`Detected ${platform.name}. Please remove adapter-static options to enable zero-config mode`
-					);
-				} else {
-					builder.log.info(`Detected ${platform.name}, using zero-config mode`);
-				}
-			}
-
-			const {
-				pages = 'build',
-				assets = pages,
-				fallback,
-				precompress
-			} = options ?? platform?.defaults ?? /** @type {import('./index').AdapterOptions} */ ({});
 
 			builder.rimraf(assets);
 			builder.rimraf(pages);

--- a/packages/adapter-static/platforms.js
+++ b/packages/adapter-static/platforms.js
@@ -71,5 +71,13 @@ export const platforms = [
 			const config = static_vercel_config(builder);
 			fs.writeFileSync('.vercel/output/config.json', JSON.stringify(config, null, '  '));
 		}
+	},
+	{
+		name: 'Tauri',
+		test: () => !!process.env.TAURI_PLATFORM_VERSION,
+		defaults: {
+			fallback: 'index.html'
+		},
+		done: () => {}
 	}
 ];


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Adds a zero-config option for Tauri applications. This uses the `TAURI_PLATFORM_VERSION` env var as documented in https://tauri.app/v1/api/config#buildconfig.beforebuildcommand.

Note that the logic for checking fallbacks had to be moved after loading the platform zero-config. If this weren't done then effectively the `fallback` value when set in a zero-config would be useless. I admittedly don't know if this could have impacts or not.

I couldn't find a test for the Vercel platform check that I referenced. If there's a suggestion on tests here then would be more than happy to add them!