### PR TITLE
chore: additional vite 5 test compatibility

### DIFF
--- a/packages/kit/test/prerendering/paths-base/vite.config.js
+++ b/packages/kit/test/prerendering/paths-base/vite.config.js
@@ -5,8 +5,8 @@ import { sveltekit } from '@sveltejs/kit/vite';
 const config = {
 	build: {
 		minify: false,
-		// lower threshold to prevent inline to test asset base path
-		assetsInlineLimit: 100
+		// disable inlining to test asset base path
+		assetsInlineLimit: 0
 	},
 
 	clearScreen: false,

--- a/packages/kit/test/prerendering/paths-base/vite.config.js
+++ b/packages/kit/test/prerendering/paths-base/vite.config.js
@@ -4,7 +4,9 @@ import { sveltekit } from '@sveltejs/kit/vite';
 /** @type {import('vite').UserConfig} */
 const config = {
 	build: {
-		minify: false
+		minify: false,
+		// lower threshold to prevent inline to test asset base path
+		assetsInlineLimit: 100
 	},
 
 	clearScreen: false,


### PR DESCRIPTION
I missed an extra place to tweak from https://github.com/sveltejs/kit/pull/10896

There's a test that tests an SVG image `src`, but it got inlined and the regex failed to match:

https://github.com/vitejs/vite-ecosystem-ci/actions/runs/6609512793/job/17949784254#step:8:2876

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
