### PR TITLE
feat: add warning for possible route filename typos

### DIFF
--- a/.changeset/brave-paws-cheer.md
+++ b/.changeset/brave-paws-cheer.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: add warning for mistyped route filenames

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -218,7 +218,7 @@ function create_routes_and_nodes(cwd, config, fallback) {
 							colors
 								.bold()
 								.yellow(
-									`Missing route file prefix. Did you mean +${file.name}?\n` +
+									`Missing route file prefix. Did you mean +${file.name}?` +
 										`  at ${path.join(dir, file.name)}`
 								)
 						);

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -1,11 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import colors from 'kleur';
 import mime from 'mime';
 import { list_files, runtime_directory } from '../../utils.js';
 import { posixify } from '../../../utils/filesystem.js';
 import { parse_route_id } from '../../../utils/routing.js';
 import { sort_routes } from './sort.js';
-import colors from 'kleur';
 
 /**
  * Generates the manifest data used for the client-side manifest and types generation.

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -208,6 +208,7 @@ function create_routes_and_nodes(cwd, config, fallback) {
 
 				if (!file.name.startsWith('+')) {
 					const name = file.name.slice(0, -ext.length);
+					// check if it is a valid route filename but missing the + prefix
 					const typo =
 						/^(?:(page(?:@(.*))?)|(layout(?:@(.*))?)|(error))$/.test(name) ||
 						/^(?:(server)|(page(?:(@[a-zA-Z0-9_-]*))?(\.server)?)|(layout(?:(@[a-zA-Z0-9_-]*))?(\.server)?))$/.test(

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -219,7 +219,7 @@ function create_routes_and_nodes(cwd, config, fallback) {
 								.bold()
 								.yellow(
 									`Missing route file prefix. Did you mean +${file.name}?` +
-										`  at ${path.join(dir, file.name)}`
+										` at ${path.join(dir, file.name)}`
 								)
 						);
 					}

--- a/packages/kit/src/core/sync/write_client_manifest.js
+++ b/packages/kit/src/core/sync/write_client_manifest.js
@@ -116,8 +116,8 @@ export function write_client_manifest(kit, manifest_data, output, metadata) {
 			colors
 				.bold()
 				.yellow(
-					`Unexpected + prefix. Did you mean ${typo.split('/').at(-1)?.slice(1)}?\n` +
-						`  at ${path.resolve(typo)}`
+					`Unexpected + prefix. Did you mean ${typo.split('/').at(-1)?.slice(1)}?` +
+						` at ${path.resolve(typo)}`
 				)
 		);
 	}

--- a/packages/kit/src/core/sync/write_client_manifest.js
+++ b/packages/kit/src/core/sync/write_client_manifest.js
@@ -1,6 +1,8 @@
+import path from 'node:path';
 import { relative_path, resolve_entry } from '../../utils/filesystem.js';
 import { s } from '../../utils/misc.js';
 import { dedent, write_if_changed } from './utils.js';
+import colors from 'kleur';
 
 /**
  * Writes the client manifest to disk. The manifest is used to power the router. It contains the
@@ -107,6 +109,18 @@ export function write_client_manifest(kit, manifest_data, output, metadata) {
 	`;
 
 	const hooks_file = resolve_entry(kit.files.hooks.client);
+
+	const typo = resolve_entry('src/+hooks.client');
+	if (typo) {
+		console.log(
+			colors
+				.bold()
+				.yellow(
+					`Unexpected + prefix. Did you mean ${typo.split('/').at(-1)?.slice(1)}?\n` +
+						`  at ${path.resolve(typo)}`
+				)
+		);
+	}
 
 	write_if_changed(
 		`${output}/app.js`,

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import { hash } from '../../runtime/hash.js';
 import { posixify, resolve_entry } from '../../utils/filesystem.js';
@@ -6,6 +5,7 @@ import { s } from '../../utils/misc.js';
 import { load_error_page, load_template } from '../config/index.js';
 import { runtime_directory } from '../utils.js';
 import { write_if_changed } from './utils.js';
+import colors from 'kleur';
 
 /**
  * @param {{
@@ -76,8 +76,19 @@ export { set_assets, set_building, set_private_env, set_public_env };
  * @param {string} output
  */
 export function write_server(config, output) {
-	// TODO the casting shouldn't be necessary — investigate
-	const hooks_file = /** @type {string} */ (resolve_entry(config.kit.files.hooks.server));
+	const hooks_file = resolve_entry(config.kit.files.hooks.server);
+
+	const typo = resolve_entry('src/+hooks.server');
+	if (typo) {
+		console.log(
+			colors
+				.bold()
+				.yellow(
+					`Unexpected + prefix. Did you mean ${typo.split('/').at(-1)?.slice(1)}?\n` +
+						`  at ${path.resolve(typo)}`
+				)
+		);
+	}
 
 	/** @param {string} file */
 	function relative(file) {
@@ -88,7 +99,7 @@ export function write_server(config, output) {
 		`${output}/server/internal.js`,
 		server_template({
 			config,
-			hooks: fs.existsSync(hooks_file) ? relative(hooks_file) : null,
+			hooks: hooks_file ? relative(hooks_file) : null,
 			has_service_worker:
 				config.kit.serviceWorker.register && !!resolve_entry(config.kit.files.serviceWorker),
 			runtime_directory: relative(runtime_directory),

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -84,8 +84,8 @@ export function write_server(config, output) {
 			colors
 				.bold()
 				.yellow(
-					`Unexpected + prefix. Did you mean ${typo.split('/').at(-1)?.slice(1)}?\n` +
-						`  at ${path.resolve(typo)}`
+					`Unexpected + prefix. Did you mean ${typo.split('/').at(-1)?.slice(1)}?` +
+						` at ${path.resolve(typo)}`
 				)
 		);
 	}


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/10528

Outputs a terminal warning if a route filename is missing a `+` or if the default hooks filename (`src/hooks.server`) mistakenly has a `+` prefix.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
