### PR TITLE
fix: `popstate` navigation wasn't cancelling ongoing `navigation()` calls when landing on the same page

### DIFF
--- a/.changeset/neat-chicken-turn.md
+++ b/.changeset/neat-chicken-turn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: navigation with browser back button always cancels ongoing navigation, preventing incorrect page being rendered

--- a/.changeset/neat-chicken-turn.md
+++ b/.changeset/neat-chicken-turn.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: navigation with browser back button always cancels ongoing navigation, preventing incorrect page being rendered
+fix: cancel ongoing navigation when the browser back button is hit to prevent an incorrect page from being rendered

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1695,7 +1695,7 @@ export function create_client(app, target) {
 						},
 						type: 'popstate',
 						delta,
-						nav_token: token,
+						nav_token: token
 					});
 				} else {
 					// since popstate event is also emitted when an anchor referencing the same

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1662,6 +1662,7 @@ export function create_client(app, target) {
 			});
 
 			addEventListener('popstate', async (event) => {
+				token = {};
 				if (event.state?.[INDEX_KEY]) {
 					// if a popstate-driven navigation is cancelled, we need to counteract it
 					// with history.go, which means we end up back here, hence this check
@@ -1693,7 +1694,8 @@ export function create_client(app, target) {
 							history.go(-delta);
 						},
 						type: 'popstate',
-						delta
+						delta,
+						nav_token: token,
 					});
 				} else {
 					// since popstate event is also emitted when an anchor referencing the same


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/issues/10512
Maybe also this? https://github.com/sveltejs/kit/issues/10700

# Bug description 

When navigating with `popstate` , there is an early return if only `#` part of the url changed.

This ignores the edgecase where quick navigation ends on the same page, e.g. `A` -> `B` -> `A`

In this case:
1. `popstate` to `B` calls `navigate()`
2. `popstate` back to `A` returns early doing nothing
3. The first `navigate()` starts rendering
4. We end up with `B` rendered, but `A` in the address bar 

# Proposed fix
`popstate` event handler should update the navigation token before anything else happens

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
