### PR TITLE
feat: support compatible node modules without prefixes

### DIFF
--- a/.changeset/old-ravens-learn.md
+++ b/.changeset/old-ravens-learn.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/adapter-cloudflare-workers': minor
+'@sveltejs/adapter-cloudflare': minor
+---
+
+feat: support compatible node modules without prefixes

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -15,6 +15,20 @@ import { fileURLToPath } from 'node:url';
  * }} WranglerConfig
  */
 
+const compatible_node_modules = [
+	'assert',
+	'async_hooks',
+	'buffer',
+	'crypto',
+	'diagnostics_channel',
+	'events',
+	'path',
+	'process',
+	'stream',
+	'string_decoder',
+	'util'
+];
+
 /** @type {import('./index.js').default} */
 export default function ({ config = 'wrangler.toml' } = {}) {
 	return {
@@ -64,19 +78,7 @@ export default function ({ config = 'wrangler.toml' } = {}) {
 
 			const external = ['__STATIC_CONTENT_MANIFEST', 'cloudflare:*'];
 			if (compatibility_flags && compatibility_flags.includes('nodejs_compat')) {
-				external.push(
-					'node:assert',
-					'node:async_hooks',
-					'node:buffer',
-					'node:crypto',
-					'node:diagnostics_channel',
-					'node:events',
-					'node:path',
-					'node:process',
-					'node:stream',
-					'node:string_decoder',
-					'node:util'
-				);
+				external.push(...compatible_node_modules.map((id) => `node:${id}`));
 			}
 
 			await esbuild.build({
@@ -88,6 +90,7 @@ export default function ({ config = 'wrangler.toml' } = {}) {
 				outfile: main,
 				bundle: true,
 				external,
+				alias: Object.fromEntries(compatible_node_modules.map((id) => [id, `node:${id}`])),
 				format: 'esm',
 				loader: {
 					'.wasm': 'copy'

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'node:url';
  * }} WranglerConfig
  */
 
+// list from https://developers.cloudflare.com/workers/runtime-apis/nodejs/
 const compatible_node_modules = [
 	'assert',
 	'async_hooks',

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -3,6 +3,20 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as esbuild from 'esbuild';
 
+const compatible_node_modules = [
+	'assert',
+	'async_hooks',
+	'buffer',
+	'crypto',
+	'diagnostics_channel',
+	'events',
+	'path',
+	'process',
+	'stream',
+	'string_decoder',
+	'util'
+];
+
 /** @type {import('./index.js').default} */
 export default function (options = {}) {
 	return {
@@ -53,20 +67,7 @@ export default function (options = {}) {
 				}
 			});
 
-			const external = [
-				'cloudflare:*',
-				'node:assert',
-				'node:async_hooks',
-				'node:buffer',
-				'node:crypto',
-				'node:diagnostics_channel',
-				'node:events',
-				'node:path',
-				'node:process',
-				'node:stream',
-				'node:string_decoder',
-				'node:util'
-			];
+			const external = ['cloudflare:*', ...compatible_node_modules.map((id) => `node:${id}`)];
 
 			await esbuild.build({
 				platform: 'browser',
@@ -81,7 +82,8 @@ export default function (options = {}) {
 				loader: {
 					'.wasm': 'copy'
 				},
-				external
+				external,
+				alias: Object.fromEntries(compatible_node_modules.map((id) => [id, `node:${id}`]))
 			});
 		}
 	};

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as esbuild from 'esbuild';
 
+// list from https://developers.cloudflare.com/workers/runtime-apis/nodejs/
 const compatible_node_modules = [
 	'assert',
 	'async_hooks',


### PR DESCRIPTION
This is a companion to #10544. Cloudflare workers let you import from `node:path`, but not from `path`. This is annoying to fix if you're not the one writing the import (i.e. it's in a dependency). We can trivially fix it with `esbuild` config.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
