### PR TITLE
fix: suggest running svelte-migrate with latest if migration does not exist

### DIFF
--- a/.changeset/cool-moles-fetch.md
+++ b/.changeset/cool-moles-fetch.md
@@ -1,0 +1,5 @@
+---
+'svelte-migrate': patch
+---
+
+suggest running migrate command with latest if migration does not exist

--- a/packages/migrate/bin.js
+++ b/packages/migrate/bin.js
@@ -15,6 +15,12 @@ if (migrations.includes(migration)) {
 	migrate();
 } else {
 	console.error(
-		colors.bold().red(`You must specify one of the following migrations: ${migrations.join(', ')}`)
+		colors
+			.bold()
+			.red(
+				`You must specify one of the following migrations: ${migrations.join(', ')}\n` +
+					'If you expected this to work, try re-running the command with the latest svelte-migrate version:\n' +
+					`  npx svelte-migrate@latest ${migration}`
+			)
 	);
 }


### PR DESCRIPTION
Sometimes we forget to add `@latest` to the svelte-migrate instructions. This PR updates the error for a missing migration to suggest re-running with latest.

Of course, people on older versions won't get this helpful error, but maybe it will be useful eventually.

Related: #11359, #11360

Example of new error:

<img width="702" alt="image" src="https://github.com/sveltejs/kit/assets/4992896/1ece4a2b-28c2-4be6-997a-1097be0fd24f">


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
