### PR TITLE
breaking: require Node 18.13 or newer

### DIFF
--- a/.changeset/thick-suits-help.md
+++ b/.changeset/thick-suits-help.md
@@ -1,0 +1,16 @@
+---
+'@sveltejs/adapter-cloudflare-workers': major
+'@sveltejs/adapter-cloudflare': major
+'@sveltejs/adapter-netlify': major
+'@sveltejs/adapter-static': major
+'@sveltejs/adapter-vercel': major
+'create-svelte': major
+'@sveltejs/adapter-auto': major
+'@sveltejs/adapter-node': major
+'svelte-migrate': major
+'@sveltejs/package': major
+'@sveltejs/kit': major
+'@sveltejs/enhanced-img': patch
+---
+
+breaking: require Node 18.13 or newer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: pnpm/action-setup@v2.4.0
       - uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint
@@ -39,9 +39,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - node-version: 16
-            os: ubuntu-latest
-            e2e-browser: 'chromium'
           - node-version: 18
             os: ubuntu-latest
             e2e-browser: 'chromium'
@@ -79,27 +76,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - node-version: 16
+          - node-version: 18
             os: windows-2019 # slowness reported on newer versions https://github.com/actions/runner-images/issues/5166
             e2e-browser: 'chromium'
             mode: 'dev'
-          - node-version: 16
+          - node-version: 18
             os: ubuntu-latest
             e2e-browser: 'firefox'
             mode: 'dev'
-          - node-version: 16
+          - node-version: 18
             os: macOS-latest
             e2e-browser: 'webkit'
             mode: 'dev'
-          - node-version: 16
+          - node-version: 18
             os: windows-2019 # slowness reported on newer versions https://github.com/actions/runner-images/issues/5166
             e2e-browser: 'chromium'
             mode: 'build'
-          - node-version: 16
+          - node-version: 18
             os: ubuntu-latest
             e2e-browser: 'firefox'
             mode: 'build'
-          - node-version: 16
+          - node-version: 18
             os: macOS-latest
             e2e-browser: 'webkit'
             mode: 'build'
@@ -134,7 +131,7 @@ jobs:
       - uses: pnpm/action-setup@v2.4.0
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: cd packages/kit && pnpm prepublishOnly

--- a/packages/adapter-auto/package.json
+++ b/packages/adapter-auto/package.json
@@ -31,7 +31,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
-		"@types/node": "^16.18.6",
+		"@types/node": "^18.19.1",
 		"typescript": "^5.3.2"
 	},
 	"dependencies": {

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -36,7 +36,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/kv-asset-handler": "^0.3.0",
-		"@types/node": "^16.18.6",
+		"@types/node": "^18.19.1",
 		"typescript": "^5.3.2"
 	},
 	"peerDependencies": {

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -37,7 +37,7 @@
 		"worktop": "0.8.0-next.15"
 	},
 	"devDependencies": {
-		"@types/node": "^16.18.6",
+		"@types/node": "^18.19.1",
 		"@types/ws": "^8.5.3",
 		"typescript": "^5.3.2"
 	},

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -43,7 +43,7 @@
 		"@rollup/plugin-json": "^6.0.1",
 		"@rollup/plugin-node-resolve": "^15.2.3",
 		"@sveltejs/kit": "workspace:^",
