### PR TITLE
feat: Allow bypassing `invalidateAll` in `enhance`

### DIFF
--- a/.changeset/shaggy-trainers-drum.md
+++ b/.changeset/shaggy-trainers-drum.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+[feat] Add `invalidateAll` boolean option to `enhance` callback

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -28,16 +28,24 @@ export function enhance(form, submit = () => {}) {
 	 * @param {{
 	 *   action: URL;
 	 *   result: import('types').ActionResult;
-	 *   reset?: boolean
+	 *   reset?: boolean;
+	 *   invalidateAll?: boolean;
 	 * }} opts
 	 */
-	const fallback_callback = async ({ action, result, reset }) => {
+	const fallback_callback = async ({
+		action,
+		result,
+		reset,
+		invalidateAll: shouldInvalidateAll
+	}) => {
 		if (result.type === 'success') {
 			if (reset !== false) {
 				// We call reset from the prototype to avoid DOM clobbering
 				HTMLFormElement.prototype.reset.call(form);
 			}
-			await invalidateAll();
+			if (shouldInvalidateAll !== false) {
+				await invalidateAll();
+			}
 		}
 
 		// For success/failure results, only apply action if it belongs to the
@@ -112,7 +120,13 @@ export function enhance(form, submit = () => {}) {
 			action,
 			data,
 			form,
-			update: (opts) => fallback_callback({ action, result, reset: opts?.reset }),
+			update: (opts) =>
+				fallback_callback({
+					action,
+					result,
+					reset: opts?.reset,
+					invalidateAll: opts?.invalidateAll
+				}),
 			// @ts-expect-error generic constraints stuff we don't care about
 			result
 		});

--- a/packages/kit/test/apps/basics/src/routes/actions/invalidate-all/+layout.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/invalidate-all/+layout.js
@@ -1,0 +1,5 @@
+export function load() {
+	return {
+		changes_every_load: new Date()
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/actions/invalidate-all/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/invalidate-all/+page.server.js
@@ -1,0 +1,10 @@
+export function load({ url }) {
+	const invalidate_all = url.searchParams.get('invalidate_all') === 'true';
+	return {
+		invalidate_all
+	};
+}
+
+export const actions = {
+	default: () => {}
+};

--- a/packages/kit/test/apps/basics/src/routes/actions/invalidate-all/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/invalidate-all/+page.svelte
@@ -1,0 +1,22 @@
+<script>
+	import { enhance } from '$app/forms';
+
+	export let data;
+
+	/**
+	 * @param {HTMLFormElement} node
+	 */
+	function enhanceWrapper(node) {
+		return enhance(
+			node,
+			() =>
+				({ update }) =>
+					update({ invalidateAll: data.invalidate_all })
+		);
+	}
+</script>
+
+<form method="POST" use:enhanceWrapper>
+	<pre>{data.changes_every_load.toISOString()}</pre>
+	<button type="submit">invalidate</button>
+</form>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -828,6 +828,28 @@ test.describe('Matchers', () => {
 });
 
 test.describe('Actions', () => {
+	test("invalidateAll = false doesn't invalidate all", async ({ page }) => {
+		await page.goto('/actions/invalidate-all?invalidate_all=false');
+		const preSubmitContent = await page.locator('pre').textContent();
+		await page.click('button');
+		// The value that should not change is time-based and might not have the granularity to change
+		// if we don't give it time to
+		await page.waitForTimeout(1000);
+		const postSubmitContent = await page.locator('pre').textContent();
+		expect(preSubmitContent).toBe(postSubmitContent);
+	});
+
+	test('invalidateAll = true does invalidate all', async ({ page }) => {
+		await page.goto('/actions/invalidate-all?invalidate_all=true');
+		const preSubmitContent = await page.locator('pre').textContent();
+		await page.click('button');
+		// The value that should not change is time-based and might not have the granularity to change
+		// if we don't give it time to
+		await page.waitForTimeout(1000);
+		const postSubmitContent = await page.locator('pre').textContent();
+		expect(preSubmitContent).not.toBe(postSubmitContent);
+	});
+
 	test('Error props are returned', async ({ page, javaScriptEnabled }) => {
 		await page.goto('/actions/form-errors');
 		await page.click('button');

--- a/packages/kit/test/apps/dev-only/package.json
+++ b/packages/kit/test/apps/dev-only/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "test-basics",
+	"name": "test-no",
 	"private": true,
 	"version": "0.0.2-next.0",
 	"scripts": {

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -95,7 +95,7 @@ declare module '$app/forms' {
 				 * Call this to get the default behavior of a form submission response.
 				 * @param options Set `reset: false` if you don't want the `<form>` values to be reset after a successful submission.
 				 */
-				update(options?: { reset: boolean }): Promise<void>;
+				update(options?: { reset?: boolean; invalidateAll?: boolean }): Promise<void>;
 		  }) => void)
 	>;
 


### PR DESCRIPTION
Closes #9476.

Adds an `invalidateAll` option to the callback from `enhance`. Setting this option to `false` will cause `enhance` not to skip the invalidation step.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
