### PR TITLE
fix(adapter-cloudflare): Generate folder path with wildcard if folder exists

### DIFF
--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -99,7 +99,20 @@ function get_routes_json(builder, assets, { include = ['/*'], exclude = ['<all>'
 								file === '_redirects'
 							)
 					)
-					.map((file) => `/${file}`);
+					.reduce((prev, file_path) => {
+						const split_path = file_path.split(path.sep);
+						/**
+						 * There is a limit of 100 rules or less. Take advantage of wildcards and generate as few file paths as possible
+						 * https://developers.cloudflare.com/pages/platform/functions/routing/#create-a-_routesjson-file
+						 */
+						if (split_path.length > 1) {
+							const shallow_folder = split_path[0];
+							const exclude_dir = `/${shallow_folder}/*`;
+
+							return prev.includes(exclude_dir) ? prev : [...prev, exclude_dir];
+						}
+						return [...prev, `/${split_path[0]}`];
+					}, []);
 			}
 
 			if (rule === '<prerendered>') {

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -100,18 +100,18 @@ function get_routes_json(builder, assets, { include = ['/*'], exclude = ['<all>'
 							)
 					)
 					.reduce((prev, file_path) => {
-						const split_path = file_path.split(path.sep);
+						const split_paths = file_path.split(path.sep);
 						/**
 						 * There is a limit of 100 rules or less. Take advantage of wildcards and generate as few file paths as possible
 						 * https://developers.cloudflare.com/pages/platform/functions/routing/#create-a-_routesjson-file
 						 */
-						if (split_path.length > 1) {
-							const shallow_folder = split_path[0];
-							const exclude_dir = `/${shallow_folder}/*`;
+						if (split_paths.length > 1) {
+							const shallow_folder = split_paths[0];
+							const exclude_pattern = `/${shallow_folder}/*`;
 
-							return prev.includes(exclude_dir) ? prev : [...prev, exclude_dir];
+							return prev.includes(exclude_pattern) ? prev : [...prev, exclude_pattern];
 						}
-						return [...prev, `/${split_path[0]}`];
+						return [...prev, `/${split_paths[0]}`];
 					}, []);
 			}
 

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -100,14 +100,14 @@ function get_routes_json(builder, assets, { include = ['/*'], exclude = ['<all>'
 							)
 					)
 					.reduce((prev, file_path) => {
-						const split_path = file_path.split('/');
+						const path_segments = file_path.split('/');
 						// There's a limit of 100 rules. Take advantage of wildcards and generate as few file paths as possible
 						// https://developers.cloudflare.com/pages/platform/functions/routing/#create-a-_routesjson-file
-						if (split_path.length > 1) {
-							const exclude_pattern = `/${split_path[0]}/*`;
+						if (path_segments.length > 1) {
+							const exclude_pattern = `/${path_segments[0]}/*`;
 							return prev.includes(exclude_pattern) ? prev : [...prev, exclude_pattern];
 						}
-						return [...prev, `/${split_path[0]}`];
+						return [...prev, `/${path_segments[0]}`];
 					}, []);
 			}
 

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -105,7 +105,6 @@ function get_routes_json(builder, assets, { include = ['/*'], exclude = ['<all>'
 						// https://developers.cloudflare.com/pages/platform/functions/routing/#create-a-_routesjson-file
 						if (split_path.length > 1) {
 							const exclude_pattern = `/${split_path[0]}/*`;
-
 							return prev.includes(exclude_pattern) ? prev : [...prev, exclude_pattern];
 						}
 						return [...prev, `/${split_path[0]}`];

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -104,8 +104,7 @@ function get_routes_json(builder, assets, { include = ['/*'], exclude = ['<all>'
 						// There's a limit of 100 rules. Take advantage of wildcards and generate as few file paths as possible
 						// https://developers.cloudflare.com/pages/platform/functions/routing/#create-a-_routesjson-file
 						if (split_path.length > 1) {
-							const shallow_folder = split_path[0];
-							const exclude_pattern = `/${shallow_folder}/*`;
+							const exclude_pattern = `/${split_path[0]}/*`;
 
 							return prev.includes(exclude_pattern) ? prev : [...prev, exclude_pattern];
 						}

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -70,7 +70,7 @@ export default function (options = {}) {
  * @param {string} file_path
  */
 function find_shallowest_exclude_pattern(builder, file_path) {
-	const exclude_file_path = `/${file_path}`
+	const exclude_file_path = `/${file_path}`;
 	const path_segments = file_path.split('/');
 	if (path_segments.length === 0) {
 		return file_path;

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -63,6 +63,34 @@ export default function (options = {}) {
 }
 
 /**
+ * There's a limit of 100 rules. Take advantage of wildcards and generate as few file paths as possible
+ * https://developers.cloudflare.com/pages/platform/functions/routing/#create-a-_routesjson-file
+ *
+ * @param {import('@sveltejs/kit').Builder} builder
+ * @param {string} file_path
+ */
+function find_shallowest_exclude_pattern(builder, file_path) {
+	const path_segments = file_path.split('/');
+	if (path_segments.length === 0) {
+		return path_segments.join('/');
+	}
+	let exclude_pattern = `/${file_path}`;
+	// Exclude patterns can conflict with sveltekit routes, so don't wildcard paths in that case.
+	for (let i = path_segments.length; i > 0; i--) {
+		const path = `/${path_segments.slice(0, i).join('/')}`;
+		// Test `dir/*` pattern against all sveltekit routes
+		// The reason `%` is used is because it's an invalid character in a file path but valid in a route pattern
+		const tmp_test_string = '%';
+		const test_string = i === path_segments.length ? file_path : `${path}/${tmp_test_string}`;
+		if (builder.routes.some((route) => route.pattern.test(test_string))) {
+			break;
+		}
+		exclude_pattern = path;
+	}
+
+	return exclude_pattern === `/${file_path}` ? exclude_pattern : `${exclude_pattern}/*`;
+}
+/**
  * @param {import('@sveltejs/kit').Builder} builder
  * @param {string[]} assets
  * @param {import('./index').AdapterOptions['routes']} routes
@@ -99,24 +127,9 @@ function get_routes_json(builder, assets, { include = ['/*'], exclude = ['<all>'
 							)
 					)
 					.reduce((prev, file_path) => {
-						const raw_file_path_return = [...prev, `/${file_path}`];
-						const path_segments = file_path.split('/');
-						// There's a limit of 100 rules. Take advantage of wildcards and generate as few file paths as possible
-						// https://developers.cloudflare.com/pages/platform/functions/routing/#create-a-_routesjson-file
-						if (path_segments.length > 1) {
-							const dir_path = path_segments.slice(0, -1).join('/');
-							// Exclude patterns can conflict with sveltekit routes, so don't wildcard paths in that case.
-							const is_matches_sveltekit_routes = builder.routes.some((route) =>
-								route.pattern.test(`/${file_path}`)
-							);
-							if (is_matches_sveltekit_routes) {
-								return raw_file_path_return;
-							}
+						const exclude_pattern = find_shallowest_exclude_pattern(builder, file_path);
 
-							const exclude_pattern = `/${dir_path}/*`;
-							return prev.includes(exclude_pattern) ? prev : [...prev, exclude_pattern];
-						}
-						return raw_file_path_return;
+						return prev.includes(exclude_pattern) ? prev : [...prev, exclude_pattern];
 					}, []);
 			}
 

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -70,11 +70,12 @@ export default function (options = {}) {
  * @param {string} file_path
  */
 function find_shallowest_exclude_pattern(builder, file_path) {
+	const exclude_file_path = `/${file_path}`
 	const path_segments = file_path.split('/');
 	if (path_segments.length === 0) {
 		return file_path;
 	}
-	let exclude_pattern = `/${file_path}`;
+	let exclude_pattern = exclude_file_path;
 	// Exclude patterns can conflict with sveltekit routes, so don't wildcard paths in that case.
 	for (let i = path_segments.length; i > 0; i--) {
 		const path = `/${path_segments.slice(0, i).join('/')}`;
@@ -88,7 +89,7 @@ function find_shallowest_exclude_pattern(builder, file_path) {
 		exclude_pattern = path;
 	}
 
-	return exclude_pattern === `/${file_path}` ? exclude_pattern : `${exclude_pattern}/*`;
+	return exclude_pattern === exclude_file_path ? exclude_pattern : `${exclude_pattern}/*`;
 }
 /**
  * @param {import('@sveltejs/kit').Builder} builder

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -72,7 +72,7 @@ export default function (options = {}) {
 function find_shallowest_exclude_pattern(builder, file_path) {
 	const path_segments = file_path.split('/');
 	if (path_segments.length === 0) {
-		return path_segments.join('/');
+		return file_path;
 	}
 	let exclude_pattern = `/${file_path}`;
 	// Exclude patterns can conflict with sveltekit routes, so don't wildcard paths in that case.

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -88,7 +88,7 @@ function get_routes_json(builder, assets, { include = ['/*'], exclude = ['<all>'
 			if (rule === '<build>') {
 				return `/${builder.config.kit.appDir}/*`;
 			}
-			console.log(assets);
+
 			if (rule === '<files>') {
 				return assets
 					.filter(

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -88,7 +88,7 @@ function get_routes_json(builder, assets, { include = ['/*'], exclude = ['<all>'
 			if (rule === '<build>') {
 				return `/${builder.config.kit.appDir}/*`;
 			}
-
+			console.log(assets);
 			if (rule === '<files>') {
 				return assets
 					.filter(
@@ -100,18 +100,18 @@ function get_routes_json(builder, assets, { include = ['/*'], exclude = ['<all>'
 							)
 					)
 					.reduce((prev, file_path) => {
-						const split_paths = file_path.split(path.sep);
+						const split_path = file_path.split('/');
 						/**
 						 * There is a limit of 100 rules or less. Take advantage of wildcards and generate as few file paths as possible
 						 * https://developers.cloudflare.com/pages/platform/functions/routing/#create-a-_routesjson-file
 						 */
-						if (split_paths.length > 1) {
-							const shallow_folder = split_paths[0];
+						if (split_path.length > 1) {
+							const shallow_folder = split_path[0];
 							const exclude_pattern = `/${shallow_folder}/*`;
 
 							return prev.includes(exclude_pattern) ? prev : [...prev, exclude_pattern];
 						}
-						return [...prev, `/${split_paths[0]}`];
+						return [...prev, `/${split_path[0]}`];
 					}, []);
 			}
 

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -101,10 +101,8 @@ function get_routes_json(builder, assets, { include = ['/*'], exclude = ['<all>'
 					)
 					.reduce((prev, file_path) => {
 						const split_path = file_path.split('/');
-						/**
-						 * There is a limit of 100 rules or less. Take advantage of wildcards and generate as few file paths as possible
-						 * https://developers.cloudflare.com/pages/platform/functions/routing/#create-a-_routesjson-file
-						 */
+						// There's a limit of 100 rules. Take advantage of wildcards and generate as few file paths as possible
+						// https://developers.cloudflare.com/pages/platform/functions/routing/#create-a-_routesjson-file
 						if (split_path.length > 1) {
 							const shallow_folder = split_path[0];
 							const exclude_pattern = `/${shallow_folder}/*`;


### PR DESCRIPTION
fixes #9616

The auto-generated _routes.json will output all files nested in the exclude array. This quickly exceeds the cloudflare limit of 100 rules.
Therefore, when it is determined that a folder is included in the output file, it has been modified to output the shallowest folder and wildcard

example (my private sveltekit project using adapter-cloudflare)
```
❯  tree static 
static
├── aaaaaads.txt
├── blog_ogp.png
├── favicon.ico
├── favicons
│   ├── a
│   │   ├── android-chrome-192x192.png
│   │   └── b
│   ├── apple-touch-icon.png
│   ├── browserconfig.xml
│   ├── c
│   │   └── android-chrome-384x384.png
│   ├── favicon-32x32.png
│   ├── favicon.ico
│   ├── favicon.png
│   └── mstile-150x150.png
├── ogp.png
├── robots.txt
├── site.webmanifest
└── x
    ├── safari-pinned-tab.svg
    └── y
```

output:
```json
{
	"version": 1,
	"description": "Generated by @sveltejs/adapter-cloudflare",
	"include": [
		"/*"
	],
	"exclude": [
		"/_app/*",
		"/aaaaaads.txt",
		"/blog_ogp.png",
		"/favicon.ico",
		"/favicons/*",
		"/ogp.png",
		"/robots.txt",
		"/site.webmanifest",
		"/x/*",
		"/about"
	]
}
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
