### PR TITLE
fix: Stop warning users that crons don't match paths when they actually do

### DIFF
--- a/.changeset/nervous-balloons-speak.md
+++ b/.changeset/nervous-balloons-speak.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+fix: stop incorrectly warning users that crons don't match paths

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -575,13 +575,9 @@ function validate_vercel_json(builder, vercel_config) {
 			continue;
 		}
 
-		for (const route of valid_routes) {
-			if (route.pattern.test(path)) {
-				continue;
-			}
+		if (!valid_routes.some((route) => route.pattern.test(path))) {
+			unmatched_paths.push(path);
 		}
-
-		unmatched_paths.push(path);
 	}
 
 	if (unmatched_paths.length) {


### PR DESCRIPTION
We were `continue`-ing an inner loop when we intended to `continue` an outer loop.

Closes #10071 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
