### PR TITLE
fix: ensure glob finds all files in folders

### DIFF
--- a/.changeset/flat-berries-stare.md
+++ b/.changeset/flat-berries-stare.md
@@ -1,0 +1,5 @@
+---
+'svelte-migrate': patch
+---
+
+fix: ensure glob finds all files in folders

--- a/packages/migrate/migrations/svelte-4/index.js
+++ b/packages/migrate/migrations/svelte-4/index.js
@@ -67,9 +67,13 @@ export async function migrate() {
 		'.svelte'
 	];
 	const extensions = [...svelte_extensions, '.ts', '.js'];
-	const files = glob(`{${folders.value.join(',')}}/**`, { filesOnly: true, dot: true })
-		.map((file) => file.replace(/\\/g, '/'))
-		.filter((file) => !file.includes('/node_modules/'));
+	// For some reason {folders.value.join(',')} as part of the glob doesn't work and returns less files
+	const files = folders.value.flatMap(
+		/** @param {string} folder */ (folder) =>
+			glob(`${folder}/**`, { filesOnly: true, dot: true })
+				.map((file) => file.replace(/\\/g, '/'))
+				.filter((file) => !file.includes('/node_modules/'))
+	);
 
 	for (const file of files) {
 		if (extensions.some((ext) => file.endsWith(ext))) {


### PR DESCRIPTION
For some reason {folders.value.join(',')} as part of the glob doesn't work and returns less files fixes #10228

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
