### PR TITLE
feat: add option to specify package.json path for @sveltejs/adapter-node

### DIFF
--- a/.changeset/poor-drinks-impress.md
+++ b/.changeset/poor-drinks-impress.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': minor
+---
+
+feat: add option to specify package.json path for @sveltejs/adapter-node

--- a/documentation/docs/25-build-and-deploy/40-adapter-node.md
+++ b/documentation/docs/25-build-and-deploy/40-adapter-node.md
@@ -132,7 +132,8 @@ export default {
 			out: 'build',
 			precompress: false,
 			envPrefix: '',
-			polyfill: true
+			polyfill: true,
+			packageJsonPath: 'package.json'
 		})
 	}
 };
@@ -166,6 +167,16 @@ node build
 Controls whether your build will load polyfills for missing modules. It defaults to `true`, and should only be disabled when using Node 18.11 or greater.
 
 Note: to use Node's built-in `crypto` global with Node 18 you will need to use the `--experimental-global-webcrypto` flag. This flag is not required with Node 20.
+
+### packageJsonPath
+
+In case your package.json is not located in the root directory of your app, you can specify the absolute path to it:
+
+```js
+adapter({
+	packageJsonPath: path.resolve('../../package.json')
+})
+```
 
 ## Custom server
 

--- a/packages/adapter-node/index.d.ts
+++ b/packages/adapter-node/index.d.ts
@@ -10,6 +10,7 @@ interface AdapterOptions {
 	precompress?: boolean;
 	envPrefix?: string;
 	polyfill?: boolean;
+	packageJsonPath: string;
 }
 
 export default function plugin(options?: AdapterOptions): Adapter;

--- a/packages/adapter-node/index.d.ts
+++ b/packages/adapter-node/index.d.ts
@@ -10,7 +10,7 @@ interface AdapterOptions {
 	precompress?: boolean;
 	envPrefix?: string;
 	polyfill?: boolean;
-	packageJsonPath: string;
+	packageJsonPath?: string;
 }
 
 export default function plugin(options?: AdapterOptions): Adapter;

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -9,7 +9,13 @@ const files = fileURLToPath(new URL('./files', import.meta.url).href);
 
 /** @type {import('./index.js').default} */
 export default function (opts = {}) {
-	const { out = 'build', precompress, envPrefix = '', polyfill = true, packageJsonPath = 'package.json' } = opts;
+	const {
+		out = 'build',
+		precompress,
+		envPrefix = '',
+		polyfill = true,
+		packageJsonPath = 'package.json'
+	} = opts;
 
 	return {
 		name: '@sveltejs/adapter-node',

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -9,7 +9,7 @@ const files = fileURLToPath(new URL('./files', import.meta.url).href);
 
 /** @type {import('./index.js').default} */
 export default function (opts = {}) {
-	const { out = 'build', precompress, envPrefix = '', polyfill = true } = opts;
+	const { out = 'build', precompress, envPrefix = '', polyfill = true, packageJsonPath = 'package.json' } = opts;
 
 	return {
 		name: '@sveltejs/adapter-node',
@@ -43,7 +43,7 @@ export default function (opts = {}) {
 					`export const prerendered = new Set(${JSON.stringify(builder.prerendered.paths)});\n`
 			);
 
-			const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+			const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
 
 			// we bundle the Vite output so that deployments only need
 			// their production dependencies. Anything in devDependencies


### PR DESCRIPTION
## Purpose of this PR

This PR adds a new option to @sveltejs/adapter-node to pass an absolute path to the package.json instead of looking in the directory where the script is executed.
The problem this PR solves is described in this issue #11093

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.