### PR TITLE
reset focus synchronously

### DIFF
--- a/.changeset/tough-masks-judge.md
+++ b/.changeset/tough-masks-judge.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: reset focus synchronously on navigation

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1904,16 +1904,20 @@ function reset_focus() {
 		// capture current selection, so we can compare the state after
 		// snapshot restoration and afterNavigate callbacks have run
 		const selection = getSelection();
+		/** @type {Range[]} */
 		const a = [];
-		for (let i = 0; i < selection.rangeCount; i += 1) {
-			a.push(selection.getRangeAt(i));
+		if (selection) {
+			for (let i = 0; i < selection.rangeCount; i += 1) {
+				a.push(selection.getRangeAt(i));
+			}
 		}
 
 		setTimeout(() => {
 			const after = getSelection();
 
+			if (!after) return;
 			if (after.rangeCount !== a.length) return;
-			for (let i = 0; i < selection.rangeCount; i += 1) {
+			for (let i = 0; i < after.rangeCount; i += 1) {
 				const old_range = a[i];
 				const new_range = after.getRangeAt(i);
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1904,7 +1904,7 @@ function reset_focus() {
 
 		setTimeout(() => {
 			// fixes https://github.com/sveltejs/kit/issues/8439
-			resolve(getSelection()?.removeAllRanges());
+			getSelection()?.removeAllRanges();
 		});
 	}
 }

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1922,11 +1922,15 @@ function reset_focus() {
 
 					// we need to do a deep comparison rather than just `a !== b` because
 					// Safari behaves differently to other browsers
-					if (a.commonAncestorContainer !== b.commonAncestorContainer) return;
-					if (a.startContainer !== b.startContainer) return;
-					if (a.endContainer !== b.endContainer) return;
-					if (a.startOffset !== b.startOffset) return;
-					if (a.endOffset !== b.endOffset) return;
+					if (
+						a.commonAncestorContainer !== b.commonAncestorContainer ||
+						a.startContainer !== b.startContainer ||
+						a.endContainer !== b.endContainer ||
+						a.startOffset !== b.startOffset ||
+						a.endOffset !== b.endOffset
+					) {
+						return;
+					}
 				}
 
 				// if the selection hasn't changed (as a result of an element being (auto)focused,

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1904,35 +1904,28 @@ function reset_focus() {
 		// capture current selection, so we can compare the state after
 		// snapshot restoration and afterNavigate callbacks have run
 		const selection = getSelection();
-		/** @type {Range[]} */
-		const a = [];
-		if (selection) {
+
+		if (selection && selection.type !== 'None') {
+			/** @type {Range[]} */
+			const ranges = [];
+
 			for (let i = 0; i < selection.rangeCount; i += 1) {
-				a.push(selection.getRangeAt(i));
+				ranges.push(selection.getRangeAt(i));
 			}
+
+			setTimeout(() => {
+				if (selection.rangeCount !== ranges.length) return;
+
+				for (let i = 0; i < selection.rangeCount; i += 1) {
+					if (selection.getRangeAt(i) !== ranges[i]) return;
+				}
+
+				// if the selection hasn't changed (as a result of an element being (auto)focused,
+				// or a programmatic selection, we reset everything as part of the navigation)
+				// fixes https://github.com/sveltejs/kit/issues/8439
+				getSelection()?.removeAllRanges();
+			});
 		}
-
-		setTimeout(() => {
-			const after = getSelection();
-
-			if (!after) return;
-			if (after.rangeCount !== a.length) return;
-			for (let i = 0; i < after.rangeCount; i += 1) {
-				const old_range = a[i];
-				const new_range = after.getRangeAt(i);
-
-				if (old_range.commonAncestorContainer !== new_range.commonAncestorContainer) return;
-				if (old_range.startContainer !== new_range.startContainer) return;
-				if (old_range.endContainer !== new_range.endContainer) return;
-				if (old_range.startOffset !== new_range.startOffset) return;
-				if (old_range.endOffset !== new_range.endOffset) return;
-			}
-
-			// if the selection hasn't changed (as a result of an element being (auto)focused,
-			// or a programmatic selection, we reset everything as part of the navigation)
-			// fixes https://github.com/sveltejs/kit/issues/8439
-			getSelection()?.removeAllRanges();
-		});
 	}
 }
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1917,7 +1917,16 @@ function reset_focus() {
 				if (selection.rangeCount !== ranges.length) return;
 
 				for (let i = 0; i < selection.rangeCount; i += 1) {
-					if (selection.getRangeAt(i) !== ranges[i]) return;
+					const a = ranges[i];
+					const b = selection.getRangeAt(i);
+
+					// we need to do a deep comparison rather than just `a !== b` because
+					// Safari behaves differently to other browsers
+					if (a.commonAncestorContainer !== b.commonAncestorContainer) return;
+					if (a.startContainer !== b.startContainer) return;
+					if (a.endContainer !== b.endContainer) return;
+					if (a.startOffset !== b.startOffset) return;
+					if (a.endOffset !== b.endOffset) return;
 				}
 
 				// if the selection hasn't changed (as a result of an element being (auto)focused,

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1902,7 +1902,31 @@ function reset_focus() {
 			root.removeAttribute('tabindex');
 		}
 
+		// capture current selection, so we can compare the state after
+		// snapshot restoration and afterNavigate callbacks have run
+		const selection = getSelection();
+		const a = [];
+		for (let i = 0; i < selection.rangeCount; i += 1) {
+			a.push(selection.getRangeAt(i));
+		}
+
 		setTimeout(() => {
+			const after = getSelection();
+
+			if (after.rangeCount !== a.length) return;
+			for (let i = 0; i < selection.rangeCount; i += 1) {
+				const old_range = a[i];
+				const new_range = after.getRangeAt(i);
+
+				if (old_range.commonAncestorContainer !== new_range.commonAncestorContainer) return;
+				if (old_range.startContainer !== new_range.startContainer) return;
+				if (old_range.endContainer !== new_range.endContainer) return;
+				if (old_range.startOffset !== new_range.startOffset) return;
+				if (old_range.endOffset !== new_range.endOffset) return;
+			}
+
+			// if the selection hasn't changed (as a result of an element being (auto)focused,
+			// or a programmatic selection, we reset everything as part of the navigation)
 			// fixes https://github.com/sveltejs/kit/issues/8439
 			getSelection()?.removeAllRanges();
 		});

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1132,6 +1132,11 @@ export function create_client(app, target) {
 		}
 
 		navigating = false;
+
+		if (type === 'popstate') {
+			restore_snapshot(current_history_index);
+		}
+
 		callbacks.after_navigate.forEach((fn) =>
 			fn(/** @type {import('types').AfterNavigate} */ (navigation))
 		);
@@ -1635,7 +1640,6 @@ export function create_client(app, target) {
 					}
 
 					const delta = event.state[INDEX_KEY] - current_history_index;
-					let blocked = false;
 
 					await navigate({
 						url: new URL(location.href),
@@ -1648,15 +1652,10 @@ export function create_client(app, target) {
 						},
 						blocked: () => {
 							history.go(-delta);
-							blocked = true;
 						},
 						type: 'popstate',
 						delta
 					});
-
-					if (!blocked) {
-						restore_snapshot(current_history_index);
-					}
 				}
 			});
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1923,7 +1923,7 @@ function reset_focus() {
 				// if the selection hasn't changed (as a result of an element being (auto)focused,
 				// or a programmatic selection, we reset everything as part of the navigation)
 				// fixes https://github.com/sveltejs/kit/issues/8439
-				getSelection()?.removeAllRanges();
+				selection.removeAllRanges();
 			});
 		}
 	}

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1902,11 +1902,9 @@ function reset_focus() {
 			root.removeAttribute('tabindex');
 		}
 
-		return new Promise((resolve) => {
-			setTimeout(() => {
-				// fixes https://github.com/sveltejs/kit/issues/8439
-				resolve(getSelection()?.removeAllRanges());
-			});
+		setTimeout(() => {
+			// fixes https://github.com/sveltejs/kit/issues/8439
+			resolve(getSelection()?.removeAllRanges());
 		});
 	}
 }


### PR DESCRIPTION
As of #8466, we wait for a `setTimeout` to complete before navigation can finish. This causes a flash between the page being updated and a subsequent `snapshot.restore(...)`, which feels somewhat janky (scroll positions aren't immediately recovered, etc).

I'm honestly not sure if the tests will pass on all browsers if we just do the `setTimeout` without awaiting its completion, but opening this PR is the easiest way to find out.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
