### PR TITLE
fix: add `"false"` value to preload link options

### DIFF
--- a/.changeset/bright-buttons-flash.md
+++ b/.changeset/bright-buttons-flash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow `"false"` value for preload link options

--- a/documentation/docs/30-advanced/30-link-options.md
+++ b/documentation/docs/30-advanced/30-link-options.md
@@ -122,8 +122,8 @@ To disable any of these options inside an element where they have been enabled, 
 </div>
 ```
 
-To apply an attribute to an element conditionally, do this (`"true"` and `"false"` are both accepted values):
+To apply an attribute to an element conditionally, do this:
 
-```html
-<div data-sveltekit-reload={shouldReload}>
+```svelte
+<div data-sveltekit-preload-data={condition ? "hover" : "false"}>
 ```

--- a/documentation/docs/30-advanced/30-link-options.md
+++ b/documentation/docs/30-advanced/30-link-options.md
@@ -125,5 +125,5 @@ To disable any of these options inside an element where they have been enabled, 
 To apply an attribute to an element conditionally, do this:
 
 ```svelte
-<div data-sveltekit-preload-data={condition ? "hover" : "false"}>
+<div data-sveltekit-preload-data={condition ? 'hover' : false}>
 ```

--- a/packages/kit/src/runtime/client/constants.js
+++ b/packages/kit/src/runtime/client/constants.js
@@ -7,5 +7,6 @@ export const PRELOAD_PRIORITIES = /** @type {const} */ ({
 	hover: 2,
 	viewport: 3,
 	eager: 4,
-	off: -1
+	off: -1,
+	false: -1
 });

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -30,8 +30,8 @@ const warned = new WeakSet();
 /** @typedef {keyof typeof valid_link_options} LinkOptionName */
 
 const valid_link_options = /** @type {const} */ ({
-	'preload-code': ['', 'off', 'tap', 'hover', 'viewport', 'eager'],
-	'preload-data': ['', 'off', 'tap', 'hover'],
+	'preload-code': ['', 'off', 'false', 'tap', 'hover', 'viewport', 'eager'],
+	'preload-data': ['', 'off', 'false', 'tap', 'hover'],
 	keepfocus: ['', 'true', 'off', 'false'],
 	noscroll: ['', 'true', 'off', 'false'],
 	reload: ['', 'true', 'off', 'false'],


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/pull/10460

Explanation: https://github.com/sveltejs/kit/pull/10460#issuecomment-1660448867

We should update the language tools as well. I think the original PR from @alesvaupotic originates from the extension incorrectly stating that `"false"` is not a valid value (although it is for the non-preloading link options).

![incorrect error message for svelte kit's link option](https://github.com/sveltejs/kit/assets/54401897/460e6dd4-0685-4003-9d06-b1098a626d2d)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
