### PR TITLE
breaking: let `beforeunload` handle links that will unload the document

### DIFF
--- a/.changeset/soft-yaks-count.md
+++ b/.changeset/soft-yaks-count.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: display confirmation dialog when cancelling beforeunload in `beforeNavigate` after clicking a link
+fix: display confirmation dialog after clicking a link when cancelling the `beforeunload` event with `cancel()` in `beforeNavigate`

--- a/.changeset/soft-yaks-count.md
+++ b/.changeset/soft-yaks-count.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: display confirmation dialog when cancelling beforeunload in `beforeNavigate` after clicking a link

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1470,15 +1470,15 @@ export function create_client(app, target) {
 				persist_state();
 
 				if (!navigating) {
-					const isLinkClick = document.activeElement?.tagName === 'A';
-					const nav = create_navigation(
-						current,
-						undefined,
-						isLinkClick
-							? new URL(/** @type {HTMLAnchorElement} */ (document.activeElement).href)
-							: null,
-						isLinkClick ? 'link' : 'leave'
-					);
+					const nav =
+						document.activeElement?.tagName === 'A'
+							? create_navigation(
+									current,
+									undefined,
+									new URL(/** @type {HTMLAnchorElement} */ (document.activeElement).href),
+									'link'
+							  )
+							: create_navigation(current, undefined, null, 'leave');
 
 					// If we're navigating, beforeNavigate was already called. If we end up in here during navigation,
 					// it's due to an external or full-page-reload link, for which we don't want to call the hook again.

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -123,6 +123,7 @@ export function create_client(app, target) {
 	let updating = false;
 	let navigating = false;
 	let hash_navigating = false;
+	let unloadFromLink = false;
 
 	let force_invalidation = false;
 
@@ -1470,7 +1471,12 @@ export function create_client(app, target) {
 				persist_state();
 
 				if (!navigating) {
-					const nav = create_navigation(current, undefined, null, 'leave');
+					const nav = create_navigation(
+						current,
+						undefined,
+						null,
+						unloadFromLink ? 'link' : 'leave'
+					);
 
 					// If we're navigating, beforeNavigate was already called. If we end up in here during navigation,
 					// it's due to an external or full-page-reload link, for which we don't want to call the hook again.
@@ -1544,20 +1550,22 @@ export function create_client(app, target) {
 				)
 					return;
 
-				if (download) return;
+				unloadFromLink = !!(external || options.reload);
+				if (download || unloadFromLink) return;
+				// if (download) return;
 
-				// Ignore the following but fire beforeNavigate
-				if (external || options.reload) {
-					if (before_navigate({ url, type: 'link' })) {
-						// set `navigating` to `true` to prevent `beforeNavigate` callbacks
-						// being called when the page unloads
-						navigating = true;
-					} else {
-						event.preventDefault();
-					}
+				// // Ignore the following but fire beforeNavigate
+				// if (external || options.reload) {
+				// 	if (before_navigate({ url, type: 'link' })) {
+				// 		// set `navigating` to `true` to prevent `beforeNavigate` callbacks
+				// 		// being called when the page unloads
+				// 		navigating = true;
+				// 	} else {
+				// 		event.preventDefault();
+				// 	}
 
-					return;
-				}
+				// 	return;
+				// }
 
 				// Check if new url only differs by hash and use the browser default behavior in that case
 				// This will ensure the `hashchange` event is fired

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1551,21 +1551,8 @@ export function create_client(app, target) {
 					return;
 
 				unloadFromLink = !!(external || options.reload);
+
 				if (download || unloadFromLink) return;
-				// if (download) return;
-
-				// // Ignore the following but fire beforeNavigate
-				// if (external || options.reload) {
-				// 	if (before_navigate({ url, type: 'link' })) {
-				// 		// set `navigating` to `true` to prevent `beforeNavigate` callbacks
-				// 		// being called when the page unloads
-				// 		navigating = true;
-				// 	} else {
-				// 		event.preventDefault();
-				// 	}
-
-				// 	return;
-				// }
 
 				// Check if new url only differs by hash and use the browser default behavior in that case
 				// This will ensure the `hashchange` event is fired

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -123,7 +123,6 @@ export function create_client(app, target) {
 	let updating = false;
 	let navigating = false;
 	let hash_navigating = false;
-	let unloadFromLink = false;
 
 	let force_invalidation = false;
 
@@ -1471,11 +1470,14 @@ export function create_client(app, target) {
 				persist_state();
 
 				if (!navigating) {
+					const isLinkClick = document.activeElement?.tagName === 'A';
 					const nav = create_navigation(
 						current,
 						undefined,
-						null,
-						unloadFromLink ? 'link' : 'leave'
+						isLinkClick
+							? new URL(/** @type {HTMLAnchorElement} */ (document.activeElement).href)
+							: null,
+						isLinkClick ? 'link' : 'leave'
 					);
 
 					// If we're navigating, beforeNavigate was already called. If we end up in here during navigation,
@@ -1550,9 +1552,7 @@ export function create_client(app, target) {
 				)
 					return;
 
-				unloadFromLink = !!(external || options.reload);
-
-				if (download || unloadFromLink) return;
+				if (download || external || options.reload) return;
 
 				// Check if new url only differs by hash and use the browser default behavior in that case
 				// This will ensure the `hashchange` event is fired

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -131,17 +131,17 @@ test.describe('Navigation lifecycle functions', () => {
 		await page.goto('/navigation-lifecycle/before-navigate/prevent-navigation');
 		await page.click('h1'); // The browsers block attempts to prevent navigation on a frame that's never had a user gesture.
 
-		let confirmationDialog = false;
-
-		page.on('dialog', async (dialog) => {
-			confirmationDialog = dialog.type() === 'beforeunload';
-			await dialog.dismiss();
+		const type = new Promise((fulfil) => {
+			page.on('dialog', async (dialog) => {
+				fulfil(dialog.type());
+				await dialog.dismiss();
+			});
 		});
 
 		page.click('a[href="https://google.de"]'); // do NOT await this, promise only resolves after successful navigation, which never happens
 		await page.waitForTimeout(500);
 		await expect(page.locator('pre')).toHaveText('1 true link');
-		expect(confirmationDialog).toBe(true);
+		expect(await type).toBe('beforeunload');
 		expect(page.url()).toBe(baseURL + '/navigation-lifecycle/before-navigate/prevent-navigation');
 	});
 

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -126,11 +126,17 @@ test.describe('Navigation lifecycle functions', () => {
 		await page.goto('/navigation-lifecycle/before-navigate/prevent-navigation');
 		await page.click('h1'); // The browsers block attempts to prevent navigation on a frame that's never had a user gesture.
 
-		page.on('dialog', (dialog) => dialog.dismiss());
+		let confirmationDialog = false;
+
+		page.on('dialog', async (dialog) => {
+			confirmationDialog = dialog.type() === 'beforeunload';
+			await dialog.dismiss();
+		});
 
 		page.click('a[href="https://google.de"]'); // do NOT await this, promise only resolves after successful navigation, which never happens
 		await page.waitForTimeout(500);
 		await expect(page.locator('pre')).toHaveText('1 true link');
+		expect(confirmationDialog).toBe(true);
 		expect(page.url()).toBe(baseURL + '/navigation-lifecycle/before-navigate/prevent-navigation');
 	});
 

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -122,7 +122,12 @@ test.describe('Navigation lifecycle functions', () => {
 		expect(await page.innerHTML('pre')).toBe('1 false link');
 	});
 
-	test('beforeNavigate prevents navigation to external', async ({ page, baseURL }) => {
+	test('beforeNavigate prevents navigation to external', async ({ page, baseURL, browserName }) => {
+		test.skip(
+			browserName === 'webkit',
+			'cancelling beforeunload is broken https://bugs.webkit.org/show_bug.cgi?id=255837'
+		);
+
 		await page.goto('/navigation-lifecycle/before-navigate/prevent-navigation');
 		await page.click('h1'); // The browsers block attempts to prevent navigation on a frame that's never had a user gesture.
 


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/8597

The issue of the missing confirmation dialog stems from this code block that prevents the `click` event behaviour if we call `cancel()` in `beforeNavigate`. As a result, the navigation is never attempted and the `beforeunload` event never occurs. It needs to occur so that we can can call `event.preventDefault()` which displays the confirmation dialog.
https://github.com/sveltejs/kit/blob/98e4b8f059d09d57f66a8b513d809867419cc071/packages/kit/src/runtime/client/client.js#L1550-L1560

The solution is to simply return in our `click` handler and delegate the responsibility to the `beforeunload` handler.

This PR also modifies an existing test to check for the `beforeunload` confirmation dialog.
However, `beforeunload` still doesn't occur when clicking on links in Safari https://github.com/sveltejs/kit/pull/9747#issuecomment-1518704630 ~so the macos tests are failing~ so the test is skipped for webkit

EDIT: upon re-reading #9747 the concerns mentioned in https://github.com/sveltejs/kit/pull/9747#issuecomment-1552253505 might mean this fix is not the one

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
