### PR TITLE
fix: default route config to `{}` for feature checking

### DIFF
--- a/.changeset/smart-jeans-repeat.md
+++ b/.changeset/smart-jeans-repeat.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: default route config to `{}` for feature checking

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -97,7 +97,7 @@ async function analyse({ manifest_path, manifest_data, server_manifest, tracked_
 			}
 		}
 
-		const route_config = page?.config ?? endpoint?.config;
+		const route_config = page?.config ?? endpoint?.config ?? {};
 		const prerender = page?.prerender ?? endpoint?.prerender;
 
 		if (prerender !== true) {


### PR DESCRIPTION
feature checking fails for a server route without an explicit config, if the feature-checking function assumes `config` is an object. this fixes it

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
