### PR TITLE
fix: correctly list dynamic routes in error log

### DIFF
--- a/.changeset/shy-zoos-sit.md
+++ b/.changeset/shy-zoos-sit.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-static': patch
+---
+
+fix: correctly list dynamic routes in error log

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -8,7 +8,8 @@ export default function (options) {
 
 		async adapt(builder) {
 			if (!options?.fallback) {
-				if (builder.routes.some((route) => route.prerender !== true) && options?.strict !== false) {
+				const dynamic_routes = builder.routes.filter((route) => route.prerender !== true);
+				if (dynamic_routes.length > 0 && options?.strict !== false) {
 					const prefix = path.relative('.', builder.config.kit.files.routes);
 					const has_param_routes = builder.routes.some((route) => route.id.includes('['));
 					const config_option =
@@ -22,7 +23,7 @@ export default function (options) {
 
 					builder.log.error(
 						`@sveltejs/adapter-static: all routes must be fully prerenderable, but found the following routes that are dynamic:
-${builder.routes.map((route) => `  - ${path.posix.join(prefix, route.id)}`).join('\n')}
+${dynamic_routes.map((route) => `  - ${path.posix.join(prefix, route.id)}`).join('\n')}
 
 You have the following options:
   - set the \`fallback\` option — see https://kit.svelte.dev/docs/single-page-apps#usage for more info.


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/10433#issuecomment-1653643602

Displays the erroneous dynamic routes instead of all routes when a page is not marked as prerenderable with the static adapter.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
