### PR TITLE
feat: more helpful errors when using incompatible node modules

### DIFF
--- a/.changeset/light-tips-hang.md
+++ b/.changeset/light-tips-hang.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/adapter-cloudflare-workers': minor
+'@sveltejs/adapter-cloudflare': minor
+---
+
+feat: more helpful errors when using incompatible Node modules

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -115,11 +115,9 @@ export default function ({ config = 'wrangler.toml' } = {}) {
 							/The package "(.+)" wasn't found on the file system but is built into node/.exec(
 								node.text
 							);
-						if (match) {
-							let id = match[1];
-							if (!id.startsWith('node:')) id = `node:${id}`;
 
-							node.text = `Cannot use "${id}" when deploying to Cloudflare.`;
+						if (match) {
+							node.text = `Cannot use "${match[1]}" when deploying to Cloudflare.`;
 						}
 					}
 				}

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -82,21 +82,61 @@ export default function ({ config = 'wrangler.toml' } = {}) {
 				external.push(...compatible_node_modules.map((id) => `node:${id}`));
 			}
 
-			await esbuild.build({
-				platform: 'browser',
-				conditions: ['worker', 'browser'],
-				sourcemap: 'linked',
-				target: 'es2022',
-				entryPoints: [`${tmp}/entry.js`],
-				outfile: main,
-				bundle: true,
-				external,
-				alias: Object.fromEntries(compatible_node_modules.map((id) => [id, `node:${id}`])),
-				format: 'esm',
-				loader: {
-					'.wasm': 'copy'
+			try {
+				const result = await esbuild.build({
+					platform: 'browser',
+					conditions: ['worker', 'browser'],
+					sourcemap: 'linked',
+					target: 'es2022',
+					entryPoints: [`${tmp}/entry.js`],
+					outfile: main,
+					bundle: true,
+					external,
+					alias: Object.fromEntries(compatible_node_modules.map((id) => [id, `node:${id}`])),
+					format: 'esm',
+					loader: {
+						'.wasm': 'copy'
+					},
+					logLevel: 'silent'
+				});
+
+				if (result.warnings.length > 0) {
+					const formatted = await esbuild.formatMessages(result.warnings, {
+						kind: 'warning',
+						color: true
+					});
+
+					console.error(formatted.join('\n'));
 				}
-			});
+			} catch (error) {
+				for (const e of error.errors) {
+					for (const node of e.notes) {
+						const match =
+							/The package "(.+)" wasn't found on the file system but is built into node/.exec(
+								node.text
+							);
+						if (match) {
+							let id = match[1];
+							if (!id.startsWith('node:')) id = `node:${id}`;
+
+							node.text = `Cannot use "${id}" when deploying to Cloudflare.`;
+						}
+					}
+				}
+
+				const formatted = await esbuild.formatMessages(error.errors, {
+					kind: 'error',
+					color: true
+				});
+
+				console.error(formatted.join('\n'));
+
+				throw new Error(
+					`Bundling with esbuild failed with ${error.errors.length} ${
+						error.errors.length === 1 ? 'error' : 'errors'
+					}`
+				);
+			}
 
 			builder.log.minor('Copying assets...');
 			const bucket_dir = `${site.bucket}${builder.config.kit.paths.base}`;

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -104,11 +104,9 @@ export default function (options = {}) {
 							/The package "(.+)" wasn't found on the file system but is built into node/.exec(
 								node.text
 							);
-						if (match) {
-							let id = match[1];
-							if (!id.startsWith('node:')) id = `node:${id}`;
 
-							node.text = `Cannot use "${id}" when deploying to Cloudflare.`;
+						if (match) {
+							node.text = `Cannot use "${match[1]}" when deploying to Cloudflare.`;
 						}
 					}
 				}

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -70,22 +70,62 @@ export default function (options = {}) {
 
 			const external = ['cloudflare:*', ...compatible_node_modules.map((id) => `node:${id}`)];
 
-			await esbuild.build({
-				platform: 'browser',
-				conditions: ['worker', 'browser'],
-				sourcemap: 'linked',
-				target: 'es2022',
-				entryPoints: [`${tmp}/_worker.js`],
-				outfile: `${dest}/_worker.js`,
-				allowOverwrite: true,
-				format: 'esm',
-				bundle: true,
-				loader: {
-					'.wasm': 'copy'
-				},
-				external,
-				alias: Object.fromEntries(compatible_node_modules.map((id) => [id, `node:${id}`]))
-			});
+			try {
+				const result = await esbuild.build({
+					platform: 'browser',
+					conditions: ['worker', 'browser'],
+					sourcemap: 'linked',
+					target: 'es2022',
+					entryPoints: [`${tmp}/_worker.js`],
+					outfile: `${dest}/_worker.js`,
+					allowOverwrite: true,
+					format: 'esm',
+					bundle: true,
+					loader: {
+						'.wasm': 'copy'
+					},
+					external,
+					alias: Object.fromEntries(compatible_node_modules.map((id) => [id, `node:${id}`])),
+					logLevel: 'silent'
+				});
+
+				if (result.warnings.length > 0) {
+					const formatted = await esbuild.formatMessages(result.warnings, {
+						kind: 'warning',
+						color: true
+					});
+
+					console.error(formatted.join('\n'));
+				}
+			} catch (error) {
+				for (const e of error.errors) {
+					for (const node of e.notes) {
+						const match =
+							/The package "(.+)" wasn't found on the file system but is built into node/.exec(
+								node.text
+							);
+						if (match) {
+							let id = match[1];
+							if (!id.startsWith('node:')) id = `node:${id}`;
+
+							node.text = `Cannot use "${id}" when deploying to Cloudflare.`;
+						}
+					}
+				}
+
+				const formatted = await esbuild.formatMessages(error.errors, {
+					kind: 'error',
+					color: true
+				});
+
+				console.error(formatted.join('\n'));
+
+				throw new Error(
+					`Bundling with esbuild failed with ${error.errors.length} ${
+						error.errors.length === 1 ? 'error' : 'errors'
+					}`
+				);
+			}
 		}
 	};
 }


### PR DESCRIPTION
Follow-up to #10544 and #11672. Replaces this...

<img width="1110" alt="image" src="https://github.com/sveltejs/kit/assets/1162160/375dc4e3-f401-4b3b-aa5b-387e4cd9e983">

...with this:

<img width="647" alt="image" src="https://github.com/sveltejs/kit/assets/1162160/d79539be-25fe-4a60-9b95-42d4b44394ac">

I think that's probably a more useful error since it explains what the problem is, rather than prompting you to adjust configuration you don't control.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
