### PR TITLE
Revert "fix: adjust missing inner content warning with svelte v5"

### DIFF
--- a/.changeset/brave-waves-accept.md
+++ b/.changeset/brave-waves-accept.md
@@ -1,5 +1,0 @@
----
-"@sveltejs/kit": patch
----
-
-fix: adjust missing inner content warning with svelte v5

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -107,14 +107,10 @@ const warning_preprocessor = {
 		if (!filename) return;
 
 		const basename = path.basename(filename);
-		if (
-			basename.startsWith('+layout.') &&
-			!content.includes(isSvelte5Plus() ? '{@render children(' : '<slot')
-		) {
+		if (basename.startsWith('+layout.') && !content.includes('<slot')) {
 			const message =
 				`\n${colors.bold().red(path.relative('.', filename))}\n` +
-				`\`${isSvelte5Plus() ? '{@render children()' : '<slot />'}\`` +
-				' missing — inner content will not be rendered';
+				'`<slot />` missing — inner content will not be rendered';
 
 			if (!warned.has(message)) {
 				console.log(message);


### PR DESCRIPTION
Reverts sveltejs/kit#11380 so that we can cut a release with the other changes