### PR TITLE
feat: show vite error overlay for unhandled errors during load

### DIFF
--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -349,6 +349,10 @@ export interface SSROptions {
 	version_hash: string;
 }
 
+export interface ServerDevOptions {
+	on_error: (route_id: string | null, error: unknown) => void;
+}
+
 export interface PageNodeIndexes {
 	errors: Array<number | undefined>;
 	layouts: Array<number | undefined>;


### PR DESCRIPTION
closes #9704

WIP, this is merely a POC at this point. Since the hook stuff is now encapsulated in the Server class, we need to pass in something from the dev server to hook into the error. Not nice, but works.
What doesn't work yet is seing these errors when `handleError` is invoked in the client.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
