### PR TITLE
fix: call worker `unref` instead of `terminate`

### DIFF
--- a/.changeset/moody-hornets-own.md
+++ b/.changeset/moody-hornets-own.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: call worker `unref` instead of `terminate`

--- a/packages/kit/src/utils/fork.js
+++ b/packages/kit/src/utils/fork.js
@@ -32,7 +32,7 @@ export function forked(module, callback) {
 	 * @param {T} opts
 	 * @returns {Promise<U>}
 	 */
-	const fn = function (opts) {
+	return function (opts) {
 		return new Promise((fulfil, reject) => {
 			const worker = new Worker(fileURLToPath(module), {
 				env: {
@@ -53,7 +53,7 @@ export function forked(module, callback) {
 					}
 
 					if (data?.type === 'result' && data.module === module) {
-						worker.terminate();
+						worker.unref();
 						fulfil(data.payload);
 					}
 				}
@@ -66,6 +66,4 @@ export function forked(module, callback) {
 			});
 		});
 	};
-
-	return fn;
 }


### PR DESCRIPTION
According to the docs, `terminate` seems to effectively stop all execution in the thread, as soon as possible. This seems to break some long running process — which was working with `child_process` before — when prerendering, either because the ample amounts of prerendered pages/routes, the huge amount of data that needs to be (pre)processed for each routes, or a combination of both.

Substituting `terminate` with `unref` would allow the worker to exit when it finds that it's the only active one in the event system, this would allow the long running process that seems to happen after `terminate` is called to finish without being interrupted.

The error thrown by the `terminate` method also seems to be very vague and random, trying to `await` it seems to give a more helpful message along with a stacktrace, but still not enough to figure out what's going on and why it's prematurely exiting the thread. This is mostly an excuse because I couldn't seem to find a way to recreate the issue in a smaller scale and push in a failing test.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
