### PR TITLE
fix: actions wrong return 415

### DIFF
--- a/.changeset/honest-terms-help.md
+++ b/.changeset/honest-terms-help.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly return 415 when unexpected content types are submitted to actions

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -220,7 +220,8 @@ async function call_action(event, actions) {
 	}
 
 	if (!is_form_content_type(event.request)) {
-		throw new Error(
+		throw error(
+			415,
 			`Actions expect form-encoded data (received ${event.request.headers.get('content-type')})`
 		);
 	}

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1220,6 +1220,21 @@ test.describe('Actions', () => {
 
 		await expect(page.locator('pre')).toHaveText('something went wrong');
 	});
+
+	test('submitting application/json should return http status code 415', async ({ baseURL }) => {
+		const response = await fetch(`${baseURL}/actions/form-errors`, {
+			method: 'POST',
+			body: JSON.stringify({ foo: 'bar' }),
+			headers: {
+				'Content-Type': 'application/json',
+				Origin: `${baseURL}`
+			}
+		});
+		const { type, error } = await response.json();
+		expect(type).toBe('error');
+		expect(error.message).toBe('Actions expect form-encoded data (received application/json)');
+		expect(response.status).toBe(415);
+	});
 });
 
 // Run in serial to not pollute the log with (correct) cookie warnings


### PR DESCRIPTION
per [discussion 11248](https://github.com/sveltejs/kit/discussions/11248), this PR adds a fix so HTTP status code 415 "Unsupported Media Type" is returned (instead of 500).

The problem with returning 500 is that it's the wrong error message and not something that should be reported to for example Sentry.

fixes #11251

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
