### PR TITLE
fix: pin undici to 5.20.0

### DIFF
--- a/.changeset/breezy-ravens-think.md
+++ b/.changeset/breezy-ravens-think.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: pin undici to 5.20.0

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -22,7 +22,7 @@
 		"set-cookie-parser": "^2.5.1",
 		"sirv": "^2.0.2",
 		"tiny-glob": "^0.2.9",
-		"undici": "5.21.0"
+		"undici": "5.20.0"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.29.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,7 +287,7 @@ importers:
       svelte-preprocess: ^5.0.0
       tiny-glob: ^0.2.9
       typescript: ^4.9.4
-      undici: 5.21.0
+      undici: 5.20.0
       uvu: ^0.5.6
       vite: ^4.2.0
     dependencies:
@@ -303,7 +303,7 @@ importers:
       set-cookie-parser: 2.5.1
       sirv: 2.0.2
       tiny-glob: 0.2.9
-      undici: 5.21.0
+      undici: 5.20.0
     devDependencies:
       '@playwright/test': 1.29.2
       '@types/connect': 3.4.35
@@ -1596,7 +1596,7 @@ packages:
       '@sveltejs/kit': ^1.0.0
       svelte: ^3.54.0
     dependencies:
-      '@sveltejs/kit': link:packages\kit
+      '@sveltejs/kit': link:packages/kit
       svelte: 3.56.0
     dev: true
 
@@ -5247,8 +5247,8 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
-  /undici/5.21.0:
-    resolution: {integrity: sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==}
+  /undici/5.20.0:
+    resolution: {integrity: sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==}
     engines: {node: '>=12.18'}
     dependencies:
       busboy: 1.6.0

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,8 @@
 	"ignoreDeps": [
 		"esbuild",
 		"rollup",
-		"typescript"
+		"typescript",
+		"undici"
 	],
 	"ignorePaths": [
 		"**/create-svelte/shared/**",


### PR DESCRIPTION
fix https://github.com/sveltejs/kit/issues/9512

pin undici to 5.20.0 and in renovate. it seems like undici reverted the fix to a memory leak a while ago:

- undici issue: https://github.com/nodejs/undici/issues/1823
- initial fix: https://github.com/nodejs/undici/pull/1824
- reverted in: https://github.com/nodejs/undici/pull/2000

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
