### PR TITLE
fix: allow rest params to be empty in resolvePath

### DIFF
--- a/.changeset/metal-toes-talk.md
+++ b/.changeset/metal-toes-talk.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow rest params to be empty in resolvePath

--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -133,7 +133,8 @@ export function resolvePath(id, params) {
 
 					// This is nested so TS correctly narrows the type
 					if (!param_value) {
-						if (optional || rest) return '';
+						if (optional) return '';
+						if (rest && param_value !== undefined) return '';
 						throw new Error(`Missing parameter '${name}' in route ${id}`);
 					}
 

--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -104,7 +104,7 @@ export function fail(status, data) {
 	return new ActionFailure(status, data);
 }
 
-const basic_param_pattern = /\[(\[)?(?:\.\.\.)?(\w+?)(?:=(\w+))?\]\]?/g;
+const basic_param_pattern = /\[(\[)?(\.\.\.)?(\w+?)(?:=(\w+))?\]\]?/g;
 
 /**
  * Populate a route ID with params to resolve a pathname.
@@ -128,12 +128,12 @@ export function resolvePath(id, params) {
 		'/' +
 		segments
 			.map((segment) =>
-				segment.replace(basic_param_pattern, (_, optional, name) => {
+				segment.replace(basic_param_pattern, (_, optional, rest, name) => {
 					const param_value = params[name];
 
 					// This is nested so TS correctly narrows the type
 					if (!param_value) {
-						if (optional) return '';
+						if (optional || rest) return '';
 						throw new Error(`Missing parameter '${name}' in route ${id}`);
 					}
 

--- a/packages/kit/src/exports/index.spec.js
+++ b/packages/kit/src/exports/index.spec.js
@@ -24,9 +24,7 @@ const from_params_tests = [
 	},
 	{
 		route: '/blog/[...one]',
-		params: {
-			one: ''
-		},
+		params: { one: '' },
 		expected: '/blog'
 	},
 	{

--- a/packages/kit/src/exports/index.spec.js
+++ b/packages/kit/src/exports/index.spec.js
@@ -23,6 +23,11 @@ const from_params_tests = [
 		expected: '/blog/one/2-and-3'
 	},
 	{
+		route: '/blog/[...one]',
+		params: {},
+		expected: '/blog'
+	},
+	{
 		route: '/blog/[one]/[...two]-not-three',
 		params: { one: 'one', two: 'two/2' },
 		expected: '/blog/one/two/2-not-three'

--- a/packages/kit/src/exports/index.spec.js
+++ b/packages/kit/src/exports/index.spec.js
@@ -24,7 +24,9 @@ const from_params_tests = [
 	},
 	{
 		route: '/blog/[...one]',
-		params: {},
+		params: {
+			one: ''
+		},
 		expected: '/blog'
 	},
 	{


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/10140,

rest params can be empty according to https://kit.svelte.dev/docs/advanced-routing#rest-parameters

Although @MrTango, your reproduction will continue to not work because you are supplying `slug` instead of `path`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
