### PR TITLE
feat: prerender & analyse in worker rather than subprocess to support Deno

### DIFF
--- a/.changeset/hot-actors-hope.md
+++ b/.changeset/hot-actors-hope.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+feat: prerender in worker rather than subprocess to support Deno

--- a/packages/kit/src/utils/fork.js
+++ b/packages/kit/src/utils/fork.js
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url';
-import child_process from 'node:child_process';
+import { Worker, isMainThread, parentPort } from 'node:worker_threads';
 
 /**
  * Runs a task in a subprocess so any dangling stuff gets killed upon completion.
@@ -11,23 +11,21 @@ import child_process from 'node:child_process';
  * @returns {(opts: T) => Promise<U>} A function that when called starts the subprocess
  */
 export function forked(module, callback) {
-	if (process.env.SVELTEKIT_FORK && process.send) {
-		process.send({ type: 'ready', module });
-
-		process.on(
+	if (!isMainThread && parentPort) {
+		parentPort.on(
 			'message',
 			/** @param {any} data */ async (data) => {
 				if (data?.type === 'args' && data.module === module) {
-					if (process.send) {
-						process.send({
-							type: 'result',
-							module,
-							payload: await callback(data.payload)
-						});
-					}
+					parentPort?.postMessage({
+						type: 'result',
+						module,
+						payload: await callback(data.payload)
+					});
 				}
 			}
 		);
+
+		parentPort.postMessage({ type: 'ready', module });
 	}
 
 	/**
@@ -36,20 +34,17 @@ export function forked(module, callback) {
 	 */
 	const fn = function (opts) {
 		return new Promise((fulfil, reject) => {
-			const child = child_process.fork(fileURLToPath(module), {
-				stdio: 'inherit',
+			const worker = new Worker(fileURLToPath(module), {
 				env: {
-					...process.env,
-					SVELTEKIT_FORK: 'true'
-				},
-				serialization: 'advanced'
+					...process.env
+				}
 			});
 
-			child.on(
+			worker.on(
 				'message',
-				/** @param {any} data */ (data) => {
+				/** @param {any} data */ async (data) => {
 					if (data?.type === 'ready' && data.module === module) {
-						child.send({
+						worker.postMessage({
 							type: 'args',
 							module,
 							payload: opts
@@ -57,13 +52,13 @@ export function forked(module, callback) {
 					}
 
 					if (data?.type === 'result' && data.module === module) {
-						child.kill();
+						worker.terminate();
 						fulfil(data.payload);
 					}
 				}
 			);
 
-			child.on('exit', (code) => {
+			worker.on('exit', (code) => {
 				if (code) {
 					reject(new Error(`Failed with code ${code}`));
 				}

--- a/packages/kit/src/utils/fork.js
+++ b/packages/kit/src/utils/fork.js
@@ -42,7 +42,7 @@ export function forked(module, callback) {
 
 			worker.on(
 				'message',
-				/** @param {any} data */ async (data) => {
+				/** @param {any} data */ (data) => {
 					if (data?.type === 'ready' && data.module === module) {
 						worker.postMessage({
 							type: 'args',


### PR DESCRIPTION
use `workers` instead of `child_process`

related:
https://github.com/denoland/deno/issues/17248

@benmccann would you be able to review this PR?