### PR TITLE
Update `vitest` to `vitest run` (not watch mode)

### DIFF
--- a/packages/create-svelte/shared/+playwright+vitest/package.json
+++ b/packages/create-svelte/shared/+playwright+vitest/package.json
@@ -5,7 +5,7 @@
 	},
 	"scripts": {
 		"test:integration": "playwright test",
-		"test:unit": "vitest",
+		"test:unit": "vitest run",
 		"test": "npm run test:integration && npm run test:unit"
 	}
 }


### PR DESCRIPTION
## Overview

When generating a new template app, playwright runs in "execute tests and exit" mode, while vitest runs in watch mode.

[Elsewhere](https://github.com/sveltejs/kit/blob/master/packages/kit/package.json#L67) non watch mode is the preferred default, this change aligns the template with that.

Users running "npm run test" for the first time might be confused to see watch mode, and in the event they have playwright and vite tests enabled, only a portion of their tests are being watched (vitest)

## Checklist

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] N/A ~~It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs~~
- [x] This message body should clearly illustrate what problems it solves.
- [ ] N/A ~~Ideally, include a test that fails without this PR but passes with it.~~

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
