### PR TITLE
fix: properly decode base64 strings inside `read`

### DIFF
--- a/.changeset/fluffy-schools-develop.md
+++ b/.changeset/fluffy-schools-develop.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: properly decode base64 strings inside `read`

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -1,6 +1,7 @@
 import { read_implementation, manifest } from '__sveltekit/server';
 import { base } from '__sveltekit/paths';
 import { DEV } from 'esm-env';
+import { b64_decode } from '../../utils.js';
 
 /**
  * Read the contents of an imported asset from the filesystem
@@ -30,7 +31,18 @@ export function read(asset) {
 		const [prelude, data] = asset.split(';');
 		const type = prelude.slice(5) || 'application/octet-stream';
 
-		const decoded = data.startsWith('base64,') ? atob(data.slice(7)) : decodeURIComponent(data);
+		if (data.startsWith('base64,')) {
+			const decoded = b64_decode(data.slice(7));
+
+			return new Response(decoded, {
+				headers: {
+					'Content-Length': decoded.byteLength.toString(),
+					'Content-Type': type
+				}
+			});
+		}
+
+		const decoded = decodeURIComponent(data);
 
 		return new Response(decoded, {
 			headers: {

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -1,5 +1,6 @@
 import { BROWSER, DEV } from 'esm-env';
 import { hash } from '../hash.js';
+import { b64_decode } from '../utils.js';
 
 let loading = 0;
 
@@ -76,22 +77,6 @@ if (DEV && BROWSER) {
 }
 
 const cache = new Map();
-
-/**
- * @param {string} text
- * @returns {ArrayBufferLike}
- */
-function b64_decode(text) {
-	const d = atob(text);
-
-	const u8 = new Uint8Array(d.length);
-
-	for (let i = 0; i < d.length; i++) {
-		u8[i] = d.charCodeAt(i);
-	}
-
-	return u8.buffer;
-}
 
 /**
  * Should be called on the initial run of load functions that hydrate the page.

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -1,6 +1,7 @@
 import { DEV } from 'esm-env';
 import { disable_search, make_trackable } from '../../../utils/url.js';
 import { validate_depends } from '../../shared.js';
+import { b64_encode } from '../../utils.js';
 
 /**
  * Calls the user's server `load` function.
@@ -205,25 +206,6 @@ export async function load_data({
 	}
 
 	return result ?? null;
-}
-
-/**
- * @param {ArrayBuffer} buffer
- * @returns {string}
- */
-function b64_encode(buffer) {
-	if (globalThis.Buffer) {
-		return Buffer.from(buffer).toString('base64');
-	}
-
-	const little_endian = new Uint8Array(new Uint16Array([1]).buffer)[0] > 0;
-
-	// The Uint16Array(Uint8Array(...)) ensures the code points are padded with 0's
-	return btoa(
-		new TextDecoder(little_endian ? 'utf-16le' : 'utf-16be').decode(
-			new Uint16Array(new Uint8Array(buffer))
-		)
-	);
 }
 
 /**

--- a/packages/kit/src/runtime/utils.js
+++ b/packages/kit/src/runtime/utils.js
@@ -1,0 +1,34 @@
+/**
+ * @param {string} text
+ * @returns {ArrayBufferLike}
+ */
+export function b64_decode(text) {
+	const d = atob(text);
+
+	const u8 = new Uint8Array(d.length);
+
+	for (let i = 0; i < d.length; i++) {
+		u8[i] = d.charCodeAt(i);
+	}
+
+	return u8.buffer;
+}
+
+/**
+ * @param {ArrayBuffer} buffer
+ * @returns {string}
+ */
+export function b64_encode(buffer) {
+	if (globalThis.Buffer) {
+		return Buffer.from(buffer).toString('base64');
+	}
+
+	const little_endian = new Uint8Array(new Uint16Array([1]).buffer)[0] > 0;
+
+	// The Uint16Array(Uint8Array(...)) ensures the code points are padded with 0's
+	return btoa(
+		new TextDecoder(little_endian ? 'utf-16le' : 'utf-16be').decode(
+			new Uint16Array(new Uint8Array(buffer))
+		)
+	);
+}

--- a/packages/kit/test/apps/basics/src/routes/read-file/auto.txt
+++ b/packages/kit/test/apps/basics/src/routes/read-file/auto.txt
@@ -1,1 +1,1 @@
-Imported without ?url
+Imported without ?url 😎

--- a/packages/kit/test/apps/basics/src/routes/read-file/url.txt
+++ b/packages/kit/test/apps/basics/src/routes/read-file/url.txt
@@ -1,1 +1,1 @@
-Imported with ?url
+Imported with ?url 😎

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -713,8 +713,9 @@ test.describe('$app/server', () => {
 		const auto = await page.textContent('[data-testid="auto"]');
 		const url = await page.textContent('[data-testid="url"]');
 
-		expect(auto.trim()).toBe('Imported without ?url');
-		expect(url.trim()).toBe('Imported with ?url');
+		// the emoji is there to check that base64 decoding works correctly
+		expect(auto.trim()).toBe('Imported without ?url 😎');
+		expect(url.trim()).toBe('Imported with ?url 😎');
 	});
 });
 


### PR DESCRIPTION
kind of incredible that `atob` and `btoa`, aside from the spectacularly shite naming, straight up don't work. clown shoes ass platform.

anyway, this fixes the weird characters identified in #11679. thanks @danielzsh and @tmarsik42 for the invaluable sleuthing here, this could have taken a while to figure out

~~ugh i guess i should add a test~~

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
