### PR TITLE
Change warning to an error when more routes than 100 are excluded/included

### DIFF
--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -119,10 +119,7 @@ function get_routes_json(builder, assets, { include = ['/*'], exclude = ['<all>'
 
 	const excess = include.length + exclude.length - 100;
 	if (excess > 0) {
-		const message = `Function includes/excludes exceeds _routes.json limits (see https://developers.cloudflare.com/pages/platform/functions/routing/#limits). Dropping ${excess} exclude rules — this will cause unnecessary function invocations.`;
-		builder.log.warn(message);
-
-		exclude.length -= excess;
+		throw new Error(`Function includes/excludes exceeds _routes.json limits (100) (see https://developers.cloudflare.com/pages/platform/functions/routing/#limits and https://kit.svelte.dev/docs/adapter-cloudflare#options).`);
 	}
 
 	return {


### PR DESCRIPTION
I came across this error but it took over an hour to find me because the error did only give a warning. 

I would propose to throw an error instead, as this likely breaks the application of the user and generates undesirable behavior

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ X] This message body should clearly illustrate what problems it solves.
- [ X] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
