### PR TITLE
chore: simplify `.prettierignore`

### DIFF
--- a/.changeset/stupid-eels-rule.md
+++ b/.changeset/stupid-eels-rule.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+chore: simplify `.prettierignore`

--- a/packages/create-svelte/shared/+prettier/.prettierignore
+++ b/packages/create-svelte/shared/+prettier/.prettierignore
@@ -1,12 +1,3 @@
-.DS_Store
-node_modules
-/build
-/.svelte-kit
-/package
-.env
-.env.*
-!.env.example
-
 # Ignore files for PNPM, NPM and YARN
 pnpm-lock.yaml
 package-lock.json


### PR DESCRIPTION
Prettier 3 uses the `.gitignore`, so we don't need to specify anything that's already in that file