### PR TITLE
chore: remove unnecessary tsconfig paths config

### DIFF
--- a/packages/kit/test/apps/amp/tsconfig.json
+++ b/packages/kit/test/apps/amp/tsconfig.json
@@ -2,13 +2,7 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
-		"noEmit": true,
-		"paths": {
-			"@sveltejs/kit": ["../../../types"],
-			"$lib": ["./src/lib"],
-			"$lib/*": ["./src/lib/*"],
-			"types": ["../../../types/internal"]
-		}
+		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"
 }

--- a/packages/kit/test/apps/basics/tsconfig.json
+++ b/packages/kit/test/apps/basics/tsconfig.json
@@ -4,10 +4,6 @@
 		"checkJs": true,
 		"esModuleInterop": true,
 		"noEmit": true,
-		"paths": {
-			"@sveltejs/kit": ["../../../types"],
-			"types": ["../../../types/internal"]
-		},
 		"resolveJsonModule": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"

--- a/packages/kit/test/apps/dev-only/tsconfig.json
+++ b/packages/kit/test/apps/dev-only/tsconfig.json
@@ -4,12 +4,6 @@
 		"checkJs": true,
 		"esModuleInterop": true,
 		"noEmit": true,
-		"paths": {
-			"@sveltejs/kit": ["../../../types"],
-			"$lib": ["./src/lib"],
-			"$lib/*": ["./src/lib/*"],
-			"types": ["../../../types/internal"]
-		},
 		"resolveJsonModule": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"

--- a/packages/kit/test/apps/embed/tsconfig.json
+++ b/packages/kit/test/apps/embed/tsconfig.json
@@ -4,10 +4,6 @@
 		"checkJs": true,
 		"esModuleInterop": true,
 		"noEmit": true,
-		"paths": {
-			"@sveltejs/kit": ["../../../types"],
-			"types": ["../../../types/internal"]
-		},
 		"resolveJsonModule": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"

--- a/packages/kit/test/apps/no-ssr/tsconfig.json
+++ b/packages/kit/test/apps/no-ssr/tsconfig.json
@@ -4,10 +4,6 @@
 		"checkJs": true,
 		"esModuleInterop": true,
 		"noEmit": true,
-		"paths": {
-			"@sveltejs/kit": ["../../../types"],
-			"types": ["../../../types/internal"]
-		},
 		"resolveJsonModule": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"

--- a/packages/kit/test/apps/options-2/tsconfig.json
+++ b/packages/kit/test/apps/options-2/tsconfig.json
@@ -2,13 +2,7 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
-		"noEmit": true,
-		"paths": {
-			"@sveltejs/kit": ["../../../types"],
-			"$lib": ["./src/lib"],
-			"$lib/*": ["./src/lib/*"],
-			"types": ["../../../types/internal"]
-		}
+		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"
 }

--- a/packages/kit/test/apps/options/tsconfig.json
+++ b/packages/kit/test/apps/options/tsconfig.json
@@ -2,13 +2,7 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
-		"noEmit": true,
-		"paths": {
-			"@sveltejs/kit": ["../../../types"],
-			"$lib": ["./source/components"],
-			"$lib/*": ["./source/components/*"],
-			"types": ["../../../types/internal"]
-		}
+		"noEmit": true
 	},
 	"extends": "./.custom-out-dir/tsconfig.json"
 }

--- a/packages/kit/test/apps/writes/tsconfig.json
+++ b/packages/kit/test/apps/writes/tsconfig.json
@@ -4,12 +4,6 @@
 		"checkJs": true,
 		"esModuleInterop": true,
 		"noEmit": true,
-		"paths": {
-			"@sveltejs/kit": ["../../../types"],
-			"$lib": ["./src/lib"],
-			"$lib/*": ["./src/lib/*"],
-			"types": ["../../../types/internal"]
-		},
 		"resolveJsonModule": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"

