### PR TITLE
fix(kit): add `submitter` type to `SubmitFunction` input argument

### DIFF
--- a/.changeset/weak-crews-report.md
+++ b/.changeset/weak-crews-report.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Add `submitter` type to `SumbitFunction` arguments in `index.d.ts`
+fix: add `submitter` type to `SumbitFunction`

--- a/.changeset/weak-crews-report.md
+++ b/.changeset/weak-crews-report.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Add `submitter` type to `SumbitFunction` arguments in `index.d.ts`

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1264,6 +1264,7 @@ export interface SubmitFunction<
 		data: FormData;
 		form: HTMLFormElement;
 		controller: AbortController;
+		submitter: HTMLElement | null;
 		cancel(): void;
 	}): MaybePromise<
 		| void


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/issues/9483

This PR adds an additional `submitter` typing to the duplicate of `SubmitFunction` in `kit/types/index.d.ts`. The main feature was added [here](https://github.com/sveltejs/kit/pull/9425).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
