### PR TITLE
fix: log whole error object in default handleError

### DIFF
--- a/.changeset/tender-cows-travel.md
+++ b/.changeset/tender-cows-travel.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: log whole error object in default handleError

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -41,8 +41,7 @@ export class Server {
 
 				this.#options.hooks = {
 					handle: module.handle || (({ event, resolve }) => resolve(event)),
-					// @ts-expect-error
-					handleError: module.handleError || (({ error }) => console.error(error?.stack)),
+					handleError: module.handleError || (({ error }) => console.error(error)),
 					handleFetch: module.handleFetch || (({ request, fetch }) => fetch(request))
 				};
 			} catch (error) {
@@ -51,8 +50,7 @@ export class Server {
 						handle: () => {
 							throw error;
 						},
-						// @ts-expect-error
-						handleError: ({ error }) => console.error(error?.stack),
+						handleError: ({ error }) => console.error(error),
 						handleFetch: ({ request, fetch }) => fetch(request)
 					};
 				} else {


### PR DESCRIPTION
ref #9785 

People may have custom errors without a stack and logging just the stack as a string misses out on some pretty terminal formatting from node, along with stuff like `Error.cause`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