--- a/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/tsconfig.json
@@ -2,12 +2,7 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
-		"noEmit": true,
-		"paths": {
-			"@sveltejs/kit": ["../../../../types"],
-			"$lib": ["./src/lib"],
-			"$lib/*": ["./src/lib/*"]
-		}
+		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"
 }

--- a/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/tsconfig.json
@@ -2,12 +2,7 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
-		"noEmit": true,
-		"paths": {
-			"@sveltejs/kit": ["../../../../types"],
-			"$lib": ["./src/lib"],
-			"$lib/*": ["./src/lib/*"]
-		}
+		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"
 }

--- a/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/tsconfig.json
@@ -2,12 +2,7 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
-		"noEmit": true,
-		"paths": {
-			"@sveltejs/kit": ["../../../../types"],
-			"$lib": ["./src/lib"],
-			"$lib/*": ["./src/lib/*"]
-		}
+		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"
 }

--- a/packages/kit/test/build-errors/apps/private-dynamic-env-dynamic-import/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/private-dynamic-env-dynamic-import/tsconfig.json
@@ -8,9 +8,6 @@
 		"resolveJsonModule": true,
 		"sourceMap": true,
 		"strict": true,
-		"noEmit": true,
-		"paths": {
-			"types": ["../../../../types/internal"]
-		}
+		"noEmit": true
 	}
 }

--- a/packages/kit/test/build-errors/apps/private-dynamic-env/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/private-dynamic-env/tsconfig.json
@@ -8,9 +8,6 @@
 		"resolveJsonModule": true,
 		"sourceMap": true,
 		"strict": true,
-		"noEmit": true,
-		"paths": {
-			"types": ["../../../../types/internal"]
-		}
+		"noEmit": true
 	}
 }

--- a/packages/kit/test/build-errors/apps/private-static-env-dynamic-import/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/private-static-env-dynamic-import/tsconfig.json
@@ -8,9 +8,6 @@
 		"resolveJsonModule": true,
 		"sourceMap": true,
 		"strict": true,
-		"noEmit": true,
-		"paths": {
-			"types": ["../../../../types/internal"]
-		}
+		"noEmit": true
 	}
 }

--- a/packages/kit/test/build-errors/apps/private-static-env/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/private-static-env/tsconfig.json
@@ -8,9 +8,6 @@
 		"resolveJsonModule": true,
 		"sourceMap": true,
 		"strict": true,
-		"noEmit": true,
-		"paths": {
-			"types": ["../../../../types/internal"]
-		}
+		"noEmit": true
 	}
 }

--- a/packages/kit/test/build-errors/apps/server-only-folder-dynamic-import/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/server-only-folder-dynamic-import/tsconfig.json
@@ -8,11 +8,6 @@
 		"resolveJsonModule": true,
 		"sourceMap": true,
 		"strict": true,
-		"noEmit": true,
-		"paths": {
-			"types": ["../../../../types/internal"],
-			"$lib": ["./src/lib"],
-			"$lib/*": ["./src/lib/*"]
-		}
+		"noEmit": true
 	}
 }

--- a/packages/kit/test/build-errors/apps/server-only-folder/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/server-only-folder/tsconfig.json
@@ -8,11 +8,6 @@
 		"resolveJsonModule": true,
 		"sourceMap": true,
 		"strict": true,
-		"noEmit": true,
-		"paths": {
-			"types": ["../../../../types/internal"],
-			"$lib": ["./src/lib"],
-			"$lib/*": ["./src/lib/*"]
-		}
+		"noEmit": true
 	}
 }

--- a/packages/kit/test/build-errors/apps/server-only-module-dynamic-import/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/server-only-module-dynamic-import/tsconfig.json
@@ -8,11 +8,6 @@
 		"resolveJsonModule": true,
 		"sourceMap": true,
 		"strict": true,
-		"noEmit": true,
-		"paths": {
-			"types": ["../../../../types/internal"],
-			"$lib": ["./src/lib"],
-			"$lib/*": ["./src/lib/*"]
-		}
+		"noEmit": true
 	}
 }

