### PR TITLE
feat: Bump site-kit to 5.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -959,8 +959,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/kit
       '@sveltejs/site-kit':
-        specifier: 5.0.2
-        version: 5.0.2(@sveltejs/kit@packages+kit)(svelte@3.56.0)
+        specifier: 5.0.3
+        version: 5.0.3(@sveltejs/kit@packages+kit)(svelte@3.56.0)
       '@types/d3-geo':
         specifier: ^3.0.2
         version: 3.0.2
@@ -1849,8 +1849,8 @@ packages:
       picomatch: 2.3.1
       rollup: 3.7.0
 
-  /@sveltejs/site-kit@5.0.2(@sveltejs/kit@packages+kit)(svelte@3.56.0):
-    resolution: {integrity: sha512-ZthuCgGd/OF4KEvf5ULxCEUnj49eyadVIV5pJCzVhNxY/xaO740Tze/yH15m3NrSF7ROT+llF1xqeT2YsDfDGQ==}
+  /@sveltejs/site-kit@5.0.3(@sveltejs/kit@packages+kit)(svelte@3.56.0):
+    resolution: {integrity: sha512-HA/L3lnsKmLVPdipaxS+MRgcExaF0WxFoHWS/TDhS7kwFcY6ds8Fp10A4Jd7lt2cv+CsyQviWFD2hA0lwE8NOA==}
     peerDependencies:
       '@sveltejs/kit': ^1.0.0
       svelte: ^3.54.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         version: 1.1.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.53.0
-        version: 5.53.0(@typescript-eslint/parser@5.58.0)(eslint@8.33.0)(typescript@4.9.4)
+        version: 5.53.0(@typescript-eslint/parser@5.59.0)(eslint@8.33.0)(typescript@4.9.4)
       eslint:
         specifier: ^8.33.0
         version: 8.33.0
@@ -959,8 +959,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/kit
       '@sveltejs/site-kit':
-        specifier: 4.1.1
-        version: 4.1.1(@sveltejs/kit@packages+kit)(svelte@3.56.0)
+        specifier: 5.0.2
+        version: 5.0.2(@sveltejs/kit@packages+kit)(svelte@3.56.0)
       '@types/d3-geo':
         specifier: ^3.0.2
         version: 3.0.2
@@ -1849,13 +1849,14 @@ packages:
       picomatch: 2.3.1
       rollup: 3.7.0
 
-  /@sveltejs/site-kit@4.1.1(@sveltejs/kit@packages+kit)(svelte@3.56.0):
-    resolution: {integrity: sha512-UJqFI++1R4LJ1ULcA0b19qJmFuw87EcpPfjGZ8H02EnVQHgPjJWwzOlyjPesc0+z4vuyTKlDuW1sR2mdUSPBPw==}
+  /@sveltejs/site-kit@5.0.2(@sveltejs/kit@packages+kit)(svelte@3.56.0):
+    resolution: {integrity: sha512-ZthuCgGd/OF4KEvf5ULxCEUnj49eyadVIV5pJCzVhNxY/xaO740Tze/yH15m3NrSF7ROT+llF1xqeT2YsDfDGQ==}
     peerDependencies:
       '@sveltejs/kit': ^1.0.0
       svelte: ^3.54.0
     dependencies:
       '@sveltejs/kit': link:packages/kit
+      esm-env: 1.0.0
       svelte: 3.56.0
       svelte-local-storage-store: 0.4.0(svelte@3.56.0)
     dev: true
