### PR TITLE
chore: prevent renovate bump vite major

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,11 +27,9 @@
 				"vite"
 			],
 			"matchUpdateTypes": [
-				"minor",
-				"patch",
-				"pin",
-				"digest"
-			]
+				"major"
+			],
+			"enabled": false
 		}
 	]
 }


### PR DESCRIPTION
The previous `packageRule` only matches a criteria, but doesn't specify what to do with it. I've updated the intent so that Vite majors will not be bumped by Renovate, using `"enabled": false`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
