### PR TITLE
Clarify docs on context-based store value propagation behavior during SSR

### DIFF
--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -113,7 +113,7 @@ You might wonder how we're able to use `$page.data` and other [app stores](modul
 <p>Welcome {$user.name}</p>
 ```
 
-Updating the context-based store value in deeper-level pages or components will not affect the value in the parent component when the page is rendered via SSR: The parent component has already been rendered by the time the store value is updated. To avoid values 'flashing' during state updates during hydration, it is generally recommended to pass state down into components rather than up.
+Updating the value of a context-based store in deeper-level pages or components will not affect the value in the parent component while the page is being rendered via SSR as the parent component has already been rendered by the time the store value is updated. Once CSR kicks in (if enabled), the value will be propagated and components, pages, and layouts higher in the hierarchy will react to the new value. To avoid values 'flashing' during state updates during hydration, it is generally recommended to pass state down into components rather than up.
 
 If you're not using SSR (and can guarantee that you won't need to use SSR in future) then you can safely keep state in a shared module, without using the context API.
 

--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -113,7 +113,7 @@ You might wonder how we're able to use `$page.data` and other [app stores](modul
 <p>Welcome {$user.name}</p>
 ```
 
-Updating the value of a context-based store in deeper-level pages or components will not affect the value in the parent component while the page is being rendered via SSR as the parent component has already been rendered by the time the store value is updated. Once CSR kicks in (if enabled), the value will be propagated and components, pages, and layouts higher in the hierarchy will react to the new value. To avoid values 'flashing' during state updates during hydration, it is generally recommended to pass state down into components rather than up.
+Updating the value of a context-based store in deeper-level pages or components while the page is being rendered via SSR will not affect the value in the parent component because it has already been rendered by the time the store value is updated. In contrast, on the client (when CSR is enabled, which is the default) the value will be propagated and components, pages, and layouts higher in the hierarchy will react to the new value. Therefore, to avoid values 'flashing' during state updates during hydration, it is generally recommended to pass state down into components rather than up.
 
 If you're not using SSR (and can guarantee that you won't need to use SSR in future) then you can safely keep state in a shared module, without using the context API.
 


### PR DESCRIPTION
Further discussion can be found in this issue https://github.com/sveltejs/kit/issues/8282.

My interpretation of the current documentation is that changes to the value of the store won't ever propagate if the page is rendered server-side.
The sentence about hydration at the end of the paragraph does technically challenge this interpretation, but I believe the updated version is much clearer about the behavior.

If any of the terminology is incorrect, feel free to correct it. I'm especially unsure about the use of "CSR". I'm not sure if this is technically "hydration" or something else.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
