### PR TITLE
adds cloudflare cf object to platform property

### DIFF
--- a/.changeset/cuddly-pigs-teach.md
+++ b/.changeset/cuddly-pigs-teach.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare-workers': minor
+---
+
+feat: add cloudflare's `request.cf` object to the `event.platform` property

--- a/packages/adapter-cloudflare-workers/ambient.d.ts
+++ b/packages/adapter-cloudflare-workers/ambient.d.ts
@@ -1,4 +1,4 @@
-import { CacheStorage } from '@cloudflare/workers-types';
+import { CacheStorage, IncomingRequestCfProperties } from '@cloudflare/workers-types';
 
 declare global {
 	namespace App {
@@ -7,6 +7,7 @@ declare global {
 				waitUntil(promise: Promise<any>): void;
 			};
 			caches: CacheStorage;
+			cf?: IncomingRequestCfProperties;
 		}
 	}
 }

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -71,7 +71,9 @@ export default {
 				env,
 				context,
 				// @ts-expect-error lib.dom is interfering with workers-types
-				caches
+				caches,
+				// @ts-expect-error req is actually a Cloudflare request not a standard request
+				cf: req.cf
 			},
 			getClientAddress() {
 				return req.headers.get('cf-connecting-ip');


### PR DESCRIPTION
this has been done for the pages package but not for workers. see #9978


```javascript
// @ts-expect-error req is actually a Cloudflare request not a standard request
cf: req.cf
```
This is a bit ugly, but changing the JSDoc req to `{import('@cloudflare/workers-types').Request} req` causes even more errors

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
