### PR TITLE
feat: read assets inside an edge function

### DIFF
--- a/packages/adapter-vercel/files/edge.js
+++ b/packages/adapter-vercel/files/edge.js
@@ -2,8 +2,35 @@ import { Server } from 'SERVER';
 import { manifest } from 'MANIFEST';
 
 const server = new Server(manifest);
+
 const initialized = server.init({
-	env: /** @type {Record<string, string>} */ (process.env)
+	env: /** @type {Record<string, string>} */ (process.env),
+	read: (file) => {
+		const controller = new AbortController();
+		const signal = controller.signal;
+
+		return new ReadableStream({
+			async start(controller) {
+				try {
+					const response = await fetch(manifest.appPath + file, { signal });
+					const reader = /** @type {ReadableStream} */ (response.body).getReader();
+
+					while (true) {
+						const { done, value } = await reader.read();
+						if (done) break;
+						controller.enqueue(value);
+					}
+
+					controller.close();
+				} catch (error) {
+					controller.error(error);
+				}
+			},
+			cancel(reason) {
+				controller.abort(reason);
+			}
+		});
+	}
 });
 
 /**

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -341,18 +341,7 @@ const plugin = function (defaults = {}) {
 		},
 
 		supports: {
-			// reading from the filesystem only works in serverless functions
-			read: ({ config, route }) => {
-				const runtime = config.runtime ?? defaults.runtime;
-
-				if (runtime === 'edge') {
-					throw new Error(
-						`${name}: Cannot use \`read\` from \`$app/server\` in route \`${route.id}\` configured with \`runtime: 'edge'\``
-					);
-				}
-
-				return true;
-			}
+			read: () => true
 		}
 	};
 };

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1145,7 +1145,7 @@ declare module '@sveltejs/kit' {
 		/** A map of environment variables */
 		env: Record<string, string>;
 		/** A function that turns an asset filename into a `ReadableStream`. Required for the `read` export from `$app/server` to work */
-		read?: (file: string) => MaybePromise<ReadableStream>;
+		read?: (file: string) => ReadableStream;
 	}
 
 	export interface SSRManifest {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1145,7 +1145,7 @@ declare module '@sveltejs/kit' {
 		/** A map of environment variables */
 		env: Record<string, string>;
 		/** A function that turns an asset filename into a `ReadableStream`. Required for the `read` export from `$app/server` to work */
-		read?: (file: string) => ReadableStream;
+		read?: (file: string) => MaybePromise<ReadableStream>;
 	}
 
 	export interface SSRManifest {

--- a/sites/kit.svelte.dev/src/routes/delete-me/+server.js
+++ b/sites/kit.svelte.dev/src/routes/delete-me/+server.js
@@ -1,0 +1,12 @@
+import { read } from '$app/server';
+import file from './file.txt?url';
+
+export const config = {
+	runtime: 'edge'
+};
+
+export const prerender = false;
+
+export function GET() {
+	return read(file);
+}

--- a/sites/kit.svelte.dev/src/routes/delete-me/file.txt
+++ b/sites/kit.svelte.dev/src/routes/delete-me/file.txt
@@ -1,0 +1,1 @@
+Hello! This file was read inside an edge function


### PR DESCRIPTION
just an experiment... wanted to see if we could implement `read` inside edge functions by just requesting them. might be useful in a pinch

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
