### PR TITLE
fix-9595: set trailing slash on data request 🛤

### DIFF
--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -175,7 +175,7 @@ export async function respond(request, options, manifest, state) {
 
 	try {
 		// determine whether we need to redirect to add/remove a trailing slash
-		if (route && !is_data_request) {
+		if (route) {
 			// if `paths.base === '/a/b/c`, then the root route is `/a/b/c/`,
 			// regardless of the `trailingSlash` route option
 			if (url.pathname === base || url.pathname === base + '/') {
@@ -217,19 +217,21 @@ export async function respond(request, options, manifest, state) {
 				}
 			}
 
-			const normalized = normalize_path(url.pathname, trailing_slash ?? 'never');
+			if (!is_data_request) {
+				const normalized = normalize_path(url.pathname, trailing_slash ?? 'never');
 
-			if (normalized !== url.pathname && !state.prerendering?.fallback) {
-				return new Response(undefined, {
-					status: 308,
-					headers: {
-						'x-sveltekit-normalize': '1',
-						location:
-							// ensure paths starting with '//' are not treated as protocol-relative
-							(normalized.startsWith('//') ? url.origin + normalized : normalized) +
-							(url.search === '?' ? '' : url.search)
-					}
-				});
+				if (normalized !== url.pathname && !state.prerendering?.fallback) {
+					return new Response(undefined, {
+						status: 308,
+						headers: {
+							'x-sveltekit-normalize': '1',
+							location:
+								// ensure paths starting with '//' are not treated as protocol-relative
+								(normalized.startsWith('//') ? url.origin + normalized : normalized) +
+								(url.search === '?' ? '' : url.search)
+						}
+					});
+				}
 			}
 		}
 


### PR DESCRIPTION
fixes #9595 
Trailing slash was never set for preloading data through `someroute/__data.json`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
