### PR TITLE
add HMR to fallback error pages in dev

### DIFF
--- a/.changeset/great-wasps-tan.md
+++ b/.changeset/great-wasps-tan.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: add HMR to fallback error pages during dev

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -1,3 +1,4 @@
+import { DEV } from 'esm-env';
 import { json, text } from '../../exports/index.js';
 import { coalesce_to_error } from '../../utils/error.js';
 import { negotiate } from '../../utils/http.js';
@@ -52,7 +53,13 @@ export function allowed_methods(mod) {
  * @param {string} message
  */
 export function static_error_page(options, status, message) {
-	return text(options.templates.error({ status, message }), {
+	let page = options.templates.error({ status, message });
+
+	if (DEV) {
+		page = page.replace('</head>', '<script type="module" src="/@vite/client"></script></head>');
+	}
+
+	return text(page, {
 		headers: { 'content-type': 'text/html; charset=utf-8' },
 		status
 	});

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -56,6 +56,7 @@ export function static_error_page(options, status, message) {
 	let page = options.templates.error({ status, message });
 
 	if (DEV) {
+		// inject Vite HMR client, for easier debugging
 		page = page.replace('</head>', '<script type="module" src="/@vite/client"></script></head>');
 	}
 


### PR DESCRIPTION
At present, if you make a change that results in a fallback error page loading (e.g. introducing a syntax error in a `+page.server.js`), SvelteKit doesn't recover from the error.

With this change, HMR is activated, meaning that when you fix the error the page reloads. Together with #9440, this makes debugging much more pleasant.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
