### PR TITLE
feat: allow SvelteKit 2 as peer dependency

### DIFF
--- a/.changeset/hungry-kings-collect.md
+++ b/.changeset/hungry-kings-collect.md
@@ -1,0 +1,12 @@
+---
+'@sveltejs/adapter-cloudflare-workers': minor
+'@sveltejs/adapter-cloudflare': minor
+'@sveltejs/adapter-netlify': minor
+'@sveltejs/adapter-static': minor
+'@sveltejs/adapter-vercel': minor
+'@sveltejs/adapter-auto': minor
+'@sveltejs/adapter-node': minor
+'@sveltejs/amp': minor
+---
+
+feat: allow SvelteKit 2 as peer dependency

--- a/packages/adapter-auto/package.json
+++ b/packages/adapter-auto/package.json
@@ -39,6 +39,6 @@
 		"import-meta-resolve": "^4.0.0"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.0.0 | ^2.0.0"
+		"@sveltejs/kit": "^1.0.0 || ^2.0.0"
 	}
 }

--- a/packages/adapter-auto/package.json
+++ b/packages/adapter-auto/package.json
@@ -39,6 +39,6 @@
 		"import-meta-resolve": "^4.0.0"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.0.0"
+		"@sveltejs/kit": "^1.0.0 | ^2.0.0"
 	}
 }

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -40,6 +40,6 @@
 		"typescript": "^5.3.2"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.0.0"
+		"@sveltejs/kit": "^1.0.0 | ^2.0.0"
 	}
 }

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -40,6 +40,6 @@
 		"typescript": "^5.3.2"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.0.0 | ^2.0.0"
+		"@sveltejs/kit": "^1.0.0 || ^2.0.0"
 	}
 }

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -42,7 +42,7 @@
 		"typescript": "^5.3.2"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.0.0"
+		"@sveltejs/kit": "^1.0.0 | ^2.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -42,7 +42,7 @@
 		"typescript": "^5.3.2"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.0.0 | ^2.0.0"
+		"@sveltejs/kit": "^1.0.0 || ^2.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -51,6 +51,6 @@
 		"vitest": "^1.0.0"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.5.0"
+		"@sveltejs/kit": "^1.5.0 | ^2.0.0"
 	}
 }

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -51,6 +51,6 @@
 		"vitest": "^1.0.0"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.5.0 | ^2.0.0"
+		"@sveltejs/kit": "^1.5.0 || ^2.0.0"
 	}
 }

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -50,6 +50,6 @@
 		"rollup": "^4.2.0"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.0.0"
+		"@sveltejs/kit": "^1.0.0 | ^2.0.0"
 	}
 }

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -50,6 +50,6 @@
 		"rollup": "^4.2.0"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.0.0 | ^2.0.0"
+		"@sveltejs/kit": "^1.0.0 || ^2.0.0"
 	}
 }

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -40,6 +40,6 @@
 		"vite": "^5.0.4"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.5.0"
+		"@sveltejs/kit": "^1.5.0 | ^2.0.0"
 	}
 }

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -40,6 +40,6 @@
 		"vite": "^5.0.4"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.5.0 | ^2.0.0"
+		"@sveltejs/kit": "^1.5.0 || ^2.0.0"
 	}
 }

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -42,6 +42,6 @@
 		"vitest": "^1.0.0"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.5.0 | ^2.0.0"
+		"@sveltejs/kit": "^1.5.0 || ^2.0.0"
 	}
 }

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -42,6 +42,6 @@
 		"vitest": "^1.0.0"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.5.0"
+		"@sveltejs/kit": "^1.5.0 | ^2.0.0"
 	}
 }

--- a/packages/amp/package.json
+++ b/packages/amp/package.json
@@ -27,6 +27,6 @@
 		"format": "pnpm lint --write"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.0.0"
+		"@sveltejs/kit": "^1.0.0 | ^2.0.0"
 	}
 }

--- a/packages/amp/package.json
+++ b/packages/amp/package.json
@@ -27,6 +27,6 @@
 		"format": "pnpm lint --write"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.0.0 | ^2.0.0"
+		"@sveltejs/kit": "^1.0.0 || ^2.0.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
         specifier: ^4.20230404.0
         version: 4.20230404.0
       '@sveltejs/kit':
-        specifier: ^1.0.0
+        specifier: ^1.0.0 || ^2.0.0
         version: 1.27.7(svelte@4.2.7)(vite@4.5.1)
       esbuild:
         specifier: ^0.19.3
@@ -98,7 +98,7 @@ importers:
         specifier: ^2.2.5
         version: 2.2.5
       '@sveltejs/kit':
-        specifier: ^1.0.0
+        specifier: ^1.0.0 || ^2.0.0
         version: 1.27.7(svelte@4.2.7)(vite@4.5.1)
       esbuild:
         specifier: ^0.19.3
@@ -297,7 +297,7 @@ importers:
   packages/amp:
     dependencies:
       '@sveltejs/kit':
-        specifier: ^1.0.0
+        specifier: ^1.0.0 || ^2.0.0
         version: 1.27.7(svelte@4.2.7)(vite@4.5.1)
 
   packages/create-svelte:


### PR DESCRIPTION
I don't think there were any changes to the adapter API, so we don't need a new major. I made this a `minor` since Kit 2 seemed sort of like a new feature. That means Kit 1 users can keep getting new adapter bug fixes.