### PR TITLE
docs: clarify why not to throw a redirect within a try/catch

### DIFF
--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -435,7 +435,7 @@ export function load({ locals }) {
 }
 ```
 
-> Make sure you're not catching the thrown redirect, which would prevent SvelteKit from handling it.
+> Don't use `throw redirect()` from within a try-catch block, as the redirect will immediately trigger the catch statement.
 
 In the browser, you can also navigate programmatically outside of a `load` function using [`goto`](modules#$app-navigation-goto) from [`$app.navigation`](modules#$app-navigation).
 


### PR DESCRIPTION
As a new Svelte / JS developer, the existing warning "Make sure you're not catching the thrown redirect" wasn't clear enough for me to understand that "catching" meant an try/catch block.

This is an attempt to be more explicit and to hopefully help other junior developers.