### PR TITLE
chore: sort packages after insert

### DIFF
--- a/.changeset/grumpy-insects-flow.md
+++ b/.changeset/grumpy-insects-flow.md
@@ -1,0 +1,5 @@
+---
+'svelte-migrate': patch
+---
+
+chore: sort packages after insert

--- a/.changeset/grumpy-insects-flow.md
+++ b/.changeset/grumpy-insects-flow.md
@@ -2,4 +2,4 @@
 'svelte-migrate': patch
 ---
 
-chore: sort packages after insert
+chore: insert package at sorted position

--- a/packages/migrate/utils.js
+++ b/packages/migrate/utils.js
@@ -1,10 +1,10 @@
-import fs from 'node:fs';
-import path from 'node:path';
 import colors from 'kleur';
-import ts from 'typescript';
 import MagicString from 'magic-string';
 import { execFileSync, execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
 import semver from 'semver';
+import ts from 'typescript';
 
 /** @param {string} message */
 export function bail(message) {
@@ -244,6 +244,10 @@ export function update_pkg(content, updates) {
 		update_pkg(...update);
 	}
 
+	['dependencies', 'devDependencies'].forEach((key) => {
+		if (key in pkg) pkg[key] = Object.fromEntries(Object.entries(pkg[key]).sort());
+	});
+
 	return JSON.stringify(pkg, null, indent);
 }
 
@@ -322,8 +326,8 @@ export function update_tsconfig(update_tsconfig_content) {
 	const file = fs.existsSync('tsconfig.json')
 		? 'tsconfig.json'
 		: fs.existsSync('jsconfig.json')
-			? 'jsconfig.json'
-			: null;
+		  ? 'jsconfig.json'
+		  : null;
 	if (file) {
 		fs.writeFileSync(file, update_tsconfig_content(fs.readFileSync(file, 'utf8')));
 	}

--- a/packages/migrate/utils.spec.js
+++ b/packages/migrate/utils.spec.js
@@ -1,0 +1,73 @@
+import { assert, test } from 'vitest';
+import { update_pkg } from './utils.js';
+
+test('Inserts package at correct position (1)', () => {
+	const result = update_pkg(
+		`{
+	"dependencies": {
+		"a": "1",
+		"z": "3",
+		"c": "4"
+	}
+}`,
+		[['b', '2', '', 'dependencies']]
+	);
+
+	assert.equal(
+		result,
+		`{
+	"dependencies": {
+		"a": "1",
+		"b": "2",
+		"z": "3",
+		"c": "4"
+	}
+}`
+	);
+});
+
+test('Inserts package at correct position (2)', () => {
+	const result = update_pkg(
+		`{
+	"dependencies": {
+		"a": "1",
+		"b": "2"
+	}
+}`,
+		[['c', '3', '', 'dependencies']]
+	);
+
+	assert.equal(
+		result,
+		`{
+	"dependencies": {
+		"a": "1",
+		"b": "2",
+		"c": "3"
+	}
+}`
+	);
+});
+
+test('Inserts package at correct position (3)', () => {
+	const result = update_pkg(
+		`{
+	"dependencies": {
+		"b": "2",
+		"c": "3"
+	}
+}`,
+		[['a', '1', '', 'dependencies']]
+	);
+
+	assert.equal(
+		result,
+		`{
+	"dependencies": {
+		"a": "1",
+		"b": "2",
+		"c": "3"
+	}
+}`
+	);
+});


### PR DESCRIPTION
`svelte-migrate@1.3.2` does not sort packages after insertion.

As the result, `@sveltejs/vite-plugin-svelte` is placed in the last row.

```jsonc
{
  "devDependencies": {
    "@sveltejs/adapter-auto": "^3.0.0",
    "@sveltejs/kit": "^2.0.0",
    "eslint": "^8.55.0",
    "eslint-config-prettier": "^9.1.0",
    "eslint-plugin-svelte": "^2.35.1",
    "prettier": "^3.1.1",
    "prettier-plugin-svelte": "^3.1.2",
    "svelte": "^4.2.8",
    "svelte-check": "^3.6.2",
    "typescript": "^5.3.3",
    "vite": "^5.0.0",
    // Appended at the end. Not alphabetically sorted.
    "@sveltejs/vite-plugin-svelte": "^3.0.0"
  }
}
```

In this PR, `dependencies` and `devDependencies` are sorted alphabetically.

```javascript
['dependencies', 'devDependencies'].forEach((key) => {
  if (key in pkg) {
    // Method used in the PR
    pkg[key] = Object.fromEntries(Object.entries(pkg[key]).sort());
    // Alternative
    pkg[key] = JSON.parse(JSON.stringify(pkg[key], Object.keys(pkg[key]).sort()));
  }
});
```

---

Migration Results Examples

- [TypeScript Template](https://github.com/hyunbinseo/svelte-kit-templates/blob/646ff36967f1c13058da4c86dc9b79beb81b0895/typescript/package.json#L29)
- [JSDoc Template](https://github.com/hyunbinseo/svelte-kit-templates/blob/646ff36967f1c13058da4c86dc9b79beb81b0895/javascript/package.json#L26)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
