### PR TITLE
chore: remove postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
 		"changeset:version": "changeset version && pnpm -r generate:version && git add --all",
 		"changeset:release": "changeset publish",
 		"start": "cd sites/kit.svelte.dev && npm run dev",
-		"build": "pnpm --filter @sveltejs/* -r build",
-		"postinstall": "pnpm -r generate:types && pnpm build"
+		"build": "pnpm --filter @sveltejs/* -r build"
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.27.1",


### PR DESCRIPTION
https://github.com/sveltejs/kit/pull/10629#discussion_r1393031332 got merged I'm guessing without seeing the pending comments I had there. Generating the types on `postinstall` doesn't make sense anymore because now they're checked in. Please don't make me build packages that I'm not working on when I install dependencies