### PR TITLE
fix: correct images cache key to avoid collisions when images have same name

### DIFF
--- a/.changeset/rare-lizards-wonder.md
+++ b/.changeset/rare-lizards-wonder.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/enhanced-img": patch
+---
+
+fix: correct images cache key to avoid collisions when images have same name


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/issues/11561
Images cache keys are wrong for relative paths

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
