### PR TITLE
docs: Fixed root import name for `typeVersions`

### DIFF
--- a/.changeset/tiny-insects-repeat.md
+++ b/.changeset/tiny-insects-repeat.md
@@ -1,0 +1,5 @@
+---
+'svelte-migrate': patch
+---
+
+fix: changed `index` for `index.d.ts` in `typesVersions`

--- a/.changeset/tiny-insects-repeat.md
+++ b/.changeset/tiny-insects-repeat.md
@@ -2,4 +2,4 @@
 'svelte-migrate': patch
 ---
 
-fix: changed `index` for `index.d.ts` in `typesVersions`
+fix: changed `index` to `index.d.ts` in `typesVersions`

--- a/documentation/docs/30-advanced/70-packaging.md
+++ b/documentation/docs/30-advanced/70-packaging.md
@@ -152,7 +152,7 @@ The second option is to (ab)use the `typesVersions` feature from TypeScript to w
 }
 ```
 
-`>4.0` tells TypeScript to check the inner map if the used TypeScript version is greater than 4 (which should in practice always be true). The inner map tells TypeScript that the typings for `your-library/foo` are found within `./dist/foo.d.ts`, which essentially replicates the `exports` condition. You also have `*` as a wildcard at your disposal to make many type definitions at once available without repeating yourself. Note that if you opt into `typesVersions` you have to declare all type imports through it, including the root import (which is defined as `"index": [..]`).
+`>4.0` tells TypeScript to check the inner map if the used TypeScript version is greater than 4 (which should in practice always be true). The inner map tells TypeScript that the typings for `your-library/foo` are found within `./dist/foo.d.ts`, which essentially replicates the `exports` condition. You also have `*` as a wildcard at your disposal to make many type definitions at once available without repeating yourself. Note that if you opt into `typesVersions` you have to declare all type imports through it, including the root import (which is defined as `"index.d.ts": [..]`).
 
 You can read more about that feature [here](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions).
 

--- a/packages/migrate/migrations/package/migrate_pkg.js
+++ b/packages/migrate/migrations/package/migrate_pkg.js
@@ -114,7 +114,7 @@ export function update_pkg_json(config, pkg, files) {
 			}`;
 
 			if (has_type) {
-				const type_key = key.slice(2) || 'index';
+				const type_key = key.slice(2) || 'index.d.ts';
 				if (!pkg.exports[key]) {
 					types_versions[type_key] = [out_dir_type_path];
 				} else {
@@ -191,7 +191,7 @@ export function update_pkg_json(config, pkg, files) {
 	// A hack to get around the limitation that TS doesn't support "exports" field  with moduleResolution: 'node'
 	if (
 		Object.keys(types_versions).length > 1 ||
-		(Object.keys(types_versions).length > 0 && !types_versions['index'])
+		(Object.keys(types_versions).length > 0 && !types_versions['index.d.ts'])
 	) {
 		pkg.typesVersions = { '>4.0': types_versions };
 	}

--- a/packages/migrate/migrations/package/migrate_pkg.spec.js
+++ b/packages/migrate/migrations/package/migrate_pkg.spec.js
@@ -94,7 +94,7 @@ test('Updates package.json', () => {
 		svelte: './package/index.js',
 		typesVersions: {
 			'>4.0': {
-				index: ['./package/index.d.ts'],
+				'index.d.ts': ['./package/index.d.ts'],
 				'foo/Bar.svelte': ['./package/foo/Bar.svelte.d.ts'],
 				baz: ['./package/baz.d.ts'],
 				bar: ['./package/bar/index.d.ts'],


### PR DESCRIPTION
The root import should be named `index.d.ts` rather than `index`. This little typo has lead to [a](https://github.com/skeletonlabs/skeleton/issues/1581) [whole](https://github.com/melt-ui/melt-ui/blob/fa4c5ff9c78094fc342cdbdb9d20fd87b8502f12/package.json#LL40C4-L40C4) [lot](https://github.com/grail-ui/grail-ui/blob/619274bcd525e9df0c06c59107166e3ce0b61b07/packages/grail-ui/package.json#L227) [of](https://github.com/ciscoheat/sveltekit-superforms/blob/0dd821ec6cb16694a52a5548a41c6a523b0a1607/package.json#LL70C6-L70C7) svelte packages adding `index` to their `typesVersions` map, causing them all to have incorrect auto-import paths. 

Here's a quick example if you've never experienced this before: 
![img](https://i.imgur.com/6wERuiy.gif)

In all of these cases, `/index` is appended to the end of the import path. 

While having to delete `/index` every single time is rather annoying on it's own, in most cases, it will also lead to runtime errors if the path isn't corrected.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
