### PR TITLE
chore: bump typescript-eslint to v6

### DIFF
--- a/.changeset/pretty-avocados-ring.md
+++ b/.changeset/pretty-avocados-ring.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+chore: bump typescript-eslint to v6

--- a/packages/create-svelte/shared/+eslint+typescript/.eslintrc.cjs
+++ b/packages/create-svelte/shared/+eslint+typescript/.eslintrc.cjs
@@ -2,12 +2,14 @@ module.exports = {
 	root: true,
 	extends: [
 		'eslint:recommended',
-		'plugin:@typescript-eslint/recommended',
+		'plugin:@typescript-eslint/recommended-type-checked',
+		'plugin:@typescript-eslint/stylistic-type-checked',
 		'plugin:svelte/recommended'
 	],
 	parser: '@typescript-eslint/parser',
 	plugins: ['@typescript-eslint'],
 	parserOptions: {
+		project: true,
 		sourceType: 'module',
 		ecmaVersion: 2020,
 		extraFileExtensions: ['.svelte']

--- a/packages/create-svelte/shared/+eslint+typescript/package.json
+++ b/packages/create-svelte/shared/+eslint+typescript/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"@typescript-eslint/eslint-plugin": "^5.45.0",
-		"@typescript-eslint/parser": "^5.45.0"
+		"@typescript-eslint/eslint-plugin": "^6.0.0",
+		"@typescript-eslint/parser": "^6.0.0"
 	}
 }

--- a/packages/create-svelte/shared/+eslint/.eslintignore
+++ b/packages/create-svelte/shared/+eslint/.eslintignore
@@ -11,3 +11,5 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+.eslintrc.cjs


### PR DESCRIPTION
Upgraded SvelteKit templates to [typescript-eslint v6].

---

[typescript-eslint v6]: https://typescript-eslint.io/blog/announcing-typescript-eslint-v6/

`.eslintrc.cjs` has been added to the `.eslintignore` file.

> Parsing error: ESLint was configured to run on `<tsconfigRootDir>/.eslintrc.cjs` using `parserOptions.project`: ~
>
> However, that TSConfig does not include this file. Either:
> - Change ESLint's list of included files to not include this file ⬅️
> - Change that TSConfig to include this file
> - Create a new TSConfig that includes this file and include it in your parserOptions.project
>
> See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-fileeslint

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
