### PR TITLE
fix: log a warning if fallback page overwrites prerendered page

### DIFF
--- a/.changeset/thin-rules-travel.md
+++ b/.changeset/thin-rules-travel.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: log a warning if fallback page overwrites prerendered page

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -1,4 +1,5 @@
-import { existsSync, statSync, createReadStream, createWriteStream } from 'node:fs';
+import colors from 'kleur';
+import { createReadStream, createWriteStream, existsSync, statSync } from 'node:fs';
 import { extname, resolve } from 'node:path';
 import { pipeline } from 'node:stream';
 import { promisify } from 'node:util';
@@ -152,6 +153,16 @@ export function create_builder({
 				manifest_path,
 				env: { ...env.private, ...env.public }
 			});
+
+			if (existsSync(dest)) {
+				console.log(
+					colors
+						.bold()
+						.yellow(
+							`Overwriting ${dest} with fallback page. Consider using a different name for the fallback.`
+						)
+				);
+			}
 
 			write(dest, fallback);
 		},


### PR DESCRIPTION
I'm tweaking the docs in https://github.com/sveltejs/kit/pull/11637 to recommend using a name other than `index.html`, but it'd still be useful to log a warning for existing projects or for people who don't read the docs (i.e. everyone).

I thought about making it throw an error, but it doesn't stop the project from working and probably wouldn't be considered backwards compatible to do so. It also risks the user turning off prerendering to solve the error, which could be counter-productive.