### PR TITLE
Update 50-adapter-static.md

### DIFF
--- a/documentation/docs/25-build-and-deploy/50-adapter-static.md
+++ b/documentation/docs/25-build-and-deploy/50-adapter-static.md
@@ -88,6 +88,23 @@ You will have to prevent GitHub's provided Jekyll from managing your site by put
 
 A config for GitHub Pages might look like the following:
 
+### SvelteKit >=1.9.0
+```js
+// @errors: 2307
+/// file: svelte.config.js
+import adapter from '@sveltejs/adapter-static';
+
+const dev = process.argv.includes('dev');
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	kit: {
+		adapter: adapter(),
+	}
+};
+```
+
+### SvelteKit <1.9.0
 ```js
 // @errors: 2307
 /// file: svelte.config.js

--- a/documentation/docs/25-build-and-deploy/50-adapter-static.md
+++ b/documentation/docs/25-build-and-deploy/50-adapter-static.md
@@ -94,8 +94,6 @@ A config for GitHub Pages might look like the following:
 /// file: svelte.config.js
 import adapter from '@sveltejs/adapter-static';
 
-const dev = process.argv.includes('dev');
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {


### PR DESCRIPTION
Since a SvelteKit update (probably 1.9.0), the `path` property isn't needed anymore because it leads to a 404 request, since it tries to request a file that doesn't exist. See also #9341 . Can anyone confirm this issue and confirm that the version that introduced it is 1.9.0 ?

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
