### PR TITLE
breaking: remove baseUrl fallback from generated tsconfig

### DIFF
--- a/.changeset/dull-eyes-check.md
+++ b/.changeset/dull-eyes-check.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": major
+---
+
+breaking: remove baseUrl fallback from generated tsconfig

--- a/.changeset/loud-parrots-flow.md
+++ b/.changeset/loud-parrots-flow.md
@@ -1,0 +1,5 @@
+---
+"svelte-migrate": minor
+---
+
+feat: add sveltekit v2 migration

--- a/documentation/docs/60-appendix/30-migrating-to-sveltekit-2.md
+++ b/documentation/docs/60-appendix/30-migrating-to-sveltekit-2.md
@@ -123,6 +123,10 @@ In SvelteKit 1, those properties included `form` and `data`. These were deprecat
 
 If a form contains an `<input type="file">` but does not have an `enctype="multipart/form-data"` attribute, non-JS submissions will omit the file. SvelteKit 2 will throw an error if it encounters a form like this during a `use:enhance` submission to ensure that your forms work correctly when JavaScript is not present.
 
+## Generated `tsconfig.json` is more strict
+
+Previously, the generated `tsconfig.json` was trying its best to still produce a somewhat valid config when your `tsconfig.json` included `paths` or `baseUrl`. In SvelteKit 2, the validation is more strict and will warn when you use either `paths` or `baseUrl` in your `tsconfig.json`. These settings are used to generate path aliases and you should use [the `alias` config](configuration#alias) option in your `svelte.config.js` instead, to also create a corresponding alias for the bundler.
+
 ## Updated dependency requirements
 
 SvelteKit 2 requires Node `18.13` or higher, and the following minimum dependency versions:

--- a/packages/kit/src/core/sync/write_tsconfig.spec.js
+++ b/packages/kit/src/core/sync/write_tsconfig.spec.js
@@ -14,7 +14,7 @@ test('Creates tsconfig path aliases from kit.alias', () => {
 		}
 	});
 
-	const { compilerOptions } = get_tsconfig(kit, false);
+	const { compilerOptions } = get_tsconfig(kit);
 
 	// $lib isn't part of the outcome because there's a "path exists"
 	// check in the implementation
@@ -24,31 +24,6 @@ test('Creates tsconfig path aliases from kit.alias', () => {
 		key: ['../value'],
 		'key/*': ['../some/other/value/*'],
 		keyToFile: ['../path/to/file.ts']
-	});
-});
-
-test('Creates tsconfig path aliases from kit.alias with existing baseUrl', () => {
-	const { kit } = validate_config({
-		kit: {
-			alias: {
-				simpleKey: 'simple/value',
-				key: 'value',
-				'key/*': 'some/other/value/*',
-				keyToFile: 'path/to/file.ts'
-			}
-		}
-	});
-
-	const { compilerOptions } = get_tsconfig(kit, true);
-
-	// $lib isn't part of the outcome because there's a "path exists"
-	// check in the implementation
-	expect(compilerOptions.paths).toEqual({
-		simpleKey: ['simple/value'],
-		'simpleKey/*': ['simple/value/*'],
-		key: ['value'],
-		'key/*': ['some/other/value/*'],
-		keyToFile: ['path/to/file.ts']
 	});
 });
 
@@ -63,7 +38,7 @@ test('Allows generated tsconfig to be mutated', () => {
 		}
 	});
 
-	const config = get_tsconfig(kit, false);
+	const config = get_tsconfig(kit);
 
 	// @ts-expect-error
 	assert.equal(config.extends, 'some/other/tsconfig.json');
@@ -81,7 +56,7 @@ test('Allows generated tsconfig to be replaced', () => {
 		}
 	});
 
-	const config = get_tsconfig(kit, false);
+	const config = get_tsconfig(kit);
 
 	// @ts-expect-error
 	assert.equal(config.extends, 'some/other/tsconfig.json');
@@ -96,7 +71,7 @@ test('Creates tsconfig include from kit.files', () => {
 		}
 	});
 
-	const { include } = get_tsconfig(kit, false);
+	const { include } = get_tsconfig(kit);
 
 	expect(include).toEqual([
 		'ambient.d.ts',

--- a/packages/migrate/migrations/sveltekit-2/migrate.js
+++ b/packages/migrate/migrations/sveltekit-2/migrate.js
@@ -66,6 +66,12 @@ export function update_tsconfig_content(content) {
 		);
 	}
 
+	if (content.includes('"paths":') || content.includes('"baseUrl":')) {
+		log_migration(
+			'`paths` and/or `baseUrl` detected in your tsconfig.json - remove it and use `kit.alias` instead: https://kit.svelte.dev/docs/v2-migration-guide#generated-tsconfigjson-is-more-strict'
+		);
+	}
+
 	return updated;
 }
 


### PR DESCRIPTION
- don't generate baseUrl anymore and don't adjust paths anymore depending on whether or not the user has paths in their tsconfig.json
- more strict validation: warn on baseUrl/paths and suggest kit.alias instead

closes #11286

also added a changeset for `svelte-migrate` because none was generated yet.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
