### PR TITLE
fix: reset form controls in `use:enhance`

### DIFF
--- a/.changeset/blue-phones-shop.md
+++ b/.changeset/blue-phones-shop.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: `use:enhance` now resets form controls after invalidation finishes to avoid incorrect values briefly showing

--- a/.changeset/blue-phones-shop.md
+++ b/.changeset/blue-phones-shop.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: `use:enhance` now resets form controls after invalidation finishes to avoid incorrect values briefly showing
+fix: `use:enhance` now resets form controls after invalidation finishes to avoid briefly showing incorrect values

--- a/.changeset/red-carrots-live.md
+++ b/.changeset/red-carrots-live.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: make `use:enhance` reset form controls to initial values instead of emptying inputs

--- a/.changeset/red-carrots-live.md
+++ b/.changeset/red-carrots-live.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: make `use:enhance` reset form controls to initial values instead of emptying inputs
+fix: make `use:enhance` reset form controls to initial values instead of emptying them

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -129,7 +129,7 @@ export function enhance(form_element, submit = () => {}) {
 				}
 			});
 
-			// Save new initial values because they may heva been invalidated
+			// Save new initial values because they may have been invalidated
 			controls = Array.from(form_element.elements);
 			values = controls.map((el) => ('value' in el ? el.value : undefined));
 		}

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -116,7 +116,7 @@ export function enhance(form_element, submit = () => {}) {
 			await client._invalidate_all_with_callback(() => {
 				if (reset !== false) {
 					// Here we call the browser-native reset. Svelte removes the form elements' value
-					// attributes during hydration (https://github.com/sveltejs/svelte/issues/9148), so this
+					// attributes during hydration (https://github.com/sveltejs/svelte/issues/8220), so this
 					// only empties the form controls - But we still need this as a fallback for any newly
 					// added elements. We call reset from the prototype to avoid DOM clobbering.
 					HTMLFormElement.prototype.reset.call(form_element);

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -115,10 +115,12 @@ export function enhance(form_element, submit = () => {}) {
 		if (result.type === 'success') {
 			await client._invalidate_all_with_callback(() => {
 				if (reset !== false) {
-					// Emulate the behavior of form.reset() because Svelte removes the form controls' value
-					// attributes during hydration (https://github.com/sveltejs/svelte/issues/9148). If Svelte
-					// starts to keep the value attributes, we could move back to using form.reset() and simply
-					// update the form controls' value attributes after calling invalidateAll() below.
+					// Here we call the browser-native reset. Svelte removes the form elements' value attributes
+					// attributes during hydration (https://github.com/sveltejs/svelte/issues/9148), so this
+					// only empties the form controls - But we still need to do this in case there are newly
+					// added elements to reset. We call reset from the prototype to avoid DOM clobbering.
+					HTMLFormElement.prototype.reset.call(form_element);
+					// Now we emulate the native behavior of form.reset() for all the values we saved earlier.
 					for (let i = 0; i < controls.length; i++) {
 						const control = controls[i];
 						if ('value' in control && control.value !== values[i]) {

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -115,10 +115,10 @@ export function enhance(form_element, submit = () => {}) {
 		if (result.type === 'success') {
 			await client._invalidate_all_with_callback(() => {
 				if (reset !== false) {
-					// Here we call the browser-native reset. Svelte removes the form elements' value attributes
+					// Here we call the browser-native reset. Svelte removes the form elements' value
 					// attributes during hydration (https://github.com/sveltejs/svelte/issues/9148), so this
-					// only empties the form controls - But we still need to do this in case there are newly
-					// added elements to reset. We call reset from the prototype to avoid DOM clobbering.
+					// only empties the form controls - But we still need this as a fallback for any newly
+					// added elements. We call reset from the prototype to avoid DOM clobbering.
 					HTMLFormElement.prototype.reset.call(form_element);
 					// Now we emulate the native behavior of form.reset() for all the values we saved earlier.
 					for (let i = 0; i < controls.length; i++) {

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -52,6 +52,7 @@ export interface Client {
 	apply_action: typeof applyAction;
 
 	// private API
+	_invalidate_all_with_callback: (before_data_write: () => void) => void;
 	_hydrate(opts: {
 		status: number;
 		error: App.Error | null;

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.server.js
@@ -7,7 +7,7 @@ export function load({ cookies }) {
 	return {
 		initial: 'initial',
 		enhance_counter,
-		stored_message: cookies.get('store-message') ?? ''
+		stored_message: (cookies.get('store-message') ?? '') + 'x'
 	};
 }
 

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.server.js
@@ -6,7 +6,8 @@ export function load({ cookies }) {
 
 	return {
 		initial: 'initial',
-		enhance_counter
+		enhance_counter,
+		stored_message: cookies.get('store-message') ?? ''
 	};
 }
 
@@ -49,6 +50,15 @@ export const actions = {
 		count += 1;
 
 		cookies.set('enhance-counter', count + '', {
+			path: '/actions/enhance'
+		});
+
+		return {};
+	},
+	store_message: async ({ request, cookies }) => {
+		const data = await request.formData();
+
+		cookies.set('store-message', data.get('store-message') + '', {
 			path: '/actions/enhance'
 		});
 

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance/+page.svelte
@@ -8,6 +8,17 @@
 	/** @type {import('./$types').PageData} */
 	export let data;
 
+	let stored_message = data.stored_message;
+
+	/**
+	 * Use a function because reactive assignment blocks keypresses
+	 * @param {string} s
+	 */
+	function update_message(s) {
+		stored_message = s;
+	}
+	$: update_message(data.stored_message);
+
 	/** @type {AbortController | undefined} */
 	let previous;
 	let count = 0;
@@ -49,7 +60,12 @@
 </form>
 
 <form action="?/counter" method="post" use:enhance>
-	<button class="form4">Submit</button>
+	<button class="form4">Submit counter</button>
+</form>
+
+<form method="post" action="?/store_message" use:enhance>
+	<input name="store-message" type="text" bind:value={stored_message} />
+	<button class="form5">Store message</button>
 </form>
 
 <dialog id="dialog" open>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -806,17 +806,19 @@ test.describe('Actions', () => {
 		await page.goto('/actions/enhance');
 		const input = page.locator('input[name="store-message"]');
 
-		await expect(input).toHaveValue('');
+		await expect(input).toHaveValue('x');
 
 		await input.fill('hello');
 		page.locator('.form5').click();
-		await page.evaluate('window.svelte_tick()'); // wait for data invalidation
 		await expect(input).toHaveValue('hello');
+		await page.evaluate('window.svelte_tick()'); // wait for data invalidation
+		await expect(input).toHaveValue('hellox');
 
 		await input.fill('world');
 		page.locator('.form5').click();
-		await page.evaluate('window.svelte_tick()'); // wait for data invalidation
 		await expect(input).toHaveValue('world');
+		await page.evaluate('window.svelte_tick()'); // wait for data invalidation
+		await expect(input).toHaveValue('worldx');
 	});
 });
 

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -801,6 +801,23 @@ test.describe('Actions', () => {
 		await page.evaluate('window.svelte_tick()');
 		await expect(pre).toHaveText('prop: 1, store: 1');
 	});
+
+	test('use:enhance correctly resets bind:values after submission', async ({ page }) => {
+		await page.goto('/actions/enhance');
+		const input = page.locator('input[name="store-message"]');
+
+		await expect(input).toHaveValue('');
+
+		await input.fill('hello');
+		page.locator('.form5').click();
+		await page.evaluate('window.svelte_tick()'); // wait for data invalidation
+		await expect(input).toHaveValue('hello');
+
+		await input.fill('world');
+		page.locator('.form5').click();
+		await page.evaluate('window.svelte_tick()'); // wait for data invalidation
+		await expect(input).toHaveValue('world');
+	});
 });
 
 test.describe('Assets', () => {


### PR DESCRIPTION
Closes #9609

This makes `use:enhance` reset form controls to their original values instead of emptying them.

I also made the form controls reset *after* `invalidateAll()` finishes loading new data, so there's no longer any "glitches" where it briefly shows a non-final value.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.