### PR TITLE
chore: upgrade svelte to standardized version 4.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"playwright": "1.30.0",
 		"prettier": "^2.8.0",
 		"rollup": "^3.7.0",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"typescript": "^4.9.4"
 	},
 	"packageManager": "pnpm@8.9.2",

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -34,7 +34,7 @@
 		"@sveltejs/kit": "workspace:^",
 		"@types/node": "^16.18.6",
 		"sirv": "^2.0.3",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"
 	},

--- a/packages/adapter-static/test/apps/prerendered/package.json
+++ b/packages/adapter-static/test/apps/prerendered/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
 		"sirv-cli": "^2.0.2",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"vite": "^4.4.9"
 	},
 	"type": "module"

--- a/packages/adapter-static/test/apps/spa/package.json
+++ b/packages/adapter-static/test/apps/spa/package.json
@@ -12,7 +12,7 @@
 		"@sveltejs/adapter-node": "workspace:^",
 		"@sveltejs/kit": "workspace:^",
 		"sirv-cli": "^2.0.2",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"vite": "^4.4.9"
 	},
 	"type": "module"

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -23,7 +23,7 @@
 		"prettier": "^2.8.0",
 		"prettier-plugin-svelte": "^2.10.1",
 		"sucrase": "^3.29.0",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"tiny-glob": "^0.2.9",
 		"vitest": "^0.34.5"
 	},

--- a/packages/create-svelte/templates/default/package.json
+++ b/packages/create-svelte/templates/default/package.json
@@ -11,7 +11,7 @@
 		"@neoconfetti/svelte": "^1.0.0",
 		"@sveltejs/adapter-auto": "workspace:*",
 		"@sveltejs/kit": "workspace:*",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"typescript": "^5.0.0",
 		"vite": "^4.4.9"
 	},

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -34,7 +34,7 @@
 		"dts-buddy": "^0.2.4",
 		"marked": "^9.0.0",
 		"rollup": "^3.7.0",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-preprocess": "^5.0.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9",

--- a/packages/kit/test/apps/amp/package.json
+++ b/packages/kit/test/apps/amp/package.json
@@ -16,7 +16,7 @@
 		"@sveltejs/kit": "workspace:^",
 		"cross-env": "^7.0.3",
 		"dropcss": "^1.0.16",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/apps/basics/package.json
+++ b/packages/kit/test/apps/basics/package.json
@@ -16,7 +16,7 @@
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
 		"cross-env": "^7.0.3",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/apps/dev-only/package.json
+++ b/packages/kit/test/apps/dev-only/package.json
@@ -12,7 +12,7 @@
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
 		"cross-env": "^7.0.3",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/apps/embed/package.json
+++ b/packages/kit/test/apps/embed/package.json
@@ -14,7 +14,7 @@
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
 		"cross-env": "^7.0.3",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/apps/options-2/package.json
+++ b/packages/kit/test/apps/options-2/package.json
@@ -15,7 +15,7 @@
 		"@sveltejs/adapter-node": "workspace:^",
 		"@sveltejs/kit": "workspace:^",
 		"cross-env": "^7.0.3",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/apps/options/package.json
+++ b/packages/kit/test/apps/options/package.json
@@ -14,7 +14,7 @@
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
 		"cross-env": "^7.0.3",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/apps/writes/package.json
+++ b/packages/kit/test/apps/writes/package.json
@@ -14,7 +14,7 @@
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
 		"cross-env": "^7.0.3",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/package.json
+++ b/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "workspace:^",
 		"@sveltejs/kit": "workspace:^",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/package.json
+++ b/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "workspace:^",
 		"@sveltejs/kit": "workspace:^",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/package.json
+++ b/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/package.json
@@ -11,7 +11,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "workspace:^",
 		"@sveltejs/kit": "workspace:^",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/build-errors/apps/private-dynamic-env-dynamic-import/package.json
+++ b/packages/kit/test/build-errors/apps/private-dynamic-env-dynamic-import/package.json
@@ -11,7 +11,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/build-errors/apps/private-dynamic-env/package.json
+++ b/packages/kit/test/build-errors/apps/private-dynamic-env/package.json
@@ -11,7 +11,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/build-errors/apps/private-static-env-dynamic-import/package.json
+++ b/packages/kit/test/build-errors/apps/private-static-env-dynamic-import/package.json
@@ -11,7 +11,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/build-errors/apps/private-static-env/package.json
+++ b/packages/kit/test/build-errors/apps/private-static-env/package.json
@@ -12,7 +12,7 @@
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
 		"cross-env": "^7.0.3",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/build-errors/apps/server-only-folder-dynamic-import/package.json
