### PR TITLE
docs: clean up some confusion about state management and pages.

### DIFF
--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -140,7 +140,9 @@ When you navigate around your application, SvelteKit reuses existing layout and 
 <div>{@html data.content}</div>
 ```
 
-...then navigating from `/blog/my-short-post` to `/blog/my-long-post` won't cause the components (layout, page and any components on the page) to be destroyed and recreated. Instead the `data` prop (and by extension `data.title` and `data.content`) will reactively change (as it would with a regular Svelte component) and, because the code isn't rerunning, `estimatedReadingTime` won't be recalculated nor will lifecycle methods like `onMount` and `onDestroy` run.
+...then navigating from `/blog/my-short-post` to `/blog/my-long-post` won't cause the components (layout and page) to be destroyed and recreated. Instead the `data` prop (and by extension `data.title` and `data.content`) will reactively change (as it would with a regular Svelte component) and, because the code isn't rerunning, `estimatedReadingTime` won't be recalculated nor will lifecycle methods like `onMount` and `onDestroy` run.
+
+> If your code in `onMount` and `onDestroy` has to run again after navigation you can use [aferNavigate](modules#$app-navigation-afternavigate) and [beforeNaviate](modules#$app-navigation-beforenavigate) respectively.
 
 Instead, we need to make the value [_reactive_](https://learn.svelte.dev/tutorial/reactive-assignments):
 
@@ -155,15 +157,13 @@ Instead, we need to make the value [_reactive_](https://learn.svelte.dev/tutoria
 </script>
 ```
 
-Reusing components like this means that things like sidebar scroll state are preserved, and you can easily animate between changing values. However, if you do need to completely destroy and remount a component on navigation, you can use this pattern:
+Reusing components like this means that things like sidebar scroll state are preserved, and you can easily animate between changing values. However, because only the state changes all other components on the page will also behave the same and will not remount if they are already visible on the page, only their props will change. In the case that you do need to completely destroy and remount a component on navigation, you can use this pattern:
 
 ```svelte
 {#key $page.url.pathname}
 	<BlogPost title={data.title} content={data.title} />
 {/key}
 ```
