### PR TITLE
docs: clarify cases where streaming don't work

### DIFF
--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -477,9 +477,7 @@ This is useful for creating skeleton loading states, for example:
 </p>
 ```
 
-> On platforms that do not support streaming, such as AWS Lambda, responses will be buffered. This means the page will only render once all promises resolve.
-
-> Make shure that your proxy (e.g. NGINX) do not buffers proxied server response on streaming route, or page will render only after all promises resolve.
+> On platforms that do not support streaming, such as AWS Lambda, responses will be buffered. This means the page will only render once all promises resolve. If you are using a proxy (e.g. NGINX), make sure it does not buffer responses from the proxied server.
 
 > Streaming data will only work when JavaScript is enabled. You should avoid returning nested promises from a universal `load` function if the page is server rendered, as these are _not_ streamed — instead, the promise is recreated when the function reruns in the browser.
 

--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -477,7 +477,9 @@ This is useful for creating skeleton loading states, for example:
 </p>
 ```
 
-On platforms that do not support streaming, such as AWS Lambda, responses will be buffered. This means the page will only render once all promises resolve.
+> On platforms that do not support streaming, such as AWS Lambda, responses will be buffered. This means the page will only render once all promises resolve.
+
+> Make shure that your proxy (e.g. NGINX) do not buffers proxied server response on streaming route, or page will render only after all promises resolve.
 
 > Streaming data will only work when JavaScript is enabled. You should avoid returning nested promises from a universal `load` function if the page is server rendered, as these are _not_ streamed — instead, the promise is recreated when the function reruns in the browser.
 


### PR DESCRIPTION
# The changes is clarify cases where streaming don't work.

I ran into this on NGINX and spent quite a bit of time trying to find a solution. Since the important comment about streaming was not obvious.

## NGINX
Is the most common way to run applications on the Node server. Maybe we should add an additional description by solving this issue with NGINX on the [Troubleshooting](https://kit.svelte.dev/docs/adapter-node#troubleshooting) section on Node servers docs?

With NGINX it's will work by adding special header:

```js
export async function load({ setHeaders }) {
  setHeaders({
    'X-Accel-Buffering': 'no'
  });
  ...
}
```  

Related issue: https://github.com/sveltejs/kit/issues/9534#issuecomment-1592802223

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
