### PR TITLE
fix: improve warning when encountering import.meta.env

### DIFF
--- a/.changeset/silly-panthers-talk.md
+++ b/.changeset/silly-panthers-talk.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/package": patch
+---
+
+fix: improve warning when encountering import.meta.env

--- a/packages/package/src/validate.js
+++ b/packages/package/src/validate.js
@@ -87,8 +87,8 @@ export function _create_validator(options) {
 
 		if (uses_import_meta) {
 			warnings.push(
-				'Avoid usage of `import.meta.env` in your code. It requires a bundler to work. ' +
-					'Consider using packages like `esm-env` instead which provide cross-bundler-compatible environment variables.'
+				'Avoid usage of `import.meta.env` in your code. It only works in apps bundled with Vite. ' +
+					'Consider using packages like `esm-env` instead which works with all bundlers or without bundling.'
 			);
 		}
 


### PR DESCRIPTION
`import.meta.env` requires Vite to work - not just a bundler

`esm-env` doesn't provide environment variables, but standard variables representing what environment you're running in and I think that's an important distinction