### PR TITLE
Shallow routing

### DIFF
--- a/.changeset/light-moons-dress.md
+++ b/.changeset/light-moons-dress.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": minor
+---
+
+feat: implement shallow routing

--- a/.changeset/serious-months-happen.md
+++ b/.changeset/serious-months-happen.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": major
+---
+
+breaking: remove state option from goto in favor of shallow routing

--- a/documentation/docs/30-advanced/67-shallow-routing.md
+++ b/documentation/docs/30-advanced/67-shallow-routing.md
@@ -1,0 +1,42 @@
+---
+title: Shallow routing
+---
+
+As you navigate around a SvelteKit app, you create _history entries_. Clicking the back and forward buttons traverses through this list of entries, re-running any `load` functions and replacing page components as necessary.
+
+Sometimes, it's useful to create history entries _without_ navigating. For example, you might want to show a modal dialog that the user can dismiss by navigating back. (This is particularly valuable on mobile devices, where swipe gestures are often more natural than interacting directly with the UI. In these cases, a modal that is _not_ associated with a history entry can be a source of frustration, as a user may swipe backwards in an attempt to dismiss it and find themselves on the wrong page.)
+
+SvelteKit makes this possible with the [`pushState`](/docs/modules#$app-navigation-pushstate) and [`replaceState`](/docs/modules#$app-navigation-replacestate) functions, which allow you to associate state with a history entry without navigating. For example, to implement a history-driven modal:
+
+```svelte
+<!--- file: +page.svelte --->
+<script>
+	import { pushState } from '$app/navigation';
+	import { page } from '$app/stores';
+	import Modal from './Modal.svelte';
+
+	function showModal() {
+		pushState('', {
+			showModal: true
+		});
+	}
+</script>
+
+{#if $page.state.showModal}
+	<Modal close={() => history.back()} />
+{/if}
+```
+
+The modal can be dismissed by navigating back (unsetting `$page.state.showModal`) or by interacting with it in a way that causes the `close` callback to run, which will navigate back programmatically.
+
+## API
+
+The first argument to `pushState` is the URL, relative to the current URL. To stay on the current URL, use `''`.
+
+The second argument is the new page state, which can be accessed via the [page store](/docs/modules#$app-stores-page) as `$page.state`. You can make page state type-safe by declaring an [`App.PageState`](/docs/types#app) interface (usually in `src/app.d.ts`).
+
+To set page state without creating a new history entry, use `replaceState` instead of `pushState`.
+
+## Caveats
+
+During server-side rendering, `$page.state` is always an empty object. The same is true for the first page the user lands on — if the user reloads the page, state will _not_ be applied until they navigate.

--- a/documentation/docs/30-advanced/67-shallow-routing.md
+++ b/documentation/docs/30-advanced/67-shallow-routing.md
@@ -4,7 +4,7 @@ title: Shallow routing
 
 As you navigate around a SvelteKit app, you create _history entries_. Clicking the back and forward buttons traverses through this list of entries, re-running any `load` functions and replacing page components as necessary.
 
-Sometimes, it's useful to create history entries _without_ navigating. For example, you might want to show a modal dialog that the user can dismiss by navigating back. (This is particularly valuable on mobile devices, where swipe gestures are often more natural than interacting directly with the UI. In these cases, a modal that is _not_ associated with a history entry can be a source of frustration, as a user may swipe backwards in an attempt to dismiss it and find themselves on the wrong page.)
+Sometimes, it's useful to create history entries _without_ navigating. For example, you might want to show a modal dialog that the user can dismiss by navigating back. This is particularly valuable on mobile devices, where swipe gestures are often more natural than interacting directly with the UI. In these cases, a modal that is _not_ associated with a history entry can be a source of frustration, as a user may swipe backwards in an attempt to dismiss it and find themselves on the wrong page.
 
 SvelteKit makes this possible with the [`pushState`](/docs/modules#$app-navigation-pushstate) and [`replaceState`](/docs/modules#$app-navigation-replacestate) functions, which allow you to associate state with a history entry without navigating. For example, to implement a history-driven modal:
 
@@ -37,6 +37,40 @@ The second argument is the new page state, which can be accessed via the [page s
 
 To set page state without creating a new history entry, use `replaceState` instead of `pushState`.
 
+## Loading data from a route
+
+When doing a shallow navigation you might want to show a reduced version of a page in a modal, for which you need the data of that page. You can retrieve it by calling `preloadData` with the desired page URL and use its result to populate the component. This will call the load function(s) associated with that route and give you back the result.
+
+```svelte
+<!--- file: Model.svelte --->
+<script>
+	import { preloadData, goto } from '$app/navigation';
+
+	export let close;
+
+	const data = preloadData('/path/to/page/this/modal/represents').then(result => {
+		if (result.type === 'loaded' && result.status === 200) {
+			return result.data;
+		} else {
+			// Something went wrong, navigate to page directly
+			goto('/path/to/page/this/modal/represents');
+		}
+	});
+</script>
+
+<dialog open>
+	{#await data}
+		<!-- add your loading UI here -->
+	{:then }
+		<h1>{data.title}</h1>
+		<p>{data.content}</p>
+	{/await}
+	<button on:click={close}>Close</button>
+</dialog>
+```
+
 ## Caveats
 
 During server-side rendering, `$page.state` is always an empty object. The same is true for the first page the user lands on — if the user reloads the page, state will _not_ be applied until they navigate.
+
+Shallow routing is a feature that requires JavaScript to work. Be mindful when using it and try to think of sensible fallback behavior in case JavaScript isn't available.

--- a/documentation/docs/60-appendix/30-migrating-to-sveltekit-2.md
+++ b/documentation/docs/60-appendix/30-migrating-to-sveltekit-2.md
@@ -66,9 +66,9 @@ export function load({ fetch }) {
 }
 ```
 
-## goto(...) no longer accepts external URLs
+## goto(...) changes
 
-To navigate to an external URL, use `window.location = url`.
+`goto(...)` no longer accepts external URLs. To navigate to an external URL, use `window.location = url`. The `state` option was removed in favor of [shallow routing](shallow-routing).
 
 ## paths are now relative by default
 

--- a/packages/create-svelte/templates/default/src/app.d.ts
+++ b/packages/create-svelte/templates/default/src/app.d.ts
@@ -5,6 +5,7 @@ declare global {
 		// interface Error {}
 		// interface Locals {}
 		// interface PageData {}
+		// interface PageState {}
 		// interface Platform {}
 	}
 }

--- a/packages/create-svelte/templates/skeleton/src/app.d.ts
+++ b/packages/create-svelte/templates/skeleton/src/app.d.ts
@@ -5,6 +5,7 @@ declare global {
 		// interface Error {}
 		// interface Locals {}
 		// interface PageData {}
+		// interface PageState {}
 		// interface Platform {}
 	}
 }

--- a/packages/create-svelte/templates/skeletonlib/src/app.d.ts
+++ b/packages/create-svelte/templates/skeletonlib/src/app.d.ts
@@ -5,6 +5,7 @@ declare global {
 		// interface Error {}
 		// interface Locals {}
 		// interface PageData {}
+		// interface PageState {}
 		// interface Platform {}
 	}
 }

--- a/packages/kit/src/core/sync/write_non_ambient.js
+++ b/packages/kit/src/core/sync/write_non_ambient.js
@@ -26,7 +26,7 @@ declare module "svelte/elements" {
 			| null;
 		'data-sveltekit-preload-data'?: true | '' | 'hover' | 'tap' | 'off' | undefined | null;
 		'data-sveltekit-reload'?: true | '' | 'off' | undefined | null;
-		'data-sveltekit-replacestate'?: true | '' | 'off' | undefined | null;
+		'data-sveltekit-replace_state'?: true | '' | 'off' | undefined | null;
 	}
 }
 

--- a/packages/kit/src/core/sync/write_non_ambient.js
+++ b/packages/kit/src/core/sync/write_non_ambient.js
@@ -26,7 +26,7 @@ declare module "svelte/elements" {
 			| null;
 		'data-sveltekit-preload-data'?: true | '' | 'hover' | 'tap' | 'off' | undefined | null;
 		'data-sveltekit-reload'?: true | '' | 'off' | undefined | null;
-		'data-sveltekit-replace_state'?: true | '' | 'off' | undefined | null;
+		'data-sveltekit-replacestate'?: true | '' | 'off' | undefined | null;
 	}
 }
 

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -845,13 +845,6 @@ export interface NavigationTarget {
  */
 export type NavigationType = 'enter' | 'form' | 'leave' | 'link' | 'goto' | 'popstate';
 
-export interface NavigationOptions {
-	replaceState?: boolean;
-	noScroll?: boolean;
-	keepFocus?: boolean;
-	invalidateAll?: boolean;
-}
-
 export interface Navigation {
 	/**
 	 * Where navigation was triggered from

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -845,6 +845,13 @@ export interface NavigationTarget {
  */
 export type NavigationType = 'enter' | 'form' | 'leave' | 'link' | 'goto' | 'popstate';
 
+export interface NavigationOptions {
+	replaceState?: boolean;
+	noScroll?: boolean;
+	keepFocus?: boolean;
+	invalidateAll?: boolean;
+}
+
 export interface Navigation {
 	/**
 	 * Where navigation was triggered from

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -962,7 +962,7 @@ export interface Page<
 	 */
 	data: App.PageData & Record<string, any>;
 	/**
-	 * The page state, which can be manipulated using the `pushState` and `replaceState` functions from `$app/navigation`.
+	 * The page state, which can be manipulated using the [`pushState`](https://kit.svelte.dev/docs/modules#$app-navigation-pushstate) and [`replaceState`](https://kit.svelte.dev/docs/modules#$app-navigation-replacestate) functions from `$app/navigation`.
 	 */
 	state: App.PageState;
 	/**

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -962,6 +962,10 @@ export interface Page<
 	 */
 	data: App.PageData & Record<string, any>;
 	/**
+	 * The page state, which can be manipulated using the `pushState` and `replaceState` functions from `$app/navigation`.
+	 */
+	state: App.PageState;
+	/**
 	 * Filled only after a form submission. See [form actions](https://kit.svelte.dev/docs/form-actions) for more info.
 	 */
 	form: any;

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -123,7 +123,7 @@ export const afterNavigate = /* @__PURE__ */ client_method('after_navigate');
 /**
  * Programmatically create a new history entry with the given `$page.state`. To use the current URL, you can pass `''` as the first argument. Used for [shallow routing](https://kit.svelte.dev/docs/shallow-routing).
  *
- * @type {(url: string | URL; state: App.PageState) => void}
+ * @type {(url: string | URL, state: App.PageState) => void}
  * @param {string | URL} url
  * @param {App.PageState} state
  * @returns {void}
@@ -133,7 +133,7 @@ export const pushState = /* @__PURE__ */ client_method('push_state');
 /**
  * Programmatically replace the current history entry with the given `$page.state`. To use the current URL, you can pass `''` as the first argument. Used for [shallow routing](https://kit.svelte.dev/docs/shallow-routing).
  *
- * @type {(url: string | URL; state: App.PageState) => void}
+ * @type {(url: string | URL, state: App.PageState) => void}
  * @param {string | URL} url
  * @param {App.PageState} state
  * @returns {void}

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -11,7 +11,7 @@ export const disableScrollHandling = /* @__PURE__ */ client_method('disable_scro
  * Returns a Promise that resolves when SvelteKit navigates (or fails to navigate, in which case the promise rejects) to the specified `url`.
  * For external URLs, use `window.location = url` instead of calling `goto(url)`.
  *
- * @type {(url: string | URL, opts?: import('@sveltejs/kit').NavigationOptions) => Promise<void>}
+ * @type {(url: string | URL, opts?: { replaceState?: boolean; noScroll?: boolean; keepFocus?: boolean; invalidateAll?: boolean; }) => Promise<void>}
  * @param {string | URL} url Where to navigate to. Note that if you've set [`config.kit.paths.base`](https://kit.svelte.dev/docs/configuration#paths) and the URL is root-relative, you need to prepend the base path if you want to navigate within the app.
  * @param {Object} [opts] Options related to the navigation
  * @param {boolean} [opts.replaceState] If `true`, will replace the current `history` entry rather than creating a new one with `pushState`

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -11,13 +11,7 @@ export const disableScrollHandling = /* @__PURE__ */ client_method('disable_scro
  * Returns a Promise that resolves when SvelteKit navigates (or fails to navigate, in which case the promise rejects) to the specified `url`.
  * For external URLs, use `window.location = url` instead of calling `goto(url)`.
  *
- * @type {(url: string | URL, opts?: {
- *   replaceState?: boolean;
- *   noScroll?: boolean;
- *   keepFocus?: boolean;
- *   invalidateAll?: boolean;
- *   state?: any
- * }) => Promise<void>}
+ * @type {(url: string | URL, opts?: import('@sveltejs/kit').NavigationOptions) => Promise<void>}
  * @param {string | URL} url Where to navigate to. Note that if you've set [`config.kit.paths.base`](https://kit.svelte.dev/docs/configuration#paths) and the URL is root-relative, you need to prepend the base path if you want to navigate within the app.
  * @param {Object} [opts] Options related to the navigation
  * @param {boolean} [opts.replaceState] If `true`, will replace the current `history` entry rather than creating a new one with `pushState`

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -121,7 +121,7 @@ export const onNavigate = /* @__PURE__ */ client_method('on_navigate');
 export const afterNavigate = /* @__PURE__ */ client_method('after_navigate');
 
 /**
- * Programmatically create a new history entry with the given `$page.state`. To use the current URL, you can pass `''` as the first argument.
+ * Programmatically create a new history entry with the given `$page.state`. To use the current URL, you can pass `''` as the first argument. Used for [shallow routing](https://kit.svelte.dev/docs/shallow-routing).
  *
  * @type {(url: string | URL, state: App.PageState) => void}
  * @param {string | URL} url
@@ -131,7 +131,7 @@ export const afterNavigate = /* @__PURE__ */ client_method('after_navigate');
 export const pushState = /* @__PURE__ */ client_method('push_state');
 
 /**
- * Programmatically replace the current history entry with the given `$page.state`. To use the current URL, you can pass `''` as the first argument.
+ * Programmatically replace the current history entry with the given `$page.state`. To use the current URL, you can pass `''` as the first argument. Used for [shallow routing](https://kit.svelte.dev/docs/shallow-routing).
  *
  * @type {(url: string | URL, state: App.PageState) => void}
  * @param {string | URL} url

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -57,11 +57,11 @@ export const invalidateAll = /* @__PURE__ */ client_method('invalidate_all');
  *
  * This is the same behaviour that SvelteKit triggers when the user taps or mouses over an `<a>` element with `data-sveltekit-preload-data`.
  * If the next navigation is to `href`, the values returned from load will be used, making navigation instantaneous.
- * Returns a Promise that resolves with the new `$page.data` when the preload is complete.
+ * Returns a Promise that resolves with the result of running the new route's `load` functions once the preload is complete.
  *
  * @type {(href: string) => Promise<Record<string, any>>}
  * @param {string} href Page to preload
- * @returns {Promise<Record<string, any>>}
+ * @returns {Promise<{ type: 'loaded', status: number, data: Record<string, any> } | { type: 'redirect', location: string }>}
  */
 export const preloadData = /* @__PURE__ */ client_method('preload_data');
 

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -61,7 +61,7 @@ export const invalidateAll = /* @__PURE__ */ client_method('invalidate_all');
  *
  * @type {(href: string) => Promise<Record<string, any>>}
  * @param {string} href Page to preload
- * @returns {Promise<{ type: 'loaded', status: number, data: Record<string, any> } | { type: 'redirect', location: string }>}
+ * @returns {Promise<{ type: 'loaded'; status: number; data: Record<string, any> } | { type: 'redirect'; location: string }>}
  */
 export const preloadData = /* @__PURE__ */ client_method('preload_data');
 
@@ -123,7 +123,7 @@ export const afterNavigate = /* @__PURE__ */ client_method('after_navigate');
 /**
  * Programmatically create a new history entry with the given `$page.state`. To use the current URL, you can pass `''` as the first argument. Used for [shallow routing](https://kit.svelte.dev/docs/shallow-routing).
  *
- * @type {(url: string | URL, state: App.PageState) => void}
+ * @type {(url: string | URL; state: App.PageState) => void}
  * @param {string | URL} url
  * @param {App.PageState} state
  * @returns {void}
@@ -133,7 +133,7 @@ export const pushState = /* @__PURE__ */ client_method('push_state');
 /**
  * Programmatically replace the current history entry with the given `$page.state`. To use the current URL, you can pass `''` as the first argument. Used for [shallow routing](https://kit.svelte.dev/docs/shallow-routing).
  *
- * @type {(url: string | URL, state: App.PageState) => void}
+ * @type {(url: string | URL; state: App.PageState) => void}
  * @param {string | URL} url
  * @param {App.PageState} state
  * @returns {void}

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -24,7 +24,6 @@ export const disableScrollHandling = /* @__PURE__ */ client_method('disable_scro
  * @param {boolean} [opts.noScroll] If `true`, the browser will maintain its scroll position rather than scrolling to the top of the page after navigation
  * @param {boolean} [opts.keepFocus] If `true`, the currently focused element will retain focus after navigation. Otherwise, focus will be reset to the body
  * @param {boolean} [opts.invalidateAll] If `true`, all `load` functions of the page will be rerun. See https://kit.svelte.dev/docs/load#rerunning-load-functions for more info on invalidation.
- * @param {any} [opts.state] The state of the new/updated history entry
  * @returns {Promise<void>}
  */
 export const goto = /* @__PURE__ */ client_method('goto');

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -57,7 +57,7 @@ export const invalidateAll = /* @__PURE__ */ client_method('invalidate_all');
  *
  * This is the same behaviour that SvelteKit triggers when the user taps or mouses over an `<a>` element with `data-sveltekit-preload-data`.
  * If the next navigation is to `href`, the values returned from load will be used, making navigation instantaneous.
- * Returns a Promise that resolves when the preload is complete.
+ * Returns a Promise that resolves with the new `$page.data` when the preload is complete.
  *
  * @type {(href: string) => Promise<Record<string, any>>}
  * @param {string} href Page to preload

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -126,3 +126,7 @@ export const onNavigate = /* @__PURE__ */ client_method('on_navigate');
  * @returns {void}
  */
 export const afterNavigate = /* @__PURE__ */ client_method('after_navigate');
+
+export const pushState = /* @__PURE__ */ client_method('push_state');
+
+export const replaceState = /* @__PURE__ */ client_method('replace_state');

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -66,9 +66,9 @@ export const invalidateAll = /* @__PURE__ */ client_method('invalidate_all');
  * If the next navigation is to `href`, the values returned from load will be used, making navigation instantaneous.
  * Returns a Promise that resolves when the preload is complete.
  *
- * @type {(href: string) => Promise<void>}
+ * @type {(href: string) => Promise<Record<string, any>>}
  * @param {string} href Page to preload
- * @returns {Promise<void>}
+ * @returns {Promise<Record<string, any>>}
  */
 export const preloadData = /* @__PURE__ */ client_method('preload_data');
 
@@ -127,6 +127,22 @@ export const onNavigate = /* @__PURE__ */ client_method('on_navigate');
  */
 export const afterNavigate = /* @__PURE__ */ client_method('after_navigate');
 
+/**
+ * Programmatically create a new history entry with the given `$page.state`.
+ *
+ * @type {(state: App.PageState, url?: string | URL) => void}
+ * @param {App.PageState} state
+ * @param {string | URL} [url]
+ * @returns {void}
+ */
 export const pushState = /* @__PURE__ */ client_method('push_state');
 
+/**
+ * Programmatically replace the current history entry with the given `$page.state`.
+ *
+ * @type {(state: App.PageState, url?: string | URL) => void}
+ * @param {App.PageState} state
+ * @param {string | URL} [url]
+ * @returns {void}
+ */
 export const replaceState = /* @__PURE__ */ client_method('replace_state');

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -128,21 +128,21 @@ export const onNavigate = /* @__PURE__ */ client_method('on_navigate');
 export const afterNavigate = /* @__PURE__ */ client_method('after_navigate');
 
 /**
- * Programmatically create a new history entry with the given `$page.state`.
+ * Programmatically create a new history entry with the given `$page.state`. To use the current URL, you can pass `''` as the first argument.
  *
- * @type {(state: App.PageState, url?: string | URL) => void}
+ * @type {(url: string | URL, state: App.PageState) => void}
+ * @param {string | URL} url
  * @param {App.PageState} state
- * @param {string | URL} [url]
  * @returns {void}
  */
 export const pushState = /* @__PURE__ */ client_method('push_state');
 
 /**
- * Programmatically replace the current history entry with the given `$page.state`.
+ * Programmatically replace the current history entry with the given `$page.state`. To use the current URL, you can pass `''` as the first argument.
  *
- * @type {(state: App.PageState, url?: string | URL) => void}
+ * @type {(url: string | URL, state: App.PageState) => void}
+ * @param {string | URL} url
  * @param {App.PageState} state
- * @param {string | URL} [url]
  * @returns {void}
  */
 export const replaceState = /* @__PURE__ */ client_method('replace_state');

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -249,8 +249,7 @@ export function create_client(app, target) {
 		if (!pending_invalidate) return;
 		pending_invalidate = null;
 
-		const url = new URL(location.href);
-		const intent = get_navigation_intent(url, true);
+		const intent = get_navigation_intent(current.url, true);
 
 		// Clear preload, it might be affected by the invalidation.
 		// Also solves an edge case where a preload is triggered, the navigation for it
@@ -264,7 +263,7 @@ export function create_client(app, target) {
 
 		if (navigation_result) {
 			if (navigation_result.type === 'redirect') {
-				await goto(new URL(navigation_result.location, url).href, {}, 1, nav_token);
+				await goto(new URL(navigation_result.location, current.url).href, {}, 1, nav_token);
 			} else {
 				if (navigation_result.props.page !== undefined) {
 					page = navigation_result.props.page;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -46,7 +46,7 @@ import { get_message, get_status } from '../../utils/error.js';
 
 let errored = false;
 
-/** @typedef {{ x: number, y: number }} ScrollPosition */
+/** @typedef {{ x: number; y: number }} ScrollPosition */
 
 // We track the scroll position associated with each history entry in sessionStorage,
 // rather than on history.state itself, because when navigation is driven by

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -310,12 +310,12 @@ export function create_client(app, target) {
 		return navigate({
 			type: 'goto',
 			url: resolve_url(url),
-			keep_focus: options.keepFocus,
-			no_scroll: options.noScroll,
+			keepfocus: options.keepFocus,
+			noscroll: options.noScroll,
 			replace_state: options.replaceState,
 			redirect_count,
 			nav_token,
-			accepted: () => {
+			accept: () => {
 				if (options.invalidateAll) {
 					force_invalidation = true;
 				}
@@ -1078,40 +1078,40 @@ export function create_client(app, target) {
 	 *     scroll: { x: number, y: number };
 	 *     delta: number;
 	 *   };
-	 *   keep_focus?: boolean;
-	 *   no_scroll?: boolean;
+	 *   keepfocus?: boolean;
+	 *   noscroll?: boolean;
 	 *   replace_state?: boolean;
 	 *   redirect_count?: number;
 	 *   nav_token?: {};
-	 *   accepted?: () => void;
-	 *   blocked?: () => void;
+	 *   accept?: () => void;
+	 *   block?: () => void;
 	 * }} opts
 	 */
 	async function navigate({
 		type,
 		url,
 		popped,
-		keep_focus,
-		no_scroll,
+		keepfocus,
+		noscroll,
 		replace_state,
 		redirect_count = 0,
 		nav_token = {},
-		accepted = noop,
-		blocked = noop
+		accept = noop,
+		block = noop
 	}) {
 		const intent = get_navigation_intent(url, false);
 		const nav = before_navigate({ url, type, delta: popped?.delta, intent });
 
 		if (!nav) {
-			blocked();
+			block();
 			return;
 		}
 
-		// store this before calling `accepted()`, which may change the index
+		// store this before calling `accept()`, which may change the index
 		const previous_history_index = current_history_index;
 		const previous_navigation_index = current_navigation_index;
 
-		accepted();
+		accept();
 
 		navigating = true;
 
@@ -1254,7 +1254,7 @@ export function create_client(app, target) {
 		await tick();
 
 		// we reset scroll before dealing with focus, to avoid a flash of unscrolled content
-		const scroll = popped ? popped.scroll : no_scroll ? scroll_state() : null;
+		const scroll = popped ? popped.scroll : noscroll ? scroll_state() : null;
 
 		if (autoscroll) {
 			const deep_linked =
@@ -1278,7 +1278,7 @@ export function create_client(app, target) {
 			// focus event might not have been fired on it yet
 			document.activeElement !== document.body;
 
-		if (!keep_focus && !changed_focus) {
+		if (!keepfocus && !changed_focus) {
 			reset_focus();
 		}
 
@@ -1812,11 +1812,11 @@ export function create_client(app, target) {
 				navigate({
 					type: 'link',
 					url,
-					keep_focus: options.keep_focus ?? false,
-					no_scroll: options.noscroll ?? false,
+					keepfocus: options.keepfocus,
+					noscroll: options.noscroll,
 					replace_state: options.replace_state ?? url.href === location.href,
-					accepted: () => event.preventDefault(),
-					blocked: () => event.preventDefault()
+					accept: () => event.preventDefault(),
+					block: () => event.preventDefault()
 				});
 			});
 
@@ -1843,8 +1843,8 @@ export function create_client(app, target) {
 
 				const event_form = /** @type {HTMLFormElement} */ (event.target);
 
-				const { keep_focus, noscroll, reload, replace_state } = get_router_options(event_form);
-				if (reload) return;
+				const options = get_router_options(event_form);
+				if (options.reload) return;
 
 				event.preventDefault();
 				event.stopPropagation();
@@ -1862,9 +1862,9 @@ export function create_client(app, target) {
 				navigate({
 					type: 'form',
 					url,
-					keep_focus: keep_focus ?? false,
-					no_scroll: noscroll ?? false,
-					replace_state: replace_state ?? url.href === location.href
+					keepfocus: options.keepfocus,
+					noscroll: options.noscroll,
+					replace_state: options.replace_state ?? url.href === location.href
 				});
 			});
 
@@ -1916,11 +1916,11 @@ export function create_client(app, target) {
 							scroll,
 							delta
 						},
-						accepted: () => {
+						accept: () => {
 							current_history_index = history_index;
 							current_navigation_index = navigation_index;
 						},
-						blocked: () => {
+						block: () => {
 							history.go(-delta);
 						},
 						nav_token: token

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -214,7 +214,7 @@ export function create_client(app, target) {
 		current_history_index = current_navigation_index = Date.now();
 
 		// create initial history entry, so we can return here
-		history.replaceState(
+		original_replace_state(
 			{
 				...history.state,
 				[HISTORY_INDEX]: current_history_index,
@@ -1937,7 +1937,7 @@ export function create_client(app, target) {
 				// we need to update history, otherwise we have to leave it alone
 				if (hash_navigating) {
 					hash_navigating = false;
-					history.replaceState(
+					original_replace_state(
 						{
 							...history.state,
 							[HISTORY_INDEX]: ++current_history_index,

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -4,6 +4,7 @@ import {
 	add_data_suffix,
 	decode_params,
 	decode_pathname,
+	strip_hash,
 	make_trackable,
 	normalize_path
 } from '../../utils/url.js';
@@ -1782,7 +1783,7 @@ export function create_client(app, target) {
 				// This will ensure the `hashchange` event is fired
 				// Removing the hash does a full page navigation in the browser, so make sure a hash is present
 				const [nonhash, hash] = url.href.split('#');
-				if (hash !== undefined && nonhash === location.href.split('#')[0]) {
+				if (hash !== undefined && nonhash === strip_hash(location)) {
 					// If we are trying to navigate to the same hash, we should only
 					// attempt to scroll to that element and avoid any history changes.
 					// Otherwise, this can cause Firefox to incorrectly assign a null
@@ -1878,7 +1879,7 @@ export function create_client(app, target) {
 					const state = states[history_index] ?? {};
 					const url = new URL(event.state[PAGE_URL_KEY] ?? location.href);
 					const navigation_index = event.state[NAVIGATION_INDEX];
-					const is_hash_change = location.href.split('#')[0] === current.url.href.split('#')[0];
+					const is_hash_change = strip_hash(location) === strip_hash(current.url);
 					const shallow =
 						navigation_index === current_navigation_index && (has_navigated || is_hash_change);
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -96,7 +96,6 @@ function clear_onward_history(current_history_index, current_navigation_index) {
 }
 
 /**
- * @param {import('./types.js').SvelteKitApp} app
  * Loads `href` the old-fashioned way, with a full page reload.
  * Returns a `Promise` that never resolves (to prevent any
  * subsequent work, e.g. history manipulation, from happening)

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -193,7 +193,7 @@ export function create_client(app, target) {
 	let updating = false;
 	let navigating = false;
 	let hash_navigating = false;
-	/** True as soon as there happened one client-side navigation */
+	/** True as soon as there happened one client-side navigation (excluding the SvelteKit-initialized initial one when in SPA mode) */
 	let has_navigated = false;
 
 	let force_invalidation = false;
@@ -1244,6 +1244,7 @@ export function create_client(app, target) {
 			}
 
 			root.$set(navigation_result.props);
+			has_navigated = true;
 		} else {
 			initialize(navigation_result);
 		}
@@ -1302,7 +1303,6 @@ export function create_client(app, target) {
 		stores.navigating.set(null);
 
 		updating = false;
-		has_navigated = true;
 	}
 
 	/**

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -192,6 +192,8 @@ export function create_client(app, target) {
 	let updating = false;
 	let navigating = false;
 	let hash_navigating = false;
+	/** True as soon as there happened one client-side navigation */
+	let has_navigated = false;
 
 	let force_invalidation = false;
 
@@ -204,8 +206,6 @@ export function create_client(app, target) {
 
 	/** @type {number} */
 	let current_navigation_index = history.state?.[NAVIGATION_INDEX];
-
-	let has_navigated = false;
 
 	if (!current_history_index) {
 		// we use Date.now() as an offset so that cross-document navigations
@@ -295,7 +295,6 @@ export function create_client(app, target) {
 
 		capture_snapshot(current_navigation_index);
 		storage.set(SNAPSHOT_KEY, snapshots);
-
 		storage.set(STATES_KEY, states, devalue.stringify);
 	}
 
@@ -1183,7 +1182,7 @@ export function create_client(app, target) {
 
 		// ensure the url pathname matches the page's trailing slash option
 		if (navigation_result.props.page.url.pathname !== url.pathname) {
-			url.pathname = navigation_result.props.page?.url.pathname;
+			url.pathname = navigation_result.props.page.url.pathname;
 		}
 
 		const state = popped ? popped.state : {};
@@ -1878,9 +1877,7 @@ export function create_client(app, target) {
 					const scroll = scroll_positions[history_index];
 					const state = states[history_index] ?? {};
 					const url = new URL(event.state[PAGE_URL_KEY] ?? location.href);
-
 					const navigation_index = event.state[NAVIGATION_INDEX];
-
 					const is_hash_change = location.href.split('#')[0] === current.url.href.split('#')[0];
 					const shallow =
 						navigation_index === current_navigation_index && (has_navigated || is_hash_change);

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -301,7 +301,7 @@ export function create_client(app, target) {
 
 	/**
 	 * @param {string | URL} url
-	 * @param {import('@sveltejs/kit').NavigationOptions} options
+	 * @param {{ replaceState?: boolean; noScroll?: boolean; keepFocus?: boolean; invalidateAll?: boolean; }} options
 	 * @param {number} redirect_count
 	 * @param {{}} [nav_token]
 	 */

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1579,7 +1579,7 @@ export function create_client(app, target) {
 			return preload_code(pathname);
 		},
 
-		push_state: (state, url = current.url) => {
+		push_state: (url, state) => {
 			if (DEV) {
 				try {
 					devalue.stringify(state);
@@ -1595,7 +1595,7 @@ export function create_client(app, target) {
 				[PAGE_URL_KEY]: page.url.href
 			};
 
-			original_push_state.call(history, opts, '', new URL(url).href);
+			original_push_state.call(history, opts, '', resolve_url(url));
 
 			page = { ...page, state };
 			root.$set({ page });
@@ -1604,7 +1604,7 @@ export function create_client(app, target) {
 			clear_onward_history(current_history_index, current_navigation_index);
 		},
 
-		replace_state: (state, url = current.url) => {
+		replace_state: (url, state) => {
 			if (DEV) {
 				try {
 					devalue.stringify(state);
@@ -1620,7 +1620,7 @@ export function create_client(app, target) {
 				[PAGE_URL_KEY]: page.url.href
 			};
 
-			original_replace_state.call(history, opts, '', new URL(url).href);
+			original_replace_state.call(history, opts, '', resolve_url(url));
 
 			page = { ...page, state };
 			root.$set({ page });

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1805,17 +1805,16 @@ export function create_client(app, target) {
 
 					// hashchange event shouldn't occur if the router is replacing state.
 					hash_navigating = false;
-					event.preventDefault();
 				}
+
+				event.preventDefault();
 
 				navigate({
 					type: 'link',
 					url,
 					keepfocus: options.keepfocus,
 					noscroll: options.noscroll,
-					replace_state: options.replace_state ?? url.href === location.href,
-					accept: () => event.preventDefault(),
-					block: () => event.preventDefault()
+					replace_state: options.replace_state ?? url.href === location.href
 				});
 			});
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -300,22 +300,18 @@ export function create_client(app, target) {
 
 	/**
 	 * @param {string | URL} url
-	 * @param {{ noScroll?: boolean; replaceState?: boolean; keepFocus?: boolean; state?: any; invalidateAll?: boolean }} opts
+	 * @param {{ noScroll?: boolean; replaceState?: boolean; keepFocus?: boolean; invalidateAll?: boolean }} opts
 	 * @param {number} redirect_count
 	 * @param {{}} [nav_token]
 	 */
 	async function goto(
 		url,
-		{
-			noScroll = false,
-			replaceState = false,
-			keepFocus = false,
-			state = {},
-			invalidateAll = false
-		},
+		{ noScroll = false, replaceState = false, keepFocus = false, invalidateAll = false },
 		redirect_count,
 		nav_token
 	) {
+		const state = {};
+
 		return navigate({
 			url: resolve_url(url),
 			scroll: noScroll ? scroll_state() : null,
@@ -1513,6 +1509,13 @@ export function create_client(app, target) {
 
 		goto: (url, opts = {}) => {
 			url = resolve_url(url);
+
+			if (DEV && opts.state) {
+				// TOOD 3.0 remove
+				throw new Error(
+					'Passing `state` to `goto` is no longer supported. Use `pushState` and `replaceState` from `$app/navigation` instead.'
+				);
+			}
 
 			if (url.origin !== origin) {
 				return Promise.reject(

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -214,7 +214,8 @@ export function create_client(app, target) {
 		current_history_index = current_navigation_index = Date.now();
 
 		// create initial history entry, so we can return here
-		original_replace_state(
+		original_replace_state.call(
+			history,
 			{
 				...history.state,
 				[HISTORY_INDEX]: current_history_index,
@@ -1937,7 +1938,8 @@ export function create_client(app, target) {
 				// we need to update history, otherwise we have to leave it alone
 				if (hash_navigating) {
 					hash_navigating = false;
-					original_replace_state(
+					original_replace_state.call(
+						history,
 						{
 							...history.state,
 							[HISTORY_INDEX]: ++current_history_index,

--- a/packages/kit/src/runtime/client/constants.js
+++ b/packages/kit/src/runtime/client/constants.js
@@ -1,6 +1,10 @@
 export const SNAPSHOT_KEY = 'sveltekit:snapshot';
 export const SCROLL_KEY = 'sveltekit:scroll';
-export const INDEX_KEY = 'sveltekit:index';
+export const STATES_KEY = 'sveltekit:states';
+export const PAGE_URL_KEY = 'sveltekit:pageurl';
+
+export const HISTORY_INDEX = 'sveltekit:history';
+export const NAVIGATION_INDEX = 'sveltekit:navigation';
 
 export const PRELOAD_PRIORITIES = /** @type {const} */ ({
 	tap: 1,

--- a/packages/kit/src/runtime/client/session-storage.js
+++ b/packages/kit/src/runtime/client/session-storage.js
@@ -1,10 +1,11 @@
 /**
  * Read a value from `sessionStorage`
  * @param {string} key
+ * @param {(value: string) => any} parse
  */
-export function get(key) {
+export function get(key, parse = JSON.parse) {
 	try {
-		return JSON.parse(sessionStorage[key]);
+		return parse(sessionStorage[key]);
 	} catch {
 		// do nothing
 	}
@@ -14,11 +15,12 @@ export function get(key) {
  * Write a value to `sessionStorage`
  * @param {string} key
  * @param {any} value
+ * @param {(value: any) => string} stringify
  */
-export function set(key, value) {
-	const json = JSON.stringify(value);
+export function set(key, value, stringify = JSON.stringify) {
+	const data = stringify(value);
 	try {
-		sessionStorage[key] = json;
+		sessionStorage[key] = data;
 	} catch {
 		// do nothing
 	}

--- a/packages/kit/src/runtime/client/singletons.js
+++ b/packages/kit/src/runtime/client/singletons.js
@@ -21,7 +21,13 @@ export function init(opts) {
  */
 export function client_method(key) {
 	if (!BROWSER) {
-		if (key === 'before_navigate' || key === 'after_navigate' || key === 'on_navigate') {
+		if (
+			key === 'before_navigate' ||
+			key === 'after_navigate' ||
+			key === 'on_navigate' ||
+			key === 'push_state' ||
+			key === 'replace_state'
+		) {
 			// @ts-expect-error doesn't recognize that both keys here return void so expects a async function
 			return () => {};
 		} else {

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -7,7 +7,9 @@ import {
 	invalidate,
 	invalidateAll,
 	preloadCode,
-	preloadData
+	preloadData,
+	pushState,
+	replaceState
 } from '../app/navigation.js';
 import { SvelteComponent } from 'svelte';
 import { ClientHooks, CSRPageNode, CSRPageNodeLoader, CSRRoute, TrailingSlash, Uses } from 'types';
@@ -51,6 +53,8 @@ export interface Client {
 	invalidate_all: typeof invalidateAll;
 	preload_code: typeof preloadCode;
 	preload_data: typeof preloadData;
+	push_state: typeof pushState;
+	replace_state: typeof replaceState;
 	apply_action: typeof applyAction;
 
 	// private API
@@ -91,8 +95,8 @@ export type NavigationFinished = {
 	state: NavigationState;
 	props: {
 		constructors: Array<typeof SvelteComponent>;
-		components?: Array<SvelteComponent>;
-		page?: Page;
+		components: Array<typeof SvelteComponent>;
+		page: Page;
 		form?: Record<string, any> | null;
 		[key: `data_${number}`]: Record<string, any>;
 	};

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -95,7 +95,7 @@ export type NavigationFinished = {
 	state: NavigationState;
 	props: {
 		constructors: Array<typeof SvelteComponent>;
-		components?: Array<typeof SvelteComponent>;
+		components?: Array<SvelteComponent>;
 		page: Page;
 		form?: Record<string, any> | null;
 		[key: `data_${number}`]: Record<string, any>;

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -95,7 +95,7 @@ export type NavigationFinished = {
 	state: NavigationState;
 	props: {
 		constructors: Array<typeof SvelteComponent>;
-		components: Array<typeof SvelteComponent>;
+		components?: Array<typeof SvelteComponent>;
 		page: Page;
 		form?: Record<string, any> | null;
 		[key: `data_${number}`]: Record<string, any>;

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -149,7 +149,7 @@ export function get_link_info(a, base) {
  */
 export function get_router_options(element) {
 	/** @type {ValidLinkOptions<'keepfocus'> | null} */
-	let keep_focus = null;
+	let keepfocus = null;
 
 	/** @type {ValidLinkOptions<'noscroll'> | null} */
 	let noscroll = null;
@@ -172,7 +172,7 @@ export function get_router_options(element) {
 	while (el && el !== document.documentElement) {
 		if (preload_code === null) preload_code = link_option(el, 'preload-code');
 		if (preload_data === null) preload_data = link_option(el, 'preload-data');
-		if (keep_focus === null) keep_focus = link_option(el, 'keepfocus');
+		if (keepfocus === null) keepfocus = link_option(el, 'keepfocus');
 		if (noscroll === null) noscroll = link_option(el, 'noscroll');
 		if (reload === null) reload = link_option(el, 'reload');
 		if (replace_state === null) replace_state = link_option(el, 'replacestate');
@@ -190,14 +190,14 @@ export function get_router_options(element) {
 			case 'false':
 				return false;
 			default:
-				return null;
+				return undefined;
 		}
 	}
 
 	return {
 		preload_code: levels[preload_code ?? 'off'],
 		preload_data: levels[preload_data ?? 'off'],
-		keep_focus: get_option_state(keep_focus),
+		keepfocus: get_option_state(keepfocus),
 		noscroll: get_option_state(noscroll),
 		reload: get_option_state(reload),
 		replace_state: get_option_state(replace_state)

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -220,12 +220,6 @@ export function notifiable_store(value) {
 		store.set(new_value);
 	}
 
-	/** @param {(value: any) => any} fn */
-	function update(fn) {
-		ready = false;
-		store.update(fn);
-	}
-
 	/** @param {(value: any) => void} run */
 	function subscribe(run) {
 		/** @type {any} */
@@ -237,7 +231,7 @@ export function notifiable_store(value) {
 		});
 	}
 
-	return { notify, set, update, subscribe };
+	return { notify, set, subscribe };
 }
 
 export function create_updated_store() {

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -220,6 +220,12 @@ export function notifiable_store(value) {
 		store.set(new_value);
 	}
 
+	/** @param {(value: any) => any} fn */
+	function update(fn) {
+		ready = false;
+		store.update(fn);
+	}
+
 	/** @param {(value: any) => void} run */
 	function subscribe(run) {
 		/** @type {any} */
@@ -231,7 +237,7 @@ export function notifiable_store(value) {
 		});
 	}
 
-	return { notify, set, subscribe };
+	return { notify, set, update, subscribe };
 }
 
 export function create_updated_store() {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -141,7 +141,8 @@ export async function render_response({
 			status,
 			url: event.url,
 			data,
-			form: form_value
+			form: form_value,
+			state: {}
 		};
 
 		// use relative paths during rendering, so that the resulting HTML is as

--- a/packages/kit/src/types/ambient.d.ts
+++ b/packages/kit/src/types/ambient.d.ts
@@ -7,6 +7,7 @@
  * 		// interface Error {}
  * 		// interface Locals {}
  * 		// interface PageData {}
+ * 		// interface PageState {}
  * 		// interface Platform {}
  * 	}
  * }
@@ -38,6 +39,11 @@ declare namespace App {
 	 * Use optional properties for data that is only present on specific pages. Do not add an index signature (`[key: string]: any`).
 	 */
 	export interface PageData {}
+
+	/**
+	 * The shape of the `$page.state` object, which can be manipulated using the `pushState` and `replaceState` functions from `$app/navigation`.
+	 */
+	export interface PageState {}
 
 	/**
 	 * If your adapter provides [platform-specific context](https://kit.svelte.dev/docs/adapters#platform-specific-context) via `event.platform`, you can specify it here.

--- a/packages/kit/src/types/ambient.d.ts
+++ b/packages/kit/src/types/ambient.d.ts
@@ -41,7 +41,7 @@ declare namespace App {
 	export interface PageData {}
 
 	/**
-	 * The shape of the `$page.state` object, which can be manipulated using the `pushState` and `replaceState` functions from `$app/navigation`.
+	 * The shape of the `$page.state` object, which can be manipulated using the [`pushState`](https://kit.svelte.dev/docs/modules#$app-navigation-pushstate) and [`replaceState`](https://kit.svelte.dev/docs/modules#$app-navigation-replacestate) functions from `$app/navigation`.
 	 */
 	export interface PageState {}
 

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -78,6 +78,14 @@ export function decode_uri(uri) {
 }
 
 /**
+ * Returns everything up to the first `#` in a URL
+ * @param {{href: string}} url_like
+ */
+export function strip_hash({ href }) {
+	return href.split('#')[0];
+}
+
+/**
  * URL properties that could change during the lifetime of the page,
  * which excludes things like `origin`
  */

--- a/packages/kit/test/apps/basics/src/app.d.ts
+++ b/packages/kit/test/apps/basics/src/app.d.ts
@@ -8,6 +8,10 @@ declare global {
 			url?: URL;
 		}
 
+		interface PageState {
+			active: boolean;
+		}
+
 		interface Platform {}
 	}
 }

--- a/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/+layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/+layout.svelte
@@ -1,0 +1,5 @@
+<a href="/shallow-routing/push-state">push-state</a>
+<a href="/shallow-routing/push-state/a">a</a>
+<a href="/shallow-routing/push-state/b">b</a>
+
+<slot />

--- a/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/+page.js
@@ -1,0 +1,5 @@
+export function load() {
+	return {
+		now: Date.now()
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/+page.svelte
@@ -1,0 +1,19 @@
+<script>
+	import { pushState } from '$app/navigation';
+	import { page } from '$app/stores';
+
+	function one() {
+		pushState('', { active: true });
+	}
+
+	function two() {
+		pushState('/shallow-routing/push-state/a', { active: true });
+	}
+</script>
+
+<h1>parent</h1>
+
+<button data-id="one" on:click={one}>push state on current page</button>
+<button data-id="two" on:click={two}>push state on child page</button>
+
+<p>active: {$page.state.active ?? false}</p>

--- a/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/+page.svelte
@@ -1,6 +1,8 @@
 <script>
-	import { pushState } from '$app/navigation';
+	import { invalidateAll, pushState } from '$app/navigation';
 	import { page } from '$app/stores';
+
+	export let data;
 
 	function one() {
 		pushState('', { active: true });
@@ -15,5 +17,7 @@
 
 <button data-id="one" on:click={one}>push state on current page</button>
 <button data-id="two" on:click={two}>push state on child page</button>
+<button data-id="invalidate" on:click={invalidateAll}>invalidate all</button>
 
 <p>active: {$page.state.active ?? false}</p>
+<span>{data.now}</span>

--- a/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/a/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/a/+page.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { page } from '$app/stores';
+</script>
+
+<h1>a</h1>
+
+<p>active: {$page.state.active ?? false}</p>

--- a/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/b/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/b/+page.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { page } from '$app/stores';
+</script>
+
+<h1>b</h1>
+
+<p>active: {$page.state.active ?? false}</p>

--- a/packages/kit/test/apps/basics/src/routes/shallow-routing/replace-state/+layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shallow-routing/replace-state/+layout.svelte
@@ -1,0 +1,5 @@
+<a href="/shallow-routing/replace-state">replace-state</a>
+<a href="/shallow-routing/replace-state/a">a</a>
+<a href="/shallow-routing/replace-state/b">b</a>
+
+<slot />

--- a/packages/kit/test/apps/basics/src/routes/shallow-routing/replace-state/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shallow-routing/replace-state/+page.svelte
@@ -1,0 +1,19 @@
+<script>
+	import { replaceState } from '$app/navigation';
+	import { page } from '$app/stores';
+
+	function one() {
+		replaceState('', { active: true });
+	}
+
+	function two() {
+		replaceState('/shallow-routing/replace-state/a', { active: true });
+	}
+</script>
+
+<h1>parent</h1>
+
+<button data-id="one" on:click={one}>replace state on current page</button>
+<button data-id="two" on:click={two}>replace state on child page</button>
+
+<p>active: {$page.state.active ?? false}</p>

--- a/packages/kit/test/apps/basics/src/routes/shallow-routing/replace-state/a/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shallow-routing/replace-state/a/+page.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { page } from '$app/stores';
+</script>
+
+<h1>a</h1>
+
+<p>active: {$page.state.active ?? false}</p>

--- a/packages/kit/test/apps/basics/src/routes/shallow-routing/replace-state/b/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shallow-routing/replace-state/b/+page.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { page } from '$app/stores';
+</script>
+
+<h1>b</h1>
+
+<p>active: {$page.state.active ?? false}</p>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -950,6 +950,23 @@ test.describe('Shallow routing', () => {
 		await expect(page.locator('p')).toHaveText('active: true');
 	});
 
+	test('Invalidates the correct route after pushing state to a new URL', async ({
+		baseURL,
+		page
+	}) => {
+		await page.goto('/shallow-routing/push-state');
+		await expect(page.locator('p')).toHaveText('active: false');
+
+		const now = await page.locator('span').textContent();
+
+		await page.locator('[data-id="two"]').click();
+		expect(page.url()).toBe(`${baseURL}/shallow-routing/push-state/a`);
+
+		await page.locator('[data-id="invalidate"]').click();
+		await expect(page.locator('h1')).toHaveText('parent');
+		await expect(page.locator('span')).not.toHaveText(now);
+	});
+
 	test('Replaces state on the current URL', async ({ baseURL, page, clicknav }) => {
 		await page.goto('/shallow-routing/replace-state/b');
 		await clicknav('[href="/shallow-routing/replace-state"]');

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -913,3 +913,74 @@ test.describe('goto', () => {
 		await expect(page.locator('p')).toHaveText(message);
 	});
 });
+
+test.describe('Shallow routing', () => {
+	test('Pushes state to the current URL', async ({ page }) => {
+		await page.goto('/shallow-routing/push-state');
+		await expect(page.locator('p')).toHaveText('active: false');
+
+		await page.locator('[data-id="one"]').click();
+		await expect(page.locator('p')).toHaveText('active: true');
+
+		await page.goBack();
+		await expect(page.locator('p')).toHaveText('active: false');
+	});
+
+	test('Pushes state to a new URL', async ({ baseURL, page }) => {
+		await page.goto('/shallow-routing/push-state');
+		await expect(page.locator('p')).toHaveText('active: false');
+
+		await page.locator('[data-id="two"]').click();
+		expect(page.url()).toBe(`${baseURL}/shallow-routing/push-state/a`);
+		await expect(page.locator('h1')).toHaveText('parent');
+		await expect(page.locator('p')).toHaveText('active: true');
+
+		await page.reload();
+		await expect(page.locator('h1')).toHaveText('a');
+		await expect(page.locator('p')).toHaveText('active: false');
+
+		await page.goBack();
+		expect(page.url()).toBe(`${baseURL}/shallow-routing/push-state`);
+		await expect(page.locator('h1')).toHaveText('parent');
+		await expect(page.locator('p')).toHaveText('active: false');
+
+		await page.goForward();
+		expect(page.url()).toBe(`${baseURL}/shallow-routing/push-state/a`);
+		await expect(page.locator('h1')).toHaveText('parent');
+		await expect(page.locator('p')).toHaveText('active: true');
+	});
+
+	test('Replaces state on the current URL', async ({ baseURL, page, clicknav }) => {
+		await page.goto('/shallow-routing/replace-state/b');
+		await clicknav('[href="/shallow-routing/replace-state"]');
+
+		await page.locator('[data-id="one"]').click();
+		await expect(page.locator('p')).toHaveText('active: true');
+
+		await page.goBack();
+		expect(page.url()).toBe(`${baseURL}/shallow-routing/replace-state/b`);
+		await expect(page.locator('h1')).toHaveText('b');
+
+		await page.goForward();
+		expect(page.url()).toBe(`${baseURL}/shallow-routing/replace-state`);
+		await expect(page.locator('h1')).toHaveText('parent');
+		await expect(page.locator('p')).toHaveText('active: true');
+	});
+
+	test('Replaces state on a new URL', async ({ baseURL, page, clicknav }) => {
+		await page.goto('/shallow-routing/replace-state/b');
+		await clicknav('[href="/shallow-routing/replace-state"]');
+
+		await page.locator('[data-id="two"]').click();
+		await expect(page.locator('p')).toHaveText('active: true');
+
+		await page.goBack();
+		expect(page.url()).toBe(`${baseURL}/shallow-routing/replace-state/b`);
+		await expect(page.locator('h1')).toHaveText('b');
+
+		await page.goForward();
+		expect(page.url()).toBe(`${baseURL}/shallow-routing/replace-state/a`);
+		await expect(page.locator('h1')).toHaveText('parent');
+		await expect(page.locator('p')).toHaveText('active: true');
+	});
+});

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -22,22 +22,8 @@ declare module '@sveltejs/kit' {
 	export type LoadProperties<input extends Record<string, any> | void> = input extends void
 		? undefined // needs to be undefined, because void will break intellisense
 		: input extends Record<string, any>
-	<<<<<<< HEAD
 			? input
 			: unknown;
-	=======
-			? {
-					[key in keyof input]: Awaited<input[key]>;
-				}
-			: {} extends input // handles the any case
-				? input
-				: unknown;
-
-	export type AwaitedProperties<input extends Record<string, any> | void> =
-		AwaitedPropertiesUnion<input> extends Record<string, any>
-			? OptionalUnion<AwaitedPropertiesUnion<input>>
-			: AwaitedPropertiesUnion<input>;
-	>>>>>>> master
 
 	export type AwaitedActions<T extends Record<string, (...args: any) => any>> = OptionalUnion<
 		{

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -827,13 +827,6 @@ declare module '@sveltejs/kit' {
 	 */
 	export type NavigationType = 'enter' | 'form' | 'leave' | 'link' | 'goto' | 'popstate';
 
-	export interface NavigationOptions {
-		replaceState?: boolean;
-		noScroll?: boolean;
-		keepFocus?: boolean;
-		invalidateAll?: boolean;
-	}
-
 	export interface Navigation {
 		/**
 		 * Where navigation was triggered from
@@ -951,7 +944,7 @@ declare module '@sveltejs/kit' {
 		 */
 		data: App.PageData & Record<string, any>;
 		/**
-		 * The page state, which can be manipulated using the `pushState` and `replaceState` functions from `$app/navigation`.
+		 * The page state, which can be manipulated using the [`pushState`](https://kit.svelte.dev/docs/modules#$app-navigation-pushstate) and [`replaceState`](https://kit.svelte.dev/docs/modules#$app-navigation-replacestate) functions from `$app/navigation`.
 		 */
 		state: App.PageState;
 		/**
@@ -1933,7 +1926,12 @@ declare module '$app/navigation' {
 	 * @param url Where to navigate to. Note that if you've set [`config.kit.paths.base`](https://kit.svelte.dev/docs/configuration#paths) and the URL is root-relative, you need to prepend the base path if you want to navigate within the app.
 	 * @param {Object} opts Options related to the navigation
 	 * */
-	export const goto: (url: string | URL, opts?: import('@sveltejs/kit').NavigationOptions) => Promise<void>;
+	export const goto: (url: string | URL, opts?: {
+		replaceState?: boolean;
+		noScroll?: boolean;
+		keepFocus?: boolean;
+		invalidateAll?: boolean;
+	}) => Promise<void>;
 	/**
 	 * Causes any `load` functions belonging to the currently active page to re-run if they depend on the `url` in question, via `fetch` or `depends`. Returns a `Promise` that resolves when the page is subsequently updated.
 	 *
@@ -2113,7 +2111,7 @@ declare namespace App {
 	export interface PageData {}
 
 	/**
-	 * The shape of the `$page.state` object, which can be manipulated using the `pushState` and `replaceState` functions from `$app/navigation`.
+	 * The shape of the `$page.state` object, which can be manipulated using the [`pushState`](https://kit.svelte.dev/docs/modules#$app-navigation-pushstate) and [`replaceState`](https://kit.svelte.dev/docs/modules#$app-navigation-replacestate) functions from `$app/navigation`.
 	 */
 	export interface PageState {}
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1961,7 +1961,7 @@ declare module '$app/navigation' {
 	 *
 	 * This is the same behaviour that SvelteKit triggers when the user taps or mouses over an `<a>` element with `data-sveltekit-preload-data`.
 	 * If the next navigation is to `href`, the values returned from load will be used, making navigation instantaneous.
-	 * Returns a Promise that resolves when the preload is complete.
+	 * Returns a Promise that resolves with the new `$page.data` when the preload is complete.
 	 *
 	 * @param href Page to preload
 	 * */

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1961,7 +1961,7 @@ declare module '$app/navigation' {
 	 *
 	 * This is the same behaviour that SvelteKit triggers when the user taps or mouses over an `<a>` element with `data-sveltekit-preload-data`.
 	 * If the next navigation is to `href`, the values returned from load will be used, making navigation instantaneous.
-	 * Returns a Promise that resolves with the new `$page.data` when the preload is complete.
+	 * Returns a Promise that resolves with the result of running the new route's `load` functions once the preload is complete.
 	 *
 	 * @param href Page to preload
 	 * */

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -827,6 +827,13 @@ declare module '@sveltejs/kit' {
 	 */
 	export type NavigationType = 'enter' | 'form' | 'leave' | 'link' | 'goto' | 'popstate';
 
+	export interface NavigationOptions {
+		replaceState?: boolean;
+		noScroll?: boolean;
+		keepFocus?: boolean;
+		invalidateAll?: boolean;
+	}
+
 	export interface Navigation {
 		/**
 		 * Where navigation was triggered from
@@ -1926,13 +1933,7 @@ declare module '$app/navigation' {
 	 * @param url Where to navigate to. Note that if you've set [`config.kit.paths.base`](https://kit.svelte.dev/docs/configuration#paths) and the URL is root-relative, you need to prepend the base path if you want to navigate within the app.
 	 * @param {Object} opts Options related to the navigation
 	 * */
-	export const goto: (url: string | URL, opts?: {
-		replaceState?: boolean;
-		noScroll?: boolean;
-		keepFocus?: boolean;
-		invalidateAll?: boolean;
-		state?: any;
-	}) => Promise<void>;
+	export const goto: (url: string | URL, opts?: import('@sveltejs/kit').NavigationOptions) => Promise<void>;
 	/**
 	 * Causes any `load` functions belonging to the currently active page to re-run if they depend on the `url` in question, via `fetch` or `depends`. Returns a `Promise` that resolves when the page is subsequently updated.
 	 *
@@ -2007,12 +2008,12 @@ declare module '$app/navigation' {
 	 * */
 	export const afterNavigate: (callback: (navigation: import('@sveltejs/kit').AfterNavigate) => void) => void;
 	/**
-	 * Programmatically create a new history entry with the given `$page.state`. To use the current URL, you can pass `''` as the first argument.
+	 * Programmatically create a new history entry with the given `$page.state`. To use the current URL, you can pass `''` as the first argument. Used for [shallow routing](https://kit.svelte.dev/docs/shallow-routing).
 	 *
 	 * */
 	export const pushState: (url: string | URL, state: App.PageState) => void;
 	/**
-	 * Programmatically replace the current history entry with the given `$page.state`. To use the current URL, you can pass `''` as the first argument.
+	 * Programmatically replace the current history entry with the given `$page.state`. To use the current URL, you can pass `''` as the first argument. Used for [shallow routing](https://kit.svelte.dev/docs/shallow-routing).
 	 *
 	 * */
 	export const replaceState: (url: string | URL, state: App.PageState) => void;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1666,7 +1666,27 @@ declare module '@sveltejs/kit' {
 	}
 
 	type ValidatedConfig = RecursiveRequired<Config>;
+	/**
+	 * Throws an error with a HTTP status code and an optional message.
+	 * When called during request handling, this will cause SvelteKit to
+	 * return an error response without invoking `handleError`.
+	 * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
+	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
+	 * @param body An object that conforms to the App.Error type. If a string is passed, it will be used as the message property.
+	 * @throws {HttpError} This error instructs SvelteKit to initiate HTTP error handling.
+	 * @throws {Error} If the provided status is invalid (not between 400 and 599).
+	 */
 	export function error(status: NumericRange<400, 599>, body: App.Error): never;
+	/**
+	 * Throws an error with a HTTP status code and an optional message.
+	 * When called during request handling, this will cause SvelteKit to
+	 * return an error response without invoking `handleError`.
+	 * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
+	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
+	 * @param body An object that conforms to the App.Error type. If a string is passed, it will be used as the message property.
+	 * @throws {HttpError} This error instructs SvelteKit to initiate HTTP error handling.
+	 * @throws {Error} If the provided status is invalid (not between 400 and 599).
+	 */
 	export function error(status: NumericRange<400, 599>, body?: {
 		message: string;
 	} extends App.Error ? App.Error | string | undefined : never): never;
@@ -1682,8 +1702,8 @@ declare module '@sveltejs/kit' {
 	 * Make sure you're not catching the thrown redirect, which would prevent SvelteKit from handling it.
 	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages). Must be in the range 300-308.
 	 * @param location The location to redirect to.
-	 * @throws This error instructs SvelteKit to redirect to the specified location.
-	 * @throws If the provided status is invalid.
+	 * @throws {Redirect} This error instructs SvelteKit to redirect to the specified location.
+	 * @throws {Error} If the provided status is invalid.
 	 * */
 	export function redirect(status: NumericRange<300, 308>, location: string | URL): never;
 	/**
@@ -1703,7 +1723,16 @@ declare module '@sveltejs/kit' {
 	 * @param init Options such as `status` and `headers` that will be added to the response. A `Content-Length` header will be added automatically.
 	 */
 	export function text(body: string, init?: ResponseInit | undefined): Response;
+	/**
+	 * Create an `ActionFailure` object.
+	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
+	 * */
 	export function fail(status: number): ActionFailure<undefined>;
+	/**
+	 * Create an `ActionFailure` object.
+	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
+	 * @param data Data associated with the failure (e.g. validation errors)
+	 * */
 	export function fail<T extends Record<string, unknown> | undefined = undefined>(status: number, data: T): ActionFailure<T>;
 	export type LessThan<TNumber extends number, TArray extends any[] = []> = TNumber extends TArray['length'] ? TArray[number] : LessThan<TNumber, [...TArray, TArray['length']]>;
 	export type NumericRange<TStart extends number, TEnd extends number> = Exclude<TEnd | LessThan<TEnd>, LessThan<TStart>>;
@@ -1720,7 +1749,7 @@ declare module '@sveltejs/kit' {
 	class Redirect_1 {
 		
 		constructor(status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308, location: string);
-		status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308;
+		status: 301 | 302 | 303 | 307 | 308 | 300 | 304 | 305 | 306;
 		location: string;
 	}
 }
@@ -1970,7 +1999,7 @@ declare module '$app/navigation' {
 	 *
 	 * `onNavigate` must be called during a component initialization. It remains active as long as the component is mounted.
 	 * */
-	export const onNavigate: (callback: (navigation: import('@sveltejs/kit').OnNavigate) => import('types').MaybePromise<(() => void) | void>) => void;
+	export const onNavigate: (callback: (navigation: import('@sveltejs/kit').OnNavigate) => MaybePromise<(() => void) | void>) => void;
 	/**
 	 * A lifecycle function that runs the supplied `callback` when the current component mounts, and also whenever we navigate to a new URL.
 	 *

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2007,15 +2007,15 @@ declare module '$app/navigation' {
 	 * */
 	export const afterNavigate: (callback: (navigation: import('@sveltejs/kit').AfterNavigate) => void) => void;
 	/**
-	 * Programmatically create a new history entry with the given `$page.state`.
+	 * Programmatically create a new history entry with the given `$page.state`. To use the current URL, you can pass `''` as the first argument.
 	 *
 	 * */
-	export const pushState: (state: App.PageState, url?: string | URL) => void;
+	export const pushState: (url: string | URL, state: App.PageState) => void;
 	/**
-	 * Programmatically replace the current history entry with the given `$page.state`.
+	 * Programmatically replace the current history entry with the given `$page.state`. To use the current URL, you can pass `''` as the first argument.
 	 *
 	 * */
-	export const replaceState: (state: App.PageState, url?: string | URL) => void;
+	export const replaceState: (url: string | URL, state: App.PageState) => void;
 	type MaybePromise<T> = T | Promise<T>;
 }
 


### PR DESCRIPTION
Closes #2673. This is a continuation of #9847, on top of the `version-2` branch. Copying the TODOs from that PR:

- [x] Add `App.PageState` and other types
- [x] remove `goto(url, { state })`
- [x] intercept `history.pushState` and `history.replaceState` to discourage their use
- [x] `invalidateAll()` should probably use `$page.url.href` rather than `location.href`, since those two things can now be different
- [x] ~~fix bugginess around reloads. If you push state and refresh the page, you go to pushed URL (as intended), and hitting the back button will take you to the page you came from, but only because there's special handling for that case. If you push state and click from there to a new page, then reload _that_ page, clicking back twice won't work as expected. Still looking into how to fix this. possibly nuke navigation index history on page reload? unless there's a better way~~ actually i'm not sure what this referred to
- [x] docs
- [x] tests

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
