### PR TITLE
chore: apply state to history.state directly

### DIFF
--- a/documentation/docs/30-advanced/67-shallow-routing.md
+++ b/documentation/docs/30-advanced/67-shallow-routing.md
@@ -93,6 +93,6 @@ For this to work, you need to load the data that the `+page.svelte` expects. A c
 
 ## Caveats
 
-During server-side rendering, `$page.state` is always an empty object. The same is true for the first page the user lands on — if the user reloads the page (or comes back from another domain), state will _not_ be applied until they navigate.
+During server-side rendering, `$page.state` is always an empty object. The same is true for the first page the user lands on — if the user reloads the page (or returns from another document), state will _not_ be applied until they navigate.
 
 Shallow routing is a feature that requires JavaScript to work. Be mindful when using it and try to think of sensible fallback behavior in case JavaScript isn't available.

--- a/documentation/docs/30-advanced/67-shallow-routing.md
+++ b/documentation/docs/30-advanced/67-shallow-routing.md
@@ -93,6 +93,6 @@ For this to work, you need to load the data that the `+page.svelte` expects. A c
 
 ## Caveats
 
-During server-side rendering, `$page.state` is always an empty object. The same is true for the first page the user lands on — if the user reloads the page, state will _not_ be applied until they navigate.
+During server-side rendering, `$page.state` is always an empty object. The same is true for the first page the user lands on — if the user reloads the page (or comes back from another domain), state will _not_ be applied until they navigate.
 
 Shallow routing is a feature that requires JavaScript to work. Be mindful when using it and try to think of sensible fallback behavior in case JavaScript isn't available.

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1627,7 +1627,7 @@ export function preload_code(pathname) {
 export function push_state(url, state) {
 	if (DEV) {
 		try {
-			// The browser history state's serialization capabilities are roughly equal to devalue.stringify
+			// use `devalue.stringify` as a convenient way to ensure we exclude values that can't be properly rehydrated, such as custom class instances
 			devalue.stringify(state);
 		} catch (error) {
 			// @ts-expect-error
@@ -1654,7 +1654,7 @@ export function push_state(url, state) {
 export function replace_state(url, state) {
 	if (DEV) {
 		try {
-			// The browser history state's serialization capabilities are roughly equal to devalue.stringify
+			// use `devalue.stringify` as a convenient way to ensure we exclude values that can't be properly rehydrated, such as custom class instances
 			devalue.stringify(state);
 		} catch (error) {
 			// @ts-expect-error

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -59,12 +59,6 @@ let errored = false;
 const scroll_positions = storage.get(SCROLL_KEY) ?? {};
 
 /**
- * history index -> any
- * @type {Record<string, Record<string, any>>}
- */
-const states = storage.get(STATES_KEY, devalue.parse) ?? {};
-
-/**
  * navigation index -> any
  * @type {Record<string, any[]>}
  */
@@ -320,7 +314,6 @@ function persist_state() {
 
 	capture_snapshot(current_navigation_index);
 	storage.set(SNAPSHOT_KEY, snapshots);
-	storage.set(STATES_KEY, states, devalue.stringify);
 }
 
 /**
@@ -1247,7 +1240,8 @@ async function navigate({
 
 		const entry = {
 			[HISTORY_INDEX]: (current_history_index += change),
-			[NAVIGATION_INDEX]: (current_navigation_index += change)
+			[NAVIGATION_INDEX]: (current_navigation_index += change),
+			[STATES_KEY]: state
 		};
 
 		const fn = replace_state ? original_replace_state : original_push_state;
@@ -1257,8 +1251,6 @@ async function navigate({
 			clear_onward_history(current_history_index, current_navigation_index);
 		}
 	}
-
-	states[current_history_index] = state;
 
 	// reset preload synchronously after the history state has been set to avoid race conditions
 	load_cache = null;
@@ -1635,6 +1627,7 @@ export function preload_code(pathname) {
 export function push_state(url, state) {
 	if (DEV) {
 		try {
+			// The browser history state's serialization capabilities are roughly equal to devalue.stringify
 			devalue.stringify(state);
 		} catch (error) {
 			// @ts-expect-error
@@ -1645,7 +1638,8 @@ export function push_state(url, state) {
 	const opts = {
 		[HISTORY_INDEX]: (current_history_index += 1),
 		[NAVIGATION_INDEX]: current_navigation_index,
-		[PAGE_URL_KEY]: page.url.href
+		[PAGE_URL_KEY]: page.url.href,
+		[STATES_KEY]: state
 	};
 
 	original_push_state.call(history, opts, '', resolve_url(url));
@@ -1653,7 +1647,6 @@ export function push_state(url, state) {
 	page = { ...page, state };
 	root.$set({ page });
 
-	states[current_history_index] = state;
 	clear_onward_history(current_history_index, current_navigation_index);
 }
 
@@ -1661,6 +1654,7 @@ export function push_state(url, state) {
 export function replace_state(url, state) {
 	if (DEV) {
 		try {
+			// The browser history state's serialization capabilities are roughly equal to devalue.stringify
 			devalue.stringify(state);
 		} catch (error) {
 			// @ts-expect-error
@@ -1671,15 +1665,14 @@ export function replace_state(url, state) {
 	const opts = {
 		[HISTORY_INDEX]: current_history_index,
 		[NAVIGATION_INDEX]: current_navigation_index,
-		[PAGE_URL_KEY]: page.url.href
+		[PAGE_URL_KEY]: page.url.href,
+		[STATES_KEY]: state
 	};
 
 	original_replace_state.call(history, opts, '', resolve_url(url));
 
 	page = { ...page, state };
 	root.$set({ page });
-
-	states[current_history_index] = state;
 }
 
 /** @type {typeof import('../app/forms.js').applyAction} */
@@ -1925,7 +1918,7 @@ export function _start_router() {
 			if (history_index === current_history_index) return;
 
 			const scroll = scroll_positions[history_index];
-			const state = states[history_index] ?? {};
+			const state = event.state[STATES_KEY] ?? {};
 			const url = new URL(event.state[PAGE_URL_KEY] ?? location.href);
 			const navigation_index = event.state[NAVIGATION_INDEX];
 			const is_hash_change = strip_hash(location) === strip_hash(current.url);


### PR DESCRIPTION
The serialization capabilities of history.state are basically identical to those of devalue.stringify . As such, the indirection of saving the data in the session storage isn't necessary, which also saves 1kb compressed / 3kb uncompressed because of the no longer needed devalue functions.

Merge target is #11340 