### PR TITLE
breaking: fix path resolution

### DIFF
--- a/.changeset/twelve-paws-remember.md
+++ b/.changeset/twelve-paws-remember.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: fix path resolution

--- a/packages/kit/src/core/postbuild/fixtures/base/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/base/output.json
@@ -2,7 +2,7 @@
 	"hrefs": [
 		"/base-path/styles.css",
 		"/base-path/favicon.png",
-		"https://external.com",
+		"https://external.com/",
 		"/base-path/wheee",
 		"/base-path/wheee2",
 		"/base-path/wheee3",

--- a/packages/kit/src/core/postbuild/fixtures/basic-href/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/basic-href/output.json
@@ -2,7 +2,7 @@
 	"hrefs": [
 		"/styles.css",
 		"/favicon.png",
-		"https://external.com",
+		"https://external.com/",
 		"/wheee",
 		"/wheee2",
 		"/wheee3",

--- a/packages/kit/src/core/postbuild/fixtures/href-with-character-reference/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/href-with-character-reference/output.json
@@ -3,9 +3,9 @@
 		"/styles.css",
 		"/favicon.png",
 		"/test&ampersand",
-		"/test\"quotation",
-		"/test♡decimal",
-		"/test♥hex"
+		"/test%22quotation",
+		"/test%E2%99%A1decimal",
+		"/test%E2%99%A5hex"
 	],
 	"ids": []
 }

--- a/packages/kit/src/core/postbuild/fixtures/ids/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/ids/output.json
@@ -1,4 +1,10 @@
 {
-	"hrefs": ["/#encöded"],
-	"ids": ["before", "after", "encöded"]
+	"hrefs": [
+		"/#enc%C3%B6ded"
+	],
+	"ids": [
+		"before",
+		"after",
+		"encöded"
+	]
 }

--- a/packages/kit/src/core/postbuild/fixtures/ids/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/ids/output.json
@@ -1,10 +1,4 @@
 {
-	"hrefs": [
-		"/#enc%C3%B6ded"
-	],
-	"ids": [
-		"before",
-		"after",
-		"encöded"
-	]
+	"hrefs": ["/#enc%C3%B6ded"],
+	"ids": ["before", "after", "encöded"]
 }

--- a/packages/kit/src/core/postbuild/fixtures/include-rel-external/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/include-rel-external/output.json
@@ -1,8 +1,4 @@
 {
-	"hrefs": [
-		"/styles.css",
-		"/favicon.png",
-		"https://external.com/"
-	],
+	"hrefs": ["/styles.css", "/favicon.png", "https://external.com/"],
 	"ids": []
 }

--- a/packages/kit/src/core/postbuild/fixtures/include-rel-external/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/include-rel-external/output.json
@@ -1,4 +1,8 @@
 {
-	"hrefs": ["/styles.css", "/favicon.png", "https://external.com"],
+	"hrefs": [
+		"/styles.css",
+		"/favicon.png",
+		"https://external.com/"
+	],
 	"ids": []
 }

--- a/packages/kit/src/core/postbuild/fixtures/meta/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/meta/output.json
@@ -1,4 +1,9 @@
 {
-	"hrefs": ["https://external.com", "/og-image.jpg", "https://example.com/audio.mp3", "/video.mp4"],
+	"hrefs": [
+		"https://external.com/",
+		"/og-image.jpg",
+		"https://example.com/audio.mp3",
+		"/video.mp4"
+	],
 	"ids": []
 }

--- a/packages/kit/src/core/postbuild/fixtures/unquoted-attributes/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/unquoted-attributes/output.json
@@ -1,9 +1,4 @@
 {
-	"hrefs": [
-		"/styles.css",
-		"/favicon.png",
-		"https://external.com/",
-		"/wheee"
-	],
+	"hrefs": ["/styles.css", "/favicon.png", "https://external.com/", "/wheee"],
 	"ids": []
 }

--- a/packages/kit/src/core/postbuild/fixtures/unquoted-attributes/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/unquoted-attributes/output.json
@@ -1,4 +1,9 @@
 {
-	"hrefs": ["/styles.css", "/favicon.png", "https://external.com", "/wheee"],
+	"hrefs": [
+		"/styles.css",
+		"/favicon.png",
+		"https://external.com/",
+		"/wheee"
+	],
 	"ids": []
 }

--- a/packages/kit/src/utils/url.spec.js
+++ b/packages/kit/src/utils/url.spec.js
@@ -61,6 +61,10 @@ describe('resolve', (test) => {
 	test('resolves empty string', () => {
 		assert.equal(resolve('/a/b/c', ''), '/a/b/c');
 	});
+
+	test('resolves .', () => {
+		assert.equal(resolve('/a/b/c', '.'), '/a/b/');
+	});
 });
 
 describe('normalize_path', (test) => {

--- a/packages/kit/test/apps/basics/src/routes/cookies/encoding/set/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/cookies/encoding/set/+server.js
@@ -3,6 +3,6 @@ import { redirect } from '@sveltejs/kit';
 /** @type {import('@sveltejs/kit').RequestHandler} */
 export const GET = (event) => {
 	const needsEncoding = 'teapot, jane austen';
-	event.cookies.set('encoding', needsEncoding, { path: '.' });
+	event.cookies.set('encoding', needsEncoding, { path: '/cookies/encoding' });
 	redirect(303, '/cookies/encoding');
 };


### PR DESCRIPTION
Our `resolve` utility was returning incorrect results in the case where `path` was just a `.` character, leading to confusion such as https://github.com/sveltejs/kit/pull/11273#issuecomment-1852182542.

This implementation delegates to `new URL(...)`, so it's more or less guaranteed to be correct whatever edge cases we throw at it

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
