### PR TITLE
fix: prevent false positive warnings for `fetch` in Firefox and Safari

### DIFF
--- a/.changeset/flat-trainers-fold.md
+++ b/.changeset/flat-trainers-fold.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prevent false positive warnings for fetch in Firefox and Safari

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -29,14 +29,12 @@ if (DEV) {
 		// We use just the filename as the method name sometimes does not appear on the CI.
 		const url = input instanceof Request ? input.url : input.toString();
 		const stack_array = /** @type {string} */ (new Error().stack).split('\n');
-		// We need to do some Firefox-specific cutoff because it (impressively) maintains the stack
-		// across events and for example traces a `fetch` call triggered from a button back
-		// to the creation of the event listener and the element creation itself,
+		// We need to do a cutoff because Safari and Firefox maintain the stack
+		// across events and for example traces a `fetch` call triggered from a button
+		// back to the creation of the event listener and the element creation itself,
 		// where at some point client.js will show up, leading to false positives.
-		const firefox_cutoff = stack_array.findIndex((a) => a.includes('*listen@'));
-		const stack = stack_array
-			.slice(0, firefox_cutoff !== -1 ? firefox_cutoff : undefined)
-			.join('\n');
+		const cutoff = stack_array.findIndex((a) => a.includes('load@') || a.includes('at load'));
+		const stack = stack_array.slice(0, cutoff + 2).join('\n');
 
 		const heuristic = can_inspect_stack_trace
 			? stack.includes('src/runtime/client/client.js')

--- a/packages/kit/test/apps/basics/src/routes/load/window-fetch/outside-load/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/window-fetch/outside-load/+page.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { page } from '$app/stores';
+	import { onMount } from 'svelte';
+
+	let answer = 0;
+
+	onMount(async () => {
+		const res = await fetch(`${$page.url.origin}/load/window-fetch/data.json`);
+		({ answer } = await res.json());
+	});
+</script>
+
+<h1>{answer}</h1>

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -742,3 +742,24 @@ test.describe('Interactivity', () => {
 		expect(errored).toBe(false);
 	});
 });
+
+test.describe('Load', () => {
+	if (process.env.DEV) {
+		test('using window.fetch does not cause false-positive warning', async ({ page, baseURL }) => {
+			/** @type {string[]} */
+			const warnings = [];
+			page.on('console', (msg) => {
+				if (msg.type() === 'warning') {
+					warnings.push(msg.text());
+				}
+			});
+
+			await page.goto('/load/window-fetch/outside-load');
+			expect(await page.textContent('h1')).toBe('42');
+
+			expect(warnings).not.toContain(
+				`Loading ${baseURL}/load/window-fetch/data.json using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/load#making-fetch-requests`
+			);
+		});
+	}
+});


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/7992

Only Chrome-like browsers have a short stack trace, leading to a correct fetch warning. However, Safari and Firefox both have a stack trace from the beginning of the client-side initialisation, leading to false positive warnings.

The fix is to cut off the stack trace at the point where the `load` function is invoked/mentioned. This makes the stack traces for Firefox and Safari similar to Chrome.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
