### PR TITLE
fix(adapter-node): Enforce `dir` to be an actual directory.

### DIFF
--- a/.changeset/sweet-ties-wonder.md
+++ b/.changeset/sweet-ties-wonder.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Enforce the calculated server directory is actually a directory (compatibility with bundlers)

--- a/.changeset/sweet-ties-wonder.md
+++ b/.changeset/sweet-ties-wonder.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-node': patch
 ---
 
-Enforce the calculated server directory is actually a directory (compatibility with bundlers)
+fix: Enforce the calculated server directory is actually a directory (compatibility with bundlers)

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -22,7 +22,7 @@ const host_header = env('HOST_HEADER', 'host').toLowerCase();
 const body_size_limit = parseInt(env('BODY_SIZE_LIMIT', '524288'));
 
 const root = fileURLToPath(import.meta.SERVER_DIR);
-const dir = root.endsWith('.js') ? path.dirname(root) : root;
+const dir = !fs.statSync(root).isDirectory() ? path.dirname(root) : root;
 
 /**
  * @param {string} path

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -21,7 +21,8 @@ const protocol_header = env('PROTOCOL_HEADER', '').toLowerCase();
 const host_header = env('HOST_HEADER', 'host').toLowerCase();
 const body_size_limit = parseInt(env('BODY_SIZE_LIMIT', '524288'));
 
-const dir = fileURLToPath(import.meta.SERVER_DIR);
+const root = fileURLToPath(import.meta.SERVER_DIR);
+const dir = root.endsWith('.js') ? path.dirname(root) : root;
 
 /**
  * @param {string} path


### PR DESCRIPTION
This PR addresses a small issue that tends to happen when trying to utilise the handler generated by `adapter-node` in monorepos that require a bundler like Webpack. For some reason, the current implementation tends to set `dir` to a JS file instead of a directory, like `/packages/stellar-desktop/dist/b1229d39b38c826bd9a3.js`, resulting in public asset lookups in paths that `/packages/stellar-desktop/dist/b1229d39b38c826bd9a3.js/client` (which are clearly invalid).

This PR contains a single one-line change that, if verified that `dir` is a `js` file, passes its value through `path.dirname` to get its actual path. This fixes the code when passed through bundlers, while retaining full functionality with no changes required for either the standalone server or standard usage of the handler. All tests have passed, although I believe including an extra one (as described by checklist item 3) is out of scope for this repo.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
Not quite an issue, but there is [this StackOverflow Question](https://stackoverflow.com/questions/71569345/sveltekit-build-w-adapter-node-404-on-newly-created-static-files) that recommends an external static asset server configuration as a solution (which goes against SvelteKit's Docs)
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
