### PR TITLE
fix: bump pnpm to 8.10.2 to avoid issue with broken arborist in 8.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"svelte": "^4.2.2",
 		"typescript": "^4.9.4"
 	},
-	"packageManager": "pnpm@8.10.0",
+	"packageManager": "pnpm@8.10.2",
 	"engines": {
 		"pnpm": "^8.0.0"
 	}


### PR DESCRIPTION
this broke vite-ecosystem-ci and also caused problems for nuxt and vite releases

https://discord.com/channels/804011606160703521/1169865487144992778

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
