### PR TITLE
Revert "fix: build service workers in IIFE format"

### DIFF
--- a/.changeset/green-cycles-shake.md
+++ b/.changeset/green-cycles-shake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prevent esbuild adding phantom exports to service worker

--- a/.changeset/tricky-meals-perform.md
+++ b/.changeset/tricky-meals-perform.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': patch
----
-
-fix: build service workers in IIFE format

--- a/packages/kit/src/exports/vite/build/build_service_worker.js
+++ b/packages/kit/src/exports/vite/build/build_service_worker.js
@@ -70,7 +70,9 @@ export async function build_service_worker(
 					'service-worker': service_worker_entry_file
 				},
 				output: {
-					entryFileNames: '[name].js',
+					format: 'es',
+					// .mjs so that esbuild doesn't incorrectly inject `export` https://github.com/vitejs/vite/issues/15379
+					entryFileNames: 'service-worker.mjs',
 					assetFileNames: `${kit.appDir}/immutable/assets/[name].[hash][extname]`,
 					inlineDynamicImports: true
 				}
@@ -92,4 +94,7 @@ export async function build_service_worker(
 			}
 		}
 	});
+
+	// rename .mjs to .js to avoid incorrect MIME types with ancient webservers
+	fs.renameSync(`${out}/client/service-worker.mjs`, `${out}/client/service-worker.js`);
 }

--- a/packages/kit/src/exports/vite/build/build_service_worker.js
+++ b/packages/kit/src/exports/vite/build/build_service_worker.js
@@ -70,7 +70,6 @@ export async function build_service_worker(
 					'service-worker': service_worker_entry_file
 				},
 				output: {
-					format: 'es',
 					// .mjs so that esbuild doesn't incorrectly inject `export` https://github.com/vitejs/vite/issues/15379
 					entryFileNames: 'service-worker.mjs',
 					assetFileNames: `${kit.appDir}/immutable/assets/[name].[hash][extname]`,

--- a/packages/kit/src/exports/vite/build/build_service_worker.js
+++ b/packages/kit/src/exports/vite/build/build_service_worker.js
@@ -70,9 +70,6 @@ export async function build_service_worker(
 					'service-worker': service_worker_entry_file
 				},
 				output: {
-					// default 'es' format would be nicer
-					// iife is workaround for https://github.com/vitejs/vite/issues/15379
-					format: 'iife',
 					entryFileNames: '[name].js',
 					assetFileNames: `${kit.appDir}/immutable/assets/[name].[hash][extname]`,
 					inlineDynamicImports: true


### PR DESCRIPTION
Reverts sveltejs/kit#11129 — there's a better workaround that doesn't result in an IIFE wrapper