### PR TITLE
fix: correctly trailing slash redirect when navigating from root page

### DIFF
--- a/.changeset/lovely-plums-move.md
+++ b/.changeset/lovely-plums-move.md
@@ -2,4 +2,4 @@
 "@sveltejs/kit": patch
 ---
 
-fix: correctly trailing slash redirect when navigating from the root page
+fix: correctly handle trailing slash redirect when navigating from the root page

--- a/.changeset/lovely-plums-move.md
+++ b/.changeset/lovely-plums-move.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: correctly trailing slash redirect when navigating from the root page

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -660,8 +660,8 @@ export function create_client(app, target) {
 			server: server_data_node,
 			universal: node.universal?.load ? { type: 'data', data, uses } : null,
 			data: data ?? server_data_node?.data ?? null,
-			// if `paths.base === '/a/b/c`, then the root route is `/a/b/c/`,
-			// regardless of the `trailingSlash` route option
+			// if `paths.base === '/a/b/c`, then the root route is always `/a/b/c/`, regardless of
+			// the `trailingSlash` route option, so that relative paths to JS and CSS work
 			slash:
 				base && (url.pathname === base || url.pathname === base + '/')
 					? 'always'

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -663,7 +663,7 @@ export function create_client(app, target) {
 			// if `paths.base === '/a/b/c`, then the root route is `/a/b/c/`,
 			// regardless of the `trailingSlash` route option
 			slash:
-				url.pathname === base || url.pathname === base + '/'
+				base && (url.pathname === base || url.pathname === base + '/')
 					? 'always'
 					: node.universal?.trailingSlash ?? server_data_node?.slash
 		};

--- a/packages/kit/test/apps/basics/src/routes/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/+page.svelte
@@ -6,3 +6,5 @@
 </script>
 
 <h1>the answer is {data.answer}</h1>
+
+<a href="/routing/trailing-slash/never/">trailing slash</a>

--- a/packages/kit/test/apps/basics/src/routes/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/+page.svelte
@@ -7,4 +7,4 @@
 
 <h1>the answer is {data.answer}</h1>
 
-<a href="/routing/trailing-slash/never/">trailing slash</a>
+<a href="/routing/trailing-slash/never/">URL with trailing slash that should redirect to remove it</a>

--- a/packages/kit/test/apps/basics/src/routes/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/+page.svelte
@@ -7,4 +7,6 @@
 
 <h1>the answer is {data.answer}</h1>
 
-<a href="/routing/trailing-slash/never/">URL with trailing slash that should redirect to remove it</a>
+<a href="/routing/trailing-slash/never/"
+	>URL with trailing slash that should redirect to remove it</a
+>

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -743,7 +743,7 @@ test.describe('Routing', () => {
 		await expect(page.locator('p')).toHaveText('/routing/trailing-slash/ignore/');
 	});
 
-	test('trailing slash redirect not is preserved when navigating from root page', async ({
+	test('trailing slash redirect works when navigating from root page', async ({
 		page,
 		clicknav
 	}) => {

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -743,7 +743,7 @@ test.describe('Routing', () => {
 		await expect(page.locator('p')).toHaveText('/routing/trailing-slash/ignore/');
 	});
 
-	test('trailing slash redirect never is preserved when navigating from root page', async ({
+	test('trailing slash redirect not is preserved when navigating from root page', async ({
 		page,
 		clicknav
 	}) => {

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -742,6 +742,16 @@ test.describe('Routing', () => {
 		expect(new URL(page.url()).pathname).toBe('/routing/trailing-slash/ignore/');
 		await expect(page.locator('p')).toHaveText('/routing/trailing-slash/ignore/');
 	});
+
+	test('trailing slash redirect never is preserved when navigating from root page', async ({
+		page,
+		clicknav
+	}) => {
+		await page.goto('/');
+		await clicknav('a[href="/routing/trailing-slash/never/"]');
+		expect(new URL(page.url()).pathname).toBe('/routing/trailing-slash/never');
+		await expect(page.locator('p')).toHaveText('/routing/trailing-slash/never');
+	});
 });
 
 test.describe('Shadow DOM', () => {


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/11317

https://github.com/sveltejs/kit/pull/10763 introduces a bug where the trailing slash option at the root page is set to always. This PR checks if a base config is set before setting trailing slash to always for the root page.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
