### PR TITLE
Fix promises auto-await deprecation warning

### DIFF
--- a/packages/kit/src/utils/promises.js
+++ b/packages/kit/src/utils/promises.js
@@ -41,7 +41,7 @@ export async function unwrap_promises(object, id) {
 
 			if (!warned.has(message)) {
 				console.warn(
-					`\n${message}\n\nIn SvelteKit 2.0, these will longer be awaited automatically. To get rid of this warning, await all promises included as top-level properties in \`load\` return values.\n`
+					`\n${message}\n\nIn SvelteKit 2.0, these will no longer be awaited automatically. To get rid of this warning, await all promises included as top-level properties in \`load\` return values.\n`
 				);
 
 				warned.add(message);

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1221,8 +1221,11 @@ test.describe('Actions', () => {
 		await expect(page.locator('pre')).toHaveText('something went wrong');
 	});
 
-	test('submitting application/json should return http status code 415', async ({ baseURL }) => {
-		const response = await fetch(`${baseURL}/actions/form-errors`, {
+	test('submitting application/json should return http status code 415', async ({
+		baseURL,
+		page
+	}) => {
+		const response = await page.request.fetch(`${baseURL}/actions/form-errors`, {
 			method: 'POST',
 			body: JSON.stringify({ foo: 'bar' }),
 			headers: {
@@ -1233,7 +1236,7 @@ test.describe('Actions', () => {
 		const { type, error } = await response.json();
 		expect(type).toBe('error');
 		expect(error.message).toBe('Actions expect form-encoded data (received application/json)');
-		expect(response.status).toBe(415);
+		expect(response.status()).toBe(415);
 	});
 });
 


### PR DESCRIPTION
Hey everyone, I know "simple typo" PRs aren't super-popular, but this irked me and I wanted to un-irk it.

Changes the following message

> In SvelteKit 2.0, these will longer be awaited automatically.

to

> In SvelteKit 2.0, these will no longer be awaited automatically.

(adds a missing `no`.)

Thanks!

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
