### PR TITLE
feat(adapter-cloudflare): expose the `external` ESBuild option

### DIFF
--- a/.changeset/little-peas-teach.md
+++ b/.changeset/little-peas-teach.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': minor
+---
+
+expose select ESBuild options as adapter options

--- a/packages/adapter-cloudflare/index.d.ts
+++ b/packages/adapter-cloudflare/index.d.ts
@@ -30,6 +30,20 @@ export interface AdapterOptions {
 		 */
 		exclude?: string[];
 	};
+	/**
+	 * Customize a restricted set of options used by ESBuild to prepare the Cloudflare adapter bundle.
+	 *
+	 * @default {}
+	 */
+	esbuildOptions?: {
+		/**
+		 * Mark a file or a package as external to exclude it from your build.
+		 * Instead of being bundled, the import will be preserved and will be evaluated at run time instead.
+		 *
+		 * @see https://esbuild.github.io/api/#external
+		 */
+		external?: import('esbuild').BuildOptions['external'];
+	};
 }
 
 export interface RoutesJSONSpec {

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -47,6 +47,7 @@ export default function (options = {}) {
 
 			await esbuild.build({
 				platform: 'browser',
+				external: options?.esbuildOptions?.external,
 				conditions: ['worker', 'browser'],
 				sourcemap: 'linked',
 				target: 'es2022',


### PR DESCRIPTION
This PR exposes the `external` ESBuild option from the `adapter-cloudflare` package.

Had a 3rd party package importing some node-native modules without the `node:` prefix, making the build fail.

Providing externals to the adapter's build step like the following allowed me to build:

```js
esbuildOptions: {
    external: ["fs", "crypto", "url", "os", "path", "stream", "zlib", "net", "tls", "http", "https"]
}
```

Might help the following issues:

- https://github.com/sveltejs/kit/issues/3564
- https://github.com/sveltejs/kit/issues/10028

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] ~~Ideally, include a test that fails without this PR but passes with it.~~

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
