### PR TITLE
fix: correctly analyse exported endpoint methods during build

### DIFF
--- a/.changeset/swift-deers-draw.md
+++ b/.changeset/swift-deers-draw.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly analyse exported server API methods during build

--- a/packages/kit/src/constants.js
+++ b/packages/kit/src/constants.js
@@ -6,14 +6,6 @@ export const SVELTE_KIT_ASSETS = '/_svelte_kit_assets';
 
 export const GENERATED_COMMENT = '// this file is generated — do not edit it\n';
 
-export const ENDPOINT_METHODS = new Set([
-	'GET',
-	'POST',
-	'PUT',
-	'PATCH',
-	'DELETE',
-	'OPTIONS',
-	'HEAD'
-]);
+export const ENDPOINT_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'];
 
-export const PAGE_METHODS = new Set(['GET', 'POST', 'HEAD']);
+export const PAGE_METHODS = ['GET', 'POST', 'HEAD'];

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -93,10 +93,11 @@ async function analyse({ manifest_path, env }) {
 				prerender = mod.prerender;
 			}
 
-			Object.values(mod).forEach((/** @type {import('types').HttpMethod} */ method) => {
-				if (mod[method] && ENDPOINT_METHODS.has(method)) {
-					api_methods.push(method);
-				} else if (mod.fallback) {
+			Object.keys(mod).forEach((key) => {
+				// @ts-ignore
+				if (mod[key] && ENDPOINT_METHODS.has(key)) {
+					api_methods.push(/** @type {import('types').HttpMethod} */ (key));
+				} else if (mod.fallback && key === 'fallback') {
 					api_methods.push('*');
 				}
 			});

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -94,9 +94,9 @@ async function analyse({ manifest_path, env }) {
 			}
 
 			Object.keys(mod).forEach((key) => {
-				// @ts-ignore
-				if (mod[key] && ENDPOINT_METHODS.has(key)) {
-					api_methods.push(/** @type {import('types').HttpMethod} */ (key));
+				const method = /** @type {import('types').HttpMethod} */ (key);
+				if (mod[method] && ENDPOINT_METHODS.has(method)) {
+					api_methods.push(method);
 				} else if (mod.fallback && key === 'fallback') {
 					api_methods.push('*');
 				}

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -93,14 +93,13 @@ async function analyse({ manifest_path, env }) {
 				prerender = mod.prerender;
 			}
 
-			Object.keys(mod).forEach((key) => {
-				const method = /** @type {import('types').HttpMethod} */ (key);
-				if (mod[method] && ENDPOINT_METHODS.has(method)) {
-					api_methods.push(method);
-				} else if (mod.fallback && key === 'fallback') {
-					api_methods.push('*');
-				}
-			});
+			for (const method of /** @type {import('types').HttpMethod[]} */ (ENDPOINT_METHODS)) {
+				if (mod[method]) api_methods.push(method);
+			}
+
+			if (mod.fallback) {
+				api_methods.push('*');
+			}
 
 			config = mod.config;
 			entries = mod.entries;

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -81,7 +81,7 @@ export function is_endpoint_request(event) {
 	const { method, headers } = event.request;
 
 	// These methods exist exclusively for endpoints
-	if (ENDPOINT_METHODS.has(method) && !PAGE_METHODS.has(method)) {
+	if (ENDPOINT_METHODS.includes(method) && !PAGE_METHODS.includes(method)) {
 		return true;
 	}
 

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -35,7 +35,7 @@ export function method_not_allowed(mod, method) {
 
 /** @param {Partial<Record<import('types').HttpMethod, any>>} mod */
 export function allowed_methods(mod) {
-	const allowed = Array.from(ENDPOINT_METHODS).filter((method) => method in mod);
+	const allowed = ENDPOINT_METHODS.filter((method) => method in mod);
 
 	if ('GET' in mod || 'HEAD' in mod) allowed.push('HEAD');
 


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/10984

Previously, the endpoint metadata would never be populated as described in the issue. However, I think it was only used in the Vercel adapter to fire off some warning https://github.com/sveltejs/kit/blob/20d2fe7dc5b9d181788889c45aea1e3745222c82/packages/adapter-vercel/index.js#L562-L593

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
