### PR TITLE
fix: ignore `dist` folders from `lint` check

### DIFF
--- a/packages/package/.gitignore
+++ b/packages/package/.gitignore
@@ -1,12 +1,12 @@
 .DS_Store
-/node_modules
-/dist
-/test/**/build
-!/src/core/adapt/fixtures/*/.svelte-kit
-!/test/node_modules
+/node_modules/
+/test/**/build/
+!/src/core/adapt/fixtures/*/.svelte-kit/
+!/test/node_modules/
 /test/apps/basics/test/errors.json
-.custom-out-dir
+.custom-out-dir/
 
 # these are already ignored by the top level .gitignore
 # repeating them here as a faux prettier ignore
-.svelte-kit
+.svelte-kit/
+dist/

--- a/packages/package/.prettierignore
+++ b/packages/package/.prettierignore
@@ -1,1 +1,0 @@
-/test/fixtures/*/dist

--- a/packages/package/.prettierignore
+++ b/packages/package/.prettierignore
@@ -1,0 +1,1 @@
+/test/fixtures/*/dist


### PR DESCRIPTION

Running the `test` before running `lint` results in:
```
│ [warn] test/fixtures/javascript/dist/index.d.ts
│ [warn] test/fixtures/javascript/dist/internal/index.d.ts
│ [warn] test/fixtures/javascript/dist/internal/Test.svelte.d.ts
│ [warn] test/fixtures/javascript/dist/Test.svelte.d.ts
│ [warn] test/fixtures/javascript/dist/Test2.svelte.d.ts
│ [warn] test/fixtures/resolve-alias/dist/baz.d.ts
│ [warn] test/fixtures/resolve-alias/dist/sub/bar.d.ts
│ [warn] test/fixtures/resolve-alias/dist/sub/foo.d.ts
│ [warn] test/fixtures/resolve-alias/dist/Test.svelte
│ [warn] test/fixtures/resolve-alias/dist/Test.svelte.d.ts
│ [warn] test/fixtures/resolve-alias/dist/utils/index.js
│ [warn] test/fixtures/svelte-3-types/dist/Test.svelte
│ [warn] test/fixtures/svelte-3-types/dist/Test.svelte.d.ts
│ [warn] test/fixtures/svelte-kit/dist/index.d.ts
│ [warn] test/fixtures/svelte-kit/dist/Test.svelte.d.ts
│ [warn] test/fixtures/typescript-esnext/dist/Plain.svelte.d.ts
│ [warn] test/fixtures/typescript-esnext/dist/Test.svelte
│ [warn] test/fixtures/typescript-esnext/dist/Test.svelte.d.ts
│ [warn] test/fixtures/typescript-esnext/dist/Test2.svelte
│ [warn] test/fixtures/typescript-esnext/dist/Test2.svelte.d.ts
│ [warn] test/fixtures/typescript-nodenext/dist/Test.svelte
│ [warn] test/fixtures/typescript-nodenext/dist/Test.svelte.d.ts
│ [warn] Code style issues found in 22 files. Run Prettier to fix.
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @sveltejs/package@2.2.3 lint: `prettier --check .`
Exit status 1
 ELIFECYCLE  Command failed with exit code 1.
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
