### PR TITLE
[security]: automatically add nonce or hash to `script-src-elem`, `style-src-attr` & `style-src-elem` csp directive if necessary

### DIFF
--- a/.changeset/giant-years-drum.md
+++ b/.changeset/giant-years-drum.md
@@ -2,4 +2,4 @@
 "@sveltejs/kit": patch
 ---
 
-nonce is automatically added if script-src-elem is defined in csp directives config
+nonce or hash is automatically added to "script-src-elem", "style-src-attr" and "style-src-elem" if defined in csp directives config

--- a/.changeset/giant-years-drum.md
+++ b/.changeset/giant-years-drum.md
@@ -2,4 +2,4 @@
 "@sveltejs/kit": patch
 ---
 
-nonce or hash is automatically added to "script-src-elem", "style-src-attr" and "style-src-elem" if defined in csp directives config
+fix: add nonce or hash to "script-src-elem", "style-src-attr" and "style-src-elem" if defined in CSP config

--- a/.changeset/giant-years-drum.md
+++ b/.changeset/giant-years-drum.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+nonce is automatically added if script-src-elem is defined in csp directives config

--- a/packages/kit/src/runtime/server/page/csp.js
+++ b/packages/kit/src/runtime/server/page/csp.js
@@ -97,7 +97,7 @@ class BaseProvider {
 			}
 
 			if (style_src_attr && !style_src_attr.includes('unsafe-inline')) {
-				d['style-src-elem'] = [...style_src_attr, 'unsafe-inline'];
+				d['style-src-attr'] = [...style_src_attr, 'unsafe-inline'];
 			}
 
 			if (style_src_elem && !style_src_elem.includes('unsafe-inline')) {

--- a/packages/kit/src/runtime/server/page/csp.js
+++ b/packages/kit/src/runtime/server/page/csp.js
@@ -41,6 +41,9 @@ class BaseProvider {
 	#script_src;
 
 	/** @type {import('types').Csp.Source[]} */
+	#script_src_elem;
+
+	/** @type {import('types').Csp.Source[]} */
 	#style_src;
 
 	/** @type {string} */
@@ -79,6 +82,7 @@ class BaseProvider {
 		}
 
 		this.#script_src = [];
+		this.#script_src_elem = [];
 		this.#style_src = [];
 
 		const effective_script_src = d['script-src'] || d['default-src'];
@@ -103,8 +107,13 @@ class BaseProvider {
 		if (this.#script_needs_csp) {
 			if (this.#use_hashes) {
 				this.#script_src.push(`sha256-${sha256(content)}`);
-			} else if (this.#script_src.length === 0) {
-				this.#script_src.push(`nonce-${this.#nonce}`);
+			} else {
+				if (this.#script_src.length === 0) {
+					this.#script_src.push(`nonce-${this.#nonce}`);
+				}
+				if (this.#script_src_elem.length === 0) {
+					this.#script_src_elem.push(`nonce-${this.#nonce}`);
+				}
 			}
 		}
 	}
@@ -143,6 +152,13 @@ class BaseProvider {
 			directives['script-src'] = [
 				...(directives['script-src'] || directives['default-src'] || []),
 				...this.#script_src
+			];
+		}
+
+		if (this.#script_src_elem.length > 0) {
+			directives['script-src-elem'] = [
+				...(directives['script-src-elem'] || []),
+				...this.#script_src_elem
 			];
 		}
 

--- a/packages/kit/src/runtime/server/page/csp.js
+++ b/packages/kit/src/runtime/server/page/csp.js
@@ -128,19 +128,21 @@ class BaseProvider {
 	/** @param {string} content */
 	add_script(content) {
 		if (this.#script_needs_csp) {
+			const d = this.#directives;
+
 			if (this.#use_hashes) {
-				const hash = sha256(content)
+				const hash = sha256(content);
 
 				this.#script_src.push(`sha256-${hash}`);
 
-				if (this.#script_src_elem.length === 0) {
+				if (d['script-src-elem']?.length) {
 					this.#script_src_elem.push(`sha256-${hash}`);
 				}
 			} else {
 				if (this.#script_src.length === 0) {
 					this.#script_src.push(`nonce-${this.#nonce}`);
 				}
-				if (this.#script_src_elem.length === 0) {
+				if (d['script-src-elem']?.length) {
 					this.#script_src_elem.push(`nonce-${this.#nonce}`);
 				}
 			}
@@ -150,25 +152,27 @@ class BaseProvider {
 	/** @param {string} content */
 	add_style(content) {
 		if (this.#style_needs_csp) {
+			const d = this.#directives;
+
 			if (this.#use_hashes) {
 				const hash = sha256(content);
 
 				this.#style_src.push(`sha256-${hash}`);
 
-				if (this.#style_src_attr.length === 0) {
+				if (d['style-src-attr']?.length) {
 					this.#style_src_attr.push(`sha256-${hash}`);
 				}
-				if (this.#style_src_elem.length === 0) {
+				if (d['style-src-elem']?.length) {
 					this.#style_src_elem.push(`sha256-${hash}`);
 				}
 			} else {
 				if (this.#style_src.length === 0) {
 					this.#style_src.push(`nonce-${this.#nonce}`);
 				}
-				if (this.#style_src_attr.length === 0) {
+				if (d['style-src-attr']?.length) {
 					this.#style_src_attr.push(`nonce-${this.#nonce}`);
 				}
-				if (this.#style_src_elem.length === 0) {
+				if (d['style-src-elem']?.length) {
 					this.#style_src_elem.push(`nonce-${this.#nonce}`);
 				}
 			}

--- a/packages/kit/src/runtime/server/page/csp.js
+++ b/packages/kit/src/runtime/server/page/csp.js
@@ -129,7 +129,7 @@ class BaseProvider {
 	add_script(content) {
 		if (this.#script_needs_csp) {
 			if (this.#use_hashes) {
-				const hash = `sha256-${sha256(content)}`;
+				const hash = sha256(content)
 
 				this.#script_src.push(`sha256-${hash}`);
 
@@ -151,7 +151,7 @@ class BaseProvider {
 	add_style(content) {
 		if (this.#style_needs_csp) {
 			if (this.#use_hashes) {
-				const hash = `sha256-${sha256(content)}`;
+				const hash = sha256(content);
 
 				this.#style_src.push(`sha256-${hash}`);
 

--- a/packages/kit/src/runtime/server/page/csp.js
+++ b/packages/kit/src/runtime/server/page/csp.js
@@ -46,6 +46,12 @@ class BaseProvider {
 	/** @type {import('types').Csp.Source[]} */
 	#style_src;
 
+	/** @type {import('types').Csp.Source[]} */
+	#style_src_attr;
+
+	/** @type {import('types').Csp.Source[]} */
+	#style_src_elem;
+
 	/** @type {string} */
 	#nonce;
 
@@ -60,6 +66,18 @@ class BaseProvider {
 
 		const d = this.#directives;
 
+		this.#script_src = [];
+		this.#script_src_elem = [];
+		this.#style_src = [];
+		this.#style_src_attr = [];
+		this.#style_src_elem = [];
+
+		const effective_script_src = d['script-src'] || d['default-src'];
+		const script_src_elem = d['script-src-elem'];
+		const effective_style_src = d['style-src'] || d['default-src'];
+		const style_src_elem = d['style-src-elem'];
+		const style_src_attr = d['style-src-attr'];
+
 		if (__SVELTEKIT_DEV__) {
 			// remove strict-dynamic in dev...
 			// TODO reinstate this if we can figure out how to make strict-dynamic work
@@ -73,29 +91,34 @@ class BaseProvider {
 			// 	if (d['script-src'].length === 0) delete d['script-src'];
 			// }
 
-			const effective_style_src = d['style-src'] || d['default-src'];
-
 			// ...and add unsafe-inline so we can inject <style> elements
 			if (effective_style_src && !effective_style_src.includes('unsafe-inline')) {
 				d['style-src'] = [...effective_style_src, 'unsafe-inline'];
 			}
+
+			if (style_src_attr && !style_src_attr.includes('unsafe-inline')) {
+				d['style-src-elem'] = [...style_src_attr, 'unsafe-inline'];
+			}
+
+			if (style_src_elem && !style_src_elem.includes('unsafe-inline')) {
+				d['style-src-elem'] = [...style_src_elem, 'unsafe-inline'];
+			}
 		}
 
-		this.#script_src = [];
-		this.#script_src_elem = [];
-		this.#style_src = [];
-
-		const effective_script_src = d['script-src'] || d['default-src'];
-		const effective_style_src = d['style-src'] || d['default-src'];
-
 		this.#script_needs_csp =
-			!!effective_script_src &&
-			effective_script_src.filter((value) => value !== 'unsafe-inline').length > 0;
+			(!!effective_script_src &&
+				effective_script_src.filter((value) => value !== 'unsafe-inline').length > 0) ||
+			(!!script_src_elem &&
+				script_src_elem.filter((value) => value !== 'unsafe-inline').length > 0);
 
 		this.#style_needs_csp =
 			!__SVELTEKIT_DEV__ &&
-			!!effective_style_src &&
-			effective_style_src.filter((value) => value !== 'unsafe-inline').length > 0;
+			((!!effective_style_src &&
+				effective_style_src.filter((value) => value !== 'unsafe-inline').length > 0) ||
+				(!!style_src_attr &&
+					style_src_attr.filter((value) => value !== 'unsafe-inline').length > 0) ||
+				(!!style_src_elem &&
+					style_src_elem.filter((value) => value !== 'unsafe-inline').length > 0));
 
 		this.script_needs_nonce = this.#script_needs_csp && !this.#use_hashes;
 		this.style_needs_nonce = this.#style_needs_csp && !this.#use_hashes;
@@ -106,7 +129,13 @@ class BaseProvider {
 	add_script(content) {
 		if (this.#script_needs_csp) {
 			if (this.#use_hashes) {
-				this.#script_src.push(`sha256-${sha256(content)}`);
+				const hash = `sha256-${sha256(content)}`;
+
+				this.#script_src.push(`sha256-${hash}`);
+
+				if (this.#script_src_elem.length === 0) {
+					this.#script_src_elem.push(`sha256-${hash}`);
+				}
 			} else {
 				if (this.#script_src.length === 0) {
 					this.#script_src.push(`nonce-${this.#nonce}`);
@@ -122,9 +151,26 @@ class BaseProvider {
 	add_style(content) {
 		if (this.#style_needs_csp) {
 			if (this.#use_hashes) {
-				this.#style_src.push(`sha256-${sha256(content)}`);
-			} else if (this.#style_src.length === 0) {
-				this.#style_src.push(`nonce-${this.#nonce}`);
+				const hash = `sha256-${sha256(content)}`;
+
+				this.#style_src.push(`sha256-${hash}`);
+
+				if (this.#style_src_attr.length === 0) {
+					this.#style_src_attr.push(`sha256-${hash}`);
+				}
+				if (this.#style_src_elem.length === 0) {
+					this.#style_src_elem.push(`sha256-${hash}`);
+				}
+			} else {
+				if (this.#style_src.length === 0) {
+					this.#style_src.push(`nonce-${this.#nonce}`);
+				}
+				if (this.#style_src_attr.length === 0) {
+					this.#style_src_attr.push(`nonce-${this.#nonce}`);
+				}
+				if (this.#style_src_elem.length === 0) {
+					this.#style_src_elem.push(`nonce-${this.#nonce}`);
+				}
 			}
 		}
 	}
@@ -145,6 +191,20 @@ class BaseProvider {
 			directives['style-src'] = [
 				...(directives['style-src'] || directives['default-src'] || []),
 				...this.#style_src
+			];
+		}
+
+		if (this.#style_src_attr.length > 0) {
+			directives['style-src-attr'] = [
+				...(directives['style-src-attr'] || []),
+				...this.#style_src_attr
+			];
+		}
+
+		if (this.#style_src_elem.length > 0) {
+			directives['style-src-elem'] = [
+				...(directives['style-src-elem'] || []),
+				...this.#style_src_elem
 			];
 		}
 

--- a/packages/kit/src/runtime/server/page/csp.js
+++ b/packages/kit/src/runtime/server/page/csp.js
@@ -75,8 +75,8 @@ class BaseProvider {
 		const effective_script_src = d['script-src'] || d['default-src'];
 		const script_src_elem = d['script-src-elem'];
 		const effective_style_src = d['style-src'] || d['default-src'];
-		const style_src_elem = d['style-src-elem'];
 		const style_src_attr = d['style-src-attr'];
+		const style_src_elem = d['style-src-elem'];
 
 		if (__SVELTEKIT_DEV__) {
 			// remove strict-dynamic in dev...

--- a/packages/kit/src/runtime/server/page/csp.spec.js
+++ b/packages/kit/src/runtime/server/page/csp.spec.js
@@ -240,7 +240,7 @@ test('uses hashes when prerendering', () => {
 
 	assert.equal(
 		csp.report_only_provider.get_header(),
-		"script-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; script-src-elem 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; report-uri /"
+		"script-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; report-uri /; script-src-elem 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
 	);
 });
 

--- a/packages/kit/src/runtime/server/page/csp.spec.js
+++ b/packages/kit/src/runtime/server/page/csp.spec.js
@@ -235,12 +235,12 @@ test('uses hashes when prerendering', () => {
 
 	assert.equal(
 		csp.csp_provider.get_header(),
-		"script-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
+		"script-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; script-src-elem 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
 	);
 
 	assert.equal(
 		csp.report_only_provider.get_header(),
-		"script-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; report-uri /"
+		"script-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; script-src-elem 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; report-uri /"
 	);
 });
 

--- a/packages/kit/src/runtime/server/page/csp.spec.js
+++ b/packages/kit/src/runtime/server/page/csp.spec.js
@@ -153,6 +153,68 @@ test('skips frame-ancestors, report-uri, sandbox from meta tags', () => {
 	);
 });
 
+test('adds nonce to script-src-elem, style-src-attr and style-src-elem if necessary', () => {
+	const csp = new Csp(
+		{
+			mode: 'auto',
+			directives: {
+				'script-src-elem': ['self'],
+				'style-src-attr': ['self'],
+				'style-src-elem': ['self']
+			},
+			reportOnly: {}
+		},
+		{
+			prerender: false
+		}
+	);
+
+	csp.add_script('');
+	csp.add_style('');
+
+	const csp_header = csp.csp_provider.get_header();
+	assert.ok(csp_header.includes("script-src-elem 'self' 'nonce-"));
+	assert.ok(csp_header.includes("style-src-attr 'self' 'nonce-"));
+	assert.ok(csp_header.includes("style-src-elem 'self' 'nonce-"));
+});
+
+test('adds hash to script-src-elem, style-src-attr and style-src-elem if necessary during prerendering', () => {
+	const csp = new Csp(
+		{
+			mode: 'auto',
+			directives: {
+				'script-src-elem': ['self'],
+				'style-src-attr': ['self'],
+				'style-src-elem': ['self']
+			},
+			reportOnly: {}
+		},
+		{
+			prerender: true
+		}
+	);
+
+	csp.add_script('');
+	csp.add_style('');
+
+	const csp_header = csp.csp_provider.get_header();
+	assert.ok(
+		csp_header.includes(
+			"script-src-elem 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
+		)
+	);
+	assert.ok(
+		csp_header.includes(
+			"style-src-attr 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
+		)
+	);
+	assert.ok(
+		csp_header.includes(
+			"style-src-elem 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
+		)
+	);
+});
+
 test('adds unsafe-inline styles in dev', () => {
 	// @ts-expect-error
 	globalThis.__SVELTEKIT_DEV__ = true;
@@ -161,10 +223,14 @@ test('adds unsafe-inline styles in dev', () => {
 		{
 			mode: 'hash',
 			directives: {
-				'default-src': ['self']
+				'default-src': ['self'],
+				'style-src-attr': ['self'],
+				'style-src-elem': ['self']
 			},
 			reportOnly: {
 				'default-src': ['self'],
+				'style-src-attr': ['self'],
+				'style-src-elem': ['self'],
 				'report-uri': ['/']
 			}
 		},
@@ -177,12 +243,12 @@ test('adds unsafe-inline styles in dev', () => {
 
 	assert.equal(
 		csp.csp_provider.get_header(),
-		"default-src 'self'; style-src 'self' 'unsafe-inline'"
+		"default-src 'self'; style-src-attr 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
 	);
 
 	assert.equal(
 		csp.report_only_provider.get_header(),
-		"default-src 'self'; report-uri /; style-src 'self' 'unsafe-inline'"
+		"default-src 'self'; style-src-attr 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; report-uri /; style-src 'self' 'unsafe-inline'"
 	);
 });
 
@@ -235,12 +301,12 @@ test('uses hashes when prerendering', () => {
 
 	assert.equal(
 		csp.csp_provider.get_header(),
-		"script-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; script-src-elem 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
+		"script-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
 	);
 
 	assert.equal(
 		csp.report_only_provider.get_header(),
-		"script-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; report-uri /; script-src-elem 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
+		"script-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; report-uri /"
 	);
 });
 


### PR DESCRIPTION
This PR adds functionality for automatically adding CSP-directives that are required only if they're used:

- `script-src-elem` 
- `style-src-attr` 
- `style-src-elem` 

error thrown because of missing nonce/hash when `script-src-elem` is used:

<img width="647" alt="Screenshot 2023-12-30 at 00 21 56" src="https://github.com/sveltejs/kit/assets/48158184/1c6bb52d-f14f-4473-835b-8db9fcdbbfaa">

error thrown because of missing nonce/hash if `style-src-attr` and/or `style-src-elem` is used:

<img width="1333" alt="Screenshot 2023-12-30 at 00 41 47" src="https://github.com/sveltejs/kit/assets/48158184/3f1be3bf-4feb-44fc-923c-de72a815b303">

`style-src-attr` and `style-src-elem` is also automatically added during dev so things work locally.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