-
-> Instead of `onMount` and `onDestroy` you can use [aferNavigate](modules#$app-navigation-afternavigate) and [beforeNaviate](modules#$app-navigation-beforenavigate) respectively.
 
 ## Storing state in the URL
 

--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -119,8 +119,6 @@ If you're not using SSR (and can guarantee that you won't need to use SSR in fut
 
 ## Component and Page states are preserved
 
-> In SvelteKit, pages and layouts are components and follow the same rules and limitations as normal Svelte components.
-
 When you navigate around your application, SvelteKit reuses existing layout and page components. For example, if you have a route like this...
 
 ```svelte
@@ -142,7 +140,7 @@ When you navigate around your application, SvelteKit reuses existing layout and 
 <div>{@html data.content}</div>
 ```
 
-...then navigating from `/blog/my-short-post` to `/blog/my-long-post` won't cause the component to be destroyed and recreated. Instead the `data` prop (and by extension `data.title` and `data.content`) will reactively change (as it would with a regular Svelte component) and, because the code isn't rerunning, `estimatedReadingTime` won't be recalculated.
+...then navigating from `/blog/my-short-post` to `/blog/my-long-post` won't cause the components (layout, page and any components on the page) to be destroyed and recreated. Instead the `data` prop (and by extension `data.title` and `data.content`) will reactively change (as it would with a regular Svelte component) and, because the code isn't rerunning, `estimatedReadingTime` won't be recalculated nor will lifecycle methods like `onMount` and `onDestroy` run.
 
 Instead, we need to make the value [_reactive_](https://learn.svelte.dev/tutorial/reactive-assignments):
 
@@ -164,6 +162,8 @@ Reusing components like this means that things like sidebar scroll state are pre
 	<BlogPost title={data.title} content={data.title} />
 {/key}
 ```
+
+> Instead of `onMount` and `onDestroy` you can use [aferNavigate](modules#$app-navigation-afternavigate) and [beforeNaviate](modules#$app-navigation-beforenavigate) respectively.
 
 ## Storing state in the URL
 

--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -117,7 +117,7 @@ Updating the context-based store value in deeper-level pages or components will 
 
 If you're not using SSR (and can guarantee that you won't need to use SSR in future) then you can safely keep state in a shared module, without using the context API.
 
-## Component and Page states are preserved
+## Component and page state is preserved
 
 When you navigate around your application, SvelteKit reuses existing layout and page components. For example, if you have a route like this...
 
@@ -140,7 +140,7 @@ When you navigate around your application, SvelteKit reuses existing layout and 
 <div>{@html data.content}</div>
 ```
 
-...then navigating from `/blog/my-short-post` to `/blog/my-long-post` won't cause the layout, page and any other components within to be destroyed and recreated. Instead the `data` prop (and by extension `data.title` and `data.content`) will reactively change (as it would with a regular Svelte component) and, because the code isn't rerunning, lifecycle methods like `onMount` and `onDestroy` won't rerun and `estimatedReadingTime` won't be recalculated.
+...then navigating from `/blog/my-short-post` to `/blog/my-long-post` won't cause the layout, page and any other components within to be destroyed and recreated. Instead the `data` prop (and by extension `data.title` and `data.content`) will update (as it would with any other Svelte component) and, because the code isn't rerunning, lifecycle methods like `onMount` and `onDestroy` won't rerun and `estimatedReadingTime` won't be recalculated.
 
 Instead, we need to make the value [_reactive_](https://learn.svelte.dev/tutorial/reactive-assignments):
 
@@ -155,7 +155,7 @@ Instead, we need to make the value [_reactive_](https://learn.svelte.dev/tutoria
 </script>
 ```
 
-> If your code in `onMount` and `onDestroy` has to run again after navigation you can use [aferNavigate](modules#$app-navigation-afternavigate) and [beforeNaviate](modules#$app-navigation-beforenavigate) respectively.
+> If your code in `onMount` and `onDestroy` has to run again after navigation you can use [afterNavigate](modules#$app-navigation-afternavigate) and [beforeNavigate](modules#$app-navigation-beforenavigate) respectively.
 
 Reusing components like this means that things like sidebar scroll state are preserved, and you can easily animate between changing values. In the case that you do need to completely destroy and remount a component on navigation, you can use this pattern:
 

--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -140,7 +140,7 @@ When you navigate around your application, SvelteKit reuses existing layout and 
 <div>{@html data.content}</div>
 ```
 
-...then navigating from `/blog/my-short-post` to `/blog/my-long-post` won't cause the components (layout and page) to be destroyed and recreated. Instead the `data` prop (and by extension `data.title` and `data.content`) will reactively change (as it would with a regular Svelte component) and, because the code isn't rerunning, `estimatedReadingTime` won't be recalculated nor will lifecycle methods like `onMount` and `onDestroy` run.
+...then navigating from `/blog/my-short-post` to `/blog/my-long-post` won't cause the components (layout and page) to be destroyed and recreated. Instead the `data` prop (and by extension `data.title` and `data.content`) will reactively change (as it would with a regular Svelte component) and, because the code isn't rerunning, `estimatedReadingTime` won't be recalculated and lifecycle methods like `onMount` and `onDestroy` won't rerun.
 
 > If your code in `onMount` and `onDestroy` has to run again after navigation you can use [aferNavigate](modules#$app-navigation-afternavigate) and [beforeNaviate](modules#$app-navigation-beforenavigate) respectively.
 

--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -140,9 +140,7 @@ When you navigate around your application, SvelteKit reuses existing layout and 
 <div>{@html data.content}</div>
 ```
 
-...then navigating from `/blog/my-short-post` to `/blog/my-long-post` won't cause the components (layout and page) to be destroyed and recreated. Instead the `data` prop (and by extension `data.title` and `data.content`) will reactively change (as it would with a regular Svelte component) and, because the code isn't rerunning, `estimatedReadingTime` won't be recalculated and lifecycle methods like `onMount` and `onDestroy` won't rerun.
-
-> If your code in `onMount` and `onDestroy` has to run again after navigation you can use [aferNavigate](modules#$app-navigation-afternavigate) and [beforeNaviate](modules#$app-navigation-beforenavigate) respectively.
+...then navigating from `/blog/my-short-post` to `/blog/my-long-post` won't cause the layout, page and any other components within to be destroyed and recreated. Instead the `data` prop (and by extension `data.title` and `data.content`) will reactively change (as it would with a regular Svelte component) and, because the code isn't rerunning, lifecycle methods like `onMount` and `onDestroy` won't rerun and `estimatedReadingTime` won't be recalculated.
 
 Instead, we need to make the value [_reactive_](https://learn.svelte.dev/tutorial/reactive-assignments):
 
@@ -157,7 +155,9 @@ Instead, we need to make the value [_reactive_](https://learn.svelte.dev/tutoria
 </script>
 ```
 
-Reusing components like this means that things like sidebar scroll state are preserved, and you can easily animate between changing values. However, because only the state changes all other components on the page will also behave the same and will not remount if they are already visible on the page, only their props will change. In the case that you do need to completely destroy and remount a component on navigation, you can use this pattern:
+> If your code in `onMount` and `onDestroy` has to run again after navigation you can use [aferNavigate](modules#$app-navigation-afternavigate) and [beforeNaviate](modules#$app-navigation-beforenavigate) respectively.
+
+Reusing components like this means that things like sidebar scroll state are preserved, and you can easily animate between changing values. In the case that you do need to completely destroy and remount a component on navigation, you can use this pattern:
 
 ```svelte
 {#key $page.url.pathname}

--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -117,7 +117,9 @@ Updating the context-based store value in deeper-level pages or components will 
 
 If you're not using SSR (and can guarantee that you won't need to use SSR in future) then you can safely keep state in a shared module, without using the context API.
 
-## Component state is preserved
+## Component and Page states are preserved
+
+> In SvelteKit, pages and layouts are considered components and follow the same rules and limitations as normal Svelte components.
 
 When you navigate around your application, SvelteKit reuses existing layout and page components. For example, if you have a route like this...
 
@@ -140,7 +142,7 @@ When you navigate around your application, SvelteKit reuses existing layout and 
 <div>{@html data.content}</div>
 ```
 
-...then navigating from `/blog/my-short-post` to `/blog/my-long-post` won't cause the component to be destroyed and recreated. The `data` prop (and by extension `data.title` and `data.content`) will change, but because the code isn't rerunning, `estimatedReadingTime` won't be recalculated.
+...then navigating from `/blog/my-short-post` to `/blog/my-long-post` won't cause the component to be destroyed and recreated. Instead the `data` prop (and by extension `data.title` and `data.content`) will change as happens with regular Svelte component, and because the code isn't rerunning, `estimatedReadingTime` won't be recalculated.
 
 Instead, we need to make the value [_reactive_](https://learn.svelte.dev/tutorial/reactive-assignments):
 

--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -142,7 +142,7 @@ When you navigate around your application, SvelteKit reuses existing layout and 
 <div>{@html data.content}</div>
 ```
 
-...then navigating from `/blog/my-short-post` to `/blog/my-long-post` won't cause the component to be destroyed and recreated. Instead the `data` prop (and by extension `data.title` and `data.content`) will change as happens with regular Svelte component, and because the code isn't rerunning, `estimatedReadingTime` won't be recalculated.
+...then navigating from `/blog/my-short-post` to `/blog/my-long-post` won't cause the component to be destroyed and recreated. Instead the `data` prop (and by extension `data.title` and `data.content`) will reactively change (as it would with a regular Svelte component) and, because the code isn't rerunning, `estimatedReadingTime` won't be recalculated.
 
 Instead, we need to make the value [_reactive_](https://learn.svelte.dev/tutorial/reactive-assignments):
 

--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -119,7 +119,7 @@ If you're not using SSR (and can guarantee that you won't need to use SSR in fut
 
 ## Component and Page states are preserved
 
-> In SvelteKit, pages and layouts are considered components and follow the same rules and limitations as normal Svelte components.
+> In SvelteKit, pages and layouts are components and follow the same rules and limitations as normal Svelte components.
 
 When you navigate around your application, SvelteKit reuses existing layout and page components. For example, if you have a route like this...
 


### PR DESCRIPTION
A commonly returning error on Discord is related to state preservation in pages due to misunderstandings how pages relate to components in regards to reactivity. While this language is not perfect, at least the title of the section will now mention "Page state is preserved" making it hopefully easier to find.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
