### PR TITLE
chore: refactor client build data

### DIFF
--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -115,18 +115,11 @@ export async function dev(vite, vite_config, svelte_config) {
 			mimeTypes: get_mime_lookup(manifest_data),
 			_: {
 				client: {
-					start: {
-						file: `${runtime_base}/client/start.js`,
-						imports: [],
-						stylesheets: [],
-						fonts: []
-					},
-					app: {
-						file: `${svelte_config.kit.outDir}/generated/client/app.js`,
-						imports: [],
-						stylesheets: [],
-						fonts: []
-					}
+					start: `${runtime_base}/client/start.js`,
+					app: `${svelte_config.kit.outDir}/generated/client/app.js`,
+					imports: [],
+					stylesheets: [],
+					fonts: []
 				},
 				nodes: manifest_data.nodes.map((node, index) => {
 					return async () => {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -726,17 +726,17 @@ function kit({ svelte_config }) {
 				/** @type {import('vite').Manifest} */
 				const client_manifest = JSON.parse(read(`${out}/client/${vite_config.build.manifest}`));
 
+				const deps_of = /** @param {string} f */ (f) =>
+					find_deps(client_manifest, posixify(path.relative('.', f)), false);
+				const start = deps_of(`${runtime_directory}/client/start.js`);
+				const app = deps_of(`${kit.outDir}/generated/client-optimized/app.js`);
+
 				build_data.client = {
-					start: find_deps(
-						client_manifest,
-						posixify(path.relative('.', `${runtime_directory}/client/start.js`)),
-						false
-					),
-					app: find_deps(
-						client_manifest,
-						posixify(path.relative('.', `${kit.outDir}/generated/client-optimized/app.js`)),
-						false
-					)
+					start: start.file,
+					app: app.file,
+					imports: [...start.imports, ...app.imports],
+					stylesheets: [...start.stylesheets, ...app.stylesheets],
+					fonts: [...start.fonts, ...app.fonts]
 				};
 
 				const css = output.filter(

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -63,9 +63,9 @@ export async function render_response({
 
 	const { client } = manifest._;
 
-	const modulepreloads = new Set([...client.start.imports, ...client.app.imports]);
-	const stylesheets = new Set(client.app.stylesheets);
-	const fonts = new Set(client.app.fonts);
+	const modulepreloads = new Set(client.imports);
+	const stylesheets = new Set(client.stylesheets);
+	const fonts = new Set(client.fonts);
 
 	/** @type {Set<string>} */
 	const link_header_preloads = new Set();
@@ -356,8 +356,8 @@ export async function render_response({
 		}
 
 		blocks.push(`Promise.all([
-						import(${s(prefixed(client.start.file))}),
-						import(${s(prefixed(client.app.file))})
+						import(${s(prefixed(client.start))}),
+						import(${s(prefixed(client.app))})
 					]).then(([kit, app]) => {
 						kit.start(${args.join(', ')});
 					});`);

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -18,7 +18,7 @@ import {
 	RouteSegment,
 	UniqueInterface
 } from './private.js';
-import { AssetDependencies, SSRNodeLoader, SSRRoute, ValidatedConfig } from './internal.js';
+import { BuildData, SSRNodeLoader, SSRRoute, ValidatedConfig } from './internal.js';
 
 export { PrerenderOption } from './private.js';
 
@@ -1059,10 +1059,7 @@ export interface SSRManifest {
 
 	/** private fields */
 	_: {
-		client: {
-			start: AssetDependencies;
-			app: AssetDependencies;
-		};
+		client: NonNullable<BuildData['client']>;
 		nodes: SSRNodeLoader[];
 		routes: SSRRoute[];
 		matchers(): Promise<Record<string, ParamMatcher>>;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -10,7 +10,6 @@ import {
 	ResolveOptions,
 	Server,
 	ServerInitOptions,
-	SSRManifest,
 	HandleFetch,
 	Actions,
 	HandleClientError
@@ -55,8 +54,11 @@ export interface BuildData {
 	manifest_data: ManifestData;
 	service_worker: string | null;
 	client: {
-		start: AssetDependencies;
-		app: AssetDependencies;
+		start: string;
+		app: string;
+		imports: string[];
+		stylesheets: string[];
+		fonts: string[];
 	} | null;
 	server_manifest: import('vite').Manifest;
 }


### PR DESCRIPTION
A first step for https://github.com/sveltejs/kit/issues/3882. It's easier to deal with `imports`, `stylesheets`, and `fonts` than `app.imports`, `app.stylesheets`, `app.fonts`, `start.imports`, `start.stylesheets`, and `start.fonts`. This will become more true when we potentially have only a single entry point, so it makes the interface more generic and easier to deal with in that case.