### PR TITLE
docs(images): update incorrect import statement

### DIFF
--- a/documentation/docs/30-advanced/60-images.md
+++ b/documentation/docs/30-advanced/60-images.md
@@ -71,7 +71,7 @@ You can also manually import an image asset and pass it to an `<enhanced:img>`. 
 
 ```svelte
 <script>
-	import { MyImage } from './path/to/your/image.jpg?enhanced';
+	import MyImage from './path/to/your/image.jpg?enhanced';
 </script>
 
 <enhanced:img src={MyImage} alt="Some alt text" />


### PR DESCRIPTION
As per issue https://github.com/sveltejs/kit/issues/11014, the official documentation for the new image preprocessor provides an incorrect import statement. This PR fixes the statement.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
