### PR TITLE
fix: refresh in dev mode when an image changes

### DIFF
--- a/.changeset/great-toys-hang.md
+++ b/.changeset/great-toys-hang.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/enhanced-img': patch
+---
+
+fix: refresh in dev mode when an image changes

--- a/packages/enhanced-img/package.json
+++ b/packages/enhanced-img/package.json
@@ -28,7 +28,7 @@
 	"dependencies": {
 		"magic-string": "^0.30.0",
 		"svelte-parse-markup": "^0.1.1",
-		"vite-imagetools": "^6.2.3"
+		"vite-imagetools": "^6.2.4"
 	},
 	"devDependencies": {
 		"@types/estree": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
         version: 4.20230404.0
       '@sveltejs/kit':
         specifier: ^1.0.0
-        version: 1.27.5(svelte@4.2.2)(vite@4.4.9)
+        version: link:../kit
       esbuild:
         specifier: ^0.18.11
         version: 0.18.11
@@ -108,7 +108,7 @@ importers:
         version: 2.2.5
       '@sveltejs/kit':
         specifier: ^1.0.0
-        version: 1.27.5(svelte@4.2.2)(vite@4.4.9)
+        version: link:../kit
       esbuild:
         specifier: ^0.18.11
         version: 0.18.11
@@ -289,7 +289,7 @@ importers:
     dependencies:
       '@sveltejs/kit':
         specifier: ^1.0.0
-        version: 1.27.5(svelte@4.2.2)(vite@4.4.9)
+        version: link:../kit
 
   packages/create-svelte:
     dependencies:
@@ -371,8 +371,8 @@ importers:
         specifier: ^0.1.1
         version: 0.1.2(svelte@4.2.2)
       vite-imagetools:
-        specifier: ^6.2.3
-        version: 6.2.3(rollup@3.29.4)
+        specifier: ^6.2.4
+        version: 6.2.4(rollup@3.29.4)
     devDependencies:
       '@types/estree':
         specifier: ^1.0.2
@@ -2056,34 +2056,6 @@ packages:
       eslint-plugin-unicorn: 49.0.0(eslint@8.52.0)
       typescript: 4.9.4
     dev: true
-
-  /@sveltejs/kit@1.27.5(svelte@4.2.2)(vite@4.4.9):
-    resolution: {integrity: sha512-+L1WPs/ZYNjXoBFoFARypD4aZOjkT51vFpRCtQI45+Fmmfi4Y0dH/8VFlmYD6VlGe89ViIPg7lgf/JpGQ2tr7A==}
-    engines: {node: ^16.14 || >=18}
-    hasBin: true
-    requiresBuild: true
-    peerDependencies:
-      svelte: ^3.54.0 || ^4.0.0-next.0 || ^5.0.0-next.0
-      vite: ^4.0.0
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.5.0(svelte@4.2.2)(vite@4.4.9)
-      '@types/cookie': 0.5.1
-      cookie: 0.5.0
-      devalue: 4.3.1
-      esm-env: 1.0.0
-      kleur: 4.1.5
-      magic-string: 0.30.5
-      mrmime: 1.0.1
-      sade: 1.8.1
-      set-cookie-parser: 2.6.0
-      sirv: 2.0.3
-      svelte: 4.2.2
-      tiny-glob: 0.2.9
-      undici: 5.26.3
-      vite: 4.4.9(@types/node@16.18.6)(lightningcss@1.21.8)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@sveltejs/site-kit@6.0.0-next.52(@sveltejs/kit@packages+kit)(svelte@4.2.2):
     resolution: {integrity: sha512-r/VoVllvrr9So9LcYT7XRXDK38Q6Fx062gosuTkDztENBw+qGp3hMq1vg9qSomJastmavRzze1cjJnQFgacWMw==}
@@ -4032,8 +4004,8 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
-  /imagetools-core@5.1.1:
-    resolution: {integrity: sha512-NragdIrgxecFO8nRKy8uAYvDxe0QLEW5ToMEviAoNXpEnDQ6I4vs+npRa+z5fNB5nIku+jr11L+MuSkk7XzsKw==}
+  /imagetools-core@6.0.0:
+    resolution: {integrity: sha512-oH6Rng1AJSwaJnQ0nJBKvEPyz0u5tXHy4dN0ujvf7hMljVBh/Dp/qoDU1gGR26eR13VgyVKiy8XzXEBCwgHtCw==}
     engines: {node: '>=12.0.0'}
     dependencies:
       sharp: 0.32.5
@@ -6337,12 +6309,12 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite-imagetools@6.2.3(rollup@3.29.4):
-    resolution: {integrity: sha512-VZTJOXDTw/Nfah2ayQCWEvNc0b2Q7uGSUCczjx0N7ULd7VZDFH3PxcqyKIRxFOenKcSTYTna1OMzdGlcRBTk+g==}
+  /vite-imagetools@6.2.4(rollup@3.29.4):
+    resolution: {integrity: sha512-ZeWDekJPb+N7WvdmyEcyvs9uLjjhjcQt7pO5LZrKcUan0V6+XizLJ/J1h4nSHduAb8+xpzfl7tPyf9rkk3ujBA==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@rollup/pluginutils': 5.0.4(rollup@3.29.4)
-      imagetools-core: 5.1.1
+      imagetools-core: 6.0.0
     transitivePeerDependencies:
       - rollup
     dev: false


### PR DESCRIPTION
I just fixed this in `vite-imagetools`. It's been annoying me for the past year, so I probably should have tracked it down earlier :laughing: But now that we have more users, I decided it was time!