### PR TITLE
feat: Add `handleLoad` hooks on client and server

### DIFF
--- a/.changeset/fifty-snakes-listen.md
+++ b/.changeset/fifty-snakes-listen.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+add `handleLoad` and `handleServerLoad` hook support

--- a/packages/kit/src/core/sync/write_client_manifest.js
+++ b/packages/kit/src/core/sync/write_client_manifest.js
@@ -127,6 +127,10 @@ export function write_client_manifest(kit, manifest_data, output, metadata) {
 				handleError: ${
 					hooks_file ? 'client_hooks.handleError || ' : ''
 				}(({ error }) => { console.error(error) }),
+
+				handleLoad: ${
+					hooks_file ? 'client_hooks.handleLoad || ' : ''
+				}(({ event, resolve }) => { return resolve(event) }),
 			};
 
 			export { default as root } from '../root.svelte';

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -684,7 +684,9 @@ export function create_client(app, target) {
 			if (DEV) {
 				try {
 					lock_fetch();
-					data = (await node.universal.load.call(null, load_input)) ?? null;
+					data =
+						(await app.hooks.handleLoad({ event: load_input, resolve: node.universal.load })) ??
+						null;
 					if (data != null && Object.getPrototypeOf(data) !== Object.prototype) {
 						throw new Error(
 							`a load function related to route '${route.id}' returned ${
@@ -702,7 +704,8 @@ export function create_client(app, target) {
 					unlock_fetch();
 				}
 			} else {
-				data = (await node.universal.load.call(null, load_input)) ?? null;
+				data =
+					(await app.hooks.handleLoad({ event: load_input, resolve: node.universal.load })) ?? null;
 			}
 			data = data ? await unwrap_promises(data) : null;
 		}

--- a/packages/kit/src/runtime/server/ambient.d.ts
+++ b/packages/kit/src/runtime/server/ambient.d.ts
@@ -5,5 +5,6 @@ declare module '__SERVER__/internal.js' {
 		handleError?: import('types').HandleServerError;
 		handleFetch?: import('types').HandleFetch;
 		handleLoad?: import('types').HandleLoad;
+		handleServerLoad?: import('types').HandleServerLoad;
 	}>;
 }

--- a/packages/kit/src/runtime/server/ambient.d.ts
+++ b/packages/kit/src/runtime/server/ambient.d.ts
@@ -4,5 +4,6 @@ declare module '__SERVER__/internal.js' {
 		handle?: import('types').Handle;
 		handleError?: import('types').HandleServerError;
 		handleFetch?: import('types').HandleFetch;
+		handleLoad?: import('types').HandleLoad;
 	}>;
 }

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -78,7 +78,8 @@ export async function render_data(
 								}
 							}
 							return data;
-						}
+						},
+						handleServerLoad: options.hooks.handleServerLoad
 					});
 				} catch (e) {
 					aborted = true;

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -41,7 +41,8 @@ export class Server {
 				handle: module.handle || (({ event, resolve }) => resolve(event)),
 				// @ts-expect-error
 				handleError: module.handleError || (({ error }) => console.error(error?.stack)),
-				handleFetch: module.handleFetch || (({ request, fetch }) => fetch(request))
+				handleFetch: module.handleFetch || (({ request, fetch }) => fetch(request)),
+				handleLoad: module.handleLoad || (({ event, resolve }) => resolve(event))
 			};
 		}
 	}

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -42,7 +42,8 @@ export class Server {
 				// @ts-expect-error
 				handleError: module.handleError || (({ error }) => console.error(error?.stack)),
 				handleFetch: module.handleFetch || (({ request, fetch }) => fetch(request)),
-				handleLoad: module.handleLoad || (({ event, resolve }) => resolve(event))
+				handleLoad: module.handleLoad || (({ event, resolve }) => resolve(event)),
+				handleServerLoad: module.handleServerLoad || (({ event, resolve }) => resolve(event))
 			};
 		}
 	}

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -180,7 +180,8 @@ export async function render_page(event, page, options, manifest, state, resolve
 						resolve_opts,
 						server_data_promise: server_promises[i],
 						state,
-						csr
+						csr,
+						handleLoad: options.hooks.handleLoad
 					});
 				} catch (e) {
 					load_error = /** @type {Error} */ (e);

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -150,7 +150,8 @@ export async function render_page(event, page, options, manifest, state, resolve
 								if (parent) Object.assign(data, await parent.data);
 							}
 							return data;
-						}
+						},
+						handleServerLoad: options.hooks.handleServerLoad
 					});
 				} catch (e) {
 					load_error = /** @type {Error} */ (e);

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -140,6 +140,7 @@ export async function load_server_data({ event, state, node, parent }) {
  *   server_data_promise: Promise<import('types').ServerDataNode | null>;
  *   state: import('types').SSRState;
  *   csr: boolean;
+ * 	 handleLoad: import('types').HandleLoad;
  * }} opts
  * @returns {Promise<Record<string, any | Promise<any>> | null>}
  */
@@ -151,7 +152,8 @@ export async function load_data({
 	server_data_promise,
 	state,
 	resolve_opts,
-	csr
+	csr,
+	handleLoad
 }) {
 	const server_data_node = await server_data_promise;
 
@@ -159,7 +161,7 @@ export async function load_data({
 		return server_data_node?.data ?? null;
 	}
 
-	const result = await node.universal.load.call(null, {
+	const load_event = {
 		url: event.url,
 		params: event.params,
 		data: server_data_node?.data ?? null,
@@ -168,7 +170,9 @@ export async function load_data({
 		setHeaders: event.setHeaders,
 		depends: () => {},
 		parent
-	});
+	};
+
+	const result = await handleLoad({ event: load_event, resolve: node.universal.load });
 
 	const data = result ? await unwrap_promises(result) : null;
 	if (__SVELTEKIT_DEV__) {

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -57,7 +57,8 @@ export async function respond_with_error({
 				resolve_opts,
 				server_data_promise,
 				state,
-				csr
+				csr,
+				handleLoad: options.hooks.handleLoad
 			});
 
 			branch.push(

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -44,7 +44,8 @@ export async function respond_with_error({
 				event,
 				state,
 				node: default_layout,
-				parent: async () => ({})
+				parent: async () => ({}),
+				handleServerLoad: options.hooks.handleServerLoad
 			});
 
 			const server_data = await server_data_promise;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -643,6 +643,14 @@ export interface HandleLoad {
 }
 
 /**
+ * The `handleServerLoad` hook runs every time a server-only `load` function (for example from +page.server.js) is called on the server.
+ * This hook provides the server load `event` and a `resolve` function to call the actual hook with the event.
+ */
+export interface HandleServerLoad {
+	(input: { event: ServerLoadEvent; resolve: ServerLoad }): ReturnType<ServerLoad>;
+}
+
+/**
  * The [`handleFetch`](https://kit.svelte.dev/docs/hooks#server-hooks-handlefetch) hook allows you to modify (or replace) a `fetch` request that happens inside a `load` function that runs on the server (or during pre-rendering)
  */
 export interface HandleFetch {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -634,6 +634,15 @@ export interface HandleClientError {
 }
 
 /**
+ * The `handleLoad` hook runs every time a universal `load` function (for example from +page.js) is called.
+ * This hook can be registered on the client as well as on the server side.
+ * This hook provides the load `event` and a `resolve` function to call the actual hook with the event.
+ */
+export interface HandleLoad {
+	(input: { event: LoadEvent; resolve: Load }): ReturnType<Load>;
+}
+
+/**
  * The [`handleFetch`](https://kit.svelte.dev/docs/hooks#server-hooks-handlefetch) hook allows you to modify (or replace) a `fetch` request that happens inside a `load` function that runs on the server (or during pre-rendering)
  */
 export interface HandleFetch {

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -95,6 +95,7 @@ export interface ServerHooks {
 	handleFetch: HandleFetch;
 	handle: Handle;
 	handleError: HandleServerError;
+	handleLoad: HandleLoad;
 }
 
 export interface ClientHooks {

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -14,7 +14,8 @@ import {
 	HandleFetch,
 	Actions,
 	HandleClientError,
-	HandleLoad
+	HandleLoad,
+	HandleServerLoad
 } from './index.js';
 import {
 	HttpMethod,
@@ -96,6 +97,7 @@ export interface ServerHooks {
 	handle: Handle;
 	handleError: HandleServerError;
 	handleLoad: HandleLoad;
+	handleServerLoad: HandleServerLoad;
 }
 
 export interface ClientHooks {

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -13,7 +13,8 @@ import {
 	SSRManifest,
 	HandleFetch,
 	Actions,
-	HandleClientError
+	HandleClientError,
+	HandleLoad
 } from './index.js';
 import {
 	HttpMethod,
@@ -98,6 +99,7 @@ export interface ServerHooks {
 
 export interface ClientHooks {
 	handleError: HandleClientError;
+	handleLoad: HandleLoad;
 }
 
 export interface Env {


### PR DESCRIPTION
This PR is a PoC implementation of our feature request from #9542. It adds support for a `handleLoad` hook in `hooks.client.js` as well as `handleLoad` and `handleServerLoad` hooks in `hooks.server.js`.

The usage of these hooks is very similar to the usage of the server-side `handle` hook, where users are provided with an `event` and a `resolve` function. 

Please take a look at #9542 for further details.

At this stage, this PR definitely needs more tests and of course a proper review. I'm more than happy to continue working on this if you decide to go forward with the proposed `handleLoad` hooks. Please feel free to request changes or apply changes yourself - whatever you prefer :)  

Also, happy to split this PR up into the individual hooks if you prefer that!

EDIT: I only ran `pnpm changeset` after opening this PR (sorry!). Should I re-open a new PR or does this still work?

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.