### PR TITLE
chore: fix cookie migration hints, and also disable them

### DIFF
--- a/packages/migrate/migrations/routes/migrate_page_js/index.spec.js
+++ b/packages/migrate/migrations/routes/migrate_page_js/index.spec.js
@@ -1,8 +1,8 @@
 import { assert, test } from 'vitest';
-import { read_samples } from '../utils.js';
 import { migrate_page } from './index.js';
+import { read_samples } from '../../../utils.js';
 
-for (const sample of read_samples(import.meta.url)) {
+for (const sample of read_samples(new URL('./samples.md', import.meta.url))) {
 	test(sample.description, () => {
 		const actual = migrate_page(sample.before, sample.filename ?? '+page.js');
 		assert.equal(actual, sample.after);

--- a/packages/migrate/migrations/routes/migrate_page_server/index.spec.js
+++ b/packages/migrate/migrations/routes/migrate_page_server/index.spec.js
@@ -1,8 +1,8 @@
 import { assert, test } from 'vitest';
-import { read_samples } from '../utils.js';
 import { migrate_page_server } from './index.js';
+import { read_samples } from '../../../utils.js';
 
-for (const sample of read_samples(import.meta.url)) {
+for (const sample of read_samples(new URL('./samples.md', import.meta.url))) {
 	test(sample.description, () => {
 		const actual = migrate_page_server(sample.before, sample.filename ?? '+page.server.js');
 		assert.equal(actual, sample.after);

--- a/packages/migrate/migrations/routes/migrate_scripts/index.spec.js
+++ b/packages/migrate/migrations/routes/migrate_scripts/index.spec.js
@@ -1,8 +1,8 @@
 import { assert, test } from 'vitest';
-import { read_samples } from '../utils.js';
 import { migrate_scripts } from './index.js';
+import { read_samples } from '../../../utils.js';
 
-for (const sample of read_samples(import.meta.url)) {
+for (const sample of read_samples(new URL('./samples.md', import.meta.url))) {
 	test(sample.description, () => {
 		const actual = migrate_scripts(
 			sample.before,

--- a/packages/migrate/migrations/routes/migrate_server/index.spec.js
+++ b/packages/migrate/migrations/routes/migrate_server/index.spec.js
@@ -1,8 +1,8 @@
 import { assert, test } from 'vitest';
-import { read_samples } from '../utils.js';
 import { migrate_server } from './index.js';
+import { read_samples } from '../../../utils.js';
 
-for (const sample of read_samples(import.meta.url)) {
+for (const sample of read_samples(new URL('./samples.md', import.meta.url))) {
 	test(sample.description, () => {
 		const actual = migrate_server(sample.before);
 		assert.equal(actual, sample.after);

--- a/packages/migrate/migrations/routes/utils.js
+++ b/packages/migrate/migrations/routes/utils.js
@@ -308,35 +308,6 @@ export function parse(content) {
 	}
 }
 
-/** @param {string} test_file */
-export function read_samples(test_file) {
-	const markdown = fs.readFileSync(new URL('./samples.md', test_file), 'utf8');
-	const samples = markdown
-		.split(/^##/gm)
-		.slice(1)
-		.map((block) => {
-			const description = block.split('\n')[0];
-			const before = /```(js|ts|svelte) before\n([^]*?)\n```/.exec(block);
-			const after = /```(js|ts|svelte) after\n([^]*?)\n```/.exec(block);
-
-			const match = /> file: (.+)/.exec(block);
-
-			return {
-				description,
-				before: before ? before[2] : '',
-				after: after ? after[2] : '',
-				filename: match?.[1],
-				solo: block.includes('> solo')
-			};
-		});
-
-	if (samples.some((sample) => sample.solo)) {
-		return samples.filter((sample) => sample.solo);
-	}
-
-	return samples;
-}
-
 /**
  * @param {ts.Node} node
  * @param {MagicString} code

--- a/packages/migrate/migrations/routes/utils.js
+++ b/packages/migrate/migrations/routes/utils.js
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import ts from 'typescript';
 import MagicString from 'magic-string';
 import { comment, indent_at_line } from '../../utils.js';

--- a/packages/migrate/migrations/sveltekit-2/migrate.js
+++ b/packages/migrate/migrations/sveltekit-2/migrate.js
@@ -173,11 +173,6 @@ function add_cookie_note(file_path, source) {
 			continue;
 		}
 
-		const expression_text = expression.getExpression().getText();
-		if (expression_text !== 'cookies') {
-			continue;
-		}
-
 		const parent_function = call.getFirstAncestor(
 			/** @returns {ancestor is import('ts-morph').FunctionDeclaration | import('ts-morph').FunctionExpression | import('ts-morph').ArrowFunction} */
 			(ancestor) => {
@@ -189,6 +184,15 @@ function add_cookie_note(file_path, source) {
 			}
 		);
 		if (!parent_function) {
+			continue;
+		}
+
+		const expression_text = expression.getExpression().getText();
+		if (
+			expression_text !== 'cookies' &&
+			(!expression_text.includes('.') ||
+				!parent_function.getParameter(expression_text.split('.')[0]))
+		) {
 			continue;
 		}
 

--- a/packages/migrate/migrations/sveltekit-2/migrate.js
+++ b/packages/migrate/migrations/sveltekit-2/migrate.js
@@ -92,7 +92,8 @@ export function transform_code(code, _is_ts, file_path) {
 	const project = new Project({ useInMemoryFileSystem: true });
 	const source = project.createSourceFile('svelte.ts', code);
 	remove_throws(source);
-	add_cookie_note(file_path, source);
+	// TODO fix the crazy indentation before reinstating this
+	// add_cookie_note(file_path, source);
 	return source.getFullText();
 }
 
@@ -132,9 +133,6 @@ function remove_throws(source) {
  * @param {import('ts-morph').SourceFile} source
  */
 function add_cookie_note(file_path, source) {
-	// TODO fix the crazy indentation before reinstating this
-	return;
-
 	const basename = path.basename(file_path);
 	if (
 		basename !== '+page.js' &&

--- a/packages/migrate/migrations/sveltekit-2/migrate.js
+++ b/packages/migrate/migrations/sveltekit-2/migrate.js
@@ -88,6 +88,7 @@ export function update_svelte_config_content(code) {
  * @param {boolean} _is_ts
  * @param {string} file_path
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function transform_code(code, _is_ts, file_path) {
 	const project = new Project({ useInMemoryFileSystem: true });
 	const source = project.createSourceFile('svelte.ts', code);
@@ -132,6 +133,7 @@ function remove_throws(source) {
  * @param {string} file_path
  * @param {import('ts-morph').SourceFile} source
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function add_cookie_note(file_path, source) {
 	const basename = path.basename(file_path);
 	if (

--- a/packages/migrate/migrations/sveltekit-2/migrate.spec.js
+++ b/packages/migrate/migrations/sveltekit-2/migrate.spec.js
@@ -59,7 +59,7 @@ error();`
 	);
 });
 
-test.skip('Notes cookies#1', () => {
+test('Notes cookies#1', () => {
 	const result = transform_code(
 		`
 export function load({ cookies }) {
@@ -73,12 +73,32 @@ export function load({ cookies }) {
 
 		`
 export function load({ cookies }) {
-	/* @migration task: add path argument */cookies.set('foo', 'bar');
+	/* @migration task: add path argument */ cookies.set('foo', 'bar');
 }`
 	);
 });
 
-test.skip('Notes cookies#2', () => {
+test('Notes cookies#2', () => {
+	const result = transform_code(
+		`
+export function load({ cookies }) {
+	cookies.delete('foo');
+	cookies.set('x', 'y', { z: '' });
+}`,
+		false,
+		'+page.js'
+	);
+	assert.equal(
+		result,
+		`
+export function load({ cookies }) {
+	/* @migration task: add path argument */ cookies.delete('foo');
+	/* @migration task: add path argument */ cookies.set('x', 'y', { z: '' });
+}`
+	);
+});
+
+test('Notes cookies#3', () => {
 	const result = transform_code(
 		`
 export function load({ cookies }) {

--- a/packages/migrate/migrations/sveltekit-2/migrate.spec.js
+++ b/packages/migrate/migrations/sveltekit-2/migrate.spec.js
@@ -8,7 +8,7 @@ import {
 test('Removes throws#1', () => {
 	const result = transform_code(
 		`import { redirect, error } from '@sveltejs/kit';
-        
+
 throw redirect();
 redirect();
 throw error();
@@ -24,7 +24,7 @@ function x() {
 		result,
 
 		`import { redirect, error } from '@sveltejs/kit';
-        
+
 redirect();
 redirect();
 error();
@@ -39,7 +39,7 @@ function x() {
 test('Removes throws#2', () => {
 	const result = transform_code(
 		`import { redirect, error } from 'somewhere-else';
-        
+
 throw redirect();
 redirect();
 throw error();
@@ -51,7 +51,7 @@ error();`,
 		result,
 
 		`import { redirect, error } from 'somewhere-else';
-        
+
 throw redirect();
 redirect();
 throw error();
@@ -59,7 +59,7 @@ error();`
 	);
 });
 
-test('Notes cookies#1', () => {
+test.skip('Notes cookies#1', () => {
 	const result = transform_code(
 		`
 export function load({ cookies }) {
@@ -78,7 +78,7 @@ export function load({ cookies }) {
 	);
 });
 
-test('Notes cookies#2', () => {
+test.skip('Notes cookies#2', () => {
 	const result = transform_code(
 		`
 export function load({ cookies }) {

--- a/packages/migrate/migrations/sveltekit-2/migrate.spec.js
+++ b/packages/migrate/migrations/sveltekit-2/migrate.spec.js
@@ -101,6 +101,24 @@ export function load({ cookies }) {
 test('Notes cookies#3', () => {
 	const result = transform_code(
 		`
+export function load(event) {
+	event.cookies.set('x', 'y');
+}`,
+		false,
+		'+page.js'
+	);
+	assert.equal(
+		result,
+		`
+export function load(event) {
+	/* @migration task: add path argument */ event.cookies.set('x', 'y');
+}`
+	);
+});
+
+test('Notes cookies#4', () => {
+	const result = transform_code(
+		`
 export function load({ cookies }) {
 	cookies.set('foo', 'bar', { path: '/' });
 }`,

--- a/packages/migrate/migrations/sveltekit-2/migrate.spec.js
+++ b/packages/migrate/migrations/sveltekit-2/migrate.spec.js
@@ -4,195 +4,29 @@ import {
 	update_svelte_config_content,
 	update_tsconfig_content
 } from './migrate.js';
+import { read_samples } from '../../utils.js';
 
-test('Removes throws#1', () => {
-	const result = transform_code(
-		`import { redirect, error } from '@sveltejs/kit';
+for (const sample of read_samples(new URL('./svelte-config-samples.md', import.meta.url))) {
+	test('svelte.config.js: ' + sample.description, () => {
+		const actual = update_svelte_config_content(sample.before);
+		assert.equal(actual, sample.after);
+	});
+}
 
-throw redirect();
-redirect();
-throw error();
-error();
-function x() {
-	let redirect = true;
-	throw redirect();
-}`,
-		false,
-		''
-	);
-	assert.equal(
-		result,
+for (const sample of read_samples(new URL('./tsconfig-samples.md', import.meta.url))) {
+	test('tsconfig.json: ' + sample.description, () => {
+		const actual = update_tsconfig_content(sample.before);
+		assert.equal(actual, sample.after);
+	});
+}
 
-		`import { redirect, error } from '@sveltejs/kit';
-
-redirect();
-redirect();
-error();
-error();
-function x() {
-	let redirect = true;
-	throw redirect();
-}`
-	);
-});
-
-test('Removes throws#2', () => {
-	const result = transform_code(
-		`import { redirect, error } from 'somewhere-else';
-
-throw redirect();
-redirect();
-throw error();
-error();`,
-		false,
-		''
-	);
-	assert.equal(
-		result,
-
-		`import { redirect, error } from 'somewhere-else';
-
-throw redirect();
-redirect();
-throw error();
-error();`
-	);
-});
-
-test('Notes cookies#1', () => {
-	const result = transform_code(
-		`
-export function load({ cookies }) {
-	cookies.set('foo', 'bar');
-}`,
-		false,
-		'+page.js'
-	);
-	assert.equal(
-		result,
-
-		`
-export function load({ cookies }) {
-	/* @migration task: add path argument */ cookies.set('foo', 'bar');
-}`
-	);
-});
-
-test('Notes cookies#2', () => {
-	const result = transform_code(
-		`
-export function load({ cookies }) {
-	cookies.delete('foo');
-	cookies.set('x', 'y', { z: '' });
-}`,
-		false,
-		'+page.js'
-	);
-	assert.equal(
-		result,
-		`
-export function load({ cookies }) {
-	/* @migration task: add path argument */ cookies.delete('foo');
-	/* @migration task: add path argument */ cookies.set('x', 'y', { z: '' });
-}`
-	);
-});
-
-test('Notes cookies#3', () => {
-	const result = transform_code(
-		`
-export function load(event) {
-	event.cookies.set('x', 'y');
-}`,
-		false,
-		'+page.js'
-	);
-	assert.equal(
-		result,
-		`
-export function load(event) {
-	/* @migration task: add path argument */ event.cookies.set('x', 'y');
-}`
-	);
-});
-
-test('Notes cookies#4', () => {
-	const result = transform_code(
-		`
-export function load({ cookies }) {
-	cookies.set('foo', 'bar', { path: '/' });
-}`,
-		false,
-		'+page.js'
-	);
-	assert.equal(
-		result,
-
-		`
-export function load({ cookies }) {
-	cookies.set('foo', 'bar', { path: '/' });
-}`
-	);
-});
-
-test('Removes old tsconfig options#1', () => {
-	const result = update_tsconfig_content(
-		`{
-	"extends": "./.svelte-kit/tsconfig.json",
-	"compilerOptions": {
-		"importsNotUsedAsValues": "error",
-		"preserveValueImports": true
-	}
-}`
-	);
-	assert.equal(
-		result,
-
-		`{
-	"extends": "./.svelte-kit/tsconfig.json",
-	"compilerOptions": {
-	}
-}`
-	);
-});
-
-test('Removes old tsconfig options#2', () => {
-	const result = update_tsconfig_content(
-		`{
-	"compilerOptions": {
-		"importsNotUsedAsValues": "error",
-		"preserveValueImports": true
-	}
-}`
-	);
-	assert.equal(
-		result,
-		`{
-	"compilerOptions": {
-		"importsNotUsedAsValues": "error",
-		"preserveValueImports": true
-	}
-}`
-	);
-});
-
-test('Updates svelte.config.js', () => {
-	const result = update_svelte_config_content(
-		`export default {
-			kit: {
-				foo: bar,
-				dangerZone: {
-					trackServerFetches: true
-				},
-				baz: qux
-		}`
-	);
-	assert.equal(
-		result,
-		`export default {
-			kit: {
-				foo: bar,
-				baz: qux
-		}`
-	);
-});
+for (const sample of read_samples(new URL('./tsjs-samples.md', import.meta.url))) {
+	test('JS/TS file: ' + sample.description, () => {
+		const actual = transform_code(
+			sample.before,
+			sample.filename?.endsWith('.ts') ?? false,
+			sample.filename ?? '+page.js'
+		);
+		assert.equal(actual, sample.after);
+	});
+}

--- a/packages/migrate/migrations/sveltekit-2/svelte-config-samples.md
+++ b/packages/migrate/migrations/sveltekit-2/svelte-config-samples.md
@@ -1,0 +1,44 @@
+## Removes dangerZone (1)
+
+```js before
+export default {
+	kit: {
+		foo: bar,
+		dangerZone: {
+			trackServerFetches: true
+		},
+		baz: qux
+	}
+};
+```
+
+```js after
+export default {
+	kit: {
+		foo: bar,
+		baz: qux
+	}
+};
+```
+
+## Removes dangerZone (2)
+
+```js before
+export default {
+	kit: {
+		foo: bar,
+		dangerZone: {
+			trackServerFetches: true
+		}
+	}
+};
+```
+
+<!-- prettier-ignore -->
+```js after
+export default {
+	kit: {
+		foo: bar,
+	}
+};
+```

--- a/packages/migrate/migrations/sveltekit-2/tsconfig-samples.md
+++ b/packages/migrate/migrations/sveltekit-2/tsconfig-samples.md
@@ -1,0 +1,40 @@
+## Removes importsNotUsedAsValues/preserveValueImports
+
+```json before
+{
+	"extends": "./.svelte-kit/tsconfig.json",
+	"compilerOptions": {
+		"importsNotUsedAsValues": "error",
+		"preserveValueImports": true
+	}
+}
+```
+
+<!-- prettier-ignore -->
+```json after
+{
+	"extends": "./.svelte-kit/tsconfig.json",
+	"compilerOptions": {
+	}
+}
+```
+
+## Leaves tsconfig alone
+
+```json before
+{
+	"compilerOptions": {
+		"importsNotUsedAsValues": "error",
+		"preserveValueImports": true
+	}
+}
+```
+
+```json after
+{
+	"compilerOptions": {
+		"importsNotUsedAsValues": "error",
+		"preserveValueImports": true
+	}
+}
+```

--- a/packages/migrate/migrations/sveltekit-2/tsjs-samples.md
+++ b/packages/migrate/migrations/sveltekit-2/tsjs-samples.md
@@ -1,0 +1,117 @@
+## Removes throws
+
+```js before
+import { redirect, error } from '@sveltejs/kit';
+
+throw redirect();
+redirect();
+throw error();
+error();
+function x() {
+	let redirect = true;
+	throw redirect();
+}
+```
+
+```js after
+import { redirect, error } from '@sveltejs/kit';
+
+redirect();
+redirect();
+error();
+error();
+function x() {
+	let redirect = true;
+	throw redirect();
+}
+```
+
+## Leaves redirect/error from other sources alone
+
+```js before
+import { redirect, error } from 'somewhere-else';
+
+throw redirect();
+redirect();
+throw error();
+error();
+```
+
+```js after
+import { redirect, error } from 'somewhere-else';
+
+throw redirect();
+redirect();
+throw error();
+error();
+```
+
+## Notes cookie migration
+
+```js before
+export function load({ cookies }) {
+	cookies.set('foo', 'bar');
+}
+```
+
+```js after
+export function load({ cookies }) {
+	/* @migration task: add path argument */ cookies.set('foo', 'bar');
+}
+```
+
+## Notes cookie migration with multiple occurences
+
+```js before
+export function load({ cookies }) {
+	cookies.delete('foo');
+	cookies.set('x', 'y', { z: '' });
+}
+```
+
+```js after
+export function load({ cookies }) {
+	/* @migration task: add path argument */ cookies.delete('foo');
+	/* @migration task: add path argument */ cookies.set('x', 'y', { z: '' });
+}
+```
+
+## Handles non-destructured argument
+
+```js before
+export function load(event) {
+	event.cookies.set('x', 'y');
+}
+```
+
+```js after
+export function load(event) {
+	/* @migration task: add path argument */ event.cookies.set('x', 'y');
+}
+```
+
+## Recognizes false positives
+
+```js before
+export function load({ cookies }) {
+	cookies.set('foo', 'bar', { path: '/' });
+}
+
+export function foo(event) {
+	x.cookies.set('foo', 'bar');
+}
+
+cookies.set('foo', 'bar');
+```
+
+```js after
+export function load({ cookies }) {
+	cookies.set('foo', 'bar', { path: '/' });
+}
+
+export function foo(event) {
+	x.cookies.set('foo', 'bar');
+}
+
+cookies.set('foo', 'bar');
+```

--- a/packages/migrate/utils.js
+++ b/packages/migrate/utils.js
@@ -313,3 +313,32 @@ export function update_js_file(file_path, transform_code) {
 		console.error(`Error updating ${file_path}:`, e);
 	}
 }
+
+/** @param {string | URL} test_file */
+export function read_samples(test_file) {
+	const markdown = fs.readFileSync(test_file, 'utf8').replaceAll('\r\n', '\n');
+	const samples = markdown
+		.split(/^##/gm)
+		.slice(1)
+		.map((block) => {
+			const description = block.split('\n')[0];
+			const before = /```(js|ts|svelte) before\n([^]*?)\n```/.exec(block);
+			const after = /```(js|ts|svelte) after\n([^]*?)\n```/.exec(block);
+
+			const match = /> file: (.+)/.exec(block);
+
+			return {
+				description,
+				before: before ? before[2] : '',
+				after: after ? after[2] : '',
+				filename: match?.[1],
+				solo: block.includes('> solo')
+			};
+		});
+
+	if (samples.some((sample) => sample.solo)) {
+		return samples.filter((sample) => sample.solo);
+	}
+
+	return samples;
+}


### PR DESCRIPTION
The cookie migration hints added in #11199 were broken — they didn't change anything in the SvelteKit demo app, because the ancestor check only cared about arrow function expressions that were assigned to a variable. Fixing the ancestor check revealed a separate bug — we need to batch up the changes, otherwise we get an error like this:

> InvalidOperationError: Attempted to get information from a node that was removed or forgotten.

By collecting the nodes that need to be commented first, and _then_ commenting them, the operation succeeds, but it leaves us with stupid-looking whitespace that's inconsistent with the surroundings:

<img width="598" alt="image" src="https://github.com/sveltejs/kit/assets/1162160/858840ba-3c9b-4ad1-9a8f-856d0c04aea6">

If we can fix that, great, otherwise I really think we're better off relying on the combination of type and runtime errors here. It's just not worth it.