### PR TITLE
fix: work around safari bug

### DIFF
--- a/.changeset/soft-falcons-cover.md
+++ b/.changeset/soft-falcons-cover.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: populate dynamic public env without using top-level await, which fails in Safari

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -418,7 +418,7 @@ async function kit({ svelte_config }) {
 				case env_dynamic_public:
 					// populate `$env/dynamic/public` from `window`
 					if (browser) {
-						return `export const env = ${global}.env ?? (await import(/* @vite-ignore */ ${global}.base + '/' + '${kit.appDir}/env.js')).env;`;
+						return `export const env = ${global}.env;`;
 					}
 
 					return create_dynamic_module(

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -308,7 +308,7 @@ export async function render_response({
 		}
 
 		if (client.uses_env_dynamic_public) {
-			properties.push(load_env_eagerly ? 'env' : `env: ${s(public_env)}`);
+			properties.push(`env: ${load_env_eagerly ? 'null' : s(public_env)}`);
 		}
 
 		if (chunks) {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -298,7 +298,9 @@ export async function render_response({
 		const blocks = [];
 
 		// when serving a prerendered page in an app that uses $env/dynamic/public, we must
-		// import the env.js module so that it evaluates before any user code can evaluate
+		// import the env.js module so that it evaluates before any user code can evaluate.
+		// TODO revert to using top-level await once https://bugs.webkit.org/show_bug.cgi?id=242740 is fixed
+		// https://github.com/sveltejs/kit/pull/11601
 		const load_env_eagerly = client.uses_env_dynamic_public && state.prerendering;
 
 		const properties = [`base: ${base_expression}`];
@@ -367,7 +369,7 @@ export async function render_response({
 				hydrate.push(`params: ${devalue.uneval(event.params)}`, `route: ${s(event.route)}`);
 			}
 
-			const indent = load_env_eagerly ? '\t\t\t\t\t\t\t' : '\t\t\t\t\t\t';
+			const indent = '\t'.repeat(load_env_eagerly ? 7 : 6);
 			args.push(`{\n${indent}\t${hydrate.join(`,\n${indent}\t`)}\n${indent}}`);
 		}
 

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -327,6 +327,11 @@ export async function render_response({
 						}`);
 		}
 
+		// create this before declaring `data`, which may contain references to `${global}`
+		blocks.push(`${global} = {
+						${properties.join(',\n\t\t\t\t\t\t')}
+					};`);
+
 		const args = ['app', 'element'];
 
 		blocks.push('const element = document.currentScript.parentElement;');
@@ -368,9 +373,7 @@ export async function render_response({
 
 		if (load_env_eagerly) {
 			blocks.push(`import(${s(`${base}/${options.app_dir}/env.js`)}).then(({ env }) => {
-						${global} = {
-							${properties.join(',\n\t\t\t\t\t\t\t')}
-						};
+						${global}.env = env;
 
 						Promise.all([
 							import(${s(prefixed(client.start))}),
@@ -380,10 +383,6 @@ export async function render_response({
 						});
 					});`);
 		} else {
-			blocks.push(`${global} = {
-						${properties.join(',\n\t\t\t\t\t\t')}
-					};`);
-
 			blocks.push(`Promise.all([
 						import(${s(prefixed(client.start))}),
 						import(${s(prefixed(client.app))})

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -301,11 +301,15 @@ export async function render_response({
 		// import the env.js module so that it evaluates before any user code can evaluate
 		const load_env_eagerly = client.uses_env_dynamic_public && state.prerendering;
 
-		const properties = [
-			paths.assets && `assets: ${s(paths.assets)}`,
-			`base: ${base_expression}`,
-			load_env_eagerly ? 'env' : `env: ${s(public_env)}`
-		].filter(Boolean);
+		const properties = [`base: ${base_expression}`];
+
+		if (paths.assets) {
+			properties.push(`assets: ${s(paths.assets)}`);
+		}
+
+		if (client.uses_env_dynamic_public) {
+			properties.push(load_env_eagerly ? 'env' : `env: ${s(public_env)}`);
+		}
 
 		if (chunks) {
 			blocks.push('const deferred = new Map();');

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -361,12 +361,23 @@ export async function render_response({
 			args.push(`{\n\t\t\t\t\t\t\t${hydrate.join(',\n\t\t\t\t\t\t\t')}\n\t\t\t\t\t\t}`);
 		}
 
-		blocks.push(`Promise.all([
+		if (client.uses_env_dynamic_public && state.prerendering) {
+			blocks.push(`Promise.all([
+						import(${s(prefixed(client.start))}),
+						import(${s(prefixed(client.app))}),
+						import(${s(`${base}/${options.app_dir}/env.js`)})
+					]).then(([kit, app, { env }]) => {
+						${global}.env = env;
+						kit.start(${args.join(', ')});
+					});`);
+		} else {
+			blocks.push(`Promise.all([
 						import(${s(prefixed(client.start))}),
 						import(${s(prefixed(client.app))})
 					]).then(([kit, app]) => {
 						kit.start(${args.join(', ')});
 					});`);
+		}
 
 		if (options.service_worker) {
 			const opts = __SVELTEKIT_DEV__ ? ", { type: 'module' }" : '';


### PR DESCRIPTION
Ref #11364. There is a [very serious Safari bug](https://bugs.webkit.org/show_bug.cgi?id=242740) that apparently very few people have encountered outside SvelteKit, possibly because few frameworks use native ESM with top-level await. That is likely to change over time, and I hope Webkit can prioritise a fix for this issue.

In the meantime we have no choice but to work around it. I don't see a better alternative than this PR, which eagerly loads the dynamic `env.js` module when on a prerendered page, such that `${global}.env` is populated by the time any user code tries to read it.

This is less good than fetching it lazily, and it only mitigates the issue (since top-level await could appear in user code, and it's likely we'll find other uses for it within the framework in future), but for now I think it will have to do.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
