### PR TITLE
breaking: Standardize resolution order for exported options from route files

### DIFF
--- a/.changeset/silver-monkeys-smash.md
+++ b/.changeset/silver-monkeys-smash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: fix resolution order for exports from route files

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -46,7 +46,7 @@ async function analyse({ manifest_path, env }) {
 	internal.set_private_env(filter_private_env(env, { public_prefix, private_prefix }));
 	internal.set_public_env(filter_public_env(env, { public_prefix, private_prefix }));
 
-	const node_promises = manifest._.nodes.map(load_node);
+	const node_promises = manifest._.nodes.map((loader) => loader());
 	const node_metadata_promise = Promise.all(node_promises.map(analyse_node));
 	const route_metadata_promise = Promise.all(
 		manifest._.routes.map((route) => analyse_route(route, { node_promises }))
@@ -77,14 +77,6 @@ function get_config(nodes) {
 	}
 
 	return Object.keys(current).length ? current : undefined;
-}
-
-/**
- * @param {import('types').SSRNodeLoader} loader
- * @returns {Promise<import('types').SSRNode>}
- */
-function load_node(loader) {
-	return loader();
 }
 
 /**

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -67,14 +67,12 @@ async function analyse({ manifest_path, env }) {
 function get_config(nodes) {
 	let current = {};
 	for (const node of nodes) {
-		const config = node?.universal?.config ?? node?.server?.config;
-		if (config) {
-			current = {
-				...current,
-				...(node?.server?.config ?? {}),
-				...(node?.universal?.config ?? {})
-			};
-		}
+		if (!(node?.server?.config || node?.universal?.config)) continue;
+		current = {
+			...current,
+			...(node?.server?.config ?? {}),
+			...(node?.universal?.config ?? {})
+		};
 	}
 
 	return Object.keys(current).length ? current : undefined;


### PR DESCRIPTION
This PR (somewhat by accident) accomplishes two goals:

- It parallelizes (or... concurrentizes? 🤷🏻) `analyse`, resolving all `Promise`-creating functions together. This should hypothetically speed it up for systems that have the resources to make use of the concurrency; previously we were `await`-ing inside the loops.
- And, the reason I started this: It fixes the resolution order for `config`, `prerender`, and `entries` -- they were inconsistent.

The correct resolution order for route-file exports is: `+page`, `+page.server`, `+server`, `+layout`, `+layout.server`. The old resolutions were... pretty much all different:
- `prerender`: `+page`, `+page.server`, `+layout`, `+layout.server`, (`false`, if a page existed, even if `+server` exported `prerender`), `+server`
- `config`: Honestly bonkers: Merged shallowly down the layout-page tree, except that each layer would only respect `universal ?? server`, all of which would hard-override anything exported from `+server`.
- `entries`: Less-insane, but still wrong: `+server`, `+page`, `+page.server` (`entries` not applicable to layouts)

These have all been standardized, and are also way easier to reason about than in their current format:

```ts
	return {
		methods: [...new Set([...endpoint.methods, ...page.methods])],
		prerender: page.prerender ?? endpoint.prerender ?? layout.prerender,
		entries: page.entries ?? endpoint.entries, // layouts can't have entries
		config: {
			...layout.config,
			...endpoint.config,
			...page.config
		}
	};
```

`config` is also merged more sensically now:

```ts
		current = {
			...current,
			...(node?.server?.config ?? {}),
			...(node?.universal?.config ?? {})
		};
```

Previously, only `server` OR `universal` would get merged into the final config at each level.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
