### PR TITLE
fix: prerender pages that use browser globals and have SSR turned off

### DIFF
--- a/.changeset/great-dryers-grin.md
+++ b/.changeset/great-dryers-grin.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly prerender pages that use browser globals and have SSR turned off

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -291,7 +291,7 @@ export async function render_page(event, page, options, manifest, state, resolve
 			resolve_opts,
 			page_config: {
 				csr: get_option(nodes, 'csr') ?? true,
-				ssr: true
+				ssr: get_option(nodes, 'ssr') ?? true
 			},
 			status,
 			error: null,

--- a/packages/kit/test/apps/basics/src/routes/prerendering/no-ssr/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/prerendering/no-ssr/+page.js
@@ -1,0 +1,2 @@
+export const prerender = true;
+export const ssr = false;

--- a/packages/kit/test/apps/basics/src/routes/prerendering/no-ssr/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/prerendering/no-ssr/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Hello world!</h1>
+<p>{window.location.origin}</p>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -622,6 +622,16 @@ test.describe('Page options', () => {
 		await page.goto('/transform-page-chunk');
 		expect(await page.getAttribute('meta[name="transform-page"]', 'content')).toBe('Worked!');
 	});
+
+	test('prerenders page that uses browser globals with ssr=false', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		test.skip(process.env.DEV, 'skip when in dev mode');
+		test.skip(!javaScriptEnabled, 'skip when JavaScript is disabled');
+		await page.goto('/prerendering/no-ssr');
+		await expect(page.getByText('Hello world!')).toBeVisible();
+	});
 });
 
 test.describe('$app/environment', () => {


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/11031

https://github.com/sveltejs/kit/pull/10988 introduced a regression where the response during prerendering would always have SSR enabled. This PR fixes this by setting it according to the SSR page option.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
