### PR TITLE
Update onNavigate doc about full-page navigation behaviour

### DIFF
--- a/documentation/docs/60-appendix/01-faq.md
+++ b/documentation/docs/60-appendix/01-faq.md
@@ -65,7 +65,7 @@ If you are still encountering issues we recommend searching both [the Vite issue
 
 ## How do I use the view transitions API with SvelteKit?
 
-While SvelteKit does not have any specific integration with [view transitions](https://developer.chrome.com/docs/web-platform/view-transitions/), you can call `document.startViewTransition` in [`onNavigate`](/docs/modules#$app-navigation-onnavigate) to trigger a view transition on every navigation.
+While SvelteKit does not have any specific integration with [view transitions](https://developer.chrome.com/docs/web-platform/view-transitions/), you can call `document.startViewTransition` in [`onNavigate`](/docs/modules#$app-navigation-onnavigate) to trigger a view transition on every navigation, except when using [`data-sveltekit-reload`](link-options#data-sveltekit-reload).
 
 ```js
 // @errors: 2339 2810

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -102,7 +102,7 @@ export const preloadCode = /* @__PURE__ */ client_method('preload_code');
 export const beforeNavigate = /* @__PURE__ */ client_method('before_navigate');
 
 /**
- * A lifecycle function that runs the supplied `callback` immediately before we navigate to a new URL.
+ * A lifecycle function that runs the supplied `callback` immediately before we navigate to a new URL, except during full-page navigations.
  *
  * If you return a `Promise`, SvelteKit will wait for it to resolve before completing the navigation. This allows you to — for example — use `document.startViewTransition`. Avoid promises that are slow to resolve, since navigation will appear stalled to the user.
  *


### PR DESCRIPTION
given that `beforeNavigate` and `afterNavigate` are fired even on links with `data-sveltekit-reload`, initially I found it a bit confusing that `onNavigate` didn't, so it might be good to clarify that in some of the docs.
