### PR TITLE
docs: refer to `@sentry/sveltekit` rather than `@sentry/node`

### DIFF
--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -164,14 +164,14 @@ export {};
 /// file: src/hooks.server.js
 // @errors: 2322
 // @filename: ambient.d.ts
-declare module '@sentry/node' {
+declare module '@sentry/sveltekit' {
 	export const init: (opts: any) => void;
 	export const captureException: (error: any, opts: any) => void;
 }
 
 // @filename: index.js
 // ---cut---
-import * as Sentry from '@sentry/node';
+import * as Sentry from '@sentry/sveltekit';
 import crypto from 'crypto';
 
 Sentry.init({/*...*/})
@@ -193,14 +193,14 @@ export async function handleError({ error, event }) {
 /// file: src/hooks.client.js
 // @errors: 2322
 // @filename: ambient.d.ts
-declare module '@sentry/svelte' {
+declare module '@sentry/sveltekit' {
 	export const init: (opts: any) => void;
 	export const captureException: (error: any, opts: any) => void;
 }
 
 // @filename: index.js
 // ---cut---
-import * as Sentry from '@sentry/svelte';
+import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({/*...*/})
 

--- a/documentation/docs/30-advanced/25-errors.md
+++ b/documentation/docs/30-advanced/25-errors.md
@@ -83,14 +83,14 @@ Unexpected errors will go through the [`handleError`](hooks#shared-hooks-handlee
 /// file: src/hooks.server.js
 // @errors: 2322 1360 2571 2339
 // @filename: ambient.d.ts
-declare module '@sentry/node' {
+declare module '@sentry/sveltekit' {
 	export const init: (opts: any) => void;
 	export const captureException: (error: any, opts: any) => void;
 }
 
 // @filename: index.js
 // ---cut---
-import * as Sentry from '@sentry/node';
+import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({/*...*/})
 


### PR DESCRIPTION
Sentry now has a sveltekit package: https://docs.sentry.io/platforms/javascript/guides/sveltekit/

Update from using "@sentry/node" and "@sentry/svelte" to "@sentry/sveltekit";

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