-		"@types/node": "^16.18.6",
+		"@types/node": "^18.19.1",
 		"@types/set-cookie-parser": "^2.4.2",
 		"rollup": "^4.2.0",
 		"typescript": "^5.3.2",

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -35,7 +35,7 @@
 	"devDependencies": {
 		"@polka/url": "^1.0.0-next.23",
 		"@sveltejs/kit": "workspace:^",
-		"@types/node": "^16.18.6",
+		"@types/node": "^18.19.1",
 		"c8": "^8.0.0",
 		"polka": "^1.0.0-next.23",
 		"sirv": "^2.0.3",

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -32,7 +32,7 @@
 	"devDependencies": {
 		"@playwright/test": "1.30.0",
 		"@sveltejs/kit": "workspace:^",
-		"@types/node": "^16.18.6",
+		"@types/node": "^18.19.1",
 		"sirv": "^2.0.3",
 		"svelte": "^4.2.7",
 		"typescript": "^5.3.2",

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -36,7 +36,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
-		"@types/node": "^16.18.6",
+		"@types/node": "^18.19.1",
 		"typescript": "^5.3.2",
 		"vitest": "^0.34.5"
 	},

--- a/packages/enhanced-img/package.json
+++ b/packages/enhanced-img/package.json
@@ -32,7 +32,7 @@
 	},
 	"devDependencies": {
 		"@types/estree": "^1.0.2",
-		"@types/node": "^16.18.6",
+		"@types/node": "^18.19.1",
 		"estree-walker": "^3.0.3",
 		"rollup": "^4.2.0",
 		"svelte": "^4.2.7",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -22,13 +22,12 @@
 		"sade": "^1.8.1",
 		"set-cookie-parser": "^2.6.0",
 		"sirv": "^2.0.2",
-		"tiny-glob": "^0.2.9",
-		"undici": "~5.26.2"
+		"tiny-glob": "^0.2.9"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.30.0",
 		"@types/connect": "^3.4.35",
-		"@types/node": "^16.18.6",
+		"@types/node": "^18.19.1",
 		"@types/sade": "^1.7.4",
 		"@types/set-cookie-parser": "^2.4.2",
 		"dts-buddy": "^0.4.0",
@@ -95,6 +94,6 @@
 	},
 	"types": "types/index.d.ts",
 	"engines": {
-		"node": "^16.14 || >=18"
+		"node": ">=18.13"
 	}
 }

--- a/packages/kit/src/exports/node/polyfills.js
+++ b/packages/kit/src/exports/node/polyfills.js
@@ -1,29 +1,12 @@
-import { ReadableStream, TransformStream, WritableStream } from 'node:stream/web';
 import buffer from 'node:buffer';
 import { webcrypto as crypto } from 'node:crypto';
-import { fetch, Response, Request, Headers, FormData, File as UndiciFile } from 'undici';
 
 // `buffer.File` was added in Node 18.13.0 while the `File` global was added in Node 20.0.0
-const File = /** @type {import('node:buffer') & { File?: File}} */ (buffer).File ?? UndiciFile;
+const File = /** @type {import('node:buffer') & { File?: File}} */ (buffer).File;
 
 /** @type {Record<string, any>} */
