### PR TITLE
Add ability to load different config file types

### DIFF
--- a/.changeset/old-monkey-business.md
+++ b/.changeset/old-monkey-business.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: add ability to load different config file types

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -56,14 +56,27 @@ export function load_error_page(config) {
 }
 
 /**
+ * Searches for svelte config file and returns its path
+ * @param {{ cwd?: string }} options
+ * @returns {string | undefined}
+ */
+export function find_config_file({ cwd = process.cwd() } = {}) {
+	const js_config_file = path.join(cwd, 'svelte.config.js');
+	const cjs_config_file = path.join(cwd, 'svelte.config.cjs');
+	const mjs_config_file = path.join(cwd, 'svelte.config.mjs');
+
+	return [js_config_file, cjs_config_file, mjs_config_file].find((file) => fs.existsSync(file));
+}
+
+/**
  * Loads and validates svelte.config.js
  * @param {{ cwd?: string }} options
  * @returns {Promise<import('types').ValidatedConfig>}
  */
 export async function load_config({ cwd = process.cwd() } = {}) {
-	const config_file = path.join(cwd, 'svelte.config.js');
+	const config_file = find_config_file({ cwd });
 
-	if (!fs.existsSync(config_file)) {
+	if (!config_file) {
 		return process_config({}, { cwd });
 	}
 


### PR DESCRIPTION
Now, it's not possible to use `svelte.config.cjs` or `svelte.config.mjs` files, the config won't be used at all. Svelte kit doesn't show any error, that the config doesn't exist, so we can face situations, when something doesn't work.

For example, I had problem with typescript (unexpected token error on any specific typescript token) and spent much time to figure out, what's going wrong. But, I just had `svelte.config.mjs`, not `.js` and kit was using empty config.

The PR allows using any config file extension to prevent similar unobvious problems.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
