### PR TITLE
feat: implement `read`

### DIFF
--- a/.changeset/rude-apples-jam.md
+++ b/.changeset/rude-apples-jam.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/adapter-netlify': major
+'@sveltejs/adapter-vercel': major
+'@sveltejs/adapter-node': major
+---
+
+breaking: update peer dependency on `@sveltejs/kit`

--- a/.changeset/tasty-masks-talk.md
+++ b/.changeset/tasty-masks-talk.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: add `$app/server` module with `read` function for reading assets from filesystem

--- a/.changeset/tiny-maps-chew.md
+++ b/.changeset/tiny-maps-chew.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/adapter-netlify': minor
+'@sveltejs/adapter-vercel': minor
+'@sveltejs/adapter-node': minor
+---
+
+feat: support `read` from `$app/server`

--- a/documentation/docs/25-build-and-deploy/99-writing-adapters.md
+++ b/documentation/docs/25-build-and-deploy/99-writing-adapters.md
@@ -23,9 +23,9 @@ export default function (options) {
 		},
 		supports: {
 			read: ({ config, route }) => {
-				// return `true` if the route with the given `config` can use `read`
-				// from `$app/server` in production, return false if it can't.
-				// or throw a descriptive error describing how to configure the deployment
+				// Return `true` if the route with the given `config` can use `read`
+				// from `$app/server` in production, return `false`` if it can't.
+				// Or throw a descriptive error describing how to configure the deployment
 			}
 		}
 	};

--- a/documentation/docs/25-build-and-deploy/99-writing-adapters.md
+++ b/documentation/docs/25-build-and-deploy/99-writing-adapters.md
@@ -24,7 +24,7 @@ export default function (options) {
 		supports: {
 			read: ({ config, route }) => {
 				// Return `true` if the route with the given `config` can use `read`
-				// from `$app/server` in production, return `false`` if it can't.
+				// from `$app/server` in production, return `false` if it can't.
 				// Or throw a descriptive error describing how to configure the deployment
 			}
 		}

--- a/documentation/docs/25-build-and-deploy/99-writing-adapters.md
+++ b/documentation/docs/25-build-and-deploy/99-writing-adapters.md
@@ -19,6 +19,13 @@ export default function (options) {
 		name: 'adapter-package-name',
 		async adapt(builder) {
 			// adapter implementation
+		},
+		supports: {
+			read: ({ config, route }) => {
+				// return `true` if the route with the given `config` can use `read`
+				// from `$app/server` in production, return false if it can't.
+				// or throw a descriptive error describing how to configure the deployment
+			}
 		}
 	};
 

--- a/documentation/docs/25-build-and-deploy/99-writing-adapters.md
+++ b/documentation/docs/25-build-and-deploy/99-writing-adapters.md
@@ -7,6 +7,7 @@ If an adapter for your preferred environment doesn't yet exist, you can build yo
 Adapters packages must implement the following API, which creates an `Adapter`:
 
 ```js
+// @errors: 2322
 // @filename: ambient.d.ts
 type AdapterSpecificOptions = any;
 

--- a/documentation/docs/30-advanced/50-server-only-modules.md
+++ b/documentation/docs/30-advanced/50-server-only-modules.md
@@ -8,6 +8,10 @@ Like a good friend, SvelteKit keeps your secrets. When writing your backend and 
 
 The `$env/static/private` and `$env/dynamic/private` modules, which are covered in the [modules](modules) section, can only be imported into modules that only run on the server, such as [`hooks.server.js`](hooks#server-hooks) or [`+page.server.js`](routing#page-page-server-js).
 
+## Server-only utilities
+
+The [`$app/server`](/docs/modules#$app-server) module, which contains a `read` function for reading assets from the filesystem, can likewise only be imported by code that runs on the server.
+
 ## Your modules
 
 You can make your own modules server-only in two ways:

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -51,6 +51,6 @@
 		"vitest": "^1.2.0"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^2.0.0"
+		"@sveltejs/kit": "^2.4.0"
 	}
 }

--- a/packages/adapter-netlify/src/serverless.js
+++ b/packages/adapter-netlify/src/serverless.js
@@ -1,7 +1,7 @@
 import './shims';
 import { Server } from '0SERVER';
 import { split_headers } from './headers.js';
-import { createReadable } from '@sveltejs/kit/node';
+import { createReadableStream } from '@sveltejs/kit/node';
 
 /**
  * @param {import('@sveltejs/kit').SSRManifest} manifest
@@ -12,7 +12,7 @@ export function init(manifest) {
 
 	let init_promise = server.init({
 		env: process.env,
-		read: (file) => createReadable(`.netlify/server/${file}`)
+		read: (file) => createReadableStream(`.netlify/server/${file}`)
 	});
 
 	return async (event, context) => {

--- a/packages/adapter-netlify/src/serverless.js
+++ b/packages/adapter-netlify/src/serverless.js
@@ -1,7 +1,7 @@
 import './shims';
 import { Server } from '0SERVER';
 import { split_headers } from './headers.js';
-import { readFile } from '@sveltejs/kit/node';
+import { Readable } from 'node:stream';
 
 /**
  * @param {import('@sveltejs/kit').SSRManifest} manifest
@@ -12,7 +12,7 @@ export function init(manifest) {
 
 	let init_promise = server.init({
 		env: process.env,
-		readAsset: (file) => readFile('.netlify/server' + file)
+		readAsset: (file) => Readable.toWeb(fs.createReadStream('.netlify/server' + file))
 	});
 
 	return async (event, context) => {

--- a/packages/adapter-netlify/src/serverless.js
+++ b/packages/adapter-netlify/src/serverless.js
@@ -12,7 +12,7 @@ export function init(manifest) {
 
 	let init_promise = server.init({
 		env: process.env,
-		readAsset: (file) => createReadable('.netlify/server' + file)
+		readAsset: (file) => createReadable(`.netlify/server/${file}`)
 	});
 
 	return async (event, context) => {

--- a/packages/adapter-netlify/src/serverless.js
+++ b/packages/adapter-netlify/src/serverless.js
@@ -12,6 +12,7 @@ export function init(manifest) {
 
 	let init_promise = server.init({
 		env: process.env,
+		// @ts-expect-error the types are wrong
 		readAsset: (file) => Readable.toWeb(fs.createReadStream('.netlify/server' + file))
 	});
 

--- a/packages/adapter-netlify/src/serverless.js
+++ b/packages/adapter-netlify/src/serverless.js
@@ -12,7 +12,7 @@ export function init(manifest) {
 
 	let init_promise = server.init({
 		env: process.env,
-		readAsset: (file) => createReadable(`.netlify/server/${file}`)
+		read: (file) => createReadable(`.netlify/server/${file}`)
 	});
 
 	return async (event, context) => {

--- a/packages/adapter-netlify/src/serverless.js
+++ b/packages/adapter-netlify/src/serverless.js
@@ -1,7 +1,7 @@
 import './shims';
 import { Server } from '0SERVER';
 import { split_headers } from './headers.js';
-import { Readable } from 'node:stream';
+import { createReadable } from '@sveltejs/kit/node';
 
 /**
  * @param {import('@sveltejs/kit').SSRManifest} manifest
@@ -12,8 +12,7 @@ export function init(manifest) {
 
 	let init_promise = server.init({
 		env: process.env,
-		// @ts-expect-error the types are wrong
-		readAsset: (file) => Readable.toWeb(fs.createReadStream('.netlify/server' + file))
+		readAsset: (file) => createReadable('.netlify/server' + file)
 	});
 
 	return async (event, context) => {

--- a/packages/adapter-netlify/src/serverless.js
+++ b/packages/adapter-netlify/src/serverless.js
@@ -1,6 +1,7 @@
 import './shims';
 import { Server } from '0SERVER';
 import { split_headers } from './headers.js';
+import { readFile } from '@sveltejs/kit/node';
 
 /**
  * @param {import('@sveltejs/kit').SSRManifest} manifest
@@ -10,7 +11,8 @@ export function init(manifest) {
 	const server = new Server(manifest);
 
 	let init_promise = server.init({
-		env: process.env
+		env: process.env,
+		readAsset: (file) => readFile('.netlify/server' + file)
 	});
 
 	return async (event, context) => {

--- a/packages/adapter-node/ambient.d.ts
+++ b/packages/adapter-node/ambient.d.ts
@@ -9,6 +9,7 @@ declare module 'HANDLER' {
 declare module 'MANIFEST' {
 	import { SSRManifest } from '@sveltejs/kit';
 
+	export const base: string;
 	export const manifest: SSRManifest;
 	export const prerendered: Set<string>;
 }

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -89,6 +89,10 @@ export default function (opts = {}) {
 					ENV_PREFIX: JSON.stringify(envPrefix)
 				}
 			});
+		},
+
+		supports: {
+			read: () => true
 		}
 	};
 }

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -39,8 +39,11 @@ export default function (opts = {}) {
 
 			writeFileSync(
 				`${tmp}/manifest.js`,
-				`export const manifest = ${builder.generateManifest({ relativePath: './' })};\n\n` +
-					`export const prerendered = new Set(${JSON.stringify(builder.prerendered.paths)});\n`
+				[
+					`export const manifest = ${builder.generateManifest({ relativePath: './' })};`,
+					`export const prerendered = new Set(${JSON.stringify(builder.prerendered.paths)});`,
+					`export const base = ${JSON.stringify(builder.config.kit.paths.base)};`
+				].join('\n\n')
 			);
 
 			const pkg = JSON.parse(readFileSync('package.json', 'utf8'));

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -50,6 +50,6 @@
 		"rollup": "^4.9.5"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^2.0.0"
+		"@sveltejs/kit": "^2.4.0"
 	}
 }

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -3,8 +3,9 @@ import fs from 'node:fs';
 import path from 'node:path';
 import sirv from 'sirv';
 import { fileURLToPath } from 'node:url';
+import { Readable } from 'node:stream';
 import { parse as polka_url_parser } from '@polka/url';
-import { getRequest, setResponse, readFile } from '@sveltejs/kit/node';
+import { getRequest, setResponse } from '@sveltejs/kit/node';
 import { Server } from 'SERVER';
 import { manifest, prerendered } from 'MANIFEST';
 import { env } from 'ENV';
@@ -15,7 +16,7 @@ const server = new Server(manifest);
 
 await server.init({
 	env: process.env,
-	readAsset: (file) => readFile(path.join(dir, 'client', file))
+	readAsset: (file) => Readable.toWeb(fs.createReadStream(path.join(dir, 'client', file)))
 });
 
 const origin = env('ORIGIN', undefined);

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -4,7 +4,7 @@ import path from 'node:path';
 import sirv from 'sirv';
 import { fileURLToPath } from 'node:url';
 import { parse as polka_url_parser } from '@polka/url';
-import { getRequest, setResponse } from '@sveltejs/kit/node';
+import { getRequest, setResponse, readFile } from '@sveltejs/kit/node';
 import { Server } from 'SERVER';
 import { manifest, prerendered } from 'MANIFEST';
 import { env } from 'ENV';
@@ -12,7 +12,12 @@ import { env } from 'ENV';
 /* global ENV_PREFIX */
 
 const server = new Server(manifest);
-await server.init({ env: process.env });
+
+await server.init({
+	env: process.env,
+	readAsset: (file) => readFile(path.join(dir, 'client', file))
+});
+
 const origin = env('ORIGIN', undefined);
 const xff_depth = parseInt(env('XFF_DEPTH', '1'));
 const address_header = env('ADDRESS_HEADER', '').toLowerCase();

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -33,7 +33,7 @@ const asset_dir = `${dir}/client${base}`;
 
 await server.init({
 	env: process.env,
-	readAsset: (file) => createReadable(`${asset_dir}/${file}`)
+	read: (file) => createReadable(`${asset_dir}/${file}`)
 });
 
 /**

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -3,9 +3,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import sirv from 'sirv';
 import { fileURLToPath } from 'node:url';
-import { Readable } from 'node:stream';
 import { parse as polka_url_parser } from '@polka/url';
-import { getRequest, setResponse } from '@sveltejs/kit/node';
+import { getRequest, setResponse, createReadable } from '@sveltejs/kit/node';
 import { Server } from 'SERVER';
 import { manifest, prerendered } from 'MANIFEST';
 import { env } from 'ENV';
@@ -16,8 +15,7 @@ const server = new Server(manifest);
 
 await server.init({
 	env: process.env,
-	// @ts-expect-error the types are wrong
-	readAsset: (file) => Readable.toWeb(fs.createReadStream(path.join(dir, 'client', file)))
+	readAsset: (file) => createReadable(path.join(dir, 'client', file))
 });
 
 const origin = env('ORIGIN', undefined);

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -16,6 +16,7 @@ const server = new Server(manifest);
 
 await server.init({
 	env: process.env,
+	// @ts-expect-error the types are wrong
 	readAsset: (file) => Readable.toWeb(fs.createReadStream(path.join(dir, 'client', file)))
 });
 

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -4,7 +4,7 @@ import path from 'node:path';
 import sirv from 'sirv';
 import { fileURLToPath } from 'node:url';
 import { parse as polka_url_parser } from '@polka/url';
-import { getRequest, setResponse, createReadable } from '@sveltejs/kit/node';
+import { getRequest, setResponse, createReadableStream } from '@sveltejs/kit/node';
 import { Server } from 'SERVER';
 import { manifest, prerendered, base } from 'MANIFEST';
 import { env } from 'ENV';
@@ -33,7 +33,7 @@ const asset_dir = `${dir}/client${base}`;
 
 await server.init({
 	env: process.env,
-	read: (file) => createReadable(`${asset_dir}/${file}`)
+	read: (file) => createReadableStream(`${asset_dir}/${file}`)
 });
 
 /**

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -6,17 +6,12 @@ import { fileURLToPath } from 'node:url';
 import { parse as polka_url_parser } from '@polka/url';
 import { getRequest, setResponse, createReadable } from '@sveltejs/kit/node';
 import { Server } from 'SERVER';
-import { manifest, prerendered } from 'MANIFEST';
+import { manifest, prerendered, base } from 'MANIFEST';
 import { env } from 'ENV';
 
 /* global ENV_PREFIX */
 
 const server = new Server(manifest);
-
-await server.init({
-	env: process.env,
-	readAsset: (file) => createReadable(path.join(dir, 'client', file))
-});
 
 const origin = env('ORIGIN', undefined);
 const xff_depth = parseInt(env('XFF_DEPTH', '1'));
@@ -33,6 +28,13 @@ if (isNaN(body_size_limit)) {
 }
 
 const dir = path.dirname(fileURLToPath(import.meta.url));
+
+const asset_dir = `${dir}/client${base}`;
+
+await server.init({
+	env: process.env,
+	readAsset: (file) => createReadable(`${asset_dir}/${file}`)
+});
 
 /**
  * @param {string} path

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -9,7 +9,7 @@ const server = new Server(manifest);
 
 await server.init({
 	env: /** @type {Record<string, string>} */ (process.env),
-	readAsset: createReadable
+	read: createReadable
 });
 
 const DATA_SUFFIX = '/__data.json';

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -1,7 +1,5 @@
-import fs from 'node:fs';
-import { Readable } from 'node:stream';
 import { installPolyfills } from '@sveltejs/kit/node/polyfills';
-import { getRequest, setResponse } from '@sveltejs/kit/node';
+import { getRequest, setResponse, createReadable } from '@sveltejs/kit/node';
 import { Server } from 'SERVER';
 import { manifest } from 'MANIFEST';
 
@@ -11,8 +9,7 @@ const server = new Server(manifest);
 
 await server.init({
 	env: /** @type {Record<string, string>} */ (process.env),
-	// @ts-expect-error the types are wrong
-	readAsset: (file) => Readable.toWeb(fs.createReadStream('.' + file))
+	readAsset: (file) => createReadable('.' + file)
 });
 
 const DATA_SUFFIX = '/__data.json';

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { Readable } from 'node:stream';
 import { installPolyfills } from '@sveltejs/kit/node/polyfills';
 import { getRequest, setResponse } from '@sveltejs/kit/node';
 import { Server } from 'SERVER';
@@ -8,7 +11,9 @@ installPolyfills();
 const server = new Server(manifest);
 
 await server.init({
-	env: /** @type {Record<string, string>} */ (process.env)
+	env: /** @type {Record<string, string>} */ (process.env),
+	// @ts-expect-error the types are wrong
+	readAsset: (file) => Readable.toWeb(fs.createReadStream('.' + file))
 });
 
 const DATA_SUFFIX = '/__data.json';

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -9,7 +9,7 @@ const server = new Server(manifest);
 
 await server.init({
 	env: /** @type {Record<string, string>} */ (process.env),
-	readAsset: (file) => createReadable('.' + file)
+	readAsset: createReadable
 });
 
 const DATA_SUFFIX = '/__data.json';

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -1,5 +1,5 @@
 import { installPolyfills } from '@sveltejs/kit/node/polyfills';
-import { getRequest, setResponse, createReadable } from '@sveltejs/kit/node';
+import { getRequest, setResponse, createReadableStream } from '@sveltejs/kit/node';
 import { Server } from 'SERVER';
 import { manifest } from 'MANIFEST';
 
@@ -9,7 +9,7 @@ const server = new Server(manifest);
 
 await server.init({
 	env: /** @type {Record<string, string>} */ (process.env),
-	read: createReadable
+	read: createReadableStream
 });
 
 const DATA_SUFFIX = '/__data.json';

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -1,5 +1,4 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import { Readable } from 'node:stream';
 import { installPolyfills } from '@sveltejs/kit/node/polyfills';
 import { getRequest, setResponse } from '@sveltejs/kit/node';

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -350,7 +350,7 @@ const plugin = function (defaults = {}) {
 
 				if (runtime === 'edge') {
 					throw new Error(
-						`${name}: Cannot use \`read\` from \`$app/server\` in a route configured with \`runtime: 'edge'\``
+						`${name}: Cannot use \`read\` from \`$app/server\` in route \`${route.id}\` configured with \`runtime: 'edge'\``
 					);
 				}
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -81,7 +81,13 @@ const plugin = function (defaults = {}) {
 
 				await create_function_bundle(builder, `${tmp}/index.js`, dir, config);
 
-				builder.writeServerAssets?.(dir, routes); // TODO remove optional chaining once peer dep contains a minimum SvelteKit version that has the method
+				// TODO remove `if` once peer dep contains a minimum SvelteKit version that has the method
+				if (builder.findServerAssets) {
+					for (const asset of builder.findServerAssets(routes)) {
+						// TODO use symlinks, once Build Output API supports doing so
+						builder.copy(`${builder.getServerDirectory()}/${asset}`, `${dir}/${asset}`);
+					}
+				}
 			}
 
 			/**

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -82,12 +82,9 @@ const plugin = function (defaults = {}) {
 
 				await create_function_bundle(builder, `${tmp}/index.js`, dir, config);
 
-				// TODO remove `if` once peer dep contains a minimum SvelteKit version that has the method
-				if (builder.findServerAssets) {
-					for (const asset of builder.findServerAssets(routes)) {
-						// TODO use symlinks, once Build Output API supports doing so
-						builder.copy(`${builder.getServerDirectory()}/${asset}`, `${dir}/${asset}`);
-					}
+				for (const asset of builder.findServerAssets(routes)) {
+					// TODO use symlinks, once Build Output API supports doing so
+					builder.copy(`${builder.getServerDirectory()}/${asset}`, `${dir}/${asset}`);
 				}
 			}
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -63,6 +63,8 @@ const plugin = function (defaults = {}) {
 			 * @param {import('@sveltejs/kit').RouteDefinition<import('.').Config>[]} routes
 			 */
 			async function generate_serverless_function(name, config, routes) {
+				const dir = `${dirs.functions}/${name}.func`;
+
 				const relativePath = path.posix.relative(tmp, builder.getServerDirectory());
 
 				builder.copy(`${files}/serverless.js`, `${tmp}/index.js`, {
@@ -77,12 +79,9 @@ const plugin = function (defaults = {}) {
 					`export const manifest = ${builder.generateManifest({ relativePath, routes })};\n`
 				);
 
-				await create_function_bundle(
-					builder,
-					`${tmp}/index.js`,
-					`${dirs.functions}/${name}.func`,
-					config
-				);
+				await create_function_bundle(builder, `${tmp}/index.js`, dir, config);
+
+				builder.writeServerAssets(dir, routes);
 			}
 
 			/**

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -42,6 +42,6 @@
 		"vitest": "^1.2.0"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^2.0.0"
+		"@sveltejs/kit": "^2.4.0"
 	}
 }

--- a/packages/kit/scripts/generate-dts.js
+++ b/packages/kit/scripts/generate-dts.js
@@ -13,6 +13,7 @@ await createBundle({
 		'$app/forms': 'src/runtime/app/forms.js',
 		'$app/navigation': 'src/runtime/app/navigation.js',
 		'$app/paths': 'src/runtime/app/paths/types.d.ts',
+		'$app/server': 'src/runtime/app/server/index.js',
 		'$app/stores': 'src/runtime/app/stores.js'
 	},
 	include: ['src']

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -10,6 +10,7 @@ import { get_env } from '../../exports/vite/utils.js';
 import generate_fallback from '../postbuild/fallback.js';
 import { write } from '../sync/utils.js';
 import { list_files } from '../utils.js';
+import { find_server_assets } from '../generate_manifest/find_server_assets.js';
 
 const pipe = promisify(pipeline);
 const extensions = ['.html', '.js', '.mjs', '.json', '.css', '.svg', '.xml', '.wasm'];
@@ -204,6 +205,20 @@ export function create_builder({
 
 		writeServer(dest) {
 			return copy(`${config.kit.outDir}/output/server`, dest);
+		},
+
+		writeServerAssets(dest, subset) {
+			const routes = subset
+				? subset.map((route) => /** @type {import('types').RouteData} */ (lookup.get(route)))
+				: route_data.filter((route) => prerender_map.get(route.id) !== true);
+
+			const server_assets = find_server_assets(build_data, routes);
+
+			for (const file of server_assets) {
+				copy(`${config.kit.outDir}/output/server/${file}`, `${dest}/${file}`);
+			}
+
+			return server_assets;
 		}
 	};
 }

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -146,6 +146,13 @@ export function create_builder({
 			}
 		},
 
