### PR TITLE
fix: make sure promises from fetch handle errors

### DIFF
--- a/.changeset/soft-colts-tell.md
+++ b/.changeset/soft-colts-tell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: make sure promises from fetch handle errors

--- a/packages/kit/test/apps/basics/src/routes/streaming/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/streaming/+page.svelte
@@ -1,2 +1,3 @@
 <a href="/streaming/universal">Universal</a>
 <a href="/streaming/server">Server</a>
+<a href="/streaming/server-error">Server Error</a>

--- a/packages/kit/test/apps/basics/src/routes/streaming/server-error/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/streaming/server-error/+page.server.js
@@ -1,0 +1,15 @@
+// Tests the case where a lazy promise is rejected before the rendering started
+export async function load({ fetch }) {
+	const eager = new Promise((resolve) => {
+		setTimeout(() => {
+			resolve('eager');
+		}, 100);
+	});
+
+	return {
+		eager: await eager,
+		lazy: {
+			fail: fetch('http://localhost:1337/')
+		}
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/streaming/server-error/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/streaming/server-error/+page.svelte
@@ -1,0 +1,12 @@
+<script>
+	/** @type {import('./$types').PageData} */
+	export let data;
+</script>
+
+<p class="eager">{data.eager}</p>
+
+{#await data.lazy.fail}
+	<p class="loadingfail">loading</p>
+{:catch}
+	<p class="fail">fail</p>
+{/await}

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -761,6 +761,14 @@ test.describe('Streaming', () => {
 		expect(page.locator('p.loadingfail')).toBeHidden();
 	});
 
+	test('Catches fetch errors from server load functions (client nav)', async ({ page }) => {
+		await page.goto('/streaming');
+		page.click('[href="/streaming/server-error"]');
+
+		await expect(page.locator('p.eager')).toHaveText('eager');
+		expect(page.locator('p.fail')).toBeVisible();
+	});
+
 	// TODO `vite preview` buffers responses, causing these tests to fail
 	if (process.env.DEV) {
 		test('Works for universal load functions (direct hit)', async ({ page }) => {
@@ -801,6 +809,12 @@ test.describe('Streaming', () => {
 			await expect(page.locator('p.fail')).toHaveText('fail');
 			expect(page.locator('p.loadingsuccess')).toBeHidden();
 			expect(page.locator('p.loadingfail')).toBeHidden();
+		});
+
+		test('Catches fetch errors from server load functions (direct hit)', async ({ page }) => {
+			page.goto('/streaming/server-error');
+			await expect(page.locator('p.eager')).toHaveText('eager');
+			await expect(page.locator('p.fail')).toHaveText('fail');
 		});
 	}
 });


### PR DESCRIPTION
Ensures that people using `fetch` directly in their load functions don't run into uncaught promise errors with streaming. Also adds some docs for this case.
related to #9785

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
