### PR TITLE
docs: fix type for form action example

### DIFF
--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -412,7 +412,7 @@ We can also implement progressive enhancement ourselves, without `use:enhance`, 
 	/** @type {any} */
 	let error;
 
-	/**  @param {{ currentTarget: EventTarget & HTMLFormElement}} event  */
+	/** @param {{ currentTarget: EventTarget & HTMLFormElement}} event */
 	async function handleSubmit(event) {
 		const data = new FormData(event.currentTarget);
 

--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -412,10 +412,11 @@ We can also implement progressive enhancement ourselves, without `use:enhance`, 
 	/** @type {any} */
 	let error;
 
+	/**  @param {{ currentTarget: EventTarget & HTMLFormElement}} event  */
 	async function handleSubmit(event) {
-		const data = new FormData(this);
+		const data = new FormData(event.currentTarget);
 
-		const response = await fetch(this.action, {
+		const response = await fetch(event.currentTarget.action, {
 			method: 'POST',
 			body: data
 		});


### PR DESCRIPTION
## Problem

The Type for this section is invalid in most typescript configurations since there really is no way of typing `this` for the event. So, Typescript users  may get unnecessarily frustrated copying this code.

## Fix
Update docs section to use currentTarget which  will make this docs section valid in typescript code.

As for the actual style of the fix I tried to keep it simple though it is kindof ugly with the chaining. So, please make an edit if you have a solution that more fits the style of the docs

## Tests
I came across this while implementing something similar in my own code. I used this typing and it worked.