+		findServerAssets(route_data) {
+			return find_server_assets(
+				build_data,
+				route_data.map((route) => /** @type {import('types').RouteData} */ (lookup.get(route)))
+			);
+		},
+
 		async generateFallback(dest) {
 			const manifest_path = `${config.kit.outDir}/output/server/manifest-full.js`;
 			const env = get_env(config.kit.env, vite_config.mode);
@@ -205,20 +212,6 @@ export function create_builder({
 
 		writeServer(dest) {
 			return copy(`${config.kit.outDir}/output/server`, dest);
-		},
-
-		writeServerAssets(dest, subset) {
-			const routes = subset
-				? subset.map((route) => /** @type {import('types').RouteData} */ (lookup.get(route)))
-				: route_data.filter((route) => prerender_map.get(route.id) !== true);
-
-			const server_assets = find_server_assets(build_data, routes);
-
-			for (const file of server_assets) {
-				copy(`${config.kit.outDir}/output/server/${file}`, `${dest}/${file}`);
-			}
-
-			return server_assets;
 		}
 	};
 }

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -96,7 +96,6 @@ export function create_builder({
 			);
 		},
 
-		// TODO this appears to be unused and should probably be deprecated (and removed in 3.0)
 		async createEntries(fn) {
 			const seen = new Set();
 

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -95,6 +95,7 @@ export function create_builder({
 			);
 		},
 
+		// TODO this appears to be unused and should probably be deprecated (and removed in 3.0)
 		async createEntries(fn) {
 			const seen = new Set();
 

--- a/packages/kit/src/core/generate_manifest/find_server_assets.js
+++ b/packages/kit/src/core/generate_manifest/find_server_assets.js
@@ -1,8 +1,7 @@
 import { find_deps } from '../../exports/vite/build/utils.js';
 
 /**
- * Generates the data used to write the server-side manifest.js file. This data is used in the Vite
- * build process, to power routing, etc.
+ * Finds all the assets that are imported by server files associated with `routes`
  * @param {import('types').BuildData} build_data
  * @param {import('types').RouteData[]} routes
  */

--- a/packages/kit/src/core/generate_manifest/find_server_assets.js
+++ b/packages/kit/src/core/generate_manifest/find_server_assets.js
@@ -40,7 +40,7 @@ export function find_server_assets(build_data, routes) {
 
 	for (const n of used_nodes) {
 		const node = build_data.manifest_data.nodes[n];
-		if (node.server) add_assets(node.server);
+		if (node?.server) add_assets(node.server);
 	}
 
 	return Array.from(server_assets);

--- a/packages/kit/src/core/generate_manifest/find_server_assets.js
+++ b/packages/kit/src/core/generate_manifest/find_server_assets.js
@@ -43,5 +43,9 @@ export function find_server_assets(build_data, routes) {
 		if (node?.server) add_assets(node.server);
 	}
 
+	if (build_data.manifest_data.hooks.server) {
+		add_assets(build_data.manifest_data.hooks.server);
+	}
+
 	return Array.from(server_assets);
 }

--- a/packages/kit/src/core/generate_manifest/find_server_assets.js
+++ b/packages/kit/src/core/generate_manifest/find_server_assets.js
@@ -1,0 +1,47 @@
+import { find_deps } from '../../exports/vite/build/utils.js';
+
+/**
+ * Generates the data used to write the server-side manifest.js file. This data is used in the Vite
+ * build process, to power routing, etc.
+ * @param {import('types').BuildData} build_data
+ * @param {import('types').RouteData[]} routes
+ */
+export function find_server_assets(build_data, routes) {
+	/**
+	 * All nodes actually used in the routes definition (prerendered routes are omitted).
+	 * Root layout/error is always included as they are needed for 404 and root errors.
+	 * @type {Set<any>}
+	 */
+	const used_nodes = new Set([0, 1]);
+
+	// TODO add hooks.server.js asset imports
+	/** @type {Set<string>} */
+	const server_assets = new Set();
+
+	/** @param {string} id */
+	function add_assets(id) {
+		const deps = find_deps(build_data.server_manifest, id, false);
+		for (const asset of deps.assets) {
+			server_assets.add(asset);
+		}
+	}
+
+	for (const route of routes) {
+		if (route.page) {
+			for (const i of route.page.layouts) used_nodes.add(i);
+			for (const i of route.page.errors) used_nodes.add(i);
+			used_nodes.add(route.page.leaf);
+		}
+
+		if (route.endpoint) {
+			add_assets(route.endpoint.file);
+		}
+	}
+
+	for (const n of used_nodes) {
+		const node = build_data.manifest_data.nodes[n];
+		if (node.server) add_assets(node.server);
+	}
+
+	return Array.from(server_assets);
+}

--- a/packages/kit/src/core/generate_manifest/find_server_assets.js
+++ b/packages/kit/src/core/generate_manifest/find_server_assets.js
@@ -20,9 +20,11 @@ export function find_server_assets(build_data, routes) {
 
 	/** @param {string} id */
 	function add_assets(id) {
-		const deps = find_deps(build_data.server_manifest, id, false);
-		for (const asset of deps.assets) {
-			server_assets.add(asset);
+		if (id in build_data.server_manifest) {
+			const deps = find_deps(build_data.server_manifest, id, false);
+			for (const asset of deps.assets) {
+				server_assets.add(asset);
+			}
 		}
 	}
 

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -73,10 +73,10 @@ export function generate_manifest({ build_data, relative_path, routes }) {
 
 	/** @type {Record<string, number>} */
 	const files = {};
-	for (const asset of server_assets) {
-		files['/' + asset] = fs.statSync(path.resolve(build_data.out_dir, 'server', asset)).size;
+	for (const file of server_assets) {
+		files[file] = fs.statSync(path.resolve(build_data.out_dir, 'server', file)).size;
 
-		const ext = path.extname(asset);
+		const ext = path.extname(file);
 		mime_types[ext] ??= mime.lookup(ext) || '';
 	}
 
@@ -91,7 +91,6 @@ export function generate_manifest({ build_data, relative_path, routes }) {
 			mimeTypes: ${s(mime_types)},
 			_: {
 				client: ${s(build_data.client)},
-				files: ${s(files)},
 				nodes: [
 					${(node_paths).map(loader).join(',\n')}
 				],
@@ -120,7 +119,8 @@ export function generate_manifest({ build_data, relative_path, routes }) {
 						type => `const { match: ${type} } = await import ('${(join_relative(relative_path, `/entries/matchers/${type}.js`))}')`
 					).join('\n')}
 					return { ${Array.from(matchers).join(', ')} };
-				}
+				},
+				server_assets: ${s(files)}
 			}
 		}
 	`;

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import * as mime from 'mrmime';
 import { s } from '../../utils/misc.js';
 import { get_mime_lookup } from '../utils.js';

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 import * as mime from 'mrmime';
 import { s } from '../../utils/misc.js';
 import { get_mime_lookup } from '../utils.js';
-import { find_deps, resolve_symlinks } from '../../exports/vite/build/utils.js';
+import { resolve_symlinks } from '../../exports/vite/build/utils.js';
 import { compact } from '../../utils/array.js';
 import { join_relative } from '../../utils/filesystem.js';
 import { dedent } from '../sync/utils.js';

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -16,6 +16,7 @@ import { filter_private_env, filter_public_env } from '../../utils/env.js';
 import { resolve_route } from '../../utils/routing.js';
 import { get_page_config } from '../../utils/route_config.js';
 import { check_feature } from '../../utils/features.js';
+import { createReadableStream } from '@sveltejs/kit/node';
 
 export default forked(import.meta.url, analyse);
 
@@ -53,6 +54,8 @@ async function analyse({ manifest_path, manifest_data, server_manifest, tracked_
 	internal.set_private_env(private_env);
 	internal.set_public_env(public_env);
 	internal.set_safe_public_env(public_env);
+	internal.set_manifest(manifest);
+	internal.set_read_implementation((file) => createReadableStream(`${server_root}/server/${file}`));
 
 	/** @type {import('types').ServerMetadata} */
 	const metadata = {

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -14,6 +14,7 @@ import { installPolyfills } from '../../exports/node/polyfills.js';
 import { ENDPOINT_METHODS } from '../../constants.js';
 import { filter_private_env, filter_public_env } from '../../utils/env.js';
 import { resolve_route } from '../../utils/routing.js';
+import { get_page_config } from '../../utils/route_config.js';
 
 export default forked(import.meta.url, analyse);
 
@@ -163,30 +164,9 @@ function analyse_page(layouts, leaf) {
 	validate_page_exports(leaf.universal, leaf.universal_id);
 
 	return {
-		config: get_config([...layouts, leaf]),
+		config: get_page_config([...layouts, leaf]),
 		entries: leaf.universal?.entries ?? leaf.server?.entries,
 		methods,
 		prerender: get_option([...layouts, leaf], 'prerender') ?? false
 	};
-}
-
-/**
- * Do a shallow merge (first level) of the config object
- * @param {Array<import('types').SSRNode | undefined>} nodes
- */
-function get_config(nodes) {
-	/** @type {any} */
-	let current = {};
-
-	for (const node of nodes) {
-		if (!node?.universal?.config && !node?.server?.config) continue;
-
-		current = {
-			...current,
-			...node?.universal?.config,
-			...node?.server?.config
-		};
-	}
-
-	return Object.keys(current).length ? current : undefined;
 }

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -95,9 +95,17 @@ async function analyse({ manifest_path, manifest_data, server_manifest, tracked_
 		}
 
 		const route_config = page?.config ?? endpoint?.config;
+		const prerender = page?.prerender ?? endpoint?.prerender;
 
-		for (const feature of list_features(route, manifest_data, server_manifest, tracked_features)) {
-			check_feature(route.id, route_config, feature, config.adapter);
+		if (prerender !== true) {
+			for (const feature of list_features(
+				route,
+				manifest_data,
+				server_manifest,
+				tracked_features
+			)) {
+				check_feature(route.id, route_config, feature, config.adapter);
+			}
 		}
 
 		const page_methods = page?.methods ?? [];
@@ -113,7 +121,7 @@ async function analyse({ manifest_path, manifest_data, server_manifest, tracked_
 			api: {
 				methods: api_methods
 			},
-			prerender: page?.prerender ?? endpoint?.prerender,
+			prerender,
 			entries:
 				entries && (await entries()).map((entry_object) => resolve_route(route.id, entry_object))
 		});

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -197,6 +197,7 @@ function list_features(route, manifest_data, server_manifest, tracked_features) 
 	/** @param {string} id */
 	function visit(id) {
 		const chunk = server_manifest[id];
+		if (!chunk) return;
 
 		if (chunk.file in tracked_features) {
 			for (const feature of tracked_features[chunk.file]) {

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -221,5 +221,11 @@ function list_features(route, manifest_data, server_manifest, tracked_features) 
 		visit(route_data.endpoint.file);
 	}
 
+	if (manifest_data.hooks.server) {
+		// TODO if hooks.server.js imports `read`, it will be in the entry chunk
+		// we don't currently account for that case
+		visit(manifest_data.hooks.server);
+	}
+
 	return Array.from(features);
 }

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -12,6 +12,7 @@ import { queue } from './queue.js';
 import { crawl } from './crawl.js';
 import { forked } from '../../utils/fork.js';
 import * as devalue from 'devalue';
+import { createReadableStream } from '@sveltejs/kit/node';
 
 export default forked(import.meta.url, prerender);
 
@@ -430,7 +431,10 @@ async function prerender({ out, manifest_path, metadata, verbose, env }) {
 	log.info('Prerendering');
 
 	const server = new Server(manifest);
-	await server.init({ env });
+	await server.init({
+		env,
+		read: (file) => createReadableStream(`${config.outDir}/output/server/${file}`)
+	});
 
 	for (const entry of config.prerender.entries) {
 		if (entry === '*') {

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 import colors from 'kleur';
 import { lookup } from 'mrmime';
 import { list_files, runtime_directory } from '../../utils.js';
-import { posixify } from '../../../utils/filesystem.js';
+import { posixify, resolve_entry } from '../../../utils/filesystem.js';
 import { parse_route_id } from '../../../utils/routing.js';
 import { sort_routes } from './sort.js';
 
@@ -22,6 +22,7 @@ export default function create_manifest_data({
 	cwd = process.cwd()
 }) {
 	const assets = create_assets(config);
+	const hooks = create_hooks(config, cwd);
 	const matchers = create_matchers(config, cwd);
 	const { nodes, routes } = create_routes_and_nodes(cwd, config, fallback);
 
@@ -35,6 +36,7 @@ export default function create_manifest_data({
 
 	return {
 		assets,
+		hooks,
 		matchers,
 		nodes,
 		routes
@@ -50,6 +52,22 @@ export function create_assets(config) {
 		size: fs.statSync(path.resolve(config.kit.files.assets, file)).size,
 		type: lookup(file) || null
 	}));
+}
+
+/**
+ * @param {import('types').ValidatedConfig} config
+ * @param {string} cwd
+ */
+function create_hooks(config, cwd) {
+	const client = resolve_entry(config.kit.files.hooks.client);
+	const server = resolve_entry(config.kit.files.hooks.server);
+	const universal = resolve_entry(config.kit.files.hooks.universal);
+
+	return {
+		client: client && posixify(path.relative(cwd, client)),
+		server: server && posixify(path.relative(cwd, server)),
+		universal: universal && posixify(path.relative(cwd, universal))
+	};
 }
 
 /**

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -30,6 +30,7 @@ const server_template = ({
 import root from '../root.${isSvelte5Plus() ? 'js' : 'svelte'}';
 import { set_building, set_prerendering } from '__sveltekit/environment';
 import { set_assets } from '__sveltekit/paths';
+import { set_read_asset } from '__sveltekit/server';
 import { set_private_env, set_public_env, set_safe_public_env } from '${runtime_directory}/shared-server.js';
 
 export const options = {
@@ -68,7 +69,7 @@ export async function get_hooks() {
 	};
 }
 
-export { set_assets, set_building, set_prerendering, set_private_env, set_public_env, set_safe_public_env };
+export { set_assets, set_building, set_prerendering, set_private_env, set_public_env, set_read_asset, set_safe_public_env };
 `;
 
 // TODO need to re-run this whenever src/app.html or src/error.html are

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -30,7 +30,7 @@ const server_template = ({
 import root from '../root.${isSvelte5Plus() ? 'js' : 'svelte'}';
 import { set_building, set_prerendering } from '__sveltekit/environment';
 import { set_assets } from '__sveltekit/paths';
-import { set_read_implementation } from '__sveltekit/server';
+import { set_manifest, set_read_implementation } from '__sveltekit/server';
 import { set_private_env, set_public_env, set_safe_public_env } from '${runtime_directory}/shared-server.js';
 
 export const options = {
@@ -69,7 +69,7 @@ export async function get_hooks() {
 	};
 }
 
-export { set_assets, set_building, set_prerendering, set_private_env, set_public_env, set_read_implementation, set_safe_public_env };
+export { set_assets, set_building, set_manifest, set_prerendering, set_private_env, set_public_env, set_read_implementation, set_safe_public_env };
 `;
 
 // TODO need to re-run this whenever src/app.html or src/error.html are

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -30,7 +30,7 @@ const server_template = ({
 import root from '../root.${isSvelte5Plus() ? 'js' : 'svelte'}';
 import { set_building, set_prerendering } from '__sveltekit/environment';
 import { set_assets } from '__sveltekit/paths';
-import { set_read_asset } from '__sveltekit/server';
+import { set_read_implementation } from '__sveltekit/server';
 import { set_private_env, set_public_env, set_safe_public_env } from '${runtime_directory}/shared-server.js';
 
 export const options = {
@@ -69,7 +69,7 @@ export async function get_hooks() {
 	};
 }
 
-export { set_assets, set_building, set_prerendering, set_private_env, set_public_env, set_read_asset, set_safe_public_env };
+export { set_assets, set_building, set_prerendering, set_private_env, set_public_env, set_read_implementation, set_safe_public_env };
 `;
 
 // TODO need to re-run this whenever src/app.html or src/error.html are

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -1,6 +1,3 @@
-import fs from 'node:fs';
-import { Readable } from 'node:stream';
-import * as mime from 'mrmime';
 import * as set_cookie_parser from 'set-cookie-parser';
 import { SvelteKitError } from '../../runtime/control.js';
 
@@ -191,23 +188,4 @@ export async function setResponse(res, response) {
 			cancel(error instanceof Error ? error : new Error(String(error)));
 		}
 	}
-}
-
-/**
- * TODO
- * @param {string} file
- */
-export function readFile(file) {
-	const stats = fs.statSync(file);
-	const body = Readable.toWeb(fs.createReadStream(file));
-
-	// @ts-expect-error I think the types are wrong
-	const response = new Response(body, {
-		headers: {
-			'Content-Length': stats.size.toString(),
-			'Content-Type': mime.lookup(file) ?? 'application/octet-stream'
-		}
-	});
-
-	return response;
 }

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -196,6 +196,7 @@ export async function setResponse(res, response) {
  * Converts a file on disk to a readable stream
  * @param {string} file
  * @returns {ReadableStream}
+ * @since 2.4.0
  */
 export function createReadableStream(file) {
 	return /** @type {ReadableStream} */ (Readable.toWeb(createReadStream(file)));

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -1,3 +1,5 @@
+import { createReadStream } from 'node:fs';
+import { Readable } from 'node:stream';
 import * as set_cookie_parser from 'set-cookie-parser';
 import { SvelteKitError } from '../../runtime/control.js';
 
@@ -188,4 +190,13 @@ export async function setResponse(res, response) {
 			cancel(error instanceof Error ? error : new Error(String(error)));
 		}
 	}
+}
+
+/**
+ * Converts a file on disk to a readable stream
+ * @param {string} file
+ * @returns {ReadableStream}
+ */
+export function createReadable(file) {
+	return /** @type {ReadableStream} */ (Readable.toWeb(createReadStream(file)));
 }

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import { Readable } from 'node:stream';
+import * as mime from 'mrmime';
 import * as set_cookie_parser from 'set-cookie-parser';
 import { SvelteKitError } from '../../runtime/control.js';
 
@@ -188,4 +191,23 @@ export async function setResponse(res, response) {
 			cancel(error instanceof Error ? error : new Error(String(error)));
 		}
 	}
+}
+
+/**
+ * TODO
+ * @param {string} file
+ */
+export function readFile(file) {
+	const stats = fs.statSync(file);
+	const body = Readable.toWeb(fs.createReadStream(file));
+
+	// @ts-expect-error I think the types are wrong
+	const response = new Response(body, {
+		headers: {
+			'Content-Length': stats.size,
+			'Content-Type': mime.lookup(file) ?? 'application/octet-stream'
+		}
+	});
+
+	return response;
 }

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -197,6 +197,6 @@ export async function setResponse(res, response) {
  * @param {string} file
  * @returns {ReadableStream}
  */
-export function createReadable(file) {
+export function createReadableStream(file) {
 	return /** @type {ReadableStream} */ (Readable.toWeb(createReadStream(file)));
 }

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -204,7 +204,7 @@ export function readFile(file) {
 	// @ts-expect-error I think the types are wrong
 	const response = new Response(body, {
 		headers: {
-			'Content-Length': stats.size,
+			'Content-Length': stats.size.toString(),
 			'Content-Type': mime.lookup(file) ?? 'application/octet-stream'
 		}
 	});

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -35,6 +35,16 @@ export interface Adapter {
 	 * @param builder An object provided by SvelteKit that contains methods for adapting the app
 	 */
 	adapt(builder: Builder): MaybePromise<void>;
+	/**
+	 * Functions called during dev and build to determine whether specific features will work in production with this adapter
+	 */
+	supports?: {
+		/**
+		 * Test support for `read` from `$app/server`
+		 * @param config The merged route config
+		 */
+		read?: (details: { config: any; route: { id: string } }) => boolean;
+	};
 }
 
 export type LoadProperties<input extends Record<string, any> | void> = input extends void

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -36,7 +36,7 @@ export interface Adapter {
 	 */
 	adapt(builder: Builder): MaybePromise<void>;
 	/**
-	 * Functions called during dev and build to determine whether specific features will work in production with this adapter
+	 * Checks called during dev and build to determine whether specific features will work in production with this adapter
 	 */
 	supports?: {
 		/**
@@ -109,7 +109,6 @@ export interface Builder {
 
 	/**
 	 * Find all the assets imported by server files belonging to `routes`
-	 * @param routes
 	 */
 	findServerAssets(routes: RouteDefinition[]): string[];
 

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -97,6 +97,12 @@ export interface Builder {
 	createEntries(fn: (route: RouteDefinition) => AdapterEntry): Promise<void>;
 
 	/**
+	 * Find all the assets imported by server files belonging to `routes`
+	 * @param routes
+	 */
+	findServerAssets(routes: RouteDefinition[]): string[];
+
+	/**
 	 * Generate a fallback page for a static webserver to use when no route is matched. Useful for single-page apps.
 	 */
 	generateFallback(dest: string): Promise<void>;
@@ -142,13 +148,6 @@ export interface Builder {
 	 * @returns an array of files written to `dest`
 	 */
 	writeServer(dest: string): string[];
-	/**
-	 * Copy any assets imported by server code to `dest`.
-	 * @param dest the destination folder
-	 * @param routes an array of routes to find asset dependencies for
-	 * @returns an array of files written to `dest`
-	 */
-	writeServerAssets(dest: string, routes?: RouteDefinition[]): string[];
 	/**
 	 * Copy a file or directory.
 	 * @param from the source file or directory

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1145,6 +1145,7 @@ export class Server {
 
 export interface ServerInitOptions {
 	env: Record<string, string>;
+	readAsset?: (file: string) => Response;
 }
 
 export interface SSRManifest {

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1145,7 +1145,7 @@ export class Server {
 
 export interface ServerInitOptions {
 	env: Record<string, string>;
-	readAsset?: (file: string) => Response;
+	readAsset?: (file: string) => ReadableStream;
 }
 
 export interface SSRManifest {
@@ -1157,6 +1157,7 @@ export interface SSRManifest {
 	/** private fields */
 	_: {
 		client: NonNullable<BuildData['client']>;
+		files: Record<string, [length: number, type: string]>;
 		nodes: SSRNodeLoader[];
 		routes: SSRRoute[];
 		matchers(): Promise<Record<string, ParamMatcher>>;

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -143,6 +143,13 @@ export interface Builder {
 	 */
 	writeServer(dest: string): string[];
 	/**
+	 * Copy any assets imported by server code to `dest`.
+	 * @param dest the destination folder
+	 * @param routes an array of routes to find asset dependencies for
+	 * @returns an array of files written to `dest`
+	 */
+	writeServerAssets(dest: string, routes?: RouteDefinition[]): string[];
+	/**
 	 * Copy a file or directory.
 	 * @param from the source file or directory
 	 * @param to the destination file or directory

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -89,6 +89,7 @@ export interface Builder {
 	/** An array of all routes (including prerendered) */
 	routes: RouteDefinition[];
 
+	// TODO 3.0 remove this method
 	/**
 	 * Create separate functions that map to one or more routes of your app.
 	 * @param fn A function that groups a set of routes into an entry point

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1164,10 +1164,11 @@ export interface SSRManifest {
 	/** private fields */
 	_: {
 		client: NonNullable<BuildData['client']>;
-		files: Record<string, [length: number, type: string]>;
 		nodes: SSRNodeLoader[];
 		routes: SSRRoute[];
 		matchers(): Promise<Record<string, ParamMatcher>>;
+		/** A `[file]: size` map of all assets imported by server code */
+		server_assets: Record<string, number>;
 	};
 }
 

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1151,7 +1151,7 @@ export class Server {
 
 export interface ServerInitOptions {
 	env: Record<string, string>;
-	readAsset?: (file: string) => ReadableStream;
+	read?: (file: string) => ReadableStream;
 }
 
 export interface SSRManifest {

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1150,7 +1150,9 @@ export class Server {
 }
 
 export interface ServerInitOptions {
+	/** A map of environment variables */
 	env: Record<string, string>;
+	/** A function that turns an asset filename into a `ReadableStream`. Required for the `read` export from `$app/server` to work */
 	read?: (file: string) => ReadableStream;
 }
 

--- a/packages/kit/src/exports/vite/build/utils.js
+++ b/packages/kit/src/exports/vite/build/utils.js
@@ -20,7 +20,7 @@ export function find_deps(manifest, entry, add_dynamic_css) {
 	const stylesheets = new Set();
 
 	/** @type {Set<string>} */
-	const fonts = new Set();
+	const imported_assets = new Set();
 
 	/**
 	 * @param {string} current
@@ -36,9 +36,7 @@ export function find_deps(manifest, entry, add_dynamic_css) {
 
 		if (chunk.assets) {
 			for (const asset of chunk.assets) {
-				if (/\.(woff2?|ttf|otf)$/.test(asset)) {
-					fonts.add(asset);
-				}
+				imported_assets.add(asset);
 			}
 		}
 
@@ -59,11 +57,15 @@ export function find_deps(manifest, entry, add_dynamic_css) {
 
 	traverse(file, true);
 
+	const assets = Array.from(imported_assets);
+
 	return {
+		assets,
 		file: chunk.file,
 		imports: Array.from(imports),
 		stylesheets: Array.from(stylesheets),
-		fonts: Array.from(fonts)
+		// TODO do we need this separately?
+		fonts: assets.filter((asset) => /\.(woff2?|ttf|otf)$/.test(asset))
 	};
 }
 

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -128,13 +128,8 @@ export async function dev(vite, vite_config, svelte_config) {
 				server_assets: new Proxy(
 					{},
 					{
-						get: (_, /** @type {string} */ file) => {
-							const stats = fs.statSync('.' + file);
-							return [stats.size, mime.lookup(file)];
-						},
-						has: (_, /** @type {string} */ file) => {
-							return fs.existsSync('.' + file);
-						}
+						has: (_, /** @type {string} */ file) => fs.existsSync(file),
+						get: (_, /** @type {string} */ file) => fs.statSync(file).size
 					}
 				),
 				nodes: manifest_data.nodes.map((node, index) => {
@@ -486,7 +481,7 @@ export async function dev(vite, vite_config, svelte_config) {
 
 				await server.init({
 					env,
-					readAsset: (file) => createReadable('.' + file)
+					readAsset: createReadable
 				});
 
 				const request = await getRequest({

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -6,7 +6,7 @@ import colors from 'kleur';
 import sirv from 'sirv';
 import * as mime from 'mrmime';
 import { isCSSRequest, loadEnv, buildErrorMessage } from 'vite';
-import { getRequest, setResponse } from '../../../exports/node/index.js';
+import { createReadable, getRequest, setResponse } from '../../../exports/node/index.js';
 import { installPolyfills } from '../../../exports/node/polyfills.js';
 import { coalesce_to_error } from '../../../utils/error.js';
 import { posixify, resolve_entry, to_fs } from '../../../utils/filesystem.js';
@@ -486,8 +486,7 @@ export async function dev(vite, vite_config, svelte_config) {
 
 				await server.init({
 					env,
-					// @ts-expect-error the types are wrong
-					readAsset: (file) => Readable.toWeb(fs.createReadStream('.' + file))
+					readAsset: (file) => createReadable('.' + file)
 				});
 
 				const request = await getRequest({

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -131,6 +131,9 @@ export async function dev(vite, vite_config, svelte_config) {
 						get: (_, /** @type {string} */ file) => {
 							const stats = fs.statSync('.' + file);
 							return [stats.size, mime.lookup(file)];
+						},
+						has: (_, /** @type {string} */ file) => {
+							return fs.existsSync('.' + file);
 						}
 					}
 				),

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -4,7 +4,7 @@ import { URL } from 'node:url';
 import colors from 'kleur';
 import sirv from 'sirv';
 import { isCSSRequest, loadEnv, buildErrorMessage } from 'vite';
-import { getRequest, setResponse } from '../../../exports/node/index.js';
+import { getRequest, readFile, setResponse } from '../../../exports/node/index.js';
 import { installPolyfills } from '../../../exports/node/polyfills.js';
 import { coalesce_to_error } from '../../../utils/error.js';
 import { posixify, resolve_entry, to_fs } from '../../../utils/filesystem.js';
@@ -470,7 +470,10 @@ export async function dev(vite, vite_config, svelte_config) {
 
 				const server = new Server(manifest);
 
-				await server.init({ env });
+				await server.init({
+					env,
+					readAsset: (file) => readFile(`.${file}`)
+				});
 
 				const request = await getRequest({
 					base,

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -16,6 +16,7 @@ import { get_mime_lookup, runtime_base } from '../../../core/utils.js';
 import { compact } from '../../../utils/array.js';
 import { not_found } from '../utils.js';
 import { SCHEME } from '../../../utils/url.js';
+import { check_feature } from '../../../utils/features.js';
 
 const cwd = process.cwd();
 
@@ -31,28 +32,10 @@ export async function dev(vite, vite_config, svelte_config) {
 	const async_local_storage = new AsyncLocalStorage();
 
 	globalThis.__SVELTEKIT_TRACK__ = (label) => {
-		switch (label) {
-			case '$app/server:read': {
-				const { event, config } = async_local_storage.getStore();
-				if (!event) return;
+		const { event, config } = async_local_storage.getStore();
+		if (!event) return;
 
-				const { adapter } = svelte_config.kit;
-				if (!adapter) return;
-
-				const supported = adapter.supports?.read?.({
-					route: event.route,
-					config
-				});
-
-				if (!supported) {
-					throw new Error(
-						`Cannot use \`read\` from \`$app/server\` in ${event.route.id} when using ${adapter.name}. Upgrading may fix this error`
-					);
-				}
-
-				return;
-			}
-		}
+		check_feature(event.route.id, config, label, svelte_config.kit.adapter);
 	};
 
 	const fetch = globalThis.fetch;

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -125,7 +125,7 @@ export async function dev(vite, vite_config, svelte_config) {
 					fonts: [],
 					uses_env_dynamic_public: true
 				},
-				files: new Proxy(
+				server_assets: new Proxy(
 					{},
 					{
 						get: (_, /** @type {string} */ file) => {

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -1,10 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { URL } from 'node:url';
-import { Readable } from 'node:stream';
 import colors from 'kleur';
 import sirv from 'sirv';
-import * as mime from 'mrmime';
 import { isCSSRequest, loadEnv, buildErrorMessage } from 'vite';
 import { createReadable, getRequest, setResponse } from '../../../exports/node/index.js';
 import { installPolyfills } from '../../../exports/node/polyfills.js';

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -5,7 +5,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import colors from 'kleur';
 import sirv from 'sirv';
 import { isCSSRequest, loadEnv, buildErrorMessage } from 'vite';
-import { createReadable, getRequest, setResponse } from '../../../exports/node/index.js';
+import { createReadableStream, getRequest, setResponse } from '../../../exports/node/index.js';
 import { installPolyfills } from '../../../exports/node/polyfills.js';
 import { coalesce_to_error } from '../../../utils/error.js';
 import { posixify, resolve_entry, to_fs } from '../../../utils/filesystem.js';
@@ -490,7 +490,7 @@ export async function dev(vite, vite_config, svelte_config) {
 
 				await server.init({
 					env,
-					read: createReadable
+					read: createReadableStream
 				});
 
 				const request = await getRequest({

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -32,10 +32,10 @@ export async function dev(vite, vite_config, svelte_config) {
 	const async_local_storage = new AsyncLocalStorage();
 
 	globalThis.__SVELTEKIT_TRACK__ = (label) => {
-		const { event, config, prerender } = async_local_storage.getStore();
-		if (!event || prerender === true) return;
+		const context = async_local_storage.getStore();
+		if (!context || context.prerender === true) return;
 
-		check_feature(event.route.id, config, label, svelte_config.kit.adapter);
+		check_feature(context.event.route.id, context.config, label, svelte_config.kit.adapter);
 	};
 
 	const fetch = globalThis.fetch;

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -479,7 +479,7 @@ export async function dev(vite, vite_config, svelte_config) {
 
 				await server.init({
 					env,
-					readAsset: createReadable
+					read: createReadable
 				});
 
 				const request = await getRequest({

--- a/packages/kit/src/exports/vite/graph_analysis/index.js
+++ b/packages/kit/src/exports/vite/graph_analysis/index.js
@@ -1,9 +1,9 @@
 import path from 'node:path';
 import { posixify } from '../../../utils/filesystem.js';
 import { strip_virtual_prefix } from '../utils.js';
-import { env_dynamic_private, env_static_private } from '../module_ids.js';
+import { app_server, env_dynamic_private, env_static_private } from '../module_ids.js';
 
-const ILLEGAL_IMPORTS = new Set([env_dynamic_private, env_static_private]);
+const ILLEGAL_IMPORTS = new Set([env_dynamic_private, env_static_private, app_server]);
 const ILLEGAL_MODULE_NAME_PATTERN = /.*\.server\..+/;
 
 /**
@@ -99,6 +99,10 @@ export function normalize_id(id, lib, cwd) {
 
 	if (id.startsWith(cwd)) {
 		id = path.relative(cwd, id);
+	}
+
+	if (id === app_server) {
+		return '$app/server';
 	}
 
 	return posixify(id);

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -708,7 +708,7 @@ async function kit({ svelte_config }) {
 		renderChunk(code, chunk) {
 			if (code.includes('__SVELTEKIT_TRACK__')) {
 				return {
-					code: code.replace(/__SVELTEKIT_TRACK__\('(.+?)'\)/g, (m, label) => {
+					code: code.replace(/__SVELTEKIT_TRACK__\('(.+?)'\)/g, (_, label) => {
 						(tracked_features[chunk.name + '.js'] ??= []).push(label);
 						return `/* track ${label}            */`;
 					}),

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -719,7 +719,7 @@ async function kit({ svelte_config }) {
 		 */
 		writeBundle: {
 			sequential: true,
-			async handler(_options) {
+			async handler(_options, bundle) {
 				if (secondary_build_started) return; // only run this once
 
 				const verbose = vite_config.logLevel === 'info';

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -498,8 +498,14 @@ async function kit({ svelte_config }) {
 					return dedent`
 						export let read_asset = null;
 
+						export let manifest = null;
+
 						export function set_read_asset(fn) {
 							read_asset = fn;
+						}
+
+						export function set_manifest(_) {
+							manifest = _;
 						}
 					`;
 				}
@@ -727,6 +733,7 @@ async function kit({ svelte_config }) {
 					app_dir: kit.appDir,
 					app_path: `${kit.paths.base.slice(1)}${kit.paths.base ? '/' : ''}${kit.appDir}`,
 					manifest_data,
+					out_dir: out,
 					service_worker: service_worker_entry_file ? 'service-worker.js' : null, // TODO make file configurable?
 					client: null,
 					server_manifest

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -714,6 +714,7 @@ async function kit({ svelte_config }) {
 				return {
 					code: code.replace(/__SVELTEKIT_TRACK__\('(.+?)'\)/g, (_, label) => {
 						(tracked_features[chunk.name + '.js'] ??= []).push(label);
+						// put extra whitespace at the end of the comment to preserve the source size and avoid interfering with source maps
 						return `/* track ${label}            */`;
 					}),
 					map: null // TODO we may need to generate a sourcemap in future

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -515,7 +515,7 @@ async function kit({ svelte_config }) {
 
 	/**
 	 * Ensures that client-side code can't accidentally import server-side code,
-	 * whether in `*.server.js` files, `$lib/server`, or `$env/[static|dynamic]/private`
+	 * whether in `*.server.js` files, `$app/server`, `$lib/server`, or `$env/[static|dynamic]/private`
 	 * @type {import('vite').Plugin}
 	 */
 	const plugin_guard = {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -225,7 +225,11 @@ async function kit({ svelte_config }) {
 	const service_worker_entry_file = resolve_entry(kit.files.serviceWorker);
 	const parsed_service_worker = path.parse(kit.files.serviceWorker);
 
-	/** @type {Record<string, string[]>} */
+	/**
+	 * A map showing which features (such as `$app/server:read`) are defined
+	 * in which chunks, so that we can later determine which routes use which features
+	 * @type {Record<string, string[]>}
+	 */
 	const tracked_features = {};
 
 	const sourcemapIgnoreList = /** @param {string} relative_path */ (relative_path) =>

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -31,7 +31,8 @@ import {
 	env_static_public,
 	service_worker,
 	sveltekit_environment,
-	sveltekit_paths
+	sveltekit_paths,
+	sveltekit_server
 } from './module_ids.js';
 import { pathToFileURL } from 'node:url';
 
@@ -489,6 +490,16 @@ async function kit({ svelte_config }) {
 
 						export function set_prerendering() {
 							prerendering = true;
+						}
+					`;
+				}
+
+				case sveltekit_server: {
+					return dedent`
+						export let read_asset = null;
+
+						export function set_read_asset(fn) {
+							read_asset = fn;
 						}
 					`;
 				}

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -496,12 +496,12 @@ async function kit({ svelte_config }) {
 
 				case sveltekit_server: {
 					return dedent`
-						export let read_asset = null;
+						export let read_implementation = null;
 
 						export let manifest = null;
 
-						export function set_read_asset(fn) {
-							read_asset = fn;
+						export function set_read_implementation(fn) {
+							read_implementation = fn;
 						}
 
 						export function set_manifest(_) {

--- a/packages/kit/src/exports/vite/module_ids.js
+++ b/packages/kit/src/exports/vite/module_ids.js
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url';
+
 export const env_static_private = '\0virtual:$env/static/private';
 export const env_static_public = '\0virtual:$env/static/public';
 export const env_dynamic_private = '\0virtual:$env/dynamic/private';
@@ -8,3 +10,7 @@ export const service_worker = '\0virtual:$service-worker';
 export const sveltekit_environment = '\0virtual:__sveltekit/environment';
 export const sveltekit_paths = '\0virtual:__sveltekit/paths';
 export const sveltekit_server = '\0virtual:__sveltekit/server';
+
+export const app_server = fileURLToPath(
+	new URL('../../runtime/app/server/index.js', import.meta.url)
+);

--- a/packages/kit/src/exports/vite/module_ids.js
+++ b/packages/kit/src/exports/vite/module_ids.js
@@ -2,6 +2,9 @@ export const env_static_private = '\0virtual:$env/static/private';
 export const env_static_public = '\0virtual:$env/static/public';
 export const env_dynamic_private = '\0virtual:$env/dynamic/private';
 export const env_dynamic_public = '\0virtual:$env/dynamic/public';
+
 export const service_worker = '\0virtual:$service-worker';
-export const sveltekit_paths = '\0virtual:__sveltekit/paths';
+
 export const sveltekit_environment = '\0virtual:__sveltekit/environment';
+export const sveltekit_paths = '\0virtual:__sveltekit/paths';
+export const sveltekit_server = '\0virtual:__sveltekit/server';

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -1,10 +1,11 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { Readable } from 'node:stream';
 import { lookup } from 'mrmime';
 import sirv from 'sirv';
 import { loadEnv, normalizePath } from 'vite';
-import { getRequest, readFile, setResponse } from '../../../exports/node/index.js';
+import { getRequest, setResponse } from '../../../exports/node/index.js';
 import { installPolyfills } from '../../../exports/node/polyfills.js';
 import { SVELTE_KIT_ASSETS } from '../../../constants.js';
 import { not_found } from '../utils.js';
@@ -48,7 +49,8 @@ export async function preview(vite, vite_config, svelte_config) {
 	const server = new Server(manifest);
 	await server.init({
 		env: loadEnv(vite_config.mode, svelte_config.kit.env.dir, ''),
-		readAsset: (file) => readFile(dir + file)
+		// @ts-expect-error the types are wrong
+		readAsset: (file) => Readable.toWeb(fs.createReadStream(dir + file))
 	});
 
 	return () => {

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -4,7 +4,7 @@ import { pathToFileURL } from 'node:url';
 import { lookup } from 'mrmime';
 import sirv from 'sirv';
 import { loadEnv, normalizePath } from 'vite';
-import { createReadable, getRequest, setResponse } from '../../../exports/node/index.js';
+import { createReadableStream, getRequest, setResponse } from '../../../exports/node/index.js';
 import { installPolyfills } from '../../../exports/node/polyfills.js';
 import { SVELTE_KIT_ASSETS } from '../../../constants.js';
 import { not_found } from '../utils.js';
@@ -48,7 +48,7 @@ export async function preview(vite, vite_config, svelte_config) {
 	const server = new Server(manifest);
 	await server.init({
 		env: loadEnv(vite_config.mode, svelte_config.kit.env.dir, ''),
-		read: (file) => createReadable(`${dir}/${file}`)
+		read: (file) => createReadableStream(`${dir}/${file}`)
 	});
 
 	return () => {

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -48,7 +48,7 @@ export async function preview(vite, vite_config, svelte_config) {
 	const server = new Server(manifest);
 	await server.init({
 		env: loadEnv(vite_config.mode, svelte_config.kit.env.dir, ''),
-		readAsset: (file) => createReadable(`${dir}/${file}`)
+		read: (file) => createReadable(`${dir}/${file}`)
 	});
 
 	return () => {

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { Readable } from 'node:stream';
 import { lookup } from 'mrmime';
 import sirv from 'sirv';
 import { loadEnv, normalizePath } from 'vite';

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -5,7 +5,7 @@ import { Readable } from 'node:stream';
 import { lookup } from 'mrmime';
 import sirv from 'sirv';
 import { loadEnv, normalizePath } from 'vite';
-import { getRequest, setResponse } from '../../../exports/node/index.js';
+import { createReadable, getRequest, setResponse } from '../../../exports/node/index.js';
 import { installPolyfills } from '../../../exports/node/polyfills.js';
 import { SVELTE_KIT_ASSETS } from '../../../constants.js';
 import { not_found } from '../utils.js';
@@ -49,8 +49,7 @@ export async function preview(vite, vite_config, svelte_config) {
 	const server = new Server(manifest);
 	await server.init({
 		env: loadEnv(vite_config.mode, svelte_config.kit.env.dir, ''),
-		// @ts-expect-error the types are wrong
-		readAsset: (file) => Readable.toWeb(fs.createReadStream(dir + file))
+		readAsset: (file) => createReadable(dir + file)
 	});
 
 	return () => {

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -4,7 +4,7 @@ import { pathToFileURL } from 'node:url';
 import { lookup } from 'mrmime';
 import sirv from 'sirv';
 import { loadEnv, normalizePath } from 'vite';
-import { getRequest, setResponse } from '../../../exports/node/index.js';
+import { getRequest, readFile, setResponse } from '../../../exports/node/index.js';
 import { installPolyfills } from '../../../exports/node/polyfills.js';
 import { SVELTE_KIT_ASSETS } from '../../../constants.js';
 import { not_found } from '../utils.js';
@@ -47,7 +47,8 @@ export async function preview(vite, vite_config, svelte_config) {
 
 	const server = new Server(manifest);
 	await server.init({
-		env: loadEnv(vite_config.mode, svelte_config.kit.env.dir, '')
+		env: loadEnv(vite_config.mode, svelte_config.kit.env.dir, ''),
+		readAsset: (file) => readFile(dir + file)
 	});
 
 	return () => {

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -49,7 +49,7 @@ export async function preview(vite, vite_config, svelte_config) {
 	const server = new Server(manifest);
 	await server.init({
 		env: loadEnv(vite_config.mode, svelte_config.kit.env.dir, ''),
-		readAsset: (file) => createReadable(dir + file)
+		readAsset: (file) => createReadable(`${dir}/${file}`)
 	});
 
 	return () => {

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -1,5 +1,6 @@
 import { read_implementation, manifest } from '__sveltekit/server';
 import { base } from '__sveltekit/paths';
+import { DEV } from 'esm-env';
 
 /**
  * Read the contents of an imported asset from the filesystem
@@ -39,7 +40,7 @@ export function read(asset) {
 		});
 	}
 
-	const file = asset.slice(base.length + 1);
+	const file = DEV && asset.startsWith('/@fs') ? asset : asset.slice(base.length + 1);
 
 	if (file in manifest._.server_assets) {
 		const length = manifest._.server_assets[file];

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -2,7 +2,7 @@ import { read_implementation, manifest } from '__sveltekit/server';
 import { base } from '__sveltekit/paths';
 
 /**
- * Read the contents of an imported asset
+ * Read the contents of an imported asset from the filesystem
  * @example
  * ```js
  * import { read } from '$app/server';

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -13,6 +13,7 @@ import { base } from '__sveltekit/paths';
  * ```
  * @param {string} asset
  * @returns {Response}
+ * @since 2.4.0
  */
 export function read(asset) {
 	__SVELTEKIT_TRACK__('$app/server:read');

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -8,7 +8,7 @@ import { read_asset } from '__sveltekit/server';
 export function readAsset(file) {
 	if (!read_asset) {
 		throw new Error(
-			`No readAsset implementation was provided. Please ensure that your adapter is up to date and supports this feature`
+			'No readAsset implementation was provided. Please ensure that your adapter is up to date and supports this feature'
 		);
 	}
 
@@ -21,7 +21,8 @@ export function readAsset(file) {
 
 		return new Response(decoded, {
 			headers: {
-				'content-type': type
+				'Content-Type': type,
+				'Content-Length': decoded.length.toString()
 			}
 		});
 	}

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -27,16 +27,16 @@ export function readAsset(file) {
 		});
 	}
 
-	let info = manifest._.files[file];
+	if (file in manifest._.files) {
+		const [length, type] = manifest._.files[file];
 
-	if (!info) {
-		throw new Error(`Asset does not exist in deployment: ${file}`);
+		return new Response(read_asset(file), {
+			headers: {
+				'Content-Length': '' + length,
+				'Content-Type': type
+			}
+		});
 	}
 
-	return new Response(read_asset(file), {
-		headers: {
-			'Content-Length': '' + info[0],
-			'Content-Type': info[1]
-		}
-	});
+	throw new Error(`Asset does not exist: ${file}`);
 }

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -1,4 +1,4 @@
-import { read_asset, manifest } from '__sveltekit/server';
+import { read_implementation, manifest } from '__sveltekit/server';
 import { base } from '__sveltekit/paths';
 
 /**
@@ -15,7 +15,7 @@ import { base } from '__sveltekit/paths';
  * @returns {Response}
  */
 export function read(asset) {
-	if (!read_asset) {
+	if (!read_implementation) {
 		throw new Error(
 			'No `read` implementation was provided. Please ensure that your adapter is up to date and supports this feature'
 		);
@@ -42,7 +42,7 @@ export function read(asset) {
 		const length = manifest._.server_assets[file];
 		const type = manifest.mimeTypes[file.slice(file.lastIndexOf('.'))];
 
-		return new Response(read_asset(file), {
+		return new Response(read_implementation(file), {
 			headers: {
 				'Content-Length': '' + length,
 				'Content-Type': type

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -15,6 +15,8 @@ import { base } from '__sveltekit/paths';
  * @returns {Response}
  */
 export function read(asset) {
+	__SVELTEKIT_TRACK__('$app/server:read');
+
 	if (!read_implementation) {
 		throw new Error(
 			'No `read` implementation was provided. Please ensure that your adapter is up to date and supports this feature'

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -2,14 +2,22 @@ import { read_asset, manifest } from '__sveltekit/server';
 import { base } from '__sveltekit/paths';
 
 /**
- * TODO docs
+ * Read the contents of an imported asset
+ * @example
+ * ```js
+ * import { read } from '$app/server';
+ * import somefile from './somefile.txt';
+ *
+ * const asset = read(somefile);
+ * const text = await asset.text();
+ * ```
  * @param {string} asset
  * @returns {Response}
  */
-export function readAsset(asset) {
+export function read(asset) {
 	if (!read_asset) {
 		throw new Error(
-			'No readAsset implementation was provided. Please ensure that your adapter is up to date and supports this feature'
+			'No `read` implementation was provided. Please ensure that your adapter is up to date and supports this feature'
 		);
 	}
 

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -1,11 +1,12 @@
 import { read_asset, manifest } from '__sveltekit/server';
+import { base } from '__sveltekit/paths';
 
 /**
  * TODO docs
- * @param {string} file
+ * @param {string} asset
  * @returns {Response}
  */
-export function readAsset(file) {
+export function readAsset(asset) {
 	if (!read_asset) {
 		throw new Error(
 			'No readAsset implementation was provided. Please ensure that your adapter is up to date and supports this feature'
@@ -13,8 +14,8 @@ export function readAsset(file) {
 	}
 
 	// handle inline assets internally
-	if (file.startsWith('data:')) {
-		const [prelude, data] = file.split(';');
+	if (asset.startsWith('data:')) {
+		const [prelude, data] = asset.split(';');
 		const type = prelude.slice(5) || 'application/octet-stream';
 
 		const decoded = data.startsWith('base64,') ? atob(data.slice(7)) : decodeURIComponent(data);
@@ -26,6 +27,8 @@ export function readAsset(file) {
 			}
 		});
 	}
+
+	const file = asset.slice(base.length + 1);
 
 	if (file in manifest._.server_assets) {
 		const length = manifest._.server_assets[file];

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -1,4 +1,4 @@
-import { read_asset } from '__sveltekit/server';
+import { read_asset, manifest } from '__sveltekit/server';
 
 /**
  * TODO docs
@@ -21,12 +21,22 @@ export function readAsset(file) {
 
 		return new Response(decoded, {
 			headers: {
-				'Content-Type': type,
-				'Content-Length': decoded.length.toString()
+				'Content-Length': decoded.length.toString(),
+				'Content-Type': type
 			}
 		});
 	}
 
-	// for everything else, delegate to adapter
-	return read_asset(file);
+	let info = manifest._.files[file];
+
+	if (!info) {
+		throw new Error(`Asset does not exist in deployment: ${file}`);
+	}
+
+	return new Response(read_asset(file), {
+		headers: {
+			'Content-Length': '' + info[0],
+			'Content-Type': info[1]
+		}
+	});
 }

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -1,0 +1,31 @@
+import { read_asset } from '__sveltekit/server';
+
+/**
+ * TODO docs
+ * @param {string} file
+ * @returns {Response}
+ */
+export function readAsset(file) {
+	if (!read_asset) {
+		throw new Error(
+			`No readAsset implementation was provided. Please ensure that your adapter is up to date and supports this feature`
+		);
+	}
+
+	// handle inline assets internally
+	if (file.startsWith('data:')) {
+		const [prelude, data] = file.split(';');
+		const type = prelude.slice(5) || 'application/octet-stream';
+
+		const decoded = data.startsWith('base64,') ? atob(data.slice(7)) : decodeURIComponent(data);
+
+		return new Response(decoded, {
+			headers: {
+				'content-type': type
+			}
+		});
+	}
+
+	// for everything else, delegate to adapter
+	return read_asset(file);
+}

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -28,7 +28,8 @@ export function readAsset(file) {
 	}
 
 	if (file in manifest._.files) {
-		const [length, type] = manifest._.files[file];
+		const length = manifest._.files[file];
+		const type = manifest.mimeTypes[file.slice(file.lastIndexOf('.'))];
 
 		return new Response(read_asset(file), {
 			headers: {

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -27,8 +27,8 @@ export function readAsset(file) {
 		});
 	}
 
-	if (file in manifest._.files) {
-		const length = manifest._.files[file];
+	if (file in manifest._.server_assets) {
+		const length = manifest._.server_assets[file];
 		const type = manifest.mimeTypes[file.slice(file.lastIndexOf('.'))];
 
 		return new Response(read_asset(file), {

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -34,10 +34,10 @@ export class Server {
 	/**
 	 * @param {{
 	 *   env: Record<string, string>;
-	 *   readAsset?: (file: string) => ReadableStream;
+	 *   read?: (file: string) => ReadableStream;
 	 * }} opts
 	 */
-	async init({ env, readAsset }) {
+	async init({ env, read }) {
 		// Take care: Some adapters may have to call `Server.init` per-request to set env vars,
 		// so anything that shouldn't be rerun should be wrapped in an `if` block to make sure it hasn't
 		// been done already.
@@ -59,8 +59,8 @@ export class Server {
 		);
 		set_safe_public_env(public_env);
 
-		if (readAsset) {
-			set_read_asset(readAsset);
+		if (read) {
+			set_read_asset(read);
 		}
 
 		if (!this.#options.hooks) {

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -4,7 +4,7 @@ import { options, get_hooks } from '__SERVER__/internal.js';
 import { DEV } from 'esm-env';
 import { filter_private_env, filter_public_env } from '../../utils/env.js';
 import { prerendering } from '__sveltekit/environment';
-import { set_read_asset } from '__sveltekit/server';
+import { set_read_asset, set_manifest } from '__sveltekit/server';
 
 /** @type {ProxyHandler<{ type: 'public' | 'private' }>} */
 const prerender_env_handler = {
@@ -27,12 +27,14 @@ export class Server {
 		/** @type {import('types').SSROptions} */
 		this.#options = options;
 		this.#manifest = manifest;
+
+		set_manifest(manifest);
 	}
 
 	/**
 	 * @param {{
 	 *   env: Record<string, string>;
-	 *   readAsset?: (file: string) => Response;
+	 *   readAsset?: (file: string) => ReadableStream;
 	 * }} opts
 	 */
 	async init({ env, readAsset }) {

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -4,7 +4,7 @@ import { options, get_hooks } from '__SERVER__/internal.js';
 import { DEV } from 'esm-env';
 import { filter_private_env, filter_public_env } from '../../utils/env.js';
 import { prerendering } from '__sveltekit/environment';
-import { set_read_asset, set_manifest } from '__sveltekit/server';
+import { set_read_implementation, set_manifest } from '__sveltekit/server';
 
 /** @type {ProxyHandler<{ type: 'public' | 'private' }>} */
 const prerender_env_handler = {
@@ -60,7 +60,7 @@ export class Server {
 		set_safe_public_env(public_env);
 
 		if (read) {
-			set_read_asset(read);
+			set_read_implementation(read);
 		}
 
 		if (!this.#options.hooks) {

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -15,6 +15,7 @@ import { render_response } from './render.js';
 import { respond_with_error } from './respond_with_error.js';
 import { get_option } from '../../../utils/options.js';
 import { get_data_json } from '../data/index.js';
+import { load_page_nodes } from './load_page_nodes.js';
 
 /**
  * The maximum request depth permitted before assuming we're stuck in an infinite loop
@@ -44,11 +45,7 @@ export async function render_page(event, page, options, manifest, state, resolve
 	}
 
 	try {
-		const nodes = await Promise.all([
-			// we use == here rather than === because [undefined] serializes as "[null]"
-			...page.layouts.map((n) => (n == undefined ? n : manifest._.nodes[n]())),
-			manifest._.nodes[page.leaf]()
-		]);
+		const nodes = await load_page_nodes(page, manifest);
 
 		const leaf_node = /** @type {import('types').SSRNode} */ (nodes.at(-1));
 

--- a/packages/kit/src/runtime/server/page/load_page_nodes.js
+++ b/packages/kit/src/runtime/server/page/load_page_nodes.js
@@ -1,0 +1,11 @@
+/**
+ * @param {import('types').PageNodeIndexes} page
+ * @param {import('@sveltejs/kit').SSRManifest} manifest
+ */
+export function load_page_nodes(page, manifest) {
+	return Promise.all([
+		// we use == here rather than === because [undefined] serializes as "[null]"
+		...page.layouts.map((n) => (n == undefined ? n : manifest._.nodes[n]())),
+		manifest._.nodes[page.leaf]()
+	]);
+}

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -274,15 +274,20 @@ export async function respond(request, options, manifest, state) {
 			if (DEV && state.before_handle) {
 				let config = {};
 
+				/** @type {import('types').PrerenderOption} */
+				let prerender = false;
+
 				if (route.endpoint) {
 					const node = await route.endpoint();
-					config = node.config;
+					config = node.config ?? config;
+					prerender = node.prerender ?? prerender;
 				} else if (route.page) {
 					const nodes = await load_page_nodes(route.page, manifest);
 					config = get_page_config(nodes);
+					prerender = get_option(nodes, 'prerender') ?? false;
 				}
 
-				state.before_handle(event, config);
+				state.before_handle(event, config, prerender);
 			}
 		}
 

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -31,6 +31,8 @@ import { json, text } from '../../exports/index.js';
 import { action_json_redirect, is_action_json_request } from './page/actions.js';
 import { INVALIDATED_PARAM, TRAILING_SLASH_PARAM } from '../shared.js';
 import { get_public_env } from './env_module.js';
+import { load_page_nodes } from './page/load_page_nodes.js';
+import { get_page_config } from '../../utils/route_config.js';
 
 /* global __SVELTEKIT_ADAPTER_NAME__ */
 
@@ -217,11 +219,7 @@ export async function respond(request, options, manifest, state) {
 			if (url.pathname === base || url.pathname === base + '/') {
 				trailing_slash = 'always';
 			} else if (route.page) {
-				const nodes = await Promise.all([
-					// we use == here rather than === because [undefined] serializes as "[null]"
-					...route.page.layouts.map((n) => (n == undefined ? n : manifest._.nodes[n]())),
-					manifest._.nodes[route.page.leaf]()
-				]);
+				const nodes = await load_page_nodes(route.page, manifest);
 
 				if (DEV) {
 					const layouts = nodes.slice(0, -1);
@@ -271,6 +269,20 @@ export async function respond(request, options, manifest, state) {
 						}
 					});
 				}
+			}
+
+			if (DEV && state.before_handle) {
+				let config = {};
+
+				if (route.endpoint) {
+					const node = await route.endpoint();
+					config = node.config;
+				} else if (route.page) {
+					const nodes = await load_page_nodes(route.page, manifest);
+					config = get_page_config(nodes);
+				}
+
+				state.before_handle(event, config);
 			}
 		}
 

--- a/packages/kit/src/types/ambient-private.d.ts
+++ b/packages/kit/src/types/ambient-private.d.ts
@@ -19,6 +19,10 @@ declare module '__sveltekit/paths' {
 
 /** Internal version of $app/server */
 declare module '__sveltekit/server' {
-	export function read_asset(path: string): Response;
-	export function set_read_asset(fn: (path: string) => Response): void;
+	import { SSRManifest } from '@sveltejs/kit';
+
+	export let manifest: SSRManifest;
+	export function read_asset(path: string): ReadableStream;
+	export function set_manifest(manifest: SSRManifest): void;
+	export function set_read_asset(fn: (path: string) => ReadableStream): void;
 }

--- a/packages/kit/src/types/ambient-private.d.ts
+++ b/packages/kit/src/types/ambient-private.d.ts
@@ -16,3 +16,9 @@ declare module '__sveltekit/paths' {
 	export function override(paths: { base: string; assets: string }): void;
 	export function set_assets(path: string): void;
 }
+
+/** Internal version of $app/server */
+declare module '__sveltekit/server' {
+	export function read_asset(path: string): Response;
+	export function set_read_asset(fn: (path: string) => Response): void;
+}

--- a/packages/kit/src/types/ambient-private.d.ts
+++ b/packages/kit/src/types/ambient-private.d.ts
@@ -22,7 +22,7 @@ declare module '__sveltekit/server' {
 	import { SSRManifest } from '@sveltejs/kit';
 
 	export let manifest: SSRManifest;
-	export function read_asset(path: string): ReadableStream;
+	export function read_implementation(path: string): ReadableStream;
 	export function set_manifest(manifest: SSRManifest): void;
-	export function set_read_asset(fn: (path: string) => ReadableStream): void;
+	export function set_read_implementation(fn: (path: string) => ReadableStream): void;
 }

--- a/packages/kit/src/types/global-private.d.ts
+++ b/packages/kit/src/types/global-private.d.ts
@@ -6,7 +6,17 @@ declare global {
 	const __SVELTEKIT_EMBEDDED__: boolean;
 	/**
 	 * This makes the use of specific features visible at both dev and build time, in such a
-	 * way that we can error when they are not supported by the target platform
+	 * way that we can error when they are not supported by the target platform.
+	 *
+	 * During dev, `globalThis.__SVELTEKIT_TRACK__` is a function that grabs the current `event`
+	 * and route `config` (from an AsyncLocalStorage instance) and calls the relevant `supports`
+	 * function on the adapter (e.g. `adapter.supports.read(...)`).
+	 *
+	 * At build time, if the function containing the `__SVELTEKIT_TRACK__` call is untreeshaken,
+	 * we locate it in the `renderChunk` build hook and a) make a note of the chunk that contains
+	 * it and b) replace it with a comment. Later, we can use this information to establish
+	 * which routes use which feature, and use the same `adapter.supports.read(...)` function
+	 * to throw an error if the feature would fail in production.
 	 */
 	var __SVELTEKIT_TRACK__: (label: string) => void;
 	var Bun: object;

--- a/packages/kit/src/types/global-private.d.ts
+++ b/packages/kit/src/types/global-private.d.ts
@@ -4,6 +4,11 @@ declare global {
 	const __SVELTEKIT_APP_VERSION_POLL_INTERVAL__: number;
 	const __SVELTEKIT_DEV__: boolean;
 	const __SVELTEKIT_EMBEDDED__: boolean;
+	/**
+	 * This makes the use of specific features visible at both dev and build time, in such a
+	 * way that we can error when they are not supported by the target platform
+	 */
+	var __SVELTEKIT_TRACK__: (label: string) => void;
 	var Bun: object;
 	var Deno: object;
 }

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -126,6 +126,7 @@ export class InternalServer extends Server {
 		options: RequestOptions & {
 			prerendering?: PrerenderOptions;
 			read: (file: string) => Buffer;
+			/** A hook called before `handle` during dev, so that `AsyncLocalStorage` can be populated */
 			before_handle?: (event: RequestEvent, config: any, prerender: PrerenderOption) => void;
 		}
 	): Promise<Response>;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -33,6 +33,7 @@ export interface ServerInternalModule {
 	set_prerendering(): void;
 	set_private_env(environment: Record<string, string>): void;
 	set_public_env(environment: Record<string, string>): void;
+	set_read_asset(implementation: (path: string) => Response): void;
 	set_safe_public_env(environment: Record<string, string>): void;
 	set_version(version: string): void;
 	set_fix_stack_trace(fix_stack_trace: (error: unknown) => string): void;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -124,7 +124,7 @@ export class InternalServer extends Server {
 		options: RequestOptions & {
 			prerendering?: PrerenderOptions;
 			read: (file: string) => Buffer;
-			before_handle?: (event: RequestEvent, config: any) => void;
+			before_handle?: (event: RequestEvent, config: any, prerender: PrerenderOption) => void;
 		}
 	): Promise<Response>;
 }
@@ -414,7 +414,7 @@ export interface SSRState {
 	 */
 	prerender_default?: PrerenderOption;
 	read?: (file: string) => Buffer;
-	before_handle?: (event: RequestEvent, config: any) => void;
+	before_handle?: (event: RequestEvent, config: any, prerender: PrerenderOption) => void;
 }
 
 export type StrictBody = string | ArrayBufferView;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -33,7 +33,7 @@ export interface ServerInternalModule {
 	set_prerendering(): void;
 	set_private_env(environment: Record<string, string>): void;
 	set_public_env(environment: Record<string, string>): void;
-	set_read_asset(implementation: (path: string) => ReadableStream): void;
+	set_read_implementation(implementation: (path: string) => ReadableStream): void;
 	set_safe_public_env(environment: Record<string, string>): void;
 	set_version(version: string): void;
 	set_fix_stack_trace(fix_stack_trace: (error: unknown) => string): void;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -131,6 +131,11 @@ export class InternalServer extends Server {
 
 export interface ManifestData {
 	assets: Asset[];
+	hooks: {
+		client: string | null;
+		server: string | null;
+		universal: string | null;
+	};
 	nodes: PageNode[];
 	routes: RouteData[];
 	matchers: Record<string, string>;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -13,7 +13,8 @@ import {
 	HandleFetch,
 	Actions,
 	HandleClientError,
-	Reroute
+	Reroute,
+	RequestEvent
 } from '@sveltejs/kit';
 import {
 	HttpMethod,
@@ -123,6 +124,7 @@ export class InternalServer extends Server {
 		options: RequestOptions & {
 			prerendering?: PrerenderOptions;
 			read: (file: string) => Buffer;
+			before_handle?: (event: RequestEvent, config: any) => void;
 		}
 	): Promise<Response>;
 }
@@ -407,6 +409,7 @@ export interface SSRState {
 	 */
 	prerender_default?: PrerenderOption;
 	read?: (file: string) => Buffer;
+	before_handle?: (event: RequestEvent, config: any) => void;
 }
 
 export type StrictBody = string | ArrayBufferView;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -14,7 +14,8 @@ import {
 	Actions,
 	HandleClientError,
 	Reroute,
-	RequestEvent
+	RequestEvent,
+	SSRManifest
 } from '@sveltejs/kit';
 import {
 	HttpMethod,
@@ -31,6 +32,7 @@ export interface ServerModule {
 export interface ServerInternalModule {
 	set_assets(path: string): void;
 	set_building(): void;
+	set_manifest(manifest: SSRManifest): void;
 	set_prerendering(): void;
 	set_private_env(environment: Record<string, string>): void;
 	set_public_env(environment: Record<string, string>): void;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -33,7 +33,7 @@ export interface ServerInternalModule {
 	set_prerendering(): void;
 	set_private_env(environment: Record<string, string>): void;
 	set_public_env(environment: Record<string, string>): void;
-	set_read_asset(implementation: (path: string) => Response): void;
+	set_read_asset(implementation: (path: string) => ReadableStream): void;
 	set_safe_public_env(environment: Record<string, string>): void;
 	set_version(version: string): void;
 	set_fix_stack_trace(fix_stack_trace: (error: unknown) => string): void;
@@ -56,6 +56,7 @@ export interface BuildData {
 	app_dir: string;
 	app_path: string;
 	manifest_data: ManifestData;
+	out_dir: string;
 	service_worker: string | null;
 	client: {
 		start: string;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -46,6 +46,7 @@ export interface Asset {
 }
 
 export interface AssetDependencies {
+	assets: string[];
 	file: string;
 	imports: string[];
 	stylesheets: string[];

--- a/packages/kit/src/utils/features.js
+++ b/packages/kit/src/utils/features.js
@@ -1,0 +1,24 @@
+/**
+ * @param {string} route_id
+ * @param {any} config
+ * @param {string} feature
+ * @param {import('@sveltejs/kit').Adapter | undefined} adapter
+ */
+export function check_feature(route_id, config, feature, adapter) {
+	if (!adapter) return;
+
+	switch (feature) {
+		case '$app/server:read': {
+			const supported = adapter.supports?.read?.({
+				route: { id: route_id },
+				config
+			});
+
+			if (!supported) {
+				throw new Error(
+					`Cannot use \`read\` from \`$app/server\` in ${route_id} when using ${adapter.name}. Upgrading may fix this error`
+				);
+			}
+		}
+	}
+}

--- a/packages/kit/src/utils/features.js
+++ b/packages/kit/src/utils/features.js
@@ -16,7 +16,7 @@ export function check_feature(route_id, config, feature, adapter) {
 
 			if (!supported) {
 				throw new Error(
-					`Cannot use \`read\` from \`$app/server\` in ${route_id} when using ${adapter.name}. Upgrading may fix this error`
+					`Cannot use \`read\` from \`$app/server\` in ${route_id} when using ${adapter.name}. Please ensure that your adapter is up to date and supports this feature.`
 				);
 			}
 		}

--- a/packages/kit/src/utils/route_config.js
+++ b/packages/kit/src/utils/route_config.js
@@ -1,0 +1,20 @@
+/**
+ * Do a shallow merge (first level) of the config object
+ * @param {Array<import('types').SSRNode | undefined>} nodes
+ */
+export function get_page_config(nodes) {
+	/** @type {any} */
+	let current = {};
+
+	for (const node of nodes) {
+		if (!node?.universal?.config && !node?.server?.config) continue;
+
+		current = {
+			...current,
+			...node?.universal?.config,
+			...node?.server?.config
+		};
+	}
+
+	return Object.keys(current).length ? current : undefined;
+}

--- a/packages/kit/test/apps/basics/src/routes/read-file/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/read-file/+page.server.js
@@ -1,0 +1,15 @@
+import { dev } from '$app/environment';
+import { read } from '$app/server';
+import auto from './auto.txt';
+import url from './url.txt?url';
+
+export async function load() {
+	if (!dev && !auto.startsWith('data:')) {
+		throw new Error('expected auto.txt to be inlined');
+	}
+
+	return {
+		auto: await read(auto).text(),
+		url: await read(url).text()
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/read-file/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/read-file/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	export let data;
+</script>
+
+<p data-testid="auto">{data.auto}</p>
+<p data-testid="url">{data.url}</p>

--- a/packages/kit/test/apps/basics/src/routes/read-file/auto.txt
+++ b/packages/kit/test/apps/basics/src/routes/read-file/auto.txt
@@ -1,0 +1,1 @@
+Imported without ?url

--- a/packages/kit/test/apps/basics/src/routes/read-file/url.txt
+++ b/packages/kit/test/apps/basics/src/routes/read-file/url.txt
@@ -1,0 +1,1 @@
+Imported with ?url

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -706,6 +706,18 @@ test.describe('$app/paths', () => {
 	});
 });
 
+test.describe('$app/server', () => {
+	test('can read a file', async ({ page }) => {
+		await page.goto('/read-file');
+
+		const auto = await page.textContent('[data-testid="auto"]');
+		const url = await page.textContent('[data-testid="url"]');
+
+		expect(auto.trim()).toBe('Imported without ?url');
+		expect(url.trim()).toBe('Imported with ?url');
+	});
+});
+
 test.describe('$app/stores', () => {
 	test('can access page.url', async ({ baseURL, page }) => {
 		await page.goto('/origin');

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1127,7 +1127,7 @@ declare module '@sveltejs/kit' {
 
 	export interface ServerInitOptions {
 		env: Record<string, string>;
-		readAsset?: (file: string) => Response;
+		readAsset?: (file: string) => ReadableStream;
 	}
 
 	export interface SSRManifest {
@@ -1139,6 +1139,7 @@ declare module '@sveltejs/kit' {
 		/** private fields */
 		_: {
 			client: NonNullable<BuildData['client']>;
+			files: Record<string, [length: number, type: string]>;
 			nodes: SSRNodeLoader[];
 			routes: SSRRoute[];
 			matchers(): Promise<Record<string, ParamMatcher>>;
@@ -1550,6 +1551,7 @@ declare module '@sveltejs/kit' {
 		app_dir: string;
 		app_path: string;
 		manifest_data: ManifestData;
+		out_dir: string;
 		service_worker: string | null;
 		client: {
 			start: string;
@@ -1874,10 +1876,6 @@ declare module '@sveltejs/kit/node' {
 	}): Promise<Request>;
 
 	export function setResponse(res: import('http').ServerResponse, response: Response): Promise<void>;
-	/**
-	 * TODO
-	 * */
-	export function readFile(file: string): Response;
 }
 
 declare module '@sveltejs/kit/node/polyfills' {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -81,7 +81,7 @@ declare module '@sveltejs/kit' {
 
 		/**
 		 * Find all the assets imported by server files belonging to `routes`
-		 */
+		 * */
 		findServerAssets(routes: RouteDefinition[]): string[];
 
 		/**
@@ -1887,7 +1887,7 @@ declare module '@sveltejs/kit/node' {
 	export function setResponse(res: import('http').ServerResponse, response: Response): Promise<void>;
 	/**
 	 * Converts a file on disk to a readable stream
-	 */
+	 * */
 	export function createReadable(file: string): ReadableStream;
 }
 
@@ -2134,7 +2134,7 @@ declare module '$app/server' {
 	 * const asset = read(somefile);
 	 * const text = await asset.text();
 	 * ```
-	 */
+	 * */
 	export function read(asset: string): Response;
 }
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1902,7 +1902,8 @@ declare module '@sveltejs/kit/node' {
 	export function setResponse(res: import('http').ServerResponse, response: Response): Promise<void>;
 	/**
 	 * Converts a file on disk to a readable stream
-	 * */
+	 * @since 2.4.0
+	 */
 	export function createReadableStream(file: string): ReadableStream;
 }
 
@@ -2149,7 +2150,8 @@ declare module '$app/server' {
 	 * const asset = read(somefile);
 	 * const text = await asset.text();
 	 * ```
-	 * */
+	 * @since 2.4.0
+	 */
 	export function read(asset: string): Response;
 }
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1132,7 +1132,7 @@ declare module '@sveltejs/kit' {
 
 	export interface ServerInitOptions {
 		env: Record<string, string>;
-		readAsset?: (file: string) => ReadableStream;
+		read?: (file: string) => ReadableStream;
 	}
 
 	export interface SSRManifest {
@@ -2122,9 +2122,17 @@ declare module '$app/paths' {
 
 declare module '$app/server' {
 	/**
-	 * TODO docs
+	 * Read the contents of an imported asset
+	 * @example
+	 * ```js
+	 * import { read } from '$app/server';
+	 * import somefile from './somefile.txt';
+	 *
+	 * const asset = read(somefile);
+	 * const text = await asset.text();
+	 * ```
 	 * */
-	export function readAsset(file: string): Response;
+	export function read(asset: string): Response;
 }
 
 declare module '$app/stores' {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1146,10 +1146,11 @@ declare module '@sveltejs/kit' {
 		/** private fields */
 		_: {
 			client: NonNullable<BuildData['client']>;
-			files: Record<string, [length: number, type: string]>;
 			nodes: SSRNodeLoader[];
 			routes: SSRRoute[];
 			matchers(): Promise<Record<string, ParamMatcher>>;
+			/** A `[file]: size` map of all assets imported by server code */
+			server_assets: Record<string, number>;
 		};
 	}
 
@@ -1883,6 +1884,10 @@ declare module '@sveltejs/kit/node' {
 	}): Promise<Request>;
 
 	export function setResponse(res: import('http').ServerResponse, response: Response): Promise<void>;
+	/**
+	 * Converts a file on disk to a readable stream
+	 * */
+	export function createReadable(file: string): ReadableStream;
 }
 
 declare module '@sveltejs/kit/node/polyfills' {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -18,7 +18,7 @@ declare module '@sveltejs/kit' {
 		 */
 		adapt(builder: Builder): MaybePromise<void>;
 		/**
-		 * Functions called during dev and build to determine whether specific features will work in production with this adapter
+		 * Checks called during dev and build to determine whether specific features will work in production with this adapter
 		 */
 		supports?: {
 			/**
@@ -91,7 +91,7 @@ declare module '@sveltejs/kit' {
 
 		/**
 		 * Find all the assets imported by server files belonging to `routes`
-		 * */
+		 */
 		findServerAssets(routes: RouteDefinition[]): string[];
 
 		/**

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -79,6 +79,11 @@ declare module '@sveltejs/kit' {
 		createEntries(fn: (route: RouteDefinition) => AdapterEntry): Promise<void>;
 
 		/**
+		 * Find all the assets imported by server files belonging to `routes`
+		 * */
+		findServerAssets(routes: RouteDefinition[]): string[];
+
+		/**
 		 * Generate a fallback page for a static webserver to use when no route is matched. Useful for single-page apps.
 		 */
 		generateFallback(dest: string): Promise<void>;
@@ -124,13 +129,6 @@ declare module '@sveltejs/kit' {
 		 * @returns an array of files written to `dest`
 		 */
 		writeServer(dest: string): string[];
-		/**
-		 * Copy any assets imported by server code to `dest`.
-		 * @param dest the destination folder
-		 * @param routes an array of routes to find asset dependencies for
-		 * @returns an array of files written to `dest`
-		 */
-		writeServerAssets(dest: string, routes?: RouteDefinition[]): string[];
 		/**
 		 * Copy a file or directory.
 		 * @param from the source file or directory

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1903,7 +1903,7 @@ declare module '@sveltejs/kit/node' {
 	/**
 	 * Converts a file on disk to a readable stream
 	 * */
-	export function createReadable(file: string): ReadableStream;
+	export function createReadableStream(file: string): ReadableStream;
 }
 
 declare module '@sveltejs/kit/node/polyfills' {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1127,6 +1127,7 @@ declare module '@sveltejs/kit' {
 
 	export interface ServerInitOptions {
 		env: Record<string, string>;
+		readAsset?: (file: string) => Response;
 	}
 
 	export interface SSRManifest {
@@ -1873,6 +1874,10 @@ declare module '@sveltejs/kit/node' {
 	}): Promise<Request>;
 
 	export function setResponse(res: import('http').ServerResponse, response: Response): Promise<void>;
+	/**
+	 * TODO
+	 * */
+	export function readFile(file: string): Response;
 }
 
 declare module '@sveltejs/kit/node/polyfills' {
@@ -2105,6 +2110,13 @@ declare module '$app/paths' {
 	 * ```
 	 */
 	export function resolveRoute(id: string, params: Record<string, string | undefined>): string;
+}
+
+declare module '$app/server' {
+	/**
+	 * TODO docs
+	 * */
+	export function readAsset(file: string): Response;
 }
 
 declare module '$app/stores' {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -125,6 +125,13 @@ declare module '@sveltejs/kit' {
 		 */
 		writeServer(dest: string): string[];
 		/**
+		 * Copy any assets imported by server code to `dest`.
+		 * @param dest the destination folder
+		 * @param routes an array of routes to find asset dependencies for
+		 * @returns an array of files written to `dest`
+		 */
+		writeServerAssets(dest: string, routes?: RouteDefinition[]): string[];
+		/**
 		 * Copy a file or directory.
 		 * @param from the source file or directory
 		 * @param to the destination file or directory

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1585,6 +1585,11 @@ declare module '@sveltejs/kit' {
 
 	interface ManifestData {
 		assets: Asset[];
+		hooks: {
+			client: string | null;
+			server: string | null;
+			universal: string | null;
+		};
 		nodes: PageNode[];
 		routes: RouteData[];
 		matchers: Record<string, string>;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -71,6 +71,7 @@ declare module '@sveltejs/kit' {
 		/** An array of all routes (including prerendered) */
 		routes: RouteDefinition[];
 
+		// TODO 3.0 remove this method
 		/**
 		 * Create separate functions that map to one or more routes of your app.
 		 * @param fn A function that groups a set of routes into an entry point
@@ -2124,7 +2125,7 @@ declare module '$app/paths' {
 
 declare module '$app/server' {
 	/**
-	 * Read the contents of an imported asset
+	 * Read the contents of an imported asset from the filesystem
 	 * @example
 	 * ```js
 	 * import { read } from '$app/server';

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -17,6 +17,16 @@ declare module '@sveltejs/kit' {
 		 * @param builder An object provided by SvelteKit that contains methods for adapting the app
 		 */
 		adapt(builder: Builder): MaybePromise<void>;
+		/**
+		 * Functions called during dev and build to determine whether specific features will work in production with this adapter
+		 */
+		supports?: {
+			/**
+			 * Test support for `read` from `$app/server`
+			 * @param config The merged route config
+			 */
+			read?: (details: { config: any; route: { id: string } }) => boolean;
+		};
 	}
 
 	export type LoadProperties<input extends Record<string, any> | void> = input extends void

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1131,7 +1131,9 @@ declare module '@sveltejs/kit' {
 	}
 
 	export interface ServerInitOptions {
+		/** A map of environment variables */
 		env: Record<string, string>;
+		/** A function that turns an asset filename into a `ReadableStream`. Required for the `read` export from `$app/server` to work */
 		read?: (file: string) => ReadableStream;
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,7 +289,7 @@ importers:
     dependencies:
       '@sveltejs/kit':
         specifier: ^1.0.0 || ^2.0.0
-        version: link:../kit
+        version: 2.3.5(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.0.11)
 
   packages/create-svelte:
     dependencies:
@@ -1266,9 +1266,6 @@ importers:
       svelte:
         specifier: ^4.2.8
         version: 4.2.8
-      tiny-glob:
-        specifier: ^0.2.9
-        version: 0.2.9
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -2317,6 +2314,33 @@ packages:
       typescript: 5.3.3
     dev: true
 
+  /@sveltejs/kit@2.3.5(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.2.8)(vite@5.0.11):
+    resolution: {integrity: sha512-Vu+ckGQu/t+pcuueryaHYacgoYsYq6KB1k1p4w1xDp1eQ2aYz3POcx3GSuqxWjJfOwMMM83xiuAnDWBKyOn1Tg==}
+    engines: {node: '>=18.13'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^3.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      vite: ^5.0.3
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.2.8)(vite@5.0.11)
+      '@types/cookie': 0.6.0
+      cookie: 0.6.0
+      devalue: 4.3.2
+      esm-env: 1.0.0
+      import-meta-resolve: 4.0.0
+      kleur: 4.1.5
+      magic-string: 0.30.5
+      mrmime: 2.0.0
+      sade: 1.8.1
+      set-cookie-parser: 2.6.0
+      sirv: 2.0.4
+      svelte: 4.2.8
+      tiny-glob: 0.2.9
+      vite: 5.0.11(@types/node@18.19.3)(lightningcss@1.22.1)
+    dev: false
+
   /@sveltejs/site-kit@6.0.0-next.59(@sveltejs/kit@packages+kit)(svelte@4.2.8):
     resolution: {integrity: sha512-nAUCuunhN0DmurQBxbsauqvdvv4mL0F/Aluxq0hFf6gB3iSn9WdaUZdPMXoujy+8cy+m6UvKuyhkgApZhmOLvw==}
     peerDependencies:
@@ -2343,7 +2367,6 @@ packages:
       vite: 5.0.11(@types/node@18.19.3)(lightningcss@1.22.1)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@sveltejs/vite-plugin-svelte@3.0.1(svelte@4.2.8)(vite@5.0.11):
     resolution: {integrity: sha512-CGURX6Ps+TkOovK6xV+Y2rn8JKa8ZPUHPZ/NKgCxAmgBrXReavzFl8aOSCj3kQ1xqT7yGJj53hjcV/gqwDAaWA==}
@@ -2363,7 +2386,6 @@ packages:
       vitefu: 0.2.5(vite@5.0.11)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@svitejs/changesets-changelog-github-compact@1.1.0:
     resolution: {integrity: sha512-qhUGGDHcpbY2zpjW3SwqchuW8J/5EzlPFud7xNntHKA7f3a/mx5+g+ruJKFHSAiVZYo30PALt+AyhmPUNKH/Og==}
@@ -2435,7 +2457,6 @@ packages:
     resolution: {integrity: sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==}
     dependencies:
       undici-types: 5.26.5
-    dev: true
 
   /@types/normalize-package-data@2.4.4:
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -3354,7 +3375,6 @@ packages:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
     engines: {node: '>=0.10'}
     hasBin: true
-    dev: true
 
   /detect-libc@2.0.2:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
@@ -4517,7 +4537,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /lightningcss-darwin-x64@1.22.1:
@@ -4526,7 +4545,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /lightningcss-freebsd-x64@1.22.1:
@@ -4535,7 +4553,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /lightningcss-linux-arm-gnueabihf@1.22.1:
@@ -4544,7 +4561,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /lightningcss-linux-arm64-gnu@1.22.1:
@@ -4553,7 +4569,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /lightningcss-linux-arm64-musl@1.22.1:
@@ -4562,7 +4577,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /lightningcss-linux-x64-gnu@1.22.1:
@@ -4571,7 +4585,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /lightningcss-linux-x64-musl@1.22.1:
@@ -4580,7 +4593,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /lightningcss-win32-x64-msvc@1.22.1:
@@ -4589,7 +4601,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /lightningcss@1.22.1:
@@ -4607,7 +4618,6 @@ packages:
       lightningcss-linux-x64-gnu: 1.22.1
       lightningcss-linux-x64-musl: 1.22.1
       lightningcss-win32-x64-msvc: 1.22.1
-    dev: true
 
   /lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
@@ -4889,7 +4899,6 @@ packages:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-    dev: true
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -5279,7 +5288,6 @@ packages:
       nanoid: 3.3.7
       picocolors: 1.0.0
       source-map-js: 1.0.2
-    dev: true
 
   /preferred-pm@3.1.2:
     resolution: {integrity: sha512-nk7dKrcW8hfCZ4H6klWcdRknBOXWzNQByJ0oJyX97BOupsYD+FzLS4hflgEu/uPUEHZCuRfMxzCBsuWd7OzT8Q==}
@@ -5984,7 +5992,6 @@ packages:
       svelte: ^3.19.0 || ^4.0.0
     dependencies:
       svelte: 4.2.8
-    dev: true
 
   /svelte-local-storage-store@0.6.4(svelte@4.2.8):
     resolution: {integrity: sha512-45WoY2vSGPQM1sIQJ9jTkPPj20hYeqm+af6mUGRFSPP5WglZf36YYoZqwmZZ8Dt/2SU8lem+BTA8/Z/8TkqNLg==}
@@ -6322,7 +6329,6 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-    dev: true
 
   /universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -6446,7 +6452,6 @@ packages:
       rollup: 4.9.5
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /vitefu@0.2.5(vite@5.0.11):
     resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
@@ -6457,7 +6462,6 @@ packages:
         optional: true
     dependencies:
       vite: 5.0.11(@types/node@18.19.3)(lightningcss@1.22.1)
-    dev: true
 
   /vitest@1.2.0(@types/node@18.19.3)(lightningcss@1.22.1):
     resolution: {integrity: sha512-Ixs5m7BjqvLHXcibkzKRQUvD/XLw0E3rvqaCMlrm/0LMsA0309ZqYvTlPzkhh81VlEyVZXFlwWnkhb6/UMtcaQ==}

--- a/sites/kit.svelte.dev/package.json
+++ b/sites/kit.svelte.dev/package.json
@@ -31,7 +31,6 @@
 		"prismjs": "^1.29.0",
 		"shiki-twoslash": "^3.1.2",
 		"svelte": "^4.2.8",
-		"tiny-glob": "^0.2.9",
 		"typescript": "5.0.4",
 		"vite": "^5.0.11",
 		"vitest": "^1.2.0"

--- a/sites/kit.svelte.dev/src/constants.js
+++ b/sites/kit.svelte.dev/src/constants.js
@@ -1,6 +1,0 @@
-export const CONTENT_BASE = '../../documentation';
-
-/** All the paths are relative to the project root when being run on server or built */
-export const CONTENT_BASE_PATHS = {
-	DOCS: `${CONTENT_BASE}/docs`
-};

--- a/sites/kit.svelte.dev/src/lib/server/docs/index.js
+++ b/sites/kit.svelte.dev/src/lib/server/docs/index.js
@@ -47,7 +47,7 @@ for (const [file, asset] of Object.entries(markdown)) {
 	if (!category) continue; // draft
 
 	const {
-		metadata: { draft, title },
+		metadata: { draft, title, rank },
 		body
 	} = extractFrontmatter(await read(asset).text());
 
@@ -59,6 +59,7 @@ for (const [file, asset] of Object.entries(markdown)) {
 	});
 
 	pages[slug] = {
+		rank: +rank || undefined,
 		category: category.title,
 		title,
 		file: `${category_dir}/${basename}`,

--- a/sites/kit.svelte.dev/src/lib/server/docs/index.js
+++ b/sites/kit.svelte.dev/src/lib/server/docs/index.js
@@ -1,4 +1,4 @@
-import { base as app_base } from '$app/paths';
+import { base } from '$app/paths';
 import { modules } from '$lib/generated/type-info.js';
 import {
 	escape,
@@ -8,96 +8,78 @@ import {
 	removeMarkdown,
 	replaceExportTypePlaceholders
 } from '@sveltejs/site-kit/markdown';
-import { readFile, readdir } from 'node:fs/promises';
 import { render_content } from '../renderer';
+import { read } from '$app/server';
+import { error } from '@sveltejs/kit';
 
-/**
- * @param {import('./types.js').DocsData} docs_data
- * @param {string} slug
- */
-export async function get_parsed_docs(docs_data, slug) {
-	for (const { pages } of docs_data) {
-		for (const page of pages) {
-			if (page.slug === slug) {
-				return {
-					...page,
-					content: await render_content(page.file, page.content)
-				};
-			}
-		}
-	}
+const meta = import.meta.glob('../../../../../../documentation/docs/*/meta.json', {
+	as: 'url',
+	eager: true
+});
+
+const markdown = import.meta.glob('../../../../../../documentation/docs/*/*.md', {
+	as: 'url',
+	eager: true
+});
+
+export const categories = {};
+export const pages = {};
+
+for (const [file, asset] of Object.entries(meta)) {
+	const slug = /\/\d{2}-(.+)\/meta\.json$/.exec(file)[1];
+
+	const { title, draft } = await read(asset).json();
+
+	if (draft) continue;
+
+	categories[slug] = {
+		title,
+		pages: []
+	};
 }
 
-const base = '../../documentation/docs';
+for (const [file, asset] of Object.entries(markdown)) {
+	const [, category_dir, basename] = /\/(\d{2}-.+?)\/(\d{2}-.+\.md)$/.exec(file);
+	const category_slug = category_dir.slice(3);
+	const slug = basename.slice(3, -3); // strip the number prefix and .md suffix
 
-/** @return {Promise<import('./types.js').DocsData>} */
-export async function get_docs_data() {
-	/** @type {import('./types.js').DocsData} */
-	const docs_data = [];
+	const {
+		metadata: { draft, title },
+		body
+	} = extractFrontmatter(await read(asset).text());
 
-	for (const category_dir of await readdir(base)) {
-		const match = /\d{2}-(.+)/.exec(category_dir);
-		if (!match) continue;
+	// skip draft pages/categories
+	if (draft === 'true' && !(category_slug in categories)) continue;
 
-		const category_slug = match[1];
+	categories[category_slug].pages.push({
+		title,
+		path: `${base}/docs/${slug}`
+	});
 
-		// Read the meta.json
-		const { title: category_title, draft = 'false' } = JSON.parse(
-			await readFile(`${base}/${category_dir}/meta.json`, 'utf-8')
-		);
-
-		if (draft === 'true') continue;
-
-		/** @type {import('./types.js').Category} */
-		const category = {
-			title: category_title,
-			slug: category_slug,
-			pages: []
-		};
-
-		for (const page_md of (await readdir(`${base}/${category_dir}`)).filter(
-			(filename) => filename !== 'meta.json'
-		)) {
-			const match = /\d{2}-(.+)/.exec(page_md);
-			if (!match) continue;
-
-			const page_slug = match[1].replace('.md', '');
-
-			const page_data = extractFrontmatter(
-				await readFile(`${base}/${category_dir}/${page_md}`, 'utf-8')
-			);
-
-			if (page_data.metadata.draft === 'true') continue;
-
-			const page_title = page_data.metadata.title;
-			const page_content = page_data.body;
-
-			category.pages.push({
-				title: page_title,
-				slug: page_slug,
-				content: page_content,
-				category: category_title,
-				sections: await get_sections(page_content),
-				path: `${app_base}/docs/${page_slug}`,
-				file: `${category_dir}/${page_md}`
-			});
-		}
-
-		docs_data.push(category);
-	}
-
-	return docs_data;
+	pages[slug] = {
+		title,
+		file: `${category_dir}/${basename}`,
+		sections: await get_sections(body),
+		body
+	};
 }
 
-/** @param {import('./types.js').DocsData} docs_data */
-export function get_docs_list(docs_data) {
-	return docs_data.map((category) => ({
-		title: category.title,
-		pages: category.pages.map((page) => ({
-			title: page.title,
-			path: page.path
-		}))
-	}));
+/** @param {string} slug */
+export async function get_parsed_docs(slug) {
+	const page = pages[slug];
+	if (!page) error(404);
+
+	// TODO this should probably use a type from site-kit
+	return {
+		title: page.title,
+		file: page.file,
+		sections: page.sections,
+		content: await render_content(page.file, page.body)
+	};
+}
+
+export function get_docs_list() {
+	return Object.values(categories);
 }
 
 /** @param {string} markdown */

--- a/sites/kit.svelte.dev/src/lib/server/docs/index.js
+++ b/sites/kit.svelte.dev/src/lib/server/docs/index.js
@@ -43,20 +43,23 @@ for (const [file, asset] of Object.entries(markdown)) {
 	const category_slug = category_dir.slice(3);
 	const slug = basename.slice(3, -3); // strip the number prefix and .md suffix
 
+	const category = categories[category_slug];
+	if (!category) continue; // draft
+
 	const {
 		metadata: { draft, title },
 		body
 	} = extractFrontmatter(await read(asset).text());
 
-	// skip draft pages/categories
-	if (draft === 'true' && !(category_slug in categories)) continue;
+	if (draft === 'true') continue;
 
-	categories[category_slug].pages.push({
+	category.pages.push({
 		title,
 		path: `${base}/docs/${slug}`
 	});
 
 	pages[slug] = {
+		category: category.title,
 		title,
 		file: `${category_dir}/${basename}`,
 		sections: await get_sections(body),
@@ -71,6 +74,7 @@ export async function get_parsed_docs(slug) {
 
 	// TODO this should probably use a type from site-kit
 	return {
+		category: page.category,
 		title: page.title,
 		file: page.file,
 		sections: page.sections,

--- a/sites/kit.svelte.dev/src/lib/server/docs/index.js
+++ b/sites/kit.svelte.dev/src/lib/server/docs/index.js
@@ -9,7 +9,6 @@ import {
 	replaceExportTypePlaceholders
 } from '@sveltejs/site-kit/markdown';
 import { readFile, readdir } from 'node:fs/promises';
-import { CONTENT_BASE_PATHS } from '../../../constants.js';
 import { render_content } from '../renderer';
 
 /**
@@ -29,8 +28,10 @@ export async function get_parsed_docs(docs_data, slug) {
 	}
 }
 
+const base = '../../documentation/docs';
+
 /** @return {Promise<import('./types.js').DocsData>} */
-export async function get_docs_data(base = CONTENT_BASE_PATHS.DOCS) {
+export async function get_docs_data() {
 	/** @type {import('./types.js').DocsData} */
 	const docs_data = [];
 

--- a/sites/kit.svelte.dev/src/lib/server/docs/index.js
+++ b/sites/kit.svelte.dev/src/lib/server/docs/index.js
@@ -88,15 +88,16 @@ export function get_docs_list() {
 
 /** @param {string} markdown */
 async function get_sections(markdown) {
-	const headingRegex = /^##\s+(.*)$/gm;
 	/** @type {import('./types.js').Section[]} */
-	const secondLevelHeadings = [];
+	const second_level_headings = [];
+
+	const pattern = /^##\s+(.*)$/gm;
 	let match;
 
 	const placeholders_rendered = await replaceExportTypePlaceholders(markdown, modules);
 
-	while ((match = headingRegex.exec(placeholders_rendered)) !== null) {
-		secondLevelHeadings.push({
+	while ((match = pattern.exec(placeholders_rendered)) !== null) {
+		second_level_headings.push({
 			title: removeMarkdown(
 				escape(await markedTransform(match[1], { paragraph: (txt) => txt }))
 					.replace(/<\/?code>/g, '')
@@ -110,5 +111,5 @@ async function get_sections(markdown) {
 		});
 	}
 
-	return secondLevelHeadings;
+	return second_level_headings;
 }

--- a/sites/kit.svelte.dev/src/routes/+layout.server.js
+++ b/sites/kit.svelte.dev/src/routes/+layout.server.js
@@ -3,7 +3,7 @@ import { fetchBanner } from '@sveltejs/site-kit/components';
 export const prerender = true;
 
 export const load = async ({ url, fetch }) => {
-	const nav_links = fetch('/nav.json').then((r) => r.json());
+	const nav_links = fetch('/nav.json').then((r) => r.json()); // TODO why is this behind a `fetch`? does `nav.json` need to be exposed publicly?
 	const banner = fetchBanner('kit.svelte.dev', fetch);
 
 	return {

--- a/sites/kit.svelte.dev/src/routes/docs/+layout.server.js
+++ b/sites/kit.svelte.dev/src/routes/docs/+layout.server.js
@@ -1,9 +1,9 @@
-import { get_docs_data, get_docs_list } from '$lib/server/docs/index.js';
+import { get_docs_list } from '$lib/server/docs/index.js';
 
 export const prerender = true;
 
 export async function load() {
 	return {
-		sections: get_docs_list(await get_docs_data())
+		sections: get_docs_list()
 	};
 }

--- a/sites/kit.svelte.dev/src/routes/docs/+layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/docs/+layout.svelte
@@ -4,8 +4,7 @@
 
 	export let data;
 
-	$: pageData = $page.data.page;
-	$: category = pageData?.category;
+	$: category = $page.data.page?.category;
 </script>
 
 <div class="container">

--- a/sites/kit.svelte.dev/src/routes/docs/[slug]/+page.server.js
+++ b/sites/kit.svelte.dev/src/routes/docs/[slug]/+page.server.js
@@ -1,12 +1,7 @@
-import { get_docs_data, get_parsed_docs } from '$lib/server/docs/index.js';
-import { error } from '@sveltejs/kit';
+import { get_parsed_docs } from '$lib/server/docs/index.js';
 
 export const prerender = true;
 
 export async function load({ params }) {
-	const processed_page = await get_parsed_docs(await get_docs_data(), params.slug);
-
-	if (!processed_page) error(404);
-
-	return { page: processed_page };
+	return { page: await get_parsed_docs(params.slug) };
 }

--- a/sites/kit.svelte.dev/src/routes/nav.json/+server.js
+++ b/sites/kit.svelte.dev/src/routes/nav.json/+server.js
@@ -1,23 +1,13 @@
-import { get_docs_data, get_docs_list } from '$lib/server/docs/index.js';
+import { get_docs_list } from '$lib/server/docs/index.js';
 import { json } from '@sveltejs/kit';
 
 export const prerender = true;
 
 export const GET = async () => {
-	return json(await get_nav_list());
-};
+	const docs_list = get_docs_list();
 
-/**
- * @returns {Promise<import('@sveltejs/site-kit').NavigationLink[]>}
- */
-async function get_nav_list() {
-	const docs_list = get_docs_list(await get_docs_data());
-	const processed_docs_list = docs_list.map(({ title, pages }) => ({
-		title,
-		sections: pages.map(({ title, path }) => ({ title, path }))
-	}));
-
-	return [
+	/** @type {import('@sveltejs/site-kit').NavigationLink[]} */
+	const nav_list = [
 		{
 			title: 'Docs',
 			prefix: 'docs',
@@ -25,9 +15,14 @@ async function get_nav_list() {
 			sections: [
 				{
 					title: 'DOCS',
-					sections: processed_docs_list
+					sections: docs_list.map(({ title, pages }) => ({
+						title,
+						sections: pages.map(({ title, path }) => ({ title, path }))
+					}))
 				}
 			]
 		}
 	];
-}
+
+	return json(nav_list);
+};


### PR DESCRIPTION
This implements the `read(file: string): Response` idea proposed in https://github.com/sveltejs/kit/pull/11647#issuecomment-1894442101.

Adapters can provide an implementation when they call `server.init`:

```js
server.init({
  env,
  read: (file) => new ReadableStream(...)
});
```

This also adds a `read` function (name bikesheddable) in `@sveltejs/kit/node` that turns a filepath into a `Response`, meaning that Node-like adapters have an easy job (see the `adapter-node` example in this PR).

Files that fall below the `assetsInlineLimit` are also handled (adapters don't need to provide an implementation, it's handled inside Kit).

TODO:

- [x] implement for other adapters (namely `adapter-netlify` and `adapter-vercel`)
- [x] docs
- [x] bikeshed the name
- [x] figure out how this all interacts with `paths.base`
- [x] add server assets imported by `hooks.server.js`
- [x] ensure `$app/server` can only be imported by server code
- [x] throw during dev/build if `read` from `$app/server` is used, but adapter provides no `read` implementation

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
