### PR TITLE
fix: don't fail on immutable headers when using native fetch

### DIFF
--- a/.changeset/violet-pans-scream.md
+++ b/.changeset/violet-pans-scream.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: gracefully handle server endpoints that return `Response`s with immutable `Headers`

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -440,6 +440,13 @@ export async function respond(request, options, manifest, state) {
 						?.split(',')
 						?.map((v) => v.trim().toLowerCase());
 					if (!(vary?.includes('accept') || vary?.includes('*'))) {
+						// the returned response might have immutable headers,
+						// so we have to clone them before trying to mutate them
+						response = new Response(response.body, {
+							status: response.status,
+							statusText: response.statusText,
+							headers: new Headers(response.headers)
+						});
 						response.headers.append('Vary', 'Accept');
 					}
 				}

--- a/packages/kit/test/apps/basics/src/routes/immutable-headers/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/immutable-headers/+page.js
@@ -1,0 +1,4 @@
+// This file will trigger the vary-header code-path in `src/runtime/server/respond.js`
+export function load() {
+	return { foo: 'bar' };
+}

--- a/packages/kit/test/apps/basics/src/routes/immutable-headers/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/immutable-headers/+server.js
@@ -1,0 +1,7 @@
+export const GET = () => {
+	const response = new Response('foo');
+	// this simulates immutable Response Headers, like those returned by undici
+	Object.defineProperty(response.headers, 'append', { value: null });
+	Object.defineProperty(response.headers, 'set', { value: null });
+	return response;
+};

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -569,4 +569,10 @@ test.describe('Miscellaneous', () => {
 		const headers = response.headers();
 		expect(headers['cache-control'] || '').not.toContain('immutable');
 	});
+
+	test('handles responses with immutable headers', async ({ request }) => {
+		const response = await request.get('/immutable-headers');
+		expect(response.status()).toBe(200);
+		expect(await response.text()).toBe('foo');
+	});
 });


### PR DESCRIPTION
## Description

Fixes #10366, related to #10030.

According to the `fetch()`-specification, a header can have an `immutable`-guard which will throw a `TypeError` if the header is changed:
https://fetch.spec.whatwg.org/#headers-class

When using `fetch()`, the spec requires the response header to be `immutable` (see step 12/4):
https://fetch.spec.whatwg.org/#fetch-method

This is implemented in undici (used by Node.js for native fetch() under the hood):
https://github.com/nodejs/undici/blob/22bdbd8c7820035276b4e876daccef513c29f5c4/lib/fetch/headers.js#L234-L239

Since PR https://github.com/sveltejs/kit/pull/9993, a `TypeError` is thrown when using native `fetch()` because SvelteKit is trying to change the header from the fetch-response-object.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
