### PR TITLE
fix: Set `loader: { '.wasm': 'copy' }` in esbuild config in `adapter-vercel`

### DIFF
--- a/.changeset/olive-rings-eat.md
+++ b/.changeset/olive-rings-eat.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-vercel": patch
+---
+
+fix: Copy .wasm files during build

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -124,7 +124,10 @@ const plugin = function (defaults = {}) {
 					format: 'esm',
 					external: config.external,
 					sourcemap: 'linked',
-					banner: { js: 'globalThis.global = globalThis;' }
+					banner: { js: 'globalThis.global = globalThis;' },
+					loader: {
+						'.wasm': 'copy'
+					}
 				});
 
 				write(


### PR DESCRIPTION
Copies WASM files on Vercel instead of trying to load them.

Related to https://github.com/sveltejs/kit/pull/9909, fixes #9930

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
