### PR TITLE
fix: restore invalid route error message during build process

### DIFF
--- a/.changeset/kind-seas-tell.md
+++ b/.changeset/kind-seas-tell.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: restore invalid route error message during build process

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -1,3 +1,5 @@
+import { BROWSER } from 'esm-env';
+
 const param_pattern = /^(\[)?(\.\.\.)?(\w+)(?:=(\w+))?(\])?$/;
 
 /**
@@ -62,9 +64,15 @@ export function parse_route_id(id) {
 											);
 										}
 
-										// We know the match cannot be null because manifest generation would have
-										// if we hit an invalid param/matcher name with non-alphanumeric character.
+										// We know the match cannot be null in the browser because manifest generation
+										// would have invoked this during build and failed if we hit an invalid
+										// param/matcher name with non-alphanumeric character.
 										const match = /** @type {RegExpExecArray} */ (param_pattern.exec(content));
+										if (!BROWSER && !match) {
+											throw new Error(
+												`Invalid param: ${content}. Params and matcher names can only have underscores and alphanumeric characters.`
+											);
+										}
 
 										const [, is_optional, is_rest, name, matcher] = match;
 										// It's assumed that the following invalid route id cases are already checked


### PR DESCRIPTION
We missed @gtm-nayan's [last comment](https://github.com/sveltejs/kit/pull/11551/files/1406830927b7e6bc4df55bb9125c4775fce606bb#r1446180087) on https://github.com/sveltejs/kit/pull/11551. Addressing it now