### PR TITLE
Infer route parameter type from matcher's guard check if applicable

### DIFF
--- a/.changeset/great-bags-heal.md
+++ b/.changeset/great-bags-heal.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+feat: infer route parameter type from matcher's guard check if applicable

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -191,7 +191,7 @@ function update_types(config, routes, route, to_delete = new Set()) {
 
 	//Returns the predicate of a matcher's type guard - or string if there is no type guard
 	declarations.push(
-		"//@ts-ignore\ntype MatcherParam<M> = M extends (param: string) => param is infer U ? U : string;"
+		'//@ts-ignore\ntype MatcherParam<M> = M extends (param: string) => param is infer U ? U : string;'
 	);
 
 	declarations.push(

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -279,7 +279,7 @@ function update_types(config, routes, route, to_delete = new Set()) {
 				if (leaf.route.page) ids.push(`"${leaf.route.id}"`);
 
 				for (const param of leaf.route.params) {
-					//Skip if already added
+					// skip if already added
 					if (layout_params.some((p) => p.name === param.name)) continue;
 					layout_params.push({ ...param, optional: true });
 				}

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -191,7 +191,11 @@ function update_types(config, routes, route, to_delete = new Set()) {
 
 	// returns the predicate of a matcher's type guard - or string if there is no type guard
 	declarations.push(
-		'//@ts-expect-error\ntype MatcherParam<M> = M extends (param: string) => param is infer U ? U : string;'
+		[
+			'// TS complains on infer U, which seems weird',
+			'// @ts-ignore',
+			'type MatcherParam<M> = M extends (param : string) => param is infer U ? U extends string ? U : string : string;'
+		].join('\n')
 	);
 
 	declarations.push(

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -189,7 +189,7 @@ function update_types(config, routes, route, to_delete = new Set()) {
 	// Makes sure a type is "repackaged" and therefore more readable
 	declarations.push('type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;');
 
-	//Returns the predicate of a matcher's type guard - or string if there is no type guard
+	// returns the predicate of a matcher's type guard - or string if there is no type guard
 	declarations.push(
 		'//@ts-ignore\ntype MatcherParam<M> = M extends (param: string) => param is infer U ? U : string;'
 	);

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -188,10 +188,14 @@ function update_types(config, routes, route, to_delete = new Set()) {
 	// add 'Expand' helper
 	// Makes sure a type is "repackaged" and therefore more readable
 	declarations.push('type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;');
+
+	//Returns the predicate of a matcher's type guard - or string if there is no type guard
 	declarations.push(
-		`type RouteParams = { ${route.params
-			.map((param) => `${param.name}${param.optional ? '?' : ''}: string`)
-			.join('; ')} }`
+		"//@ts-ignore\ntype MatcherParam<M> = M extends (param: string) => param is infer U ? U : string;"
+	);
+
+	declarations.push(
+		'type RouteParams = ' + generate_params_type(route.params, outdir, config) + ';'
 	);
 
 	if (route.params.length > 0) {
@@ -265,7 +269,8 @@ function update_types(config, routes, route, to_delete = new Set()) {
 
 	if (route.layout) {
 		let all_pages_have_load = true;
-		const layout_params = new Set();
+		/** @type {import('types').RouteParam[]} */
+		const layout_params = [];
 		const ids = ['RouteId'];
 
 		route.layout.child_pages?.forEach((page) => {
@@ -274,7 +279,9 @@ function update_types(config, routes, route, to_delete = new Set()) {
 				if (leaf.route.page) ids.push(`"${leaf.route.id}"`);
 
 				for (const param of leaf.route.params) {
-					layout_params.add(param.name);
+					//Skip if already added
+					if (layout_params.some((p) => p.name === param.name)) continue;
+					layout_params.push({ ...param, optional: true });
 				}
 
 				ensureProxies(page, leaf.proxies);
@@ -301,9 +308,7 @@ function update_types(config, routes, route, to_delete = new Set()) {
 		declarations.push(`type LayoutRouteId = ${ids.join(' | ')}`);
 
 		declarations.push(
-			`type LayoutParams = RouteParams & { ${Array.from(layout_params).map(
-				(param) => `${param}?: string`
-			)} }`
+			`type LayoutParams = RouteParams & ` + generate_params_type(layout_params, outdir, config)
 		);
 
 		const {
@@ -565,6 +570,28 @@ function replace_ext_with_js(file_path) {
 	// will result in TS failing to lookup the file
 	const ext = path.extname(file_path);
 	return file_path.slice(0, -ext.length) + '.js';
+}
+
+/**
+ * @param {import('types').RouteParam[]} params
+ * @param {string} outdir
+ * @param {import('types').ValidatedConfig} config
+ */
+function generate_params_type(params, outdir, config) {
+	/** @param {string} matcher */
+	const path_to_matcher = (matcher) =>
+		posixify(path.relative(outdir, path.join(config.kit.files.params, matcher)));
+
+	return `{ ${params
+		.map(
+			(param) =>
+				`${param.name}${param.optional ? '?' : ''}: ${
+					param.matcher
+						? `MatcherParam<typeof import('${path_to_matcher(param.matcher)}').match>`
+						: 'string'
+				}`
+		)
+		.join('; ')} }`;
 }
 
 /**

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -191,8 +191,8 @@ function update_types(config, routes, route, to_delete = new Set()) {
 
 	// returns the predicate of a matcher's type guard - or string if there is no type guard
 	declarations.push(
+		// TS complains on infer U, which seems weird, therefore ts-ignore it
 		[
-			'// TS complains on infer U, which seems weird',
 			'// @ts-ignore',
 			'type MatcherParam<M> = M extends (param : string) => param is infer U ? U extends string ? U : string : string;'
 		].join('\n')

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -191,7 +191,7 @@ function update_types(config, routes, route, to_delete = new Set()) {
 
 	// returns the predicate of a matcher's type guard - or string if there is no type guard
 	declarations.push(
-		'//@ts-ignore\ntype MatcherParam<M> = M extends (param: string) => param is infer U ? U : string;'
+		'//@ts-expect-error\ntype MatcherParam<M> = M extends (param: string) => param is infer U ? U : string;'
 	);
 
 	declarations.push(

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -308,7 +308,7 @@ function update_types(config, routes, route, to_delete = new Set()) {
 		declarations.push(`type LayoutRouteId = ${ids.join(' | ')}`);
 
 		declarations.push(
-			`type LayoutParams = RouteParams & ` + generate_params_type(layout_params, outdir, config)
+			'type LayoutParams = RouteParams & ' + generate_params_type(layout_params, outdir, config)
 		);
 
 		const {

--- a/packages/kit/src/core/sync/write_types/index.spec.js
+++ b/packages/kit/src/core/sync/write_types/index.spec.js
@@ -18,7 +18,7 @@ async function run_test(dir) {
 	const initial = options({}, 'config');
 
 	initial.kit.files.assets = path.resolve(cwd, 'static');
-	initial.kit.files.params = path.resolve(cwd, 'params');
+	initial.kit.files.params = path.resolve(cwd, dir, 'params');
 	initial.kit.files.routes = path.resolve(cwd, dir);
 	initial.kit.outDir = path.resolve(cwd, path.join(dir, '.svelte-kit'));
 
@@ -40,6 +40,7 @@ test('Creates correct $types', async () => {
 	await run_test('layout-advanced');
 	await run_test('slugs');
 	await run_test('slugs-layout-not-all-pages-have-load');
+	await run_test('param-type-inference');
 	try {
 		execSync('pnpm testtypes', { cwd });
 	} catch (e) {

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/optional/[[optionalNarrowedParam=narrowed]]/+page.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/optional/[[optionalNarrowedParam=narrowed]]/+page.js
@@ -1,0 +1,8 @@
+/** @type {import('../../.svelte-kit/types/src/core/sync/write_types/test/param-type-inference/optional/[[optionalNarrowedParam=narrowed]]/$types').PageLoad} */
+export function load({ params }) {
+	if (params.optionalNarrowedParam) {
+		/** @type {"a" | "b"} */
+		let a;
+		a = params.optionalNarrowedParam;
+	}
+}

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/optional/[[optionalNarrowedParam=narrowed]]/+page.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/optional/[[optionalNarrowedParam=narrowed]]/+page.js
@@ -1,8 +1,11 @@
+/* eslint-disable */
+
 /** @type {import('../../.svelte-kit/types/src/core/sync/write_types/test/param-type-inference/optional/[[optionalNarrowedParam=narrowed]]/$types').PageLoad} */
 export function load({ params }) {
 	if (params.optionalNarrowedParam) {
 		/** @type {"a" | "b"} */
 		let a;
 		a = params.optionalNarrowedParam;
+		return { a };
 	}
 }

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/params/narrowed.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/params/narrowed.js
@@ -1,0 +1,5 @@
+/**
+ * @param {string} param 
+ * @returns {param is "a" | "b"}
+ */
+export const match = (param) => ["a", "b"].includes(param);

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/params/narrowed.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/params/narrowed.js
@@ -1,5 +1,5 @@
 /**
- * @param {string} param 
+ * @param {string} param
  * @returns {param is "a" | "b"}
  */
-export const match = (param) => ["a", "b"].includes(param);
+export const match = (param) => ['a', 'b'].includes(param);

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/params/not_narrowed.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/params/not_narrowed.js
@@ -1,5 +1,5 @@
 /**
- * @param {string} param 
- * @returns {boolean} 
+ * @param {string} param
+ * @returns {boolean}
  */
 export const match = (param) => true;

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/params/not_narrowed.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/params/not_narrowed.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 /**
  * @param {string} param
  * @returns {boolean}

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/params/not_narrowed.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/params/not_narrowed.js
@@ -1,0 +1,5 @@
+/**
+ * @param {string} param 
+ * @returns {boolean} 
+ */
+export const match = (param) => true;

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/required/+layout.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/required/+layout.js
@@ -1,9 +1,10 @@
+/* eslint-disable */
+
 /** @type {import('../.svelte-kit/types/src/core/sync/write_types/test/param-type-inference/required/$types').LayoutLoad} */
 export function load({ params }) {
 	if (params.narrowedParam) {
 		/** @type {"a" | "b"} */
-		let a;
-		a = params.narrowedParam;
+		const a = params.narrowedParam;
 	}
 
 	if (params.regularParam) {

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/required/+layout.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/required/+layout.js
@@ -1,0 +1,19 @@
+/** @type {import('../.svelte-kit/types/src/core/sync/write_types/test/param-type-inference/required/$types').LayoutLoad} */
+export function load({ params }) {
+	if (params.narrowedParam) {
+		/** @type {"a" | "b"} */
+		let a;
+		a = params.narrowedParam;
+	}
+
+	if (params.regularParam) {
+		/** @type {"a" | "b"} */
+		let a;
+
+		//@ts-expect-error
+		a = params.regularParam;
+
+		/** @type {string} b*/
+		const b = params.regularParam;
+	}
+}

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/required/[narrowedParam=narrowed]/+page.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/required/[narrowedParam=narrowed]/+page.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 /** @type {import('../../.svelte-kit/types/src/core/sync/write_types/test/param-type-inference/required/[narrowedParam=narrowed]/$types').PageLoad} */
 export function load({ params }) {
 	/** @type {"a" | "b"} */

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/required/[narrowedParam=narrowed]/+page.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/required/[narrowedParam=narrowed]/+page.js
@@ -1,0 +1,6 @@
+/** @type {import('../../.svelte-kit/types/src/core/sync/write_types/test/param-type-inference/required/[narrowedParam=narrowed]/$types').PageLoad} */
+export function load({ params }) {
+    /** @type {"a" | "b"} */
+    let a;
+    a = params.narrowedParam
+}

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/required/[narrowedParam=narrowed]/+page.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/required/[narrowedParam=narrowed]/+page.js
@@ -1,6 +1,6 @@
 /** @type {import('../../.svelte-kit/types/src/core/sync/write_types/test/param-type-inference/required/[narrowedParam=narrowed]/$types').PageLoad} */
 export function load({ params }) {
-    /** @type {"a" | "b"} */
-    let a;
-    a = params.narrowedParam
+	/** @type {"a" | "b"} */
+	let a;
+	a = params.narrowedParam;
 }

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/required/[regularParam=not_narrowed]/+page.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/required/[regularParam=not_narrowed]/+page.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 /** @type {import('../../.svelte-kit/types/src/core/sync/write_types/test/param-type-inference/required/[regularParam=not_narrowed]/$types').PageLoad} */
 export function load({ params }) {
 	/** @type {string} a*/

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/required/[regularParam=not_narrowed]/+page.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/required/[regularParam=not_narrowed]/+page.js
@@ -1,11 +1,11 @@
 /** @type {import('../../.svelte-kit/types/src/core/sync/write_types/test/param-type-inference/required/[regularParam=not_narrowed]/$types').PageLoad} */
 export function load({ params }) {
 	/** @type {string} a*/
-    const a = params.regularParam;
-    
-    /** @type {"a" | "b"} b*/
-    let b;
+	const a = params.regularParam;
 
-    //@ts-expect-error
-    b = params.regularParam;
+	/** @type {"a" | "b"} b*/
+	let b;
+
+	//@ts-expect-error
+	b = params.regularParam;
 }

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/required/[regularParam=not_narrowed]/+page.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/required/[regularParam=not_narrowed]/+page.js
@@ -1,0 +1,11 @@
+/** @type {import('../../.svelte-kit/types/src/core/sync/write_types/test/param-type-inference/required/[regularParam=not_narrowed]/$types').PageLoad} */
+export function load({ params }) {
+	/** @type {string} a*/
+    const a = params.regularParam;
+    
+    /** @type {"a" | "b"} b*/
+    let b;
+
+    //@ts-expect-error
+    b = params.regularParam;
+}

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/spread/[...spread=narrowed]/+page.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/spread/[...spread=narrowed]/+page.js
@@ -1,0 +1,6 @@
+/** @type {import('../../.svelte-kit/types/src/core/sync/write_types/test/param-type-inference/spread/[...spread=narrowed]/$types').PageLoad} */
+export function load({ params }) {
+	/** @type {"a" | "b"} */
+	let a;
+	a = params.spread;
+}

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/spread/[...spread=narrowed]/+page.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/spread/[...spread=narrowed]/+page.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 /** @type {import('../../.svelte-kit/types/src/core/sync/write_types/test/param-type-inference/spread/[...spread=narrowed]/$types').PageLoad} */
 export function load({ params }) {
 	/** @type {"a" | "b"} */


### PR DESCRIPTION
closes #8137 - Just not for `$page.params`

Currently all route parameters always have type `string`. This type is correct, but often broader than it needs to be.
If a matcher is used on a route parameter, and that matcher is annotated with a guard check, we can infer the type much more narrowly.

```ts
// src/params/ab.ts
export const match = (param) : param is "a" | "b" => param == "a" || param == "b";
```

```ts
// src/routes/[myParam=ab]/+page.ts
export async function load({params}) {
    params.myParam //Has type "a" | "b"
}
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
