### PR TITLE
chore: check range is valid

### DIFF
--- a/packages/migrate/migrations/sveltekit-2/index.js
+++ b/packages/migrate/migrations/sveltekit-2/index.js
@@ -49,7 +49,7 @@ export async function migrate() {
 		bail('Please install Svelte before continuing');
 	}
 
-	if (semver.gtr('4.0.0', svelte_dep)) {
+	if (semver.validRange(svelte_dep) && semver.gtr('4.0.0', svelte_dep)) {
 		console.log(
 			colors
 				.bold()

--- a/packages/migrate/migrations/sveltekit-2/migrate.js
+++ b/packages/migrate/migrations/sveltekit-2/migrate.js
@@ -162,7 +162,10 @@ function remove_throws(source) {
 			const call_expression = id.getParent();
 			const throw_stmt = call_expression?.getParent();
 			if (Node.isCallExpression(call_expression) && Node.isThrowStatement(throw_stmt)) {
-				throw_stmt.replaceWithText(call_expression.getText() + ';');
+				throw_stmt.replaceWithText((writer) => {
+					writer.setIndentationLevel(0);
+					writer.write(call_expression.getText() + ';');
+				});
 			}
 		}
 	}


### PR DESCRIPTION
prevents `svelte-migrate` crashing on encountering a `workspace:` dependency