### PR TITLE
docs: resolve `@link` JSDoc tags

### DIFF
--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -5,16 +5,15 @@ import { get_route_segments } from '../utils/routing.js';
 export { VERSION } from '../version.js';
 
 /**
+ * Creates an `HttpError` object with an HTTP status code and an optional message.
+ * This object, if thrown during request handling, will cause SvelteKit to
+ * return an error response without invoking `handleError`.
+ * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
+ * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
+ * @param {App.Error} body An object that conforms to the App.Error type. If a string is passed, it will be used as the message property.
  * @overload
  * @param {number} status
  * @param {App.Error} body
- * @return {HttpError}
- */
-
-/**
- * @overload
- * @param {number} status
- * @param {{ message: string } extends App.Error ? App.Error | string | undefined : never} [body]
  * @return {HttpError}
  */
 
@@ -23,8 +22,17 @@ export { VERSION } from '../version.js';
  * This object, if thrown during request handling, will cause SvelteKit to
  * return an error response without invoking `handleError`.
  * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
- * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
- * @param {{ message: string } extends App.Error ? App.Error | string | undefined : never} body An object that conforms to the App.Error type. If a string is passed, it will be used as the message property.
+ *  * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
+ * @param {{ message: string } extends App.Error ? App.Error | string | undefined : never} [body] An object that conforms to the App.Error type. If a string is passed, it will be used as the message property.
+ * @overload
+ * @param {number} status
+ * @param {{ message: string } extends App.Error ? App.Error | string | undefined : never} [body]
+ * @return {HttpError}
+ */
+
+/**
+ * @param {number} status
+ * @param {{ message: string } extends App.Error ? App.Error | string | undefined : never} body
  */
 export function error(status, body) {
 	if ((!BROWSER || DEV) && (isNaN(status) || status < 400 || status > 599)) {

--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -5,12 +5,6 @@ import { get_route_segments } from '../utils/routing.js';
 export { VERSION } from '../version.js';
 
 /**
- * Creates an `HttpError` object with an HTTP status code and an optional message.
- * This object, if thrown during request handling, will cause SvelteKit to
- * return an error response without invoking `handleError`.
- * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
- * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
- * @param {App.Error} body An object that conforms to the App.Error type. If a string is passed, it will be used as the message property.
  * @overload
  * @param {number} status
  * @param {App.Error} body
@@ -18,12 +12,6 @@ export { VERSION } from '../version.js';
  */
 
 /**
- * Creates an `HttpError` object with an HTTP status code and an optional message.
- * This object, if thrown during request handling, will cause SvelteKit to
- * return an error response without invoking `handleError`.
- * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
- *  * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
- * @param {{ message: string } extends App.Error ? App.Error | string | undefined : never} [body] An object that conforms to the App.Error type. If a string is passed, it will be used as the message property.
  * @overload
  * @param {number} status
  * @param {{ message: string } extends App.Error ? App.Error | string | undefined : never} [body]
@@ -31,8 +19,12 @@ export { VERSION } from '../version.js';
  */
 
 /**
- * @param {number} status
- * @param {{ message: string } extends App.Error ? App.Error | string | undefined : never} body
+ * Creates an `HttpError` object with an HTTP status code and an optional message.
+ * This object, if thrown during request handling, will cause SvelteKit to
+ * return an error response without invoking `handleError`.
+ * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
+ * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
+ * @param {{ message: string } extends App.Error ? App.Error | string | undefined : never} body An object that conforms to the App.Error type. If a string is passed, it will be used as the message property.
  */
 export function error(status, body) {
 	if ((!BROWSER || DEV) && (isNaN(status) || status < 400 || status > 599)) {

--- a/sites/kit.svelte.dev/scripts/types/index.js
+++ b/sites/kit.svelte.dev/scripts/types/index.js
@@ -55,10 +55,6 @@ async function get_types(code, statements) {
 				// @ts-ignore no idea why it's complaining here
 				const name = name_node.name?.escapedText;
 
-				if (name === 'error') {
-					console.log(statement);
-				}
-
 				let start = statement.pos;
 				let comment = '';
 				/** @type {string | null} */

--- a/sites/kit.svelte.dev/scripts/types/index.js
+++ b/sites/kit.svelte.dev/scripts/types/index.js
@@ -55,6 +55,10 @@ async function get_types(code, statements) {
 				// @ts-ignore no idea why it's complaining here
 				const name = name_node.name?.escapedText;
 
+				if (name === 'error') {
+					console.log(statement);
+				}
+
 				let start = statement.pos;
 				let comment = '';
 				/** @type {string | null} */
@@ -65,7 +69,14 @@ async function get_types(code, statements) {
 					// @ts-ignore
 					const jsDoc = statement.jsDoc[0];
 
-					comment = jsDoc.comment;
+					// resolve `@link` JSDoc tags
+					if (Array.isArray(jsDoc.comment)) {
+						comment = jsDoc.comment
+							.map(({ name, text }) => (name ? `\`${name.escapedText}\`` : text))
+							.join('');
+					} else {
+						comment = jsDoc.comment;
+					}
 
 					if (jsDoc?.tags?.[0]?.tagName?.escapedText === 'deprecated') {
 						deprecated_notice = jsDoc.tags[0].comment;

--- a/sites/kit.svelte.dev/scripts/types/index.js
+++ b/sites/kit.svelte.dev/scripts/types/index.js
@@ -65,7 +65,7 @@ async function get_types(code, statements) {
 					// @ts-ignore
 					const jsDoc = statement.jsDoc[0];
 
-					// resolve `@link` JSDoc tags
+					// `@link` JSDoc tags (and maybe others?) turn this property into an array, which we need to join manually
 					if (Array.isArray(jsDoc.comment)) {
 						comment = jsDoc.comment
 							.map(({ name, text }) => (name ? `\`${name.escapedText}\`` : text))


### PR DESCRIPTION
unblocks https://github.com/sveltejs/kit/pull/11165

Correctly parses the `{@link ...}` JSDoc tags when converting the types to docs for the website.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
