### PR TITLE
fix(site): give logo image a label and bump site-kit

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -962,8 +962,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/kit
       '@sveltejs/site-kit':
-        specifier: 5.0.3
-        version: 5.0.3(@sveltejs/kit@packages+kit)(svelte@3.56.0)
+        specifier: 5.0.4
+        version: 5.0.4(@sveltejs/kit@packages+kit)(svelte@3.56.0)
       '@types/d3-geo':
         specifier: ^3.0.2
         version: 3.0.2
@@ -1852,8 +1852,8 @@ packages:
       picomatch: 2.3.1
       rollup: 3.7.0
 
-  /@sveltejs/site-kit@5.0.3(@sveltejs/kit@packages+kit)(svelte@3.56.0):
-    resolution: {integrity: sha512-HA/L3lnsKmLVPdipaxS+MRgcExaF0WxFoHWS/TDhS7kwFcY6ds8Fp10A4Jd7lt2cv+CsyQviWFD2hA0lwE8NOA==}
+  /@sveltejs/site-kit@5.0.4(@sveltejs/kit@packages+kit)(svelte@3.56.0):
+    resolution: {integrity: sha512-bn0Lk3hmIz/pDTMvVjiVX/US4OPoc1CzfceI0Y0ljxHs2fdxRTZz881xvItZRF7istLIueoFR1x3HAZPdI2F6g==}
     peerDependencies:
       '@sveltejs/kit': ^1.0.0
       svelte: ^3.54.0

--- a/sites/kit.svelte.dev/package.json
+++ b/sites/kit.svelte.dev/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/adapter-vercel": "workspace:^",
 		"@sveltejs/amp": "workspace:^",
 		"@sveltejs/kit": "workspace:^",
-		"@sveltejs/site-kit": "5.0.3",
+		"@sveltejs/site-kit": "5.0.4",
 		"@types/d3-geo": "^3.0.2",
 		"@types/node": "^16.18.6",
 		"flexsearch": "^0.7.31",

--- a/sites/kit.svelte.dev/src/routes/home/Hero.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Hero.svelte
@@ -7,7 +7,7 @@
 <section class="hero">
 	<div class="hero-contents">
 		<div class="hero-text">
-			<div class="logotype" role="img">
+			<div class="logotype" role="img" aria-label="SvelteKit">
 				<Logotype />
 			</div>
 


### PR DESCRIPTION
Fixes a couple a11y issues on the SvelteKit site - see https://github.com/sveltejs/site-kit/pull/107 for details on the site-kit a11y fixes

Fixes:
- SvelteKit logo on homepage was not properly labelled 
- Dark mode toggle was incorrectly nested inside a `<ul>` (site-kit fix)
- Dark mode toggle was not labelled properly (site-kit fix)
- Mobile navigation did not have background set (site-kit fix)
