### PR TITLE
implement serverAssets

### DIFF
--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -29,7 +29,7 @@ const server_template = ({
 }) => `
 import root from '../root.${isSvelte5Plus() ? 'js' : 'svelte'}';
 import { set_building, set_prerendering } from '__sveltekit/environment';
-import { set_assets } from '__sveltekit/paths';
+import { set_assets, set_server_assets } from '__sveltekit/paths';
 import { set_private_env, set_public_env, set_safe_public_env } from '${runtime_directory}/shared-server.js';
 
 export const options = {
@@ -68,7 +68,7 @@ export async function get_hooks() {
 	};
 }
 
-export { set_assets, set_building, set_prerendering, set_private_env, set_public_env, set_safe_public_env };
+export { set_assets, set_server_assets, set_building, set_prerendering, set_private_env, set_public_env, set_safe_public_env };
 `;
 
 // TODO need to re-run this whenever src/app.html or src/error.html are

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -465,8 +465,9 @@ export async function dev(vite, vite_config, svelte_config) {
 				);
 				set_fix_stack_trace(fix_stack_trace);
 
-				const { set_assets } = await vite.ssrLoadModule('__sveltekit/paths');
+				const { set_assets, set_server_assets } = await vite.ssrLoadModule('__sveltekit/paths');
 				set_assets(assets);
+				set_server_assets(process.cwd());
 
 				const server = new Server(manifest);
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -447,12 +447,14 @@ async function kit({ svelte_config }) {
 						return dedent`
 							export const base = ${global}?.base ?? ${s(base)};
 							export const assets = ${global}?.assets ?? ${assets ? s(assets) : 'base'};
+							export let serverAssets = '';
 						`;
 					}
 
 					return dedent`
 						export let base = ${s(base)};
 						export let assets = ${assets ? s(assets) : 'base'};
+						export let serverAssets = '';
 
 						export const relative = ${svelte_config.kit.paths.relative};
 
@@ -471,6 +473,11 @@ async function kit({ svelte_config }) {
 						/** @param {string} path */
 						export function set_assets(path) {
 							assets = initial.assets = path;
+						}
+
+						/** @param {string} path */
+						export function set_server_assets(path) {
+							serverAssets = path;
 						}
 					`;
 				}

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -36,7 +36,9 @@ export async function preview(vite, vite_config, svelte_config) {
 	}
 
 	/** @type {import('types').ServerInternalModule} */
-	const { set_assets } = await import(pathToFileURL(join(dir, 'internal.js')).href);
+	const { set_assets, set_server_assets } = await import(
+		pathToFileURL(join(dir, 'internal.js')).href
+	);
 
 	/** @type {import('types').ServerModule} */
 	const { Server } = await import(pathToFileURL(join(dir, 'index.js')).href);
