### PR TITLE
remove outdated text

### DIFF
--- a/documentation/docs/20-core-concepts/40-page-options.md
+++ b/documentation/docs/20-core-concepts/40-page-options.md
@@ -78,8 +78,6 @@ For that reason among others, it's recommended that you always include a file ex
 
 For _pages_, we skirt around this problem by writing `foo/index.html` instead of `foo`.
 
-Note that this will disable client-side routing for any navigation from this page, regardless of whether the router is already active.
-
 ### Troubleshooting
 
 If you encounter an error like 'The following routes were marked as prerenderable, but were not prerendered' it's because the route in question (or a parent layout, if it's a page) has `export const prerender = true` but the page wasn't actually prerendered, because it wasn't reached by the prerendering crawler.


### PR DESCRIPTION
this was left over from the old `router` option, it hasn't applied in a long time