### PR TITLE
fix: Set loader: { '.wasm': 'copy' } in esbuild config in `adapter-cloudflare-workers`

### DIFF
--- a/.changeset/brave-peaches-buy.md
+++ b/.changeset/brave-peaches-buy.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-cloudflare-workers": patch
+---
+
+fix: Copy .wasm files during build

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -64,9 +64,9 @@ export default function ({ config = 'wrangler.toml' } = {}) {
 				bundle: true,
 				external: ['__STATIC_CONTENT_MANIFEST'],
 				format: 'esm',
- 				loader: {
- 					'.wasm': 'copy'
- 				}
+				loader: {
+					'.wasm': 'copy'
+				}
 			});
 
 			builder.log.minor('Copying assets...');

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -64,7 +64,6 @@ export default function ({ config = 'wrangler.toml' } = {}) {
 				bundle: true,
 				external: ['__STATIC_CONTENT_MANIFEST'],
 				format: 'esm',
-				bundle: true,
  				loader: {
  					'.wasm': 'copy'
  				}

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -63,7 +63,11 @@ export default function ({ config = 'wrangler.toml' } = {}) {
 				outfile: main,
 				bundle: true,
 				external: ['__STATIC_CONTENT_MANIFEST'],
-				format: 'esm'
+				format: 'esm',
+				bundle: true,
+ 				loader: {
+ 					'.wasm': 'copy'
+ 				}
 			});
 
 			builder.log.minor('Copying assets...');


### PR DESCRIPTION
Copies WASM files in Cloudflare instead of trying to load them.

Related to #9909

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
