### PR TITLE
 feat: accept `URL` in `redirect`

### DIFF
--- a/.changeset/shy-turtles-fail.md
+++ b/.changeset/shy-turtles-fail.md
@@ -2,4 +2,4 @@
 "@sveltejs/kit": patch
 ---
 
-fix: made `redirect` accept URL objects
+feat: accept `URL` in `redirect`

--- a/.changeset/shy-turtles-fail.md
+++ b/.changeset/shy-turtles-fail.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: made `redirect` accept URL objects

--- a/.changeset/shy-turtles-fail.md
+++ b/.changeset/shy-turtles-fail.md
@@ -1,5 +1,5 @@
 ---
-"@sveltejs/kit": patch
+"@sveltejs/kit": minor
 ---
 
 feat: accept `URL` in `redirect`

--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -45,7 +45,7 @@ export function redirect(status, location) {
 		throw new Error('Invalid status code');
 	}
 
-	return new Redirect(status, String(location));
+	return new Redirect(status, location.toString());
 }
 
 /**

--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -38,14 +38,14 @@ export function error(status, body) {
  * Create a `Redirect` object. If thrown during request handling, SvelteKit will return a redirect response.
  * Make sure you're not catching the thrown redirect, which would prevent SvelteKit from handling it.
  * @param {300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages). Must be in the range 300-308.
- * @param {string} location The location to redirect to.
+ * @param {string | URL} location The location to redirect to.
  */
 export function redirect(status, location) {
 	if ((!BROWSER || DEV) && (isNaN(status) || status < 300 || status > 308)) {
 		throw new Error('Invalid status code');
 	}
 
-	return new Redirect(status, location);
+	return new Redirect(status, String(location));
 }
 
 /**


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Tiny update to `redirect` to allow passing URL objects as is:

```js
const location = new URL(`https://${site}/route`);
location.searchParams.set('param1', env.PUBLIC_THING);

throw redirect(307, location); // instead of location.href
```
