### PR TITLE
fix: correct line numbers when console logging stack traces

### DIFF
--- a/.changeset/clean-panthers-remain.md
+++ b/.changeset/clean-panthers-remain.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correct line numbers in stack trace

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -233,7 +233,7 @@ export async function dev(vite, vite_config, svelte_config) {
 					for (const key in manifest_data.matchers) {
 						const file = manifest_data.matchers[key];
 						const url = path.resolve(cwd, file);
-						const module = await vite.ssrLoadModule(url);
+						const module = await vite.ssrLoadModule(url, { fixStacktrace: true });
 
 						if (module.match) {
 							matchers[key] = module.match;

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -58,7 +58,10 @@ export async function dev(vite, vite_config, svelte_config) {
 		} catch (/** @type {any} */ err) {
 			const msg = buildErrorMessage(err, [colors.red(`Internal server error: ${err.message}`)]);
 
-			vite.config.logger.error(msg, { error: err });
+			if (!vite.config.logger.hasErrorLogged(err)) {
+				vite.config.logger.error(msg, { error: err });
+			}
+
 			vite.ws.send({
 				type: 'error',
 				err: {

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -54,7 +54,7 @@ export async function dev(vite, vite_config, svelte_config) {
 	/** @param {string} url */
 	async function loud_ssr_load_module(url) {
 		try {
-			return await vite.ssrLoadModule(url);
+			return await vite.ssrLoadModule(url, { fixStacktrace: true });
 		} catch (/** @type {any} */ err) {
 			const msg = buildErrorMessage(err, [colors.red(`Internal server error: ${err.message}`)]);
 
@@ -248,9 +248,10 @@ export async function dev(vite, vite_config, svelte_config) {
 		};
 	}
 
-	/** @param {string} stack */
-	function fix_stack_trace(stack) {
-		return stack ? vite.ssrRewriteStacktrace(stack) : stack;
+	/** @param {Error} error */
+	function fix_stack_trace(error) {
+		vite.ssrFixStacktrace(error);
+		return error.stack;
 	}
 
 	await update_manifest();
@@ -393,7 +394,7 @@ export async function dev(vite, vite_config, svelte_config) {
 		} catch (e) {
 			const error = coalesce_to_error(e);
 			res.statusCode = 500;
-			res.end(fix_stack_trace(/** @type {string} */ (error.stack)));
+			res.end(fix_stack_trace(error));
 		}
 	});
 
@@ -523,7 +524,7 @@ export async function dev(vite, vite_config, svelte_config) {
 			} catch (e) {
 				const error = coalesce_to_error(e);
 				res.statusCode = 500;
-				res.end(fix_stack_trace(/** @type {string} */ (error.stack)));
+				res.end(fix_stack_trace(error));
 			}
 		});
 	};

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -455,7 +455,7 @@ export async function dev(vite, vite_config, svelte_config) {
 
 				// we have to import `Server` before calling `set_assets`
 				const { Server } = /** @type {import('types').ServerModule} */ (
-					await vite.ssrLoadModule(`${runtime_base}/server/index.js`)
+					await vite.ssrLoadModule(`${runtime_base}/server/index.js`, { fixStacktrace: true })
 				);
 
 				const { set_fix_stack_trace } = await vite.ssrLoadModule(

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -99,15 +99,7 @@ export async function handle_error_and_jsonify(event, options, error) {
 		return error.body;
 	} else {
 		if (__SVELTEKIT_DEV__ && typeof error == 'object') {
-			error = new Proxy(error, {
-				get: (target, property) => {
-					if (property === 'stack') {
-						return fix_stack_trace(target.stack);
-					}
-
-					return Reflect.get(target, property, target);
-				}
-			});
+			fix_stack_trace(error);
 		}
 
 		return (

--- a/packages/kit/src/runtime/shared-server.js
+++ b/packages/kit/src/runtime/shared-server.js
@@ -4,8 +4,8 @@ export let private_env = {};
 /** @type {Record<string, string>} */
 export let public_env = {};
 
-/** @param {any} _error */
-export let fix_stack_trace = (_error) => '';
+/** @param {any} error */
+export let fix_stack_trace = (error) => error?.stack;
 
 /** @type {(environment: Record<string, string>) => void} */
 export function set_private_env(environment) {

--- a/packages/kit/src/runtime/shared-server.js
+++ b/packages/kit/src/runtime/shared-server.js
@@ -4,8 +4,8 @@ export let private_env = {};
 /** @type {Record<string, string>} */
 export let public_env = {};
 
-/** @param {string} stack */
-export let fix_stack_trace = (stack) => stack;
+/** @param {any} _error */
+export let fix_stack_trace = (_error) => '';
 
 /** @type {(environment: Record<string, string>) => void} */
 export function set_private_env(environment) {
@@ -17,7 +17,7 @@ export function set_public_env(environment) {
 	public_env = environment;
 }
 
-/** @param {(stack: string) => string} value */
+/** @param {(error: Error) => string} value */
 export function set_fix_stack_trace(value) {
 	fix_stack_trace = value;
 }

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -32,7 +32,7 @@ export interface ServerInternalModule {
 	set_private_env(environment: Record<string, string>): void;
 	set_public_env(environment: Record<string, string>): void;
 	set_version(version: string): void;
-	set_fix_stack_trace(fix_stack_trace: (stack: string) => string): void;
+	set_fix_stack_trace(fix_stack_trace: (error: unknown) => string): void;
 }
 
 export interface Asset {


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/10138

This PR fixes the server stack trace by mutating the error object with `vite.ssrFixStacktrace` rather than using a Proxy. It also fixes the stack trace output by Vite in the server logs and the vite HMR overlay by passing in the option when loading user code as SSR modules.

Thanks to @dmoebius we know that `console.log`, etc. bypasses proxies (for some strange reason). We can also safely use `vite.ssrFixStacktrace` without worrying about repeatedly fixing the same error object because it memoizes the error objects fixed. This optimisation wasn't available when `vite.rewriteStacktrace` was first exposed (but it has been now for some time!).

No test because I can't figure out how to capture the output of `console.log` and Vite's own messages.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
