### PR TITLE
fix: the type of Navigation.type

### DIFF
--- a/.changeset/real-otters-report.md
+++ b/.changeset/real-otters-report.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Make the ts type of Navigation["type"] consistent with the docs
+fix: Make the ts type of Navigation["type"] consistent with the docs

--- a/.changeset/real-otters-report.md
+++ b/.changeset/real-otters-report.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Make the ts type of Navigation["type"] consistent with the docs

--- a/.changeset/real-otters-report.md
+++ b/.changeset/real-otters-report.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: Make the ts type of Navigation["type"] consistent with the docs
+fix: adjust the type of `Navigation["type"]`

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -851,7 +851,7 @@ export interface Navigation {
 	 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
 	 * - `popstate`: Navigation was triggered by back/forward navigation
 	 */
-	type: Omit<NavigationType, 'enter'>;
+	type: Exclude<NavigationType, 'enter'>;
 	/**
 	 * Whether or not the navigation will result in the page being unloaded (i.e. not a client-side navigation)
 	 */
@@ -875,7 +875,7 @@ export interface BeforeNavigate extends Navigation {
 /**
  * The argument passed to [`afterNavigate`](https://kit.svelte.dev/docs/modules#$app-navigation-afternavigate) callbacks.
  */
-export interface AfterNavigate extends Navigation {
+export interface AfterNavigate extends Omit<Navigation, 'type'> {
 	/**
 	 * The type of navigation:
 	 * - `enter`: The app has hydrated
@@ -884,7 +884,7 @@ export interface AfterNavigate extends Navigation {
 	 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
 	 * - `popstate`: Navigation was triggered by back/forward navigation
 	 */
-	type: Omit<NavigationType, 'leave'>;
+	type: Exclude<NavigationType, 'leave'>;
 	/**
 	 * Since `afterNavigate` is called after a navigation completes, it will never be called with a navigation that unloads the page.
 	 */

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -902,7 +902,7 @@ export function create_client(app, target) {
 	/**
 	 * @param {{
 	 *   url: URL;
-	 *   type: import('@sveltejs/kit').NavigationType;
+	 *   type: import('@sveltejs/kit').Navigation["type"];
 	 *   intent?: import('./types').NavigationIntent;
 	 *   delta?: number;
 	 * }} opts
@@ -955,7 +955,7 @@ export function create_client(app, target) {
 	 *     replaceState: boolean;
 	 *     state: any;
 	 *   } | null;
-	 *   type: import('@sveltejs/kit').NavigationType;
+	 *   type: import('@sveltejs/kit').Navigation["type"];
 	 *   delta?: number;
 	 *   nav_token?: {};
 	 *   accepted: () => void;


### PR DESCRIPTION
To exclude a member of string literal union type, `Exclude` utility type should be used instead of `Omit`. Using `Omit` turns the union type into just `string`

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
