### PR TITLE
fix: correctly map prerendered pages when base path is set

### DIFF
--- a/.changeset/cold-walls-film.md
+++ b/.changeset/cold-walls-film.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+---
+
+fix: correctly map prerendered pages when base path is set

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -45,13 +45,20 @@ export default function ({ config = 'wrangler.toml' } = {}) {
 				}
 			});
 
+			let prerendered_entries = Array.from(builder.prerendered.pages.entries());
+
+			if (builder.config.kit.paths.base) {
+				prerendered_entries = prerendered_entries.map(([path, { file }]) => [
+					path,
+					{ file: `${builder.config.kit.paths.base}/${file}` }
+				]);
+			}
+
 			writeFileSync(
 				`${tmp}/manifest.js`,
 				`export const manifest = ${builder.generateManifest({
 					relativePath
-				})};\n\nexport const prerendered = new Map(${JSON.stringify(
-					Array.from(builder.prerendered.pages.entries())
-				)});\n`
+				})};\n\nexport const prerendered = new Map(${JSON.stringify(prerendered_entries)});\n`
 			);
 
 			await esbuild.build({


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/11210

Previously, the prerendered manifest didn't set the base path so it looked like this:
```js
export const prerendered = {
  '/base/about': 'about.html'
}
```
However, this is incorrect because it is stored in the KV with the key `/base/about.1asdf34.html` (ignore the hash, cloudflare handles it). This is also because we upload the build output such that the public files live in the base folder `.cloudflare/public/base/about.html`.

Therefore, the new manifest when a base path is set should look like this:
```js
export const prerendered = {
  '/base/about': '/base/about.html'
}
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
