### PR TITLE
add failing cross-platform server test

### DIFF
--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -535,7 +535,7 @@ export async function dev(vite, vite_config, svelte_config) {
  * @param {import('connect').Server} server
  */
 function remove_static_middlewares(server) {
-	const static_middlewares = ['viteServeStaticMiddleware'];
+	const static_middlewares = ['viteServeStaticMiddleware', 'viteServePublicMiddleware'];
 	for (let i = server.stack.length - 1; i > 0; i--) {
 		// @ts-expect-error using internals
 		if (static_middlewares.includes(server.stack[i].handle.name)) {

--- a/packages/kit/test/apps/basics/test/cross-platform/server.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/server.test.js
@@ -1,0 +1,15 @@
+import { expect } from '@playwright/test';
+import { test } from '../../../../utils.js';
+
+/** @typedef {import('@playwright/test').Response} Response */
+
+test.skip(({ javaScriptEnabled }) => javaScriptEnabled);
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe('Static files', () => {
+	test('Filenames are case-sensitive', async ({ request }) => {
+		const response = await request.get('/static.JSON');
+		expect(response.status()).toBe(404);
+	});
+});

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -567,11 +567,6 @@ test.describe('Static files', () => {
 		expect(await r2.json()).toEqual({ works: true });
 	});
 
-	test('Filenames are case-sensitive', async ({ request }) => {
-		const response = await request.get('/static.JSON');
-		expect(response.status()).toBe(404);
-	});
-
 	test('Serves symlinked asset', async ({ request }) => {
 		const response = await request.get('/symlink-from/hello.txt');
 		expect(response.status()).toBe(200);


### PR DESCRIPTION
Not sure how this eluded us up till now, but I _think_ there's a case sensitivity bug that manifests on platforms like Mac OS. Moving the relevant test into a cross-platform file to see if it shows up in CI as well.

I hope I'm mistaken, because if not this is presumably an issue with Vite 5, possibly bypassing our middleware? Investigating