### PR TITLE
feat: unshadow `form` and `data` in `enhance`

### DIFF
--- a/.changeset/odd-crews-own.md
+++ b/.changeset/odd-crews-own.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: Unshadow `data` and `form` in `enhance`, warn about future deprecation in dev

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -20,7 +20,7 @@ export function deserialize(result) {
  * @param {string} callLocation
  * @returns void
  */
-function warnOnAccess(oldName, newName, callLocation) {
+function warn_on_access(oldName, newName, callLocation) {
 	if (!DEV) return;
 	// TODO 2.0: Remove this code
 	console.warn(
@@ -97,12 +97,12 @@ export function enhance(formElement, submit = () => {}) {
 				cancel,
 				controller,
 				get data() {
-					warnOnAccess('data', 'formData', 'use:enhance submit function');
+					warn_on_access('data', 'formData', 'use:enhance submit function');
 					return formData;
 				},
 				formData,
 				get form() {
-					warnOnAccess('form', 'formElement', 'use:enhance submit function');
+					warn_on_access('form', 'formElement', 'use:enhance submit function');
 					return formElement;
 				},
 				formElement,
@@ -135,12 +135,12 @@ export function enhance(formElement, submit = () => {}) {
 		callback({
 			action,
 			get data() {
-				warnOnAccess('data', 'formData', 'callback returned from use:enhance submit function');
+				warn_on_access('data', 'formData', 'callback returned from use:enhance submit function');
 				return formData;
 			},
 			formData,
 			get form() {
-				warnOnAccess('form', 'formElement', 'callback returned from use:enhance submit function');
+				warn_on_access('form', 'formElement', 'callback returned from use:enhance submit function');
 				return formElement;
 			},
 			formElement,

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -15,24 +15,24 @@ export function deserialize(result) {
 }
 
 /**
- * @param {string} oldName
- * @param {string} newName
- * @param {string} callLocation
+ * @param {string} old_name
+ * @param {string} new_name
+ * @param {string} call_location
  * @returns void
  */
-function warn_on_access(oldName, newName, callLocation) {
+function warn_on_access(old_name, new_name, call_location) {
 	if (!DEV) return;
 	// TODO 2.0: Remove this code
 	console.warn(
-		`\`${oldName}\` has been deprecated in favor of \`${newName}\`. \`${oldName}\` will be removed in a future version. (Called from ${callLocation})`
+		`\`${old_name}\` has been deprecated in favor of \`${new_name}\`. \`${old_name}\` will be removed in a future version. (Called from ${call_location})`
 	);
 }
 
 /** @type {import('$app/forms').enhance} */
-export function enhance(formElement, submit = () => {}) {
+export function enhance(form_element, submit = () => {}) {
 	if (
 		DEV &&
-		/** @type {HTMLFormElement} */ (HTMLFormElement.prototype.cloneNode.call(formElement))
+		/** @type {HTMLFormElement} */ (HTMLFormElement.prototype.cloneNode.call(form_element))
 			.method !== 'post'
 	) {
 		throw new Error('use:enhance can only be used on <form> fields with method="POST"');
@@ -49,7 +49,7 @@ export function enhance(formElement, submit = () => {}) {
 		if (result.type === 'success') {
 			if (reset !== false) {
 				// We call reset from the prototype to avoid DOM clobbering
-				HTMLFormElement.prototype.reset.call(formElement);
+				HTMLFormElement.prototype.reset.call(form_element);
 			}
 			await invalidateAll();
 		}
@@ -74,15 +74,15 @@ export function enhance(formElement, submit = () => {}) {
 			// We do cloneNode for avoid DOM clobbering - https://github.com/sveltejs/kit/issues/7593
 			event.submitter?.hasAttribute('formaction')
 				? /** @type {HTMLButtonElement | HTMLInputElement} */ (event.submitter).formAction
-				: /** @type {HTMLFormElement} */ (HTMLFormElement.prototype.cloneNode.call(formElement))
+				: /** @type {HTMLFormElement} */ (HTMLFormElement.prototype.cloneNode.call(form_element))
 						.action
 		);
 
-		const formData = new FormData(formElement);
+		const form_data = new FormData(form_element);
 
 		const submitter_name = event.submitter?.getAttribute('name');
 		if (submitter_name) {
-			formData.append(submitter_name, event.submitter?.getAttribute('value') ?? '');
+			form_data.append(submitter_name, event.submitter?.getAttribute('value') ?? '');
 		}
 
 		const controller = new AbortController();
@@ -98,14 +98,14 @@ export function enhance(formElement, submit = () => {}) {
 				controller,
 				get data() {
 					warn_on_access('data', 'formData', 'use:enhance submit function');
-					return formData;
+					return form_data;
 				},
-				formData,
+				formData: form_data,
 				get form() {
 					warn_on_access('form', 'formElement', 'use:enhance submit function');
-					return formElement;
+					return form_element;
 				},
-				formElement,
+				formElement: form_element,
 				submitter: event.submitter
 			})) ?? fallback_callback;
 		if (cancelled) return;
@@ -121,7 +121,7 @@ export function enhance(formElement, submit = () => {}) {
 					'x-sveltekit-action': 'true'
 				},
 				cache: 'no-store',
-				body: formData,
+				body: form_data,
 				signal: controller.signal
 			});
 
@@ -136,14 +136,14 @@ export function enhance(formElement, submit = () => {}) {
 			action,
 			get data() {
 				warn_on_access('data', 'formData', 'callback returned from use:enhance submit function');
-				return formData;
+				return form_data;
 			},
-			formData,
+			formData: form_data,
 			get form() {
 				warn_on_access('form', 'formElement', 'callback returned from use:enhance submit function');
-				return formElement;
+				return form_element;
 			},
-			formElement,
+			formElement: form_element,
 			update: (opts) => fallback_callback({ action, result, reset: opts?.reset }),
 			// @ts-expect-error generic constraints stuff we don't care about
 			result
@@ -151,12 +151,12 @@ export function enhance(formElement, submit = () => {}) {
 	}
 
 	// @ts-expect-error
-	HTMLFormElement.prototype.addEventListener.call(formElement, 'submit', handle_submit);
+	HTMLFormElement.prototype.addEventListener.call(form_element, 'submit', handle_submit);
 
 	return {
 		destroy() {
 			// @ts-expect-error
-			HTMLFormElement.prototype.removeEventListener.call(formElement, 'submit', handle_submit);
+			HTMLFormElement.prototype.removeEventListener.call(form_element, 'submit', handle_submit);
 		}
 	};
 }

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance/old-property-access/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance/old-property-access/+page.server.js
@@ -1,26 +1,26 @@
 // TODO 2.0: Remove this code and corresponding tests
 export const actions = {
-	formSubmit: () => {
+	form_submit: () => {
 		return {
-			formSubmit: true
+			form_submit: true
 		};
 	},
 
-	formCallback: () => {
+	form_callback: () => {
 		return {
-			formCallback: true
+			form_callback: true
 		};
 	},
 
-	dataSubmit: () => {
+	data_submit: () => {
 		return {
-			dataSubmit: true
+			data_submit: true
 		};
 	},
 
-	dataCallback: () => {
+	data_callback: () => {
 		return {
-			dataCallback: true
+			data_callback: true
 		};
 	}
 };

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance/old-property-access/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance/old-property-access/+page.server.js
@@ -1,0 +1,26 @@
+// TODO 2.0: Remove this code and corresponding tests
+export const actions = {
+	formSubmit: () => {
+		return {
+			formSubmit: true
+		};
+	},
+
+	formCallback: () => {
+		return {
+			formCallback: true
+		};
+	},
+
+	dataSubmit: () => {
+		return {
+			dataSubmit: true
+		};
+	},
+
+	dataCallback: () => {
+		return {
+			dataCallback: true
+		};
+	}
+};

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance/old-property-access/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance/old-property-access/+page.svelte
@@ -3,13 +3,13 @@
 
 	export let form;
 
-	const accessFormSubmit = (node) => {
+	const access_form_submit = (node) => {
 		return enhance(node, ({ form }) => {});
 	};
-	const accessDataSubmit = (node) => {
+	const access_data_submit = (node) => {
 		return enhance(node, ({ data }) => {});
 	};
-	const accessFormCallback = (node) => {
+	const access_form_callback = (node) => {
 		return enhance(
 			node,
 			() =>
@@ -17,7 +17,7 @@
 					update()
 		);
 	};
-	const accessDataCallback = (node) => {
+	const access_data_callback = (node) => {
 		return enhance(
 			node,
 			() =>
@@ -27,26 +27,26 @@
 	};
 </script>
 
-<form method="POST" action="?/formSubmit" use:accessFormSubmit>
+<form method="POST" action="?/form_submit" use:access_form_submit>
 	<button id="access-form-in-submit" type="submit"
-		>{form?.formSubmit ? 'processed' : 'not processed'}</button
+		>{form?.form_submit ? 'processed' : 'not processed'}</button
 	>
 </form>
 
-<form method="POST" action="?/dataSubmit" use:accessDataSubmit>
+<form method="POST" action="?/data_submit" use:access_data_submit>
 	<button id="access-data-in-submit" type="submit"
-		>{form?.dataSubmit ? 'processed' : 'not processed'}</button
+		>{form?.data_submit ? 'processed' : 'not processed'}</button
 	>
 </form>
 
-<form method="POST" action="?/formCallback" use:accessFormCallback>
+<form method="POST" action="?/form_callback" use:access_form_callback>
 	<button id="access-form-in-callback" type="submit"
-		>{form?.formCallback ? 'processed' : 'not processed'}</button
+		>{form?.form_callback ? 'processed' : 'not processed'}</button
 	>
 </form>
 
-<form method="POST" action="?/dataCallback" use:accessDataCallback>
+<form method="POST" action="?/data_callback" use:access_data_callback>
 	<button id="access-data-in-callback" type="submit"
-		>{form?.dataCallback ? 'processed' : 'not processed'}</button
+		>{form?.data_callback ? 'processed' : 'not processed'}</button
 	>
 </form>

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance/old-property-access/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance/old-property-access/+page.svelte
@@ -1,0 +1,52 @@
+<script>
+	import { enhance } from '$app/forms';
+
+	export let form;
+
+	const accessFormSubmit = (node) => {
+		return enhance(node, ({ form }) => {});
+	};
+	const accessDataSubmit = (node) => {
+		return enhance(node, ({ data }) => {});
+	};
+	const accessFormCallback = (node) => {
+		return enhance(
+			node,
+			() =>
+				({ form, update }) =>
+					update()
+		);
+	};
+	const accessDataCallback = (node) => {
+		return enhance(
+			node,
+			() =>
+				({ data, update }) =>
+					update()
+		);
+	};
+</script>
+
+<form method="POST" action="?/formSubmit" use:accessFormSubmit>
+	<button id="access-form-in-submit" type="submit"
+		>{form?.formSubmit ? 'processed' : 'not processed'}</button
+	>
+</form>
+
+<form method="POST" action="?/dataSubmit" use:accessDataSubmit>
+	<button id="access-data-in-submit" type="submit"
+		>{form?.dataSubmit ? 'processed' : 'not processed'}</button
+	>
+</form>
+
+<form method="POST" action="?/formCallback" use:accessFormCallback>
+	<button id="access-form-in-callback" type="submit"
+		>{form?.formCallback ? 'processed' : 'not processed'}</button
+	>
+</form>
+
+<form method="POST" action="?/dataCallback" use:accessDataCallback>
+	<button id="access-data-in-callback" type="submit"
+		>{form?.dataCallback ? 'processed' : 'not processed'}</button
+	>
+</form>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -828,30 +828,30 @@ test.describe('Matchers', () => {
 });
 
 test.describe('Actions', () => {
-	for (const { id, oldName, newName, callLocation } of [
+	for (const { id, old_name, new_name, call_location } of [
 		{
 			id: 'access-form-in-submit',
-			oldName: 'form',
-			newName: 'formElement',
-			callLocation: 'use:enhance submit function'
+			old_name: 'form',
+			new_name: 'formElement',
+			call_location: 'use:enhance submit function'
 		},
 		{
 			id: 'access-form-in-callback',
-			oldName: 'form',
-			newName: 'formElement',
-			callLocation: 'callback returned from use:enhance submit function'
+			old_name: 'form',
+			new_name: 'formElement',
+			call_location: 'callback returned from use:enhance submit function'
 		},
 		{
 			id: 'access-data-in-submit',
-			oldName: 'data',
-			newName: 'formData',
-			callLocation: 'use:enhance submit function'
+			old_name: 'data',
+			new_name: 'formData',
+			call_location: 'use:enhance submit function'
 		},
 		{
 			id: 'access-data-in-callback',
-			oldName: 'data',
-			newName: 'formData',
-			callLocation: 'callback returned from use:enhance submit function'
+			old_name: 'data',
+			new_name: 'formData',
+			call_location: 'callback returned from use:enhance submit function'
 		}
 	]) {
 		test(`Accessing v2 deprecated properties results in a warning log, type: ${id}`, async ({
@@ -867,7 +867,7 @@ test.describe('Actions', () => {
 			await button.textContent('processed');
 			const log = await logPromise;
 			expect(log.text()).toBe(
-				`\`${oldName}\` has been deprecated in favor of \`${newName}\`. \`${oldName}\` will be removed in a future version. (Called from ${callLocation})`
+				`\`${old_name}\` has been deprecated in favor of \`${new_name}\`. \`${old_name}\` will be removed in a future version. (Called from ${call_location})`
 			);
 			expect(log.type()).toBe('warning');
 		});

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -828,6 +828,51 @@ test.describe('Matchers', () => {
 });
 
 test.describe('Actions', () => {
+	for (const { id, oldName, newName, callLocation } of [
+		{
+			id: 'access-form-in-submit',
+			oldName: 'form',
+			newName: 'formElement',
+			callLocation: 'use:enhance submit function'
+		},
+		{
+			id: 'access-form-in-callback',
+			oldName: 'form',
+			newName: 'formElement',
+			callLocation: 'callback returned from use:enhance submit function'
+		},
+		{
+			id: 'access-data-in-submit',
+			oldName: 'data',
+			newName: 'formData',
+			callLocation: 'use:enhance submit function'
+		},
+		{
+			id: 'access-data-in-callback',
+			oldName: 'data',
+			newName: 'formData',
+			callLocation: 'callback returned from use:enhance submit function'
+		}
+	]) {
+		test(`Accessing v2 deprecated properties results in a warning log, type: ${id}`, async ({
+			page,
+			javaScriptEnabled
+		}) => {
+			test.skip(!javaScriptEnabled, 'skip when js is disabled');
+			test.skip(!process.env.DEV, 'skip when not in dev mode');
+			await page.goto('/actions/enhance/old-property-access');
+			const logPromise = page.waitForEvent('console');
+			const button = page.locator(`#${id}`);
+			await button.click();
+			await button.textContent('processed');
+			const log = await logPromise;
+			expect(log.text()).toBe(
+				`\`${oldName}\` has been deprecated in favor of \`${newName}\`. \`${oldName}\` will be removed in a future version. (Called from ${callLocation})`
+			);
+			expect(log.type()).toBe('warning');
+		});
+	}
+
 	test('Error props are returned', async ({ page, javaScriptEnabled }) => {
 		await page.goto('/actions/form-errors');
 		await page.click('button');

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -864,7 +864,7 @@ test.describe('Actions', () => {
 			const log_promise = page.waitForEvent('console');
 			const button = page.locator(`#${id}`);
 			await button.click();
-			await button.textContent('processed');
+			expect(await button.textContent()).toBe('processed'); // needed to make sure action completes
 			const log = await log_promise;
 			expect(log.text()).toBe(
 				`\`${old_name}\` has been deprecated in favor of \`${new_name}\`. \`${old_name}\` will be removed in a future version. (Called from ${call_location})`

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -861,11 +861,11 @@ test.describe('Actions', () => {
 			test.skip(!javaScriptEnabled, 'skip when js is disabled');
 			test.skip(!process.env.DEV, 'skip when not in dev mode');
 			await page.goto('/actions/enhance/old-property-access');
-			const logPromise = page.waitForEvent('console');
+			const log_promise = page.waitForEvent('console');
 			const button = page.locator(`#${id}`);
 			await button.click();
 			await button.textContent('processed');
-			const log = await logPromise;
+			const log = await log_promise;
 			expect(log.text()).toBe(
 				`\`${old_name}\` has been deprecated in favor of \`${new_name}\`. \`${old_name}\` will be removed in a future version. (Called from ${call_location})`
 			);

--- a/packages/kit/test/apps/dev-only/package.json
+++ b/packages/kit/test/apps/dev-only/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "test-basics",
+	"name": "fack-off",
 	"private": true,
 	"version": "0.0.2-next.0",
 	"scripts": {

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -80,8 +80,16 @@ declare module '$app/forms' {
 		Invalid extends Record<string, unknown> | undefined = Record<string, any>
 	> = (input: {
 		action: URL;
+		/**
+		 * use `formData` instead of `data`
+		 * @deprecated
+		 */
 		data: FormData;
 		formData: FormData;
+		/**
+		 * use `formElement` instead of `form`
+		 * @deprecated
+		 */
 		form: HTMLFormElement;
 		formElement: HTMLFormElement;
 		controller: AbortController;
@@ -90,8 +98,16 @@ declare module '$app/forms' {
 	}) => MaybePromise<
 		| void
 		| ((opts: {
+				/**
+				 * use `formData` instead of `data`
+				 * @deprecated
+				 */
 				data: FormData;
 				formData: FormData;
+				/**
+				 * use `formElement` instead of `form`
+				 * @deprecated
+				 */
 				form: HTMLFormElement;
 				formElement: HTMLFormElement;
 				action: URL;

--- a/packages/kit/types/ambient.d.ts
+++ b/packages/kit/types/ambient.d.ts
@@ -81,14 +81,19 @@ declare module '$app/forms' {
 	> = (input: {
 		action: URL;
 		data: FormData;
+		formData: FormData;
 		form: HTMLFormElement;
+		formElement: HTMLFormElement;
 		controller: AbortController;
 		cancel(): void;
 		submitter: HTMLElement | null;
 	}) => MaybePromise<
 		| void
 		| ((opts: {
+				data: FormData;
+				formData: FormData;
 				form: HTMLFormElement;
+				formElement: HTMLFormElement;
 				action: URL;
 				result: ActionResult<Success, Invalid>;
 				/**
@@ -108,7 +113,7 @@ declare module '$app/forms' {
 		Success extends Record<string, unknown> | undefined = Record<string, any>,
 		Invalid extends Record<string, unknown> | undefined = Record<string, any>
 	>(
-		form: HTMLFormElement,
+		formElement: HTMLFormElement,
 		/**
 		 * Called upon submission with the given FormData and the `action` that should be triggered.
 		 * If `cancel` is called, the form will not be submitted.


### PR DESCRIPTION
Closes #9845.

Adds a deprecation warning when accessing `data` and `form` in both the `submit` argument to `enhance` _and_ the callback returned from that `submit` argument.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
