### PR TITLE
fix: set ESLint config type to `Config` instead of `FlatConfig`

### DIFF
--- a/.changeset/silver-hornets-eat.md
+++ b/.changeset/silver-hornets-eat.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+fix: set the correct type for the ESLint config object

--- a/packages/create-svelte/shared/+eslint+prettier+typescript/.eslintrc.cjs
+++ b/packages/create-svelte/shared/+eslint+prettier+typescript/.eslintrc.cjs
@@ -1,4 +1,4 @@
-/** @type { import("eslint").Linter.FlatConfig } */
+/** @type { import("eslint").Linter.Config } */
 module.exports = {
 	root: true,
 	extends: [

--- a/packages/create-svelte/shared/+eslint+prettier-typescript/.eslintrc.cjs
+++ b/packages/create-svelte/shared/+eslint+prettier-typescript/.eslintrc.cjs
@@ -1,4 +1,4 @@
-/** @type { import("eslint").Linter.FlatConfig } */
+/** @type { import("eslint").Linter.Config } */
 module.exports = {
 	root: true,
 	extends: ['eslint:recommended', 'plugin:svelte/recommended', 'prettier'],

--- a/packages/create-svelte/shared/+eslint+typescript/.eslintrc.cjs
+++ b/packages/create-svelte/shared/+eslint+typescript/.eslintrc.cjs
@@ -1,4 +1,4 @@
-/** @type { import("eslint").Linter.FlatConfig } */
+/** @type { import("eslint").Linter.Config } */
 module.exports = {
 	root: true,
 	extends: [

--- a/packages/create-svelte/shared/+eslint-typescript/.eslintrc.cjs
+++ b/packages/create-svelte/shared/+eslint-typescript/.eslintrc.cjs
@@ -1,4 +1,4 @@
-/** @type { import("eslint").Linter.FlatConfig } */
+/** @type { import("eslint").Linter.Config } */
 module.exports = {
 	root: true,
 	extends: ['eslint:recommended', 'plugin:svelte/recommended'],

--- a/packages/create-svelte/shared/+eslint/package.json
+++ b/packages/create-svelte/shared/+eslint/package.json
@@ -1,6 +1,7 @@
 {
 	"devDependencies": {
-		"eslint": "^8.28.0",
-		"eslint-plugin-svelte": "^2.30.0"
+		"@types/eslint": "8.56.0",
+		"eslint": "^8.56.0",
+		"eslint-plugin-svelte": "^2.35.1"
 	}
 }


### PR DESCRIPTION
This PR adds a dev dependency for `@types/eslint` and bumps the eslint package versions. The flat config file had a JSDoc type annotation but didn't include the types package, so we weren't getting the autocomplete. The type has also been changed to non-flat config too.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
