### PR TITLE
fix: avoid creating conflicting import statements

### DIFF
--- a/.changeset/violet-moons-tease.md
+++ b/.changeset/violet-moons-tease.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/enhanced-img': patch
+---
+
+fix: avoid creating conflicting import statements

--- a/packages/enhanced-img/test/Output.svelte
+++ b/packages/enhanced-img/test/Output.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import ___ASSET___6 from "./foo.svg";
+	import ___ASSET___0 from "./foo.svg";
 	
 	import manual_image1 from './no.png';
 	
@@ -30,7 +30,7 @@
 
 <picture><source srcset="/1 1440w, /2 960w" type="image/avif" /><source srcset="/3 1440w, /4 960w" type="image/webp" /><source srcset="5 1440w, /6 960w" type="image/png" /><img src=/7 alt="absolute path test" width=1440 height=1440 /></picture>
 
-<img src={___ASSET___6} alt="svg test" />
+<img src={___ASSET___0} alt="svg test" />
 
 {#each images as image}
 	{#if typeof image === 'string'}


### PR DESCRIPTION
The fix was changing `const name = ASSET_PREFIX + images.size;` to `const name = ASSET_PREFIX + imports.size;`. You can see the test output is better now

I also noticed that `details.name` was unused, so simplified things by removing that field. 