### PR TITLE
fix: revert recent error changes

### DIFF
--- a/.changeset/fast-radios-tell.md
+++ b/.changeset/fast-radios-tell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: revert recent 'correctly return 415' and 'correctly return 404' changes

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -216,12 +216,11 @@ async function call_action(event, actions) {
 
 	const action = actions[name];
 	if (!action) {
-		throw error(404, `No action with name '${name}' found`);
+		throw new Error(`No action with name '${name}' found`);
 	}
 
 	if (!is_form_content_type(event.request)) {
-		throw error(
-			415,
+		throw new Error(
 			`Actions expect form-encoded data (received ${event.request.headers.get('content-type')})`
 		);
 	}

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1242,42 +1242,6 @@ test.describe('Actions', () => {
 
 		await expect(page.locator('pre')).toHaveText('something went wrong');
 	});
-
-	test('submitting application/json should return http status code 415', async ({
-		baseURL,
-		page
-	}) => {
-		const response = await page.request.fetch(`${baseURL}/actions/form-errors`, {
-			method: 'POST',
-			body: JSON.stringify({ foo: 'bar' }),
-			headers: {
-				'Content-Type': 'application/json',
-				Origin: `${baseURL}`
-			}
-		});
-		const { type, error } = await response.json();
-		expect(type).toBe('error');
-		expect(error.message).toBe('Actions expect form-encoded data (received application/json)');
-		expect(response.status()).toBe(415);
-	});
-
-	test('submitting to a form action that does not exists, should return http status code 404', async ({
-		baseURL,
-		page
-	}) => {
-		const randomActionName = 'some-random-action';
-		const response = await page.request.fetch(`${baseURL}/actions/enhance?/${randomActionName}`, {
-			method: 'POST',
-			body: 'irrelevant',
-			headers: {
-				Origin: `${baseURL}`
-			}
-		});
-		const { type, error } = await response.json();
-		expect(type).toBe('error');
-		expect(error.message).toBe(`No action with name '${randomActionName}' found`);
-		expect(response.status()).toBe(404);
-	});
 });
 
 // Run in serial to not pollute the log with (correct) cookie warnings


### PR DESCRIPTION
We shouldn't have merged #11255 and #11278. They were reasonable changes on the face of it, but they were the wrong fix. Instead, we should have a way to include a status code with unexpected errors. This PR doesn't implement that, as it needs further discussion on #11287.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
