### PR TITLE
chore: bump undici to address security issue

### DIFF
--- a/.changeset/fast-donuts-own.md
+++ b/.changeset/fast-donuts-own.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: bump undici to address security issue

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -23,7 +23,7 @@
 		"set-cookie-parser": "^2.6.0",
 		"sirv": "^2.0.2",
 		"tiny-glob": "^0.2.9",
-		"undici": "~5.26.0"
+		"undici": "~5.26.2"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,8 +401,8 @@ importers:
         specifier: ^0.2.9
         version: 0.2.9
       undici:
-        specifier: ~5.26.0
-        version: 5.26.0
+        specifier: ~5.26.2
+        version: 5.26.3
     devDependencies:
       '@playwright/test':
         specifier: 1.30.0
@@ -6242,8 +6242,8 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
-  /undici@5.26.0:
-    resolution: {integrity: sha512-MLqGMyaJk2ubSl7FrmWuV7ZOsYWmdF7gcBHDRxm4AR8NoodQhgy3vO/D1god79HoetxR0uAeVNB65yj2lNRQnQ==}
+  /undici@5.26.3:
+    resolution: {integrity: sha512-H7n2zmKEWgOllKkIUkLvFmsJQj062lSm3uA4EYApG8gLuiOM0/go9bIoC3HVaSnfg4xunowDE2i9p8drkXuvDw==}
     engines: {node: '>=14.0'}
     dependencies:
       '@fastify/busboy': 2.0.0


### PR DESCRIPTION
https://github.com/sveltejs/kit/security/dependabot/9