### PR TITLE
chore: cleanup some project setup

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://unpkg.com/@changesets/config@1.5.0/schema.json",
+	"$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
 	"changelog": ["@svitejs/changesets-changelog-github-compact", { "repo": "sveltejs/kit" }],
 	"commit": false,
 	"linked": [],

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
-	"name": "kit",
+	"name": "kit-monorepo",
 	"version": "0.0.1",
 	"description": "monorepo for @sveltejs/kit and friends",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"test": "pnpm test -r --filter=./packages/* --filter=!./packages/create-svelte",
 		"test:cross-platform:dev": "pnpm run --dir packages/kit test:cross-platform:dev",
@@ -16,16 +17,6 @@
 		"release": "changeset publish",
 		"start": "cd sites/kit.svelte.dev && npm run dev"
 	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/sveltejs/kit.git"
-	},
-	"author": "",
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/sveltejs/kit/issues"
-	},
-	"homepage": "https://github.com/sveltejs/kit#readme",
 	"devDependencies": {
 		"@changesets/cli": "^2.26.0",
 		"@rollup/plugin-commonjs": "^25.0.0",
@@ -49,6 +40,5 @@
 	"packageManager": "pnpm@8.4.0",
 	"engines": {
 		"pnpm": "^8.0.0"
-	},
-	"type": "module"
+	}
 }


### PR DESCRIPTION
Some things I noticed while setting up the `sveltejs/svelte` monorepo. The changesets schema is a bit outdated and we have several unused fields in the main `package.json` - the ones in sub-projects get shown on npm.com, but the main `package.json` doesn't need them