### PR TITLE
fix(site): Responsive home page SvelteKit headng

### DIFF
--- a/sites/kit.svelte.dev/src/routes/home/Hero.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Hero.svelte
@@ -78,7 +78,7 @@
 		margin: 0 auto;
 	}
 
-	.logotype {
+	.logotype :global(svg) {
 		position: relative;
 		width: 100%;
 		max-width: 400px;


### PR DESCRIPTION
Fixes the SvelteKit hero text on homepage. Previous PR #9607 broke it, made it unresponsive. This makes it responsive