### PR TITLE
fix: correctly handle BODY_SIZE_LIMIT=0 in Node adapter

### DIFF
--- a/.changeset/short-crews-give.md
+++ b/.changeset/short-crews-give.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-node": patch
+---
+
+fix: correctly handle BODY_SIZE_LIMIT=0

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -19,7 +19,7 @@ const address_header = env('ADDRESS_HEADER', '').toLowerCase();
 const protocol_header = env('PROTOCOL_HEADER', '').toLowerCase();
 const host_header = env('HOST_HEADER', 'host').toLowerCase();
 const port_header = env('PORT_HEADER', '').toLowerCase();
-const body_size_limit = parseInt(env('BODY_SIZE_LIMIT', '524288'));
+const body_size_limit = parseInt(env('BODY_SIZE_LIMIT', '524288')) || undefined;
 
 const dir = path.dirname(fileURLToPath(import.meta.url));
 


### PR DESCRIPTION
Fixes #11381. Briefly tested locally. The last I knew, there was not a good way to test adapted output.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
