### PR TITLE
docs: use `node:` prefix in example

### DIFF
--- a/documentation/faq/60-read-package-json.md
+++ b/documentation/faq/60-read-package-json.md
@@ -8,10 +8,10 @@ You cannot directly require JSON files, since SvelteKit expects [`svelte.config.
 /// file: svelte.config.js
 // @filename: index.js
 /// <reference types="@types/node" />
-import { URL } from 'url';
+import { URL } from 'node:url';
 // ---cut---
-import { readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 const file = fileURLToPath(new URL('package.json', import.meta.url));
 const json = readFileSync(file, 'utf8');

--- a/documentation/faq/60-read-package-json.md
+++ b/documentation/faq/60-read-package-json.md
@@ -13,7 +13,6 @@ import { URL } from 'node:url';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
-const file = fileURLToPath(new URL('package.json', import.meta.url));
-const json = readFileSync(file, 'utf8');
-const pkg = JSON.parse(json);
+const path = fileURLToPath(new URL('package.json', import.meta.url));
+const pkg = JSON.parse(readFileSync(path, 'utf8'));
 ```


### PR DESCRIPTION
We should encourage usage of `node:`