### PR TITLE
use import-meta-resolve to resolve vite-imagetools

### DIFF
--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -12,6 +12,7 @@
 	"type": "module",
 	"dependencies": {
 		"esm-env": "^1.0.0",
+		"import-meta-resolve": "^3.0.0",
 		"svelte-preprocess-import-assets": "^1.0.0"
 	},
 	"devDependencies": {

--- a/packages/image/src/vite-plugin.js
+++ b/packages/image/src/vite-plugin.js
@@ -1,4 +1,5 @@
 import { importAssets } from 'svelte-preprocess-import-assets';
+import { resolve } from 'import-meta-resolve';
 
 /**
  * @template T
@@ -118,7 +119,8 @@ async function imagetools(options) {
 	/** @type {typeof import('vite-imagetools').getMetadata} */
 	let getMetadata;
 	try {
-		({ imagetools, format, resize, getMetadata } = await import('vite-imagetools'));
+		const resolved = resolve('vite-imagetools', '.');
+		({ imagetools, format, resize, getMetadata } = await import(resolved));
 	} catch (err) {
 		return;
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,9 @@ importers:
       esm-env:
         specifier: ^1.0.0
         version: 1.0.0
+      import-meta-resolve:
+        specifier: ^3.0.0
+        version: 3.0.0
       svelte-preprocess-import-assets:
         specifier: ^1.0.0
         version: 1.0.0(svelte@3.56.0)


### PR DESCRIPTION
fixes resolution of `vite-imagetools` — see https://github.com/sveltejs/kit/pull/9787/files#r1183860328