### PR TITLE
feat(node): add `PORT_HEADER` env var for reverse proxies with non-standard ports

### DIFF
--- a/.changeset/thick-pears-own.md
+++ b/.changeset/thick-pears-own.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': minor
+---
+
+feat: add `PORT_HEADER` env var for reverse proxies with non-standard ports

--- a/documentation/docs/25-build-and-deploy/40-adapter-node.md
+++ b/documentation/docs/25-build-and-deploy/40-adapter-node.md
@@ -63,7 +63,7 @@ Alternatively, the server can be configured to accept connections on a specified
 SOCKET_PATH=/tmp/socket node build
 ```
 
-### `ORIGIN`, `PROTOCOL_HEADER` and `HOST_HEADER`
+### `ORIGIN`, `PROTOCOL_HEADER`, `HOST_HEADER`, and `PORT_HEADER`
 
 HTTP doesn't give SvelteKit a reliable way to know the URL that is currently being requested. The simplest way to tell SvelteKit where the app is being served is to set the `ORIGIN` environment variable:
 
@@ -81,6 +81,8 @@ PROTOCOL_HEADER=x-forwarded-proto HOST_HEADER=x-forwarded-host node build
 ```
 
 > [`x-forwarded-proto`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto) and [`x-forwarded-host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host) are de facto standard headers that forward the original protocol and host if you're using a reverse proxy (think load balancers and CDNs). You should only set these variables if your server is behind a trusted reverse proxy; otherwise, it'd be possible for clients to spoof these headers.
+>
+> If you're hosting your proxy on a non-standard port and your reverse proxy supports [`x-forwarded-port`](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html#x-forwarded-port), you can also set `PORT_HEADER=x-forwarded-port`.
 
 If `adapter-node` can't correctly determine the URL of your deployment, you may experience this error when using [form actions](form-actions):
 

--- a/packages/adapter-node/src/env.js
+++ b/packages/adapter-node/src/env.js
@@ -9,6 +9,7 @@ const expected = new Set([
 	'ADDRESS_HEADER',
 	'PROTOCOL_HEADER',
 	'HOST_HEADER',
+	'PORT_HEADER',
 	'BODY_SIZE_LIMIT'
 ]);
 

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -18,6 +18,7 @@ const xff_depth = parseInt(env('XFF_DEPTH', '1'));
 const address_header = env('ADDRESS_HEADER', '').toLowerCase();
 const protocol_header = env('PROTOCOL_HEADER', '').toLowerCase();
 const host_header = env('HOST_HEADER', 'host').toLowerCase();
+const port_header = env('PORT_HEADER', '').toLowerCase();
 const body_size_limit = parseInt(env('BODY_SIZE_LIMIT', '524288'));
 
 const dir = path.dirname(fileURLToPath(import.meta.url));
@@ -167,7 +168,12 @@ function sequence(handlers) {
 function get_origin(headers) {
 	const protocol = (protocol_header && headers[protocol_header]) || 'https';
 	const host = headers[host_header];
-	return `${protocol}://${host}`;
+	const port = port_header && headers[port_header];
+	if (port) {
+		return `${protocol}://${host}:${port}`;
+	} else {
+		return `${protocol}://${host}`;
+	}
 }
 
 export const handler = sequence(


### PR DESCRIPTION
Add support for the `PORT_HEADER` environment variable to `@sveltejs/adapter-node` that can be used to read the original port of a request from a reverse proxy, which is needed if the reverse proxy is hosted on a non-standard port (e.g. not port 80 for http nor port 443 for https).

This port is normally added as part of a [`x-forwarded-port`][1] header, which is used by many reverse proxies, although it's not as popular as the more common [`x-forwarded-proto`][2] and [`x-forwarded-host`][3] headers.

[1]: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html#x-forwarded-port
[2]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
[3]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
  - It looks like tests for `adapter-node` have been broken and disabled since https://github.com/sveltejs/kit/commit/ecb423b54d459be8c0693c723799be4171369afd, see https://github.com/sveltejs/kit/blob/336d8ae9266112b2ae938099c2443b0cec0281ea/packages/adapter-node/package.json#L29

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
  - `pnpm test` is failing for me on the `master` branch, but I don't think this is necessary, since `adapter-node` doesn't currently have any tests. I have linted and checked my changes.

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
