### PR TITLE
breaking: stricten types around `depends` and `invalidate`

### DIFF
--- a/.changeset/dirty-phones-report.md
+++ b/.changeset/dirty-phones-report.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: stricten types around `depends` and `invalidate` to require a `:` when passing a string

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -779,7 +779,7 @@ export interface LoadEvent<
 	 * <button on:click={increase}>Increase Count</button>
 	 * ```
 	 */
-	depends(...deps: string[]): void;
+	depends(...deps: Array<`${string}:${string}`>): void;
 }
 
 export interface NavigationEvent<

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -44,8 +44,8 @@ export const goto = /* @__PURE__ */ client_method('goto');
  *
  * invalidate((url) => url.pathname === '/path');
  * ```
- * @type {(url: string | URL | ((url: URL) => boolean)) => Promise<void>}
- * @param {string | URL | ((url: URL) => boolean)} url The invalidated URL
+ * @type {(url: `${string}:${string}` | URL | ((url: URL) => boolean)) => Promise<void>}
+ * @param {`${string}:${string}` | URL | ((url: URL) => boolean)} url The invalidated URL
  * @returns {Promise<void>}
  */
 export const invalidate = /* @__PURE__ */ client_method('invalidate');


### PR DESCRIPTION
require a `:` when passing a string now
closes #9763

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
