### PR TITLE
docs: update wrangler cli deployment command

### DIFF
--- a/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
+++ b/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
@@ -58,7 +58,7 @@ wrangler login
 Then, you can build your app and deploy it:
 
 ```sh
-wrangler publish
+wrangler deploy
 ```
 
 ## Custom config


### PR DESCRIPTION
I got the following message when deploying to cloudflare workers so we should update the deployment command in the docs.

```sh
❯ wrangler publish
 ⛅️ wrangler 3.19.0
-------------------
▲ [WARNING] `wrangler publish` is deprecated and will be removed in the next major version.

  Please use `wrangler deploy` instead, which accepts exactly the same arguments.
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
