### PR TITLE
chore: fix path to app script on windows

### DIFF
--- a/.changeset/perfect-walls-mix.md
+++ b/.changeset/perfect-walls-mix.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: fix import path to app script on windows

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -116,7 +116,7 @@ export async function dev(vite, vite_config, svelte_config) {
 			_: {
 				client: {
 					start: `${runtime_base}/client/start.js`,
-					app: `${svelte_config.kit.outDir}/generated/client/app.js`,
+					app: `${to_fs(svelte_config.kit.outDir)}/generated/client/app.js`,
 					imports: [],
 					stylesheets: [],
 					fonts: []


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

As noted on discord, in dev mode the hydration script inserted into pages is rendered as
`import("./D:\\some\\path\\kit\\sites\\kit.svelte.dev\\.svelte-kit/generated/client/app.js")`

which works for our current intents and purposes, hence why this is marked as a chore instead of a fix, but it just looks plain weird and might confuse users.

This PR makes it so that these paths have correct facing slashes and the /@fs/ prefix on both Linux and Windows.
