### PR TITLE
fix: set path: '/' in demo

### DIFF
--- a/.changeset/breezy-pens-exercise.md
+++ b/.changeset/breezy-pens-exercise.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+fix: set path: '/' in demo

--- a/packages/create-svelte/templates/default/src/routes/sverdle/+page.server.ts
+++ b/packages/create-svelte/templates/default/src/routes/sverdle/+page.server.ts
@@ -45,7 +45,7 @@ export const actions = {
 			game.guesses[i] += key;
 		}
 
-		cookies.set('sverdle', game.toString(), { path: '' });
+		cookies.set('sverdle', game.toString(), { path: '/' });
 	},
 
 	/**
@@ -62,10 +62,10 @@ export const actions = {
 			return fail(400, { badGuess: true });
 		}
 
-		cookies.set('sverdle', game.toString(), { path: '' });
+		cookies.set('sverdle', game.toString(), { path: '/' });
 	},
 
 	restart: async ({ cookies }) => {
-		cookies.delete('sverdle', { path: '' });
+		cookies.delete('sverdle', { path: '/' });
 	}
 } satisfies Actions;


### PR DESCRIPTION
We recommend `path: '/'` for most cases in the docs, but the demo uses `path: ''` instead. I think it's better to be consistent.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