@@ -44,6 +46,7 @@ export async function preview(vite, vite_config, svelte_config) {
 	const { manifest } = await import(pathToFileURL(join(dir, 'manifest.js')).href);
 
 	set_assets(assets);
+	set_server_assets(dir);
 
 	const server = new Server(manifest);
 	await server.init({

--- a/packages/kit/src/runtime/app/paths/index.js
+++ b/packages/kit/src/runtime/app/paths/index.js
@@ -1,4 +1,4 @@
-export { base, assets } from '__sveltekit/paths';
+export { base, assets, serverAssets } from '__sveltekit/paths';
 import { base } from '__sveltekit/paths';
 import { resolve_route } from '../../../utils/routing.js';
 

--- a/packages/kit/src/runtime/app/paths/types.d.ts
+++ b/packages/kit/src/runtime/app/paths/types.d.ts
@@ -13,6 +13,20 @@ export let base: '' | `/${string}`;
 export let assets: '' | `https://${string}` | `http://${string}` | '/_svelte_kit_assets';
 
 /**
+ * The directory containing assets imported by files on the server. On Node-based platforms, this allows you to read assets from the filesystem.
+ *
+ * @example
+ * ```js
+ * import fs from 'node:fs';
+ * import somefile from './somefile.txt';
+ * import { serverAssets } from '$app/paths';
+ *
+ * const data = fs.readFileSync(`${serverAssets}/${somefile}`, 'utf-8');
+ * ```
+ */
+export let serverAssets: string;
+
+/**
  * Populate a route ID with params to resolve a pathname.
  * @example
  * ```js

--- a/packages/kit/src/types/ambient-private.d.ts
+++ b/packages/kit/src/types/ambient-private.d.ts
@@ -11,8 +11,10 @@ declare module '__sveltekit/environment' {
 declare module '__sveltekit/paths' {
 	export let base: '' | `/${string}`;
 	export let assets: '' | `https://${string}` | `http://${string}` | '/_svelte_kit_assets';
+	export let serverAssets: string;
 	export let relative: boolean;
 	export function reset(): void;
 	export function override(paths: { base: string; assets: string }): void;
 	export function set_assets(path: string): void;
+	export function set_server_assets(path: string): void;
 }

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -34,6 +34,7 @@ export interface ServerInternalModule {
 	set_private_env(environment: Record<string, string>): void;
 	set_public_env(environment: Record<string, string>): void;
 	set_safe_public_env(environment: Record<string, string>): void;
+	set_server_assets(path: string): void;
 	set_version(version: string): void;
 	set_fix_stack_trace(fix_stack_trace: (error: unknown) => string): void;
 }

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2092,6 +2092,20 @@ declare module '$app/paths' {
 	export let assets: '' | `https://${string}` | `http://${string}` | '/_svelte_kit_assets';
 
 	/**
+	 * The directory containing assets imported by files on the server. On Node-based platforms, this allows you to read assets from the filesystem.
+	 *
+	 * @example
+	 * ```js
+	 * import fs from 'node:fs';
+	 * import somefile from './somefile.txt';
+	 * import { serverAssets } from '$app/paths';
+	 *
+	 * const data = fs.readFileSync(`${serverAssets}/${somefile}`, 'utf-8');
+	 * ```
+	 */
+	export let serverAssets: string;
+
+	/**
 	 * Populate a route ID with params to resolve a pathname.
 	 * @example
 	 * ```js


### PR DESCRIPTION
This might not go anywhere, I'm just putting it here for posterity.

It implements the `serverAssets` idea mentioned in https://github.com/sveltejs/kit/issues/11020#issuecomment-1847684818. If adapters set the value correctly (and include the assets in functions, where applicable — see #10979), this would allow Node-based deployments to read stuff from the filesystem:

```js
import fs from 'node:fs';
import file from './file.txt';
import { serverAssets } from '$app/paths';

export function GET() {
  return new Response(fs.readFileSync(`${serverAssets}/${file}`, 'utf-8'));
}
```

There are two problems:

1. It would be nice to have a more platform-agnostic approach, if possible (i.e. use `node:fs` in dev/preview, but a platform-native approach elsewhere)
2. You have to be very careful to avoid assets being inlined. ``fs.readFile(`${serverAssets}/data:...`)`` doesn't work

We could maybe solve the second part by forcing `assetsInlineLimit` to `0` in SSR mode, but this would result in mismatches in cases like this, if the asset was inlined in the client build:

```svelte
<script>
  import icon from '$lib/icons/whatever.png';
</script>

<img src={icon} alt="icon" />
```

Maybe that's fine though?

For the platform-agnostic thing, we'd presumably need to have something like this:

```js
import { text } from '$app/fs';
import file from './file.txt';

export async function GET() {
  return new Response(await text(file));
}
```

Pros of a dedicated `$app/fs` module:

- Platform-agnostic (within reason)
- Can handle `data:` URLs
- More convenient APIs (`await text(...)`, `await json(...)`, streaming, etc — maybe we could even offer helpers for creating `Response` objects with correct `content-type` etc?)
- We can know which utilities are imported in which contexts, which would be helpful for e.g. saying 'you can't read from the filesystem in an edge function' (though this wouldn't account for inlined assets)

Costs:

- Increased surface area
- We're not likely to replicate the entirety of `node:fs`

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
