### PR TITLE
fix: reinstantiate state parameter for goto

### DIFF
--- a/.changeset/late-queens-build.md
+++ b/.changeset/late-queens-build.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: reinstantiate state parameter for goto

--- a/documentation/docs/60-appendix/30-migrating-to-sveltekit-2.md
+++ b/documentation/docs/60-appendix/30-migrating-to-sveltekit-2.md
@@ -68,7 +68,7 @@ export function load({ fetch }) {
 
 ## goto(...) changes
 
-`goto(...)` no longer accepts external URLs. To navigate to an external URL, use `window.location = url`. The `state` object now contributes to `$page.state` and requires an `App.PageState` shape, see [shallow routing](shallow-routing) for more info.
+`goto(...)` no longer accepts external URLs. To navigate to an external URL, use `window.location = url`. The `state` object now determines `$page.state` and must adhere to the `App.PageState` interface, if declared. See [shallow routing](shallow-routing) for more details.
 
 ## paths are now relative by default
 

--- a/documentation/docs/60-appendix/30-migrating-to-sveltekit-2.md
+++ b/documentation/docs/60-appendix/30-migrating-to-sveltekit-2.md
@@ -68,7 +68,7 @@ export function load({ fetch }) {
 
 ## goto(...) changes
 
-`goto(...)` no longer accepts external URLs. To navigate to an external URL, use `window.location = url`. The `state` option was removed in favor of [shallow routing](shallow-routing).
+`goto(...)` no longer accepts external URLs. To navigate to an external URL, use `window.location = url`. The `state` object now contributes to `$page.state` and requires an `App.PageState` shape, see [shallow routing](shallow-routing) for more info.
 
 ## paths are now relative by default
 

--- a/packages/kit/src/runtime/app/navigation.js
+++ b/packages/kit/src/runtime/app/navigation.js
@@ -18,6 +18,7 @@ export const disableScrollHandling = /* @__PURE__ */ client_method('disable_scro
  * @param {boolean} [opts.noScroll] If `true`, the browser will maintain its scroll position rather than scrolling to the top of the page after navigation
  * @param {boolean} [opts.keepFocus] If `true`, the currently focused element will retain focus after navigation. Otherwise, focus will be reset to the body
  * @param {boolean} [opts.invalidateAll] If `true`, all `load` functions of the page will be rerun. See https://kit.svelte.dev/docs/load#rerunning-load-functions for more info on invalidation.
+ * @param {App.PageState} [opts.state] An optional object that will be available on the `$page.state` store
  * @returns {Promise<void>}
  */
 export const goto = /* @__PURE__ */ client_method('goto');

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -302,7 +302,7 @@ export function create_client(app, target) {
 
 	/**
 	 * @param {string | URL} url
-	 * @param {{ replaceState?: boolean; noScroll?: boolean; keepFocus?: boolean; invalidateAll?: boolean; }} options
+	 * @param {{ replaceState?: boolean; noScroll?: boolean; keepFocus?: boolean; invalidateAll?: boolean; state?: Record<string, any> }} options
 	 * @param {number} redirect_count
 	 * @param {{}} [nav_token]
 	 */
@@ -314,6 +314,7 @@ export function create_client(app, target) {
 			noscroll: options.noScroll,
 			replace_state: options.replaceState,
 			redirect_count,
+			state: options.state,
 			nav_token,
 			accept: () => {
 				if (options.invalidateAll) {
@@ -1107,6 +1108,7 @@ export function create_client(app, target) {
 	 *   keepfocus?: boolean;
 	 *   noscroll?: boolean;
 	 *   replace_state?: boolean;
+	 *   state?: Record<string, any>;
 	 *   redirect_count?: number;
 	 *   nav_token?: {};
 	 *   accept?: () => void;
@@ -1120,6 +1122,7 @@ export function create_client(app, target) {
 		keepfocus,
 		noscroll,
 		replace_state,
+		state = {},
 		redirect_count = 0,
 		nav_token = {},
 		accept = noop,
@@ -1213,7 +1216,7 @@ export function create_client(app, target) {
 			url.pathname = navigation_result.props.page.url.pathname;
 		}
 
-		const state = popped ? popped.state : {};
+		state = popped ? popped.state : state;
 
 		if (!popped) {
 			// this is a new navigation, rather than a popstate
@@ -1532,14 +1535,6 @@ export function create_client(app, target) {
 
 		goto: (url, opts = {}) => {
 			url = resolve_url(url);
-
-			// @ts-expect-error
-			if (DEV && opts.state) {
-				// TOOD 3.0 remove
-				throw new Error(
-					'Passing `state` to `goto` is no longer supported. Use `pushState` and `replaceState` from `$app/navigation` instead.'
-				);
-			}
 
 			if (url.origin !== origin) {
 				return Promise.reject(


### PR DESCRIPTION
This reinstantiates the `state` parameter for the `options` argument to `goto`. In the original shallow routing PR, this was mentioned as the alternative, and it may make sense to do it this way instead of requiring people to do `await goto(..); replaceState({ ..})` instead of just `goto(..., { state: { .. } })`. It also means the page store is updated directly, and doesn't have a tick were it's empty.

Open for debate if we really want to do this, but the change itself is rather easy so I thought I'd open the PR. Probably needs a test if we reinstantiate.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
