### PR TITLE
chore: align changesets setup with svelte core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         uses: changesets/action@v1
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: pnpm release
+          publish: pnpm changeset:release
           version: pnpm changeset:version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
 		"lint": "pnpm -r lint && eslint --cache --cache-location node_modules/.eslintcache 'packages/**/*.js'",
 		"format": "pnpm -r format",
 		"precommit": "pnpm format && pnpm lint",
-		"changeset:version": "pnpm -r generate:version && git add --all",
-		"release": "changeset publish",
+		"changeset:version": "changeset version && pnpm -r generate:version && git add --all",
+		"changeset:release": "changeset publish",
 		"start": "cd sites/kit.svelte.dev && npm run dev"
 	},
 	"devDependencies": {


### PR DESCRIPTION
`sveltejs/svelte` calls `changeset version`. I'm not sure why https://github.com/sveltejs/kit/pull/9969 omitted that