### PR TITLE
chore: ignore vite config timestamp files when prettier linting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -21,14 +21,14 @@
 		{
 			"files": [
 				"**/CHANGELOG.md",
+				"**/vite.config.js.timestamp-*",
 				"**/.svelte-kit/**",
 				"documentation/**/*.md",
 				"packages/package/test/fixtures/**/expected/**/*",
 				"packages/package/test/watch/expected/**/*",
 				"packages/package/test/watch/package/**/*",
 				"packages/kit/src/core/postbuild/fixtures/**/*",
-				"packages/migrate/migrations/routes/*/samples.md",
-				"**/vite.config.js.timestamp-*"
+				"packages/migrate/migrations/routes/*/samples.md"
 			],
 			"options": {
 				"requirePragma": true

--- a/.prettierrc
+++ b/.prettierrc
@@ -27,7 +27,8 @@
 				"packages/package/test/watch/expected/**/*",
 				"packages/package/test/watch/package/**/*",
 				"packages/kit/src/core/postbuild/fixtures/**/*",
-				"packages/migrate/migrations/routes/*/samples.md"
+				"packages/migrate/migrations/routes/*/samples.md",
+				"**/vite.config.js.timestamp-*"
 			],
 			"options": {
 				"requirePragma": true


### PR DESCRIPTION
Finally found out why my pushes keep failing. The pre-push lint is erroring on those test artefact files when running local tests.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
