### PR TITLE
fix: finish getting Vite 5 working

### DIFF
--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -636,7 +636,10 @@ function kit({ svelte_config }) {
 							}
 							if (vite_config.preview.cors) {
 								res.setHeader('Access-Control-Allow-Origin', '*');
-								res.setHeader('Access-Control-Allow-Headers', 'Origin, Content-Type, Accept, Range');
+								res.setHeader(
+									'Access-Control-Allow-Headers',
+									'Origin, Content-Type, Accept, Range'
+								);
 							}
 						}
 					})

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -624,6 +624,8 @@ function kit({ svelte_config }) {
 		 */
 		configurePreviewServer(vite) {
 			// generated client assets and the contents of `static`
+			// should we use Vite's built-in asset server for this?
+			// we would need to set the outDir to do so
 			const { paths } = svelte_config.kit;
 			const assets = paths.assets ? SVELTE_KIT_ASSETS : paths.base;
 			vite.middlewares.use(

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -631,9 +631,12 @@ function kit({ svelte_config }) {
 					assets,
 					sirv(join(svelte_config.kit.outDir, 'output/client'), {
 						setHeaders: (res, pathname) => {
-							// only apply to immutable directory, not e.g. version.json
 							if (pathname.startsWith(`/${svelte_config.kit.appDir}/immutable`)) {
 								res.setHeader('cache-control', 'public,max-age=31536000,immutable');
+							}
+							if (vite_config.preview.cors) {
+								res.setHeader('Access-Control-Allow-Origin', '*');
+								res.setHeader('Access-Control-Allow-Headers', 'Origin, Content-Type, Accept, Range');
 							}
 						}
 					})

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -126,7 +126,6 @@ export async function preview(vite, vite_config, svelte_config) {
 		vite.middlewares.use(async (req, res) => {
 			const host = req.headers['host'];
 			req.url = req.originalUrl;
-			const resolved = new URL(base, `${protocol}://${host}`).href;
 			let request;
 			try {
 				request = await getRequest({

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -125,6 +125,7 @@ export async function preview(vite, vite_config, svelte_config) {
 		// SSR
 		vite.middlewares.use(async (req, res) => {
 			const host = req.headers['host'];
+			req.url = req.originalUrl;
 			const resolved = new URL(base, `${protocol}://${host}`).href;
 			let request;
 			try {

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -129,7 +129,7 @@ export async function preview(vite, vite_config, svelte_config) {
 			let request;
 			try {
 				request = await getRequest({
-					base: `${protocol}://${host}`
+					base: `${protocol}://${host}`,
 					request: req
 				});
 			} catch (/** @type {any} */ err) {

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -125,11 +125,11 @@ export async function preview(vite, vite_config, svelte_config) {
 		// SSR
 		vite.middlewares.use(async (req, res) => {
 			const host = req.headers['host'];
-
+			const resolved = new URL(base, `${protocol}://${host}`).href;
 			let request;
 			try {
 				request = await getRequest({
-					base: new URL(base, `${protocol}://${host}`).href,
+					base: resolved.endsWith('/') ? resolved.substring(0, resolved.length - 1) : resolved,
 					request: req
 				});
 			} catch (/** @type {any} */ err) {

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -24,7 +24,6 @@ export async function preview(vite, vite_config, svelte_config) {
 	}
 
 	const { paths } = svelte_config.kit;
-	const base = paths.base;
 	const assets = paths.assets ? SVELTE_KIT_ASSETS : paths.base;
 
 	const protocol = vite_config.preview.https ? 'https' : 'http';

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -130,7 +130,7 @@ export async function preview(vite, vite_config, svelte_config) {
 			let request;
 			try {
 				request = await getRequest({
-					base: resolved.endsWith('/') ? resolved.substring(0, resolved.length - 1) : resolved,
+					base: `${protocol}://${host}`
 					request: req
 				});
 			} catch (/** @type {any} */ err) {

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -542,7 +542,11 @@ test.describe('Static files', () => {
 		response = await request.get('/subdirectory/static.json');
 		expect(await response.json()).toBe('subdirectory file');
 
-		expect(response.headers()['access-control-allow-origin']).toBe('*');
+		// TODO: should this actually be set by default?
+		// it was set in https://github.com/sveltejs/kit/pull/7688
+		// but sirv sets it only if cors is enabled:
+		// https://github.com/lukeed/sirv/blob/19c6895483cc71e9ef367f8a6a863af1e558ecb0/packages/sirv-cli/index.js#L37
+		// expect(response.headers()['access-control-allow-origin']).toBe('*');
 
 		response = await request.get('/favicon.ico');
 		expect(response.status()).toBe(200);

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -542,7 +542,7 @@ test.describe('Static files', () => {
 		response = await request.get('/subdirectory/static.json');
 		expect(await response.json()).toBe('subdirectory file');
 
-		// TODO: should this actually be set by default?
+		// TODO: pass Vite's cors option to sirv. https://vitejs.dev/config/server-options.html#server-cors
 		// it was set in https://github.com/sveltejs/kit/pull/7688
 		// but sirv sets it only if cors is enabled:
 		// https://github.com/lukeed/sirv/blob/19c6895483cc71e9ef367f8a6a863af1e558ecb0/packages/sirv-cli/index.js#L37

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -542,11 +542,7 @@ test.describe('Static files', () => {
 		response = await request.get('/subdirectory/static.json');
 		expect(await response.json()).toBe('subdirectory file');
 
-		// TODO: pass Vite's cors option to sirv. https://vitejs.dev/config/server-options.html#server-cors
-		// it was set in https://github.com/sveltejs/kit/pull/7688
-		// but sirv sets it only if cors is enabled:
-		// https://github.com/lukeed/sirv/blob/19c6895483cc71e9ef367f8a6a863af1e558ecb0/packages/sirv-cli/index.js#L37
-		// expect(response.headers()['access-control-allow-origin']).toBe('*');
+		expect(response.headers()['access-control-allow-origin']).toBe('*');
 
 		response = await request.get('/favicon.ico');
 		expect(response.status()).toBe(200);

--- a/packages/kit/test/apps/options-2/test/test.js
+++ b/packages/kit/test/apps/options-2/test/test.js
@@ -59,7 +59,7 @@ test.describe('Service worker', () => {
 		});
 
 		expect(self.base).toBe('/basepath');
-		expect(self.build[0]).toMatch(/\/basepath\/_app\/immutable\/entry\/start\.[\w-]+\.js/);
+		expect(self.build?.[0]).toMatch(/\/basepath\/_app\/immutable\/entry\/start\.[\w-]+\.js/);
 	});
 
 	test('does not register /basepath/service-worker.js', async ({ page }) => {

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import http from 'node:http';
-import { test as base, devices } from '@playwright/test';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { test as base, devices } from '@playwright/test';
 
 export const test = base.extend({
 	app: async ({ page }, use) => {
@@ -73,7 +73,7 @@ export const test = base.extend({
 		/** @param {string} selector */
 		async function in_view(selector) {
 			const box = await page.locator(selector).boundingBox();
-			const view = await page.viewportSize();
+			const view = page.viewportSize();
 			return box && view && box.y < view.height && box.y + box.height > 0;
 		}
 


### PR DESCRIPTION
https://github.com/vitejs/vite/pull/14818 broke a lot of tests. I mostly fixed it here: https://github.com/sveltejs/kit/commit/43a745ad5f516c48f08718ae256e73d9e47ef0eb.

I don't know what's causing the remaining failures, but I think it's also something related to the base path - if I remove the base path from the failing tests then they start working. You can reproduce them with:
```
cd packages/kit/test/apps/options-2
pnpm build
pnpm test:build
```

When I run `pnpm preview` in that directory everything seems to work and it looks like `started` is added to the `body`, so I don't know why the tests are failing with a timeout looking for `started`.