### PR TITLE
fix: make adapter plugin param type optional

### DIFF
--- a/.changeset/hungry-moles-turn.md
+++ b/.changeset/hungry-moles-turn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+---
+
+fix: the adapter plugin parameter is now optional

--- a/.changeset/hungry-moles-turn.md
+++ b/.changeset/hungry-moles-turn.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-cloudflare-workers': patch
 ---
 
-fix: the adapter plugin parameter is now optional
+fix: declare the adapter plugin options as optional

--- a/packages/adapter-cloudflare-workers/index.d.ts
+++ b/packages/adapter-cloudflare-workers/index.d.ts
@@ -1,4 +1,4 @@
 import { Adapter } from '@sveltejs/kit';
 import './ambient.js';
 
-export default function plugin(options: { config?: string }): Adapter;
+export default function plugin(options?: { config?: string }): Adapter;


### PR DESCRIPTION
The types for the cloudflare workers adapter plugin method requires an object as a parameter. This PR makes that optional so it's in tune with the docs https://kit.svelte.dev/docs/adapter-cloudflare-workers#usage

```diff
import adapter from '@sveltejs/adapter-cloudflare-workers';

export default {
	kit: {
-		adapter: adapter({ })
+		adapter: adapter()
	}
};
```

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
