### PR TITLE
fix: use `window.fetch` in `load` functions to allow libraries to patch it

### DIFF
--- a/.changeset/sharp-birds-invent.md
+++ b/.changeset/sharp-birds-invent.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: Use `window.fetch` instead of unpatched fetch in `load` functions

--- a/.changeset/sharp-birds-invent.md
+++ b/.changeset/sharp-birds-invent.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: Use `window.fetch` instead of unpatched fetch in `load` functions
+fix: use `window.fetch` in `load` functions to allow libraries to patch it

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -94,17 +94,7 @@ export function initial_fetch(resource, opts) {
 		return Promise.resolve(new Response(body, init));
 	}
 
-	const patched_opts = { ...opts };
-	if (DEV) {
-		// This assigns the __sveltekit_fetch__ flag and makes it non-enumerable
-		Object.defineProperty(patched_opts, '__sveltekit_fetch__', {
-			value: true,
-			writable: true,
-			configurable: true
-		});
-	}
-
-	return window.fetch(resource, patched_opts);
+	return DEV ? dev_fetch(resource, opts) : window.fetch(resource, opts);
 }
 
 /**
@@ -130,17 +120,22 @@ export function subsequent_fetch(resource, resolved, opts) {
 		}
 	}
 
-	const patched_opts = { ...opts };
-	if (DEV) {
-		// This assigns the __sveltekit_fetch__ flag and makes it non-enumerable
-		Object.defineProperty(patched_opts, '__sveltekit_fetch__', {
-			value: true,
-			writable: true,
-			configurable: true
-		});
-	}
+	return DEV ? dev_fetch(resolved, opts) : window.fetch(resolved, opts);
+}
 
-	return window.fetch(resolved, patched_opts);
+/**
+ * @param {RequestInfo | URL} resource
+ * @param {RequestInit & Record<string, any> | undefined} opts
+ */
+function dev_fetch(resource, opts) {
+	const patched_opts = { ...opts };
+	// This assigns the __sveltekit_fetch__ flag and makes it non-enumerable
+	Object.defineProperty(patched_opts, '__sveltekit_fetch__', {
+		value: true,
+		writable: true,
+		configurable: true
+	});
+	return window.fetch(resource, patched_opts);
 }
 
 /**

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -24,7 +24,6 @@ if (DEV) {
 	check_stack_trace();
 
 	/**
-	 *
 	 * @param {RequestInfo | URL} input
 	 * @param {RequestInit & Record<string, any> | undefined} init
 	 */
