### PR TITLE
only inject artificial error annotation in js blocks

### DIFF
--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -557,16 +557,16 @@ export interface KitConfig {
 	 * If SvelteKit encounters an error while loading the page and detects that a new version has been deployed (using the `name` specified here, which defaults to a timestamp of the build) it will fall back to traditional full-page navigation.
 	 * Not all navigations will result in an error though, for example if the JavaScript for the next page is already loaded. If you still want to force a full-page navigation in these cases, use techniques such as setting the `pollInterval` and then using `beforeNavigate`:
 	 * ```html
-	 * /// +layout.svelte
+	 * /// file: +layout.svelte
 	 * <script>
-	 * import { beforeNavigate } from '$app/navigation';
-	 * import { updated } from '$app/stores';
+	 *   import { beforeNavigate } from '$app/navigation';
+	 *   import { updated } from '$app/stores';
 	 *
-	 * beforeNavigate(({ willUnload, to }) => {
-	 *   if ($updated && !willUnload && to?.url) {
-	 *     location.href = to.url.href;
-	 *   }
-	 * });
+	 *   beforeNavigate(({ willUnload, to }) => {
+	 *     if ($updated && !willUnload && to?.url) {
+	 *       location.href = to.url.href;
+	 *     }
+	 *   });
 	 * </script>
 	 * ```
 	 *

--- a/sites/kit.svelte.dev/scripts/types/index.js
+++ b/sites/kit.svelte.dev/scripts/types/index.js
@@ -201,10 +201,10 @@ function read_d_ts_file(file) {
 	// We can't use JSDoc comments inside JSDoc, so we would get ts(7031) errors if
 	// we didn't ignore this error specifically for `/// file:` code examples
 	const str = fs.readFileSync(resolved, 'utf-8');
-	return str.replace(
-		/(\s*\*\s*)\/\/\/ file:/g,
-		(match, prefix) => prefix + '// @errors: 7031' + match
-	);
+
+	return str.replace(/(\s*\*\s*)```js([\s\S]+?)```/g, (match, prefix, code) => {
+		return `${prefix}\`\`\`js${prefix}// @errors: 7031${code}\`\`\``;
+	});
 }
 
 {


### PR DESCRIPTION
current: 

<img width="850" alt="image" src="https://user-images.githubusercontent.com/1162160/232608776-9f813c32-7e5e-438e-b56b-9371c77b418d.png">

fixed (simply changing the docs isn't sufficient, because `// @errors: 7031` then becomes visible):

<img width="844" alt="image" src="https://user-images.githubusercontent.com/1162160/232608861-a2444fe6-3061-4e95-b4a7-2a3322732f62.png">
