### PR TITLE
fix: pass publicDir in ssr

### DIFF
--- a/.changeset/sharp-wolves-march.md
+++ b/.changeset/sharp-wolves-march.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: pass `publicDir` Vite config in SSR

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -564,11 +564,12 @@ function kit({ svelte_config }) {
 							preserveEntrySignatures: 'strict'
 						},
 						ssrEmitAssets: true,
+						copyPublicDir: !ssr,
 						target: ssr ? 'node16.14' : undefined,
 						// don't use the default name to avoid collisions with 'static/manifest.json'
 						manifest: 'vite-manifest.json'
 					},
-					publicDir: ssr ? false : kit.files.assets,
+					publicDir: kit.files.assets,
 					worker: {
 						rollupOptions: {
 							output: {


### PR DESCRIPTION
We're not passing `kit.files.assets` to Vite's `publicDir` in SSR, which I believe is because we don't want to copy those files over in the SSR build?

This PR uses the new (experimental but stable) `build.copyPublicDir: false` option to prevent the copying instead. I'm not sure if there's anything else I miss, but the tests pass for me locally.

NOTE: I stumbled on this while building the new svelte.dev site as it generates a lot of warnings for missing references to public files, because the option is not set in SSR. This should fix it too.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
