### PR TITLE
fix: edit this page on GitHub anchor

### DIFF
--- a/sites/kit.svelte.dev/src/routes/docs/[slug]/+page.svelte
+++ b/sites/kit.svelte.dev/src/routes/docs/[slug]/+page.svelte
@@ -53,7 +53,7 @@
 
 	<a
 		class="edit"
-		href="https://github.com/sveltejs/kit/edit/master/documentation/docs/{data.page.file}"
+		href="https://github.com/sveltejs/kit/edit/main/documentation/docs/{data.page.file}"
 	>
 		<Icon size={50} name="edit" /> Edit this page on GitHub
 	</a>

--- a/sites/kit.svelte.dev/src/routes/home/Deployment.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Deployment.svelte
@@ -34,7 +34,7 @@
 			<a
 				target="_blank"
 				rel="noreferrer"
-				href="https://github.com/sveltejs/kit/tree/master/packages/adapter-static"
+				href="https://github.com/sveltejs/kit/tree/main/packages/adapter-static"
 				class="invert"
 			>
 				<img src={html5} alt="" />
@@ -43,7 +43,7 @@
 			<a
 				target="_blank"
 				rel="noreferrer"
-				href="https://github.com/sveltejs/kit/tree/master/packages/adapter-node"
+				href="https://github.com/sveltejs/kit/tree/main/packages/adapter-node"
 				class="invert"
 			>
 				<img src={node} alt="" />
@@ -61,7 +61,7 @@
 			<a
 				target="_blank"
 				rel="noreferrer"
-				href="https://github.com/sveltejs/kit/tree/master/packages/adapter-netlify"
+				href="https://github.com/sveltejs/kit/tree/main/packages/adapter-netlify"
 			>
 				<img src={netlify} alt="" />
 				<span>Netlify</span>
@@ -69,7 +69,7 @@
 			<a
 				target="_blank"
 				rel="noreferrer"
-				href="https://github.com/sveltejs/kit/tree/master/packages/adapter-cloudflare"
+				href="https://github.com/sveltejs/kit/tree/main/packages/adapter-cloudflare"
 			>
 				<img src={cloudflare} alt="" />
 				<span>Cloudflare</span>

--- a/sites/kit.svelte.dev/src/routes/schema.json
+++ b/sites/kit.svelte.dev/src/routes/schema.json
@@ -9,7 +9,7 @@
 	"programmingLanguage": ["JavaScript", "TypeScript"],
 	"image": "https://raw.githubusercontent.com/sveltejs/branding/master/svelte-logo.svg",
 	"sameAs": ["https://github.com/sveltejs/kit", "https://www.npmjs.com/package/@sveltejs/kit"],
-	"license": "https://github.com/sveltejs/kit/blob/master/LICENSE",
+	"license": "https://github.com/sveltejs/kit/blob/main/LICENSE",
 	"releasedEvent": {
 		"@type": "PublicationEvent",
 		"startDate": "2022-12-14T17:00:00",


### PR DESCRIPTION
GitHub does not redirect `/edit` routes to the renamed master branch.

This causes a '404 - page not found' error in the GitHub website.

- https://github.com/sveltejs/kit/edit/master/documentation/docs/10-getting-started/10-introduction.md
- https://github.com/sveltejs/kit/edit/main/documentation/docs/10-getting-started/10-introduction.md

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