--- a/packages/kit/test/build-errors/apps/server-only-module/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/server-only-module/tsconfig.json
@@ -8,11 +8,6 @@
 		"resolveJsonModule": true,
 		"sourceMap": true,
 		"strict": true,
-		"noEmit": true,
-		"paths": {
-			"types": ["../../../../types/internal"],
-			"$lib": ["./src/lib"],
-			"$lib/*": ["./src/lib/*"]
-		}
+		"noEmit": true
 	}
 }

--- a/packages/kit/test/build-errors/apps/service-worker-dynamic-public-env/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/service-worker-dynamic-public-env/tsconfig.json
@@ -8,9 +8,6 @@
 		"resolveJsonModule": true,
 		"sourceMap": true,
 		"strict": true,
-		"noEmit": true,
-		"paths": {
-			"types": ["../../../../types/internal"]
-		}
+		"noEmit": true
 	}
 }

--- a/packages/kit/test/build-errors/apps/service-worker-private-env/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/service-worker-private-env/tsconfig.json
@@ -8,9 +8,6 @@
 		"resolveJsonModule": true,
 		"sourceMap": true,
 		"strict": true,
-		"noEmit": true,
-		"paths": {
-			"types": ["../../../../types/internal"]
-		}
+		"noEmit": true
 	}
 }

--- a/packages/kit/test/build-errors/apps/syntax-error/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/syntax-error/tsconfig.json
@@ -8,11 +8,6 @@
 		"resolveJsonModule": true,
 		"sourceMap": true,
 		"strict": true,
-		"noEmit": true,
-		"paths": {
-			"types": ["../../../../types/internal"],
-			"$lib": ["./src/lib"],
-			"$lib/*": ["./src/lib/*"]
-		}
+		"noEmit": true
 	}
 }

--- a/packages/kit/test/prerendering/basics/tsconfig.json
+++ b/packages/kit/test/prerendering/basics/tsconfig.json
@@ -2,13 +2,7 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
-		"noEmit": true,
-		"paths": {
-			"@sveltejs/kit": ["../../../types"],
-			"$lib": ["./src/lib"],
-			"$lib/*": ["./src/lib/*"],
-			"types": ["../../../types/internal"]
-		}
+		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"
 }

--- a/packages/kit/test/prerendering/options/tsconfig.json
+++ b/packages/kit/test/prerendering/options/tsconfig.json
@@ -2,13 +2,7 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
-		"noEmit": true,
-		"paths": {
-			"@sveltejs/kit": ["../../../types"],
-			"$lib": ["./src/lib"],
-			"$lib/*": ["./src/lib/*"],
-			"types": ["../../../types/internal"]
-		}
+		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"
 }

--- a/packages/kit/test/prerendering/paths-base/tsconfig.json
+++ b/packages/kit/test/prerendering/paths-base/tsconfig.json
@@ -2,13 +2,7 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
-		"noEmit": true,
-		"paths": {
-			"@sveltejs/kit": ["../../../types"],
-			"$lib": ["./src/lib"],
-			"$lib/*": ["./src/lib/*"],
-			"types": ["../../../types/internal"]
-		}
+		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"
 }

--- a/packages/kit/test/tsconfig.json
+++ b/packages/kit/test/tsconfig.json
@@ -7,11 +7,6 @@
 		"target": "esnext",
 		"module": "esnext",
 		"moduleResolution": "node",
-		"allowSyntheticDefaultImports": true,
-		"paths": {
-			"@sveltejs/kit": ["../types/index"],
-			// internal use only
-			"types": ["../types/internal"]
-		}
+		"allowSyntheticDefaultImports": true
 	}
 }


### PR DESCRIPTION
am trying to make the test output less chaotic, so it's easier to diagnose failures. step one: get rid of the 'You have specified a baseUrl and/or paths in your tsconfig.json...' warnings. It looks like `"paths"` is no longer necessary (not sure why it ever was)