### PR TITLE
fix: allow optional param in middle of route

### DIFF
--- a/.changeset/tricky-geckos-poke.md
+++ b/.changeset/tricky-geckos-poke.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow optional param in middle of route

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -136,6 +136,7 @@ export function exec(match, params, matchers) {
 	const result = {};
 
 	const values = match.slice(1);
+	const values_needing_match = values.filter((value) => value !== undefined);
 
 	let buffered = 0;
 
@@ -168,6 +169,15 @@ export function exec(match, params, matchers) {
 			const next_param = params[i + 1];
 			const next_value = values[i + 1];
 			if (next_param && !next_param.rest && next_param.optional && next_value && param.chained) {
+				buffered = 0;
+			}
+
+			// There are no more params and no more values, but all non-empty values have been matched
+			if (
+				!next_param &&
+				!next_value &&
+				Object.keys(result).length === values_needing_match.length
+			) {
 				buffered = 0;
 			}
 			continue;

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -198,6 +198,16 @@ const exec_tests = [
 		expected: { slug2: 'b', slug3: 'c' }
 	},
 	{
+		route: '/[[slug1=doesntmatch]]/[[slug2=matches]]/[[slug3=matches]]',
+		path: '/b/c',
+		expected: { slug2: 'b', slug3: 'c' }
+	},
+	{
+		route: '/[slug1]/[[lang=doesntmatch]]/[[page=matches]]',
+		path: '/a/2',
+		expected: { slug1: 'a', lang: undefined, page: '2' }
+	},
+	{
 		route: '/[[slug1=doesntmatch]]/[slug2=matches]/[slug3]',
 		path: '/a/b/c',
 		expected: undefined


### PR DESCRIPTION
I have a route with multiple optional params, but both have matchers that are exclusive to each other. That means for a given URL, there is no ambiguity which param matches.

Consider this example:

```
Route:           /[user]/[[type=type]]/[[page=page]]
Matcher `type`:  (param) => ["overview", "finished", "pending"].includes(param)
Matcher `page`:  (param) => /^\d+$/.test(param) && Number(param) > 0

Link:            "/daniel/2"
Expected Params: { user: "daniel", page: "2" }
Actual Result:   No match, SvelteKit raises 404
```

Looking at the code and the test cases, I think this might have been an accidental oversight, just due to the pretty complex routing algorithm.

This fix now allows the variant where all values have been matched and all params have been used.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
