### PR TITLE
docs: specify that the 'form' navigation type only applies to method="GET"

### DIFF
--- a/.changeset/tough-weeks-join.md
+++ b/.changeset/tough-weeks-join.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+docs: update inline NavigationType documentation

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -821,7 +821,7 @@ export interface NavigationTarget {
 
 /**
  * - `enter`: The app has hydrated
- * - `form`: The user submitted a `<form>`
+ * - `form`: The user submitted a `<form>` with a GET method
  * - `leave`: The user is leaving the app by closing the tab or using the back/forward buttons to go to a different document
  * - `link`: Navigation was triggered by a link click
  * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect


### PR DESCRIPTION
Closes #10237

This makes it clear in the docs that `$navigating.type` is only 'form' when a `<form method="GET">` has been submitted, not for POSTs.

Added a patch changeset since #10037 did for a similar change

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
