### PR TITLE
docs: use es2022 for shiki

### DIFF
--- a/sites/kit.svelte.dev/src/lib/docs/server/index.js
+++ b/sites/kit.svelte.dev/src/lib/docs/server/index.js
@@ -215,7 +215,7 @@ export async function read_file(file) {
 						defaultCompilerOptions: {
 							allowJs: true,
 							checkJs: true,
-							target: ts.ScriptTarget.ES2021
+							target: ts.ScriptTarget.ES2022
 						}
 					});
 


### PR DESCRIPTION
es2022 is used everywhere else in the codebase. We should be consistent