### PR TITLE
chore: better cookie migration

### DIFF
--- a/documentation/docs/60-appendix/30-migrating-to-sveltekit-2.md
+++ b/documentation/docs/60-appendix/30-migrating-to-sveltekit-2.md
@@ -36,7 +36,7 @@ export function load({ cookies }) {
 }
 ```
 
-`svelte-migrate` will add comments highlighting the locations that need to be adjusted.
+`svelte-migrate` will add the `path` option automatically where possible using `'.'` as the `path` value (which reflects the previous default behavior), but it's a good opportunity to review these locations and adjust them where it makes sense.
 
 ## Top-level promises are no longer awaited
 

--- a/packages/migrate/migrations/sveltekit-2/migrate.js
+++ b/packages/migrate/migrations/sveltekit-2/migrate.js
@@ -208,7 +208,7 @@ function add_cookie_note(file_path, source) {
 				// Additional hoop-jumping necessary to not mix tabs and spaces
 				options_arg.addPropertyAssignment({
 					name: 'path',
-					initializer: `'.'`,
+					initializer: "'.'",
 					leadingTrivia: (writer) => {
 						writer.setIndentationLevel(0);
 					},
@@ -219,7 +219,7 @@ function add_cookie_note(file_path, source) {
 				call.formatText({ convertTabsToSpaces: !indent.includes('\t') });
 			});
 		} else {
-			calls.push(() => call.insertArguments(name === 'delete' ? 1 : 2, [`{ path: '.' }`]));
+			calls.push(() => call.insertArguments(name === 'delete' ? 1 : 2, ["{ path: '.' }"]));
 		}
 	}
 

--- a/packages/migrate/migrations/sveltekit-2/tsjs-samples.md
+++ b/packages/migrate/migrations/sveltekit-2/tsjs-samples.md
@@ -46,33 +46,33 @@ throw error();
 error();
 ```
 
-## Notes cookie migration
+## Migrates cookies
 
 ```js before
 export function load({ cookies }) {
-	cookies.set('foo', 'bar');
-}
-```
-
-```js after
-export function load({ cookies }) {
-	/* @migration task: add path argument */ cookies.set('foo', 'bar');
-}
-```
-
-## Notes cookie migration with multiple occurences
-
-```js before
-export function load({ cookies }) {
-	cookies.delete('foo');
+	cookies.delete('x');
 	cookies.set('x', 'y', { z: '' });
+	cookies.serialize('x', 'y', {});
+	cookies.set('x', 'y', {
+		z: ''
+	});
 }
 ```
 
 ```js after
 export function load({ cookies }) {
-	/* @migration task: add path argument */ cookies.delete('foo');
-	/* @migration task: add path argument */ cookies.set('x', 'y', { z: '' });
+	cookies.delete('x', { path: '.' });
+	cookies.set('x', 'y', {
+		z: '',
+		path: '.'
+	});
+	cookies.serialize('x', 'y', {
+		path: '.'
+	});
+	cookies.set('x', 'y', {
+		z: '',
+		path: '.'
+	});
 }
 ```
 
@@ -81,12 +81,17 @@ export function load({ cookies }) {
 ```js before
 export function load(event) {
 	event.cookies.set('x', 'y');
+	event.cookies.delete('x', { x: '' });
 }
 ```
 
 ```js after
 export function load(event) {
-	/* @migration task: add path argument */ event.cookies.set('x', 'y');
+	event.cookies.set('x', 'y', { path: '.' });
+	event.cookies.delete('x', {
+		x: '',
+		path: '.'
+	});
 }
 ```
 


### PR DESCRIPTION
`'.'` is equivalent to the current default behavior, therefore use that instead of just adding a comment
