### PR TITLE
feat: redact internal stack trace when reporting config errors

### DIFF
--- a/.changeset/smart-crabs-lick.md
+++ b/.changeset/smart-crabs-lick.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: redact internal stack trace when reporting config errors

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -72,9 +72,11 @@ export async function load_config({ cwd = process.cwd() } = {}) {
 	try {
 		return process_config(config.default, { cwd });
 	} catch (e) {
+		const error = /** @type {Error} */ (e);
+
 		// redact the stack trace — it's not helpful to users
-		e.stack = `Could not load svelte.config.js: ${e.message}\n`;
-		throw e;
+		error.stack = `Could not load svelte.config.js: ${error.message}\n`;
+		throw error;
 	}
 }
 

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -69,7 +69,13 @@ export async function load_config({ cwd = process.cwd() } = {}) {
 
 	const config = await import(`${url.pathToFileURL(config_file).href}?ts=${Date.now()}`);
 
-	return process_config(config.default, { cwd });
+	try {
+		return process_config(config.default, { cwd });
+	} catch (e) {
+		// redact the stack trace — it's not helpful to users
+		e.stack = `Could not load svelte.config.js: ${e.message}\n`;
+		throw e;
+	}
 }
 
 /**


### PR DESCRIPTION
Part of #11291. This _only_ redacts stack traces when the config is malformed — other errors will keep their stack traces

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
