### PR TITLE
fix: remove scrollbars on default error page

### DIFF
--- a/.changeset/rich-candles-wait.md
+++ b/.changeset/rich-candles-wait.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: remove scrollbars from default error page

--- a/packages/kit/src/core/config/default-error.html
+++ b/packages/kit/src/core/config/default-error.html
@@ -17,6 +17,7 @@
 				align-items: center;
 				justify-content: center;
 				height: 100vh;
+				margin: 0;
 			}
 
 			.error {


### PR DESCRIPTION
## Description

The CSS rule `body { height: 100vh }` on the default error-page will cause vertical scrollbars if the default body-margin isn't removed.

I didn't include a changelog because it is such a minor change. (But I can add one if you want.)

### How to test

Open `@sveltejs/kit/src/core/config/default-error.html` and verify that there are no vertical scrollbars.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