@@ -41,14 +40,14 @@ if (DEV) {
 		const cutoff = stack_array.findIndex((a) => a.includes('load@') || a.includes('at load'));
 		const stack = stack_array.slice(0, cutoff + 2).join('\n');
 
-		const inLoadHeuristic = can_inspect_stack_trace
+		const in_load_heuristic = can_inspect_stack_trace
 			? stack.includes('src/runtime/client/client.js')
 			: loading;
 
 		// This flag is set in initial_fetch and subsequent_fetch
-		const calledViaSvelteKitFetch = init?.__sveltekit_fetch__;
+		const used_kit_fetch = init?.__sveltekit_fetch__;
 
-		if (inLoadHeuristic && !calledViaSvelteKitFetch) {
+		if (in_load_heuristic && !used_kit_fetch) {
 			console.warn(
 				`Loading ${url} using \`window.fetch\`. For best results, use the \`fetch\` that is passed to your \`load\` function: https://kit.svelte.dev/docs/load#making-fetch-requests`
 			);
@@ -95,14 +94,14 @@ export function initial_fetch(resource, opts) {
 		return Promise.resolve(new Response(body, init));
 	}
 
-	const patchedOpts = DEV
+	const patched_opts = DEV
 		? {
 				...opts,
 				__sveltekit_fetch__: true
 		  }
 		: opts;
 
-	return window.fetch(resource, patchedOpts);
+	return window.fetch(resource, patched_opts);
 }
 
 /**

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -94,12 +94,15 @@ export function initial_fetch(resource, opts) {
 		return Promise.resolve(new Response(body, init));
 	}
 
-	const patched_opts = DEV
-		? {
-				...opts,
-				__sveltekit_fetch__: true
-		  }
-		: opts;
+	const patched_opts = { ...opts };
+	if (DEV) {
+		// This assigns the __sveltekit_fetch__ flag and makes it non-enumerable
+		Object.defineProperty(patched_opts, '__sveltekit_fetch__', {
+			value: true,
+			writable: true,
+			configurable: true
+		});
+	}
 
 	return window.fetch(resource, patched_opts);
 }
@@ -127,14 +130,17 @@ export function subsequent_fetch(resource, resolved, opts) {
 		}
 	}
 
-	const patchedOpts = DEV
-		? {
-				...opts,
-				__sveltekit_fetch__: true
-		  }
-		: opts;
+	const patched_opts = { ...opts };
+	if (DEV) {
+		// This assigns the __sveltekit_fetch__ flag and makes it non-enumerable
+		Object.defineProperty(patched_opts, '__sveltekit_fetch__', {
+			value: true,
+			writable: true,
+			configurable: true
+		});
+	}
 
-	return window.fetch(resolved, patchedOpts);
+	return window.fetch(resolved, patched_opts);
 }
 
 /**

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -86,7 +86,7 @@ export function initial_fetch(resource, opts) {
 		return Promise.resolve(new Response(body, init));
 	}
 
-	return native_fetch(resource, opts);
+	return DEV ? native_fetch(resource, opts) : window.fetch(resource, opts);
 }
 
 /**
@@ -112,7 +112,7 @@ export function subsequent_fetch(resource, resolved, opts) {
 		}
 	}
 
-	return native_fetch(resolved, opts);
+	return DEV ? native_fetch(resolved, opts) : window.fetch(resolved, opts);
 }
 
 /**

--- a/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching/+page.js
@@ -1,0 +1,20 @@
+import { browser } from '$app/environment';
+
+/** @type {import('./$types').PageLoad} */
+export async function load({ url, fetch }) {
+	// simulate fetch being monkey-patched by a 3rd party library
+	// run everything only in browser to avoid SSR caching
+	if (browser) {
+		const original_fetch = window.fetch;
+		window.fetch = (input, init) => {
+			console.log('Called a patched window.fetch');
+			return original_fetch(input, init);
+		};
+
+		const res = await fetch(`${url.origin}/load/window-fetch/data.json`);
+		const { answer } = await res.json();
+		window.fetch = original_fetch;
+		return { answer };
+	}
+	return {};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	/** @type {import('./$types').PageData} */
+	export let data;
+</script>
+
+<h1>{data.answer}</h1>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -228,6 +228,21 @@ test.describe('Load', () => {
 		expect(requests).toEqual([]);
 	});
 
+	test('permits 3rd party patching of fetch in universal load functions', async ({ page }) => {
+		/** @type {string[]} */
+		const logs = [];
+		page.on('console', (msg) => {
+			if (msg.type() === 'log') {
+				logs.push(msg.text());
+			}
+		});
+
+		await page.goto('/load/window-fetch/patching');
+		expect(await page.textContent('h1')).toBe('42');
+
+		expect(logs).toContain('Called a patched window.fetch');
+	});
+
 	if (process.env.DEV) {
 		test('using window.fetch causes a warning', async ({ page, baseURL }) => {
 			await Promise.all([


### PR DESCRIPTION
This PR makes `initial_fetch` and `subsequent_fetch` use the patched `window.fetch` function instead of the unpatched and stored away `native_fetch` function. 

This change brings one big benefit: Additional behaviour added by libraries (like Sentry but there are many others)  that patch `window.fetch` is now also invoked in `event.fetch` calls within client-side universal `load` functions. 

Additionally, this provides a way for libraries to instrument fetch in load functions _without_ causing unintended cache misses (see https://github.com/getsentry/sentry-javascript/issues/8174)

Kit patches `window.fetch` for two reasons:
  - to warn about directly calling `window.fetch` it in `DEV` mode (this we should leave as-is)
  - to clean the cache 

I'm not sure if I'm missing something but cleaning the cache should be alright in `load` functions as well 🤔 

Getting this PR merged would de-prioritize needing a dedicated `handleFetch` hook on the client-side (#9530) for us (which might still be worthwhile but for other reasons).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following: 
* [x]  It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
* [x]   This message body should clearly illustrate what problems it solves.
* [x]  Ideally, include a test that fails without this PR but passes with it.

### Tests
* [x]  Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
 
### Changesets
* [x]  If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

ref: #9530
ref: https://github.com/getsentry/sentry-javascript/issues/8174
(ref: https://github.com/Lms24/gh-js-8174)