### PR TITLE
adds cloudflare cf object to platform property

### DIFF
--- a/.changeset/afraid-bikes-count.md
+++ b/.changeset/afraid-bikes-count.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-cloudflare': minor
 ---
 
-adds the cloudflare's request.cf object to the event.platform property
+feat: add cloudflare's `request.cf` object to the `event.platform` property

--- a/.changeset/afraid-bikes-count.md
+++ b/.changeset/afraid-bikes-count.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': minor
+---
+
+adds the cloudflare's request.cf object to the event.platform property

--- a/packages/adapter-cloudflare/ambient.d.ts
+++ b/packages/adapter-cloudflare/ambient.d.ts
@@ -1,4 +1,4 @@
-import { Cache, CacheStorage } from '@cloudflare/workers-types';
+import { Cache, CacheStorage, IncomingRequestCfProperties } from '@cloudflare/workers-types';
 
 declare global {
 	namespace App {
@@ -7,6 +7,7 @@ declare global {
 				waitUntil(promise: Promise<any>): void;
 			};
 			caches?: CacheStorage & { default: Cache };
+			cf?: IncomingRequestCfProperties;
 		}
 	}
 }

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -46,7 +46,7 @@ const worker = {
 			// dynamically-generated pages
 			res = await server.respond(req, {
 				// @ts-ignore
-				platform: { env, context, caches },
+				platform: { env, context, caches, cf: req.cf },
 				getClientAddress() {
 					return req.headers.get('cf-connecting-ip');
 				}


### PR DESCRIPTION
Cloudflare provides a CF object on the incoming Request ([docs](https://developers.cloudflare.com/workers/runtime-apis/request/#incomingrequestcfproperties))
The CF object contains geolocation info similar to Vercel's X-Vercel-IP-*.

Since it is specific to Cloudflare, it is preferable to add it to the platform property.

Without this CF object, it is currently not possible to get the user location (edge function location)
It will also close this issue https://github.com/sveltejs/kit/issues/5447