### PR TITLE
feat: add unit suffix support for `BODY_SIZE_LIMIT`

### DIFF
--- a/.changeset/great-hats-cough.md
+++ b/.changeset/great-hats-cough.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-node": minor
+---
+
+feat: Add unit suffixes to BODY_SIZE_LIMIT environment variable

--- a/.changeset/great-hats-cough.md
+++ b/.changeset/great-hats-cough.md
@@ -2,4 +2,4 @@
 "@sveltejs/adapter-node": minor
 ---
 
-feat: Add unit suffixes to BODY_SIZE_LIMIT environment variable
+feat: add unit suffixes to the `BODY_SIZE_LIMIT` environment variable

--- a/documentation/docs/25-build-and-deploy/40-adapter-node.md
+++ b/documentation/docs/25-build-and-deploy/40-adapter-node.md
@@ -118,6 +118,8 @@ We instead read from the _right_, accounting for the number of trusted proxies. 
 
 The maximum request body size to accept in bytes including while streaming. Defaults to 512kb. You can disable this option with a value of 0 and implement a custom check in [`handle`](hooks#server-hooks-handle) if you need something more advanced.
 
+The body size variable can also specify unit suffixes for kilobytes (`K`), megabytes (`M`), and gigabytes (`G`). For example `512K` and `1M`
+
 ## Options
 
 The adapter can be configured with various options:

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -19,7 +19,21 @@ const address_header = env('ADDRESS_HEADER', '').toLowerCase();
 const protocol_header = env('PROTOCOL_HEADER', '').toLowerCase();
 const host_header = env('HOST_HEADER', 'host').toLowerCase();
 const port_header = env('PORT_HEADER', '').toLowerCase();
-const body_size_limit = Number(env('BODY_SIZE_LIMIT', '524288'));
+
+/**
+ * @param {string} bytes
+ */
+function parse_body_size_limit(bytes) {
+	const multiplier =
+		{
+			K: 1024,
+			M: 1024 * 1024,
+			G: 1024 * 1024 * 1024
+		}[bytes[bytes.length - 1]?.toUpperCase()] ?? 1;
+	return Number(multiplier != 1 ? bytes.substring(0, bytes.length - 1) : bytes) * multiplier;
+}
+
+const body_size_limit = parse_body_size_limit(env('BODY_SIZE_LIMIT', '512K'));
 
 if (isNaN(body_size_limit)) {
 	throw new Error(


### PR DESCRIPTION
This PR adds unit suffixes support to the adapter-node `BODY_SIZE_LIMIT` environment variable.

Currently, achieving large byte values is only achievable with the exact byte value, and using exponents (like `1e6` to be parsed by Number) results in a byte value in base 10.

Nginx and Cloudflare both use base 2 for byte calculations (1024 based):
Nginx (source code): https://hg.nginx.org/nginx/file/default/src/core/ngx_parse.c
Cloudflare (forum question): https://community.cloudflare.com/t/is-max-upload-size-mb-1024-or-1000/239102

Adding unit suffixes to the byte values will make it easier to write and comprehend large byte values, as they can be written such as `100M` instead of `104857600`

Nginx also supports the size units `K` and `M` (https://nginx.org/en/docs/syntax.html) so it would be relevant for Sveltekit to support these units as well 

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
