### PR TITLE
fix: fetch doesn't respect headers from 1st arg if its type is Request

### DIFF
--- a/.changeset/tricky-bikes-tan.md
+++ b/.changeset/tricky-bikes-tan.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: Fetch doesn't respect headers from 1st arg if its type is Request

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -204,7 +204,10 @@ export function create_universal_fetch(event, state, fetched, csr, resolve_opts)
 	return async (input, init) => {
 		const cloned_body = input instanceof Request && input.body ? input.clone().body : null;
 
-		const cloned_headers = input instanceof Request && [...input.headers].length ? new Headers(input.headers) : init?.headers;
+		const cloned_headers =
+			input instanceof Request && [...input.headers].length
+				? new Headers(input.headers)
+				: init?.headers;
 
 		let response = await event.fetch(input, init);
 

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -203,6 +203,15 @@ export function create_universal_fetch(event, state, fetched, csr, resolve_opts)
 	 */
 	return async (input, init) => {
 		const cloned_body = input instanceof Request && input.body ? input.clone().body : null;
+
+		/** @type {HeadersInit | undefined} */
+		let cloned_headers;
+		if (input instanceof Request && input.headers.keys().next().value?.length) {
+			cloned_headers = new Headers(input.headers);
+		} else {
+			cloned_headers = init?.headers;
+		}
+
 		let response = await event.fetch(input, init);
 
 		const url = new URL(input instanceof Request ? input.url : input, event.url);
@@ -260,7 +269,7 @@ export function create_universal_fetch(event, state, fetched, csr, resolve_opts)
 									? await stream_to_string(cloned_body)
 									: init?.body
 							),
-							request_headers: init?.headers,
+							request_headers: cloned_headers,
 							response_body: body,
 							response
 						});

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -204,13 +204,7 @@ export function create_universal_fetch(event, state, fetched, csr, resolve_opts)
 	return async (input, init) => {
 		const cloned_body = input instanceof Request && input.body ? input.clone().body : null;
 
-		/** @type {HeadersInit | undefined} */
-		let cloned_headers;
-		if (input instanceof Request && input.headers.keys().next().value?.length) {
-			cloned_headers = new Headers(input.headers);
-		} else {
-			cloned_headers = init?.headers;
-		}
+		const cloned_headers = input instanceof Request && [...input.headers].length ? new Headers(input.headers) : init?.headers;
 
 		let response = await event.fetch(input, init);
 

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -264,10 +264,10 @@ test.describe('Load', () => {
 			const payload_b = '{"status":200,"statusText":"","headers":{},"body":"Y"}';
 			// by the time JS has run, hydration will have nuked these scripts
 			const script_contents_a = await page.innerHTML(
-				'script[data-sveltekit-fetched][data-url="/load/serialization-post.json"][data-hash="3t25"]'
+				'script[data-sveltekit-fetched][data-url="/load/serialization-post.json"][data-hash="1vn6nlx"]'
 			);
 			const script_contents_b = await page.innerHTML(
-				'script[data-sveltekit-fetched][data-url="/load/serialization-post.json"][data-hash="3t24"]'
+				'script[data-sveltekit-fetched][data-url="/load/serialization-post.json"][data-hash="1vn6nlw"]'
 			);
 
 			expect(script_contents_a).toBe(payload_a);


### PR DESCRIPTION
Fixes compatibility with libraries that call the fetch API as `fetch(new Request(...someParams))` without an `init` argument

One of these libraries is https://github.com/sindresorhus/ky (https://github.com/sindresorhus/ky/blob/main/source/utils/timeout.ts)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
