### PR TITLE
feat: import maps

### DIFF
--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -134,6 +134,10 @@ const options = object(
 				errorTemplate: string(join('src', 'error.html'))
 			}),
 
+			importMap: object({
+				enabled: boolean(false)
+			}),
+
 			inlineStyleThreshold: number(0),
 
 			moduleExtensions: string_array(['.js', '.ts']),

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -41,6 +41,7 @@ export const options = {
 	env_public_prefix: '${config.kit.env.publicPrefix}',
 	env_private_prefix: '${config.kit.env.privatePrefix}',
 	hooks: null, // added lazily, via \`get_hooks\`
+	import_map_enabled: ${config.kit.importMap.enabled},
 	preload_strategy: ${s(config.kit.output.preloadStrategy)},
 	root,
 	service_worker: ${has_service_worker},

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -432,6 +432,14 @@ export interface KitConfig {
 		 */
 		errorTemplate?: string;
 	};
+	importMap?: {
+		/**
+		 * Whether to generate import maps. This will result in better long term cacheability, as changes to a single module will no longer invalidate all its dependents.
+		 * However, it will increase the size of the HTML document, and force `modulepreload` links to be part of the document rather than being added as HTTP headers.
+		 * @default false;
+		 */
+		enabled?: false;
+	};
 	/**
 	 * Inline CSS inside a `<style>` block at the head of the HTML. This option is a number that specifies the maximum length of a CSS file in UTF-16 code units, as specified by the [String.length](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length) property, to be inlined. All CSS files needed for the page and smaller than this value are merged and inlined in a `<style>` block.
 	 *

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -438,7 +438,7 @@ export interface KitConfig {
 		 * However, it will increase the size of the HTML document, and force `modulepreload` links to be part of the document rather than being added as HTTP headers.
 		 * @default false;
 		 */
-		enabled?: false;
+		enabled?: boolean;
 	};
 	/**
 	 * Inline CSS inside a `<style>` block at the head of the HTML. This option is a number that specifies the maximum length of a CSS file in UTF-16 code units, as specified by the [String.length](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length) property, to be inlined. All CSS files needed for the page and smaller than this value are merged and inlined in a `<style>` block.

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -121,7 +121,8 @@ export async function dev(vite, vite_config, svelte_config) {
 					imports: [],
 					stylesheets: [],
 					fonts: [],
-					uses_env_dynamic_public: true
+					uses_env_dynamic_public: true,
+					import_map_lookup: []
 				},
 				nodes: manifest_data.nodes.map((node, index) => {
 					return async () => {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -696,7 +696,7 @@ async function kit({ svelte_config }) {
 		},
 
 		renderChunk(code, chunk) {
-			if (!is_build || vite_config.build.ssr) return;
+			if (!is_build || vite_config.build.ssr || !svelte_config.kit.importMap.enabled) return;
 			if (!has_placeholder(code)) return;
 
 			return {
@@ -737,18 +737,20 @@ async function kit({ svelte_config }) {
 			/** @type {Array<[string, string]>} */
 			const import_map_lookup = [];
 
