### PR TITLE
fix: do not crash server if specified `ADDRESS_HEADER` is missing from a request

### DIFF
--- a/.changeset/funny-brooms-fold.md
+++ b/.changeset/funny-brooms-fold.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+fix: do not crash server if specified `ADDRESS_HEADER` is missing from a request

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -91,20 +91,20 @@ const ssr = async (req, res) => {
 		return;
 	}
 
-	if (address_header && !(address_header in req.headers)) {
-		throw new Error(
-			`Address header was specified with ${
-				ENV_PREFIX + 'ADDRESS_HEADER'
-			}=${address_header} but is absent from request`
-		);
-	}
-
 	setResponse(
 		res,
 		await server.respond(request, {
 			platform: { req },
 			getClientAddress: () => {
 				if (address_header) {
+					if (!(address_header in req.headers)) {
+						throw new Error(
+							`Address header was specified with ${
+								ENV_PREFIX + 'ADDRESS_HEADER'
+							}=${address_header} but is absent from request`
+						);
+					}
+
 					const value = /** @type {string} */ (req.headers[address_header]) || '';
 
 					if (address_header === 'x-forwarded-for') {


### PR DESCRIPTION
This fixes #10284 by moving the check for the presence of the header specified in `ADDRESS_HEADER` inside the `getClientAddress` function. The old behavior is that non-prerendered requests without the appropriate header will instantly crash the server. The new behavior is that `getClientAddress()` will throw an exception, like with the other checks.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
