### PR TITLE
Add `sveltekit` plugin to `worker.plugins` Vite config

### DIFF
--- a/.changeset/big-lies-hide.md
+++ b/.changeset/big-lies-hide.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+fix: add sveltekit plugin to vite's worker config

--- a/packages/create-svelte/templates/default/vite.config.js
+++ b/packages/create-svelte/templates/default/vite.config.js
@@ -5,6 +5,11 @@ import { defineConfig } from 'vite';
 export default defineConfig({
 	plugins: [sveltekit()],
 
+	worker: {
+		plugins: [sveltekit()],
+		format: 'es'
+	},
+
 	server: {
 		fs: {
 			allow: [path.resolve('../../../kit')]

--- a/packages/create-svelte/templates/skeleton/vite.config.js
+++ b/packages/create-svelte/templates/skeleton/vite.config.js
@@ -2,5 +2,10 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+
+	worker: {
+		plugins: [sveltekit()],
+		format: 'es'
+	}
 });

--- a/packages/create-svelte/templates/skeletonlib/vite.config.js
+++ b/packages/create-svelte/templates/skeletonlib/vite.config.js
@@ -2,5 +2,10 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+
+	worker: {
+		plugins: [sveltekit()],
+		format: 'es'
+	}
 });


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

## Intent

In order for web workers to import variables from files dynamically created by SvelteKit (e.g. `$env/...`, `$app/...`), we need to define the `sveltekit` plugin in our vite `worker.plugins` config.

Resolves #10370
