### PR TITLE
fix: generate `__data.json` when prerendering and SSR is turned off

### DIFF
--- a/.changeset/eight-moons-kick.md
+++ b/.changeset/eight-moons-kick.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: generate `__data.json` for prerendered pages when SSR is turned off

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -99,7 +99,7 @@ export async function render_page(event, page, options, manifest, state, resolve
 		/** @type {import('./types').Fetched[]} */
 		const fetched = [];
 
-		if (get_option(nodes, 'ssr') === false) {
+		if (get_option(nodes, 'ssr') === false && !state.prerendering) {
 			return await render_response({
 				branch: [],
 				fetched,

--- a/packages/kit/test/prerendering/basics/src/routes/shadowed-get/ssr-off/+page.server.js
+++ b/packages/kit/test/prerendering/basics/src/routes/shadowed-get/ssr-off/+page.server.js
@@ -1,0 +1,7 @@
+export const ssr = false;
+
+export function load() {
+	return {
+		answer: 42
+	};
+}

--- a/packages/kit/test/prerendering/basics/src/routes/shadowed-get/ssr-off/+page.svelte
+++ b/packages/kit/test/prerendering/basics/src/routes/shadowed-get/ssr-off/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	/** @type {import('./$types').PageData} */
+	export let data;
+</script>
+
+<h1>The answer is {data.answer}</h1>

--- a/packages/kit/test/prerendering/basics/test/tests.spec.js
+++ b/packages/kit/test/prerendering/basics/test/tests.spec.js
@@ -114,6 +114,21 @@ test('generates __data.json file for shadow endpoints', () => {
 	});
 });
 
+test('generates __data.json file for shadow endpoints with ssr turned off', () => {
+	const data = JSON.parse(read('shadowed-get/ssr-off/__data.json'));
+	expect(data).toEqual({
+		type: 'data',
+		nodes: [
+			null,
+			{
+				type: 'data',
+				data: [{ answer: 1 }, 42],
+				uses: {}
+			}
+		]
+	});
+});
+
 test('does not prerender page with shadow endpoint with non-load handler', () => {
 	assert.isFalse(fs.existsSync(`${build}/shadowed-post.html`));
 	assert.isFalse(fs.existsSync(`${build}/shadowed-post/__data.json`));


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/10983

This PR adds a check to see if we're prerendering and SSR is turned off to avoid responding with CSR only too early. With this check in place, the `should_prerender` check can now be reached and generate the `__data.json` file.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
