### PR TITLE
fix: correctly close dialog when using enhanced forms

### DIFF
--- a/.changeset/proud-cobras-rhyme.md
+++ b/.changeset/proud-cobras-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly close dialogs when form is enhanced

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -130,9 +130,11 @@ export function enhance(form_element, submit = () => {}) {
 
 	/** @param {SubmitEvent} event */
 	async function handle_submit(event) {
-		const method = /** @type {HTMLButtonElement | HTMLInputElement} */ (event.submitter).formMethod;
+		const method = event.submitter?.hasAttribute('formmethod')
+			? /** @type {HTMLButtonElement | HTMLInputElement} */ (event.submitter).formMethod
+			: clone(form_element).method;
 		if (method === 'dialog') return;
-		
+
 		event.preventDefault();
 
 		const action = new URL(

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -133,7 +133,7 @@ export function enhance(form_element, submit = () => {}) {
 		const method = event.submitter?.hasAttribute('formmethod')
 			? /** @type {HTMLButtonElement | HTMLInputElement} */ (event.submitter).formMethod
 			: clone(form_element).method;
-		if (method === 'dialog') return;
+		if (method !== 'post') return;
 
 		event.preventDefault();
 

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -130,6 +130,9 @@ export function enhance(form_element, submit = () => {}) {
 
 	/** @param {SubmitEvent} event */
 	async function handle_submit(event) {
+		const method = /** @type {HTMLButtonElement | HTMLInputElement} */ (event.submitter).formMethod;
+		if (method === 'dialog') return;
+		
 		event.preventDefault();
 
 		const action = new URL(

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.svelte
@@ -51,3 +51,9 @@
 <form action="?/counter" method="post" use:enhance>
 	<button class="form4">Submit</button>
 </form>
+
+<dialog id="dialog" open>
+	<form action="?/echo" method="post" use:enhance>
+		<button formmethod="dialog">Cancel</button>
+	</form>
+</dialog>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1043,6 +1043,14 @@ test.describe('Actions', () => {
 		);
 	});
 
+	test('use:enhance button with formAction dialog', async ({ page }) => {
+		await page.goto('/actions/enhance');
+
+		await page.locator('button[formmethod="dialog"]').click();
+
+		await expect(page.locator('button[formmethod="dialog"]')).not.toBeVisible();
+	});
+
 	test('use:enhance button with name', async ({ page }) => {
 		await page.goto('/actions/enhance');
 


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/10092

Allows the submit event to go through (to close the dialog) if the form method is set to dialog.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog#usage_notes

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
