### PR TITLE
docs: demonstrate JavaScript heap setting

### DIFF
--- a/documentation/docs/25-build-and-deploy/50-adapter-static.md
+++ b/documentation/docs/25-build-and-deploy/50-adapter-static.md
@@ -141,6 +141,7 @@ jobs:
       - name: build
         env:
           BASE_PATH: '/your-repo-name'
+		      NODE_OPTIONS: '--max-old-space-size=4096'
         run: |
           npm run build
           touch build/.nojekyll

--- a/documentation/docs/25-build-and-deploy/50-adapter-static.md
+++ b/documentation/docs/25-build-and-deploy/50-adapter-static.md
@@ -141,7 +141,7 @@ jobs:
       - name: build
         env:
           BASE_PATH: '/your-repo-name'
-		      NODE_OPTIONS: '--max-old-space-size=4096'
+          NODE_OPTIONS: '--max-old-space-size=4096'
         run: |
           npm run build
           touch build/.nojekyll

--- a/documentation/docs/25-build-and-deploy/50-adapter-static.md
+++ b/documentation/docs/25-build-and-deploy/50-adapter-static.md
@@ -141,7 +141,9 @@ jobs:
       - name: build
         env:
           BASE_PATH: '/your-repo-name'
-          NODE_OPTIONS: '--max-old-space-size=4096'
+          # Uncomment this if you encounter a "heap out of memory" error
+          # CF https://github.com/actions/runner-images/issues/70
+          # NODE_OPTIONS: '--max-old-space-size=4096'
         run: |
           npm run build
           touch build/.nojekyll


### PR DESCRIPTION
Error prevented described here : https://github.com/actions/runner-images/issues/70

Note: This "heap out of memory" error happened on BOTH github actions & Netlify, 

In BOTH cases the error was solved with this

(In Netlify I had to manually set the environment variable)

It was with a Sveltekit project that was a landing page,

When built, the build folder was only 29 files & 935 kb

So I expect other to experience the error as well.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
