### PR TITLE
fix: set `{ stream: true }` when calling `decoder.decode` on multiple chunks

### DIFF
--- a/.changeset/good-carrots-repeat.md
+++ b/.changeset/good-carrots-repeat.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: decode server data with `stream: true` during client-side navigation

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2161,7 +2161,7 @@ async function load_data(url, invalid) {
 			const { done, value } = await reader.read();
 			if (done && !text) break;
 
-			text += !value && text ? '\n' : decoder.decode(value, {stream: true}); // no value -> final chunk -> add a new line to trigger the last parse
+			text += !value && text ? '\n' : decoder.decode(value, { stream: true }); // no value -> final chunk -> add a new line to trigger the last parse
 
 			while (true) {
 				const split = text.indexOf('\n');

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2161,7 +2161,7 @@ async function load_data(url, invalid) {
 			const { done, value } = await reader.read();
 			if (done && !text) break;
 
-			text += !value && text ? '\n' : decoder.decode(value); // no value -> final chunk -> add a new line to trigger the last parse
+			text += !value && text ? '\n' : decoder.decode(value, {stream: true}); // no value -> final chunk -> add a new line to trigger the last parse
 
 			while (true) {
 				const split = text.indexOf('\n');


### PR DESCRIPTION
Fixes #11044

## The bug
1. Visit this page: https://svkit-bug.slk.is
2. click "go"

� will appear. refreshing fixes.

![image](https://github.com/sveltejs/kit/assets/1473102/06077e89-c3d9-4fbf-ab16-773085efffe4)


## The reason

https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/decode#stream

> A boolean flag indicating whether additional data will follow in subsequent calls to <code>decode()</code>.
> Set to <code>true</code> if processing the data in chunks, and <code>false</code> for the final chunk or if the data is not chunked.
> It defaults to <code>false</code>.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
