### PR TITLE
feat: add actionResult option in handle hook to change form result

### DIFF
--- a/.changeset/orange-ducks-wonder.md
+++ b/.changeset/orange-ducks-wonder.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: add actionResult option in handle hook to change form result

--- a/packages/kit/src/exports/hooks/sequence.js
+++ b/packages/kit/src/exports/hooks/sequence.js
@@ -34,9 +34,11 @@ export function sequence(...handlers) {
 						return html;
 					};
 
+					const actionResult = options?.actionResult ?? parent_options?.actionResult;
+
 					return i < length - 1
-						? apply_handle(i + 1, event, { transformPageChunk })
-						: resolve(event, { transformPageChunk });
+						? apply_handle(i + 1, event, { transformPageChunk, actionResult })
+						: resolve(event, { transformPageChunk, actionResult });
 				}
 			});
 		}

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -19,8 +19,9 @@ export function is_action_json_request(event) {
  * @param {import('types').RequestEvent} event
  * @param {import('types').SSROptions} options
  * @param {import('types').SSRNode['server'] | undefined} server
+ * @param {import("types").ResolveOptions["actionResult"]} hook_action_result
  */
-export async function handle_action_json_request(event, options, server) {
+export async function handle_action_json_request(event, options, server, hook_action_result) {
 	const actions = server?.actions;
 
 	if (!actions) {
@@ -45,7 +46,7 @@ export async function handle_action_json_request(event, options, server) {
 	check_named_default_separate(actions);
 
 	try {
-		const data = await call_action(event, actions);
+		const data = hook_action_result ?? (await call_action(event, actions));
 
 		if (__SVELTEKIT_DEV__) {
 			validate_action_return(data);
@@ -118,9 +119,10 @@ export function is_action_request(event) {
 /**
  * @param {import('types').RequestEvent} event
  * @param {import('types').SSRNode['server'] | undefined} server
+ * @param {import("types").ResolveOptions["actionResult"]} hook_action_result
  * @returns {Promise<import('types').ActionResult>}
  */
-export async function handle_action_request(event, server) {
+export async function handle_action_request(event, server, hook_action_result) {
 	const actions = server?.actions;
 
 	if (!actions) {
@@ -139,7 +141,7 @@ export async function handle_action_request(event, server) {
 	check_named_default_separate(actions);
 
 	try {
-		const data = await call_action(event, actions);
+		const data = hook_action_result ?? (await call_action(event, actions));
 
 		if (__SVELTEKIT_DEV__) {
 			validate_action_return(data);

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -40,7 +40,7 @@ export async function render_page(event, page, options, manifest, state, resolve
 
 	if (is_action_json_request(event)) {
 		const node = await manifest._.nodes[page.leaf]();
-		return handle_action_json_request(event, options, node?.server);
+		return handle_action_json_request(event, options, node?.server, resolve_opts.actionResult);
 	}
 
 	try {
@@ -60,7 +60,11 @@ export async function render_page(event, page, options, manifest, state, resolve
 		if (is_action_request(event)) {
 			// for action requests, first call handler in +page.server.js
 			// (this also determines status code)
-			action_result = await handle_action_request(event, leaf_node.server);
+			action_result = await handle_action_request(
+				event,
+				leaf_node.server,
+				resolve_opts.actionResult
+			);
 			if (action_result?.type === 'redirect') {
 				return redirect_response(action_result.status, action_result.location);
 			}

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -169,7 +169,8 @@ export async function respond(request, options, manifest, state) {
 	let resolve_opts = {
 		transformPageChunk: default_transform,
 		filterSerializedResponseHeaders: default_filter,
-		preload: default_preload
+		preload: default_preload,
+		actionResult: null
 	};
 
 	try {
@@ -333,7 +334,8 @@ export async function respond(request, options, manifest, state) {
 				resolve_opts = {
 					transformPageChunk: opts.transformPageChunk || default_transform,
 					filterSerializedResponseHeaders: opts.filterSerializedResponseHeaders || default_filter,
-					preload: opts.preload || default_preload
+					preload: opts.preload || default_preload,
+					actionResult: opts.actionResult ?? null
 				};
 			}
 

--- a/packages/kit/test/apps/basics/src/hooks.server.js
+++ b/packages/kit/test/apps/basics/src/hooks.server.js
@@ -113,6 +113,15 @@ export const handle = sequence(
 		}
 
 		return resolve(event);
+	},
+	async ({ event, resolve }) => {
+		if (event.url.pathname === '/actions/form-hook-result') {
+			return resolve(event, {
+				actionResult: { from_hook_handle: true }
+			});
+		}
+
+		return resolve(event);
 	}
 );
 

--- a/packages/kit/test/apps/basics/src/routes/actions/form-hook-result/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/form-hook-result/+page.server.js
@@ -1,0 +1,6 @@
+/** @type {import('./$types').Actions} */
+export const actions = {
+	default: async () => {
+		return { success: true };
+	}
+};

--- a/packages/kit/test/apps/basics/src/routes/actions/form-hook-result/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/form-hook-result/+page.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { browser } from '$app/environment';
+	import { enhance } from '$app/forms';
+
+	/** @type {import('./$types').ActionData} */
+	export let form;
+</script>
+
+<pre>{JSON.stringify(form)}</pre>
+
+<form method="post">
+	<button type="submit">Submit</button>
+</form>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1052,6 +1052,17 @@ test.describe('Actions', () => {
 
 		await expect(page.locator('h1')).toHaveText('400');
 	});
+
+	test('actionResult hook handle resolve option', async ({ page }) => {
+		await page.goto('/actions/form-hook-result');
+
+		await Promise.all([
+			page.waitForRequest((request) => request.url().includes('/actions/form-hook-result')),
+			page.click('form button')
+		]);
+
+		await expect(page.locator('pre')).toHaveText(JSON.stringify({ from_hook_handle: true }));
+	});
 });
 
 // Run in serial to not pollute the log with (correct) cookie warnings

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1024,6 +1024,8 @@ export interface ResolveOptions {
 	 * @param input the type of the file and its path
 	 */
 	preload?(input: { type: 'font' | 'css' | 'js' | 'asset'; path: string }): boolean;
+
+	actionResult?: Record<string, any> | null;
 }
 
 export interface RouteDefinition<Config = any> {


### PR DESCRIPTION
Closes #9676

Allow users to return form action result from handle hook using:`resolve(event, {actionResult: ...})`


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
