### PR TITLE
breaking: require SvelteKit 2 for all adapters

### DIFF
--- a/.changeset/hip-spoons-crash.md
+++ b/.changeset/hip-spoons-crash.md
@@ -1,0 +1,7 @@
+---
+"@sveltejs/adapter-cloudflare-workers": major
+"@sveltejs/adapter-cloudflare": major
+"@sveltejs/adapter-netlify": major
+---
+
+breaking: require SvelteKit 2

--- a/.changeset/silly-frogs-love.md
+++ b/.changeset/silly-frogs-love.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-auto": major
+---
+
+breaking: require SvelteKit 2

--- a/packages/adapter-auto/adapters.js
+++ b/packages/adapter-auto/adapters.js
@@ -5,7 +5,7 @@ export const adapters = [
 		name: 'Vercel',
 		test: () => !!process.env.VERCEL,
 		module: '@sveltejs/adapter-vercel',
-		version: '2'
+		version: '4'
 	},
 	{
 		name: 'Cloudflare Pages',

--- a/packages/adapter-auto/adapters.js
+++ b/packages/adapter-auto/adapters.js
@@ -11,13 +11,13 @@ export const adapters = [
 		name: 'Cloudflare Pages',
 		test: () => !!process.env.CF_PAGES,
 		module: '@sveltejs/adapter-cloudflare',
-		version: '2'
+		version: '3'
 	},
 	{
 		name: 'Netlify',
 		test: () => !!process.env.NETLIFY,
 		module: '@sveltejs/adapter-netlify',
-		version: '2'
+		version: '3'
 	},
 	{
 		name: 'Azure Static Web Apps',

--- a/packages/adapter-auto/package.json
+++ b/packages/adapter-auto/package.json
@@ -39,6 +39,6 @@
 		"import-meta-resolve": "^4.0.0"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.0.0 || ^2.0.0"
+		"@sveltejs/kit": "^2.0.0"
 	}
 }

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -40,6 +40,6 @@
 		"typescript": "^5.3.3"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.0.0 || ^2.0.0"
+		"@sveltejs/kit": "^2.0.0"
 	}
 }

--- a/packages/adapter-cloudflare-workers/package.json
+++ b/packages/adapter-cloudflare-workers/package.json
@@ -35,6 +35,7 @@
 		"esbuild": "^0.19.9"
 	},
 	"devDependencies": {
+		"@sveltejs/kit": "workspace:^",
 		"@cloudflare/kv-asset-handler": "^0.3.0",
 		"@types/node": "^18.19.3",
 		"typescript": "^5.3.3"

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -37,6 +37,7 @@
 		"worktop": "0.8.0-next.15"
 	},
 	"devDependencies": {
+		"@sveltejs/kit": "workspace:^",
 		"@types/node": "^18.19.3",
 		"@types/ws": "^8.5.10",
 		"typescript": "^5.3.3"

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -42,7 +42,7 @@
 		"typescript": "^5.3.3"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.0.0 || ^2.0.0"
+		"@sveltejs/kit": "^2.0.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -51,6 +51,6 @@
 		"vitest": "^1.0.4"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^1.5.0 || ^2.0.0"
+		"@sveltejs/kit": "^2.0.0"
 	}
 }

--- a/packages/create-svelte/templates/default/package.template.json
+++ b/packages/create-svelte/templates/default/package.template.json
@@ -9,7 +9,7 @@
 	"devDependencies": {
 		"@fontsource/fira-mono": "^4.5.10",
 		"@neoconfetti/svelte": "^1.0.0",
-		"@sveltejs/adapter-auto": "^2.0.0",
+		"@sveltejs/adapter-auto": "^3.0.0",
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
 		"svelte": "^4.2.7",

--- a/packages/create-svelte/templates/skeleton/package.template.json
+++ b/packages/create-svelte/templates/skeleton/package.template.json
@@ -8,7 +8,7 @@
 		"preview": "vite preview"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "^2.0.0",
+		"@sveltejs/adapter-auto": "^3.0.0",
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
 		"svelte": "^4.2.7",

--- a/packages/create-svelte/templates/skeletonlib/package.template.json
+++ b/packages/create-svelte/templates/skeletonlib/package.template.json
@@ -19,7 +19,7 @@
 		"svelte": "^4.0.0"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "^2.0.0",
+		"@sveltejs/adapter-auto": "^3.0.0",
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/package": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",

--- a/packages/migrate/migrations/sveltekit-2/migrate.js
+++ b/packages/migrate/migrations/sveltekit-2/migrate.js
@@ -18,6 +18,12 @@ export function update_pkg_json_content(content) {
 		// All other bumps are done as part of the Svelte 4 migration
 		['@sveltejs/kit', '^2.0.0'],
 		['@sveltejs/adapter-static', '^3.0.0'],
+		['@sveltejs/adapter-node', '^2.0.0'],
+		['@sveltejs/adapter-vercel', '^4.0.0'],
+		['@sveltejs/adapter-netlify', '^3.0.0'],
+		['@sveltejs/adapter-cloudflare', '^3.0.0'],
+		['@sveltejs/adapter-cloudflare-workers', '^2.0.0'],
+		['@sveltejs/adapter-auto', '^3.0.0'],
 		['vite', '^5.0.0'],
 		['vitest', '^1.0.0'],
 		['typescript', '^5.0.0'], // should already be done by Svelte 4 migration, but who knows

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,9 +72,6 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20231121.0
         version: 4.20231121.0
-      '@sveltejs/kit':
-        specifier: ^1.0.0 || ^2.0.0
-        version: link:../kit
       esbuild:
         specifier: ^0.19.9
         version: 0.19.9
@@ -82,6 +79,9 @@ importers:
         specifier: 0.8.0-next.15
         version: 0.8.0-next.15
     devDependencies:
+      '@sveltejs/kit':
+        specifier: workspace:^
+        version: link:../kit
       '@types/node':
         specifier: ^18.19.3
         version: 18.19.3
@@ -100,9 +100,6 @@ importers:
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
-      '@sveltejs/kit':
-        specifier: ^1.0.0 || ^2.0.0
-        version: link:../kit
       esbuild:
         specifier: ^0.19.9
         version: 0.19.9
@@ -110,6 +107,9 @@ importers:
       '@cloudflare/kv-asset-handler':
         specifier: ^0.3.0
         version: 0.3.0
+      '@sveltejs/kit':
+        specifier: workspace:^
+        version: link:../kit
       '@types/node':
         specifier: ^18.19.3
         version: 18.19.3


### PR DESCRIPTION
Bumping all the adapters to require SvelteKit 2, because a) esbuild changes and we want to be careful b) easier to do minors using new capabilities c) adapter-auto is more robust in installing correct versions then

No changeset for the migration script because that's not released yet.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
