### PR TITLE
Update SW docs to use paths as cache-keys

### DIFF
--- a/documentation/docs/30-advanced/40-service-workers.md
+++ b/documentation/docs/30-advanced/40-service-workers.md
@@ -66,7 +66,7 @@ self.addEventListener('fetch', (event) => {
 
 		// `build`/`files` can always be served from the cache
 		if (ASSETS.includes(url.pathname)) {
-			return cache.match(event.request);
+			return cache.match(url.pathname);
 		}
 
 		// for everything else, try the network first, but


### PR DESCRIPTION
For some reason Chrome and other Chromium based browsers do not match a cached response when using a request as the cache-key if the cache was initialised from a path and not a request object. The example uses an array of pathnames to populate the cache, so you also need to use paths to retrieve responses from the cache. This weird behaviour causes cache-misses on resources that are very clearly in the cache.

Using the pathname itself as the cache key fixes the issue.

The issue does not occur in Firefox or Safari, and it only happens if you are deployed on a domain, so it's really easy to miss and really confusing to debug. This took me ages.