### PR TITLE
fix: use conditional chaining for page.error.message

### DIFF
--- a/documentation/docs/20-core-concepts/10-routing.md
+++ b/documentation/docs/20-core-concepts/10-routing.md
@@ -124,7 +124,7 @@ If an error occurs during `load`, SvelteKit will render a default error page. Yo
 	import { page } from '$app/stores';
 </script>
 
-<h1>{$page.status}: {$page.error.message}</h1>
+<h1>{$page.status}: {$page.error?.message}</h1>
 ```
 
 SvelteKit will 'walk up the tree' looking for the closest error boundary — if the file above didn't exist it would try `src/routes/blog/+error.svelte` and then `src/routes/+error.svelte` before rendering the default error page. If _that_ fails (or if the error was thrown from the `load` function of the root `+layout`, which sits 'above' the root `+error`), SvelteKit will bail out and render a static fallback error page, which you can customise by creating a `src/error.html` file.

--- a/documentation/docs/30-advanced/25-errors.md
+++ b/documentation/docs/30-advanced/25-errors.md
@@ -48,7 +48,7 @@ This tells SvelteKit to set the response status code to 404 and render an [`+err
 	import { page } from '$app/stores';
 </script>
 
-<h1>{$page.error.message}</h1>
+<h1>{$page.error?.message}</h1>
 ```
 
 You can add extra properties to the error object if needed...

--- a/packages/kit/test/apps/basics/src/routes/+error.svelte
+++ b/packages/kit/test/apps/basics/src/routes/+error.svelte
@@ -3,12 +3,12 @@
 </script>
 
 <svelte:head>
-	<title>Custom error page: {$page.error.message}</title>
+	<title>Custom error page: {$page.error?.message}</title>
 </svelte:head>
 
 <h1>{$page.status}</h1>
 
-<p id="message">This is your custom error page saying: "<b>{$page.error.message}</b>"</p>
+<p id="message">This is your custom error page saying: "<b>{$page.error?.message}</b>"</p>
 
 <style>
 	h1,

--- a/packages/kit/test/apps/basics/src/routes/errors/nested-error-page/+error.svelte
+++ b/packages/kit/test/apps/basics/src/routes/errors/nested-error-page/+error.svelte
@@ -6,7 +6,7 @@
 
 <h1>Nested error page</h1>
 <p id="nested-error-status">status: {$page.status}</p>
-<p id="nested-error-message">error.message: {$page.error && $page.error.message}</p>
+<p id="nested-error-message">error.message: {$page.error && $page.error?.message}</p>
 <p id="nested-error-loaded">answer: {answer}</p>
 
 <style>

--- a/packages/kit/test/apps/basics/src/routes/nested-layout/foo/bar/+error.svelte
+++ b/packages/kit/test/apps/basics/src/routes/nested-layout/foo/bar/+error.svelte
@@ -4,7 +4,7 @@
 
 <h1>Nested error page</h1>
 <p id="nested-error-status">status: {$page.status}</p>
-<p id="nested-error-message">error.message: {$page.error.message}</p>
+<p id="nested-error-message">error.message: {$page.error?.message}</p>
 
 <style>
 	h1 {

--- a/packages/kit/test/apps/basics/src/routes/prerendering/+error.svelte
+++ b/packages/kit/test/apps/basics/src/routes/prerendering/+error.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { page } from '$app/stores';
 
-	$: title = `${$page.status}: ${$page.error.message}`;
+	$: title = `${$page.status}: ${$page.error?.message}`;
 </script>
 
 <h1>{title}</h1>

--- a/packages/kit/test/apps/dev-only/src/routes/+error.svelte
+++ b/packages/kit/test/apps/dev-only/src/routes/+error.svelte
@@ -2,4 +2,4 @@
 	import { page } from '$app/stores';
 </script>
 
-<pre>{$page.error.message}</pre>
+<pre>{$page.error?.message}</pre>

--- a/sites/kit.svelte.dev/src/routes/+error.svelte
+++ b/sites/kit.svelte.dev/src/routes/+error.svelte
@@ -16,7 +16,7 @@
 	{:else if online}
 		<h1>Yikes!</h1>
 
-		{#if $page.error.message}
+		{#if $page.error?.message}
 			<p class="error">{$page.status}: {$page.error.message}</p>
 		{/if}
 


### PR DESCRIPTION
The types for the `page.error` allow it to be null, which causes ESLint warnings if conditional chaining is not used. (My SvelteKit project uses JavaScript with JSDoc comments.) I updated all instances to use conditional chaining where required. 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.