### PR TITLE
docs: use em dash instead of ellipsis for text continuation

### DIFF
--- a/documentation/docs/20-core-concepts/10-routing.md
+++ b/documentation/docs/20-core-concepts/10-routing.md
@@ -145,13 +145,13 @@ But in many apps, there are elements that should be visible on _every_ page, suc
 
 ### +layout.svelte
 
-To create a layout that applies to every page, make a file called `src/routes/+layout.svelte`. The default layout (the one that SvelteKit uses if you don't bring your own) looks like this...
+To create a layout that applies to every page, make a file called `src/routes/+layout.svelte`. The default layout (the one that SvelteKit uses if you don't bring your own) looks like this &mdash;
 
 ```html
 <slot></slot>
 ```
 
-...but we can add whatever markup, styles and behaviour we want. The only requirement is that the component includes a `<slot>` for the page content. For example, let's add a nav bar:
+&mdash; but we can add whatever markup, styles and behaviour we want. The only requirement is that the component includes a `<slot>` for the page content. For example, let's add a nav bar:
 
 ```html
 /// file: src/routes/+layout.svelte
@@ -164,7 +164,7 @@ To create a layout that applies to every page, make a file called `src/routes/+l
 <slot></slot>
 ```
 
-If we create pages for `/`, `/about` and `/settings`...
+If we create pages for `/`, `/about` and `/settings`&mdash;
 
 ```html
 /// file: src/routes/+page.svelte
@@ -181,7 +181,7 @@ If we create pages for `/`, `/about` and `/settings`...
 <h1>Settings</h1>
 ```
 
-...the nav will always be visible, and clicking between the three pages will only result in the `<h1>` being replaced.
+&mdash;the nav will always be visible, and clicking between the three pages will only result in the `<h1>` being replaced.
 
 Layouts can be _nested_. Suppose we don't just have a single `/settings` page, but instead have nested pages like `/settings/profile` and `/settings/notifications` with a shared submenu (for a real-life example, see [github.com/settings](https://github.com/settings)).
 

--- a/documentation/docs/30-advanced/10-advanced-routing.md
+++ b/documentation/docs/30-advanced/10-advanced-routing.md
@@ -4,13 +4,13 @@ title: Advanced routing
 
 ## Rest parameters
 
-If the number of route segments is unknown, you can use rest syntax — for example you might implement GitHub's file viewer like so...
+If the number of route segments is unknown, you can use rest syntax — for example you might implement GitHub's file viewer like so &mdash;
 
 ```bash
 /[org]/[repo]/tree/[branch]/[...file]
 ```
 
-...in which case a request for `/sveltejs/kit/tree/master/documentation/docs/04-advanced-routing.md` would result in the following parameters being available to the page:
+&mdash; in which case a request for `/sveltejs/kit/tree/master/documentation/docs/04-advanced-routing.md` would result in the following parameters being available to the page:
 
 ```js
 // @noErrors
@@ -26,7 +26,7 @@ If the number of route segments is unknown, you can use rest syntax — for exam
 
 ### 404 pages
 
-Rest parameters also allow you to render custom 404s. Given these routes...
+Rest parameters also allow you to render custom 404s. Given these routes &mdash;
 
 ```
 src/routes/
@@ -38,7 +38,7 @@ src/routes/
 └ +error.svelte
 ```
 
-...the `marx-brothers/+error.svelte` file will _not_ be rendered if you visit `/marx-brothers/karl`, because no route was matched. If you want to render the nested error page, you should create a route that matches any `/marx-brothers/*` request, and return a 404 from it:
+&mdash; the `marx-brothers/+error.svelte` file will _not_ be rendered if you visit `/marx-brothers/karl`, because no route was matched. If you want to render the nested error page, you should create a route that matches any `/marx-brothers/*` request, and return a 404 from it:
 
 ```diff
 src/routes/
@@ -71,7 +71,7 @@ Note that an optional route parameter cannot follow a rest parameter (`[...rest]
 
 ## Matching
 
-A route like `src/routes/archive/[page]` would match `/archive/3`, but it would also match `/archive/potato`. We don't want that. You can ensure that route parameters are well-formed by adding a _matcher_ — which takes the parameter string (`"3"` or `"potato"`) and returns `true` if it is valid — to your [`params`](configuration#files) directory...
+A route like `src/routes/archive/[page]` would match `/archive/3`, but it would also match `/archive/potato`. We don't want that. You can ensure that route parameters are well-formed by adding a _matcher_ — which takes the parameter string (`"3"` or `"potato"`) and returns `true` if it is valid — to your [`params`](configuration#files) directory &mdash;
 
 ```js
 /// file: src/params/integer.js
@@ -81,7 +81,7 @@ export function match(param) {
 }
 ```
 
-...and augmenting your routes:
+&mdash; and augmenting your routes:
 
 ```diff
 -src/routes/archive/[page]
@@ -106,14 +106,14 @@ src/routes/foo-[c]/+page.svelte
 src/routes/foo-abc/+page.svelte
 ```
 
-SvelteKit needs to know which route is being requested. To do so, it sorts them according to the following rules...
+SvelteKit needs to know which route is being requested. To do so, it sorts them according to the following rules &mdash;
 
 - More specific routes are higher priority (e.g. a route with no parameters is more specific than a route with one dynamic parameter, and so on)
 - Parameters with [matchers](#matching) (`[name=type]`) are higher priority than those without (`[name]`)
 - `[[optional]]` and `[...rest]` parameters are ignored unless they are the final part of the route, in which case they are treated with lowest priority. In other words `x/[[y]]/z` is treated equivalently to `x/z` for the purposes of sorting
 - Ties are resolved alphabetically
 
-...resulting in this ordering, meaning that `/foo-abc` will invoke `src/routes/foo-abc/+page.svelte`, and `/foo-def` will invoke `src/routes/foo-[c]/+page.svelte` rather than less specific routes:
+&mdash; resulting in this ordering, meaning that `/foo-abc` will invoke `src/routes/foo-abc/+page.svelte`, and `/foo-def` will invoke `src/routes/foo-[c]/+page.svelte` rather than less specific routes:
 
 ```bash
 src/routes/foo-abc/+page.svelte


### PR DESCRIPTION
Only made the change in a couple of files, looking for more feedback before changing other files as well.

Basically there's a bit of noise when grepping for '...' looking for instances of rest parameters, using the em dash seems a bit visually cleaner as well. I'm not sure if I want to get into discussions on whether it has the correct semantics or not, but it seems to be at least as applicable as the ellipsis for these cases.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.