### PR TITLE
avoid using `isMainThread`, since it interacts poorly with vitest

### DIFF
--- a/packages/kit/src/utils/fork.js
+++ b/packages/kit/src/utils/fork.js
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url';
-import { Worker, isMainThread, parentPort } from 'node:worker_threads';
+import { Worker, parentPort } from 'node:worker_threads';
 
 /**
  * Runs a task in a subprocess so any dangling stuff gets killed upon completion.
@@ -11,7 +11,7 @@ import { Worker, isMainThread, parentPort } from 'node:worker_threads';
  * @returns {(opts: T) => Promise<U>} A function that when called starts the subprocess
  */
 export function forked(module, callback) {
-	if (!isMainThread && parentPort) {
+	if (process.env.SVELTEKIT_FORK && parentPort) {
 		parentPort.on(
 			'message',
 			/** @param {any} data */ async (data) => {
@@ -36,7 +36,8 @@ export function forked(module, callback) {
 		return new Promise((fulfil, reject) => {
 			const worker = new Worker(fileURLToPath(module), {
 				env: {
-					...process.env
+					...process.env,
+					SVELTEKIT_FORK: 'true'
 				}
 			});
 


### PR DESCRIPTION
#9919 and #9899 don't work in combination, because Vitest defaults to running everything in a worker thread (https://github.com/vitest-dev/vitest/issues/2882), causing `isMainThread` to have the wrong value.

The easiest way to fix this is to use the previous mechanism for detecting whether we're in the 'main' thread or not — an environment variable that we control.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
