### PR TITLE
fix: Enabling $page.url store changes when URL is changed directly in address bar

### DIFF
--- a/.changeset/great-kangaroos-train.md
+++ b/.changeset/great-kangaroos-train.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: Enables $page.url changes when URL is directly altered in address bar
+fix: update `$page.url` when URL hash is directly altered in address bar

--- a/.changeset/great-kangaroos-train.md
+++ b/.changeset/great-kangaroos-train.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: Enables $page.url changes when URL is directly altered in address bar

--- a/.changeset/long-monkeys-sniff.md
+++ b/.changeset/long-monkeys-sniff.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': patch
----
-
-Enables $page.url updates when URL is changed directly in address bar

--- a/.changeset/long-monkeys-sniff.md
+++ b/.changeset/long-monkeys-sniff.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Enables $page.url updates when URL is changed directly in address bar

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1487,6 +1487,10 @@ export function create_client(app, target) {
 					callbacks.before_navigate.forEach((fn) => fn(navigation));
 				}
 
+				const url = new URL(location.href, document.baseURI);
+				update_url_and_page_store_notifying_with_url(url);
+
+
 				if (should_block) {
 					e.preventDefault();
 					e.returnValue = '';
@@ -1570,9 +1574,7 @@ export function create_client(app, target) {
 
 					update_scroll_positions(current_history_index);
 
-					current.url = url;
-					stores.page.set({ ...page, url });
-					stores.page.notify();
+					update_url_and_page_store_notifying_with_url(url);
 
 					return;
 				}
@@ -1700,15 +1702,6 @@ export function create_client(app, target) {
 						'',
 						location.href
 					);
-				} else {
-					// when the hash is updated directly through the browser's
-					// address bar, the page store needs to be updated
-					const url = new URL(location.href, document.baseURI);
-
-					current.url = url;
-
-					stores.page.set({ ...page, url });
-					stores.page.notify();
 				}
 			});
 
@@ -1728,6 +1721,15 @@ export function create_client(app, target) {
 					stores.navigating.set(null);
 				}
 			});
+
+			/**
+			* @param {URL} url
+			*/
+			function update_url_and_page_store_notifying_with_url(url) {
+				current.url = url;
+				stores.page.set({ ...page, url });
+				stores.page.notify();
+			}
 		},
 
 		_hydrate: async ({

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1701,9 +1701,8 @@ export function create_client(app, target) {
 						location.href
 					);
 				} else {
-					// In the occasion of the hash being updated directly through
-					// the browser's address bar, the page store needs to be
-					// updated
+					// when the hash is updated directly through the browser's
+					// address bar, the page store needs to be updated
 					const url = new URL(location.href, document.baseURI);
 
 					current.url = url;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1700,6 +1700,16 @@ export function create_client(app, target) {
 						'',
 						location.href
 					);
+				} else {
+					// In the occasion of the hash being updated directly through
+					// the browser's address bar, the page store needs to be
+					// updated
+					const url = new URL(location.href, document.baseURI);
+
+					current.url = url;
+
+					stores.page.set({ ...page, url });
+					stores.page.notify();
 				}
 			});
 

--- a/packages/kit/test/apps/basics/src/routes/store/data/+layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/store/data/+layout.svelte
@@ -4,6 +4,7 @@
 
 <div id="store-data">{JSON.stringify($page.data)}</div>
 <div id="store-error">{$page.error?.message}</div>
+<div id="page-url">{$page.url}</div>
 
 <nav>
 	<a href="/store/data/xxx">xxx</a> <a href="/store/data/yyy">yyy</a>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -784,16 +784,9 @@ test.describe('$app/stores', () => {
 				history.pushState({}, '', '#2');
 			});
 
-			await page.reload();
-
-			await page.waitForTimeout(500);
-
-			const url = await page.evaluate(() => {
-				const el = document.getElementById('page-url');
-				return el && el.textContent;
+			expect(await page.locator('#page-url').textContent({ timeout: 5000 })).toMatch(/#2$/, {
+				timeout: 5000
 			});
-
-			expect(url).toMatch(/#2$/);
 		}
 	});
 });

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -769,6 +769,28 @@ test.describe('$app/stores', () => {
 			expect(await page.textContent('#nav-status')).toBe('not currently navigating');
 		}
 	});
+
+	test("url's hash is updated when it is modified in the address bar", async ({ page, javaScriptEnabled }) => {
+		if (javaScriptEnabled) {
+			const baseUrl = '/store/data/www';
+			// Go to page where store data, as well as URL, are displayed
+			await page.goto(baseUrl);
+
+			// Change hash to #2 in address bar
+			await page.evaluate(() => {
+				history.pushState({}, '', '#2');
+			});
+
+			await page.waitForTimeout(500);
+
+			const url = await page.evaluate(() => {
+				const el = document.getElementById("page-url");
+				return el && el.textContent;
+			});
+
+			expect(url).toMatch(/#2$/);
+		}
+	});
 });
 
 test.describe('searchParams', () => {

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -781,6 +781,8 @@ test.describe('$app/stores', () => {
 				history.pushState({}, '', '#2');
 			});
 
+      await page.reload();
+
 			await page.waitForTimeout(500);
 
 			const url = await page.evaluate(() => {

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -770,7 +770,10 @@ test.describe('$app/stores', () => {
 		}
 	});
 
-	test("url's hash is updated when it is modified in the address bar", async ({ page, javaScriptEnabled }) => {
+	test("url's hash is updated when it is modified in the address bar", async ({
+		page,
+		javaScriptEnabled
+	}) => {
 		if (javaScriptEnabled) {
 			const baseUrl = '/store/data/www';
 			// Go to page where store data, as well as URL, are displayed
@@ -781,12 +784,12 @@ test.describe('$app/stores', () => {
 				history.pushState({}, '', '#2');
 			});
 
-      await page.reload();
+			await page.reload();
 
 			await page.waitForTimeout(500);
 
 			const url = await page.evaluate(() => {
-				const el = document.getElementById("page-url");
+				const el = document.getElementById('page-url');
 				return el && el.textContent;
 			});
 


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Fixes #9374

Whilst the hashchange event is already fire when the URL is altered directly in the address bar, the $page.url store would not be updated. This PR enables the expected change.

