### PR TITLE
fix: Update body_size_limit to use Number instead of parseInt

### DIFF
--- a/.changeset/chatty-swans-pretend.md
+++ b/.changeset/chatty-swans-pretend.md
@@ -1,5 +1,5 @@
 ---
-"@sveltejs/adapter-node": minor
+"@sveltejs/adapter-node": major
 ---
 
-Updated the parsing of the BODY_SIZE_LIMIT environment variable from parseInt to parseFloat.
+breaking: allow any numeric value for `BODY_SIZE_LIMIT`, and interpret literally. Use `Infinity` rather than `0` for unrestricted body sizes

--- a/.changeset/chatty-swans-pretend.md
+++ b/.changeset/chatty-swans-pretend.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-node": minor
+---
+
+Updated the parsing of the BODY_SIZE_LIMIT environment variable from parseInt to parseFloat.

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -19,7 +19,7 @@ const address_header = env('ADDRESS_HEADER', '').toLowerCase();
 const protocol_header = env('PROTOCOL_HEADER', '').toLowerCase();
 const host_header = env('HOST_HEADER', 'host').toLowerCase();
 const port_header = env('PORT_HEADER', '').toLowerCase();
-const body_size_limit = parseInt(env('BODY_SIZE_LIMIT', '524288')) || undefined;
+const body_size_limit = parseFloat(env('BODY_SIZE_LIMIT', '524288')) || undefined;
 
 const dir = path.dirname(fileURLToPath(import.meta.url));
 

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -19,12 +19,14 @@ const address_header = env('ADDRESS_HEADER', '').toLowerCase();
 const protocol_header = env('PROTOCOL_HEADER', '').toLowerCase();
 const host_header = env('HOST_HEADER', 'host').toLowerCase();
 const port_header = env('PORT_HEADER', '').toLowerCase();
-const body_size_limit = parseFloat(env('BODY_SIZE_LIMIT', '524288')) || undefined;
+const body_size_limit = parseFloat(env('BODY_SIZE_LIMIT', '524288'));
+
 if (isNaN(body_size_limit)) {
 	throw new Error(
 		`Invalid BODY_SIZE_LIMIT: '${env('BODY_SIZE_LIMIT')}'. Please provide a numeric value.`
 	);
 }
+
 const dir = path.dirname(fileURLToPath(import.meta.url));
 
 /**

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -21,7 +21,9 @@ const host_header = env('HOST_HEADER', 'host').toLowerCase();
 const port_header = env('PORT_HEADER', '').toLowerCase();
 const body_size_limit = parseFloat(env('BODY_SIZE_LIMIT', '524288')) || undefined;
 if (isNaN(body_size_limit)) {
-    throw new Error(`Invalid BODY_SIZE_LIMIT: '${env('BODY_SIZE_LIMIT')}'. Please provide a numeric value.`);
+	throw new Error(
+		`Invalid BODY_SIZE_LIMIT: '${env('BODY_SIZE_LIMIT')}'. Please provide a numeric value.`
+	);
 }
 const dir = path.dirname(fileURLToPath(import.meta.url));
 

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -20,7 +20,9 @@ const protocol_header = env('PROTOCOL_HEADER', '').toLowerCase();
 const host_header = env('HOST_HEADER', 'host').toLowerCase();
 const port_header = env('PORT_HEADER', '').toLowerCase();
 const body_size_limit = parseFloat(env('BODY_SIZE_LIMIT', '524288')) || undefined;
-
+if (isNaN(body_size_limit)) {
+    throw new Error(`Invalid BODY_SIZE_LIMIT: '${env('BODY_SIZE_LIMIT')}'. Please provide a numeric value.`);
+}
 const dir = path.dirname(fileURLToPath(import.meta.url));
 
 /**

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -19,7 +19,7 @@ const address_header = env('ADDRESS_HEADER', '').toLowerCase();
 const protocol_header = env('PROTOCOL_HEADER', '').toLowerCase();
 const host_header = env('HOST_HEADER', 'host').toLowerCase();
 const port_header = env('PORT_HEADER', '').toLowerCase();
-const body_size_limit = parseFloat(env('BODY_SIZE_LIMIT', '524288'));
+const body_size_limit = Number(env('BODY_SIZE_LIMIT', '524288'));
 
 if (isNaN(body_size_limit)) {
 	throw new Error(

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -34,11 +34,15 @@ function get_raw_body(req, body_size_limit) {
 	return new ReadableStream({
 		start(controller) {
 			if (body_size_limit !== undefined && content_length > body_size_limit) {
-				const error = new SvelteKitError(
-					413,
-					'Payload Too Large',
-					`Content-length of ${content_length} exceeds limit of ${body_size_limit} bytes.`
-				);
+				let message = `Content-length of ${content_length} exceeds limit of ${body_size_limit} bytes.`;
+
+				if (body_size_limit === 0) {
+					// https://github.com/sveltejs/kit/pull/11589
+					// TODO this exists to aid migration — remove in a future version
+					message += ' To disable body size limits, specify Infinity rather than 0.';
+				}
+
+				const error = new SvelteKitError(413, 'Payload Too Large', message);
 
 				controller.error(error);
 				return;


### PR DESCRIPTION
**Summary**
This pull request updates the environment variable handling in our SvelteKit application to support floating-point values for the BODY_SIZE_LIMIT. Previously, the BODY_SIZE_LIMIT was parsed using parseInt, which limited it to integer values. By switching to parseFloat, we can now define more precise limits, improving the flexibility of our application's configuration.

**Changes**
Changed the parsing method for BODY_SIZE_LIMIT from parseInt to parseFloat. This allows the use of both integers and floating-point numbers, providing more granular control over the body size limit.

**Impact**
Enhanced Flexibility: Users can now specify decimal values in the BODY_SIZE_LIMIT environment variable, enabling more precise control over request body size limits.

Backward Compatibility: Integer values are still supported. Existing configurations using integer values for BODY_SIZE_LIMIT will continue to work as expected.

```
BODY_SIZE_LIMIT=Infinity
BODY_SIZE_LIMIT=0x80000
BODY_SIZE_LIMIT=1e5
```

solve #11580 