### PR TITLE
fix: correctly update `$page.url.hash` when navigating history

### DIFF
--- a/.changeset/eleven-ads-destroy.md
+++ b/.changeset/eleven-ads-destroy.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: correctly track URL hash when navigating history
+fix: correctly update `$page.url.hash` when navigating history

--- a/.changeset/eleven-ads-destroy.md
+++ b/.changeset/eleven-ads-destroy.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly track URL hash when navigating history

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1668,10 +1668,12 @@ export function create_client(app, target) {
 					if (event.state[INDEX_KEY] === current_history_index) return;
 
 					const scroll = scroll_positions[event.state[INDEX_KEY]];
+					const url = new URL(location.href);
 
 					// if the only change is the hash, we don't need to do anything...
 					if (current.url.href.split('#')[0] === location.href.split('#')[0]) {
-						// ...except handle scroll
+						// ...except update our internal URL tracking and handle scroll
+						update_url(url);
 						scroll_positions[current_history_index] = scroll_state();
 						current_history_index = event.state[INDEX_KEY];
 						scrollTo(scroll.x, scroll.y);
@@ -1681,7 +1683,7 @@ export function create_client(app, target) {
 					const delta = event.state[INDEX_KEY] - current_history_index;
 
 					await navigate({
-						url: new URL(location.href),
+						url,
 						scroll,
 						keepfocus: false,
 						redirect_chain: [],

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -641,6 +641,9 @@ test.describe('Routing', () => {
 		await page.locator('[href="/routing/hashes/pagestore"]').click();
 		await expect(page.locator('#window-hash')).toHaveText('#target'); // hashchange doesn't fire for these
 		await expect(page.locator('#page-url-hash')).toHaveText('');
+		await page.goBack();
+		expect(await page.textContent('#window-hash')).toBe('#target');
+		expect(await page.textContent('#page-url-hash')).toBe('#target');
 	});
 
 	test('back button returns to previous route when previous route has been navigated to via hash anchor', async ({


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/10607

We weren't updating the `page.url` store when the user navigates between same route history entries. This caused the `$page.url.hash` to not reflect the correct value.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
