### PR TITLE
fix: check property descriptors for configurability before polyfill

### DIFF
--- a/.changeset/rude-bears-drop.md
+++ b/.changeset/rude-bears-drop.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: check property descriptors for configurability before polyfill
+fix: only polyfill APIs if they don't exist

--- a/.changeset/rude-bears-drop.md
+++ b/.changeset/rude-bears-drop.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: check property descriptors for configurability before polyfill

--- a/packages/kit/src/exports/node/polyfills.js
+++ b/packages/kit/src/exports/node/polyfills.js
@@ -32,17 +32,12 @@ const globals = {
  */
 export function installPolyfills() {
 	for (const name in globals) {
-		const desc = Object.getOwnPropertyDescriptor(globalThis, name);
-		if (desc === undefined || desc.configurable) {
-			Object.defineProperty(globalThis, name, {
-				enumerable: true,
-				configurable: true,
-				writable: true,
-				value: globals[name]
-			});
-		} else if (desc.writable) {
-			// @ts-expect-error
-			globalThis[name] = globals[name];
-		}
+		if (Object.hasOwnProperty.call(globalThis, name)) continue;
+		Object.defineProperty(globalThis, name, {
+			enumerable: true,
+			configurable: true,
+			writable: true,
+			value: globals[name]
+		});
 	}
 }

--- a/packages/kit/src/exports/node/polyfills.js
+++ b/packages/kit/src/exports/node/polyfills.js
@@ -32,11 +32,17 @@ const globals = {
  */
 export function installPolyfills() {
 	for (const name in globals) {
-		Object.defineProperty(globalThis, name, {
-			enumerable: true,
-			configurable: true,
-			writable: true,
-			value: globals[name]
-		});
+		const desc = Object.getOwnPropertyDescriptor(globalThis, name);
+		if (desc === undefined || desc.configurable) {
+			Object.defineProperty(globalThis, name, {
+				enumerable: true,
+				configurable: true,
+				writable: true,
+				value: globals[name]
+			});
+		} else if (desc.writable) {
+			// @ts-expect-error
+			globalThis[name] = globals[name];
+		}
 	}
 }

--- a/packages/kit/src/runtime/server/page/csp.spec.js
+++ b/packages/kit/src/runtime/server/page/csp.spec.js
@@ -1,5 +1,8 @@
 import { assert, beforeAll, test } from 'vitest';
 import { Csp } from './csp.js';
+import { installPolyfills } from '../../../exports/node/polyfills.js';
+
+installPolyfills();
 
 beforeAll(() => {
 	// @ts-expect-error

--- a/packages/kit/src/runtime/server/page/csp.spec.js
+++ b/packages/kit/src/runtime/server/page/csp.spec.js
@@ -1,9 +1,5 @@
-import { webcrypto } from 'node:crypto';
 import { assert, beforeAll, test } from 'vitest';
 import { Csp } from './csp.js';
-
-// @ts-expect-error
-globalThis.crypto = webcrypto;
 
 beforeAll(() => {
 	// @ts-expect-error


### PR DESCRIPTION
Before installing polyfills, other libraries may have already Polyfilled, and these libraries may have set incorrect `configurable` or/and `writable`, which can cause the failure of executing `Object.defineProperty`. For example, the vscode extension Console Ninja can prevent the startup of yarn dev with error:

```
error when starting dev server:
TypeError: Cannot redefine property: crypto
    at Function.defineProperty (<anonymous>)
    at installPolyfills (file:///Users/justjavac/work/op/wms-web/node_modules/@sveltejs/kit/src/exports/node/polyfills.js:35:10)
    at dev (file:///Users/justjavac/work/op/wms-web/node_modules/@sveltejs/kit/src/exports/vite/dev/index.js:29:3)
    at configureServer (file:///Users/justjavac/work/op/wms-web/node_modules/@sveltejs/kit/src/exports/vite/index.js:605:17)
    at _createServer (file:///Users/justjavac/work/op/wms-web/node_modules/vite/dist/node/chunks/dep-e8f070e8.js:63461:30)
    at async CAC.<anonymous> (file:///Users/justjavac/work/op/wms-web/node_modules/vite/dist/node/cli.js:733:24)
```

-------


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
