### PR TITLE
remove `envVarsInUse`

### DIFF
--- a/.changeset/fast-dancers-grab.md
+++ b/.changeset/fast-dancers-grab.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': major
+---
+
+breaking: remove obsolete `envVarsInUse` option

--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -54,8 +54,7 @@ The following options apply to all functions:
 - `regions`: an array of [edge network regions](https://vercel.com/docs/concepts/edge-network/regions) (defaulting to `["iad1"]` for serverless functions) or `'all'` if `runtime` is `edge` (its default). Note that multiple regions for serverless functions are only supported on Enterprise plans
 - `split`: if `true`, causes a route to be deployed as an individual function. If `split` is set to `true` at the adapter level, all routes will be deployed as individual functions
 
-Additionally, the following options apply to edge functions:
-- `envVarsInUse`: an array of environment variables that should be accessible inside the edge function
+Additionally, the following option applies to edge functions:
 - `external`: an array of dependencies that esbuild should treat as external when bundling functions. This should only be used to exclude optional dependencies that will not run outside Node
 
 And the following option apply to serverless functions:
@@ -130,7 +129,7 @@ export function load() {
 <p>This staging environment was deployed from {data.deploymentGitBranch}.</p>
 ```
 
-Since all of these variables are unchanged between build time and run time when building on Vercel, we recommend using `$env/static/private` — which will statically replace the variables, enabling optimisations like dead code elimination — rather than `$env/dynamic/private`. If you're deploying with `edge: true` you must either use `$env/static/private` or populate the `envVarsInUse` configuration.
+Since all of these variables are unchanged between build time and run time when building on Vercel, we recommend using `$env/static/private` — which will statically replace the variables, enabling optimisations like dead code elimination — rather than `$env/dynamic/private`.
 
 ## Notes
 

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -64,11 +64,6 @@ export interface EdgeConfig {
 	 */
 	regions?: string[] | 'all';
 	/**
-	 * List of environment variable names that will be available for the Edge Function to utilize.
-	 * Edge only.
-	 */
-	envVarsInUse?: string[];
-	/**
 	 * List of packages that should not be bundled into the Edge Function.
 	 * Edge only.
 	 */

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -96,13 +96,6 @@ const plugin = function (defaults = {}) {
 				const tmp = builder.getBuildDirectory(`vercel-tmp/${name}`);
 				const relativePath = path.posix.relative(tmp, builder.getServerDirectory());
 
-				const envVarsInUse = new Set();
-				routes.forEach((route) => {
-					route.config?.envVarsInUse?.forEach((x) => {
-						envVarsInUse.add(x);
-					});
-				});
-
 				builder.copy(`${files}/edge.js`, `${tmp}/edge.js`, {
 					replace: {
 						SERVER: `${relativePath}/index.js`,
@@ -133,7 +126,6 @@ const plugin = function (defaults = {}) {
 						{
 							runtime: config.runtime,
 							regions: config.regions,
-							envVarsInUse: [...envVarsInUse],
 							entrypoint: 'index.js'
 						},
 						null,


### PR DESCRIPTION
Until today, it was necessary to specify which environment variables were needed inside a Vercel edge function, unless it could determine them statically (by detecting use of `process.env.<SOMETHING>`). That restriction has been removed, which means `$env/dynamic/private` and `$env/dynamic/public` will work the same on Vercel as on other platforms.

Marked this as a breaking change, since projects that currently use `envVarsInUse` will experience typechecking errors if they've set it up correctly.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
