### PR TITLE
fix: don't stash away original `history` methods so other libs can monkeypatch it

### DIFF
--- a/.changeset/bright-moose-brake.md
+++ b/.changeset/bright-moose-brake.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: don't stash away original `history` methods so other libs can monkeypatch it

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -64,14 +64,20 @@ const scroll_positions = storage.get(SCROLL_KEY) ?? {};
  */
 const snapshots = storage.get(SNAPSHOT_KEY) ?? {};
 
-const original_push_state = BROWSER ? history.pushState : () => {};
-const original_replace_state = BROWSER ? history.replaceState : () => {};
-
 if (DEV && BROWSER) {
 	let warned = false;
 
 	const warn = () => {
 		if (warned) return;
+
+		// Avoid stashing away the original history methods which prevents monkeypatching by other libs,
+		// instead inspect the stack trace to see if we're being called from within SvelteKit.
+		let stack = new Error().stack?.split('\n');
+		if (!stack) return;
+		if (!stack[0].includes('https:') && !stack[0].includes('http:')) stack = stack.slice(1); // Chrome includes the error message in the stack
+		stack = stack.slice(2); // remove `warn` and the place where `warn` was called
+		if (stack[0].includes('src/runtime/client/client.js')) return;
+
 		warned = true;
 
 		console.warn(
@@ -79,14 +85,16 @@ if (DEV && BROWSER) {
 		);
 	};
 
+	const push_state = history.pushState;
 	history.pushState = (...args) => {
 		warn();
-		return original_push_state.apply(history, args);
+		return push_state.apply(history, args);
 	};
 
+	const replace_state = history.replaceState;
 	history.replaceState = (...args) => {
 		warn();
-		return original_replace_state.apply(history, args);
+		return replace_state.apply(history, args);
 	};
 }
 
@@ -252,8 +260,7 @@ export async function start(_app, _target, hydrate) {
 		current_history_index = current_navigation_index = Date.now();
 
 		// create initial history entry, so we can return here
-		original_replace_state.call(
-			history,
+		history.replaceState(
 			{
 				...history.state,
 				[HISTORY_INDEX]: current_history_index,
@@ -1296,7 +1303,7 @@ async function navigate({
 			[STATES_KEY]: state
 		};
 
-		const fn = replace_state ? original_replace_state : original_push_state;
+		const fn = replace_state ? history.replaceState : history.pushState;
 		fn.call(history, entry, '', url);
 
 		if (!replace_state) {
@@ -1812,7 +1819,7 @@ export function pushState(url, state) {
 		[STATES_KEY]: state
 	};
 
-	original_push_state.call(history, opts, '', resolve_url(url));
+	history.pushState(opts, '', resolve_url(url));
 
 	page = { ...page, state };
 	root.$set({ page });
@@ -1849,7 +1856,7 @@ export function replaceState(url, state) {
 		[STATES_KEY]: state
 	};
 
-	original_replace_state.call(history, opts, '', resolve_url(url));
+	history.replaceState(opts, '', resolve_url(url));
 
 	page = { ...page, state };
 	root.$set({ page });
@@ -2180,8 +2187,7 @@ function _start_router() {
 		// we need to update history, otherwise we have to leave it alone
 		if (hash_navigating) {
 			hash_navigating = false;
-			original_replace_state.call(
-				history,
+			history.replaceState(
 				{
 					...history.state,
 					[HISTORY_INDEX]: ++current_history_index,

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -70,13 +70,13 @@ if (DEV && BROWSER) {
 	const warn = () => {
 		if (warned) return;
 
-		// Avoid stashing away the original history methods which prevents monkeypatching by other libs,
-		// instead inspect the stack trace to see if we're being called from within SvelteKit.
+		// Rather than saving a pointer to the original history methods, which would prevent monkeypatching by other libs,
+		// inspect the stack trace to see if we're being called from within SvelteKit.
 		let stack = new Error().stack?.split('\n');
 		if (!stack) return;
 		if (!stack[0].includes('https:') && !stack[0].includes('http:')) stack = stack.slice(1); // Chrome includes the error message in the stack
 		stack = stack.slice(2); // remove `warn` and the place where `warn` was called
-		if (stack[0].includes('src/runtime/client/client.js')) return;
+		if (stack[0].includes(import.meta.url)) return;
 
 		warned = true;
 

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -17,6 +17,7 @@ export function unlock_fetch() {
 if (DEV && BROWSER) {
 	let can_inspect_stack_trace = false;
 
+	// detect whether async stack traces work
 	const check_stack_trace = async () => {
 		const stack = /** @type {string} */ (new Error().stack);
 		can_inspect_stack_trace = stack.includes('check_stack_trace');


### PR DESCRIPTION
Some other libraries might hook into `history.replaceState/pushState` to do additional work. This no longer works since the introduction of shallow routing because we're stashing away the original history methods. This PR adjusts the DEV time check logic so that this is no longer necessary.
Fixes #11499
Fixes https://github.com/vercel/analytics/issues/121

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
