### PR TITLE
fix: prevent duplicate `<link>` module preloads

### DIFF
--- a/.changeset/funny-items-deny.md
+++ b/.changeset/funny-items-deny.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prevent duplicate module preload

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -712,7 +712,12 @@ function kit({ svelte_config }) {
 							minify: initial_config.build?.minify,
 							assetsInlineLimit: vite_config.build.assetsInlineLimit,
 							sourcemap: vite_config.build.sourcemap,
-							modulePreload: false
+							modulePreload: {
+								// disable Vite's JS module preload
+								resolveDependencies: () => {
+									return [];
+								}
+							}
 						},
 						optimizeDeps: {
 							force: vite_config.optimizeDeps.force

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -43,6 +43,7 @@ const enforced_config = {
 			formats: true
 		},
 		manifest: true,
+		modulePreload: true,
 		outDir: true,
 		rollupOptions: {
 			input: true,
@@ -555,6 +556,10 @@ function kit({ svelte_config }) {
 						cssMinify: initial_config.build?.minify == null ? true : !!initial_config.build.minify,
 						// don't use the default name to avoid collisions with 'static/manifest.json'
 						manifest: 'vite-manifest.json',
+						modulePreload: {
+							// disable Vite's JS module preload
+							resolveDependencies: () => []
+						},
 						outDir: `${out}/${ssr ? 'server' : 'client'}`,
 						rollupOptions: {
 							input,
@@ -711,13 +716,7 @@ function kit({ svelte_config }) {
 						build: {
 							minify: initial_config.build?.minify,
 							assetsInlineLimit: vite_config.build.assetsInlineLimit,
-							sourcemap: vite_config.build.sourcemap,
-							modulePreload: {
-								// disable Vite's JS module preload
-								resolveDependencies: () => {
-									return [];
-								}
-							}
+							sourcemap: vite_config.build.sourcemap
 						},
 						optimizeDeps: {
 							force: vite_config.optimizeDeps.force

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -711,7 +711,8 @@ function kit({ svelte_config }) {
 						build: {
 							minify: initial_config.build?.minify,
 							assetsInlineLimit: vite_config.build.assetsInlineLimit,
-							sourcemap: vite_config.build.sourcemap
+							sourcemap: vite_config.build.sourcemap,
+							modulePreload: false
 						},
 						optimizeDeps: {
 							force: vite_config.optimizeDeps.force

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -43,7 +43,6 @@ const enforced_config = {
 			formats: true
 		},
 		manifest: true,
-		modulePreload: true,
 		outDir: true,
 		rollupOptions: {
 			input: true,
@@ -546,7 +545,8 @@ function kit({ svelte_config }) {
 				// E.g. Vite generates `new URL('/asset.png', import.meta).href` for a relative path vs just '/asset.png'.
 				// That's larger and takes longer to run and also causes an HTML diff between SSR and client
 				// causing us to do a more expensive hydration check.
-				const client_base = kit.paths.relative || kit.paths.assets ? './' : kit.paths.base || '/';
+				const client_base =
+					kit.paths.relative !== false || kit.paths.assets ? './' : kit.paths.base || '/';
 
 				new_config = {
 					base: ssr ? assets_base(kit) : client_base,
@@ -556,10 +556,6 @@ function kit({ svelte_config }) {
 						cssMinify: initial_config.build?.minify == null ? true : !!initial_config.build.minify,
 						// don't use the default name to avoid collisions with 'static/manifest.json'
 						manifest: 'vite-manifest.json',
-						modulePreload: {
-							// disable Vite's JS module preload
-							resolveDependencies: () => []
-						},
 						outDir: `${out}/${ssr ? 'server' : 'client'}`,
 						rollupOptions: {
 							input,

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -802,3 +802,27 @@ test.describe('Actions', () => {
 		await expect(pre).toHaveText('prop: 1, store: 1');
 	});
 });
+
+test.describe('Assets', () => {
+	test('only one link per stylesheet', async ({ page }) => {
+		if (process.env.DEV) return;
+
+		await page.goto('/');
+
+		expect(
+			await page.evaluate(() => {
+				const links = Array.from(document.head.querySelectorAll('link[rel=stylesheet]'));
+
+				for (let i = 0; i < links.length; ) {
+					const link = links.shift();
+					const asset_name = link.href.split('/').at(-1);
+					if (links.some((link) => link.href.includes(asset_name))) {
+						return false;
+					}
+				}
+
+				return true;
+			})
+		).toBe(true);
+	});
+});


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/10358
fixes https://github.com/sveltejs/kit/issues/10379

~This PR disables [Vite's module preload](https://vitejs.dev/config/build-options.html#build-modulepreload) for JS files only (Vite still injects CSS) which adds the preloads on [startup](https://github.com/vitejs/vite/blob/1292ad08a06e2ae8c44307797ba533f64a602759/packages/vite/src/node/plugins/importAnalysisBuild.ts#L121-L128) in addition to the preloads already [added by Kit](https://github.com/sveltejs/kit/blob/b251b235b321b9c75236429cc3a1ac2415475775/packages/kit/src/runtime/server/page/render.js#L240). I'm not currently aware of any side-effects disabling this may have so this PR might be somewhat naive.~

This PR matches the Vite base path setting [optimisation](https://github.com/sveltejs/kit/pull/10287/files) with the [page rendering](https://github.com/sveltejs/kit/blob/926c22d94fe7884dc9bc020ce735a911f50c8509/packages/kit/src/runtime/server/page/render.js#L96C4-L108) base path setting, resulting in identical hrefs. Hence, Vite no longer duplicates asset links that are already in the `<head>`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
