### PR TITLE
Added instructions to enable Typescript Plugin in VS Code Extension.

### DIFF
--- a/documentation/docs/10-getting-started/20-creating-a-project.md
+++ b/documentation/docs/10-getting-started/20-creating-a-project.md
@@ -22,4 +22,4 @@ Try editing the files to get a feel for how everything works.
 
 ## Editor setup
 
-We recommend using [Visual Studio Code (aka VS Code)](https://code.visualstudio.com/download) with [the Svelte extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode), but [support also exists for numerous other editors](https://sveltesociety.dev/tools#editor-support).
+We recommend using [Visual Studio Code (aka VS Code)](https://code.visualstudio.com/download) with [the Svelte extension](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode), but [support also exists for numerous other editors](https://sveltesociety.dev/tools#editor-support). If you're using Typescript, you'll want to turn on `Svelte: Enable-TS-plugin` in settings.


### PR DESCRIPTION
Previously, the SvelteKit documentation had no instructions for enabling Typescript in the VS Code extension, resulting in many users asking how to fix an issue where the IDE didn't know how to handle `.svelte` files with Typescript.

This pull request adds documentation for enable `Svelte: Enable-TS-plugin` if you're using Typescript with Sveltekit:

```
+ If you're using Typescript, you'll want to turn on `Svelte: Enable-TS-plugin` in settings.
```