### PR TITLE
fix: prevent `beforeNavigate()` for download links

### DIFF
--- a/.changeset/shiny-eels-greet.md
+++ b/.changeset/shiny-eels-greet.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+fix: do not call beforeNavigate for download links

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1266,8 +1266,8 @@ export function create_client(app, target) {
 			const a = find_anchor(element, container);
 			if (!a) return;
 
-			const { url, external } = get_link_info(a, base);
-			if (external) return;
+			const { url, external, download } = get_link_info(a, base);
+			if (external || download) return;
 
 			const options = get_router_options(a);
 
@@ -1300,8 +1300,8 @@ export function create_client(app, target) {
 			observer.disconnect();
 
 			for (const a of container.querySelectorAll('a')) {
-				const { url, external } = get_link_info(a, base);
-				if (external) continue;
+				const { url, external, download } = get_link_info(a, base);
+				if (external || download) continue;
 
 				const options = get_router_options(a);
 				if (options.reload) continue;
@@ -1517,7 +1517,7 @@ export function create_client(app, target) {
 				const a = find_anchor(/** @type {Element} */ (event.composedPath()[0]), container);
 				if (!a) return;
 
-				const { url, external, target } = get_link_info(a, base);
+				const { url, external, target, download } = get_link_info(a, base);
 				if (!url) return;
 
 				// bail out before `beforeNavigate` if link opens in a different tab
@@ -1544,6 +1544,8 @@ export function create_client(app, target) {
 					!(url.protocol === 'https:' || url.protocol === 'http:')
 				)
 					return;
+
+				if (download) return;
 
 				// Ignore the following but fire beforeNavigate
 				if (external || options.reload) {

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -133,10 +133,11 @@ export function get_link_info(a, base) {
 		!url ||
 		!!target ||
 		is_external_url(url, base) ||
-		(a.getAttribute('rel') || '').split(/\s+/).includes('external') ||
-		a.hasAttribute('download');
+		(a.getAttribute('rel') || '').split(/\s+/).includes('external');
 
-	return { url, external, target };
+	const download = url?.origin === location.origin && a.hasAttribute('download');
+
+	return { url, external, target, download };
 }
 
 /**

--- a/packages/kit/test/apps/basics/src/routes/before-navigate/prevent-navigation/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/before-navigate/prevent-navigation/+page.svelte
@@ -20,4 +20,5 @@
 <a href="/before-navigate/prevent-navigation?x=1">self</a>
 <a href="https://google.com" target="_blank" rel="noreferrer">_blank</a>
 <a href="https://google.de">external</a>
+<a download href="#">external</a>
 <pre>{times_triggered} {unload} {navigation_type}</pre>

--- a/packages/kit/test/apps/basics/src/routes/before-navigate/prevent-navigation/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/before-navigate/prevent-navigation/+page.svelte
@@ -20,5 +20,5 @@
 <a href="/before-navigate/prevent-navigation?x=1">self</a>
 <a href="https://google.com" target="_blank" rel="noreferrer">_blank</a>
 <a href="https://google.de">external</a>
-<a download href="#">external</a>
+<a download href="">external</a>
 <pre>{times_triggered} {unload} {navigation_type}</pre>

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -213,6 +213,18 @@ test.describe('beforeNavigate', () => {
 
 		expect(await page.innerHTML('pre')).toBe('2 false goto');
 	});
+
+	test('is triggered after clicking a download link', async ({ page, baseURL }) => {
+		await page.goto('/before-navigate/prevent-navigation');
+
+		await page.click('a[download]');
+		expect(await page.innerHTML('pre')).toBe('0 false undefined');
+
+		await page.click('a[href="/before-navigate/a"]');
+
+		expect(page.url()).toBe(baseURL + '/before-navigate/prevent-navigation');
+		expect(await page.innerHTML('pre')).toBe('1 false link');
+	});
 });
 
 test.describe('Scrolling', () => {


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/9611

This is a breaking change that causes the client to ignore download links instead of treating them as an external link.
This fixes the issue of the internal `navigating` flag being incorrectly set, leading to missing subsequent `beforeNavigate()` calls.

The `navigating` flag prevents the `beforeunload` event from triggering a second round of `beforeNavigate()` callbacks when an external link is clicked. Because the external link causes the page to unload, Kit doesn't care that the `navigating` flag isn't reset to false. In our download link case, the page isn't unloaded, causing subsequent navigations to not call `beforeNavigate()`. Therefore, we should treat download and external links differently by opting out of the same logic as external links.

It's possible for us to still call `beforeNavigate` for download links but downloading isn't really navigating? I'm open to this.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
