### PR TITLE
fix: prevent JSON parse error when loading data

### DIFF
--- a/.changeset/unlucky-knives-bake.md
+++ b/.changeset/unlucky-knives-bake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly show 404 for prerendered dynamic routes when navigating client-side without a root layout server load

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1857,6 +1857,8 @@ async function load_data(url, invalid) {
 
 	const res = await native_fetch(data_url.href);
 
+	// if `__data.json` doesn't exist or the server has an internal error,
+	// fallback to native navigation so we avoid parsing the HTML error page as a JSON
 	if (res.headers.get('content-type')?.includes('text/html')) {
 		await native_navigation(url);
 	}

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1857,7 +1857,7 @@ async function load_data(url, invalid) {
 
 	const res = await native_fetch(data_url.href);
 
-	if (res.headers.get('content-type') !== 'application/json') {
+	if (res.headers.get('content-type')?.includes('text/html')) {
 		await native_navigation(url);
 	}
 


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/8751

This PR handles the edge case where loading the data of a non-existent prerendered dynamic route returns a 404 HTML page instead of JSON data. No test because our /basics test app has a root server layout load function, which causes it to do a native navigation instead, returning a 404 SSR response. The error only occurs when there is no root server layout load.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
