### PR TITLE
Add node:* to external whitelist

### DIFF
--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -53,6 +53,20 @@ export default function (options = {}) {
 				}
 			});
 
+			const nodeModules = [
+				'node:assert',
+				'node:async_hooks',
+				'node:buffer',
+				'node:crypto',
+				'node:diagnostics_channel',
+				'node:events',
+				'node:path',
+				'node:process',
+				'node:stream',
+				'node:string_decoder',
+				'node:util'
+			];
+
 			await esbuild.build({
 				platform: 'browser',
 				conditions: ['worker', 'browser'],
@@ -66,7 +80,7 @@ export default function (options = {}) {
 				loader: {
 					'.wasm': 'copy'
 				},
-				external: ['cloudflare:*', 'node:*']
+				external: ['cloudflare:*', ...nodeModules]
 			});
 		}
 	};

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -66,7 +66,7 @@ export default function (options = {}) {
 				loader: {
 					'.wasm': 'copy'
 				},
-				external: ['cloudflare:*']
+				external: ['cloudflare:*', 'node:*']
 			});
 		}
 	};


### PR DESCRIPTION
Allows for running [supported Node packages](https://developers.cloudflare.com/workers/runtime-apis/nodejs/) on Cloudflare.

This is a rather serious oversight, given that no official solution has been rolled out after ~8 months of user attempts.

This PR is based on @chientrm's efforts (among others) at getting this pushed through.

Prior attempts:

#10028 -- support node compat in CF adapter
#10110 -- expose `external` esbuild option
#10214 -- allow override esbuild option
#10424 -- pass `external` to esbuild
#10521 -- pass `alias` and `external` to esbuild

The proposals to expose data to esbuild sound great... but for most use-cases, it's overkill for the simple need to access Node packages on Cloudflare.

@benmccann Can we please just add `node:*` to the `external` array?

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
