### PR TITLE
docs: update Cloudflare Pages deployment settings

### DIFF
--- a/documentation/docs/25-build-and-deploy/60-adapter-cloudflare.md
+++ b/documentation/docs/25-build-and-deploy/60-adapter-cloudflare.md
@@ -53,13 +53,9 @@ Please follow the [Get Started Guide](https://developers.cloudflare.com/pages/ge
 
 When configuring your project settings, you must use the following settings:
 
-- **Framework preset** – None
+- **Framework preset** – SvelteKit
 - **Build command** – `npm run build` or `vite build`
 - **Build output directory** – `.svelte-kit/cloudflare`
-- **Environment variables**
-	- `NODE_VERSION`: `16`
-
-> You need to add a `NODE_VERSION` environment variable to both the "production" and "preview" environments. You can add this during project setup or later in the Pages project settings. SvelteKit requires Node `16.14` or later, so you should use `16` as the `NODE_VERSION` value.
 
 ## Bindings
 


### PR DESCRIPTION
1. The Cloudflare Pages deployment screen says new projects will use [their v2 build system](https://developers.cloudflare.com/pages/platform/language-support-and-tools/), which by default uses Node 18. 

2. The deployment screen also has a SvelteKit framework preset that will pre-fill the required fields. This seems preferable than to recommend setting the framework preset to "None."

![image](https://github.com/sveltejs/kit/assets/44459660/d74b3d1a-bdfa-4f63-8ce2-fc50923d7860)


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
