### PR TITLE
chore: remove `resolution-mode=highest` in template `.npmrc`

### DIFF
--- a/.changeset/happy-pots-protect.md
+++ b/.changeset/happy-pots-protect.md
@@ -2,4 +2,4 @@
 'create-svelte': minor
 ---
 
-feat: remove resolution-mode=highest in template .npmrc
+feat: remove `resolution-mode=highest` in template `.npmrc`

--- a/.changeset/happy-pots-protect.md
+++ b/.changeset/happy-pots-protect.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': minor
+---
+
+feat: remove resolution-mode=highest in template .npmrc

--- a/.changeset/happy-pots-protect.md
+++ b/.changeset/happy-pots-protect.md
@@ -2,4 +2,4 @@
 'create-svelte': minor
 ---
 
-feat: remove `resolution-mode=highest` in template `.npmrc`
+chore: remove `resolution-mode=highest` in template `.npmrc`

--- a/packages/create-svelte/templates/default/.npmrc
+++ b/packages/create-svelte/templates/default/.npmrc
@@ -1,2 +1,1 @@
 engine-strict=true
-resolution-mode=highest

--- a/packages/create-svelte/templates/skeleton/.npmrc
+++ b/packages/create-svelte/templates/skeleton/.npmrc
@@ -1,2 +1,1 @@
 engine-strict=true
-resolution-mode=highest

--- a/packages/create-svelte/templates/skeletonlib/.npmrc
+++ b/packages/create-svelte/templates/skeletonlib/.npmrc
@@ -1,2 +1,1 @@
 engine-strict=true
-resolution-mode=highest


### PR DESCRIPTION
In pnpm [v8.7.0](https://github.com/pnpm/pnpm/releases/tag/v8.7.0), the `resolution-mode` is now set to `highest` by default.
Thus, I believe it is possible to remove the settings previously made in [this PR](https://github.com/sveltejs/kit/pull/9781)

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
