### PR TITLE
fix: handle inspector changes

### DIFF
--- a/.changeset/hungry-guests-bake.md
+++ b/.changeset/hungry-guests-bake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: handle vite-plugin-svelte inspector changes

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -139,6 +139,15 @@ export async function sveltekit() {
 		...svelte_config.vitePlugin
 	};
 
+	// Set `appendTo` if user enables the inspector so it mounts correctly
+	const inspectorOptions = vite_plugin_svelte_options.inspector;
+	if (inspectorOptions) {
+		vite_plugin_svelte_options.inspector = {
+			appendTo: '/generated/root.svelte',
+			...(inspectorOptions === true ? {} : inspectorOptions)
+		};
+	}
+
 	return [...svelte(vite_plugin_svelte_options), ...kit({ svelte_config })];
 }
 


### PR DESCRIPTION
**Marking as draft until the linked PR is ready**

SvelteKit should set v-p-s inspector `appendTo` option so that v-p-s doesn't have kit-specific code. This goes in hand to https://github.com/sveltejs/vite-plugin-svelte/pull/631 so once that's merged, we should upgrade v-p-s and merge this.

cc @dominikg 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
