### PR TITLE
fix: action not found should return 404

### DIFF
--- a/.changeset/warm-sloths-cry.md
+++ b/.changeset/warm-sloths-cry.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly return 404 when a form action is not found

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -216,7 +216,7 @@ async function call_action(event, actions) {
 
 	const action = actions[name];
 	if (!action) {
-		throw new Error(`No action with name '${name}' found`);
+		throw error(404, `No action with name '${name}' found`);
 	}
 
 	if (!is_form_content_type(event.request)) {

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1238,18 +1238,15 @@ test.describe('Actions', () => {
 		expect(error.message).toBe('Actions expect form-encoded data (received application/json)');
 		expect(response.status()).toBe(415);
 	});
+
 	test('submitting to a form action that does not exists, should return http status code 404', async ({
 		baseURL,
 		page
 	}) => {
 		const randomActionName = 'some-random-action';
-
-		const body = new FormData();
-		body.append('foo', 'bar');
-
 		const response = await page.request.fetch(`${baseURL}/actions/enhance?/${randomActionName}`, {
 			method: 'POST',
-			body,
+			body: 'irrelevant',
 			headers: {
 				Origin: `${baseURL}`
 			}

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1238,6 +1238,27 @@ test.describe('Actions', () => {
 		expect(error.message).toBe('Actions expect form-encoded data (received application/json)');
 		expect(response.status()).toBe(415);
 	});
+	test('submitting to a form action that does not exists, should return http status code 404', async ({
+		baseURL,
+		page
+	}) => {
+		const randomActionName = 'some-random-action';
+
+		const body = new FormData();
+		body.append('foo', 'bar');
+
+		const response = await page.request.fetch(`${baseURL}/actions/enhance?/${randomActionName}`, {
+			method: 'POST',
+			body,
+			headers: {
+				Origin: `${baseURL}`
+			}
+		});
+		const { type, error } = await response.json();
+		expect(type).toBe('error');
+		expect(error.message).toBe(`No action with name '${randomActionName}' found`);
+		expect(response.status()).toBe(404);
+	});
 });
 
 // Run in serial to not pollute the log with (correct) cookie warnings


### PR DESCRIPTION
When posting to a form action, that does not exist, the server returned 500(!)
With this fix, it will return 404 error "not found".

The problem with returning 500 is that it's the wrong error message and not something that should be reported to for example Sentry.

This is something I found, in relation to [discussion 11248](https://github.com/sveltejs/kit/discussions/11248).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
