### PR TITLE
fix: adjust missing inner content warning

### DIFF
--- a/.changeset/giant-planets-sing.md
+++ b/.changeset/giant-planets-sing.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: adjust missing inner content warning

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -107,10 +107,14 @@ const warning_preprocessor = {
 		if (!filename) return;
 
 		const basename = path.basename(filename);
-		if (basename.startsWith('+layout.') && !content.includes('<slot')) {
+		if (
+			basename.startsWith('+layout.') &&
+			(!content.includes('<slot') || (isSvelte5Plus() && !content.includes('{@render')))
+		) {
 			const message =
 				`\n${colors.bold().red(path.relative('.', filename))}\n` +
-				'`<slot />` missing — inner content will not be rendered';
+				`\`<slot />\`${isSvelte5Plus() ? ' or `{@render ...}` tag' : ''}` +
+				' missing — inner content will not be rendered';
 
 			if (!warned.has(message)) {
 				console.log(message);

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -107,7 +107,8 @@ const warning_preprocessor = {
 		if (!filename) return;
 
 		const basename = path.basename(filename);
-		const has_children = content.includes('<slot') || (isSvelte5Plus() && content.includes('{@render'));
+		const has_children =
+			content.includes('<slot') || (isSvelte5Plus() && content.includes('{@render'));
 
 		if (basename.startsWith('+layout.') && !has_children) {
 			const message =

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -107,10 +107,9 @@ const warning_preprocessor = {
 		if (!filename) return;
 
 		const basename = path.basename(filename);
-		if (
-			basename.startsWith('+layout.') &&
-			(!content.includes('<slot') || (isSvelte5Plus() && !content.includes('{@render')))
-		) {
+		const has_children = content.includes('<slot') || (isSvelte5Plus() && content.includes('{@render'));
+
+		if (basename.startsWith('+layout.') && !has_children) {
 			const message =
 				`\n${colors.bold().red(path.relative('.', filename))}\n` +
 				`\`<slot />\`${isSvelte5Plus() ? ' or `{@render ...}` tag' : ''}` +


### PR DESCRIPTION
Alright, v2 of #11380 

Svelte 5 can still use `<slot>` and `+layout` can now accept "named slots" with snippets. I think we can safely assume _some_ content will be rendered, as long as a `{@render` tag exists in the markup, without having to check which snippet(s) also exists in the script.

Closes #11127 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