+++ b/packages/kit/test/build-errors/apps/server-only-folder-dynamic-import/package.json
@@ -11,7 +11,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/build-errors/apps/server-only-folder/package.json
+++ b/packages/kit/test/build-errors/apps/server-only-folder/package.json
@@ -11,7 +11,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/build-errors/apps/server-only-module-dynamic-import/package.json
+++ b/packages/kit/test/build-errors/apps/server-only-module-dynamic-import/package.json
@@ -11,7 +11,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/build-errors/apps/server-only-module/package.json
+++ b/packages/kit/test/build-errors/apps/server-only-module/package.json
@@ -11,7 +11,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/build-errors/apps/syntax-error/package.json
+++ b/packages/kit/test/build-errors/apps/syntax-error/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9"

--- a/packages/kit/test/prerendering/basics/package.json
+++ b/packages/kit/test/prerendering/basics/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9",

--- a/packages/kit/test/prerendering/options/package.json
+++ b/packages/kit/test/prerendering/options/package.json
@@ -11,7 +11,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9",

--- a/packages/kit/test/prerendering/paths-base/package.json
+++ b/packages/kit/test/prerendering/paths-base/package.json
@@ -11,7 +11,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-check": "^3.4.4",
 		"typescript": "^4.9.4",
 		"vite": "^4.4.9",

