### PR TITLE
chore: remove `ignorePatterns: ['*.cjs']` from template `.eslintrc.cjs`

### DIFF
--- a/.changeset/weak-poets-return.md
+++ b/.changeset/weak-poets-return.md
@@ -1,5 +1,5 @@
 ---
-'create-svelte': minor
+'create-svelte': patch
 ---
 
-remove `ignorePatterns: ['*.cjs']` from .eslintrc.cjs
+fix: remove obsolete `ignorePatterns: ['*.cjs']` from .eslintrc.cjs

--- a/.changeset/weak-poets-return.md
+++ b/.changeset/weak-poets-return.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': minor
+---
+
+remove `ignorePatterns: ['*.cjs']` from .eslintrc.cjs

--- a/packages/create-svelte/shared/+eslint+prettier+typescript/.eslintrc.cjs
+++ b/packages/create-svelte/shared/+eslint+prettier+typescript/.eslintrc.cjs
@@ -8,7 +8,6 @@ module.exports = {
 	],
 	parser: '@typescript-eslint/parser',
 	plugins: ['@typescript-eslint'],
-	ignorePatterns: ['*.cjs'],
 	parserOptions: {
 		sourceType: 'module',
 		ecmaVersion: 2020,

--- a/packages/create-svelte/shared/+eslint+typescript/.eslintrc.cjs
+++ b/packages/create-svelte/shared/+eslint+typescript/.eslintrc.cjs
@@ -7,7 +7,6 @@ module.exports = {
 	],
 	parser: '@typescript-eslint/parser',
 	plugins: ['@typescript-eslint'],
-	ignorePatterns: ['*.cjs'],
 	parserOptions: {
 		sourceType: 'module',
 		ecmaVersion: 2020,


### PR DESCRIPTION
close: https://github.com/sveltejs/kit/pull/9749#issuecomment-1526868297

I tested with `create-svelte version 4.1.0`, but I didn't get error even without `ignorePatterns: ['*.cjs']`.
I think kit users can add this config if needed.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
