### PR TITLE
feat: allow writing suffixes with reserved filename

### DIFF
--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -425,7 +425,7 @@ function create_routes_and_nodes(cwd, config, fallback) {
 function analyze(project_relative, file, component_extensions, module_extensions) {
 	const component_extension = component_extensions.find((ext) => file.endsWith(ext));
 	if (component_extension) {
-		const name = file.slice(0, -component_extension.length);
+		const name = file.slice(0, -component_extension.length).replace(/\.[^/.]+$/, '');
 		const pattern = /^\+(?:(page(?:@(.*))?)|(layout(?:@(.*))?)|(error))$/;
 		const match = pattern.exec(name);
 		if (!match) {


### PR DESCRIPTION
This PR aims to allow users to write suffixes with the reserved filename.

Previously, we were only able to write `+page.svelte` and `+layout.svelte`

Now, we can write the file name like `+page.about.svelte` and `+layout.secondary.svelte`

It improves developer experience while dealing with hundreds of files in a same project named with `+page`, `+layout`. Also, it would be easier to jump into the file through fuzzy search in the IDE.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
