### PR TITLE
fix: return plaintext 404 for anything under appDir

### DIFF
--- a/.changeset/clever-clocks-drop.md
+++ b/.changeset/clever-clocks-drop.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: return plaintext 404 for anything under appDir

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -113,6 +113,10 @@ export async function respond(request, options, manifest, state) {
 		return get_public_env(request);
 	}
 
+	if (decoded.startsWith(`/${options.app_dir}`)) {
+		return text('Not found', { status: 404 });
+	}
+
 	const is_data_request = has_data_suffix(decoded);
 	/** @type {boolean[] | undefined} */
 	let invalidated_data_nodes;


### PR DESCRIPTION
closes #9802. Any requests to `/_app/*` (other than `/_app/env.js`) that make it to the SvelteKit server (i.e. they're not already handled by a static webserver) immediately result in a plaintext 404, instead of doing anything more involved.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
