### PR TITLE
fix: auto-import of svg images

### DIFF
--- a/.changeset/wise-moose-bathe.md
+++ b/.changeset/wise-moose-bathe.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/enhanced-img': patch
+---
+
+fix: auto-import of svg images

--- a/packages/enhanced-img/test/Input.svelte
+++ b/packages/enhanced-img/test/Input.svelte
@@ -32,6 +32,8 @@
 
 <enhanced:img src="/src/foo.png" alt="absolute path test" />
 
+<enhanced:img src="./foo.svg" alt="svg test" />
+
 {#each images as image}
 	<enhanced:img src={image} alt="opt-in test" />
 {/each}

--- a/packages/enhanced-img/test/Output.svelte
+++ b/packages/enhanced-img/test/Output.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
+	import ___ASSET___6 from "./foo.svg";
+	
 	import manual_image1 from './no.png';
+	
 	import manual_image2 from './no.svg';
 
 	const images = [
@@ -31,6 +34,8 @@
 <picture><source srcset="/1 1440w, /2 960w" type="image/avif" /><source srcset="/3 1440w, /4 960w" type="image/webp" /><source srcset="5 1440w, /6 960w" type="image/png" /><img src=/7 alt="alias test" width=1440 height=1440 /></picture>
 
 <picture><source srcset="/1 1440w, /2 960w" type="image/avif" /><source srcset="/3 1440w, /4 960w" type="image/webp" /><source srcset="5 1440w, /6 960w" type="image/png" /><img src=/7 alt="absolute path test" width=1440 height=1440 /></picture>
+
+<img src={___ASSET___6} alt="svg test" />
 
 {#each images as image}
 	{#if typeof image === 'string'}

--- a/packages/enhanced-img/test/preprocessor.spec.js
+++ b/packages/enhanced-img/test/preprocessor.spec.js
@@ -29,7 +29,10 @@ it('Image preprocess snapshot test', async () => {
 		{ filename }
 	);
 
-	expect(processed.code).toMatchFileSnapshot('./Output.svelte');
+	// Make imports readable
+	const ouput = processed.code.replace(/import/g, '\n\timport');
+
+	expect(ouput).toMatchFileSnapshot('./Output.svelte');
 });
 
 it('parses a minimized object', () => {


### PR DESCRIPTION
I accidentally pushed the changeset for this to `master` already :confused:  https://github.com/sveltejs/kit/commit/4426daebe1d345f60554225e3f12ea932b0110e4

So I'm going to go ahead and merge this as soon as the tests are green to avoid separating the change from its changset by too much. Feel free to leave comments though - I can address in a followup

I'd had most of this code in an earlier version of the image PR, but it accidentally got removed when I rewrote it to resolve the image inside the preprocessor as an optimization. https://github.com/sveltejs/kit/pull/10788/commits/5050172d89b99960f3fc7ffe72b78374c3eca038#diff-f318d5cf67f7e975aecc26dfb6056ae55058442cf36dd7e6f53c4a292edeb2d9