### PR TITLE
chore: remove tiny-glob dependency

### DIFF
--- a/.changeset/chilly-gorillas-switch.md
+++ b/.changeset/chilly-gorillas-switch.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+chore: remove `tiny-glob` as a dependency

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -22,7 +22,6 @@
 		"sade": "^1.8.1",
 		"set-cookie-parser": "^2.6.0",
 		"sirv": "^2.0.2",
-		"tiny-glob": "^0.2.9",
 		"undici": "~5.22.0"
 	},
 	"devDependencies": {

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import mime from 'mime';
-import { runtime_directory } from '../../utils.js';
+import { list_files, runtime_directory } from '../../utils.js';
 import { posixify } from '../../../utils/filesystem.js';
 import { parse_route_id } from '../../../utils/routing.js';
 import { sort_routes } from './sort.js';
@@ -466,28 +466,6 @@ function analyze(project_relative, file, component_extensions, module_extensions
 	}
 
 	throw new Error(`Files and directories prefixed with + are reserved (saw ${project_relative})`);
-}
-
-/** @param {string} dir */
-function list_files(dir) {
-	/** @type {string[]} */
-	const files = [];
-
-	/** @param {string} current */
-	function walk(current) {
-		for (const file of fs.readdirSync(path.resolve(dir, current))) {
-			const child = path.posix.join(current, file);
-			if (fs.statSync(path.resolve(dir, child)).isDirectory()) {
-				walk(child);
-			} else {
-				files.push(child);
-			}
-		}
-	}
-
-	if (fs.existsSync(dir)) walk('');
-
-	return files;
 }
 
 /**

--- a/packages/kit/src/core/utils.js
+++ b/packages/kit/src/core/utils.js
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import colors from 'kleur';
@@ -55,4 +56,31 @@ export function get_mime_lookup(manifest_data) {
 	});
 
 	return mime;
+}
+
+/**
+ * @param {string} dir
+ * @param {(file: string) => boolean} [filter]
+ */
+export function list_files(dir, filter) {
+	/** @type {string[]} */
+	const files = [];
+
+	/** @param {string} current */
+	function walk(current) {
+		for (const file of fs.readdirSync(path.resolve(dir, current))) {
+			const child = path.posix.join(current, file);
+			if (fs.statSync(path.resolve(dir, child)).isDirectory()) {
+				walk(child);
+			} else {
+				if (!filter || filter(child)) {
+					files.push(child);
+				}
+			}
+		}
+	}
+
+	if (fs.existsSync(dir)) walk('');
+
+	return files;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,9 +406,6 @@ importers:
       sirv:
         specifier: ^2.0.2
         version: 2.0.2
-      tiny-glob:
-        specifier: ^0.2.9
-        version: 0.2.9
       undici:
         specifier: ~5.22.0
         version: 5.22.0


### PR DESCRIPTION
This change makes kit a bit smaller so that learn.svelte.dev will load just a bit faster. Removes 3 deps weighing in at a total of 41k

I was surprised to see `tiny-glob` as a dependency because I thought removed all glob deps in https://github.com/sveltejs/kit/pull/2430, but maybe we missed one or it got added back