### PR TITLE
fix: Don't set defaults when parsing cookies from headers

### DIFF
--- a/.changeset/olive-dogs-bathe.md
+++ b/.changeset/olive-dogs-bathe.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: stop setting Kit cookie defaults on cookies parsed from headers

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -107,42 +107,7 @@ export function get_cookies(request, url, trailing_slash) {
 		 * @param {import('cookie').CookieSerializeOptions} opts
 		 */
 		set(name, value, opts = {}) {
-			return this.set_internal(name, value, { with_defaults: true, ...opts });
-		},
-
-		/**
-		 * @param {string} name
-		 * @param {string} value
-		 * @param {import('cookie').CookieSerializeOptions & { with_defaults?: boolean }} opts
-		 */
-		set_internal(name, value, opts = {}) {
-			let path = opts.path ?? default_path;
-			const with_defaults = opts.with_defaults ?? true;
-
-			new_cookies[name] = {
-				name,
-				value,
-				options: {
-					...(with_defaults ? defaults : {}),
-					...opts,
-					path
-				}
-			};
-
-			if (__SVELTEKIT_DEV__) {
-				const serialized = serialize(name, value, new_cookies[name].options);
-				if (new TextEncoder().encode(serialized).byteLength > MAX_COOKIE_SIZE) {
-					throw new Error(`Cookie "${name}" is too large, and will be discarded by the browser`);
-				}
-
-				cookie_paths[name] ??= new Set();
-
-				if (!value) {
-					cookie_paths[name].delete(path);
-				} else {
-					cookie_paths[name].add(path);
-				}
-			}
+			set_internal(name, value, { ...defaults, ...opts });
 		},
 
 		/**
@@ -203,7 +168,40 @@ export function get_cookies(request, url, trailing_slash) {
 			.join('; ');
 	}
 
-	return { cookies, new_cookies, get_cookie_header };
+	/**
+	 * @param {string} name
+	 * @param {string} value
+	 * @param {import('cookie').CookieSerializeOptions} opts
+	 */
+	function set_internal(name, value, opts) {
+		let path = opts.path ?? default_path;
+
+		new_cookies[name] = {
+			name,
+			value,
+			options: {
+				...opts,
+				path
+			}
+		};
+
+		if (__SVELTEKIT_DEV__) {
+			const serialized = serialize(name, value, new_cookies[name].options);
+			if (new TextEncoder().encode(serialized).byteLength > MAX_COOKIE_SIZE) {
+				throw new Error(`Cookie "${name}" is too large, and will be discarded by the browser`);
+			}
+
+			cookie_paths[name] ??= new Set();
+
+			if (!value) {
+				cookie_paths[name].delete(path);
+			} else {
+				cookie_paths[name].add(path);
+			}
+		}
+	}
+
+	return { cookies, new_cookies, get_cookie_header, set_internal };
 }
 
 /**

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -107,13 +107,23 @@ export function get_cookies(request, url, trailing_slash) {
 		 * @param {import('cookie').CookieSerializeOptions} opts
 		 */
 		set(name, value, opts = {}) {
+			return this.set_internal(name, value, { with_defaults: true, ...opts });
+		},
+
+		/**
+		 * @param {string} name
+		 * @param {string} value
+		 * @param {import('cookie').CookieSerializeOptions & { with_defaults?: boolean }} opts
+		 */
+		set_internal(name, value, opts = {}) {
 			let path = opts.path ?? default_path;
+			const with_defaults = opts.with_defaults ?? true;
 
 			new_cookies[name] = {
 				name,
 				value,
 				options: {
-					...defaults,
+					...(with_defaults ? defaults : {}),
 					...opts,
 					path
 				}

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -195,4 +195,19 @@ test('get all cookies from header and set calls', () => {
 	]);
 });
 
