### PR TITLE
fix: prevent history change when clicking same hash link

### DIFF
--- a/.changeset/cool-snakes-join.md
+++ b/.changeset/cool-snakes-join.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prevent history change when clicking same hash link

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1539,6 +1539,15 @@ export function create_client(app, target) {
 				// Removing the hash does a full page navigation in the browser, so make sure a hash is present
 				const [nonhash, hash] = url.href.split('#');
 				if (hash !== undefined && nonhash === location.href.split('#')[0]) {
+					// If we are trying to navigate to the same hash, we should only
+					// attempt to scroll to that element and avoid any history changes.
+					// Otherwise, this can cause Firefox to incorrectly assign a null
+					// history state value without any signal that we can detect.
+					if (current.url.hash === url.hash) {
+						event.preventDefault();
+						a.scrollIntoView();
+						return;
+					}
 					// set this flag to distinguish between navigations triggered by
 					// clicking a hash link and those triggered by popstate
 					hash_navigating = true;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1545,7 +1545,7 @@ export function create_client(app, target) {
 					// history state value without any signal that we can detect.
 					if (current.url.hash === url.hash) {
 						event.preventDefault();
-						a.scrollIntoView();
+						a.ownerDocument.getElementById(hash)?.scrollIntoView();
 						return;
 					}
 					// set this flag to distinguish between navigations triggered by


### PR DESCRIPTION
Fixes #8725.

This PR fixes an outstanding issue with routing hash links in Firefox. Specifically, clicking a link that contains as hash and where the link is the same as the current page URL, Firefox clears the history `state`, causing browser navigation to fail thereafter. In order to tackle this, we need to detect where the URL for a hash link is the same and manually prevent any client-side routing to take place. Instead we just apply the same scrolling heuristics – fixing the issue in FF.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
