### PR TITLE
security: Stop automatically adding URLs from server-side `load` `fetch` calls to dependencies

### DIFF
--- a/.changeset/shaggy-moons-sort.md
+++ b/.changeset/shaggy-moons-sort.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+security: Stop implicitly tracking URLs as dependencies in server-side `load`s

--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -537,7 +537,7 @@ Dependency tracking does not apply _after_ the `load` function has returned — 
 
 ### Manual invalidation
 
-You can also re-run `load` functions that apply to the current page using [`invalidate(url)`](modules#$app-navigation-invalidate), which re-runs all `load` functions that depend on `url`, and [`invalidateAll()`](modules#$app-navigation-invalidateall), which re-runs every `load` function.
+You can also re-run `load` functions that apply to the current page using [`invalidate(url)`](modules#$app-navigation-invalidate), which re-runs all `load` functions that depend on `url`, and [`invalidateAll()`](modules#$app-navigation-invalidateall), which re-runs every `load` function. Server load functions will never automatically depend on a fetched `url` to avoid leaking secrets to the client.
 
 A `load` function depends on `url` if it calls `fetch(url)` or `depends(url)`. Note that `url` can be a custom identifier that starts with `[a-z]:`:
 
@@ -585,7 +585,7 @@ To summarize, a `load` function will re-run in the following situations:
 - It references a property of `params` whose value has changed
 - It references a property of `url` (such as `url.pathname` or `url.search`) whose value has changed. Properties in `request.url` are _not_ tracked
 - It calls `await parent()` and a parent `load` function re-ran
-- It declared a dependency on a specific URL via [`fetch`](#making-fetch-requests) or [`depends`](types#public-types-loadevent), and that URL was marked invalid with [`invalidate(url)`](modules#$app-navigation-invalidate)
+- It declared a dependency on a specific URL via [`fetch`](#making-fetch-requests) (universal load only) or [`depends`](types#public-types-loadevent), and that URL was marked invalid with [`invalidate(url)`](modules#$app-navigation-invalidate)
 - All active `load` functions were forcibly re-run with [`invalidateAll()`](modules#$app-navigation-invalidateall)
 
 `params` and `url` can change in response to a `<a href="..">` link click, a [`<form>` interaction](form-actions#get-vs-post), a [`goto`](modules#$app-navigation-goto) invocation, or a [`redirect`](modules#sveltejs-kit-redirect).

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -70,7 +70,7 @@ const get_defaults = (prefix = '') => ({
 			checkOrigin: true
 		},
 		dangerZone: {
-			trackServerFetchesPotentiallyExposingSecrets: false
+			trackServerFetches: false
 		},
 		embedded: false,
 		env: {

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -69,6 +69,9 @@ const get_defaults = (prefix = '') => ({
 		csrf: {
 			checkOrigin: true
 		},
+		dangerZone: {
+			trackServerFetchesPotentiallyExposingSecrets: false
+		},
 		embedded: false,
 		env: {
 			dir: process.cwd(),

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -112,6 +112,7 @@ const options = object(
 			}),
 
 			dangerZone: object({
+				// TODO 2.0: Remove this
 				trackServerFetchesPotentiallyExposingSecrets: boolean(false)
 			}),
 

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -113,7 +113,7 @@ const options = object(
 
 			dangerZone: object({
 				// TODO 2.0: Remove this
-				trackServerFetchesPotentiallyExposingSecrets: boolean(false)
+				trackServerFetches: boolean(false)
 			}),
 
 			embedded: boolean(false),

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -111,6 +111,10 @@ const options = object(
 				checkOrigin: boolean(true)
 			}),
 
+			dangerZone: object({
+				trackServerFetchesPotentiallyExposingSecrets: boolean(false)
+			}),
+
 			embedded: boolean(false),
 
 			env: object({

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -36,7 +36,7 @@ export const options = {
 	csrf_check_origin: ${s(config.kit.csrf.checkOrigin)},
 	track_server_fetches_potentially_exposing_secrets: ${s(
 		config.kit.dangerZone.trackServerFetchesPotentiallyExposingSecrets
-	)}
+	)},
 	embedded: ${config.kit.embedded},
 	env_public_prefix: '${config.kit.env.publicPrefix}',
 	hooks: null, // added lazily, via \`get_hooks\`

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -34,9 +34,7 @@ export const options = {
 	app_template_contains_nonce: ${template.includes('%sveltekit.nonce%')},
 	csp: ${s(config.kit.csp)},
 	csrf_check_origin: ${s(config.kit.csrf.checkOrigin)},
-	track_server_fetches_potentially_exposing_secrets: ${s(
-		config.kit.dangerZone.trackServerFetchesPotentiallyExposingSecrets
-	)},
+	track_server_fetches: ${s(config.kit.dangerZone.trackServerFetches)},
 	embedded: ${config.kit.embedded},
 	env_public_prefix: '${config.kit.env.publicPrefix}',
 	hooks: null, // added lazily, via \`get_hooks\`

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -34,6 +34,9 @@ export const options = {
 	app_template_contains_nonce: ${template.includes('%sveltekit.nonce%')},
 	csp: ${s(config.kit.csp)},
 	csrf_check_origin: ${s(config.kit.csrf.checkOrigin)},
+	track_server_fetches_potentially_exposing_secrets: ${s(
+		config.kit.dangerZone.trackServerFetchesPotentiallyExposingSecrets
+	)}
 	embedded: ${config.kit.embedded},
 	env_public_prefix: '${config.kit.env.publicPrefix}',
 	hooks: null, // added lazily, via \`get_hooks\`

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -76,7 +76,9 @@ export async function render_data(
 								}
 							}
 							return data;
-						}
+						},
+						track_server_fetches_potentially_exposing_secrets:
+							options.track_server_fetches_potentially_exposing_secrets
 					});
 				} catch (e) {
 					aborted = true;

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -77,8 +77,7 @@ export async function render_data(
 							}
 							return data;
 						},
-						track_server_fetches_potentially_exposing_secrets:
-							options.track_server_fetches_potentially_exposing_secrets
+						track_server_fetches: options.track_server_fetches
 					});
 				} catch (e) {
 					aborted = true;

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -151,8 +151,7 @@ export async function render_page(event, page, options, manifest, state, resolve
 							}
 							return data;
 						},
-						track_server_fetches_potentially_exposing_secrets:
-							options.track_server_fetches_potentially_exposing_secrets
+						track_server_fetches: options.track_server_fetches
 					});
 				} catch (e) {
 					load_error = /** @type {Error} */ (e);

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -150,7 +150,9 @@ export async function render_page(event, page, options, manifest, state, resolve
 								if (parent) Object.assign(data, await parent.data);
 							}
 							return data;
-						}
+						},
+						track_server_fetches_potentially_exposing_secrets:
+							options.track_server_fetches_potentially_exposing_secrets
 					});
 				} catch (e) {
 					load_error = /** @type {Error} */ (e);

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -211,9 +211,11 @@ export function create_universal_fetch(event, state, fetched, csr, resolve_opts)
 		/** @type {import('types').PrerenderDependency} */
 		let dependency;
 
-		if (same_origin && state.prerendering) {
-			dependency = { response, body: null };
-			state.prerendering.dependencies.set(url.pathname, dependency);
+		if (same_origin) {
+			if (state.prerendering) {
+				dependency = { response, body: null };
+				state.prerendering.dependencies.set(url.pathname, dependency);
+			}
 		} else {
 			// simulate CORS errors and "no access to body in no-cors mode" server-side for consistency with client-side behaviour
 			const mode = input instanceof Request ? input.mode : init?.mode ?? 'cors';

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -10,7 +10,7 @@ import { validate_depends } from '../../shared.js';
  *   state: import('types').SSRState;
  *   node: import('types').SSRNode | undefined;
  *   parent: () => Promise<Record<string, any>>;
- *   track_server_fetches_potentially_exposing_secrets: boolean;
+ *   track_server_fetches: boolean;
  * }} opts
  * @returns {Promise<import('types').ServerDataNode | null>}
  */
@@ -20,7 +20,7 @@ export async function load_server_data({
 	node,
 	parent,
 	// TODO 2.0: Remove this
-	track_server_fetches_potentially_exposing_secrets
+	track_server_fetches
 }) {
 	if (!node?.server) return null;
 
@@ -60,7 +60,7 @@ export async function load_server_data({
 			}
 
 			// TODO 2.0: Remove this
-			if (track_server_fetches_potentially_exposing_secrets) {
+			if (track_server_fetches) {
 				uses.dependencies.add(url.href);
 			}
 

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -10,10 +10,18 @@ import { validate_depends } from '../../shared.js';
  *   state: import('types').SSRState;
  *   node: import('types').SSRNode | undefined;
  *   parent: () => Promise<Record<string, any>>;
+ *   track_server_fetches_potentially_exposing_secrets: boolean;
  * }} opts
  * @returns {Promise<import('types').ServerDataNode | null>}
  */
-export async function load_server_data({ event, state, node, parent }) {
+export async function load_server_data({
+	event,
+	state,
+	node,
+	parent,
+	// TODO 2.0: Remove this
+	track_server_fetches_potentially_exposing_secrets
+}) {
 	if (!node?.server) return null;
 
 	let done = false;
@@ -51,7 +59,10 @@ export async function load_server_data({ event, state, node, parent }) {
 				);
 			}
 
-			uses.dependencies.add(url.href);
+			// TODO 2.0: Remove this
+			if (track_server_fetches_potentially_exposing_secrets) {
+				uses.dependencies.add(url.href);
+			}
 
 			return event.fetch(info, init);
 		},
@@ -200,11 +211,9 @@ export function create_universal_fetch(event, state, fetched, csr, resolve_opts)
 		/** @type {import('types').PrerenderDependency} */
 		let dependency;
 
-		if (same_origin) {
-			if (state.prerendering) {
-				dependency = { response, body: null };
-				state.prerendering.dependencies.set(url.pathname, dependency);
-			}
+		if (same_origin && state.prerendering) {
+			dependency = { response, body: null };
+			state.prerendering.dependencies.set(url.pathname, dependency);
 		} else {
 			// simulate CORS errors and "no access to body in no-cors mode" server-side for consistency with client-side behaviour
 			const mode = input instanceof Request ? input.mode : init?.mode ?? 'cors';

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -44,7 +44,9 @@ export async function respond_with_error({
 				event,
 				state,
 				node: default_layout,
-				parent: async () => ({})
+				parent: async () => ({}),
+				track_server_fetches_potentially_exposing_secrets:
+					options.track_server_fetches_potentially_exposing_secrets
 			});
 
 			const server_data = await server_data_promise;

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -45,8 +45,7 @@ export async function respond_with_error({
 				state,
 				node: default_layout,
 				parent: async () => ({}),
-				track_server_fetches_potentially_exposing_secrets:
-					options.track_server_fetches_potentially_exposing_secrets
+				track_server_fetches: options.track_server_fetches
 			});
 
 			const server_data = await server_data_promise;

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -457,7 +457,7 @@ test.describe('Invalidation', () => {
 	});
 
 	test('fetch in server load cannot be invalidated', async ({ page, app, request }) => {
-		// TODO 2.0: Can remove this test after `dangerZone.trackServerFetchesPotentiallyExposingSecrets` and associated code is removed
+		// TODO 2.0: Can remove this test after `dangerZone.trackServerFetches` and associated code is removed
 		await request.get('/load/invalidation/server-fetch/count.json?reset');
 		await page.goto('/load/invalidation/server-fetch');
 		const selector = '[data-testid="count"]';

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -456,14 +456,15 @@ test.describe('Invalidation', () => {
 		expect(shared).not.toBe(next_shared);
 	});
 
-	test('fetch in server load can be invalidated', async ({ page, app, request }) => {
+	test('fetch in server load cannot be invalidated', async ({ page, app, request }) => {
+		// TODO 2.0: Can remove this test after `dangerZone.trackServerFetchesPotentiallyExposingSecrets` and associated code is removed
 		await request.get('/load/invalidation/server-fetch/count.json?reset');
 		await page.goto('/load/invalidation/server-fetch');
 		const selector = '[data-testid="count"]';
 
 		expect(await page.textContent(selector)).toBe('1');
 		await app.invalidate('/load/invalidation/server-fetch/count.json');
-		expect(await page.textContent(selector)).toBe('2');
+		expect(await page.textContent(selector)).toBe('1');
 	});
 
 	test('+layout.js is re-run when shared dep is invalidated', async ({ page }) => {

--- a/packages/kit/test/apps/options/source/pages/server-fetch-invalidate/+page.server.js
+++ b/packages/kit/test/apps/options/source/pages/server-fetch-invalidate/+page.server.js
@@ -1,0 +1,5 @@
+/** @type {import('./$types').PageServerLoad} */
+export async function load({ fetch }) {
+	const res = await fetch('/load/invalidation/server-fetch/count.json');
+	return res.json();
+}

--- a/packages/kit/test/apps/options/source/pages/server-fetch-invalidate/+page.server.js
+++ b/packages/kit/test/apps/options/source/pages/server-fetch-invalidate/+page.server.js
@@ -1,5 +1,6 @@
+// TODO 2.0: Delete
 /** @type {import('./$types').PageServerLoad} */
 export async function load({ fetch }) {
-	const res = await fetch('/load/invalidation/server-fetch/count.json');
+	const res = await fetch('/path-base/server-fetch-invalidate/count.json');
 	return res.json();
 }

--- a/packages/kit/test/apps/options/source/pages/server-fetch-invalidate/+page.svelte
+++ b/packages/kit/test/apps/options/source/pages/server-fetch-invalidate/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let data;
+</script>
+
+<p data-testid="count">{data.count}</p>

--- a/packages/kit/test/apps/options/source/pages/server-fetch-invalidate/+page.svelte
+++ b/packages/kit/test/apps/options/source/pages/server-fetch-invalidate/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	// TODO 2.0: Delete
 	export let data;
 </script>
 

--- a/packages/kit/test/apps/options/source/pages/server-fetch-invalidate/count.json/+server.js
+++ b/packages/kit/test/apps/options/source/pages/server-fetch-invalidate/count.json/+server.js
@@ -1,0 +1,9 @@
+import { json } from '@sveltejs/kit';
+
+let count = 0;
+
+/** @type {import('./$types').RequestHandler} */
+export function GET({ url }) {
+	if (url.searchParams.has('reset')) count = 0;
+	return json({ count: count++ });
+}

--- a/packages/kit/test/apps/options/source/pages/server-fetch-invalidate/count.json/+server.js
+++ b/packages/kit/test/apps/options/source/pages/server-fetch-invalidate/count.json/+server.js
@@ -1,3 +1,4 @@
+// TODO 2.0: Delete
 import { json } from '@sveltejs/kit';
 
 let count = 0;

--- a/packages/kit/test/apps/options/svelte.config.js
+++ b/packages/kit/test/apps/options/svelte.config.js
@@ -10,7 +10,7 @@ const config = {
 			}
 		},
 		dangerZone: {
-			trackServerFetchesPotentiallyExposingSecrets: true
+			trackServerFetches: true
 		},
 		files: {
 			assets: 'public',

--- a/packages/kit/test/apps/options/svelte.config.js
+++ b/packages/kit/test/apps/options/svelte.config.js
@@ -9,6 +9,9 @@ const config = {
 				'require-trusted-types-for': ['script']
 			}
 		},
+		dangerZone: {
+			trackServerFetchesPotentiallyExposingSecrets: true
+		},
 		files: {
 			assets: 'public',
 			lib: 'source/components',

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -305,12 +305,12 @@ test.describe('load', () => {
 		app,
 		request
 	}) => {
-		await request.get('/server-fetch-invalidate/count.json?reset');
-		await page.goto('/server-fetch-invalidate');
+		await request.get('/path-base/server-fetch-invalidate/count.json?reset');
+		await page.goto('/path-base/server-fetch-invalidate');
 		const selector = '[data-testid="count"]';
 
 		expect(await page.textContent(selector)).toBe('1');
-		await app.invalidate('/server-fetch-invalidate/count.json');
+		await app.invalidate('/path-base/server-fetch-invalidate/count.json');
 		expect(await page.textContent(selector)).toBe('2');
 	});
 });

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -300,7 +300,7 @@ test.describe('Routing', () => {
 
 test.describe('load', () => {
 	// TODO 2.0: Remove this test
-	test('fetch in server load can be invalidated when `dangerZone.trackServerFetchesPotentiallyExposingSecrets` is set', async ({
+	test('fetch in server load can be invalidated when `dangerZone.trackServerFetches` is set', async ({
 		page,
 		app,
 		request,

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -303,8 +303,10 @@ test.describe('load', () => {
 	test('fetch in server load can be invalidated when `dangerZone.trackServerFetchesPotentiallyExposingSecrets` is set', async ({
 		page,
 		app,
-		request
+		request,
+		javaScriptEnabled
 	}) => {
+		test.skip(!javaScriptEnabled, 'JavaScript is disabled');
 		await request.get('/path-base/server-fetch-invalidate/count.json?reset');
 		await page.goto('/path-base/server-fetch-invalidate');
 		const selector = '[data-testid="count"]';

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -297,3 +297,20 @@ test.describe('Routing', () => {
 		await expect(page.locator('h2')).toHaveText('target: 0');
 	});
 });
+
+test.describe('load', () => {
+	// TODO 2.0: Remove this test
+	test('fetch in server load can be invalidated when `dangerZone.trackServerFetchesPotentiallyExposingSecrets` is set', async ({
+		page,
+		app,
+		request
+	}) => {
+		await request.get('/server-fetch-invalidate/count.json?reset');
+		await page.goto('/server-fetch-invalidate');
+		const selector = '[data-testid="count"]';
+
+		expect(await page.textContent(selector)).toBe('1');
+		await app.invalidate('/server-fetch-invalidate/count.json');
+		expect(await page.textContent(selector)).toBe('2');
+	});
+});

--- a/packages/kit/test/prerendering/basics/test/tests.spec.js
+++ b/packages/kit/test/prerendering/basics/test/tests.spec.js
@@ -170,9 +170,7 @@ test('fetches data from local endpoint', () => {
 			{
 				type: 'data',
 				data: [{ message: 1 }, 'hello'],
-				uses: {
-					dependencies: ['http://example.com/origin/message.json']
-				}
+				uses: {}
 			}
 		]
 	});

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -348,7 +348,7 @@ export interface KitConfig {
 		 * Automatically add server-side `fetch`ed URLs to the `dependencies` map of `load` functions. This will expose secrets
 		 * to the client if your URL contains them.
 		 */
-		trackServerFetchesPotentiallyExposingSecrets?: boolean;
+		trackServerFetches?: boolean;
 	};
 	/**
 	 * Whether or not the app is embedded inside a larger app. If `true`, SvelteKit will add its event listeners related to navigation etc on the parent of `%sveltekit.body%` instead of `window`, and will pass `params` from the server rather than inferring them from `location.pathname`.

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -341,6 +341,16 @@ export interface KitConfig {
 		checkOrigin?: boolean;
 	};
 	/**
+	 * Here be dragons. Enable at your peril.
+	 */
+	dangerZone?: {
+		/**
+		 * Automatically add server-side `fetch`ed URLs to the `dependencies` map of `load` functions. This will expose secrets
+		 * to the client if your URL contains them.
+		 */
+		trackServerFetchesPotentiallyExposingSecrets?: boolean;
+	};
+	/**
 	 * Whether or not the app is embedded inside a larger app. If `true`, SvelteKit will add its event listeners related to navigation etc on the parent of `%sveltekit.body%` instead of `window`, and will pass `params` from the server rather than inferring them from `location.pathname`.
 	 * @default false
 	 */

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -333,7 +333,7 @@ export interface SSROptions {
 	app_template_contains_nonce: boolean;
 	csp: ValidatedConfig['kit']['csp'];
 	csrf_check_origin: boolean;
-	track_server_fetches_potentially_exposing_secrets: boolean;
+	track_server_fetches: boolean;
 	embedded: boolean;
 	env_public_prefix: string;
 	hooks: ServerHooks;

--- a/packages/kit/types/internal.d.ts
+++ b/packages/kit/types/internal.d.ts
@@ -333,6 +333,7 @@ export interface SSROptions {
 	app_template_contains_nonce: boolean;
 	csp: ValidatedConfig['kit']['csp'];
 	csrf_check_origin: boolean;
+	track_server_fetches_potentially_exposing_secrets: boolean;
 	embedded: boolean;
 	env_public_prefix: string;
 	hooks: ServerHooks;


### PR DESCRIPTION
Closes #9803. This is a breaking change for security purposes.

This PR prevents server `load` function from implicitly depending on URLs passed to `fetch`. This is because dependencies from server `load` functions have to be sent to the client in order to be invalidated, which can leak secrets (if they're in the search params, for example).

If you understand the risk and want to keep the old behavior, you can set `config.kit.dangerZone.trackServerFetchesPotentiallyExposingSecrets` to `true`.

TODO:
- [x] Tests
- [x] Docs

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
