### PR TITLE
resolve relative cookie paths before storing

### DIFF
--- a/.changeset/eighty-files-sell.md
+++ b/.changeset/eighty-files-sell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: resolve relative cookie paths before storing

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -23,7 +23,7 @@ const MAX_COOKIE_SIZE = 4129;
 function deprecate_missing_path(opts, method) {
 	if (opts.path === undefined) {
 		warn_with_callsite(
-			`Calling \`cookies.${method}}(...)\` without specifying a \`path\` is deprecated, and will be disallowed in SvelteKit 2.0. Relative paths can be used`,
+			`Calling \`cookies.${method}(...)\` without specifying a \`path\` is deprecated, and will be disallowed in SvelteKit 2.0. Relative paths can be used`,
 			1
 		);
 	}
@@ -152,7 +152,7 @@ export function get_cookies(request, url, trailing_slash) {
 		 * @param {string} value
 		 * @param {import('cookie').CookieSerializeOptions} opts
 		 */
-		serialize(name, value, opts) {
+		serialize(name, value, opts = {}) {
 			deprecate_missing_path(opts, 'serialize');
 
 			return serialize(name, value, {

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -204,7 +204,7 @@ export function get_cookies(request, url, trailing_slash) {
 	function set_internal(name, value, opts) {
 		let path = opts.path;
 
-		if (domain_matches(url.hostname, opts.domain)) {
+		if (!opts.domain || opts.domain === url.hostname) {
 			if (path) {
 				if (path[0] === '.') path = resolve(url.pathname, path);
 			} else {

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -230,8 +230,10 @@ export function get_cookies(request, url, trailing_slash) {
 			cookie_paths[name] ??= new Set();
 
 			if (!value) {
+				// @ts-expect-error temporary
 				cookie_paths[name].delete(path);
 			} else {
+				// @ts-expect-error temporary
 				cookie_paths[name].add(path);
 			}
 		}


### PR DESCRIPTION
per https://github.com/sveltejs/kit/issues/9299#issuecomment-1848596296, this resolve relative (same-domain) cookie paths before storing them locally. It doesn't affect the behaviour of cookies in the browser, but means that if you do this...

```js
cookies.set('a', 'b', { path: '.' });
console.log(cookies.get('a'));
```

...it will correctly log `b` instead of trying to retrieve the cookie from headers. Super niche bug that AFAIK no-one has hit, but now that we're explicitly recommending that people use relative paths, it makes sense to fix it.

Tested locally, didn't add one to this PR because it's covered in `version-2`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
