### PR TITLE
cache location.origin on startup

### DIFF
--- a/.changeset/small-readers-decide.md
+++ b/.changeset/small-readers-decide.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: cache location.origin on startup

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -22,7 +22,8 @@ import {
 	get_link_info,
 	get_router_options,
 	is_external_url,
-	scroll_state
+	scroll_state,
+	origin
 } from './utils.js';
 
 import { base } from '__sveltekit/paths';
@@ -843,7 +844,7 @@ export function create_client(app, target) {
 			} catch {
 				// at this point we have no choice but to fall back to the server, if it wouldn't
 				// bring us right back here, turning this into an endless loop
-				if (url.origin !== location.origin || url.pathname !== location.pathname || hydrated) {
+				if (url.origin !== origin || url.pathname !== location.pathname || hydrated) {
 					await native_navigation(url);
 				}
 			}
@@ -1173,7 +1174,7 @@ export function create_client(app, target) {
 	 * @returns {Promise<import('./types').NavigationFinished>}
 	 */
 	async function server_fallback(url, route, error, status) {
-		if (url.origin === location.origin && url.pathname === location.pathname && !hydrated) {
+		if (url.origin === origin && url.pathname === location.pathname && !hydrated) {
 			// We would reload the same page we're currently on, which isn't hydrated,
 			// which means no SSR, which means we would end up in an endless loop
 			return await load_root_error_page({

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -6,7 +6,7 @@ import { PRELOAD_PRIORITIES } from './constants.js';
 
 /* global __SVELTEKIT_APP_VERSION_FILE__, __SVELTEKIT_APP_VERSION_POLL_INTERVAL__ */
 
-export const origin = location.origin;
+export const origin = BROWSER ? location.origin : '';
 
 /** @param {HTMLDocument} doc */
 export function get_base_uri(doc) {

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -6,6 +6,8 @@ import { PRELOAD_PRIORITIES } from './constants.js';
 
 /* global __SVELTEKIT_APP_VERSION_FILE__, __SVELTEKIT_APP_VERSION_POLL_INTERVAL__ */
 
+export const origin = location.origin;
+
 /** @param {HTMLDocument} doc */
 export function get_base_uri(doc) {
 	let baseURI = doc.baseURI;
@@ -135,7 +137,7 @@ export function get_link_info(a, base) {
 		is_external_url(url, base) ||
 		(a.getAttribute('rel') || '').split(/\s+/).includes('external');
 
-	const download = url?.origin === location.origin && a.hasAttribute('download');
+	const download = url?.origin === origin && a.hasAttribute('download');
 
 	return { url, external, target, download };
 }
@@ -290,5 +292,5 @@ export function create_updated_store() {
  * @param {string} base
  */
 export function is_external_url(url, base) {
-	return url.origin !== location.origin || !url.pathname.startsWith(base);
+	return url.origin !== origin || !url.pathname.startsWith(base);
 }


### PR DESCRIPTION
this is a very small thing, but it turns out that repeatedly accessing `location.origin` (when evaluating `<a>` elements to know if they're external etc) has a small but measurable impact. since it can't change, we can cache it on startup

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
