### PR TITLE
feat: use latest Azure adapter in adapter-auto

### DIFF
--- a/.changeset/healthy-beers-run.md
+++ b/.changeset/healthy-beers-run.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-auto": minor
+---
+
+feat: bump Azure adapter version

--- a/packages/adapter-auto/adapters.js
+++ b/packages/adapter-auto/adapters.js
@@ -23,7 +23,7 @@ export const adapters = [
 		name: 'Azure Static Web Apps',
 		test: () => process.env.GITHUB_ACTION_REPOSITORY === 'Azure/static-web-apps-deploy',
 		module: 'svelte-adapter-azure-swa',
-		version: '0.13'
+		version: '0.20'
 	},
 	{
 		name: 'AWS via SST',


### PR DESCRIPTION
I just released svelte-adapter-azure-swa v0.20 with support for SvelteKit v2. This bumps the version of that package in the auto adapter.

Previous versions of the Azure adapter did not support SvelteKit v2, so this isn't a breaking change.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
