### PR TITLE
fix: only disallow dynamic env access when prerendering

### DIFF
--- a/.changeset/perfect-eyes-brush.md
+++ b/.changeset/perfect-eyes-brush.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow dynamic env access when building but not prerendering

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -39,7 +39,7 @@ async function analyse({ manifest_path, env }) {
 
 	// configure `import { building } from '$app/environment'` —
 	// essential we do this before analysing the code
-	internal.set_building(true);
+	internal.set_building();
 
 	// set env, in case it's used in initialisation
 	const { publicPrefix: public_prefix, privatePrefix: private_prefix } = config.env;

--- a/packages/kit/src/core/postbuild/fallback.js
+++ b/packages/kit/src/core/postbuild/fallback.js
@@ -30,7 +30,7 @@ async function generate_fallback({ manifest_path, env }) {
 	/** @type {import('@sveltejs/kit').SSRManifest} */
 	const manifest = (await import(pathToFileURL(manifest_path).href)).manifest;
 
-	set_building(true);
+	set_building();
 
 	const server = new Server(manifest);
 	await server.init({ env });

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -36,7 +36,8 @@ async function prerender({ out, manifest_path, metadata, verbose, env }) {
 
 	// configure `import { building } from '$app/environment'` —
 	// essential we do this before analysing the code
-	internal.set_building(true);
+	internal.set_building();
+	internal.set_prerendering();
 
 	/**
 	 * @template {{message: string}} T
@@ -97,9 +98,6 @@ async function prerender({ out, manifest_path, metadata, verbose, env }) {
 
 	/** @type {Map<string, string>} */
 	const saved = new Map();
-
-	const server = new Server(manifest);
-	await server.init({ env });
 
 	const handle_http_error = normalise_error_handler(
 		log,
@@ -413,15 +411,26 @@ async function prerender({ out, manifest_path, metadata, verbose, env }) {
 		}
 	}
 
-	if (
-		config.prerender.entries.length > 1 ||
-		config.prerender.entries[0] !== '*' ||
-		route_level_entries.length > 0 ||
-		prerender_map.size > 0
-	) {
-		// Only log if we're actually going to do something to not confuse users
-		log.info('Prerendering');
+	let has_prerenderable_routes = false;
+
+	for (const value of prerender_map.values()) {
+		if (value) {
+			has_prerenderable_routes = true;
+			break;
+		}
 	}
+
+	if (
+		(config.prerender.entries.length === 0 && route_level_entries.length === 0) ||
+		!has_prerenderable_routes
+	) {
+		return { prerendered, prerender_map };
+	}
+
+	log.info('Prerendering');
+
+	const server = new Server(manifest);
+	await server.init({ env });
 
 	for (const entry of config.prerender.entries) {
 		if (entry === '*') {

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -26,7 +26,7 @@ const server_template = ({
 	error_page
 }) => `
 import root from '../root.${isSvelte5Plus() ? 'js' : 'svelte'}';
-import { set_building } from '__sveltekit/environment';
+import { set_building, set_prerendering } from '__sveltekit/environment';
 import { set_assets } from '__sveltekit/paths';
 import { set_private_env, set_public_env, set_safe_public_env } from '${runtime_directory}/shared-server.js';
 
@@ -63,7 +63,7 @@ export function get_hooks() {
 	return ${hooks ? `import(${s(hooks)})` : '{}'};
 }
 
-export { set_assets, set_building, set_private_env, set_public_env, set_safe_public_env };
+export { set_assets, set_building, set_prerendering, set_private_env, set_public_env, set_safe_public_env };
 `;
 
 // TODO need to re-run this whenever src/app.html or src/error.html are

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -442,9 +442,14 @@ function kit({ svelte_config }) {
 					return dedent`
 						export const version = ${s(version.name)};
 						export let building = false;
+						export let prerendering = false;
 
 						export function set_building() {
 							building = true;
+						}
+
+						export function set_prerendering() {
+							prerendering = true;
 						}
 					`;
 				}

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -3,7 +3,7 @@ import { set_private_env, set_public_env, set_safe_public_env } from '../shared-
 import { options, get_hooks } from '__SERVER__/internal.js';
 import { DEV } from 'esm-env';
 import { filter_private_env, filter_public_env } from '../../utils/env.js';
-import { building } from '../app/environment.js';
+import { prerendering } from '__sveltekit/environment';
 
 /** @type {ProxyHandler<{ type: 'public' | 'private' }>} */
 const prerender_env_handler = {
@@ -47,8 +47,12 @@ export class Server {
 		const private_env = filter_private_env(env, prefixes);
 		const public_env = filter_public_env(env, prefixes);
 
-		set_private_env(building ? new Proxy({ type: 'private' }, prerender_env_handler) : private_env);
-		set_public_env(building ? new Proxy({ type: 'public' }, prerender_env_handler) : public_env);
+		set_private_env(
+			prerendering ? new Proxy({ type: 'private' }, prerender_env_handler) : private_env
+		);
+		set_public_env(
+			prerendering ? new Proxy({ type: 'public' }, prerender_env_handler) : public_env
+		);
 		set_safe_public_env(public_env);
 
 		if (!this.#options.hooks) {

--- a/packages/kit/src/types/ambient.d.ts
+++ b/packages/kit/src/types/ambient.d.ts
@@ -87,10 +87,15 @@ declare module '__sveltekit/environment' {
 	 */
 	export const building: boolean;
 	/**
+	 * True during prerendering, false otherwise.
+	 */
+	export const prerendering: boolean;
+	/**
 	 * The value of `config.kit.version.name`.
 	 */
 	export const version: string;
 	export function set_building(): void;
+	export function set_prerendering(): void;
 }
 
 /** Internal version of $app/paths */

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -27,8 +27,9 @@ export interface ServerModule {
 }
 
 export interface ServerInternalModule {
-	set_building(building: boolean): void;
 	set_assets(path: string): void;
+	set_building(): void;
+	set_prerendering(): void;
 	set_private_env(environment: Record<string, string>): void;
 	set_public_env(environment: Record<string, string>): void;
 	set_safe_public_env(environment: Record<string, string>): void;

--- a/packages/kit/test/apps/options/source/hooks.server.js
+++ b/packages/kit/test/apps/options/source/hooks.server.js
@@ -1,3 +1,9 @@
+import { env } from '$env/dynamic/private';
+
+// this verifies that dynamic env vars can be read during analysis phase
+// (it would fail if this app contained prerendered routes)
+const FOO = env.FOO;
+
 /** @type {import('@sveltejs/kit').Handle} */
 export function handle({ event, resolve }) {
 	return resolve(event, {

--- a/packages/kit/test/apps/options/source/hooks.server.js
+++ b/packages/kit/test/apps/options/source/hooks.server.js
@@ -2,6 +2,7 @@ import { env } from '$env/dynamic/private';
 
 // this verifies that dynamic env vars can be read during analysis phase
 // (it would fail if this app contained prerendered routes)
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const FOO = env.FOO;
 
 /** @type {import('@sveltejs/kit').Handle} */

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2186,10 +2186,15 @@ declare module '__sveltekit/environment' {
 	 */
 	export const building: boolean;
 	/**
+	 * True during prerendering, false otherwise.
+	 */
+	export const prerendering: boolean;
+	/**
 	 * The value of `config.kit.version.name`.
 	 */
 	export const version: string;
 	export function set_building(): void;
+	export function set_prerendering(): void;
 }
 
 /** Internal version of $app/paths */


### PR DESCRIPTION
In SvelteKit 2, we disallow access to `$env/dynamic/[public|private]` during prerendering so that you can't bake stale values into your app. We do it slightly overzealously, however — they are also disallowed during the _analysis_ phase, which is an unnecessary restriction.

This PR distinguishes between the two phases. It also bails out of prerendering early if no prerenderable routes were found during the analysis phase, meaning that if you're not prerendering anything it's safe to access dynamic env vars in (for example) `hooks.server.js`.

Closes #11341, closes #11425.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