@@ -2010,7 +2011,7 @@ packages:
       '@types/node': 16.18.6
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.53.0(@typescript-eslint/parser@5.58.0)(eslint@8.33.0)(typescript@4.9.4):
+  /@typescript-eslint/eslint-plugin@5.53.0(@typescript-eslint/parser@5.59.0)(eslint@8.33.0)(typescript@4.9.4):
     resolution: {integrity: sha512-alFpFWNucPLdUOySmXCJpzr6HKC3bu7XooShWM+3w/EL6J2HIoB2PFxpLnq4JauWVk6DiVeNKzQlFEaE+X9sGw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2021,7 +2022,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.58.0(eslint@8.33.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.59.0(eslint@8.33.0)(typescript@4.9.4)
       '@typescript-eslint/scope-manager': 5.53.0
       '@typescript-eslint/type-utils': 5.53.0(eslint@8.33.0)(typescript@4.9.4)
       '@typescript-eslint/utils': 5.53.0(eslint@8.33.0)(typescript@4.9.4)
@@ -2038,8 +2039,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.58.0(eslint@8.33.0)(typescript@4.9.4):
-    resolution: {integrity: sha512-ixaM3gRtlfrKzP8N6lRhBbjTow1t6ztfBvQNGuRM8qH1bjFFXIJ35XY+FC0RRBKn3C6cT+7VW1y8tNm7DwPHDQ==}
+  /@typescript-eslint/parser@5.59.0(eslint@8.33.0)(typescript@4.9.4):
+    resolution: {integrity: sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2048,9 +2049,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.58.0
-      '@typescript-eslint/types': 5.58.0
-      '@typescript-eslint/typescript-estree': 5.58.0(typescript@4.9.4)
+      '@typescript-eslint/scope-manager': 5.59.0
+      '@typescript-eslint/types': 5.59.0
+      '@typescript-eslint/typescript-estree': 5.59.0(typescript@4.9.4)
       debug: 4.3.4
       eslint: 8.33.0
       typescript: 4.9.4
@@ -2066,12 +2067,12 @@ packages:
       '@typescript-eslint/visitor-keys': 5.53.0
     dev: true
 
-  /@typescript-eslint/scope-manager@5.58.0:
-    resolution: {integrity: sha512-b+w8ypN5CFvrXWQb9Ow9T4/6LC2MikNf1viLkYTiTbkQl46CnR69w7lajz1icW0TBsYmlpg+mRzFJ4LEJ8X9NA==}
+  /@typescript-eslint/scope-manager@5.59.0:
+    resolution: {integrity: sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.58.0
-      '@typescript-eslint/visitor-keys': 5.58.0
+      '@typescript-eslint/types': 5.59.0
+      '@typescript-eslint/visitor-keys': 5.59.0
     dev: true
 
   /@typescript-eslint/type-utils@5.53.0(eslint@8.33.0)(typescript@4.9.4):
@@ -2099,8 +2100,8 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/types@5.58.0:
-    resolution: {integrity: sha512-JYV4eITHPzVQMnHZcYJXl2ZloC7thuUHrcUmxtzvItyKPvQ50kb9QXBkgNAt90OYMqwaodQh2kHutWZl1fc+1g==}
+  /@typescript-eslint/types@5.59.0:
+    resolution: {integrity: sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -2125,8 +2126,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.58.0(typescript@4.9.4):
-    resolution: {integrity: sha512-cRACvGTodA+UxnYM2uwA2KCwRL7VAzo45syNysqlMyNyjw0Z35Icc9ihPJZjIYuA5bXJYiJ2YGUB59BqlOZT1Q==}
+  /@typescript-eslint/typescript-estree@5.59.0(typescript@4.9.4):
+    resolution: {integrity: sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -2134,12 +2135,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.58.0
-      '@typescript-eslint/visitor-keys': 5.58.0
+      '@typescript-eslint/types': 5.59.0
+      '@typescript-eslint/visitor-keys': 5.59.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.4.0
+      semver: 7.5.0
       tsutils: 3.21.0(typescript@4.9.4)
       typescript: 4.9.4
     transitivePeerDependencies:
@@ -2174,11 +2175,11 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
-  /@typescript-eslint/visitor-keys@5.58.0:
-    resolution: {integrity: sha512-/fBraTlPj0jwdyTwLyrRTxv/3lnU2H96pNTVM6z3esTWLtA5MZ9ghSMJ7Rb+TtUAdtEw9EyJzJ0EydIMKxQ9gA==}
+  /@typescript-eslint/visitor-keys@5.59.0:
+    resolution: {integrity: sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.58.0
+      '@typescript-eslint/types': 5.59.0
       eslint-visitor-keys: 3.4.0
     dev: true
 
@@ -3133,7 +3134,6 @@ packages:
 
   /esm-env@1.0.0:
     resolution: {integrity: sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==}
-    dev: false
 
   /espree@9.4.1:
     resolution: {integrity: sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==}
@@ -4957,8 +4957,8 @@ packages:
     dependencies:
       lru-cache: 6.0.0
 
-  /semver@7.4.0:
-    resolution: {integrity: sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==}
+  /semver@7.5.0:
+    resolution: {integrity: sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:

--- a/sites/kit.svelte.dev/package.json
+++ b/sites/kit.svelte.dev/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/adapter-vercel": "workspace:^",
 		"@sveltejs/amp": "workspace:^",
 		"@sveltejs/kit": "workspace:^",
-		"@sveltejs/site-kit": "5.0.2",
+		"@sveltejs/site-kit": "5.0.3",
 		"@types/d3-geo": "^3.0.2",
 		"@types/node": "^16.18.6",
 		"flexsearch": "^0.7.31",

--- a/sites/kit.svelte.dev/package.json
+++ b/sites/kit.svelte.dev/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/adapter-vercel": "workspace:^",
 		"@sveltejs/amp": "workspace:^",
 		"@sveltejs/kit": "workspace:^",
-		"@sveltejs/site-kit": "4.1.1",
+		"@sveltejs/site-kit": "5.0.2",
 		"@types/d3-geo": "^3.0.2",
 		"@types/node": "^16.18.6",
 		"flexsearch": "^0.7.31",

--- a/sites/kit.svelte.dev/src/routes/home/Deployment.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Deployment.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { Section } from '@sveltejs/site-kit/components';
+	import { Section, theme } from '@sveltejs/site-kit/components';
 	import html5 from './logos/html5.svg';
 	import node from './logos/node.svg';
 	import vercel from './logos/vercel.svg';
@@ -10,7 +10,6 @@
 	import lambda from './logos/lambda.svg';
 	import azure from './logos/azure.svg';
 	import plus from '$lib/icons/plus.svg';
-	import { theme } from '@sveltejs/site-kit/theme';
 </script>
 
 <Section --background="var(--background-1)">

--- a/sites/kit.svelte.dev/src/routes/home/Hero.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Hero.svelte
@@ -120,7 +120,7 @@
 			padding: calc(10rem + var(--sk-nav-height)) var(--sk-page-padding-side) 16rem;
 		}
 		.hero-contents {
-			max-width: calc(120rem - 2 * var(--side-nav));
+			max-width: calc(120rem - 2 * var(--sk-page-padding-side));
 			padding-bottom: 0rem;
 		}
 

--- a/sites/kit.svelte.dev/src/routes/home/Try.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Try.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { Section } from '@sveltejs/site-kit/components';
+	import { Section, TryTerminal } from '@sveltejs/site-kit/components';
 </script>
 
 <Section --background="var(--background-2)">
@@ -27,22 +27,7 @@
 			see for yourself
 		</h2>
 		<div class="try">
-			<div class="terminal">
-				<div class="chrome">
-					<span class="red dot" />
-					<span class="yellow dot" />
-					<span class="green dot" />
-					<span class="title">terminal</span>
-				</div>
-				<pre><code
-						><span class="line"
-							>npm create <span class="orange-highlight">svelte</span>@latest my-app</span
-						>
-<span class="line">cd my-app</span>
-<span class="line">npm install</span>
-<span class="line">npm run dev -- --open</span></code
-					></pre>
-			</div>
+			<TryTerminal />
 		</div>
 	</div>
 	<p class="create-an-app">
@@ -65,63 +50,6 @@
 		color: white;
 	}
 
-	.terminal {
-		background: rgba(0, 0, 0, 0.7);
-		margin: 0;
-		border-radius: var(--sk-border-radius);
-		overflow: hidden;
-	}
-
-	.terminal .chrome {
-		position: relative;
-		background: var(--sk-back-3);
-		color: var(--sk-text-3);
-		display: flex;
-		align-items: center;
-		font-size: var(--sk-text-s);
-		padding: 1rem;
-		gap: 1rem;
-	}
-
-	.terminal .dot {
-		width: 1rem;
-		height: 1rem;
-		border-radius: 50%;
-	}
-
-	.red {
-		background-color: hsl(15, 100%, 65%);
-	}
-
-	.yellow {
-		background-color: hsl(48, 100%, 67%);
-	}
-
-	.green {
-		background-color: hsl(141, 53%, 53%);
-	}
-
-	.title {
-		position: absolute;
-		display: flex;
-		left: 0;
-		top: 0;
-		width: 100%;
-		height: 100%;
-		align-items: center;
-		justify-content: center;
-	}
-
-	.terminal pre {
-		padding: 1em;
-		font-size: var(--sk-text-xs);
-	}
-
-	.line::before {
-		content: '$ ';
-		opacity: 0.3;
-	}
-
 	h2 {
 		color: white;
 		font-size: var(--sk-text-xl);
@@ -133,15 +61,6 @@
 		display: none;
 	}
 
-	pre code {
-		color: white;
-		font-size: 1em;
-	}
-
-	.orange-highlight {
-		color: hsl(15, 100%, 65%);
-	}
-
 	.create-an-app {
 		color: white;
 	}
@@ -149,18 +68,6 @@
 	a {
 		color: inherit;
 		text-decoration: underline;
-	}
-
-	@media (min-width: 440px) {
-		.terminal pre {
-			font-size: var(--sk-text-s);
-		}
-	}
-
-	@media (min-width: 1080px) {
-		.terminal pre {
-			font-size: var(--sk-text-m);
-		}
 	}
 
 	@media (min-width: 900px) {

--- a/sites/kit.svelte.dev/tsconfig.json
+++ b/sites/kit.svelte.dev/tsconfig.json
@@ -2,7 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
-		"allowSyntheticDefaultImports": true
+		"allowSyntheticDefaultImports": true,
+		"moduleResolution": "bundler"
 	},
 	"extends": "./.svelte-kit/tsconfig.json"
 }


### PR DESCRIPTION
Updates site-kit to 5.0

Advantage: Smaller tokens.css. Try.svelte becomes smaller

Breaking: No more `/theme` export

