### PR TITLE
fix: preload fonts by default

### DIFF
--- a/.changeset/polite-scissors-applaud.md
+++ b/.changeset/polite-scissors-applaud.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: preload fonts by default

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -40,7 +40,7 @@ const default_transform = ({ html }) => html;
 const default_filter = () => false;
 
 /** @type {import('types').RequiredResolveOptions['preload']} */
-const default_preload = ({ type }) => type === 'js' || type === 'css';
+const default_preload = ({ type }) => type === 'js' || type === 'css' || type === 'font';
 
 /**
  * @param {Request} request


### PR DESCRIPTION
ResolveOptions.preload docs: "By default, `js`, `css` and `font` files will be preloaded."

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
