### PR TITLE
fix: ensure `File` is pollyfilled for Node 18.11+

### DIFF
--- a/.changeset/tricky-radios-stare.md
+++ b/.changeset/tricky-radios-stare.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: missing `File` Node polyfill for versions below Node 20
+fix: missing `File` Node polyfill for Node version 18.11.0+

--- a/.changeset/tricky-radios-stare.md
+++ b/.changeset/tricky-radios-stare.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: missing `File` Node polyfill for versions below Node 20

--- a/packages/kit/src/exports/node/polyfills.js
+++ b/packages/kit/src/exports/node/polyfills.js
@@ -3,13 +3,14 @@ import buffer from 'node:buffer';
 import { webcrypto as crypto } from 'node:crypto';
 import { fetch, Response, Request, Headers, FormData, File as UndiciFile } from 'undici';
 
+// @ts-expect-error `buffer.File` is added in Node 20
+const File = buffer.File ?? UndiciFile;
+
 /** @type {Record<string, any>} */
 const globals_post_node_18_11 = {
-	crypto
+	crypto,
+	File
 };
-
-// @ts-expect-error
-const File = buffer.File ?? UndiciFile;
 
 /** @type {Record<string, any>} */
 // TODO: remove this once we only support Node 18.11+ (the version multipart/form-data was added)

--- a/packages/kit/src/exports/node/polyfills.js
+++ b/packages/kit/src/exports/node/polyfills.js
@@ -3,8 +3,8 @@ import buffer from 'node:buffer';
 import { webcrypto as crypto } from 'node:crypto';
 import { fetch, Response, Request, Headers, FormData, File as UndiciFile } from 'undici';
 
-// @ts-expect-error `buffer.File` is added in Node 20
-const File = buffer.File ?? UndiciFile;
+// `buffer.File` was added in Node 18.13.0 while the `File` global was added in Node 20.0.0
+const File = /** @type {import('node:buffer') & { File?: File}} */ (buffer).File ?? UndiciFile;
 
 /** @type {Record<string, any>} */
 const globals_post_node_18_11 = {


### PR DESCRIPTION
fixes #10946 

Quick fix that ensures `File` is always polyfilled rather than just pre Node 18.11.0. The global was only added in Node 20, while `buffer.File` was only added in Node 18.13.0
https://nodejs.org/dist/latest-v20.x/docs/api/globals.html#class-file

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