-const globals_post_node_18_11 = {
+const globals = {
 	crypto,
-	File
-};
-
-/** @type {Record<string, any>} */
-// TODO: remove this once we only support Node 18.11+ (the version multipart/form-data was added)
-const globals_pre_node_18_11 = {
-	crypto,
-	fetch,
-	Response,
-	Request,
-	Headers,
-	ReadableStream,
-	TransformStream,
-	WritableStream,
-	FormData,
 	File
 };
 
@@ -31,23 +14,9 @@ const globals_pre_node_18_11 = {
 /**
  * Make various web APIs available as globals:
  * - `crypto`
- * - `fetch` (only in node < 18.11)
- * - `Headers` (only in node < 18.11)
- * - `Request` (only in node < 18.11)
- * - `Response` (only in node < 18.11)
+ * - `File`
  */
 export function installPolyfills() {
-	// Be defensive (we don't know in which environments this is called) and always apply if something goes wrong
-	let globals = globals_pre_node_18_11;
-	try {
-		const version = process.versions.node.split('.').map((n) => parseInt(n, 10));
-		if ((version[0] === 18 && version[1] >= 11) || version[0] > 18) {
-			globals = globals_post_node_18_11;
-		}
-	} catch (e) {
-		// ignore
-	}
-
 	for (const name in globals) {
 		Object.defineProperty(globalThis, name, {
 			enumerable: true,

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -33,7 +33,7 @@
 		"typescript": "^5.3.2"
 	},
 	"devDependencies": {
-		"@types/node": "^16.18.6",
+		"@types/node": "^18.19.1",
 		"@types/prompts": "^2.4.1",
 		"@types/semver": "^7.5.0",
 		"prettier": "^3.1.0",

--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -18,7 +18,7 @@
 		"svelte2tsx": "~0.6.19"
 	},
 	"devDependencies": {
-		"@types/node": "^16.18.6",
+		"@types/node": "^18.19.1",
 		"@types/semver": "^7.5.0",
 		"svelte": "^4.2.7",
 		"svelte-preprocess": "^5.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: workspace:^
         version: link:../kit
       '@types/node':
-        specifier: ^16.18.6
-        version: 16.18.6
+        specifier: ^18.19.1
+        version: 18.19.1
       typescript:
         specifier: ^5.3.2
         version: 5.3.2
@@ -77,8 +77,8 @@ importers:
         version: 0.8.0-next.15
     devDependencies:
       '@types/node':
-        specifier: ^16.18.6
-        version: 16.18.6
+        specifier: ^18.19.1
+        version: 18.19.1
       '@types/ws':
         specifier: ^8.5.3
         version: 8.5.3
@@ -105,8 +105,8 @@ importers:
         specifier: ^0.3.0
         version: 0.3.0
       '@types/node':
-        specifier: ^16.18.6
-        version: 16.18.6
+        specifier: ^18.19.1
+        version: 18.19.1
       typescript:
         specifier: ^5.3.2
         version: 5.3.2
@@ -139,8 +139,8 @@ importers:
         specifier: workspace:^
         version: link:../kit
       '@types/node':
-        specifier: ^16.18.6
-        version: 16.18.6
+        specifier: ^18.19.1
+        version: 18.19.1
       '@types/set-cookie-parser':
         specifier: ^2.4.2
         version: 2.4.2
@@ -176,8 +176,8 @@ importers:
         specifier: workspace:^
         version: link:../kit
       '@types/node':
-        specifier: ^16.18.6
-        version: 16.18.6
+        specifier: ^18.19.1
+        version: 18.19.1
       c8:
         specifier: ^8.0.0
         version: 8.0.0
@@ -203,8 +203,8 @@ importers:
         specifier: workspace:^
         version: link:../kit
       '@types/node':
-        specifier: ^16.18.6
-        version: 16.18.6
+        specifier: ^18.19.1
+        version: 18.19.1
       sirv:
         specifier: ^2.0.3
         version: 2.0.3
@@ -216,7 +216,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/adapter-static/test/apps/prerendered:
     devDependencies:
@@ -231,7 +231,7 @@ importers:
         version: 4.2.7
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/adapter-static/test/apps/spa:
     devDependencies:
@@ -249,7 +249,7 @@ importers:
         version: 4.2.7
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/adapter-vercel:
     dependencies:
@@ -264,8 +264,8 @@ importers:
         specifier: workspace:^
         version: link:../kit
       '@types/node':
-        specifier: ^16.18.6
-        version: 16.18.6
+        specifier: ^18.19.1
+        version: 18.19.1
       typescript:
         specifier: ^5.3.2
         version: 5.3.2
@@ -339,7 +339,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/create-svelte/templates/skeleton:
     devDependencies:
@@ -363,8 +363,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.3
       '@types/node':
-        specifier: ^16.18.6
-        version: 16.18.6
+        specifier: ^18.19.1
+        version: 18.19.1
       estree-walker:
         specifier: ^3.0.3
         version: 3.0.3
@@ -379,7 +379,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
       vitest:
         specifier: ^0.34.0
         version: 0.34.5(playwright@1.30.0)
@@ -422,9 +422,6 @@ importers:
       tiny-glob:
         specifier: ^0.2.9
         version: 0.2.9
-      undici:
-        specifier: ~5.26.2
-        version: 5.26.3
     devDependencies:
       '@playwright/test':
         specifier: 1.30.0
@@ -433,8 +430,8 @@ importers:
         specifier: ^3.4.35
         version: 3.4.35
       '@types/node':
-        specifier: ^16.18.6
-        version: 16.18.6
+        specifier: ^18.19.1
+        version: 18.19.1
       '@types/sade':
         specifier: ^1.7.4
         version: 1.7.4
@@ -458,7 +455,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
       vitest:
         specifier: ^0.34.5
         version: 0.34.5(playwright@1.30.0)
@@ -488,7 +485,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/apps/basics:
     devDependencies:
@@ -512,7 +509,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/apps/dev-only:
     devDependencies:
@@ -533,7 +530,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/apps/embed:
     devDependencies:
@@ -554,7 +551,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/apps/options:
     devDependencies:
@@ -575,7 +572,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/apps/options-2:
     devDependencies:
@@ -599,7 +596,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/apps/writes:
     devDependencies:
@@ -620,7 +617,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/build-errors:
     devDependencies:
@@ -647,7 +644,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment:
     devDependencies:
@@ -668,7 +665,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/build-errors/apps/prerenderable-not-prerendered:
     devDependencies:
@@ -689,7 +686,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/build-errors/apps/private-dynamic-env:
     devDependencies:
@@ -707,7 +704,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/build-errors/apps/private-dynamic-env-dynamic-import:
     devDependencies:
@@ -725,7 +722,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/build-errors/apps/private-static-env:
     devDependencies:
@@ -746,7 +743,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/build-errors/apps/private-static-env-dynamic-import:
     devDependencies:
@@ -764,7 +761,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/build-errors/apps/server-only-folder:
     devDependencies:
@@ -782,7 +779,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/build-errors/apps/server-only-folder-dynamic-import:
     devDependencies:
@@ -800,7 +797,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/build-errors/apps/server-only-module:
     devDependencies:
@@ -818,7 +815,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/build-errors/apps/server-only-module-dynamic-import:
     devDependencies:
@@ -836,7 +833,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/build-errors/apps/syntax-error:
     devDependencies:
@@ -854,7 +851,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   packages/kit/test/prerendering/basics:
     devDependencies:
@@ -872,7 +869,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
       vitest:
         specifier: ^0.34.5
         version: 0.34.5(playwright@1.30.0)
@@ -893,7 +890,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
       vitest:
         specifier: ^0.34.5
         version: 0.34.5(playwright@1.30.0)
@@ -914,7 +911,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
       vitest:
         specifier: ^0.34.5
         version: 0.34.5(playwright@1.30.0)
@@ -944,8 +941,8 @@ importers:
         version: 5.3.2
     devDependencies:
       '@types/node':
-        specifier: ^16.18.6
-        version: 16.18.6
+        specifier: ^18.19.1
+        version: 18.19.1
       '@types/prompts':
         specifier: ^2.4.1
         version: 2.4.1
@@ -978,8 +975,8 @@ importers:
         version: 0.6.19(svelte@4.2.7)(typescript@5.3.2)
     devDependencies:
       '@types/node':
-        specifier: ^16.18.6
-        version: 16.18.6
+        specifier: ^18.19.1
+        version: 18.19.1
       '@types/semver':
         specifier: ^7.5.0
         version: 7.5.0
@@ -1012,7 +1009,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
 
   sites/kit.svelte.dev:
     dependencies:
@@ -1045,8 +1042,8 @@ importers:
         specifier: ^3.0.4
         version: 3.0.4
       '@types/node':
-        specifier: ^16.18.6
-        version: 16.18.6
+        specifier: ^18.19.1
+        version: 18.19.1
       browserslist:
         specifier: ^4.21.10
         version: 4.21.10
@@ -1085,7 +1082,7 @@ importers:
         version: 5.3.2
       vite:
         specifier: ^5.0.4
-        version: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+        version: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
       vitest:
         specifier: ^0.34.5
         version: 0.34.5(lightningcss@1.21.8)(playwright@1.30.0)
@@ -1966,11 +1963,6 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@fastify/busboy@2.0.0:
-    resolution: {integrity: sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==}
-    engines: {node: '>=14'}
-    dev: false
-
   /@fontsource/fira-mono@5.0.5:
     resolution: {integrity: sha512-R5HaONNjI8zzZgjATOrtDhhl58U19OslqNOanPpiHqXV8XWKmFqRF1hIekrWemLfpSTK1WO3wyNcFMZMwkKhlA==}
     dev: false
@@ -2136,7 +2128,7 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
     dependencies:
-      '@types/node': 16.18.6
+      '@types/node': 18.19.1
       playwright-core: 1.30.0
     dev: true
 
@@ -2441,7 +2433,7 @@ packages:
       '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.2.7)(vite@5.0.4)
       debug: 4.3.4
       svelte: 4.2.7
-      vite: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+      vite: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2460,7 +2452,7 @@ packages:
       magic-string: 0.30.5
       svelte: 4.2.7
       svelte-hmr: 0.15.3(svelte@4.2.7)
-      vite: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+      vite: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
       vitefu: 0.2.5(vite@5.0.4)
     transitivePeerDependencies:
       - supports-color
@@ -2498,7 +2490,7 @@ packages:
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 16.18.6
+      '@types/node': 18.19.1
     dev: true
 
   /@types/cookie@0.5.1:
@@ -2551,8 +2543,10 @@ packages:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
-  /@types/node@16.18.6:
-    resolution: {integrity: sha512-vmYJF0REqDyyU0gviezF/KHq/fYaUbFhkcNbQCuPGFQj6VTbXuHZoxs/Y7mutWe73C8AC6l9fFu8mSYiBAqkGA==}
+  /@types/node@18.19.1:
+    resolution: {integrity: sha512-mZJ9V11gG5Vp0Ox2oERpeFDl+JvCwK24PGy76vVY/UgBtjwJWc5rYBThFxmbnYOm9UPZNm6wEl/sxHt2SU7x9A==}
+    dependencies:
+      undici-types: 5.26.5
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -2561,7 +2555,7 @@ packages:
   /@types/prompts@2.4.1:
     resolution: {integrity: sha512-1Mqzhzi9W5KlooNE4o0JwSXGUDeQXKldbGn9NO4tpxwZbHXYd+WcKpCksG2lbhH7U9I9LigfsdVsP2QAY0lNPA==}
     dependencies:
-      '@types/node': 16.18.6
+      '@types/node': 18.19.1
     dev: true
 
   /@types/pug@2.0.6:
@@ -2584,13 +2578,13 @@ packages:
   /@types/set-cookie-parser@2.4.2:
     resolution: {integrity: sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==}
     dependencies:
-      '@types/node': 16.18.6
+      '@types/node': 18.19.1
     dev: true
 
   /@types/ws@8.5.3:
     resolution: {integrity: sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==}
     dependencies:
-      '@types/node': 16.18.6
+      '@types/node': 18.19.1
     dev: true
 
   /@typescript-eslint/eslint-plugin@6.0.0(@typescript-eslint/parser@6.13.1)(eslint@8.52.0)(typescript@5.3.2):
@@ -6661,12 +6655,8 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
-  /undici@5.26.3:
-    resolution: {integrity: sha512-H7n2zmKEWgOllKkIUkLvFmsJQj062lSm3uA4EYApG8gLuiOM0/go9bIoC3HVaSnfg4xunowDE2i9p8drkXuvDw==}
-    engines: {node: '>=14.0'}
-    dependencies:
-      '@fastify/busboy': 2.0.0
-    dev: false
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   /universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -6734,7 +6724,7 @@ packages:
       - rollup
     dev: false
 
-  /vite-node@0.34.5(@types/node@16.18.6):
+  /vite-node@0.34.5(@types/node@18.19.1):
     resolution: {integrity: sha512-RNZ+DwbCvDoI5CbCSQSyRyzDTfFvFauvMs6Yq4ObJROKlIKuat1KgSX/Ako5rlDMfVCyMcpMRMTkJBxd6z8YRA==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -6744,7 +6734,7 @@ packages:
       mlly: 1.4.2
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.9(@types/node@16.18.6)(lightningcss@1.21.8)
+      vite: 4.4.9(@types/node@18.19.1)(lightningcss@1.21.8)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -6756,7 +6746,7 @@ packages:
       - terser
     dev: true
 
-  /vite-node@0.34.5(@types/node@16.18.6)(lightningcss@1.21.8):
+  /vite-node@0.34.5(@types/node@18.19.1)(lightningcss@1.21.8):
     resolution: {integrity: sha512-RNZ+DwbCvDoI5CbCSQSyRyzDTfFvFauvMs6Yq4ObJROKlIKuat1KgSX/Ako5rlDMfVCyMcpMRMTkJBxd6z8YRA==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -6766,7 +6756,7 @@ packages:
       mlly: 1.4.2
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+      vite: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -6778,7 +6768,7 @@ packages:
       - terser
     dev: true
 
-  /vite@4.4.9(@types/node@16.18.6)(lightningcss@1.21.8):
+  /vite@4.4.9(@types/node@18.19.1)(lightningcss@1.21.8):
     resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -6806,7 +6796,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 16.18.6
+      '@types/node': 18.19.1
       esbuild: 0.18.20
       lightningcss: 1.21.8
       postcss: 8.4.31
@@ -6815,7 +6805,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vite@5.0.4(@types/node@16.18.6)(lightningcss@1.21.8):
+  /vite@5.0.4(@types/node@18.19.1)(lightningcss@1.21.8):
     resolution: {integrity: sha512-RzAr8LSvM8lmhB4tQ5OPcBhpjOZRZjuxv9zO5UcxeoY2bd3kP3Ticd40Qma9/BqZ8JS96Ll/jeBX9u+LJZrhVg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -6843,7 +6833,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 16.18.6
+      '@types/node': 18.19.1
       esbuild: 0.19.8
       lightningcss: 1.21.8
       postcss: 8.4.31
@@ -6859,7 +6849,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 5.0.4(@types/node@16.18.6)(lightningcss@1.21.8)
+      vite: 5.0.4(@types/node@18.19.1)(lightningcss@1.21.8)
     dev: false
 
   /vitest@0.34.5(lightningcss@1.21.8)(playwright@1.30.0):
@@ -6895,7 +6885,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.6
       '@types/chai-subset': 1.3.3
-      '@types/node': 16.18.6
+      '@types/node': 18.19.1
       '@vitest/expect': 0.34.5
       '@vitest/runner': 0.34.5
       '@vitest/snapshot': 0.34.5
@@ -6915,8 +6905,8 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.5.0
       tinypool: 0.7.0
-      vite: 4.4.9(@types/node@16.18.6)(lightningcss@1.21.8)
-      vite-node: 0.34.5(@types/node@16.18.6)(lightningcss@1.21.8)
+      vite: 4.4.9(@types/node@18.19.1)(lightningcss@1.21.8)
+      vite-node: 0.34.5(@types/node@18.19.1)(lightningcss@1.21.8)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -6961,7 +6951,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.6
       '@types/chai-subset': 1.3.3
-      '@types/node': 16.18.6
+      '@types/node': 18.19.1
       '@vitest/expect': 0.34.5
       '@vitest/runner': 0.34.5
       '@vitest/snapshot': 0.34.5
@@ -6981,8 +6971,8 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.5.0
       tinypool: 0.7.0
-      vite: 4.4.9(@types/node@16.18.6)(lightningcss@1.21.8)
-      vite-node: 0.34.5(@types/node@16.18.6)
+      vite: 4.4.9(@types/node@18.19.1)(lightningcss@1.21.8)
+      vite-node: 0.34.5(@types/node@18.19.1)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/sites/kit.svelte.dev/package.json
+++ b/sites/kit.svelte.dev/package.json
@@ -19,7 +19,7 @@
 		"@sveltejs/kit": "workspace:^",
 		"@sveltejs/site-kit": "6.0.0-next.52",
 		"@types/d3-geo": "^3.0.4",
-		"@types/node": "^16.18.6",
+		"@types/node": "^18.19.1",
 		"browserslist": "^4.21.10",
 		"flexsearch": "^0.7.31",
 		"lightningcss": "^1.21.8",


### PR DESCRIPTION
Should we remove the `shouldPolyfill` method and polyfill whenever it's not already on `globalThis`?