### PR TITLE
fix(adapter-cloudflare-workers): throws status 404 if KVError instanceof

### DIFF
--- a/.changeset/cool-foxes-battle.md
+++ b/.changeset/cool-foxes-battle.md
@@ -1,0 +1,4 @@
+---
+'@sveltejs/adapter-cloudflare-workers': minor
+---
+return 404 for non-existent asset rather than throwing KVError


### PR DESCRIPTION
# Describe the problem

Fixes #9288. The bug occurs when deploying to Cloudflare Workers, where requests for non-existing assets result in a 500 internal error instead of a 404 error. 

# The Solution

Add a `try-catch` clause to handle the exception if the `error` is an instance of [KVError from Cloudflare Workers](https://github.com/cloudflare/kv-asset-handler#getassetfromkv) it will change the `error.status` to `404 `instead of the default `500` as described in the PR.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
