### PR TITLE
fix: "Cannot access uninitialized variable" in Safari when using "$env/dynamic/public"

### DIFF
--- a/.changeset/red-bottles-walk.md
+++ b/.changeset/red-bottles-walk.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: "Cannot access uninitialized variable" in Safari when using "$env/dynamic/public"

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -385,7 +385,7 @@ function kit({ svelte_config }) {
 				case env_dynamic_public:
 					// populate `$env/dynamic/public` from `window`
 					if (browser) {
-						return `export const env = ${global}.env ?? (await import(/* @vite-ignore */ ${global}.base + '/' + '${kit.appDir}/env.js')).env;`;
+						return `export const env = ${global}.env`;
 					}
 
 					return create_dynamic_module(


### PR DESCRIPTION
Fixes #11364 

Using global await is causing issues in Safari: https://bugs.webkit.org/show_bug.cgi?id=242740.
This bug was introduced in https://github.com/sveltejs/kit/commit/94391905f7deb33f830f3fb76df4289833ccf3bd

This PR removes a fallback, but I'm not sure when the global variable is available but the env property is null or undefined.
So this PR might re-introduce a bug, but that is probably less common bug than trying to use "$env/dynamic/public" on sites that need to support iOS.


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
