### PR TITLE
fix: apply `adapter-cloudflare` trailing slash fix to `adapter-cloudflare-workers`

### DIFF
--- a/.changeset/silver-suns-yell.md
+++ b/.changeset/silver-suns-yell.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-cloudflare-workers': patch
 ---
 
-fix: correctly check url pathnames
+fix: correctly check url pathnames for trailing slashes

--- a/.changeset/silver-suns-yell.md
+++ b/.changeset/silver-suns-yell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+---
+
+fix: correctly check url pathnames

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -40,7 +40,7 @@ export default {
 			});
 		}
 
-		let { pathname } = new URL(req.url);
+		let { pathname } = url;
 		try {
 			pathname = decodeURIComponent(pathname);
 		} catch {

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -40,21 +40,26 @@ export default {
 			});
 		}
 
-		// prerendered pages and index.html files
-		const pathname = url.pathname.replace(/\/$/, '');
-		let file = pathname.substring(1);
-
+		let { pathname } = new URL(req.url);
 		try {
-			file = decodeURIComponent(file);
-		} catch (err) {
-			// ignore
+			pathname = decodeURIComponent(pathname);
+		} catch {
+			// ignore invalid URI
 		}
 
-		if (
-			manifest.assets.has(file) ||
-			manifest.assets.has(file + '/index.html') ||
-			prerendered.has(pathname || '/')
-		) {
+		const stripped_pathname = pathname.replace(/\/$/, '');
+
+		// prerendered pages and /static files
+		let is_static_asset = false;
+		const filename = stripped_pathname.substring(1);
+		if (filename) {
+			is_static_asset =
+				manifest.assets.has(filename) || manifest.assets.has(filename + '/index.html');
+		}
+
+		const location = pathname.at(-1) === '/' ? stripped_pathname : pathname + '/';
+
+		if (is_static_asset || prerendered.has(pathname)) {
 			return get_asset_from_kv(req, env, context, (request, options) => {
 				if (prerendered.has(pathname || '/')) {
 					url.pathname = '/' + prerendered.get(pathname || '/').file;
@@ -62,6 +67,13 @@ export default {
 				}
 
 				return mapRequestToAsset(request, options);
+			});
+		} else if (location && prerendered.has(location)) {
+			return new Response('', {
+				status: 308,
+				headers: {
+					location
+				}
 			});
 		}
 

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -61,8 +61,8 @@ export default {
 
 		if (is_static_asset || prerendered.has(pathname)) {
 			return get_asset_from_kv(req, env, context, (request, options) => {
-				if (prerendered.has(pathname || '/')) {
-					url.pathname = '/' + prerendered.get(pathname || '/').file;
+				if (prerendered.has(pathname)) {
+					url.pathname = '/' + prerendered.get(pathname).file;
 					return new Request(url.toString(), request);
 				}
 


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/10937

This PR applies the same adapter-cloudflare fix from https://github.com/sveltejs/kit/pull/8733 which I forgot to add to adapter-cloudflare-workers in the past. This should fix the trailing slash issue in the aforementioned issue where the trailing slash of `/base/` was being stripped too early and therefore, would never match with the prerendered page `/base/`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
