### PR TITLE
feat: typed `+server.ts` responses with `fetch`

### DIFF
--- a/packages/kit/src/core/sync/write_types/index.spec.js
+++ b/packages/kit/src/core/sync/write_types/index.spec.js
@@ -58,7 +58,7 @@ test('Rewrites types for a TypeScript module', () => {
 		};
 	`;
 
-	const rewritten = tweak_types(source, false);
+	const rewritten = tweak_types(source, 'page');
 
 	expect(rewritten?.exports).toEqual(['load']);
 	assert.equal(
@@ -83,7 +83,7 @@ test('Rewrites types for a TypeScript module without param', () => {
 		};
 	`;
 
-	const rewritten = tweak_types(source, false);
+	const rewritten = tweak_types(source, 'page');
 
 	expect(rewritten?.exports).toEqual(['load']);
 	assert.equal(
@@ -109,7 +109,7 @@ test('Rewrites types for a TypeScript module without param and jsdoc without typ
 		};
 	`;
 
-	const rewritten = tweak_types(source, false);
+	const rewritten = tweak_types(source, 'page');
 
 	expect(rewritten?.exports).toEqual(['load']);
 	assert.equal(
@@ -136,7 +136,7 @@ test('Rewrites types for a JavaScript module with `function`', () => {
 		};
 	`;
 
-	const rewritten = tweak_types(source, false);
+	const rewritten = tweak_types(source, 'page');
 
 	expect(rewritten?.exports).toEqual(['load']);
 	assert.equal(
@@ -163,7 +163,7 @@ test('Rewrites types for a JavaScript module with `const`', () => {
 		};
 	`;
 
-	const rewritten = tweak_types(source, false);
+	const rewritten = tweak_types(source, 'page');
 
 	expect(rewritten?.exports).toEqual(['load']);
 	assert.equal(
@@ -190,7 +190,7 @@ test('Appends @ts-nocheck after @ts-check', () => {
 		};
 	`;
 
-	const rewritten = tweak_types(source, false);
+	const rewritten = tweak_types(source, 'page');
 
 	expect(rewritten?.exports).toEqual(['load']);
 	assert.equal(
@@ -219,7 +219,7 @@ test('Rewrites action types for a JavaScript module', () => {
 		}
 	`;
 
-	const rewritten = tweak_types(source, true);
+	const rewritten = tweak_types(source, 'page.server');
 
 	expect(rewritten?.exports).toEqual(['actions']);
 	assert.equal(
@@ -248,7 +248,7 @@ test('Rewrites action types for a TypeScript module', () => {
 		}
 	`;
 
-	const rewritten = tweak_types(source, true);
+	const rewritten = tweak_types(source, 'page.server');
 
 	expect(rewritten?.exports).toEqual(['actions']);
 	assert.equal(
@@ -281,7 +281,7 @@ test('Leaves satisfies operator untouched', () => {
 		} satisfies Actions
 	`;
 
-	const rewritten = tweak_types(source, true);
+	const rewritten = tweak_types(source, 'page.server');
 
 	expect(rewritten?.exports).toEqual(['load', 'actions']);
 	assert.equal(rewritten?.modified, false);

--- a/packages/kit/test/apps/basics/src/routes/endpoint-typing/foo/+server.ts
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-typing/foo/+server.ts
@@ -1,0 +1,14 @@
+import { json } from '@sveltejs/kit';
+
+interface TypedResponse<A> extends Response {
+    json(): Promise<A>;
+}
+
+// A typed json wrapper (this could probably just replace `json`
+function typed_json<A>(data: A): TypedResponse<A> {
+    return json(data)
+}
+
+export async function GET(): Promise<TypedResponse<{ foo: string }>> {
+    return typed_json({ foo: 'bar' })
+}


### PR DESCRIPTION
Attempting to solve
- [ ] https://github.com/sveltejs/kit/discussions/11042
- [ ] https://github.com/sveltejs/kit/issues/11101
- [x] https://github.com/sveltejs/kit/issues/647
- [ ] https://github.com/sveltejs/kit/issues/11101
- [ ] https://github.com/sveltejs/kit/issues/7110
- [ ] https://github.com/sveltejs/kit/issues/9732
- [ ] https://github.com/sveltejs/kit/issues/5700
- [x] https://github.com/sveltejs/kit/issues/9579
- [ ] + more

## Approach
`/api/[post]/+server.ts`
```ts
import { typed_json } from '@sveltejs/kit';

export async function GET({ params }) {
    return typed_json({ post_id: params.post })
}
```

`utils`
```ts
interface TypedResponse<A> extends Response {
    json(): Promise<A>;
}

// A typed json wrapper (this could probably just replace `json`
function typed_json<A>(data: A): TypedResponse<A> {
    return json(data)
}
```

`+page.ts`
```ts
import { api_fetch } from "$api";

export async function load({ fetch }) {
    const data = await fetch("/api/[post]", {
        method: "GET",
        params: { post: "123" }
    });

    return {
        text: data.post_id // typed as a string
    }
}
```

`+page.svelte`
```svelte
<script lang="ts">
// a typed custom version of fetch available inside of components
import api_fetch from "$api"
</script>
```

### Theory
Using function overloading in typescript we can overload the `fetch` or custom fetch method with type info that gives us information about available APIs, return types and parameters.

This system could also be extended to provide typed inputs for the `body` parameter in `fetch` as well as supporting typed `goto`s `redirect`s and more

The custom `fetch` provided in the `load` functions and other places would more or less reflect the structure of the native `fetch` except with a few changes:
1. The URL is parsed, to obtain areas to inject the provided `params`
2. Some of the `RequestInit` properties are overrided to force things such as `method: "GET"` as well as providing an additional parameter called `params`

`example`
```ts
type Methods = "GET" | "POST" | "UPDATE" | "DELETE"
type FetchOptions<Params = never, Method extends Methods = Methods> =
    Parameters<typeof fetch>[1] & {
        params: Params,
        method: Method
    }
    
 
export async function api_fetch(url: "/api/posts/[post]", options?: FetchOptions<ApiPostsPostParamParams, "GET">): Promise<TypedResponse<{ foo: string }>>;
export async function api_fetch(url: string, options?: Parameters<typeof fetch>[1] | undefined): Promise<any> {
    // parse the url
    // inject the params in the correct locations
    // call the fetch method
}
```

**Proof of concept example**
```ts
interface TypedResponse<O> extends Response {
    json(): Promise<O>
}

type ApiPostsPostParamParams = {
    post: string
}

type Methods = "GET" | "POST" | "UPDATE" | "DELETE"

type FetchOptions<Params = never, Method extends Methods = Methods> =
    Parameters<typeof fetch>[1] & {
        params: Params,
        method: Method
    }


// we declare these inside of `.svelte-kit/types/src/api/posts/[post]/$types.d.ts`
type RouteId1 = "/api/posts/[post]"
type RouteParams1 = { post: string }
type Route1Output = { abc: string }

declare module "$api" {
    export function api_fetch(url: RouteId1, options?: FetchOptions<RouteParams1, "GET">): Promise<TypedResponse<Route1Output>>;
}

// we declare these inside of `.svelte-kit/types/src/api/comments/[comments]/$types.d.ts`
type RouteId2 = "/api/comments/[comments]"
type RouteParams2 = { comment: string }
type Route2Output = { xyz: string }

declare module "$api" {
    export function api_fetch(url: RouteId2, options?: FetchOptions<RouteParams2, "GET">): Promise<TypedResponse<Route2Output>>;
}
```

```ts
import { api_fetch } from "$api"

// no errors & correct typing
const data = await api_fetch("/api/posts/[post]", {
    method: "GET",
    params: {
        post: "post-id"
    }
})
```


I am posting this as a draft PR to gain feedback from the community and contributors.

Some unresolved matters:
- [x] [Can we somehow type request inputs (fetch body)](https://github.com/sveltejs/kit/pull/11108#issuecomment-1828787380)
- [ ] How do we deal with server error return types (eg: do we use `App.Error` somewhere?)

---

Related PRs
- [ ] https://github.com/sveltejs/kit/pull/9938