### PR TITLE
generate __data.json files as siblings of .html files

### DIFF
--- a/.changeset/happy-beds-run.md
+++ b/.changeset/happy-beds-run.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: generate `__data.json` files as sibling to `.html` files

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -1,5 +1,5 @@
 import { parse, serialize } from 'cookie';
-import { normalize_path, resolve } from '../../utils/url.js';
+import { add_data_suffix, normalize_path, resolve } from '../../utils/url.js';
 
 /**
  * Tracks all cookies set during dev mode so we can emit warnings
@@ -245,6 +245,14 @@ export function add_cookies_to_headers(headers, cookies) {
 	for (const new_cookie of cookies) {
 		const { name, value, options } = new_cookie;
 		headers.append('set-cookie', serialize(name, value, options));
+
+		// special case — for routes ending with .html, the route data lives in a sibling
+		// `.html__data.json` file rather than a child `/__data.json` file, which means
+		// we need to duplicate the cookie
+		if (options.path.endsWith('.html')) {
+			const path = add_data_suffix(options.path);
+			headers.append('set-cookie', serialize(name, value, { ...options, path }));
+		}
 	}
 }
 

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -78,7 +78,7 @@ export async function render_page(event, page, options, manifest, state, resolve
 
 		// it's crucial that we do this before returning the non-SSR response, otherwise
 		// SvelteKit will erroneously believe that the path has been prerendered,
-		// causing functions to be omitted from the manifesst generated later
+		// causing functions to be omitted from the manifest generated later
 		const should_prerender = get_option(nodes, 'prerender') ?? false;
 		if (should_prerender) {
 			const mod = leaf_node.server;

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -208,18 +208,24 @@ function allow_nodejs_console_log(url) {
 }
 
 const DATA_SUFFIX = '/__data.json';
+const HTML_DATA_SUFFIX = '.html__data.json';
 
 /** @param {string} pathname */
 export function has_data_suffix(pathname) {
-	return pathname.endsWith(DATA_SUFFIX);
+	return pathname.endsWith(DATA_SUFFIX) || pathname.endsWith(HTML_DATA_SUFFIX);
 }
 
 /** @param {string} pathname */
 export function add_data_suffix(pathname) {
+	if (pathname.endsWith('.html')) return pathname.replace(/\.html$/, HTML_DATA_SUFFIX);
 	return pathname.replace(/\/$/, '') + DATA_SUFFIX;
 }
 
 /** @param {string} pathname */
 export function strip_data_suffix(pathname) {
+	if (pathname.endsWith(HTML_DATA_SUFFIX)) {
+		return pathname.slice(0, -HTML_DATA_SUFFIX.length) + '.html';
+	}
+
 	return pathname.slice(0, -DATA_SUFFIX.length);
 }

--- a/packages/kit/test/prerendering/basics/src/routes/page.html/+page.server.js
+++ b/packages/kit/test/prerendering/basics/src/routes/page.html/+page.server.js
@@ -1,0 +1,5 @@
+export function load() {
+	return {
+		message: 'hello'
+	};
+}

--- a/packages/kit/test/prerendering/basics/src/routes/page.html/+page.svelte
+++ b/packages/kit/test/prerendering/basics/src/routes/page.html/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let data;
+</script>
+
+<h1>{data.message}</h1>


### PR DESCRIPTION
This is a possible solution to #8676. It's _technically_ breaking insofar as it clobbers any routes that happen to end with `.html__data.json`, but given how unlikely that is it's not really breaking.

It solves the problem (that you can't prerender both `foo.html` and `foo.html/__data.json`) by making the files siblings — the data is generated as `foo.html__data.json` instead. This requires no configuration changes, and very little complexity in terms of implementation — no 'is it prerendered?' or 'what do we do with cookies?' questions, just a simple 'does the route end with `.html`?' check.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
