### PR TITLE
fix: balance parentheses in error about wrong content type for action

### DIFF
--- a/.changeset/unlucky-garlics-yell.md
+++ b/.changeset/unlucky-garlics-yell.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: Balance parantheses in error about wrong content type for action
+fix: balance parentheses in error about wrong content type for action

--- a/.changeset/unlucky-garlics-yell.md
+++ b/.changeset/unlucky-garlics-yell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: Balance parantheses in error about wrong content type for action

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -214,7 +214,7 @@ async function call_action(event, actions) {
 
 	if (!is_form_content_type(event.request)) {
 		throw new Error(
-			`Actions expect form-encoded data (received ${event.request.headers.get('content-type')}`
+			`Actions expect form-encoded data (received ${event.request.headers.get('content-type')})`
 		);
 	}
 


### PR DESCRIPTION
When you send the wrong content type to an action, SvelteKit throws a helpful error, but it's missing the parentheses at the end:

```
Actions expect form-encoded data (received application/json;
                                                            ^ Whoops
```

This PR adds it. That's all! Thanks!

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
