### PR TITLE
load: inline fetch `response.body` data to page

### DIFF
--- a/.changeset/short-oranges-kiss.md
+++ b/.changeset/short-oranges-kiss.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": minor
+---
+
+inline load fetch `response.body` stream data as base64 in page

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -312,6 +312,36 @@ export function create_universal_fetch(event, state, fetched, csr, resolve_opts)
 					});
 				}
 
+				if (key === 'body') {
+					const body = response.body;
+					if (!body) return body;
+					const [a, b] = body.tee();
+					let buffer = new Uint8Array();
+					const reader = a.getReader();
+					/**
+					 * @param {{
+					 * 	done: boolean
+					 * 	value?: Uint8Array
+					 * }} opts
+					 */
+					function buffer_to_fetched({ done, value }) {
+						if (done) {
+							if (dependency) {
+								dependency.body = new Uint8Array(buffer);
+							}
+							push_fetched(b64_encode(buffer), true);
+						} else if (value) {
+							const newBuffer = new Uint8Array(buffer.length + value.length);
+							newBuffer.set(buffer, 0);
+							newBuffer.set(value, buffer.length);
+							buffer = newBuffer;
+							reader.read().then(buffer_to_fetched);
+						}
+					}
+					reader.read().then(buffer_to_fetched);
+					return b;
+				}
+
 				if (key === 'arrayBuffer') {
 					return async () => {
 						const buffer = await response.arrayBuffer();

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-body-stream-b64/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-body-stream-b64/+page.js
@@ -1,0 +1,29 @@
+const body_stream_to_buffer = async (body) => {
+	let buffer = new Uint8Array();
+	const reader = body.getReader();
+	while (true) {
+		const { done, value } = await reader.read();
+		if (value != null) {
+			const newBuffer = new Uint8Array(buffer.length + value.length);
+			newBuffer.set(buffer, 0);
+			newBuffer.set(value, buffer.length);
+			buffer = newBuffer;
+		}
+		if (done) break;
+	}
+	return buffer;
+};
+
+export async function load({ fetch }) {
+	const res = await fetch('/load/fetch-body-stream-b64/data');
+
+	const l = await fetch('/load/fetch-body-stream-b64/data', {
+		body: Uint8Array.from(Array(256).fill(0), (_, i) => i),
+		method: 'POST'
+	});
+
+	return {
+		data: await body_stream_to_buffer(res.body),
+		data_long: await body_stream_to_buffer(l.body)
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-body-stream-b64/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-body-stream-b64/+page.svelte
@@ -1,0 +1,30 @@
+<script>
+	export let data;
+
+	$: arr = [...new Uint8Array(data.data)];
+
+	let ok = 'Ok';
+
+	$: {
+		const p = new Uint8Array(data.data_long);
+		ok = p.length === 256 ? 'Ok' : 'Wrong length';
+
+		if (p.length === 256) {
+			for (let i = 0; i < p.length; i++) {
+				if (p[i] !== i) {
+					ok = `Expected ${i} but got ${p[i]}`;
+					break;
+				}
+			}
+		}
+	}
+</script>
+
+<span class="test-content">{JSON.stringify(arr)}</span>
+
+<br />
+
+{ok}
+<span style="word-wrap: break-word;">
+	{JSON.stringify([...new Uint8Array(data.data_long)])}
+</span>

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-body-stream-b64/data/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-body-stream-b64/data/+server.js
@@ -1,0 +1,7 @@
+export const GET = () => {
+	return new Response(new Uint8Array([1, 2, 3, 4]));
+};
+
+export const POST = async ({ request }) => {
+	return new Response(await request.arrayBuffer());
+};

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -297,6 +297,28 @@ test.describe('Load', () => {
 		}
 	});
 
+	test('fetches using a body stream serialized with b64', async ({ page, javaScriptEnabled }) => {
+		await page.goto('/load/fetch-body-stream-b64');
+
+		expect(await page.textContent('.test-content')).toBe('[1,2,3,4]');
+
+		if (!javaScriptEnabled) {
+			const payload = '{"status":200,"statusText":"","headers":{},"body":"AQIDBA=="}';
+			const post_payload =
+				'{"status":200,"statusText":"","headers":{},"body":"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+/w=="}';
+
+			const script_content = await page.innerHTML(
+				'script[data-sveltekit-fetched][data-b64][data-url="/load/fetch-body-stream-b64/data"]'
+			);
+			const post_script_content = await page.innerHTML(
+				'script[data-sveltekit-fetched][data-b64][data-url="/load/fetch-body-stream-b64/data"][data-hash="16h3sp1"]'
+			);
+
+			expect(script_content).toBe(payload);
+			expect(post_script_content).toBe(post_payload);
+		}
+	});
+
 	test('json string is returned', async ({ page }) => {
 		await page.goto('/load/relay');
 		expect(await page.textContent('h1')).toBe('42');


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

This PR follows up from recent PR https://github.com/sveltejs/kit/pull/10535

The previous PR linked above added support for inlining fetch `response.arrayBuffer()` data on the page.
This PR adds support for inlining fetch `response.body.getReader()` data on the page.

Much of the groundwork of using base64 was laid by @Elia872 in his previous PR.

My app's API client library handles both long running streams (such as messages in a chat widget) and standard api calls  via a single call to `response.body.getReader()`. It's a relatively popular library in the small world of GRPC clients, [you can see it here](https://github.com/deeplay-io/nice-grpc/blob/master/packages/nice-grpc-web/src/client/transports/fetch.ts#L79).

Long running streams shouldn't be invoked in SSR and this PR doesn't support that. But any short lived streamed data could also be inlined in the page much like the other `response.arrrayBuffer/text/json/...()` methods.

Pros:
* ever more support for de-duplicating fetch calls in loads
Cons:
* it's likely a narrow usecase

I skipped creating an issue because I already have this code lying around, I'm using it today in my app.
