### PR TITLE
feat: use Svelte 4 typings when packaging if dependencies allow it

### DIFF
--- a/.changeset/famous-points-complain.md
+++ b/.changeset/famous-points-complain.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/package': minor
+---
+
+feat: use Svelte 4 typings when packaging if dependencies allow it

--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -14,10 +14,12 @@
 		"chokidar": "^3.5.3",
 		"kleur": "^4.1.5",
 		"sade": "^1.8.1",
-		"svelte2tsx": "~0.6.16"
+		"semver": "^7.5.3",
+		"svelte2tsx": "~0.6.19"
 	},
 	"devDependencies": {
 		"@types/node": "^16.18.6",
+		"@types/semver": "^7.5.0",
 		"svelte": "^4.0.3",
 		"svelte-preprocess": "^5.0.4",
 		"typescript": "^4.9.4",

--- a/packages/package/src/config.js
+++ b/packages/package/src/config.js
@@ -25,3 +25,17 @@ export async function load_config({ cwd = process.cwd() } = {}) {
 
 	return config;
 }
+
+/**
+ * @param {string} cwd
+ * @returns Record<string, any>
+ */
+export function load_pkg_json(cwd = process.cwd()) {
+	const pkg_json_file = path.join(cwd, 'package.json');
+
+	if (!fs.existsSync(pkg_json_file)) {
+		return {};
+	}
+
+	return JSON.parse(fs.readFileSync(pkg_json_file, 'utf-8'));
+}

--- a/packages/package/test/fixtures/javascript/expected/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/javascript/expected/Test.svelte.d.ts
@@ -1,7 +1,7 @@
 /** @typedef {typeof __propDef.props}  TestProps */
 /** @typedef {typeof __propDef.events}  TestEvents */
 /** @typedef {typeof __propDef.slots}  TestSlots */
-export default class Test extends SvelteComponentTyped<
+export default class Test extends SvelteComponent<
 	{
 		astring?: string;
 	},
@@ -21,7 +21,7 @@ export default class Test extends SvelteComponentTyped<
 export type TestProps = typeof __propDef.props;
 export type TestEvents = typeof __propDef.events;
 export type TestSlots = typeof __propDef.slots;
-import { SvelteComponentTyped } from 'svelte';
+import { SvelteComponent } from 'svelte';
 declare const __propDef: {
 	props: {
 		astring?: string;

--- a/packages/package/test/fixtures/javascript/expected/Test2.svelte.d.ts
+++ b/packages/package/test/fixtures/javascript/expected/Test2.svelte.d.ts
@@ -1,7 +1,7 @@
 /** @typedef {typeof __propDef.props}  Test2Props */
 /** @typedef {typeof __propDef.events}  Test2Events */
 /** @typedef {typeof __propDef.slots}  Test2Slots */
-export default class Test2 extends SvelteComponentTyped<
+export default class Test2 extends SvelteComponent<
 	{
 		foo: boolean;
 	},
@@ -13,7 +13,7 @@ export default class Test2 extends SvelteComponentTyped<
 export type Test2Props = typeof __propDef.props;
 export type Test2Events = typeof __propDef.events;
 export type Test2Slots = typeof __propDef.slots;
-import { SvelteComponentTyped } from 'svelte';
+import { SvelteComponent } from 'svelte';
 declare const __propDef: {
 	props: {
 		foo: import('./foo').Foo;

--- a/packages/package/test/fixtures/javascript/expected/internal/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/javascript/expected/internal/Test.svelte.d.ts
@@ -1,7 +1,7 @@
 /** @typedef {typeof __propDef.props}  TestProps */
 /** @typedef {typeof __propDef.events}  TestEvents */
 /** @typedef {typeof __propDef.slots}  TestSlots */
-export default class Test extends SvelteComponentTyped<
+export default class Test extends SvelteComponent<
 	{
 		foo: boolean;
 	},
@@ -13,7 +13,7 @@ export default class Test extends SvelteComponentTyped<
 export type TestProps = typeof __propDef.props;
 export type TestEvents = typeof __propDef.events;
 export type TestSlots = typeof __propDef.slots;
-import { SvelteComponentTyped } from 'svelte';
+import { SvelteComponent } from 'svelte';
 declare const __propDef: {
 	props: {
 		foo: import('./foo').Foo;

--- a/packages/package/test/fixtures/resolve-alias/expected/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/resolve-alias/expected/Test.svelte.d.ts
@@ -1,4 +1,4 @@
-import { SvelteComponentTyped } from 'svelte';
+import { SvelteComponent } from 'svelte';
 declare const __propDef: {
 	props: {
 		bar?: import('./sub/foo').Foo;
@@ -11,5 +11,5 @@ declare const __propDef: {
 export type TestProps = typeof __propDef.props;
 export type TestEvents = typeof __propDef.events;
 export type TestSlots = typeof __propDef.slots;
-export default class Test extends SvelteComponentTyped<TestProps, TestEvents, TestSlots> {}
+export default class Test extends SvelteComponent<TestProps, TestEvents, TestSlots> {}
 export {};

--- a/packages/package/test/fixtures/svelte-3-types/expected/Test.svelte
+++ b/packages/package/test/fixtures/svelte-3-types/expected/Test.svelte
@@ -1,0 +1,8 @@
+<script>
+import { createEventDispatcher } from 'svelte';
+export const astring = 'potato';
+const dispatch = createEventDispatcher();
+dispatch('event', true);
+</script>
+
+<slot {astring} />

--- a/packages/package/test/fixtures/svelte-3-types/expected/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/svelte-3-types/expected/Test.svelte.d.ts
@@ -1,4 +1,4 @@
-import { SvelteComponent } from 'svelte';
+import { SvelteComponentTyped } from 'svelte';
 declare const __propDef: {
 	props: {
 		astring?: string;
@@ -17,7 +17,7 @@ declare const __propDef: {
 export type TestProps = typeof __propDef.props;
 export type TestEvents = typeof __propDef.events;
 export type TestSlots = typeof __propDef.slots;
-export default class Test extends SvelteComponent<TestProps, TestEvents, TestSlots> {
+export default class Test extends SvelteComponentTyped<TestProps, TestEvents, TestSlots> {
 	get astring(): string;
 }
 export {};

--- a/packages/package/test/fixtures/svelte-3-types/expected/index.d.ts
+++ b/packages/package/test/fixtures/svelte-3-types/expected/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Test } from './Test.svelte';

--- a/packages/package/test/fixtures/svelte-3-types/expected/index.js
+++ b/packages/package/test/fixtures/svelte-3-types/expected/index.js
@@ -1,0 +1,1 @@
+export { default as Test } from './Test.svelte';

--- a/packages/package/test/fixtures/svelte-3-types/package.json
+++ b/packages/package/test/fixtures/svelte-3-types/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "svelte-3-types",
+	"private": true,
+	"version": "1.0.0",
+	"description": "creates Svelte 3 backwards compatible types",
+	"type": "module",
+	"peerDependencies": {
+		"svelte": "^3.0.0 || ^4.0.0"
+	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"svelte": "./dist/index.js"
+		}
+	}
+}

--- a/packages/package/test/fixtures/svelte-3-types/src/lib/Test.svelte
+++ b/packages/package/test/fixtures/svelte-3-types/src/lib/Test.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	export const astring: string = 'potato';
+
+	const dispatch = createEventDispatcher<{ event: boolean }>();
+	dispatch('event', true);
+</script>
+
+<slot {astring} />

--- a/packages/package/test/fixtures/svelte-3-types/src/lib/index.ts
+++ b/packages/package/test/fixtures/svelte-3-types/src/lib/index.ts
@@ -1,0 +1,1 @@
+export { default as Test } from './Test.svelte';

--- a/packages/package/test/fixtures/svelte-3-types/svelte.config.js
+++ b/packages/package/test/fixtures/svelte-3-types/svelte.config.js
@@ -1,0 +1,7 @@
+import preprocess from 'svelte-preprocess';
+
+export default {
+	preprocess: preprocess({
+		preserve: ['ld+json']
+	})
+};

--- a/packages/package/test/fixtures/svelte-3-types/tsconfig.json
+++ b/packages/package/test/fixtures/svelte-3-types/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext"
+	}
+}

--- a/packages/package/test/fixtures/svelte-kit/expected/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/svelte-kit/expected/Test.svelte.d.ts
@@ -1,7 +1,7 @@
 /** @typedef {typeof __propDef.props}  TestProps */
 /** @typedef {typeof __propDef.events}  TestEvents */
 /** @typedef {typeof __propDef.slots}  TestSlots */
-export default class Test extends SvelteComponentTyped<
+export default class Test extends SvelteComponent<
 	{
 		astring?: string;
 	},
@@ -21,7 +21,7 @@ export default class Test extends SvelteComponentTyped<
 export type TestProps = typeof __propDef.props;
 export type TestEvents = typeof __propDef.events;
 export type TestSlots = typeof __propDef.slots;
-import { SvelteComponentTyped } from 'svelte';
+import { SvelteComponent } from 'svelte';
 declare const __propDef: {
 	props: {
 		astring?: string;

--- a/packages/package/test/fixtures/typescript/expected/Plain.svelte.d.ts
+++ b/packages/package/test/fixtures/typescript/expected/Plain.svelte.d.ts
@@ -1,7 +1,7 @@
 /** @typedef {typeof __propDef.props}  PlainProps */
 /** @typedef {typeof __propDef.events}  PlainEvents */
 /** @typedef {typeof __propDef.slots}  PlainSlots */
-export default class Plain extends SvelteComponentTyped<
+export default class Plain extends SvelteComponent<
 	{
 		foo: boolean;
 	},
@@ -13,7 +13,7 @@ export default class Plain extends SvelteComponentTyped<
 export type PlainProps = typeof __propDef.props;
 export type PlainEvents = typeof __propDef.events;
 export type PlainSlots = typeof __propDef.slots;
-import { SvelteComponentTyped } from 'svelte';
+import { SvelteComponent } from 'svelte';
 declare const __propDef: {
 	props: {
 		foo: import('./foo').Foo;

--- a/packages/package/test/fixtures/typescript/expected/Test2.svelte.d.ts
+++ b/packages/package/test/fixtures/typescript/expected/Test2.svelte.d.ts
@@ -1,4 +1,4 @@
-import { SvelteComponentTyped } from 'svelte';
+import { SvelteComponent } from 'svelte';
 import type { Foo } from './foo';
 declare const __propDef: {
 	props: {
@@ -12,5 +12,5 @@ declare const __propDef: {
 export type Test2Props = typeof __propDef.props;
 export type Test2Events = typeof __propDef.events;
 export type Test2Slots = typeof __propDef.slots;
-export default class Test2 extends SvelteComponentTyped<Test2Props, Test2Events, Test2Slots> {}
+export default class Test2 extends SvelteComponent<Test2Props, Test2Events, Test2Slots> {}
 export {};

--- a/packages/package/test/index.js
+++ b/packages/package/test/index.js
@@ -135,6 +135,10 @@ test('create package with emitTypes settings disabled', async () => {
 	await test_make_package('emitTypes-false', { types: false });
 });
 
+test('create package with SvelteComponentTyped for backwards compatibility', async () => {
+	await test_make_package('svelte-3-types');
+});
+
 test('create package and resolves $lib alias', async () => {
 	await test_make_package('resolve-alias');
 });

--- a/packages/package/test/watch/expected/Test.svelte.d.ts
+++ b/packages/package/test/watch/expected/Test.svelte.d.ts
@@ -1,4 +1,4 @@
-import { SvelteComponentTyped } from "svelte";
+import { SvelteComponent } from "svelte";
 declare const __propDef: {
     props: {
         answer: number;
@@ -11,6 +11,6 @@ declare const __propDef: {
 export type TestProps = typeof __propDef.props;
 export type TestEvents = typeof __propDef.events;
 export type TestSlots = typeof __propDef.slots;
-export default class Test extends SvelteComponentTyped<TestProps, TestEvents, TestSlots> {
+export default class Test extends SvelteComponent<TestProps, TestEvents, TestSlots> {
 }
 export {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -957,13 +957,19 @@ importers:
       sade:
         specifier: ^1.8.1
         version: 1.8.1
+      semver:
+        specifier: ^7.5.3
+        version: 7.5.3
       svelte2tsx:
-        specifier: ~0.6.16
-        version: 0.6.16(svelte@4.0.3)(typescript@4.9.4)
+        specifier: ~0.6.19
+        version: 0.6.19(svelte@4.0.3)(typescript@4.9.4)
     devDependencies:
       '@types/node':
         specifier: ^16.18.6
         version: 16.18.6
+      '@types/semver':
+        specifier: ^7.5.0
+        version: 7.5.0
       svelte:
         specifier: ^4.0.3
         version: 4.0.3
@@ -1624,7 +1630,7 @@ packages:
       nopt: 5.0.0
       npmlog: 5.0.1
       rimraf: 3.0.2
-      semver: 7.5.1
+      semver: 7.5.3
       tar: 6.1.12
     transitivePeerDependencies:
       - encoding
@@ -1936,8 +1942,8 @@ packages:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
     dev: true
 
-  /@types/semver@7.3.13:
-    resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
+  /@types/semver@7.5.0:
+    resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
     dev: true
 
   /@types/set-cookie-parser@2.4.2:
@@ -1973,7 +1979,7 @@ packages:
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
-      semver: 7.3.8
+      semver: 7.5.3
       tsutils: 3.21.0(typescript@4.9.4)
       typescript: 4.9.4
     transitivePeerDependencies:
@@ -2060,7 +2066,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.8
+      semver: 7.5.3
       tsutils: 3.21.0(typescript@4.9.4)
       typescript: 4.9.4
     transitivePeerDependencies:
@@ -2095,14 +2101,14 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@types/json-schema': 7.0.11
-      '@types/semver': 7.3.13
+      '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 5.53.0
       '@typescript-eslint/types': 5.53.0
       '@typescript-eslint/typescript-estree': 5.53.0(typescript@4.9.4)
       eslint: 8.40.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@8.40.0)
-      semver: 7.3.8
+      semver: 7.5.3
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3160,7 +3166,7 @@ packages:
       regexp-tree: 0.1.24
       regjsparser: 0.10.0
       safe-regex: 2.1.1
-      semver: 7.5.0
+      semver: 7.5.3
       strip-indent: 3.0.0
     dev: true
 
@@ -5247,37 +5253,12 @@ packages:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
     hasBin: true
 
-  /semver@7.3.8:
-    resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
-    dev: true
-
-  /semver@7.5.0:
-    resolution: {integrity: sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
-    dev: true
-
-  /semver@7.5.1:
-    resolution: {integrity: sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
-    dev: false
-
   /semver@7.5.3:
     resolution: {integrity: sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -5807,8 +5788,8 @@ packages:
       typescript: 5.0.4
     dev: true
 
-  /svelte2tsx@0.6.16(svelte@4.0.3)(typescript@4.9.4):
-    resolution: {integrity: sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==}
+  /svelte2tsx@0.6.19(svelte@4.0.3)(typescript@4.9.4):
+    resolution: {integrity: sha512-h3b5OtcO8zyVL/RiB2zsDwCopeo/UH+887uyhgb2mjnewOFwiTxu+4IGuVwrrlyuh2onM2ktfUemNrNmQwXONQ==}
     peerDependencies:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0
       typescript: ^4.9.4 || ^5.0.0


### PR DESCRIPTION
When the (peer)dependency states that only Svelte 4 is allowed, invoke the dts generation script with the Svelte 4 shims instead of the Svelte 3 shims. The noticable difference is that then SvelteComponent instead of the deprecated SvelteComponentTyped will be used to declare the component typings. closes #10223

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
