### PR TITLE
docs: add example for setting outgoing header

### DIFF
--- a/documentation/docs/10-getting-started/40-web-standards.md
+++ b/documentation/docs/10-getting-started/40-web-standards.md
@@ -44,7 +44,7 @@ export function GET({ request }) {
 		userAgent: request.headers.get('user-agent')
 	}, {
 		// set a header on the response
-		headers: { 'x-custom-header': 'potato'}
+		headers: { 'x-custom-header': 'potato' }
 	});
 }
 ```

--- a/documentation/docs/10-getting-started/40-web-standards.md
+++ b/documentation/docs/10-getting-started/40-web-standards.md
@@ -39,9 +39,9 @@ export function GET(event) {
 	console.log(...event.request.headers);
 
 	// set a custom header
-    event.setHeaders({
-        'x-custom-header': 'potato',
-    });
+	event.setHeaders({
+		'x-custom-header': 'potato',
+	});
 
 	return json({
 		// retrieve a specific header

--- a/documentation/docs/10-getting-started/40-web-standards.md
+++ b/documentation/docs/10-getting-started/40-web-standards.md
@@ -34,19 +34,20 @@ The [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) interf
 import { json } from '@sveltejs/kit';
 
 /** @type {import('./$types').RequestHandler} */
-export function GET({ request, setHeaders }) {
+export function GET({ request }) {
 	// log all headers
 	console.log(...request.headers);
 
-	// set a custom header
-	setHeaders({
-		'x-custom-header': 'potato',
-	});
-
-	return json({
+	// create a Response from JSON
+	const response = json({
 		// retrieve a specific header
 		userAgent: request.headers.get('user-agent')
 	});
+
+	// set a custom header on the response
+	response.headers.set('x-custom-header', 'potato');
+
+	return response;
 }
 ```
 

--- a/documentation/docs/10-getting-started/40-web-standards.md
+++ b/documentation/docs/10-getting-started/40-web-standards.md
@@ -34,18 +34,18 @@ The [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) interf
 import { json } from '@sveltejs/kit';
 
 /** @type {import('./$types').RequestHandler} */
-export function GET(event) {
+export function GET({ request, setHeaders }) {
 	// log all headers
-	console.log(...event.request.headers);
+	console.log(...request.headers);
 
 	// set a custom header
-	event.setHeaders({
+	setHeaders({
 		'x-custom-header': 'potato',
 	});
 
 	return json({
 		// retrieve a specific header
-		userAgent: event.request.headers.get('user-agent')
+		userAgent: request.headers.get('user-agent')
 	});
 }
 ```

--- a/documentation/docs/10-getting-started/40-web-standards.md
+++ b/documentation/docs/10-getting-started/40-web-standards.md
@@ -38,13 +38,13 @@ export function GET({ request }) {
 	// log all headers
 	console.log(...request.headers);
 
-	// create a Response from JSON
+	// create a JSON  Response using a header we received
 	const response = json({
 		// retrieve a specific header
 		userAgent: request.headers.get('user-agent')
 	});
 
-	// set a custom header on the response
+	// set a custom header on the Response we will return
 	response.headers.set('x-custom-header', 'potato');
 
 	return response;

--- a/documentation/docs/10-getting-started/40-web-standards.md
+++ b/documentation/docs/10-getting-started/40-web-standards.md
@@ -38,7 +38,7 @@ export function GET({ request }) {
 	// log all headers
 	console.log(...request.headers);
 
-	// create a JSON  Response using a header we received
+	// create a JSON Response using a header we received
 	const response = json({
 		// retrieve a specific header
 		userAgent: request.headers.get('user-agent')

--- a/documentation/docs/10-getting-started/40-web-standards.md
+++ b/documentation/docs/10-getting-started/40-web-standards.md
@@ -38,6 +38,11 @@ export function GET(event) {
 	// log all headers
 	console.log(...event.request.headers);
 
+	// set a custom header
+    event.setHeaders({
+      'x-resp-test': 'test',
+    });
+
 	return json({
 		// retrieve a specific header
 		userAgent: event.request.headers.get('user-agent')

--- a/documentation/docs/10-getting-started/40-web-standards.md
+++ b/documentation/docs/10-getting-started/40-web-standards.md
@@ -40,7 +40,7 @@ export function GET(event) {
 
 	// set a custom header
     event.setHeaders({
-      'x-resp-test': 'test',
+        'x-custom-header': 'potato',
     });
 
 	return json({

--- a/documentation/docs/10-getting-started/40-web-standards.md
+++ b/documentation/docs/10-getting-started/40-web-standards.md
@@ -26,7 +26,7 @@ An instance of [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Res
 
 ### Headers
 
-The [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) interface allows you to read incoming `request.headers` and set outgoing `response.headers`:
+The [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) interface allows you to read incoming `request.headers` and set outgoing `response.headers`. For example, you can get the `request.headers` as shown below, and use the [`json` convenience function](modules#sveltejs-kit-json) to send modified `response.headers`:
 
 ```js
 // @errors: 2461
@@ -39,15 +39,13 @@ export function GET({ request }) {
 	console.log(...request.headers);
 
 	// create a JSON Response using a header we received
-	const response = json({
+	return json({
 		// retrieve a specific header
 		userAgent: request.headers.get('user-agent')
+	}, {
+		// set a header on the response
+		headers: { 'x-custom-header': 'potato'}
 	});
-
-	// set a custom header on the Response we will return
-	response.headers.set('x-custom-header', 'potato');
-
-	return response;
 }
 ```
 


### PR DESCRIPTION
Add an example to the documentation for setting an outgoing response header, earlier on in the documentation, as it is mentioned in the prose right before.

Reading the existing documentation leads to the idea that you might be able to do something like `event.response.headers.set` but `setHeaders` isn't mentioned until later.

I think it would be an improvement to show the example earlier than later, but I'm torn between the current PR and something more like:

```js
    // create a json response
    const response = json({
		// retrieve a specific header
		userAgent: event.request.headers.get('user-agent')
	});

    // set a custom header on the response
    response.headers.set('x-custom-header', 'potato');

    return response;
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
