### PR TITLE
docs: add missing service-worker.js location in src tree visualization

### DIFF
--- a/documentation/docs/10-getting-started/30-project-structure.md
+++ b/documentation/docs/10-getting-started/30-project-structure.md
@@ -18,7 +18,8 @@ my-project/
 │ ├ app.html
 │ ├ error.html
 │ ├ hooks.client.js
-│ └ hooks.server.js
+│ ├ hooks.server.js
+│ └ service-worker.js
 ├ static/
 │ └ [your static assets]
 ├ tests/


### PR DESCRIPTION
Page refers to service-worker.js, but it was missing in the visualization of the src tree

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
