### PR TITLE
fix: use Proxy to track usage of client-side load `event.route`

### DIFF
--- a/.changeset/weak-vans-change.md
+++ b/.changeset/weak-vans-change.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: Use Proxy to track usage of client side load `event.route`

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -449,12 +449,12 @@ export function create_client(app, target) {
 
 			/** @type {import('@sveltejs/kit').LoadEvent} */
 			const load_input = {
-				route: {
-					get id() {
+				route: new Proxy(route, {
+					get: (target, key) => {
 						uses.route = true;
-						return route.id;
+						return target[/** @type {'id'} */ (key)];
 					}
-				},
+				}),
 				params: new Proxy(params, {
 					get: (target, key) => {
 						uses.params.add(/** @type {string} */ (key));


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it. (This is already covered by a test)

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.


### Referenced issues:
* https://github.com/sveltejs/kit/issues/9542#issuecomment-1682306310
* https://github.com/getsentry/sentry-javascript/issues/8818
* https://github.com/getsentry/sentry-javascript/issues/8610

### Background

Our Sentry SvelteKit SDK exposes `wrap(Server)LoadWithSentry` functions that users can manually or with the help of our VIte plugin, automatically wrap around their `load` functions. In these functions we access the load event's `route.id` value to create a span that tracks the duration of a `load` function and what happens inside it (e.g. fetch calls).

This is currently problematic because SvelteKit internally tracks accesses to `route.id` by [setting a getter (client side)](https://github.com/sveltejs/kit/blob/32afba695088b946aefe96da75b36de9b0667fbe/packages/kit/src/runtime/client/client.js#L452-L457) or a [Proxy (server side for server only loads)](https://github.com/sveltejs/kit/blob/32afba695088b946aefe96da75b36de9b0667fbe/packages/kit/src/runtime/server/page/load_data.js#L111-L124). If users themselves don't use `route` but only our wrapper does, they get confused why their loaded data is invalidated on route changes. It's important to note that Sentry doesn't change any behaviour based on `route.id`, we just need to access it to get the name of the current route, nothing more.

### PR Description

This PR changes the client-side `uses.route` tracking mechanism to use a `Proxy` instead of directly using a getter. This allows us in Sentry's `wrap(Server)LoadWithSentry` functions to use `Object.getOwnPropertyDescriptor` to access `event.route.id` _without_ triggering the `uses.route` change. We already [did this successfully](https://github.com/getsentry/sentry-javascript/pull/8801) for the server load wrapper and we'd like to do the same for the client side of universal `load` functions. This allows us to record a high-fidelity load span (useful for SvelteKit/our users).

I believe correct client-side invalidation based on `route` is [already tested](https://github.com/Lms24/kit/blob/92328eef1da121ab18037dd9254796d23c8c9458/packages/kit/test/apps/basics/test/client.test.js#L519-L526) but I'm happy to add more tests if reviewers request it. 

Would be awesome if we could get this merged in! 🙏 


