### PR TITLE
fix: only apply some polyfills below node 18.11

### DIFF
--- a/.changeset/mean-cheetahs-tell.md
+++ b/.changeset/mean-cheetahs-tell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: only apply some polyfills below node 18.11

--- a/packages/kit/src/exports/node/polyfills.js
+++ b/packages/kit/src/exports/node/polyfills.js
@@ -37,14 +37,15 @@ const globals_pre_node_18_11 = {
  */
 export function installPolyfills() {
 	// Be defensive (we don't know in which environments this is called) and always apply if something goes wrong
-	const version =
-		(typeof process !== undefined &&
-			process.versions?.node?.split('.').map((n) => parseInt(n, 10))) ||
-		[];
-	const globals =
-		(version[0] === 18 && version[1] >= 11) || version[0] > 18
-			? globals_post_node_18_11
-			: globals_pre_node_18_11;
+	let globals = globals_pre_node_18_11;
+	try {
+		const version = process.versions.node.split('.').map((n) => parseInt(n, 10));
+		if ((version[0] === 18 && version[1] >= 11) || version[0] > 18) {
+			globals = globals_post_node_18_11;
+		}
+	} catch (e) {
+		// ignore
+	}
 
 	for (const name in globals) {
 		Object.defineProperty(globalThis, name, {

--- a/packages/kit/src/exports/node/polyfills.js
+++ b/packages/kit/src/exports/node/polyfills.js
@@ -3,11 +3,16 @@ import buffer from 'node:buffer';
 import { webcrypto as crypto } from 'node:crypto';
 import { fetch, Response, Request, Headers, FormData, File as UndiciFile } from 'undici';
 
+/** @type {Record<string, any>} */
+const globals_post_node_18_11 = {
+	crypto
+};
+
 // @ts-expect-error
 const File = buffer.File ?? UndiciFile;
 
 /** @type {Record<string, any>} */
-const globals = {
+const globals_pre_node_18_11 = {
 	crypto,
 	fetch,
 	Response,
@@ -21,16 +26,21 @@ const globals = {
 };
 
 // exported for dev/preview and node environments
-// TODO: remove this once we only support Node 18.11+ (the version multipart/form-data was added)
 /**
  * Make various web APIs available as globals:
  * - `crypto`
- * - `fetch`
- * - `Headers`
- * - `Request`
- * - `Response`
+ * - `fetch` (only in node 18.11-)
+ * - `Headers` (only in node 18.11-)
+ * - `Request` (only in node 18.11-)
+ * - `Response` (only in node 18.11-)
  */
 export function installPolyfills() {
+	const version = process.versions.node.split('.').map((n) => parseInt(n, 10));
+	const globals =
+		(version[0] === 18 && version[1] >= 11) || version[0] > 18
+			? globals_post_node_18_11
+			: globals_pre_node_18_11;
+
 	for (const name in globals) {
 		Object.defineProperty(globalThis, name, {
 			enumerable: true,

--- a/packages/kit/src/exports/node/polyfills.js
+++ b/packages/kit/src/exports/node/polyfills.js
@@ -12,6 +12,7 @@ const globals_post_node_18_11 = {
 const File = buffer.File ?? UndiciFile;
 
 /** @type {Record<string, any>} */
+// TODO: remove this once we only support Node 18.11+ (the version multipart/form-data was added)
 const globals_pre_node_18_11 = {
 	crypto,
 	fetch,
@@ -35,7 +36,11 @@ const globals_pre_node_18_11 = {
  * - `Response` (only in node < 18.11)
  */
 export function installPolyfills() {
-	const version = process.versions.node.split('.').map((n) => parseInt(n, 10));
+	// Be defensive (we don't know in which environments this is called) and always apply if something goes wrong
+	const version =
+		(typeof process !== undefined &&
+			process.versions?.node?.split('.').map((n) => parseInt(n, 10))) ||
+		[];
 	const globals =
 		(version[0] === 18 && version[1] >= 11) || version[0] > 18
 			? globals_post_node_18_11

--- a/packages/kit/src/exports/node/polyfills.js
+++ b/packages/kit/src/exports/node/polyfills.js
@@ -29,10 +29,10 @@ const globals_pre_node_18_11 = {
 /**
  * Make various web APIs available as globals:
  * - `crypto`
- * - `fetch` (only in node 18.11-)
- * - `Headers` (only in node 18.11-)
- * - `Request` (only in node 18.11-)
- * - `Response` (only in node 18.11-)
+ * - `fetch` (only in node < 18.11)
+ * - `Headers` (only in node < 18.11)
+ * - `Request` (only in node < 18.11)
+ * - `Response` (only in node < 18.11)
  */
 export function installPolyfills() {
 	const version = process.versions.node.split('.').map((n) => parseInt(n, 10));


### PR DESCRIPTION
This is somewhat of a quickfix for #10918 by not applying the undici polyfills above the versions where we no longer need to apply it. Pinging @Conduitry as he might have some thoughts on this and was very hesitant towards similar things in the past. We could also bump the minimum required version to ensure people get a more up-to-date/robust version of undici.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
