### PR TITLE
docs(migrate): add link to changelog

### DIFF
--- a/packages/migrate/README.md
+++ b/packages/migrate/README.md
@@ -13,3 +13,7 @@ The available migrations are:
 - `routes` - This will update your pre-SvelteKit-1.0 codebase to the SvelteKit 1.0 routes format. The script will automate as much of the conversion as possible, then annotate your codebase with tasks for completion that you can find by searching for `@migration`. Read [the discussion](https://github.com/sveltejs/kit/discussions/5748) for full details.
 - `package` - Migration to @sveltejs/package v2. Review the migration guide at [#8922](https://github.com/sveltejs/kit/pull/) and read the updated docs at https://kit.svelte.dev/docs/packaging
 - `svelte-4` - This will migrate your codebase from Svelte 3 to Svelte 4
+
+## Changelog
+
+[The Changelog for this package is available on GitHub](https://github.com/sveltejs/kit/blob/master/packages/migrate/CHANGELOG.md).


### PR DESCRIPTION
Minor DX nit: I often look up a package on NPM for the link to the Changelog. Other Svelte(Kit) packages already do this (e.g., `@sveltejs/kit`, `@sveltejs/package`).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
