### PR TITLE
docs: remove outdated section from SEO docs

### DIFF
--- a/documentation/docs/40-best-practices/20-seo.md
+++ b/documentation/docs/40-best-practices/20-seo.md
@@ -14,7 +14,7 @@ While search engines have got better in recent years at indexing content that wa
 
 ### Performance
 
-Signals such as [Core Web Vitals](https://web.dev/vitals/#core-web-vitals) impact search engine ranking. Because Svelte and SvelteKit introduce minimal overhead, it's easier to build high performance sites. You can test your site's performance using Google's [PageSpeed Insights](https://pagespeed.web.dev/) or [Lighthouse](https://developers.google.com/web/tools/lighthouse).
+Signals such as [Core Web Vitals](https://web.dev/vitals/#core-web-vitals) impact search engine ranking. Because Svelte and SvelteKit introduce minimal overhead, it's easier to build high performance sites. You can test your site's performance using Google's [PageSpeed Insights](https://pagespeed.web.dev/) or [Lighthouse](https://developers.google.com/web/tools/lighthouse). Read [the performance page](performance) for more details.
 
 ### Normalized URLs
 
@@ -27,30 +27,6 @@ SvelteKit redirects pathnames with trailing slashes to ones without (or vice ver
 Every page should have well-written and unique `<title>` and `<meta name="description">` elements inside a [`<svelte:head>`](https://svelte.dev/docs#template-syntax-svelte-head). Guidance on how to write descriptive titles and descriptions, along with other suggestions on making content understandable by search engines, can be found on Google's [Lighthouse SEO audits](https://web.dev/lighthouse-seo/) documentation.
 
 > A common pattern is to return SEO-related `data` from page [`load`](load) functions, then use it (as [`$page.data`](modules#$app-stores)) in a `<svelte:head>` in your root [layout](routing#layout).
-
-### Structured data
-
-[Structured data](https://developers.google.com/search/docs/advanced/structured-data/intro-structured-data) helps search engines understand the content of a page. If you're using structured data alongside [`svelte-preprocess`](https://github.com/sveltejs/svelte-preprocess), you will need to explicitly preserve `ld+json` data (this [may change in future](https://github.com/sveltejs/svelte-preprocess/issues/305)):
-
-```js
-/// file: svelte.config.js
-// @filename: ambient.d.ts
-declare module 'svelte-preprocess';
-
-// @filename: index.js
-// ---cut---
-import preprocess from 'svelte-preprocess';
-
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	preprocess: preprocess({
-		preserve: ['ld+json']
-		// ...
-	})
-};
-
-export default config;
-```
 
 ### Sitemaps
 


### PR DESCRIPTION
You no longer have to do this when using `svelte-preprocess`, so we can remove this section from the docs. We should almost remove the option from `svelte-preprocess` as it has no effect: https://github.com/sveltejs/svelte-preprocess/pull/622