### PR TITLE
chore: fix TODO by removing unused variable

### DIFF
--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -57,8 +57,7 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 			exports.push(
 				`export const component = async () => (await import('../${
 					resolve_symlinks(server_manifest, node.component).chunk.file
-				}')).default;`,
-				`export const file = '${entry.file}';` // TODO what is this?
+				}')).default;`
 			);
 		}
 

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -145,12 +145,11 @@ export async function dev(vite, vite_config, svelte_config) {
 
 						if (node.component) {
 							result.component = async () => {
-								const { module_node, module, url } = await resolve(
+								const { module_node, module } = await resolve(
 									/** @type {string} */ (node.component)
 								);
 
 								module_nodes.push(module_node);
-								result.file = url.endsWith('.svelte') ? url : url + '?import'; // TODO what is this for?
 
 								return module.default;
 							};

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -290,8 +290,6 @@ export interface SSRNode {
 	component: SSRComponentLoader;
 	/** index into the `components` array in client/manifest.js */
 	index: number;
-	/** client-side module URL for this component */
-	file: string;
 	/** external JS files */
 	imports: string[];
 	/** external CSS files */


### PR DESCRIPTION
As far as I can tell, this variable is unused. `kit.svelte.dev` works without it and all the tests pass without it