--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -20,7 +20,7 @@
 	"devDependencies": {
 		"@types/node": "^16.18.6",
 		"@types/semver": "^7.5.0",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"svelte-preprocess": "^5.0.4",
 		"typescript": "^4.9.4",
 		"uvu": "^0.5.6"

--- a/playgrounds/basic/package.json
+++ b/playgrounds/basic/package.json
@@ -10,7 +10,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "workspace:*",
 		"@sveltejs/kit": "workspace:*",
-		"svelte": "^4.0.5",
+		"svelte": "^4.2.2",
 		"typescript": "^5.0.0",
 		"vite": "^4.4.9"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,13 +22,13 @@ importers:
         version: 15.0.1(rollup@3.7.0)
       '@sveltejs/eslint-config':
         specifier: ^6.0.4
-        version: 6.0.4(@typescript-eslint/eslint-plugin@6.0.0)(@typescript-eslint/parser@6.8.0)(eslint-config-prettier@9.0.0)(eslint-plugin-svelte@2.31.0)(eslint-plugin-unicorn@48.0.0)(eslint@8.45.0)(typescript@4.9.4)
+        version: 6.0.4(@typescript-eslint/eslint-plugin@6.0.0)(@typescript-eslint/parser@6.9.0)(eslint-config-prettier@9.0.0)(eslint-plugin-svelte@2.31.0)(eslint-plugin-unicorn@48.0.0)(eslint@8.45.0)(typescript@4.9.4)
       '@svitejs/changesets-changelog-github-compact':
         specifier: ^1.1.0
         version: 1.1.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.0.0
-        version: 6.0.0(@typescript-eslint/parser@6.8.0)(eslint@8.45.0)(typescript@4.9.4)
+        version: 6.0.0(@typescript-eslint/parser@6.9.0)(eslint@8.45.0)(typescript@4.9.4)
       eslint:
         specifier: ^8.45.0
         version: 8.45.0
@@ -37,7 +37,7 @@ importers:
         version: 9.0.0(eslint@8.45.0)
       eslint-plugin-svelte:
         specifier: ^2.31.0
-        version: 2.31.0(eslint@8.45.0)(svelte@4.1.2)
+        version: 2.31.0(eslint@8.45.0)(svelte@4.2.2)
       eslint-plugin-unicorn:
         specifier: ^48.0.0
         version: 48.0.0(eslint@8.45.0)
@@ -51,8 +51,8 @@ importers:
         specifier: ^3.7.0
         version: 3.7.0
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -221,8 +221,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -239,8 +239,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       vite:
         specifier: ^4.4.9
         version: 4.4.9(@types/node@16.18.6)(lightningcss@1.21.8)
@@ -257,8 +257,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       vite:
         specifier: ^4.4.9
         version: 4.4.9(@types/node@16.18.6)(lightningcss@1.21.8)
@@ -317,13 +317,13 @@ importers:
         version: 2.8.0
       prettier-plugin-svelte:
         specifier: ^2.10.1
-        version: 2.10.1(prettier@2.8.0)(svelte@4.1.2)
+        version: 2.10.1(prettier@2.8.0)(svelte@4.2.2)
       sucrase:
         specifier: ^3.29.0
         version: 3.29.0
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       tiny-glob:
         specifier: ^0.2.9
         version: 0.2.9
@@ -347,8 +347,8 @@ importers:
         specifier: workspace:*
         version: link:../../../kit
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       typescript:
         specifier: ^5.0.0
         version: 5.0.4
@@ -366,7 +366,7 @@ importers:
     dependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^2.4.1
-        version: 2.4.1(svelte@4.1.2)(vite@4.4.9)
+        version: 2.4.1(svelte@4.2.2)(vite@4.4.9)
       '@types/cookie':
         specifier: ^0.5.1
         version: 0.5.1
@@ -429,11 +429,11 @@ importers:
         specifier: ^3.7.0
         version: 3.7.0
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-preprocess:
         specifier: ^5.0.4
-        version: 5.0.4(postcss@8.4.31)(svelte@4.1.2)(typescript@4.9.4)
+        version: 5.0.4(postcss@8.4.31)(svelte@4.2.2)(typescript@4.9.4)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -459,11 +459,11 @@ importers:
         specifier: ^1.0.16
         version: 1.0.16
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -480,11 +480,11 @@ importers:
         specifier: ^7.0.3
         version: 7.0.3
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -501,11 +501,11 @@ importers:
         specifier: ^7.0.3
         version: 7.0.3
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -522,11 +522,11 @@ importers:
         specifier: ^7.0.3
         version: 7.0.3
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -543,11 +543,11 @@ importers:
         specifier: ^7.0.3
         version: 7.0.3
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -567,11 +567,11 @@ importers:
         specifier: ^7.0.3
         version: 7.0.3
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -588,11 +588,11 @@ importers:
         specifier: ^7.0.3
         version: 7.0.3
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -615,11 +615,11 @@ importers:
         specifier: workspace:^
         version: link:../../../..
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -636,11 +636,11 @@ importers:
         specifier: workspace:^
         version: link:../../../..
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -657,11 +657,11 @@ importers:
         specifier: workspace:^
         version: link:../../../..
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -675,11 +675,11 @@ importers:
         specifier: workspace:^
         version: link:../../../..
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -693,11 +693,11 @@ importers:
         specifier: workspace:^
         version: link:../../../..
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -714,11 +714,11 @@ importers:
         specifier: ^7.0.3
         version: 7.0.3
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -732,11 +732,11 @@ importers:
         specifier: workspace:^
         version: link:../../../..
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -750,11 +750,11 @@ importers:
         specifier: workspace:^
         version: link:../../../..
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -768,11 +768,11 @@ importers:
         specifier: workspace:^
         version: link:../../../..
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -786,11 +786,11 @@ importers:
         specifier: workspace:^
         version: link:../../../..
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -804,11 +804,11 @@ importers:
         specifier: workspace:^
         version: link:../../../..
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -822,11 +822,11 @@ importers:
         specifier: workspace:^
         version: link:../../../..
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -840,11 +840,11 @@ importers:
         specifier: workspace:^
         version: link:../../..
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -861,11 +861,11 @@ importers:
         specifier: workspace:^
         version: link:../../..
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -882,11 +882,11 @@ importers:
         specifier: workspace:^
         version: link:../../..
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-check:
         specifier: ^3.4.4
-        version: 3.4.4(postcss@8.4.31)(svelte@4.1.2)
+        version: 3.4.4(postcss@8.4.31)(svelte@4.2.2)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -953,7 +953,7 @@ importers:
         version: 7.5.3
       svelte2tsx:
         specifier: ~0.6.19
-        version: 0.6.19(svelte@4.1.2)(typescript@4.9.4)
+        version: 0.6.19(svelte@4.2.2)(typescript@4.9.4)
     devDependencies:
       '@types/node':
         specifier: ^16.18.6
@@ -962,11 +962,11 @@ importers:
         specifier: ^7.5.0
         version: 7.5.0
       svelte:
-        specifier: ^4.0.5
-        version: 4.1.2
+        specifier: ^4.2.2
+        version: 4.2.2
       svelte-preprocess:
         specifier: ^5.0.4
-        version: 5.0.4(postcss@8.4.31)(svelte@4.1.2)(typescript@4.9.4)
+        version: 5.0.4(postcss@8.4.31)(svelte@4.2.2)(typescript@4.9.4)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -983,8 +983,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/kit
       svelte:
-        specifier: ^4.0.5
-        version: 4.2.0
+        specifier: ^4.2.2
+        version: 4.2.2
       typescript:
         specifier: ^5.0.0
         version: 5.0.4
@@ -1015,7 +1015,7 @@ importers:
         version: link:../../packages/kit
       '@sveltejs/site-kit':
         specifier: 6.0.0-next.52
-        version: 6.0.0-next.52(@sveltejs/kit@packages+kit)(svelte@4.2.0)
+        version: 6.0.0-next.52(@sveltejs/kit@packages+kit)(svelte@4.2.2)
       '@types/d3-geo':
         specifier: ^3.0.4
         version: 3.0.4
@@ -1047,8 +1047,8 @@ importers:
         specifier: ^3.1.2
         version: 3.1.2(typescript@5.0.4)
       svelte:
-        specifier: ^4.2.0
-        version: 4.2.0
+        specifier: ^4.2.2
+        version: 4.2.2
       tiny-glob:
         specifier: ^0.2.9
         version: 0.2.9
@@ -2000,7 +2000,7 @@ packages:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
-  /@sveltejs/eslint-config@6.0.4(@typescript-eslint/eslint-plugin@6.0.0)(@typescript-eslint/parser@6.8.0)(eslint-config-prettier@9.0.0)(eslint-plugin-svelte@2.31.0)(eslint-plugin-unicorn@48.0.0)(eslint@8.45.0)(typescript@4.9.4):
+  /@sveltejs/eslint-config@6.0.4(@typescript-eslint/eslint-plugin@6.0.0)(@typescript-eslint/parser@6.9.0)(eslint-config-prettier@9.0.0)(eslint-plugin-svelte@2.31.0)(eslint-plugin-unicorn@48.0.0)(eslint@8.45.0)(typescript@4.9.4):
     resolution: {integrity: sha512-U9pwmDs+DbmsnCgTfu6Bacdwqn0DuI1IQNSiQqTgzVyYfaaj+zy9ZoQCiJfxFBGXHkklyXuRHp0KMx346N0lcQ==}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': '>= 5'
@@ -2011,16 +2011,16 @@ packages:
       eslint-plugin-unicorn: '>= 47'
       typescript: '>= 4'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.0.0(@typescript-eslint/parser@6.8.0)(eslint@8.45.0)(typescript@4.9.4)
-      '@typescript-eslint/parser': 6.8.0(eslint@8.45.0)(typescript@4.9.4)
+      '@typescript-eslint/eslint-plugin': 6.0.0(@typescript-eslint/parser@6.9.0)(eslint@8.45.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 6.9.0(eslint@8.45.0)(typescript@4.9.4)
       eslint: 8.45.0
       eslint-config-prettier: 9.0.0(eslint@8.45.0)
-      eslint-plugin-svelte: 2.31.0(eslint@8.45.0)(svelte@4.1.2)
+      eslint-plugin-svelte: 2.31.0(eslint@8.45.0)(svelte@4.2.2)
       eslint-plugin-unicorn: 48.0.0(eslint@8.45.0)
       typescript: 4.9.4
     dev: true
 
-  /@sveltejs/site-kit@6.0.0-next.52(@sveltejs/kit@packages+kit)(svelte@4.2.0):
+  /@sveltejs/site-kit@6.0.0-next.52(@sveltejs/kit@packages+kit)(svelte@4.2.2):
     resolution: {integrity: sha512-r/VoVllvrr9So9LcYT7XRXDK38Q6Fx062gosuTkDztENBw+qGp3hMq1vg9qSomJastmavRzze1cjJnQFgacWMw==}
     peerDependencies:
       '@sveltejs/kit': ^1.20.0
@@ -2028,11 +2028,11 @@ packages:
     dependencies:
       '@sveltejs/kit': link:packages/kit
       esm-env: 1.0.0
-      svelte: 4.2.0
-      svelte-local-storage-store: 0.6.0(svelte@4.2.0)
+      svelte: 4.2.2
+      svelte-local-storage-store: 0.6.0(svelte@4.2.2)
     dev: true
 
-  /@sveltejs/vite-plugin-svelte-inspector@1.0.3(@sveltejs/vite-plugin-svelte@2.4.1)(svelte@4.1.2)(vite@4.4.9):
+  /@sveltejs/vite-plugin-svelte-inspector@1.0.3(@sveltejs/vite-plugin-svelte@2.4.1)(svelte@4.2.2)(vite@4.4.9):
     resolution: {integrity: sha512-Khdl5jmmPN6SUsVuqSXatKpQTMIifoQPDanaxC84m9JxIibWvSABJyHpyys0Z+1yYrxY5TTEQm+6elh0XCMaOA==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
@@ -2040,28 +2040,28 @@ packages:
       svelte: ^3.54.0 || ^4.0.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.1(svelte@4.1.2)(vite@4.4.9)
+      '@sveltejs/vite-plugin-svelte': 2.4.1(svelte@4.2.2)(vite@4.4.9)
       debug: 4.3.4
-      svelte: 4.1.2
+      svelte: 4.2.2
       vite: 4.4.9(@types/node@16.18.6)(lightningcss@1.21.8)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@sveltejs/vite-plugin-svelte@2.4.1(svelte@4.1.2)(vite@4.4.9):
+  /@sveltejs/vite-plugin-svelte@2.4.1(svelte@4.2.2)(vite@4.4.9):
     resolution: {integrity: sha512-bNNKvoRY89ptY7udeBSCmTdCVwkjmMcZ0j/z9J5MuedT8jPjq0zrknAo/jF1sToAza4NVaAgR9AkZoD9oJJmnA==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
       svelte: ^3.54.0 || ^4.0.0-next.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 1.0.3(@sveltejs/vite-plugin-svelte@2.4.1)(svelte@4.1.2)(vite@4.4.9)
+      '@sveltejs/vite-plugin-svelte-inspector': 1.0.3(@sveltejs/vite-plugin-svelte@2.4.1)(svelte@4.2.2)(vite@4.4.9)
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.2
-      svelte: 4.1.2
-      svelte-hmr: 0.15.3(svelte@4.1.2)
+      svelte: 4.2.2
+      svelte-hmr: 0.15.3(svelte@4.2.2)
       vite: 4.4.9(@types/node@16.18.6)(lightningcss@1.21.8)
       vitefu: 0.2.4(vite@4.4.9)
     transitivePeerDependencies:
@@ -2200,7 +2200,7 @@ packages:
       '@types/node': 16.18.6
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.0.0(@typescript-eslint/parser@6.8.0)(eslint@8.45.0)(typescript@4.9.4):
+  /@typescript-eslint/eslint-plugin@6.0.0(@typescript-eslint/parser@6.9.0)(eslint@8.45.0)(typescript@4.9.4):
     resolution: {integrity: sha512-xuv6ghKGoiq856Bww/yVYnXGsKa588kY3M0XK7uUW/3fJNNULKRfZfSBkMTSpqGG/8ZCXCadfh8G/z/B4aqS/A==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -2212,7 +2212,7 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.6.2
-      '@typescript-eslint/parser': 6.8.0(eslint@8.45.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 6.9.0(eslint@8.45.0)(typescript@4.9.4)
       '@typescript-eslint/scope-manager': 6.0.0
       '@typescript-eslint/type-utils': 6.0.0(eslint@8.45.0)(typescript@4.9.4)
       '@typescript-eslint/utils': 6.0.0(eslint@8.45.0)(typescript@4.9.4)
@@ -2231,8 +2231,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.8.0(eslint@8.45.0)(typescript@4.9.4):
-    resolution: {integrity: sha512-5tNs6Bw0j6BdWuP8Fx+VH4G9fEPDxnVI7yH1IAPkQH5RUtvKwRoqdecAPdQXv4rSOADAaz1LFBZvZG7VbXivSg==}
+  /@typescript-eslint/parser@6.9.0(eslint@8.45.0)(typescript@4.9.4):
+    resolution: {integrity: sha512-GZmjMh4AJ/5gaH4XF2eXA8tMnHWP+Pm1mjQR2QN4Iz+j/zO04b9TOvJYOX2sCNIQHtRStKTxRY1FX7LhpJT4Gw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -2241,10 +2241,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 6.8.0
-      '@typescript-eslint/types': 6.8.0
-      '@typescript-eslint/typescript-estree': 6.8.0(typescript@4.9.4)
-      '@typescript-eslint/visitor-keys': 6.8.0
+      '@typescript-eslint/scope-manager': 6.9.0
+      '@typescript-eslint/types': 6.9.0
+      '@typescript-eslint/typescript-estree': 6.9.0(typescript@4.9.4)
+      '@typescript-eslint/visitor-keys': 6.9.0
       debug: 4.3.4
       eslint: 8.45.0
       typescript: 4.9.4
@@ -2260,12 +2260,12 @@ packages:
       '@typescript-eslint/visitor-keys': 6.0.0
     dev: true
 
-  /@typescript-eslint/scope-manager@6.8.0:
-    resolution: {integrity: sha512-xe0HNBVwCph7rak+ZHcFD6A+q50SMsFwcmfdjs9Kz4qDh5hWhaPhFjRs/SODEhroBI5Ruyvyz9LfwUJ624O40g==}
+  /@typescript-eslint/scope-manager@6.9.0:
+    resolution: {integrity: sha512-1R8A9Mc39n4pCCz9o79qRO31HGNDvC7UhPhv26TovDsWPBDx+Sg3rOZdCELIA3ZmNoWAuxaMOT7aWtGRSYkQxw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.8.0
-      '@typescript-eslint/visitor-keys': 6.8.0
+      '@typescript-eslint/types': 6.9.0
+      '@typescript-eslint/visitor-keys': 6.9.0
     dev: true
 
   /@typescript-eslint/type-utils@6.0.0(eslint@8.45.0)(typescript@4.9.4):
@@ -2293,8 +2293,8 @@ packages:
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/types@6.8.0:
-    resolution: {integrity: sha512-p5qOxSum7W3k+llc7owEStXlGmSl8FcGvhYt8Vjy7FqEnmkCVlM3P57XQEGj58oqaBWDQXbJDZxwUWMS/EAPNQ==}
+  /@typescript-eslint/types@6.9.0:
+    resolution: {integrity: sha512-+KB0lbkpxBkBSiVCuQvduqMJy+I1FyDbdwSpM3IoBS7APl4Bu15lStPjgBIdykdRqQNYqYNMa8Kuidax6phaEw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
@@ -2319,8 +2319,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.8.0(typescript@4.9.4):
-    resolution: {integrity: sha512-ISgV0lQ8XgW+mvv5My/+iTUdRmGspducmQcDw5JxznasXNnZn3SKNrTRuMsEXv+V/O+Lw9AGcQCfVaOPCAk/Zg==}
+  /@typescript-eslint/typescript-estree@6.9.0(typescript@4.9.4):
+    resolution: {integrity: sha512-NJM2BnJFZBEAbCfBP00zONKXvMqihZCrmwCaik0UhLr0vAgb6oguXxLX1k00oQyD+vZZ+CJn3kocvv2yxm4awQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       typescript: '*'
@@ -2328,8 +2328,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 6.8.0
-      '@typescript-eslint/visitor-keys': 6.8.0
+      '@typescript-eslint/types': 6.9.0
+      '@typescript-eslint/visitor-keys': 6.9.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
@@ -2368,11 +2368,11 @@ packages:
       eslint-visitor-keys: 3.4.2
     dev: true
 
-  /@typescript-eslint/visitor-keys@6.8.0:
-    resolution: {integrity: sha512-oqAnbA7c+pgOhW2OhGvxm0t1BULX5peQI/rLsNDpGM78EebV3C9IGbX5HNZabuZ6UQrYveCLjKo8Iy/lLlBkkg==}
+  /@typescript-eslint/visitor-keys@6.9.0:
+    resolution: {integrity: sha512-dGtAfqjV6RFOtIP8I0B4ZTBRrlTT8NHHlZZSchQx3qReaoDeXhYM++M4So2AgFK9ZB0emRPA6JI1HkafzA2Ibg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.8.0
+      '@typescript-eslint/types': 6.9.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -2879,16 +2879,6 @@ packages:
       estree-walker: 3.0.3
       periscopic: 3.1.0
 
-  /code-red@1.0.4:
-    resolution: {integrity: sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
-      '@types/estree': 1.0.1
-      acorn: 8.10.0
-      estree-walker: 3.0.3
-      periscopic: 3.1.0
-    dev: true
-
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
     dependencies:
@@ -3383,7 +3373,7 @@ packages:
       eslint: 8.45.0
     dev: true
 
-  /eslint-plugin-svelte@2.31.0(eslint@8.45.0)(svelte@4.1.2):
+  /eslint-plugin-svelte@2.31.0(eslint@8.45.0)(svelte@4.2.2):
     resolution: {integrity: sha512-Q70jPFRraTkc/giPSfY7yuatmJcb5fPelWNplevqd45gfaJDjc3qXRtWQ6m9U5tWVVYERU9dcdUod294vwD8Gw==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3403,8 +3393,8 @@ packages:
       postcss-load-config: 3.1.4(postcss@8.4.31)
       postcss-safe-parser: 6.0.0(postcss@8.4.31)
       postcss-selector-parser: 6.0.13
-      svelte: 4.1.2
-      svelte-eslint-parser: 0.31.0(svelte@4.1.2)
+      svelte: 4.2.2
+      svelte-eslint-parser: 0.31.0(svelte@4.2.2)
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -4158,12 +4148,6 @@ packages:
     dependencies:
       '@types/estree': 1.0.1
 
-  /is-reference@3.0.2:
-    resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
-    dependencies:
-      '@types/estree': 1.0.1
-    dev: true
-
   /is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
@@ -4516,6 +4500,13 @@ packages:
 
   /magic-string@0.30.3:
     resolution: {integrity: sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
+  /magic-string@0.30.5:
+    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -5100,14 +5091,14 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-svelte@2.10.1(prettier@2.8.0)(svelte@4.1.2):
+  /prettier-plugin-svelte@2.10.1(prettier@2.8.0)(svelte@4.2.2):
     resolution: {integrity: sha512-Wlq7Z5v2ueCubWo0TZzKc9XHcm7TDxqcuzRuGd0gcENfzfT4JZ9yDlCbEgxWgiPmLHkBjfOtpAWkcT28MCDpUQ==}
     peerDependencies:
       prettier: ^1.16.4 || ^2.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0
     dependencies:
       prettier: 2.8.0
-      svelte: 4.1.2
+      svelte: 4.2.2
     dev: true
 
   /prettier@2.8.0:
@@ -5725,7 +5716,7 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  /svelte-check@3.4.4(postcss@8.4.31)(svelte@4.1.2):
+  /svelte-check@3.4.4(postcss@8.4.31)(svelte@4.2.2):
     resolution: {integrity: sha512-Uys9+R65cj8TmP8f5UpS7B2xKpNLYNxEWJsA5ZoKcWq/uwvABFF7xS6iPQGLoa7hxz0DS6xU60YFpmq06E4JxA==}
     hasBin: true
     peerDependencies:
@@ -5737,8 +5728,8 @@ packages:
       import-fresh: 3.3.0
       picocolors: 1.0.0
       sade: 1.8.1
-      svelte: 4.1.2
-      svelte-preprocess: 5.0.4(postcss@8.4.31)(svelte@4.1.2)(typescript@5.2.2)
+      svelte: 4.2.2
+      svelte-preprocess: 5.0.4(postcss@8.4.31)(svelte@4.2.2)(typescript@5.2.2)
       typescript: 5.2.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -5752,7 +5743,7 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-eslint-parser@0.31.0(svelte@4.1.2):
+  /svelte-eslint-parser@0.31.0(svelte@4.2.2):
     resolution: {integrity: sha512-/31RpBf/e3YjoFphjsyo3JRyN1r4UalGAGafXrZ6EJK4h4COOO0rbfBoen5byGsXnIJKsrlC1lkEd2Vzpq2IDg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5766,28 +5757,28 @@ packages:
       espree: 9.6.1
       postcss: 8.4.31
       postcss-scss: 4.0.6(postcss@8.4.31)
-      svelte: 4.1.2
+      svelte: 4.2.2
     dev: true
 
-  /svelte-hmr@0.15.3(svelte@4.1.2):
+  /svelte-hmr@0.15.3(svelte@4.2.2):
     resolution: {integrity: sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       svelte: ^3.19.0 || ^4.0.0
     dependencies:
-      svelte: 4.1.2
+      svelte: 4.2.2
     dev: false
 
-  /svelte-local-storage-store@0.6.0(svelte@4.2.0):
+  /svelte-local-storage-store@0.6.0(svelte@4.2.2):
     resolution: {integrity: sha512-UbCY/yT/YUadU5IX/gZkoRQnA+ebFZHKKQjlJvfWHnBj3CPe9sNn8ndxYz/xy4LUzGjuBLq8+wH5RYK54ba3wA==}
     engines: {node: '>=0.14'}
     peerDependencies:
       svelte: ^3.48.0 || ^4.0.0
     dependencies:
-      svelte: 4.2.0
+      svelte: 4.2.2
     dev: true
 
-  /svelte-preprocess@5.0.4(postcss@8.4.31)(svelte@4.1.2)(typescript@4.9.4):
+  /svelte-preprocess@5.0.4(postcss@8.4.31)(svelte@4.2.2)(typescript@4.9.4):
     resolution: {integrity: sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==}
     engines: {node: '>= 14.10.0'}
     requiresBuild: true
@@ -5831,11 +5822,11 @@ packages:
       postcss: 8.4.31
       sorcery: 0.11.0
       strip-indent: 3.0.0
-      svelte: 4.1.2
+      svelte: 4.2.2
       typescript: 4.9.4
     dev: true
 
-  /svelte-preprocess@5.0.4(postcss@8.4.31)(svelte@4.1.2)(typescript@5.2.2):
+  /svelte-preprocess@5.0.4(postcss@8.4.31)(svelte@4.2.2)(typescript@5.2.2):
     resolution: {integrity: sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==}
     engines: {node: '>= 14.10.0'}
     requiresBuild: true
@@ -5879,11 +5870,11 @@ packages:
       postcss: 8.4.31
       sorcery: 0.11.0
       strip-indent: 3.0.0
-      svelte: 4.1.2
+      svelte: 4.2.2
       typescript: 5.2.2
     dev: true
 
-  /svelte2tsx@0.6.19(svelte@4.1.2)(typescript@4.9.4):
+  /svelte2tsx@0.6.19(svelte@4.2.2)(typescript@4.9.4):
     resolution: {integrity: sha512-h3b5OtcO8zyVL/RiB2zsDwCopeo/UH+887uyhgb2mjnewOFwiTxu+4IGuVwrrlyuh2onM2ktfUemNrNmQwXONQ==}
     peerDependencies:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0
@@ -5891,12 +5882,12 @@ packages:
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 4.1.2
+      svelte: 4.2.2
       typescript: 4.9.4
     dev: false
 
-  /svelte@4.1.2:
-    resolution: {integrity: sha512-/evA8U6CgOHe5ZD1C1W3va9iJG7mWflcCdghBORJaAhD2JzrVERJty/2gl0pIPrJYBGZwZycH6onYf+64XXF9g==}
+  /svelte@4.2.2:
+    resolution: {integrity: sha512-My2tytF2e2NnHSpn2M7/3VdXT4JdTglYVUuSuK/mXL2XtulPYbeBfl8Dm1QiaKRn0zoULRnL+EtfZHHP0k4H3A==}
     engines: {node: '>=16'}
     dependencies:
       '@ampproject/remapping': 2.2.1
@@ -5910,27 +5901,8 @@ packages:
       estree-walker: 3.0.3
       is-reference: 3.0.1
       locate-character: 3.0.0
-      magic-string: 0.30.3
+      magic-string: 0.30.5
       periscopic: 3.1.0
-
-  /svelte@4.2.0:
-    resolution: {integrity: sha512-kVsdPjDbLrv74SmLSUzAsBGquMs4MPgWGkGLpH+PjOYnFOziAvENVzgJmyOCV2gntxE32aNm8/sqNKD6LbIpeQ==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@ampproject/remapping': 2.2.1
-      '@jridgewell/sourcemap-codec': 1.4.15
-      '@jridgewell/trace-mapping': 0.3.19
-      acorn: 8.10.0
-      aria-query: 5.3.0
-      axobject-query: 3.2.1
-      code-red: 1.0.4
-      css-tree: 2.3.1
-      estree-walker: 3.0.3
-      is-reference: 3.0.2
-      locate-character: 3.0.0
-      magic-string: 0.30.3
-      periscopic: 3.1.0
-    dev: true
 
   /tar-fs@2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}

--- a/sites/kit.svelte.dev/package.json
+++ b/sites/kit.svelte.dev/package.json
@@ -27,7 +27,7 @@
 		"prism-svelte": "^0.5.0",
 		"prismjs": "^1.29.0",
 		"shiki-twoslash": "^3.1.2",
-		"svelte": "^4.2.0",
+		"svelte": "^4.2.2",
 		"tiny-glob": "^0.2.9",
 		"typescript": "5.0.4",
 		"vite": "^4.4.9",


### PR DESCRIPTION
we have multiple versions right now :stuck_out_tongue_closed_eyes: 

no changeset since these are `devDependencies`