### PR TITLE
chore: upgrade to prettier 3.1.1

### DIFF
--- a/.changeset/tricky-rats-pull.md
+++ b/.changeset/tricky-rats-pull.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+chore: upgrade to prettier 3.1.1

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"eslint-plugin-svelte": "^2.31.0",
 		"eslint-plugin-unicorn": "^49.0.0",
 		"playwright": "1.30.0",
-		"prettier": "^3.1.0",
+		"prettier": "^3.1.1",
 		"rollup": "^3.29.4",
 		"svelte": "^4.2.7",
 		"typescript": "^4.9.4"

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -18,7 +18,7 @@ export default function (options) {
 									has_param_routes
 										? '(routes with parameters are not part of entry points by default)'
 										: ''
-							  } — see https://kit.svelte.dev/docs/configuration#prerender for more info.`
+								} — see https://kit.svelte.dev/docs/configuration#prerender for more info.`
 							: '';
 
 					builder.log.error(

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -19,7 +19,7 @@
 		"@playwright/test": "1.30.0",
 		"@types/gitignore-parser": "^0.0.2",
 		"gitignore-parser": "^0.0.2",
-		"prettier": "^3.1.0",
+		"prettier": "^3.1.1",
 		"prettier-plugin-svelte": "^3.0.0",
 		"sucrase": "^3.29.0",
 		"svelte": "^4.2.7",

--- a/packages/create-svelte/shared/+eslint+prettier/package.json
+++ b/packages/create-svelte/shared/+eslint+prettier/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"eslint-config-prettier": "^9.0.0"
+		"eslint-config-prettier": "^9.1.0"
 	},
 	"scripts": {
 		"lint": "prettier --check . && eslint .",

--- a/packages/create-svelte/shared/+prettier/package.json
+++ b/packages/create-svelte/shared/+prettier/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"prettier": "^3.0.0",
-		"prettier-plugin-svelte": "^3.0.0"
+		"prettier": "^3.1.1",
+		"prettier-plugin-svelte": "^3.1.2"
 	}
 }

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -213,7 +213,7 @@ async function compress_file(file, format = 'gz') {
 						[zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,
 						[zlib.constants.BROTLI_PARAM_SIZE_HINT]: statSync(file).size
 					}
-			  })
+				})
 			: zlib.createGzip({ level: zlib.constants.Z_BEST_COMPRESSION });
 
 	const source = createReadStream(file);

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -182,8 +182,8 @@ function validate_user_config(kit, cwd, out, config) {
 		typeof extend === 'string'
 			? path.resolve(cwd, extend) === out
 			: Array.isArray(extend)
-			  ? extend.some((e) => path.resolve(cwd, e) === out)
-			  : false;
+				? extend.some((e) => path.resolve(cwd, e) === out)
+				: false;
 
 	const options = config.options.compilerOptions || {};
 

--- a/packages/kit/src/exports/hooks/sequence.js
+++ b/packages/kit/src/exports/hooks/sequence.js
@@ -111,7 +111,7 @@ export function sequence(...handlers) {
 								transformPageChunk,
 								filterSerializedResponseHeaders,
 								preload
-						  })
+							})
 						: resolve(event, { transformPageChunk, filterSerializedResponseHeaders, preload });
 				}
 			});

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -124,7 +124,7 @@ export async function setResponse(res, response) {
 					? set_cookie_parser.splitCookiesString(
 							// This is absurd but necessary, TODO: investigate why
 							/** @type {string}*/ (response.headers.get(key))
-					  )
+						)
 					: value
 			);
 		} catch (error) {

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -42,12 +42,12 @@ export interface Adapter {
 type AwaitedPropertiesUnion<input extends Record<string, any> | void> = input extends void
 	? undefined // needs to be undefined, because void will break intellisense
 	: input extends Record<string, any>
-	  ? {
+		? {
 				[key in keyof input]: Awaited<input[key]>;
-	    }
-	  : {} extends input // handles the any case
-	    ? input
-	    : unknown;
+			}
+		: {} extends input // handles the any case
+			? input
+			: unknown;
 
 export type AwaitedProperties<input extends Record<string, any> | void> =
 	AwaitedPropertiesUnion<input> extends Record<string, any>
@@ -70,8 +70,8 @@ type OptionalUnion<
 type UnpackValidationError<T> = T extends ActionFailure<infer X>
 	? X
 	: T extends void
-	  ? undefined // needs to be undefined, because void will corrupt union type
-	  : T;
+		? undefined // needs to be undefined, because void will corrupt union type
+		: T;
 
 /**
  * This object is passed to the `adapt` function of adapters.

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -223,7 +223,7 @@ export async function dev(vite, vite_config, svelte_config) {
 								? async () => {
 										const url = path.resolve(cwd, endpoint.file);
 										return await loud_ssr_load_module(url);
-								  }
+									}
 								: null,
 							endpoint_id: endpoint?.file
 						};

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -204,7 +204,7 @@ const mutable = (dir) =>
 		? sirv(dir, {
 				etag: true,
 				maxAge: 0
-		  })
+			})
 		: (_req, _res, next) => next();
 
 /**

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -550,10 +550,10 @@ export function create_client(app, target) {
 								typeof data !== 'object'
 									? `a ${typeof data}`
 									: data instanceof Response
-									  ? 'a Response object'
-									  : Array.isArray(data)
-									    ? 'an array'
-									    : 'a non-plain object'
+										? 'a Response object'
+										: Array.isArray(data)
+											? 'an array'
+											: 'a non-plain object'
 							}, but must return a plain object at the top level (i.e. \`return {...}\`)`
 						);
 					}

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -398,10 +398,10 @@ function validate_load_response(data, id) {
 				typeof data !== 'object'
 					? `a ${typeof data}`
 					: data instanceof Response
-					  ? 'a Response object'
-					  : Array.isArray(data)
-					    ? 'an array'
-					    : 'a non-plain object'
+						? 'a Response object'
+						: Array.isArray(data)
+							? 'an array'
+							: 'a non-plain object'
 			}, but must return a plain object at the top level (i.e. \`return {...}\`)`
 		);
 	}

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -467,7 +467,7 @@ export async function render_response({
 		? text(transformed, {
 				status,
 				headers
-		  })
+			})
 		: new Response(
 				new ReadableStream({
 					async start(controller) {
@@ -485,7 +485,7 @@ export async function render_response({
 						'content-type': 'text/html'
 					}
 				}
-		  );
+			);
 }
 
 /**

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -341,8 +341,8 @@ export async function respond(request, options, manifest, state) {
 			const response = is_data_request
 				? redirect_json_response(e)
 				: route?.page && is_action_json_request(event)
-				  ? action_json_redirect(e)
-				  : redirect_response(e.status, e.location);
+					? action_json_redirect(e)
+					: redirect_response(e.status, e.location);
 			add_cookies_to_headers(response.headers, Object.values(cookies_to_add));
 			return response;
 		}

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -91,7 +91,7 @@ export function parse_route_id(id) {
 							return '/' + result;
 						})
 						.join('')}/?$`
-			  );
+				);
 
 	return { pattern, params };
 }

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -270,7 +270,7 @@ export const config = {
 		? [
 				['dot'],
 				[path.resolve(fileURLToPath(import.meta.url), '../github-flaky-warning-reporter.js')]
-		  ]
+			]
 		: 'list',
 	testDir: 'test',
 	testMatch: /(.+\.)?(test|spec)\.[jt]s/

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -22,12 +22,12 @@ declare module '@sveltejs/kit' {
 	type AwaitedPropertiesUnion<input extends Record<string, any> | void> = input extends void
 		? undefined // needs to be undefined, because void will break intellisense
 		: input extends Record<string, any>
-		  ? {
+			? {
 					[key in keyof input]: Awaited<input[key]>;
-		    }
-		  : {} extends input // handles the any case
-		    ? input
-		    : unknown;
+				}
+			: {} extends input // handles the any case
+				? input
+				: unknown;
 
 	export type AwaitedProperties<input extends Record<string, any> | void> =
 		AwaitedPropertiesUnion<input> extends Record<string, any>
@@ -50,8 +50,8 @@ declare module '@sveltejs/kit' {
 	type UnpackValidationError<T> = T extends ActionFailure<infer X>
 		? X
 		: T extends void
-		  ? undefined // needs to be undefined, because void will corrupt union type
-		  : T;
+			? undefined // needs to be undefined, because void will corrupt union type
+			: T;
 
 	/**
 	 * This object is passed to the `adapt` function of adapters.

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -36,7 +36,7 @@
 		"@types/node": "^16.18.6",
 		"@types/prompts": "^2.4.1",
 		"@types/semver": "^7.5.0",
-		"prettier": "^3.1.0",
+		"prettier": "^3.1.1",
 		"vitest": "^0.34.5"
 	},
 	"scripts": {

--- a/packages/package/src/utils.js
+++ b/packages/package/src/utils.js
@@ -84,10 +84,10 @@ export function analyze(file, extensions) {
 	const dest = svelte_extension
 		? name.slice(0, -svelte_extension.length) + '.svelte'
 		: name.endsWith('.d.ts')
-		  ? name
-		  : name.endsWith('.ts')
-		    ? name.slice(0, -3) + '.js'
-		    : name;
+			? name
+			: name.endsWith('.ts')
+				? name.slice(0, -3) + '.js'
+				: name;
 
 	return {
 		name,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,13 +22,13 @@ importers:
         version: 15.0.1(rollup@3.29.4)
       '@sveltejs/eslint-config':
         specifier: ^6.0.4
-        version: 6.0.4(@typescript-eslint/eslint-plugin@6.0.0)(@typescript-eslint/parser@6.12.0)(eslint-config-prettier@9.0.0)(eslint-plugin-svelte@2.31.0)(eslint-plugin-unicorn@49.0.0)(eslint@8.52.0)(typescript@4.9.4)
+        version: 6.0.4(@typescript-eslint/eslint-plugin@6.0.0)(@typescript-eslint/parser@6.14.0)(eslint-config-prettier@9.0.0)(eslint-plugin-svelte@2.31.0)(eslint-plugin-unicorn@49.0.0)(eslint@8.52.0)(typescript@4.9.4)
       '@svitejs/changesets-changelog-github-compact':
         specifier: ^1.1.0
         version: 1.1.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.0.0
-        version: 6.0.0(@typescript-eslint/parser@6.12.0)(eslint@8.52.0)(typescript@4.9.4)
+        version: 6.0.0(@typescript-eslint/parser@6.14.0)(eslint@8.52.0)(typescript@4.9.4)
       eslint:
         specifier: ^8.52.0
         version: 8.52.0
@@ -45,8 +45,8 @@ importers:
         specifier: 1.30.0
         version: 1.30.0
       prettier:
-        specifier: ^3.1.0
-        version: 3.1.0
+        specifier: ^3.1.1
+        version: 3.1.1
       rollup:
         specifier: ^3.29.4
         version: 3.29.4
@@ -310,11 +310,11 @@ importers:
         specifier: ^0.0.2
         version: 0.0.2
       prettier:
-        specifier: ^3.1.0
-        version: 3.1.0
+        specifier: ^3.1.1
+        version: 3.1.1
       prettier-plugin-svelte:
         specifier: ^3.0.0
-        version: 3.0.3(prettier@3.1.0)(svelte@4.2.7)
+        version: 3.0.3(prettier@3.1.1)(svelte@4.2.7)
       sucrase:
         specifier: ^3.29.0
         version: 3.29.0
@@ -962,8 +962,8 @@ importers:
         specifier: ^7.5.0
         version: 7.5.0
       prettier:
-        specifier: ^3.1.0
-        version: 3.1.0
+        specifier: ^3.1.1
+        version: 3.1.1
       vitest:
         specifier: ^0.34.5
         version: 0.34.5(lightningcss@1.21.8)(playwright@1.30.0)
@@ -1069,11 +1069,11 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
       prettier:
-        specifier: ^3.1.0
-        version: 3.1.0
+        specifier: ^3.1.1
+        version: 3.1.1
       prettier-plugin-svelte:
         specifier: ^3.0.3
-        version: 3.0.3(prettier@3.1.0)(svelte@4.2.7)
+        version: 3.0.3(prettier@3.1.1)(svelte@4.2.7)
       prism-svelte:
         specifier: ^0.5.0
         version: 0.5.0
@@ -2034,7 +2034,7 @@ packages:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
-  /@sveltejs/eslint-config@6.0.4(@typescript-eslint/eslint-plugin@6.0.0)(@typescript-eslint/parser@6.12.0)(eslint-config-prettier@9.0.0)(eslint-plugin-svelte@2.31.0)(eslint-plugin-unicorn@49.0.0)(eslint@8.52.0)(typescript@4.9.4):
+  /@sveltejs/eslint-config@6.0.4(@typescript-eslint/eslint-plugin@6.0.0)(@typescript-eslint/parser@6.14.0)(eslint-config-prettier@9.0.0)(eslint-plugin-svelte@2.31.0)(eslint-plugin-unicorn@49.0.0)(eslint@8.52.0)(typescript@4.9.4):
     resolution: {integrity: sha512-U9pwmDs+DbmsnCgTfu6Bacdwqn0DuI1IQNSiQqTgzVyYfaaj+zy9ZoQCiJfxFBGXHkklyXuRHp0KMx346N0lcQ==}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': '>= 5'
@@ -2045,8 +2045,8 @@ packages:
       eslint-plugin-unicorn: '>= 47'
       typescript: '>= 4'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.0.0(@typescript-eslint/parser@6.12.0)(eslint@8.52.0)(typescript@4.9.4)
-      '@typescript-eslint/parser': 6.12.0(eslint@8.52.0)(typescript@4.9.4)
+      '@typescript-eslint/eslint-plugin': 6.0.0(@typescript-eslint/parser@6.14.0)(eslint@8.52.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 6.14.0(eslint@8.52.0)(typescript@4.9.4)
       eslint: 8.52.0
       eslint-config-prettier: 9.0.0(eslint@8.52.0)
       eslint-plugin-svelte: 2.31.0(eslint@8.52.0)(svelte@4.2.7)
@@ -2226,7 +2226,7 @@ packages:
       '@types/node': 16.18.6
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.0.0(@typescript-eslint/parser@6.12.0)(eslint@8.52.0)(typescript@4.9.4):
+  /@typescript-eslint/eslint-plugin@6.0.0(@typescript-eslint/parser@6.14.0)(eslint@8.52.0)(typescript@4.9.4):
     resolution: {integrity: sha512-xuv6ghKGoiq856Bww/yVYnXGsKa588kY3M0XK7uUW/3fJNNULKRfZfSBkMTSpqGG/8ZCXCadfh8G/z/B4aqS/A==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -2238,7 +2238,7 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.6.2
-      '@typescript-eslint/parser': 6.12.0(eslint@8.52.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 6.14.0(eslint@8.52.0)(typescript@4.9.4)
       '@typescript-eslint/scope-manager': 6.0.0
       '@typescript-eslint/type-utils': 6.0.0(eslint@8.52.0)(typescript@4.9.4)
       '@typescript-eslint/utils': 6.0.0(eslint@8.52.0)(typescript@4.9.4)
@@ -2257,8 +2257,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.12.0(eslint@8.52.0)(typescript@4.9.4):
-    resolution: {integrity: sha512-s8/jNFPKPNRmXEnNXfuo1gemBdVmpQsK1pcu+QIvuNJuhFzGrpD7WjOcvDc/+uEdfzSYpNu7U/+MmbScjoQ6vg==}
+  /@typescript-eslint/parser@6.14.0(eslint@8.52.0)(typescript@4.9.4):
+    resolution: {integrity: sha512-QjToC14CKacd4Pa7JK4GeB/vHmWFJckec49FR4hmIRf97+KXole0T97xxu9IFiPxVQ1DBWrQ5wreLwAGwWAVQA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -2267,10 +2267,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 6.12.0
-      '@typescript-eslint/types': 6.12.0
-      '@typescript-eslint/typescript-estree': 6.12.0(typescript@4.9.4)
-      '@typescript-eslint/visitor-keys': 6.12.0
+      '@typescript-eslint/scope-manager': 6.14.0
+      '@typescript-eslint/types': 6.14.0
+      '@typescript-eslint/typescript-estree': 6.14.0(typescript@4.9.4)
+      '@typescript-eslint/visitor-keys': 6.14.0
       debug: 4.3.4
       eslint: 8.52.0
       typescript: 4.9.4
@@ -2286,12 +2286,12 @@ packages:
       '@typescript-eslint/visitor-keys': 6.0.0
     dev: true
 
-  /@typescript-eslint/scope-manager@6.12.0:
-    resolution: {integrity: sha512-5gUvjg+XdSj8pcetdL9eXJzQNTl3RD7LgUiYTl8Aabdi8hFkaGSYnaS6BLc0BGNaDH+tVzVwmKtWvu0jLgWVbw==}
+  /@typescript-eslint/scope-manager@6.14.0:
+    resolution: {integrity: sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.12.0
-      '@typescript-eslint/visitor-keys': 6.12.0
+      '@typescript-eslint/types': 6.14.0
+      '@typescript-eslint/visitor-keys': 6.14.0
     dev: true
 
   /@typescript-eslint/type-utils@6.0.0(eslint@8.52.0)(typescript@4.9.4):
@@ -2319,8 +2319,8 @@ packages:
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/types@6.12.0:
-    resolution: {integrity: sha512-MA16p/+WxM5JG/F3RTpRIcuOghWO30//VEOvzubM8zuOOBYXsP+IfjoCXXiIfy2Ta8FRh9+IO9QLlaFQUU+10Q==}
+  /@typescript-eslint/types@6.14.0:
+    resolution: {integrity: sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
@@ -2345,8 +2345,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.12.0(typescript@4.9.4):
-    resolution: {integrity: sha512-vw9E2P9+3UUWzhgjyyVczLWxZ3GuQNT7QpnIY3o5OMeLO/c8oHljGc8ZpryBMIyympiAAaKgw9e5Hl9dCWFOYw==}
+  /@typescript-eslint/typescript-estree@6.14.0(typescript@4.9.4):
+    resolution: {integrity: sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       typescript: '*'
@@ -2354,8 +2354,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 6.12.0
-      '@typescript-eslint/visitor-keys': 6.12.0
+      '@typescript-eslint/types': 6.14.0
+      '@typescript-eslint/visitor-keys': 6.14.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
@@ -2394,11 +2394,11 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@typescript-eslint/visitor-keys@6.12.0:
-    resolution: {integrity: sha512-rg3BizTZHF1k3ipn8gfrzDXXSFKyOEB5zxYXInQ6z0hUvmQlhaZQzK+YmHmNViMA9HzW5Q9+bPPt90bU6GQwyw==}
+  /@typescript-eslint/visitor-keys@6.14.0:
+    resolution: {integrity: sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.12.0
+      '@typescript-eslint/types': 6.14.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -5122,13 +5122,13 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-svelte@3.0.3(prettier@3.1.0)(svelte@4.2.7):
+  /prettier-plugin-svelte@3.0.3(prettier@3.1.1)(svelte@4.2.7):
     resolution: {integrity: sha512-dLhieh4obJEK1hnZ6koxF+tMUrZbV5YGvRpf2+OADyanjya5j0z1Llo8iGwiHmFWZVG/hLEw/AJD5chXd9r3XA==}
     peerDependencies:
       prettier: ^3.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0
     dependencies:
-      prettier: 3.1.0
+      prettier: 3.1.1
       svelte: 4.2.7
     dev: true
 
@@ -5138,8 +5138,8 @@ packages:
     hasBin: true
     dev: true
 
-  /prettier@3.1.0:
-    resolution: {integrity: sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==}
+  /prettier@3.1.1:
+    resolution: {integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true

--- a/sites/kit.svelte.dev/package.json
+++ b/sites/kit.svelte.dev/package.json
@@ -24,7 +24,7 @@
 		"flexsearch": "^0.7.31",
 		"lightningcss": "^1.21.8",
 		"marked": "^11.0.0",
-		"prettier": "^3.1.0",
+		"prettier": "^3.1.1",
 		"prettier-plugin-svelte": "^3.0.3",
 		"prism-svelte": "^0.5.0",
 		"prismjs": "^1.29.0",


### PR DESCRIPTION
I updated the templates in `create-svelte` as well because 3.0.0 will actually be broken and won't work. It shouldn't matter for most users as they'll still get the latest unless they're on an older version of pnpm, but better safe than sorry

This PR will fix the lint errors on https://github.com/sveltejs/kit/pull/9847