### PR TITLE
fix: move Vite file removal to adapter methods

### DIFF
--- a/.changeset/young-wolves-sing.md
+++ b/.changeset/young-wolves-sing.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: only remove Vite manifest when copying files

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -181,9 +181,10 @@ export function create_builder({
 		},
 
 		writeClient(dest) {
-			const files = copy(`${config.kit.outDir}/output/client`, dest);
-			// avoid making vite files public
-			rimraf(`${dest}/.vite`);
+			const files = copy(`${config.kit.outDir}/output/client`, dest, {
+				// avoid making vite files public
+				filter: (basename) => basename === '.vite'
+			});
 			return filter_vite_files(files);
 		},
 

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -183,7 +183,7 @@ export function create_builder({
 		writeClient(dest) {
 			const files = copy(`${config.kit.outDir}/output/client`, dest, {
 				// avoid making vite files public
-				filter: (basename) => basename === '.vite'
+				filter: (basename) => basename !== '.vite'
 			});
 			return filter_vite_files(files);
 		},

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -1,4 +1,4 @@
-import { existsSync, statSync, createReadStream, createWriteStream, rmSync } from 'node:fs';
+import { existsSync, statSync, createReadStream, createWriteStream } from 'node:fs';
 import { extname, resolve } from 'node:path';
 import { pipeline } from 'node:stream';
 import { promisify } from 'node:util';
@@ -183,7 +183,7 @@ export function create_builder({
 		writeClient(dest) {
 			const files = copy(`${config.kit.outDir}/output/client`, dest);
 			// avoid making vite files public
-			rmSync(`${dest}/.vite`, { force: true, recursive: true });
+			rimraf(`${dest}/.vite`);
 			return filter_vite_files(files);
 		},
 

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -1,4 +1,4 @@
-import { existsSync, statSync, createReadStream, createWriteStream } from 'node:fs';
+import { existsSync, statSync, createReadStream, createWriteStream, unlinkSync } from 'node:fs';
 import { extname, resolve } from 'node:path';
 import { pipeline } from 'node:stream';
 import { promisify } from 'node:util';
@@ -181,7 +181,10 @@ export function create_builder({
 		},
 
 		writeClient(dest) {
-			return copy(`${config.kit.outDir}/output/client`, dest);
+			const files = copy(`${config.kit.outDir}/output/client`, dest);
+			// avoid making vite files public
+			unlinkSync(`${dest}/.vite`);
+			return files;
 		},
 
 		writePrerendered(dest) {
@@ -190,7 +193,10 @@ export function create_builder({
 		},
 
 		writeServer(dest) {
-			return copy(`${config.kit.outDir}/output/server`, dest);
+			const files = copy(`${config.kit.outDir}/output/server`, dest);
+			// remove unused vite files
+			unlinkSync(`${dest}/.vite`);
+			return files;
 		}
 	};
 }

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -181,11 +181,10 @@ export function create_builder({
 		},
 
 		writeClient(dest) {
-			const files = copy(`${config.kit.outDir}/output/client`, dest, {
+			return copy(`${config.kit.outDir}/output/client`, dest, {
 				// avoid making vite files public
 				filter: (basename) => basename !== '.vite'
 			});
-			return filter_vite_files(files);
 		},
 
 		writePrerendered(dest) {
@@ -194,8 +193,7 @@ export function create_builder({
 		},
 
 		writeServer(dest) {
-			const files = copy(`${config.kit.outDir}/output/server`, dest);
-			return filter_vite_files(files);
+			return copy(`${config.kit.outDir}/output/server`, dest);
 		}
 	};
 }
@@ -220,12 +218,4 @@ async function compress_file(file, format = 'gz') {
 	const destination = createWriteStream(`${file}.${format}`);
 
 	await pipe(source, compress, destination);
-}
-
-/**
- * @param {string[]} files
- * @returns {string[]}
- */
-export function filter_vite_files(files) {
-	return files.filter((file) => !file.startsWith('.vite/'));
 }

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -194,8 +194,6 @@ export function create_builder({
 
 		writeServer(dest) {
 			const files = copy(`${config.kit.outDir}/output/server`, dest);
-			// remove unused vite files
-			rmSync(`${dest}/.vite`, { force: true, recursive: true });
 			return filter_vite_files(files);
 		}
 	};
@@ -224,7 +222,6 @@ async function compress_file(file, format = 'gz') {
 }
 
 /**
- *
  * @param {string[]} files
  * @returns {string[]}
  */

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -182,7 +182,7 @@ export function create_builder({
 
 		writeClient(dest) {
 			return copy(`${config.kit.outDir}/output/client`, dest, {
-				// avoid making vite files public
+				// avoid making vite build artefacts public
 				filter: (basename) => basename !== '.vite'
 			});
 		},

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -1,4 +1,4 @@
-import { existsSync, statSync, createReadStream, createWriteStream, unlinkSync } from 'node:fs';
+import { existsSync, statSync, createReadStream, createWriteStream, rmSync } from 'node:fs';
 import { extname, resolve } from 'node:path';
 import { pipeline } from 'node:stream';
 import { promisify } from 'node:util';
@@ -183,8 +183,8 @@ export function create_builder({
 		writeClient(dest) {
 			const files = copy(`${config.kit.outDir}/output/client`, dest);
 			// avoid making vite files public
-			unlinkSync(`${dest}/.vite`);
-			return files;
+			rmSync(`${dest}/.vite`, { force: true, recursive: true });
+			return filter_vite_files(files);
 		},
 
 		writePrerendered(dest) {
@@ -195,8 +195,8 @@ export function create_builder({
 		writeServer(dest) {
 			const files = copy(`${config.kit.outDir}/output/server`, dest);
 			// remove unused vite files
-			unlinkSync(`${dest}/.vite`);
-			return files;
+			rmSync(`${dest}/.vite`, { force: true, recursive: true });
+			return filter_vite_files(files);
 		}
 	};
 }
@@ -221,4 +221,13 @@ async function compress_file(file, format = 'gz') {
 	const destination = createWriteStream(`${file}.${format}`);
 
 	await pipe(source, compress, destination);
+}
+
+/**
+ *
+ * @param {string[]} files
+ * @returns {string[]}
+ */
+export function filter_vite_files(files) {
+	return files.filter((file) => !file.startsWith('.vite/'));
 }

--- a/packages/kit/src/core/adapt/builder.spec.js
+++ b/packages/kit/src/core/adapt/builder.spec.js
@@ -2,7 +2,7 @@ import { existsSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { assert, expect, test } from 'vitest';
-import { create_builder, filter_vite_files } from './builder.js';
+import { create_builder } from './builder.js';
 import { posixify } from '../../utils/filesystem.js';
 import { list_files } from '../utils.js';
 

--- a/packages/kit/src/core/adapt/builder.spec.js
+++ b/packages/kit/src/core/adapt/builder.spec.js
@@ -2,7 +2,7 @@ import { existsSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { assert, expect, test } from 'vitest';
-import { create_builder } from './builder.js';
+import { create_builder, filter_vite_files } from './builder.js';
 import { posixify } from '../../utils/filesystem.js';
 import { list_files } from '../utils.js';
 
@@ -47,12 +47,12 @@ test('copy files', () => {
 	rmSync(dest, { recursive: true, force: true });
 
 	expect(builder.writeClient(dest)).toEqual(list_files(dest).map(posixify));
-	expect(list_files(`${outDir}/output/client`)).toEqual(list_files(dest));
+	expect(filter_vite_files(list_files(`${outDir}/output/client`))).toEqual(list_files(dest));
 
 	rmSync(dest, { recursive: true, force: true });
 
 	expect(builder.writeServer(dest)).toEqual(list_files(dest).map(posixify));
-	expect(list_files(`${outDir}/output/server`)).toEqual(list_files(dest));
+	expect(filter_vite_files(list_files(`${outDir}/output/server`))).toEqual(list_files(dest));
 
 	rmSync(dest, { force: true, recursive: true });
 });

--- a/packages/kit/src/core/adapt/builder.spec.js
+++ b/packages/kit/src/core/adapt/builder.spec.js
@@ -47,12 +47,14 @@ test('copy files', () => {
 	rmSync(dest, { recursive: true, force: true });
 
 	expect(builder.writeClient(dest)).toEqual(list_files(dest).map(posixify));
-	expect(filter_vite_files(list_files(`${outDir}/output/client`))).toEqual(list_files(dest));
+	expect(
+		list_files(`${outDir}/output/client`).filter((file) => !file.startsWith('.vite/'))
+	).toEqual(list_files(dest));
 
 	rmSync(dest, { recursive: true, force: true });
 
 	expect(builder.writeServer(dest)).toEqual(list_files(dest).map(posixify));
-	expect(filter_vite_files(list_files(`${outDir}/output/server`))).toEqual(list_files(dest));
+	expect(list_files(`${outDir}/output/server`)).toEqual(list_files(dest));
 
 	rmSync(dest, { force: true, recursive: true });
 });

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -555,7 +555,7 @@ function kit({ svelte_config }) {
 						cssCodeSplit: true,
 						cssMinify: initial_config.build?.minify == null ? true : !!initial_config.build.minify,
 						// don't use the default name to avoid collisions with 'static/manifest.json'
-						manifest: '.vite/manifest.json', // TODO: we can remove this when vite 5 comes out
+						manifest: '.vite/manifest.json', // TODO: remove this after bumping peer dep to vite 5
 						outDir: `${out}/${ssr ? 'server' : 'client'}`,
 						rollupOptions: {
 							input,

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -555,7 +555,7 @@ function kit({ svelte_config }) {
 						cssCodeSplit: true,
 						cssMinify: initial_config.build?.minify == null ? true : !!initial_config.build.minify,
 						// don't use the default name to avoid collisions with 'static/manifest.json'
-						manifest: 'vite-manifest.json',
+						manifest: '.vite/manifest.json', // TODO: we can remove this when vite 5 comes out
 						outDir: `${out}/${ssr ? 'server' : 'client'}`,
 						rollupOptions: {
 							input,
@@ -804,10 +804,6 @@ function kit({ svelte_config }) {
 							.bold()
 							.cyan('npm run preview')} to preview your production build locally.`
 					);
-
-					// avoid making the manifest available to users
-					fs.unlinkSync(`${out}/client/${vite_config.build.manifest}`);
-					fs.unlinkSync(`${out}/server/${vite_config.build.manifest}`);
 
 					if (kit.adapter) {
 						const { adapt } = await import('../../core/adapt/index.js');


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/10268

I can't reproduce the original issue on my system but this simple fix makes it worth leaving the Vite manifest file alone?
We can just remove it when copying files so it doesn't get exposed publicly. https://github.com/sveltejs/kit/issues/8360 https://github.com/sveltejs/kit/pull/8815

This would also make it forwards compatible with whatever vite files get generated in the future since Vite 5 will put all these files in the `.vite` folder. https://github.com/vitejs/vite/issues/9636#issuecomment-1441958636 https://github.com/vitejs/vite/pull/14230/files

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
