### PR TITLE
perf: only have Vite generate relative paths when required

### DIFF
--- a/.changeset/violet-dryers-nail.md
+++ b/.changeset/violet-dryers-nail.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+perf: only have Vite generate relative paths when required

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -545,7 +545,7 @@ function kit({ svelte_config }) {
 				// E.g. Vite generates `new URL('/asset.png', import.meta).href` for a relative path vs just '/asset.png'.
 				// That's larger and takes longer to run and also causes an HTML diff between SSR and client
 				// causing us to do a more expensive hydration check.
-				const client_base = kit.paths.relative || kit.paths.assets ? './' : kit.paths.base;
+				const client_base = kit.paths.relative || kit.paths.assets ? './' : kit.paths.base || '/';
 
 				new_config = {
 					base: ssr ? assets_base(kit) : client_base,

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -541,8 +541,14 @@ function kit({ svelte_config }) {
 				// see the kit.output.preloadStrategy option for details on why we have multiple options here
 				const ext = kit.output.preloadStrategy === 'preload-mjs' ? 'mjs' : 'js';
 
+				// We could always use a relative asset base path here, but it's better for performance not to.
+				// E.g. Vite generates `new URL('/asset.png', import.meta).href` for a relative path vs just '/asset.png'.
+				// That's larger and takes longer to run and also causes an HTML diff between SSR and client
+				// causing us to do a more expensive hydration check.
+				const client_base = kit.paths.relative || kit.paths.assets ? './' : kit.paths.base;
+
 				new_config = {
-					base: ssr ? assets_base(kit) : './',
+					base: ssr ? assets_base(kit) : client_base,
 					build: {
 						copyPublicDir: !ssr,
 						cssCodeSplit: true,


### PR DESCRIPTION
Even after https://github.com/sveltejs/svelte/pull/8868 is merged this is still a bit better for performance in the case that you're not using relative paths.