### PR TITLE
chore: restructure CI stuff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
-  Lint:
+  lint-all:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
       - run: pnpm run lint
       - run: cd packages/kit && pnpm prepublishOnly && { [ "`git status --porcelain=v1`" == "" ] || (echo "Generated types have changed — please run prepublishOnly locally and commit the changes after you have reviewed them"; git diff; exit 1); }
       - run: pnpm run check
-  Tests:
+  test-kit:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -57,7 +57,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm playwright install ${{ matrix.e2e-browser }}
-      - run: pnpm test
+      - run: pnpm test:kit
       - name: Archive test results
         if: failure()
         shell: bash
@@ -69,7 +69,7 @@ jobs:
           retention-days: 3
           name: test-failure-${{ github.run_id }}-${{ matrix.os }}-${{ matrix.node-version }}-${{ matrix.e2e-browser }}
           path: test-results.tar.gz
-  Cross-browser-test:
+  test-kit-cross-browser:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -124,7 +124,7 @@ jobs:
           retention-days: 3
           name: test-failure-cross-platform-${{ matrix.mode }}-${{ github.run_id }}-${{ matrix.os }}-${{ matrix.node-version }}-${{ matrix.e2e-browser }}
           path: test-results-cross-platform-${{ matrix.mode }}.tar.gz
-  Test-create-svelte:
+  test-others:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -135,4 +135,4 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: cd packages/kit && pnpm prepublishOnly
-      - run: pnpm run test:create-svelte
+      - run: pnpm run test:others

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,5 +134,6 @@ jobs:
           node-version: 18
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm playwright install chromium
       - run: cd packages/kit && pnpm prepublishOnly
       - run: pnpm run test:others

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"test": "pnpm test -r --filter=./packages/* --filter=!./packages/create-svelte",
+		"test:kit": "pnpm run --dir packages/kit test",
 		"test:cross-platform:dev": "pnpm run --dir packages/kit test:cross-platform:dev",
 		"test:cross-platform:build": "pnpm run --dir packages/kit test:cross-platform:build",
 		"test:vite-ecosystem-ci": "pnpm test --dir packages/kit",
-		"test:create-svelte": "pnpm run --dir packages/create-svelte test",
+		"test:others": "pnpm test -r --filter=./packages/* --filter=!./packages/kit/ --workspace-concurrency=1",
 		"check": "pnpm -r prepublishOnly && pnpm -r check",
 		"lint": "pnpm -r lint && eslint --cache --cache-location node_modules/.eslintcache 'packages/**/*.js'",
 		"format": "pnpm -r format",

--- a/packages/enhanced-img/package.json
+++ b/packages/enhanced-img/package.json
@@ -14,7 +14,7 @@
 		"lint": "prettier --check .",
 		"check": "tsc",
 		"format": "prettier --write .",
-		"test": "vitest"
+		"test": "vitest run"
 	},
 	"files": [
 		"src",


### PR DESCRIPTION
See also #11606, #11608

The test output is much easier to read if tests run serially. Since the `kit` tests take much longer to run than the others, it makes sense to separate them out into their own job and have all the others in a separate job