### PR TITLE
fix: Allow overriding server `fetch` dependency (#9803)

### DIFF
--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -51,7 +51,8 @@ export async function load_server_data({ event, state, node, parent }) {
 				);
 			}
 
-			uses.dependencies.add(url.href);
+			// @ts-expect-error: Property 'svelte' does not exist on type 'RequestInit'.
+			uses.dependencies.add(init?.svelte?.depends ?? url.href);
 
 			return event.fetch(info, init);
 		},

--- a/packages/kit/test/apps/basics/src/routes/load/invalidation/server-fetch/private/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/invalidation/server-fetch/private/+page.server.js
@@ -1,0 +1,11 @@
+/** @type {import('./$types').PageServerLoad} */
+
+import { PRIVATE_STATIC } from '$env/static/private';
+
+export async function load({ fetch }) {
+	return {
+		time: fetch(`http://worldtimeapi.org/api/ip?PRIVATE=${encodeURIComponent(PRIVATE_STATIC)}`, {
+			svelte: { depends: 'app:hidden-time-api' }
+		}).then((res) => res.json())
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/invalidation/server-fetch/private/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/invalidation/server-fetch/private/+page.svelte
@@ -1,0 +1,15 @@
+<script>
+	import { invalidate } from '$app/navigation';
+
+	export let data;
+</script>
+
+<h1>Server Private Fetch</h1>
+
+<p>Time: {new Date(data.time.datetime)}</p>
+
+<p>
+	<button on:click={e => invalidate('app:hidden-time-api')}>
+		Fetch Current Time
+	</button>
+</p>


### PR DESCRIPTION
* Fixes #9803 by allowing custom `fetch` invalidation dependcy in server `load` which prevents default behavior of exposing all (including private) urls to clients.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
