### PR TITLE
fix: make server assets accessible during `vite preview`

### DIFF
--- a/.changeset/selfish-walls-rhyme.md
+++ b/.changeset/selfish-walls-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: make server assets available during `vite preview`

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -1,5 +1,5 @@
 import { existsSync, statSync, createReadStream, createWriteStream } from 'node:fs';
-import { extname, join, resolve } from 'node:path';
+import { extname, resolve } from 'node:path';
 import { pipeline } from 'node:stream';
 import { promisify } from 'node:util';
 import zlib from 'node:zlib';
@@ -181,12 +181,7 @@ export function create_builder({
 		},
 
 		writeClient(dest) {
-			const server_assets = copy(
-				`${config.kit.outDir}/output/server/${config.kit.appDir}/immutable/assets`,
-				join(dest, config.kit.appDir, 'immutable/assets')
-			).map((filename) => join(config.kit.appDir, 'immutable/assets', filename));
-			const client_assets = copy(`${config.kit.outDir}/output/client`, dest);
-			return Array.from(new Set([...server_assets, ...client_assets]));
+			return copy(`${config.kit.outDir}/output/client`, dest);
 		},
 
 		writePrerendered(dest) {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -5,7 +5,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 import colors from 'kleur';
 import * as vite from 'vite';
 
-import { mkdirp, posixify, read, resolve_entry, rimraf } from '../../utils/filesystem.js';
+import { copy, mkdirp, posixify, read, resolve_entry, rimraf } from '../../utils/filesystem.js';
 import { create_static_module, create_dynamic_module } from '../../core/env.js';
 import * as sync from '../../core/sync/sync.js';
 import { create_assets } from '../../core/sync/create_manifest_data/index.js';
@@ -718,6 +718,11 @@ function kit({ svelte_config }) {
 							force: vite_config.optimizeDeps.force
 						}
 					})
+				);
+
+				copy(
+					`${out}/server/${kit.appDir}/immutable/assets`,
+					`${out}/client/${kit.appDir}/immutable/assets`
 				);
 
 				/** @type {import('vite').Manifest} */


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/9961

This moves the server assets copying to client assets closer to the `vite build` process instead of as part of the adapter process. This ensures server assets are always included in `.svelte-kit/output/client` so that `vite preview` serves them correctly.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
