### PR TITLE
chore: removed deprecated config.package type

### DIFF
--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -179,14 +179,6 @@ export interface Config {
 	extensions?: string[];
 	/** SvelteKit options */
 	kit?: KitConfig;
-	/** [`@sveltejs/package`](/docs/packaging) options. */
-	package?: {
-		source?: string;
-		dir?: string;
-		emitTypes?: boolean;
-		exports?(filepath: string): boolean;
-		files?(filepath: string): boolean;
-	};
 	/** Preprocessor options, if any. Preprocessing can alternatively also be done through Vite's preprocessor capabilities. */
 	preprocess?: any;
 	/** `vite-plugin-svelte` plugin options. */


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

Support for config.package was removed in #8922 (10 month ago) but the type declaration survived the svelte-kit v2 major version. I guess it should be removed now, as I tried using it (encouraged by the type declaration) and failed with this message

```
> config.package is no longer supported. See https://github.com/sveltejs/kit/discussions/8825 for more information.
    at load_config (file:///@sveltejs/package/src/config.js:21:9)
    at async file:///@sveltejs/package/src/cli.js:29:19
```

It may be time to remove this message too, it can be found here:

https://github.com/sveltejs/kit/blame/main/packages/package/src/config.js#L20-L24

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
