### PR TITLE
fix: ensure `beforeNavigate` still runs after clicking a download link

### DIFF
--- a/packages/kit/test/apps/basics/src/routes/before-navigate/download/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/before-navigate/download/+server.js
@@ -1,0 +1,7 @@
+export function GET() {
+	return new Response('ok', {
+		headers: {
+			'content-disposition': 'attachment'
+		}
+	});
+}

--- a/packages/kit/test/apps/basics/src/routes/before-navigate/download/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/before-navigate/download/+server.js
@@ -1,7 +1,7 @@
 export function GET() {
 	return new Response('ok', {
 		headers: {
-			'content-disposition': 'attachment'
+			'Content-Disposition': 'attachment'
 		}
 	});
 }

--- a/packages/kit/test/apps/basics/src/routes/before-navigate/prevent-navigation/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/before-navigate/prevent-navigation/+page.svelte
@@ -4,10 +4,15 @@
 	let times_triggered = 0;
 	let unload = false;
 	let navigation_type;
+
 	beforeNavigate(({ cancel, type, willUnload, to }) => {
 		times_triggered++;
 		unload = willUnload;
 		navigation_type = type;
+
+		// we don't want the beforeunload alert to pop up for downloads.
+		if (to?.route.id?.includes("download")) return;
+
 		if (!to?.route.id?.includes('redirect')) {
 			cancel();
 		}
@@ -20,6 +25,6 @@
 <a href="/before-navigate/prevent-navigation?x=1">self</a>
 <a href="https://google.com" target="_blank" rel="noreferrer">_blank</a>
 <a href="https://google.de">external</a>
-<a download href="">explicit download</a>
-<a href="/before-navigate/download" rel="external">implicit download</a>
+<a download href="/before-navigate/prevent-navigation">explicit download</a>
+<a href="/before-navigate/download">implicit download</a>
 <pre>{times_triggered} {unload} {navigation_type}</pre>

--- a/packages/kit/test/apps/basics/src/routes/before-navigate/prevent-navigation/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/before-navigate/prevent-navigation/+page.svelte
@@ -20,5 +20,6 @@
 <a href="/before-navigate/prevent-navigation?x=1">self</a>
 <a href="https://google.com" target="_blank" rel="noreferrer">_blank</a>
 <a href="https://google.de">external</a>
-<a download href="">external</a>
+<a download href="">explicit download</a>
+<a href="/before-navigate/download" rel="external">implicit download</a>
 <pre>{times_triggered} {unload} {navigation_type}</pre>

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -214,10 +214,22 @@ test.describe('beforeNavigate', () => {
 		expect(await page.innerHTML('pre')).toBe('2 false goto');
 	});
 
-	test('is triggered after clicking a download link', async ({ page, baseURL }) => {
+	test('is triggered after clicking an explicit download link', async ({ page, baseURL }) => {
 		await page.goto('/before-navigate/prevent-navigation');
 
 		await page.click('a[download]');
+		expect(await page.innerHTML('pre')).toBe('0 false undefined');
+
+		await page.click('a[href="/before-navigate/a"]');
+
+		expect(page.url()).toBe(baseURL + '/before-navigate/prevent-navigation');
+		expect(await page.innerHTML('pre')).toBe('1 false link');
+	});
+
+	test('is triggered after clicking an implicit download link', async ({ page, baseURL }) => {
+		await page.goto('/before-navigate/prevent-navigation');
+
+		await page.click('a[href="/before-navigate/download"]');
 		expect(await page.innerHTML('pre')).toBe('0 false undefined');
 
 		await page.click('a[href="/before-navigate/a"]');

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -230,12 +230,12 @@ test.describe('beforeNavigate', () => {
 		await page.goto('/before-navigate/prevent-navigation');
 
 		await page.click('a[href="/before-navigate/download"]');
-		expect(await page.innerHTML('pre')).toBe('0 false undefined');
+		expect(await page.innerHTML('pre')).toBe('1 true link');
 
 		await page.click('a[href="/before-navigate/a"]');
 
 		expect(page.url()).toBe(baseURL + '/before-navigate/prevent-navigation');
-		expect(await page.innerHTML('pre')).toBe('1 false link');
+		expect(await page.innerHTML('pre')).toBe('2 false link');
 	});
 });
 


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/9744

Clicking on a URL that returns the response header `content-disposition: attachment` will trigger a download instead of an external navigation. Currently, Kit thinks it's an external navigation and that the page will unload.

This fix moves the `before_navigate` call out of the `click` event handler and solely into the `beforeunload` event handler (there was already one there but would check the `navigating` flag to determine if it should run or not). Hence, only links that will actually unload the page (external links) will be treated as such, and not get mixed up with these implicit download links (they trigger a download but have no `download` attribute).

Notes:
Don't know if there's a way to know if a link is a download before receiving the response. Therefore, `beforeNavigate` will always run for these types of implicit download links.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
