### PR TITLE
chore: in `adapter-vercel`, symlink everything

### DIFF
--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -520,7 +520,9 @@ async function create_function_bundle(builder, entry, dir, config) {
 			// do nothing
 		}
 
-		fs.symlinkSync(path.relative(path.dirname(dest), realpath), dest, is_dir ? 'dir' : 'file');
+		if (!is_dir) {
+			fs.linkSync(realpath, dest, is_dir ? 'dir' : 'file');
+		}
 	}
 
 	write(

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -63,6 +63,7 @@ const plugin = function (defaults = {}) {
 			 * @param {import('@sveltejs/kit').RouteDefinition<import('.').Config>[]} routes
 			 */
 			async function generate_serverless_function(name, config, routes) {
+				const tmp = builder.getBuildDirectory(`vercel-tmp/${name}`);
 				const relativePath = path.posix.relative(tmp, builder.getServerDirectory());
 
 				builder.copy(`${files}/serverless.js`, `${tmp}/index.js`, {
@@ -519,12 +520,7 @@ async function create_function_bundle(builder, entry, dir, config) {
 			// do nothing
 		}
 
-		if (source !== realpath) {
-			const realdest = path.join(dir, path.relative(ancestor, realpath));
-			fs.symlinkSync(path.relative(path.dirname(dest), realdest), dest, is_dir ? 'dir' : 'file');
-		} else if (!is_dir) {
-			fs.copyFileSync(source, dest);
-		}
+		fs.symlinkSync(path.relative(path.dirname(dest), realpath), dest, is_dir ? 'dir' : 'file');
 	}
 
 	write(


### PR DESCRIPTION
For reasons that I'm unclear on, we symlink some files but copy others when creating serverless functions on Vercel.

If we just symlink everything, the `functions` directory gets way smaller when you have multiple functions, since many dependencies are shared between them. I believe this allows the platform to generate more efficient artifacts (though that's outside my wheelhouse).

Noticed this while looking into how best to copy server assets over (#11649) without excessive duplication.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
