### PR TITLE
fix: disallow exporting `actions` from a `+layout.server` file

### DIFF
--- a/.changeset/new-peaches-count.md
+++ b/.changeset/new-peaches-count.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: disallow `actions` export from a `+layout.server` file

--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -2,7 +2,7 @@
 title: Form actions
 ---
 
-A `+page.server.js` and `+layout.server.js` file can export _actions_, which allow you to `POST` data to the server using the `<form>` element.
+A `+page.server.js` file can export _actions_, which allow you to `POST` data to the server using the `<form>` element.
 
 When using `<form>`, client-side JavaScript is optional, but you can easily _progressively enhance_ your form interactions with JavaScript to provide the best user experience.
 

--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -2,7 +2,7 @@
 title: Form actions
 ---
 
-A `+page.server.js` file can export _actions_, which allow you to `POST` data to the server using the `<form>` element.
+A `+page.server.js` and `+layout.server.js` file can export _actions_, which allow you to `POST` data to the server using the `<form>` element.
 
 When using `<form>`, client-side JavaScript is optional, but you can easily _progressively enhance_ your form interactions with JavaScript to provide the best user experience.
 

--- a/packages/kit/src/utils/exports.js
+++ b/packages/kit/src/utils/exports.js
@@ -70,7 +70,7 @@ const valid_layout_exports = new Set([
 ]);
 const valid_page_exports = new Set([...valid_layout_exports, 'entries']);
 const valid_layout_server_exports = new Set([...valid_layout_exports]);
-const valid_page_server_exports = new Set([...valid_layout_server_exports, 'entries', 'actions']);
+const valid_page_server_exports = new Set([...valid_layout_server_exports, 'actions', 'entries']);
 const valid_server_exports = new Set([
 	'GET',
 	'POST',

--- a/packages/kit/src/utils/exports.js
+++ b/packages/kit/src/utils/exports.js
@@ -69,8 +69,8 @@ const valid_layout_exports = new Set([
 	'config'
 ]);
 const valid_page_exports = new Set([...valid_layout_exports, 'entries']);
-const valid_layout_server_exports = new Set([...valid_layout_exports, 'actions']);
-const valid_page_server_exports = new Set([...valid_layout_server_exports, 'entries']);
+const valid_layout_server_exports = new Set([...valid_layout_exports]);
+const valid_page_server_exports = new Set([...valid_layout_server_exports, 'entries', 'actions']);
 const valid_server_exports = new Set([
 	'GET',
 	'POST',

--- a/packages/kit/src/utils/exports.spec.js
+++ b/packages/kit/src/utils/exports.spec.js
@@ -50,7 +50,7 @@ test('validates +layout.js', () => {
 			},
 			'src/routes/foo/+page.ts'
 		);
-	}, "Invalid export 'actions' in src/routes/foo/+page.ts ('actions' is a valid export in +layout.server.ts or +page.server.ts)");
+	}, "Invalid export 'actions' in src/routes/foo/+page.ts ('actions' is a valid export in +page.server.ts)");
 
 	check_error(() => {
 		validate_layout_exports({
@@ -87,7 +87,7 @@ test('validates +page.js', () => {
 			},
 			'src/routes/foo/+page.ts'
 		);
-	}, "Invalid export 'actions' in src/routes/foo/+page.ts ('actions' is a valid export in +layout.server.ts or +page.server.ts)");
+	}, "Invalid export 'actions' in src/routes/foo/+page.ts ('actions' is a valid export in +page.server.ts)");
 
 	check_error(() => {
 		validate_page_exports({
@@ -115,6 +115,15 @@ test('validates +layout.server.js', () => {
 			answer: 42
 		});
 	}, "Invalid export 'answer' (valid exports are load, prerender, csr, ssr, trailingSlash, config, or anything with a '_' prefix)");
+
+	check_error(() => {
+		validate_layout_exports(
+			{
+				actions: {}
+			},
+			'src/routes/foo/+page.ts'
+		);
+	}, "Invalid export 'actions' in src/routes/foo/+page.ts ('actions' is a valid export in +page.server.ts)");
 
 	check_error(() => {
 		validate_layout_server_exports({

--- a/packages/kit/src/utils/exports.spec.js
+++ b/packages/kit/src/utils/exports.spec.js
@@ -103,8 +103,7 @@ test('validates +layout.server.js', () => {
 		csr: false,
 		ssr: false,
 		trailingSlash: false,
-		config: {},
-		actions: {}
+		config: {}
 	});
 
 	validate_layout_server_exports({
@@ -115,7 +114,7 @@ test('validates +layout.server.js', () => {
 		validate_layout_server_exports({
 			answer: 42
 		});
-	}, "Invalid export 'answer' (valid exports are load, prerender, csr, ssr, trailingSlash, config, actions, or anything with a '_' prefix)");
+	}, "Invalid export 'answer' (valid exports are load, prerender, csr, ssr, trailingSlash, config, or anything with a '_' prefix)");
 
 	check_error(() => {
 		validate_layout_server_exports({


### PR DESCRIPTION
~Found out we can export `actions` in a layout file but it isn't mentioned anywhere in the docs.~
I don't think we're suppose to export actions from a layout file. https://github.com/sveltejs/kit/pull/10046#issuecomment-1565286897

This PR changes the list of valid exports to disallow the `actions` export from a `+layout.server` file (matching the language tools behaviour).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
