### PR TITLE
feat: provide HTTP reason phrase in `error()`

### DIFF
--- a/.changeset/purple-pugs-enjoy.md
+++ b/.changeset/purple-pugs-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+feat: provide http reason phrase in error

--- a/packages/kit/src/runtime/control.js
+++ b/packages/kit/src/runtime/control.js
@@ -10,7 +10,49 @@ export class HttpError {
 		} else if (body) {
 			this.body = body;
 		} else {
-			this.body = { message: `Error: ${status}` };
+			this.body = {
+				message:
+					{
+						400: 'Bad Request',
+						401: 'Unauthorized',
+						402: 'Payment Required',
+						403: 'Forbidden',
+						404: 'Not Found',
+						405: 'Method Not Allowed',
+						406: 'Not Acceptable',
+						407: 'Proxy Authentication Required',
+						408: 'Request Timeout',
+						409: 'Conflict',
+						410: 'Gone',
+						411: 'Length Required',
+						412: 'Precondition Failed',
+						413: 'Request Entity Too Large',
+						414: 'Request-URI Too Long',
+						415: 'Unsupported Media Type',
+						416: 'Requested Range Not Satisfiable',
+						417: 'Expectation Failed',
+						418: "I'm a teapot",
+						419: 'Insufficient Space on Resource',
+						420: 'Method Failure',
+						421: 'Misdirected Request',
+						422: 'Unprocessable Entity',
+						423: 'Locked',
+						424: 'Failed Dependency',
+						426: 'Upgrade Required',
+						428: 'Precondition Required',
+						429: 'Too Many Requests',
+						431: 'Request Header Fields Too Large',
+						451: 'Unavailable For Legal Reasons',
+						500: 'Internal Server Error',
+						501: 'Not Implemented',
+						502: 'Bad Gateway',
+						503: 'Service Unavailable',
+						504: 'Gateway Timeout',
+						505: 'HTTP Version Not Supported',
+						507: 'Insufficient Storage',
+						511: 'Network Authentication Required'
+					}[status] || 'Unknown Error'
+			};
 		}
 	}
 

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -515,7 +515,7 @@ test.describe.serial('Errors', () => {
 
 		expect(await page.textContent('footer')).toBe('Custom layout');
 		expect(await page.textContent('#message')).toBe(
-			'This is your custom error page saying: "Error: 401"'
+			'This is your custom error page saying: "Unauthorized"'
 		);
 		expect(await page.innerHTML('h1')).toBe('401');
 	});

--- a/packages/kit/test/apps/basics/test/cross-platform/test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/test.js
@@ -348,7 +348,7 @@ test.describe('Errors', () => {
 
 		expect(res && res.status()).toBe(555);
 		expect(await page.textContent('#message')).toBe(
-			'This is your custom error page saying: "Error: 555"'
+			'This is your custom error page saying: "Unknown Error"'
 		);
 	});
 

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import { test } from '../../../utils.js';
 import { createHash, randomBytes } from 'node:crypto';
+import { test } from '../../../utils.js';
 
 /** @typedef {import('@playwright/test').Response} Response */
 
@@ -431,7 +431,7 @@ test.describe('Load', () => {
 		request
 	}) => {
 		const response = await request.get('/errors/error-in-layout');
-		expect(await response.text()).toContain('Error: 404');
+		expect(await response.text()).toContain('Not Found');
 	});
 
 	test('fetch does not load a file with a # character', async ({ request }) => {


### PR DESCRIPTION
<!-- Your PR description here -->

If an error body is not provided, it generates a `Error: ${status_code}` message.

```ts
import { error } from '@sveltejs/kit';

export const load = () => { error(403); };
```

This does not look good on the default `+error.svelte` [example](https://kit.svelte.dev/docs/routing#error).

```svelte
<script>
  import { page } from '$app/stores';
</script>

<h1>{$page.status}: {$page.error.message}</h1>
<h1>403: Error: 403</h1>
```

Since the `HttpError` class is used in server and client, the HTTP reason phrases are provided as an object.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
