### PR TITLE
experimental: Add scroll state to `beforeNavigate` and `afterNavigate`

### DIFF
--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -804,6 +804,14 @@ export interface NavigationTarget {
 	 * The URL that is navigated to
 	 */
 	url: URL;
+
+	/**
+	 * The scroll position of the target
+	 */
+	scroll: {
+		x: number;
+		y: number;
+	};
 }
 
 /**


### PR DESCRIPTION
Would close #9914 

This seems to work in all of the circumstances I could figure out. Here's a test app to play around with: https://github.com/tcc-sejohnson/test-sk-nav-scrollstate

Just make sure the pnpm overrides are pointing at a local version of `kit` checked out to this branch.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
