### PR TITLE
fix: update type to indicate that route ID may be null

### DIFF
--- a/.changeset/honest-planes-cheat.md
+++ b/.changeset/honest-planes-cheat.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: update type to indicate that route ID may be null

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -795,9 +795,10 @@ export interface NavigationEvent<
 	 */
 	route: {
 		/**
-		 * The ID of the current route - e.g. for `src/routes/blog/[slug]`, it would be `/blog/[slug]`
+		 * The ID of the current route - e.g. for `src/routes/blog/[slug]`, it would be `/blog/[slug]`.
+		 * May be null if vthere is no corresponding route — i.e. a page returning status code 404.
 		 */
-		id: RouteId;
+		id: RouteId | null;
 	};
 	/**
 	 * The URL of the current page


### PR DESCRIPTION
We've hit this a couple times recently on svelte.dev. Hopefully better types will prevent us from making the same mistake