### PR TITLE
create separate functions for ISR routes

### DIFF
--- a/.changeset/early-pigs-boil.md
+++ b/.changeset/early-pigs-boil.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+fix: create separate functions for ISR routes

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -358,7 +358,8 @@ function hash_config(config) {
 		config.external ?? '',
 		config.regions ?? '',
 		config.memory ?? '',
-		config.maxDuration ?? ''
+		config.maxDuration ?? '',
+		!!config.isr // need to distinguish ISR from non-ISR functions, because ISR functions can't use streaming mode
 	].join('/');
 }
 


### PR DESCRIPTION
Follow-up to #9182 — we disable streaming mode for ISR routes, but we don't consider `config.isr` when splitting functions in the first place. This means that if you have an SSR route and an ISR route that share the same config, one of two things will happen, depending on the order in which they're encountered during build:

* the SSR route won't use streaming
* the ISR route will 'fall back' to SSR

Both are undesirable. This fixes it

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
