### PR TITLE
docs: update `sveltesociety.dev` links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Web development, streamlined. Read the [documentation](https://kit.svelte.dev/do
 | [create-svelte](packages/create-svelte)                                     | [Changelog](packages/create-svelte/CHANGELOG.md)              |
 | [svelte-migrate](packages/migrate)                                          | [Changelog](packages/migrate/CHANGELOG.md)                    |
 
-[Additional adapters](<(https://sveltesociety.dev/packages#svelte-kit-adapters)>) are maintained by the community.
+[Additional adapters](https://sveltesociety.dev/packages?tag=svelte-kit-adapters) are maintained by the community.
 
 ## Bug reporting
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Web development, streamlined. Read the [documentation](https://kit.svelte.dev/do
 | [create-svelte](packages/create-svelte)                                     | [Changelog](packages/create-svelte/CHANGELOG.md)              |
 | [svelte-migrate](packages/migrate)                                          | [Changelog](packages/migrate/CHANGELOG.md)                    |
 
-[Additional adapters](https://sveltesociety.dev/packages?tag=sveltekit-adapters) are maintained by the community.
+[Additional adapters](https://sveltesociety.dev/packages?category=sveltekit-adapters) are maintained by the community.
 
 ## Bug reporting
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Web development, streamlined. Read the [documentation](https://kit.svelte.dev/do
 | [create-svelte](packages/create-svelte)                                     | [Changelog](packages/create-svelte/CHANGELOG.md)              |
 | [svelte-migrate](packages/migrate)                                          | [Changelog](packages/migrate/CHANGELOG.md)                    |
 
-[Additional adapters](https://sveltesociety.dev/packages?tag=svelte-kit-adapters) are maintained by the community.
+[Additional adapters](https://sveltesociety.dev/packages?tag=sveltekit-adapters) are maintained by the community.
 
 ## Bug reporting
 

--- a/documentation/docs/25-build-and-deploy/20-adapters.md
+++ b/documentation/docs/25-build-and-deploy/20-adapters.md
@@ -13,7 +13,7 @@ Official adapters exist for a variety of platforms — these are documented on t
 - [`@sveltejs/adapter-static`](adapter-static) for static site generation (SSG)
 - [`@sveltejs/adapter-vercel`](adapter-vercel) for Vercel
 
-Additional [community-provided adapters](https://sveltesociety.dev/packages?tag=sveltekit-adapters) exist for other platforms.
+Additional [community-provided adapters](https://sveltesociety.dev/packages?category=sveltekit-adapters) exist for other platforms.
 
 ## Using adapters
 

--- a/documentation/docs/25-build-and-deploy/20-adapters.md
+++ b/documentation/docs/25-build-and-deploy/20-adapters.md
@@ -13,7 +13,7 @@ Official adapters exist for a variety of platforms — these are documented on t
 - [`@sveltejs/adapter-static`](adapter-static) for static site generation (SSG)
 - [`@sveltejs/adapter-vercel`](adapter-vercel) for Vercel
 
-Additional [community-provided adapters](https://sveltesociety.dev/packages?tag=svelte-kit-adapters) exist for other platforms.
+Additional [community-provided adapters](https://sveltesociety.dev/packages?tag=sveltekit-adapters) exist for other platforms.
 
 ## Using adapters
 

--- a/documentation/docs/25-build-and-deploy/20-adapters.md
+++ b/documentation/docs/25-build-and-deploy/20-adapters.md
@@ -13,7 +13,7 @@ Official adapters exist for a variety of platforms — these are documented on t
 - [`@sveltejs/adapter-static`](adapter-static) for static site generation (SSG)
 - [`@sveltejs/adapter-vercel`](adapter-vercel) for Vercel
 
-Additional [community-provided adapters](https://sveltesociety.dev/packages#svelte-kit-adapters) exist for other platforms.
+Additional [community-provided adapters](https://sveltesociety.dev/packages?tag=svelte-kit-adapters) exist for other platforms.
 
 ## Using adapters
 

--- a/documentation/docs/60-appendix/20-integrations.md
+++ b/documentation/docs/60-appendix/20-integrations.md
@@ -27,7 +27,7 @@ You will need to install `svelte-preprocess` with `npm install --save-dev svelte
 
 ## Adders
 
-[Svelte Adders](https://sveltesociety.dev/templates?tag=svelte-add) allow you to setup many different complex integrations like Tailwind, PostCSS, Storybook, Firebase, GraphQL, mdsvex, and more with a single command. Please see [sveltesociety.dev](https://sveltesociety.dev/) for a full listing of templates, components, and tools available for use with Svelte and SvelteKit.
+[Svelte Adders](https://sveltesociety.dev/templates?category=svelte-add) allow you to setup many different complex integrations like Tailwind, PostCSS, Storybook, Firebase, GraphQL, mdsvex, and more with a single command. Please see [sveltesociety.dev](https://sveltesociety.dev/) for a full listing of templates, components, and tools available for use with Svelte and SvelteKit.
 
 ## Vite plugins
 

--- a/documentation/docs/60-appendix/20-integrations.md
+++ b/documentation/docs/60-appendix/20-integrations.md
@@ -4,7 +4,7 @@ title: Integrations
 
 ## Preprocessors
 
-Preprocessors transform your `.svelte` files before passing them to the compiler. For example, if your `.svelte` file uses TypeScript and PostCSS, it must first be transformed into JavaScript and CSS so that the Svelte compiler can handle it. There are many [available preprocessors](https://sveltesociety.dev/packages?tag=preprocessors). The Svelte team maintains two official ones discussed below.
+Preprocessors transform your `.svelte` files before passing them to the compiler. For example, if your `.svelte` file uses TypeScript and PostCSS, it must first be transformed into JavaScript and CSS so that the Svelte compiler can handle it. There are many [available preprocessors](https://sveltesociety.dev/packages?category=preprocessors). The Svelte team maintains two official ones discussed below.
 
 ### `vitePreprocess`
 

--- a/documentation/docs/60-appendix/20-integrations.md
+++ b/documentation/docs/60-appendix/20-integrations.md
@@ -4,7 +4,7 @@ title: Integrations
 
 ## Preprocessors
 
-Preprocessors transform your `.svelte` files before passing them to the compiler. For example, if your `.svelte` file uses TypeScript and PostCSS, it must first be transformed into JavaScript and CSS so that the Svelte compiler can handle it. There are many [available preprocessors](https://sveltesociety.dev/packages#preprocessors). The Svelte team maintains two official ones discussed below.
+Preprocessors transform your `.svelte` files before passing them to the compiler. For example, if your `.svelte` file uses TypeScript and PostCSS, it must first be transformed into JavaScript and CSS so that the Svelte compiler can handle it. There are many [available preprocessors](https://sveltesociety.dev/packages?tag=preprocessors). The Svelte team maintains two official ones discussed below.
 
 ### `vitePreprocess`
 
@@ -27,7 +27,7 @@ You will need to install `svelte-preprocess` with `npm install --save-dev svelte
 
 ## Adders
 
-[Svelte Adders](https://sveltesociety.dev/templates#adders) allow you to setup many different complex integrations like Tailwind, PostCSS, Storybook, Firebase, GraphQL, mdsvex, and more with a single command. Please see [sveltesociety.dev](https://sveltesociety.dev/) for a full listing of templates, components, and tools available for use with Svelte and SvelteKit.
+[Svelte Adders](https://sveltesociety.dev/templates?tag=adders) allow you to setup many different complex integrations like Tailwind, PostCSS, Storybook, Firebase, GraphQL, mdsvex, and more with a single command. Please see [sveltesociety.dev](https://sveltesociety.dev/) for a full listing of templates, components, and tools available for use with Svelte and SvelteKit.
 
 ## Vite plugins
 

--- a/documentation/docs/60-appendix/20-integrations.md
+++ b/documentation/docs/60-appendix/20-integrations.md
@@ -27,7 +27,7 @@ You will need to install `svelte-preprocess` with `npm install --save-dev svelte
 
 ## Adders
 
-[Svelte Adders](https://sveltesociety.dev/templates?tag=adders) allow you to setup many different complex integrations like Tailwind, PostCSS, Storybook, Firebase, GraphQL, mdsvex, and more with a single command. Please see [sveltesociety.dev](https://sveltesociety.dev/) for a full listing of templates, components, and tools available for use with Svelte and SvelteKit.
+[Svelte Adders](https://sveltesociety.dev/templates?tag=svelte-add) allow you to setup many different complex integrations like Tailwind, PostCSS, Storybook, Firebase, GraphQL, mdsvex, and more with a single command. Please see [sveltesociety.dev](https://sveltesociety.dev/) for a full listing of templates, components, and tools available for use with Svelte and SvelteKit.
 
 ## Vite plugins
 

--- a/documentation/docs/60-appendix/50-additional-resources.md
+++ b/documentation/docs/60-appendix/50-additional-resources.md
@@ -17,7 +17,7 @@ We've written and published a few different SvelteKit sites as examples:
 - [`kit.svelte.dev`](https://github.com/sveltejs/kit/tree/main/sites/kit.svelte.dev)
 - [`svelte.dev`](https://github.com/sveltejs/svelte/tree/main/sites/svelte.dev)
 
-SvelteKit users have also published plenty of examples on GitHub, under the [#sveltekit](https://github.com/topics/sveltekit) and [#sveltekit-template](https://github.com/topics/sveltekit-template) topics, as well as on [the Svelte Society site](https://sveltesociety.dev/templates#svelte-kit). Note that these have not been vetted by the maintainers and may not be up to date.
+SvelteKit users have also published plenty of examples on GitHub, under the [#sveltekit](https://github.com/topics/sveltekit) and [#sveltekit-template](https://github.com/topics/sveltekit-template) topics, as well as on [the Svelte Society site](https://sveltesociety.dev/templates?tag=svelte-kit). Note that these have not been vetted by the maintainers and may not be up to date.
 
 ## Support
 

--- a/documentation/docs/60-appendix/50-additional-resources.md
+++ b/documentation/docs/60-appendix/50-additional-resources.md
@@ -17,7 +17,7 @@ We've written and published a few different SvelteKit sites as examples:
 - [`kit.svelte.dev`](https://github.com/sveltejs/kit/tree/main/sites/kit.svelte.dev)
 - [`svelte.dev`](https://github.com/sveltejs/svelte/tree/main/sites/svelte.dev)
 
-SvelteKit users have also published plenty of examples on GitHub, under the [#sveltekit](https://github.com/topics/sveltekit) and [#sveltekit-template](https://github.com/topics/sveltekit-template) topics, as well as on [the Svelte Society site](https://sveltesociety.dev/templates?tag=sveltekit). Note that these have not been vetted by the maintainers and may not be up to date.
+SvelteKit users have also published plenty of examples on GitHub, under the [#sveltekit](https://github.com/topics/sveltekit) and [#sveltekit-template](https://github.com/topics/sveltekit-template) topics, as well as on [the Svelte Society site](https://sveltesociety.dev/templates?category=sveltekit). Note that these have not been vetted by the maintainers and may not be up to date.
 
 ## Support
 

--- a/documentation/docs/60-appendix/50-additional-resources.md
+++ b/documentation/docs/60-appendix/50-additional-resources.md
@@ -17,7 +17,7 @@ We've written and published a few different SvelteKit sites as examples:
 - [`kit.svelte.dev`](https://github.com/sveltejs/kit/tree/main/sites/kit.svelte.dev)
 - [`svelte.dev`](https://github.com/sveltejs/svelte/tree/main/sites/svelte.dev)
 
-SvelteKit users have also published plenty of examples on GitHub, under the [#sveltekit](https://github.com/topics/sveltekit) and [#sveltekit-template](https://github.com/topics/sveltekit-template) topics, as well as on [the Svelte Society site](https://sveltesociety.dev/templates?tag=svelte-kit). Note that these have not been vetted by the maintainers and may not be up to date.
+SvelteKit users have also published plenty of examples on GitHub, under the [#sveltekit](https://github.com/topics/sveltekit) and [#sveltekit-template](https://github.com/topics/sveltekit-template) topics, as well as on [the Svelte Society site](https://sveltesociety.dev/templates?tag=sveltekit). Note that these have not been vetted by the maintainers and may not be up to date.
 
 ## Support
 


### PR DESCRIPTION
### Changes

This PR updates the [sveltesociety.dev](https://sveltesociety.dev/) links to use URL query params to filter tags, rather than the previous URL fragment.

For example, https://sveltesociety.dev/packages#svelte-kit-adapters becomes https://sveltesociety.dev/packages?tag=sveltekit-adapters

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
