### PR TITLE
fix: ensure ssrRewriteStacktrace doesn't throw

### DIFF
--- a/.changeset/wicked-planes-approve.md
+++ b/.changeset/wicked-planes-approve.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+ensure ssrRewriteStacktrace doesn't throw

--- a/.changeset/wicked-planes-approve.md
+++ b/.changeset/wicked-planes-approve.md
@@ -2,4 +2,4 @@
 "@sveltejs/kit": patch
 ---
 
-ensure ssrRewriteStacktrace doesn't throw
+fix: ensure ssrRewriteStacktrace doesn't throw

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -249,7 +249,11 @@ export async function dev(vite, vite_config, svelte_config) {
 
 	/** @param {string} stack */
 	function fix_stack_trace(stack) {
-		return stack ? vite.ssrRewriteStacktrace(stack) : stack;
+		try{
+			return stack ? vite.ssrRewriteStacktrace(stack) : stack;
+		}catch(_e){
+			return stack;
+		}
 	}
 
 	await update_manifest();

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -249,9 +249,9 @@ export async function dev(vite, vite_config, svelte_config) {
 
 	/** @param {string} stack */
 	function fix_stack_trace(stack) {
-		try{
+		try {
 			return stack ? vite.ssrRewriteStacktrace(stack) : stack;
-		}catch(_e){
+		} catch (_e) {
 			return stack;
 		}
 	}


### PR DESCRIPTION
This is a weird edge case so feel free to just close this PR if it doesn't make sense.

Basically right now there's a weird bug in webcontainers where any error during ssr makes the dev server crash. The reason it happens is because `ssrRewriteStackTrace` it's called twice (for some reason it doesn't happen locally).

This PR fixes this behavior by wrapping `ssrRewriteStackTrace` in a try/catch and returning the stack as is if it throws.

Again i understand this is a small enough edge case but i tought that given that sometimes `ssrRewriteStackTrace`can throw would still be a good addition.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