+test("set_internal isn't affected by defaults", () => {
+	const { cookies, new_cookies, set_internal } = cookies_setup({
+		href: 'https://example.com/a/b/c'
+	});
+	const options = /** @type {const} */ ({
+		secure: false,
+		httpOnly: false,
+		sameSite: 'none',
+		path: '/a/b/c'
+	});
+	set_internal('test', 'foo', options);
+	assert.equal(cookies.get('test'), 'foo');
+	assert.equal(new_cookies['test']?.options, options);
+});
+
 test.run();

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -131,11 +131,10 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 						const { name, value, ...options } = set_cookie_parser.parseString(str);
 
 						// options.sameSite is string, something more specific is required - type cast is safe
-						event.cookies.set(
-							name,
-							value,
-							/** @type {import('cookie').CookieSerializeOptions} */ (options)
-						);
+						event.cookies.set_internal(name, value, {
+							with_defaults: false,
+							.../** @type {import('cookie').CookieSerializeOptions} */ (options)
+						});
 					}
 				}
 

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -132,9 +132,11 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 						const { name, value, ...options } = set_cookie_parser.parseString(str);
 
 						// options.sameSite is string, something more specific is required - type cast is safe
-						set_internal(name, value, {
-							.../** @type {import('cookie').CookieSerializeOptions} */ (options)
-						});
+						set_internal(
+							name,
+							value,
+							/** @type {import('cookie').CookieSerializeOptions} */ (options)
+						);
 					}
 				}
 

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -9,10 +9,11 @@ import * as paths from '__sveltekit/paths';
  *   manifest: import('types').SSRManifest;
  *   state: import('types').SSRState;
  *   get_cookie_header: (url: URL, header: string | null) => string;
+ *   set_internal: (name: string, value: string, opts: import('cookie').CookieSerializeOptions) => void;
  * }} opts
  * @returns {typeof fetch}
  */
-export function create_fetch({ event, options, manifest, state, get_cookie_header }) {
+export function create_fetch({ event, options, manifest, state, get_cookie_header, set_internal }) {
 	return async (info, init) => {
 		const original_request = normalize_fetch_input(info, init, event.url);
 
@@ -131,8 +132,7 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 						const { name, value, ...options } = set_cookie_parser.parseString(str);
 
 						// options.sameSite is string, something more specific is required - type cast is safe
-						event.cookies.set_internal(name, value, {
-							with_defaults: false,
+						set_internal(name, value, {
 							.../** @type {import('cookie').CookieSerializeOptions} */ (options)
 						});
 					}

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -244,7 +244,7 @@ export async function respond(request, options, manifest, state) {
 			}
 		}
 
-		const { cookies, new_cookies, get_cookie_header } = get_cookies(
+		const { cookies, new_cookies, get_cookie_header, set_internal } = get_cookies(
 			request,
 			url,
 			trailing_slash ?? 'never'
@@ -252,7 +252,14 @@ export async function respond(request, options, manifest, state) {
 
 		cookies_to_add = new_cookies;
 		event.cookies = cookies;
-		event.fetch = create_fetch({ event, options, manifest, state, get_cookie_header });
+		event.fetch = create_fetch({
+			event,
+			options,
+			manifest,
+			state,
+			get_cookie_header,
+			set_internal
+		});
 
 		if (state.prerendering && !state.prerendering.fallback) disable_search(url);
 


### PR DESCRIPTION
Closes #9901 

Bypasses setting Kit defaults on cookies parsed from fetch response headers. To illustrate what the problem was:

- Set a cookie in `+server.ts`: `cookies.set('foo', 'bar', { httpOnly: false })`
- `fetch` this endpoint from `+page.server.ts`
- As part of `fetch`, parse the cookies from the headers
- `httpOnly` isn't set (because `false === unset`)
- Adding this cookie to the cookies causes the default `httpOnly: true` to be added

The better solution here is not to apply defaults to cookies we parse from fetch response headers. _If_ these cookies were set through `cookies.set` in a `+server.ts` endpoint, we've already set the defaults, and if they're not, we shouldn't touch them anyway.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
