### PR TITLE
breaking: generate plaintext 404.html for Cloudflare Pages, instead of SPA-style fallback

### DIFF
--- a/.changeset/gold-rocks-compare.md
+++ b/.changeset/gold-rocks-compare.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': major
+---
+
+breaking: generate plaintext 404.html instead of SPA-style fallback page

--- a/packages/adapter-cloudflare/index.d.ts
+++ b/packages/adapter-cloudflare/index.d.ts
@@ -5,6 +5,18 @@ export default function plugin(options?: AdapterOptions): Adapter;
 
 export interface AdapterOptions {
 	/**
+	 * Whether to render a plaintext 404.html page, or a rendered SPA fallback page. This page will
+	 * only be served when a request that matches an entry in `routes.exclude` fails to match an asset.
+	 *
+	 * Most of the time `plaintext` is sufficient, but if you are using `routes.exclude` to manually
+	 * exclude a set of prerendered pages without exceeding the 100 route limit, you may wish to
+	 * use `spa` instead.
+	 *
+	 * @default 'plaintext'
+	 */
+	fallback?: 'plaintext' | 'spa';
+
+	/**
 	 * Customize the automatically-generated `_routes.json` file
 	 * https://developers.cloudflare.com/pages/platform/functions/routing/#create-a-_routesjson-file
 	 */

--- a/packages/adapter-cloudflare/index.d.ts
+++ b/packages/adapter-cloudflare/index.d.ts
@@ -10,7 +10,7 @@ export interface AdapterOptions {
 	 *
 	 * Most of the time `plaintext` is sufficient, but if you are using `routes.exclude` to manually
 	 * exclude a set of prerendered pages without exceeding the 100 route limit, you may wish to
-	 * use `spa` instead.
+	 * use `spa` instead to avoid showing an unstyled 404 page to users.
 	 *
 	 * @default 'plaintext'
 	 */

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -19,7 +19,7 @@ export default function (options = {}) {
 			builder.mkdirp(tmp);
 
 			// generate plaintext 404.html first which can then be overridden by prerendering, if the user defined such a page
-			writeFileSync(`${dest}/404.html`, `Not Found`);
+			writeFileSync(`${dest}/404.html`, 'Not Found');
 
 			const dest_dir = `${dest}${builder.config.kit.paths.base}`;
 			const written_files = builder.writeClient(dest_dir);

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -19,7 +19,12 @@ export default function (options = {}) {
 			builder.mkdirp(tmp);
 
 			// generate plaintext 404.html first which can then be overridden by prerendering, if the user defined such a page
-			writeFileSync(`${dest}/404.html`, 'Not Found');
+			const fallback = path.join(dest, '404.html');
+			if (options.fallback === 'spa') {
+				await builder.generateFallback(fallback);
+			} else {
+				writeFileSync(fallback, 'Not Found');
+			}
 
 			const dest_dir = `${dest}${builder.config.kit.paths.base}`;
 			const written_files = builder.writeClient(dest_dir);

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -16,8 +16,8 @@ export default function (options = {}) {
 			builder.rimraf(tmp);
 			builder.mkdirp(tmp);
 
-			// generate 404.html first which can then be overridden by prerendering, if the user defined such a page
-			await builder.generateFallback(path.join(dest, '404.html'));
+			// generate plaintext 404.html first which can then be overridden by prerendering, if the user defined such a page
+			writeFileSync(`${dest}/404.html`, `Not Found`);
 
 			const dest_dir = `${dest}${builder.config.kit.paths.base}`;
 			const written_files = builder.writeClient(dest_dir);

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -14,6 +14,8 @@ export default function (options = {}) {
 
 			builder.rimraf(dest);
 			builder.rimraf(tmp);
+
+			builder.mkdirp(dest);
 			builder.mkdirp(tmp);
 
 			// generate plaintext 404.html first which can then be overridden by prerendering, if the user defined such a page


### PR DESCRIPTION
Alternative to #9762. Closes #9386. Instead of generating an SPA-style fallback page, we render a plaintext `Not Found` page, which is sufficient for the case where a request is made for a missing asset that is covered by an `exclude` rule. For all other requests, we will hit the worker, which will generate the correct 404 page.

Today:

- [/missing](https://kit-5ry.pages.dev/missing)
- [/_app/immutable/missing](https://kit-5ry.pages.dev/_app/immutable/missing)

With this PR:

- [/missing](https://b91f918d.kit-5ry.pages.dev/missing) (same as before)
- [/_app/immutable/missing](https://b91f918d.kit-5ry.pages.dev/_app/immutable/missing) (plaintext 404)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
