### PR TITLE
chore: new mime library

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -18,7 +18,7 @@
 		"esm-env": "^1.0.0",
 		"kleur": "^4.1.5",
 		"magic-string": "^0.30.0",
-		"mime": "^3.0.0",
+		"mrmime": "^1.0.1",
 		"sade": "^1.8.1",
 		"set-cookie-parser": "^2.6.0",
 		"sirv": "^2.0.2",

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import mime from 'mime';
+import { lookup } from 'mrmime';
 import { runtime_directory } from '../../utils.js';
 import { posixify } from '../../../utils/filesystem.js';
 import { parse_route_id } from '../../../utils/routing.js';
@@ -47,7 +47,7 @@ export function create_assets(config) {
 	return list_files(config.kit.files.assets).map((file) => ({
 		file,
 		size: fs.statSync(path.resolve(config.kit.files.assets, file)).size,
-		type: mime.getType(file)
+		type: lookup(file)
 	}));
 }
 

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -38,7 +38,7 @@ export interface ServerInternalModule {
 export interface Asset {
 	file: string;
 	size: number;
-	type: string | null;
+	type: string | void;
 }
 
 export interface AssetDependencies {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,9 +394,9 @@ importers:
       magic-string:
         specifier: ^0.30.0
         version: 0.30.0
-      mime:
-        specifier: ^3.0.0
-        version: 3.0.0
+      mrmime:
+        specifier: ^1.0.1
+        version: 1.0.1
       sade:
         specifier: ^1.8.1
         version: 1.8.1
@@ -4235,6 +4235,7 @@ packages:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
     hasBin: true
+    dev: true
 
   /mimic-fn@1.2.0:
     resolution: {integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==}


### PR DESCRIPTION
This reduces the number of dependencies in `@sveltejs/kit`. It already depends on `mrmime` via `sirv` where as `mime` would introduce a new dependency