### PR TITLE
fix: correctly replace state when using `data-sveltekit-replacestate` with a hash link

### DIFF
--- a/.changeset/flat-planes-kneel.md
+++ b/.changeset/flat-planes-kneel.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly replace state when `data-sveltekit-replacestate` is used with a hash link

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1063,6 +1063,7 @@ export function create_client(app, target) {
 		if (details) {
 			const change = details.replaceState ? 0 : 1;
 			details.state[INDEX_KEY] = current_history_index += change;
+			console.log('details.replaceState', details.replaceState);
 			history[details.replaceState ? 'replaceState' : 'pushState'](details.state, '', url);
 
 			if (!details.replaceState) {
@@ -1532,7 +1533,6 @@ export function create_client(app, target) {
 				if (hash !== undefined && nonhash === location.href.split('#')[0]) {
 					// set this flag to distinguish between navigations triggered by
 					// clicking a hash link and those triggered by popstate
-					// TODO why not update history here directly?
 					hash_navigating = true;
 
 					update_scroll_positions(current_history_index);
@@ -1541,7 +1541,11 @@ export function create_client(app, target) {
 					stores.page.set({ ...page, url });
 					stores.page.notify();
 
-					return;
+					if (!options.replace_state) return;
+
+					// hashchange event shouldn't occur if the router is replacing state.
+					hash_navigating = false;
+					event.preventDefault();
 				}
 
 				navigate({
@@ -1658,6 +1662,7 @@ export function create_client(app, target) {
 			});
 
 			addEventListener('hashchange', () => {
+				console.log('hashchange');
 				// if the hashchange happened as a result of clicking on a link,
 				// we need to update history, otherwise we have to leave it alone
 				if (hash_navigating) {

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1063,7 +1063,6 @@ export function create_client(app, target) {
 		if (details) {
 			const change = details.replaceState ? 0 : 1;
 			details.state[INDEX_KEY] = current_history_index += change;
-			console.log('details.replaceState', details.replaceState);
 			history[details.replaceState ? 'replaceState' : 'pushState'](details.state, '', url);
 
 			if (!details.replaceState) {
@@ -1662,7 +1661,6 @@ export function create_client(app, target) {
 			});
 
 			addEventListener('hashchange', () => {
-				console.log('hashchange');
 				// if the hashchange happened as a result of clicking on a link,
 				// we need to update history, otherwise we have to leave it alone
 				if (hash_navigating) {

--- a/packages/kit/test/apps/basics/package.json
+++ b/packages/kit/test/apps/basics/package.json
@@ -11,7 +11,7 @@
 		"test:dev": "rimraf test/errors.json && cross-env DEV=true playwright test",
 		"test:build": "rimraf test/errors.json && playwright test",
 		"test:cross-platform:dev": "node test/setup.js && rimraf test/errors.json && cross-env DEV=true playwright test test/cross-platform/",
-		"test:cross-platform:build": "node test/setup.js && rimraf test/errors.json && playwright test test/cross-platform/"
+		"test:cross-platform:build": "node test/setup.js && rimraf test/errors.json && KIT_E2E_BROWSER=webkit playwright test test/cross-platform/"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",

--- a/packages/kit/test/apps/basics/package.json
+++ b/packages/kit/test/apps/basics/package.json
@@ -11,7 +11,7 @@
 		"test:dev": "rimraf test/errors.json && cross-env DEV=true playwright test",
 		"test:build": "rimraf test/errors.json && playwright test",
 		"test:cross-platform:dev": "node test/setup.js && rimraf test/errors.json && cross-env DEV=true playwright test test/cross-platform/",
-		"test:cross-platform:build": "node test/setup.js && rimraf test/errors.json && KIT_E2E_BROWSER=webkit playwright test test/cross-platform/"
+		"test:cross-platform:build": "node test/setup.js && rimraf test/errors.json && playwright test test/cross-platform/"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",

--- a/packages/kit/test/apps/basics/src/routes/routing/hashes/a/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/hashes/a/+page.svelte
@@ -1,3 +1,4 @@
 <h1 id="hash-target">a</h1>
 <a href="#hash-target">hash link</a>
 <a href="/routing/hashes/b">b</a>
+<a href="#replace-state" data-sveltekit-replacestate>replace state</a>

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -636,6 +636,20 @@ test.describe('Routing', () => {
 		expect(await page.textContent('h1')).toBe('a');
 	});
 
+	test('replaces state if the data-sveltekit-replacestate router option is specified for the hash link', async ({
+		page,
+		clicknav,
+		baseURL
+	}) => {
+		await page.goto('/routing/hashes/a');
+
+		await clicknav('[href="#hash-target"]');
+		await clicknav('[href="#replace-state"]');
+
+		await page.goBack();
+		expect(await page.url()).toBe(`${baseURL}/routing/hashes/a`);
+	});
+
 	test('does not normalize external path', async ({ page, start_server }) => {
 		const html_ok = '<html><head></head><body>ok</body></html>';
 		const { port } = await start_server((_req, res) => {

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -623,6 +623,19 @@ test.describe('Routing', () => {
 		await expect(page.locator('#page-url-hash')).toHaveText('');
 	});
 
+	test('back button returns to previous route when previous route has been navigated to via hash anchor', async ({
+		page,
+		clicknav
+	}) => {
+		await page.goto('/routing/hashes/a');
+
+		await page.locator('[href="#hash-target"]').click();
+		await clicknav('[href="/routing/hashes/b"]');
+
+		await page.goBack();
+		expect(await page.textContent('h1')).toBe('a');
+	});
+
 	test('does not normalize external path', async ({ page, start_server }) => {
 		const html_ok = '<html><head></head><body>ok</body></html>';
 		const { port } = await start_server((_req, res) => {

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -623,6 +623,20 @@ test.describe('Routing', () => {
 		await expect(page.locator('#page-url-hash')).toHaveText('');
 	});
 
+	test('replaces state if the data-sveltekit-replacestate router option is specified for the hash link', async ({
+		page,
+		clicknav,
+		baseURL
+	}) => {
+		await page.goto('/routing/hashes/a');
+
+		await clicknav('[href="#hash-target"]');
+		await clicknav('[href="#replace-state"]');
+
+		await page.goBack();
+		expect(await page.url()).toBe(`${baseURL}/routing/hashes/a`);
+	});
+
 	test('does not normalize external path', async ({ page, start_server }) => {
 		const html_ok = '<html><head></head><body>ok</body></html>';
 		const { port } = await start_server((_req, res) => {

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -623,20 +623,6 @@ test.describe('Routing', () => {
 		await expect(page.locator('#page-url-hash')).toHaveText('');
 	});
 
-	test('replaces state if the data-sveltekit-replacestate router option is specified for the hash link', async ({
-		page,
-		clicknav,
-		baseURL
-	}) => {
-		await page.goto('/routing/hashes/a');
-
-		await clicknav('[href="#hash-target"]');
-		await clicknav('[href="#replace-state"]');
-
-		await page.goBack();
-		expect(await page.url()).toBe(`${baseURL}/routing/hashes/a`);
-	});
-
 	test('does not normalize external path', async ({ page, start_server }) => {
 		const html_ok = '<html><head></head><body>ok</body></html>';
 		const { port } = await start_server((_req, res) => {

--- a/packages/kit/test/apps/basics/test/cross-platform/test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/test.js
@@ -756,6 +756,20 @@ test.describe('Routing', () => {
 		expect(await page.textContent('h1')).toBe('a');
 	});
 
+	test('replaces state if the data-sveltekit-replacestate router option is specified for the hash link', async ({
+		page,
+		clicknav,
+		baseURL
+	}) => {
+		await page.goto('/routing/hashes/a');
+
+		await clicknav('[href="#hash-target"]');
+		await clicknav('[href="#replace-state"]');
+
+		await page.goBack();
+		expect(await page.url()).toBe(`${baseURL}/routing/hashes/a`);
+	});
+
 	test('focus works if page load has hash', async ({ page, browserName }) => {
 		await page.goto('/routing/hashes/target#p2');
 

--- a/packages/kit/test/apps/basics/test/cross-platform/test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/test.js
@@ -743,19 +743,6 @@ test.describe('Routing', () => {
 		expect(await page.textContent('h1')).toBe('Great success!');
 	});
 
-	test('back button returns to previous route when previous route has been navigated to via hash anchor', async ({
-		page,
-		clicknav
-	}) => {
-		await page.goto('/routing/hashes/a');
-
-		await page.locator('[href="#hash-target"]').click();
-		await clicknav('[href="/routing/hashes/b"]');
-
-		await page.goBack();
-		expect(await page.textContent('h1')).toBe('a');
-	});
-
 	test('replaces state if the data-sveltekit-replacestate router option is specified for the hash link', async ({
 		page,
 		clicknav,

--- a/packages/kit/test/apps/basics/test/cross-platform/test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/test.js
@@ -743,20 +743,6 @@ test.describe('Routing', () => {
 		expect(await page.textContent('h1')).toBe('Great success!');
 	});
 
-	test('replaces state if the data-sveltekit-replacestate router option is specified for the hash link', async ({
-		page,
-		clicknav,
-		baseURL
-	}) => {
-		await page.goto('/routing/hashes/a');
-
-		await clicknav('[href="#hash-target"]');
-		await clicknav('[href="#replace-state"]');
-
-		await page.goBack();
-		expect(await page.url()).toBe(`${baseURL}/routing/hashes/a`);
-	});
-
 	test('focus works if page load has hash', async ({ page, browserName }) => {
 		await page.goto('/routing/hashes/target#p2');
 


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/9546

Checks for the `replacestate` attribute when clicking on a hash link.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
