### PR TITLE
adapter-cloudflare: respect response status code for caching

### DIFF
--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -57,11 +57,7 @@ const worker = {
 		pragma = res.headers.get('cache-control');
 
 		// only save good responses to Cache
-		if (should_cache(res)) {
-			return Cache.save(req, res, context);
-		}
-
-		return res;
+		return should_cache(res) ? Cache.save(req, res, context) : res;
 	}
 };
 

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -53,10 +53,24 @@ const worker = {
 			});
 		}
 
-		// Writes to Cache only if allowed & specified
+		// write to Cache only if allowed & specified
 		pragma = res.headers.get('cache-control');
-		return pragma && res.ok ? Cache.save(req, res, context) : res;
+
+		// only save good responses to Cache
+		if (pragma && res.ok && !is_error(res.status)) {
+			return Cache.save(req, res, context);
+		}
+
+		return res;
 	}
 };
+
+/**
+ * @param {number} status
+ * @returns {boolean}
+ */
+function is_error(status) {
+	return status > 399;
+}
 
 export default worker;

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -57,13 +57,22 @@ const worker = {
 		pragma = res.headers.get('cache-control');
 
 		// only save good responses to Cache
-		if (pragma && res.ok && !is_error(res.status)) {
+		if (should_cache(res)) {
 			return Cache.save(req, res, context);
 		}
 
 		return res;
 	}
 };
+
+/**
+ * @param {Response} res
+ * @returns {boolean}
+ */
+function should_cache(res) {
+	const cacheControl = res.headers.get('cache-control');
+	return cacheControl && res.ok && !is_error(res.status);
+}
 
 /**
  * @param {number} status

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -67,15 +67,7 @@ const worker = {
  */
 function should_cache(res) {
 	const cacheControl = res.headers.get('cache-control');
-	return cacheControl && res.ok && !is_error(res.status);
-}
-
-/**
- * @param {number} status
- * @returns {boolean}
- */
-function is_error(status) {
-	return status > 399;
+	return cacheControl && res.ok && res.status < 400;
 }
 
 export default worker;


### PR DESCRIPTION
This aims to solve #9721 .

Currently, adapter-cloudflare does not respect the status code of internal requests for caching.

This is behavior is different to how [adapter-cloudflare-workers](https://github.com/sveltejs/kit/blob/29ffc78560a99ce387b10a24f48b7f01205f51e7/packages/adapter-cloudflare-workers/files/entry.js#L26) and [adapter-node](https://github.com/cdemi/kit/blob/43f37af6e43516455c4ca6d9c20714553b409efc/packages/adapter-node/src/handler.js#L40) behave.

This PR extends the cache-check to behave similarly.

This will also help with out-of-sync cache misses during deployments (outdated edge nodes receive a request from the freshly deployed app version, respond with 404s, DNS caches the bad response). This affects thousands of my users on each deployment. Rapid build, test and deploy cycles is one of the reasons I chose SvelteKit.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
