### PR TITLE
breaking: Remove `dangerZone.trackServerFetches`

### DIFF
--- a/.changeset/twenty-birds-eat.md
+++ b/.changeset/twenty-birds-eat.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: remove `dangerZone.trackServerFetches`

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -69,7 +69,6 @@ const get_defaults = (prefix = '') => ({
 		csrf: {
 			checkOrigin: true
 		},
-		dangerZone: {},
 		embedded: false,
 		env: {
 			dir: process.cwd(),

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -69,9 +69,7 @@ const get_defaults = (prefix = '') => ({
 		csrf: {
 			checkOrigin: true
 		},
-		dangerZone: {
-			trackServerFetches: false
-		},
+		dangerZone: {},
 		embedded: false,
 		env: {
 			dir: process.cwd(),

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -111,8 +111,6 @@ const options = object(
 				checkOrigin: boolean(true)
 			}),
 
-			dangerZone: object({}),
-
 			embedded: boolean(false),
 
 			env: object({

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -111,10 +111,7 @@ const options = object(
 				checkOrigin: boolean(true)
 			}),
 
-			dangerZone: object({
-				// TODO 2.0: Remove this
-				trackServerFetches: boolean(false)
-			}),
+			dangerZone: object({}),
 
 			embedded: boolean(false),
 

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -34,7 +34,6 @@ export const options = {
 	app_template_contains_nonce: ${template.includes('%sveltekit.nonce%')},
 	csp: ${s(config.kit.csp)},
 	csrf_check_origin: ${s(config.kit.csrf.checkOrigin)},
-	track_server_fetches: ${s(config.kit.dangerZone.trackServerFetches)},
 	embedded: ${config.kit.embedded},
 	env_public_prefix: '${config.kit.env.publicPrefix}',
 	env_private_prefix: '${config.kit.env.privatePrefix}',

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -346,13 +346,7 @@ export interface KitConfig {
 	/**
 	 * Here be dragons. Enable at your peril.
 	 */
-	dangerZone?: {
-		/**
-		 * Automatically add server-side `fetch`ed URLs to the `dependencies` map of `load` functions. This will expose secrets
-		 * to the client if your URL contains them.
-		 */
-		trackServerFetches?: boolean;
-	};
+	dangerZone?: Record<string, never>;
 	/**
 	 * Whether or not the app is embedded inside a larger app. If `true`, SvelteKit will add its event listeners related to navigation etc on the parent of `%sveltekit.body%` instead of `window`, and will pass `params` from the server rather than inferring them from `location.pathname`.
 	 * @default false

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -344,10 +344,6 @@ export interface KitConfig {
 		checkOrigin?: boolean;
 	};
 	/**
-	 * Here be dragons. Enable at your peril.
-	 */
-	dangerZone?: Record<string, never>;
-	/**
 	 * Whether or not the app is embedded inside a larger app. If `true`, SvelteKit will add its event listeners related to navigation etc on the parent of `%sveltekit.body%` instead of `window`, and will pass `params` from the server rather than inferring them from `location.pathname`.
 	 * @default false
 	 */

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -76,8 +76,7 @@ export async function render_data(
 								}
 							}
 							return data;
-						},
-						track_server_fetches: options.track_server_fetches
+						}
 					});
 				} catch (e) {
 					aborted = true;

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -150,8 +150,7 @@ export async function render_page(event, page, options, manifest, state, resolve
 								if (parent) Object.assign(data, await parent.data);
 							}
 							return data;
-						},
-						track_server_fetches: options.track_server_fetches
+						}
 					});
 				} catch (e) {
 					load_error = /** @type {Error} */ (e);

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -10,18 +10,10 @@ import { validate_depends } from '../../shared.js';
  *   state: import('types').SSRState;
  *   node: import('types').SSRNode | undefined;
  *   parent: () => Promise<Record<string, any>>;
- *   track_server_fetches: boolean;
  * }} opts
  * @returns {Promise<import('types').ServerDataNode | null>}
  */
-export async function load_server_data({
-	event,
-	state,
-	node,
-	parent,
-	// TODO 2.0: Remove this
-	track_server_fetches
-}) {
+export async function load_server_data({ event, state, node, parent }) {
 	if (!node?.server) return null;
 
 	let done = false;
@@ -57,11 +49,6 @@ export async function load_server_data({
 				console.warn(
 					`${node.server_id}: Calling \`event.fetch(...)\` in a promise handler after \`load(...)\` has returned will not cause the function to re-run when the dependency is invalidated`
 				);
-			}
-
-			// TODO 2.0: Remove this
-			if (track_server_fetches) {
-				uses.dependencies.add(url.href);
 			}
 
 			return event.fetch(info, init);

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -49,8 +49,7 @@ export async function respond_with_error({
 				event,
 				state,
 				node: default_layout,
-				parent: async () => ({}),
-				track_server_fetches: options.track_server_fetches
+				parent: async () => ({})
 			});
 
 			const server_data = await server_data_promise;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -333,7 +333,6 @@ export interface SSROptions {
 	app_template_contains_nonce: boolean;
 	csp: ValidatedConfig['kit']['csp'];
 	csrf_check_origin: boolean;
-	track_server_fetches: boolean;
 	embedded: boolean;
 	env_public_prefix: string;
 	env_private_prefix: string;

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -483,7 +483,8 @@ test.describe('Invalidation', () => {
 	});
 
 	test('fetch in server load cannot be invalidated', async ({ page, app, request }) => {
-		// TODO 2.0: Can remove this test after `dangerZone.trackServerFetches` and associated code is removed
+		// legacy behavior was to track server dependencies -- this could leak secrets to the client (see github.com/sveltejs/kit/pull/9945)
+		// we keep this test just to make sure the behavior stays the same.
 		await request.get('/load/invalidation/server-fetch/count.json?reset');
 		await page.goto('/load/invalidation/server-fetch');
 		const selector = '[data-testid="count"]';

--- a/packages/kit/test/apps/options/svelte.config.js
+++ b/packages/kit/test/apps/options/svelte.config.js
@@ -9,9 +9,6 @@ const config = {
 				'require-trusted-types-for': ['script']
 			}
 		},
-		dangerZone: {
-			trackServerFetches: true
-		},
 		files: {
 			assets: 'public',
 			lib: 'source/components',

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -302,22 +302,3 @@ test.describe('Routing', () => {
 		await expect(page.locator('h2')).toHaveText('target: 0');
 	});
 });
-
-test.describe('load', () => {
-	// TODO 2.0: Remove this test
-	test('fetch in server load can be invalidated when `dangerZone.trackServerFetches` is set', async ({
-		page,
-		app,
-		request,
-		javaScriptEnabled
-	}) => {
-		test.skip(!javaScriptEnabled, 'JavaScript is disabled');
-		await request.get('/path-base/server-fetch-invalidate/count.json?reset');
-		await page.goto('/path-base/server-fetch-invalidate');
-		const selector = '[data-testid="count"]';
-
-		expect(await page.textContent(selector)).toBe('1');
-		await app.invalidate('/path-base/server-fetch-invalidate/count.json');
-		expect(await page.textContent(selector)).toBe('2');
-	});
-});


### PR DESCRIPTION
We had to make a breaking change in #9945, so we added this option to give people who knew it was safe an easy way to keep their apps running while they implemented fixes. Since we're releasing 2.0, we can remove this security-related override.

Closes #11234 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
