### PR TITLE
fix: rest matcher skipped if optional is empty

### DIFF
--- a/.changeset/strange-lizards-drive.md
+++ b/.changeset/strange-lizards-drive.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: use rest param's matcher if optional is empty
+fix: don't skip rest parameter's matcher when there is a non-matching optional parameter

--- a/.changeset/strange-lizards-drive.md
+++ b/.changeset/strange-lizards-drive.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: use rest param's matcher if optional is empty

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -141,18 +141,17 @@ export function exec(match, params, matchers) {
 
 	for (let i = 0; i < params.length; i += 1) {
 		const param = params[i];
-		const value = values[i - buffered];
+		let value = values[i - buffered];
 
 		// in the `[[a=b]]/.../[...rest]` case, if one or more optional parameters
 		// weren't matched, roll the skipped values into the rest
 		if (param.chained && param.rest && buffered) {
-			result[param.name] = values
+			value = values
 				.slice(i - buffered, i + 1)
 				.filter((s) => s)
 				.join('/');
 
 			buffered = 0;
-			continue;
 		}
 
 		// if `value` is undefined, it means this is an optional or rest parameter

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -226,6 +226,11 @@ const exec_tests = [
 		route: '/[[lang=matches]]/[asset=matches]/[[categoryType]]/[...categories]',
 		path: '/es/sfx/category/car/crash',
 		expected: { lang: 'es', asset: 'sfx', categoryType: 'category', categories: 'car/crash' }
+	},
+	{
+		route: '/[[slug1=doesntmatch]]/[...slug2=doesntmatch]',
+		path: '/a/b/c',
+		expected: undefined
 	}
 ];
 


### PR DESCRIPTION
I found that since version 1.3.6 a matcher on a rest parameter is not called anymore if an optional parameter before it is empty. I'm using the optional for localization and the following rest parameter has a matcher.

Example route:
`[[locale=locale]]/[...rest=page]`

For `/en/test`, the `page` matcher will be called with param `test`.
For `/test`, the `page` matcher was not called since version 1.3.6.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
