### PR TITLE
chore: bump svelte peer-dependency

### DIFF
--- a/.changeset/strange-cameras-work.md
+++ b/.changeset/strange-cameras-work.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/package': minor
+---
+
+feat: support Svelte 4

--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -24,7 +24,7 @@
 		"uvu": "^0.5.6"
 	},
 	"peerDependencies": {
-		"svelte": "^3.44.0"
+		"svelte": "^3.44.0 || ^4.0.0"
 	},
 	"bin": {
 		"svelte-package": "svelte-package.js"


### PR DESCRIPTION
Cannot update a Svelte library to Svelte v4 due to peer-dependency issue.

```shell
npx svelte-migrate svelte-4
npm install
```

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: @sveltejs/package@2.0.2
npm ERR! Found: svelte@4.0.0
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer svelte@"^3.44.0" from @sveltejs/package@2.0.2
npm ERR! node_modules/@sveltejs/package
npm ERR!   dev @sveltejs/package@"^2.0.0" from the root project
```

Hopefully this fixes the problem?

```diff
{
  "name": "@sveltejs/package",
  "peerDependencies": {
-   "svelte": "^3.44.0"
+   "svelte": "^3.44.0 || ^4.0.0"
  }
}
```

---

- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
