### PR TITLE
docs: .nojekyll in static folder.

### DIFF
--- a/documentation/docs/25-build-and-deploy/50-adapter-static.md
+++ b/documentation/docs/25-build-and-deploy/50-adapter-static.md
@@ -86,7 +86,9 @@ When building for [GitHub Pages](https://docs.github.com/en/pages/getting-starte
 
 You'll also want to generate a fallback `404.html` page to replace the default 404 page shown by GitHub Pages.
 
-A config for GitHub Pages might look like the following:
+
+
+A config for GitHub Pages might look like the following. Please note: you will have to prevent GitHub's provided Jekyll from managing your site. If you are not using the following GitHub config page, then you must put `.nojekyll` file in your `static` folder.
 
 ```js
 // @errors: 2307 2322

--- a/documentation/docs/25-build-and-deploy/50-adapter-static.md
+++ b/documentation/docs/25-build-and-deploy/50-adapter-static.md
@@ -88,7 +88,7 @@ You'll also want to generate a fallback `404.html` page to replace the default 4
 
 
 
-A config for GitHub Pages might look like the following. Please note: you will have to prevent GitHub's provided Jekyll from managing your site. If you are not using the following GitHub config page, then you must put `.nojekyll` file in your `static` folder.
+A config for GitHub Pages might look like the following:
 
 ```js
 // @errors: 2307 2322
@@ -110,7 +110,7 @@ const config = {
 export default config;
 ```
 
-You can use GitHub actions to automatically deploy your site to GitHub Pages when you make a change. Here's an example workflow:
+You can use GitHub actions to automatically deploy your site to GitHub Pages when you make a change. Please note: you will have to prevent GitHub's provided Jekyll from managing your site. If you are not using the following workflow, then you must put `.nojekyll` file in your `static` folder. Here's an example workflow:
 
 ```yaml
 ### file: .github/workflows/deploy.yml

--- a/documentation/docs/25-build-and-deploy/50-adapter-static.md
+++ b/documentation/docs/25-build-and-deploy/50-adapter-static.md
@@ -108,7 +108,7 @@ const config = {
 export default config;
 ```
 
-You can use GitHub actions to automatically deploy your site to GitHub Pages when you make a change. Please note: you will have to prevent GitHub's provided Jekyll from managing your site. If you are not using the following workflow, then you must put `.nojekyll` file in your `static` folder. Here's an example workflow:
+You can use GitHub actions to automatically deploy your site to GitHub Pages when you make a change. Here's an example workflow:
 
 ```yaml
 ### file: .github/workflows/deploy.yml
@@ -169,3 +169,5 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v2
 ```
+
+If you're not using GitHub actions to deploy your site (for example, you're pushing the built site to its own repo), add an empty `.nojekyll` file in your `static` directory to prevent Jekyll from interfering.

--- a/documentation/docs/25-build-and-deploy/50-adapter-static.md
+++ b/documentation/docs/25-build-and-deploy/50-adapter-static.md
@@ -86,8 +86,6 @@ When building for [GitHub Pages](https://docs.github.com/en/pages/getting-starte
 
 You'll also want to generate a fallback `404.html` page to replace the default 404 page shown by GitHub Pages.
 
-
-
 A config for GitHub Pages might look like the following:
 
 ```js


### PR DESCRIPTION
### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.


---

adding the following instruction: make sure `.nojekyll` exists without the github page config.

My note: the `.nojekyll` instruction is missing in [#10083](https://github.com/sveltejs/kit/pull/10083). People that do not use custom github pages config will be confused (like me). I read that before, and I noticed that the instruction is missing. Moreover, people debugging will read this very popular [thread](https://stackoverflow.com/questions/75497065/sveltekit-deployment-on-gh-pages-doesnt-work-only-html-is-shown-css-and-js) and get mislead because the instruction to add `.nojekyll` is missing.