-			for (const chunk of Object.values(bundle)) {
-				if (chunk.type === 'chunk') {
-					const key = sanitize_chunk_name(chunk.preliminaryFileName).replace(
-						`${svelte_config.kit.appDir}/immutable/`,
-						''
-					);
+			if (svelte_config.kit.importMap.enabled) {
+				for (const chunk of Object.values(bundle)) {
+					if (chunk.type === 'chunk') {
+						const key = sanitize_chunk_name(chunk.preliminaryFileName).replace(
+							`${svelte_config.kit.appDir}/immutable/`,
+							''
+						);
 
-					import_map_lookup.push([key, chunk.fileName]);
+						import_map_lookup.push([key, chunk.fileName]);
+					}
 				}
-			}
 
-			import_map_lookup.sort((a, b) => (a < b ? -1 : 1));
+				import_map_lookup.sort((a, b) => (a < b ? -1 : 1));
+			}
 
 			this.emitFile({
 				type: 'asset',

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -277,6 +277,18 @@ export async function render_response({
 	}
 
 	if (page_config.csr) {
+		if (options.import_map_enabled) {
+			head += `<script type="importmap">
+			{
+				"imports": {
+					${client.import_map_lookup
+						.map(([key, value]) => `${s(key)}: ${s(prefixed(value))}`)
+						.join('\n\t\t\t\t\t')}
+				}
+			},
+		</script>`;
+		}
+
 		if (client.uses_env_dynamic_public && state.prerendering) {
 			modulepreloads.add(`${options.app_dir}/env.js`);
 		}
@@ -290,7 +302,7 @@ export async function render_response({
 			link_header_preloads.add(`<${encodeURI(path)}>; rel="modulepreload"; nopush`);
 			if (options.preload_strategy !== 'modulepreload') {
 				head += `\n\t\t<link rel="preload" as="script" crossorigin="anonymous" href="${path}">`;
-			} else if (state.prerendering) {
+			} else if (state.prerendering || options.import_map_enabled) {
 				head += `\n\t\t<link rel="modulepreload" href="${path}">`;
 			}
 		}
@@ -448,7 +460,7 @@ export async function render_response({
 			headers.set('content-security-policy-report-only', report_only_header);
 		}
 
-		if (link_header_preloads.size) {
+		if (link_header_preloads.size && !options.import_map_enabled) {
 			headers.set('link', Array.from(link_header_preloads).join(', '));
 		}
 	}

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -63,6 +63,7 @@ export interface BuildData {
 		stylesheets: string[];
 		fonts: string[];
 		uses_env_dynamic_public: boolean;
+		import_map_lookup: Array<[string, string]>;
 	} | null;
 	server_manifest: import('vite').Manifest;
 }
@@ -344,6 +345,7 @@ export interface SSROptions {
 	env_public_prefix: string;
 	env_private_prefix: string;
 	hooks: ServerHooks;
+	import_map_enabled: boolean;
 	preload_strategy: ValidatedConfig['kit']['output']['preloadStrategy'];
 	root: SSRComponent['default'];
 	service_worker: boolean;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -414,6 +414,14 @@ declare module '@sveltejs/kit' {
 			 */
 			errorTemplate?: string;
 		};
+		importMap?: {
+			/**
+			 * Whether to generate import maps. This will result in better long term cacheability, as changes to a single module will no longer invalidate all its dependents.
+			 * However, it will increase the size of the HTML document, and force `modulepreload` links to be part of the document rather than being added as HTTP headers.
+			 * @default false;
+			 */
+			enabled?: boolean;
+		};
 		/**
 		 * Inline CSS inside a `<style>` block at the head of the HTML. This option is a number that specifies the maximum length of a CSS file in UTF-16 code units, as specified by the [String.length](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length) property, to be inlined. All CSS files needed for the page and smaller than this value are merged and inlined in a `<style>` block.
 		 *
@@ -1557,6 +1565,7 @@ declare module '@sveltejs/kit' {
 			stylesheets: string[];
 			fonts: string[];
 			uses_env_dynamic_public: boolean;
+			import_map_lookup: Array<[string, string]>;
 		} | null;
 		server_manifest: import('vite').Manifest;
 	}

--- a/sites/kit.svelte.dev/svelte.config.js
+++ b/sites/kit.svelte.dev/svelte.config.js
@@ -7,6 +7,10 @@ const config = {
 			runtime: 'edge'
 		}),
 
+		importMap: {
+			enabled: true
+		},
+
 		paths: {
 			relative: true
 		}


### PR DESCRIPTION
This adds import map support to SvelteKit. If you add the relevant config...

```js
export default {
  kit: {
    importMap: {
      enabled: true
    }
};
```

...SvelteKit will generate an import map for your `.js` files, and rewrite import declarations (and dynamic imports) to point to the identifiers in the import map.

It will also disable `modulepreload` HTTP headers in favour of `<link>` elements in the HTML, since the import map must precede any preloads.

The reason you'd want to enable this is that it makes your assets more cacheable. Today, if multiple pages import the same component or module from `src/lib` (for example), then any changes to that module will cause all the page chunks to be invalidated as well as the module itself. With import maps this is no longer necessary, since the pages import the module via a stable identifier. (There's a caveat here in that Rollup can choose to chunk things up however it likes — if the overall structure of the bundle changes then things will be invalidated. Most changes aren't like that, however.)

Closes #4482.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
