### PR TITLE
fix: remove unnecessary @types/cookie package

### DIFF
--- a/.changeset/new-hounds-retire.md
+++ b/.changeset/new-hounds-retire.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+fix: remove unnecessary @types/cookie package

--- a/packages/create-svelte/shared/+default+checkjs/package.json
+++ b/packages/create-svelte/shared/+default+checkjs/package.json
@@ -1,5 +1,0 @@
-{
-	"devDependencies": {
-		"@types/cookie": "^0.5.1"
-	}
-}

--- a/packages/create-svelte/shared/+default+typescript/package.json
+++ b/packages/create-svelte/shared/+default+typescript/package.json
@@ -1,5 +1,0 @@
-{
-	"devDependencies": {
-		"@types/cookie": "^0.5.1"
-	}
-}


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/11350

I don't remember the history of this, but `npm run check` and `pnpm run check` both pass without it