### PR TITLE
fix: respect `build.target` config supplied by user

### DIFF
--- a/.changeset/fluffy-insects-build.md
+++ b/.changeset/fluffy-insects-build.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: use Vite's default value for `build.target` and respect override supplied by user

--- a/documentation/docs/60-appendix/30-migrating-to-sveltekit-2.md
+++ b/documentation/docs/60-appendix/30-migrating-to-sveltekit-2.md
@@ -161,5 +161,3 @@ SvelteKit 2 requires Node `18.13` or higher, and the following minimum dependenc
 `svelte-migrate` will update your `package.json` for you.
 
 As part of the TypeScript upgrade, the generated `tsconfig.json` (the one your `tsconfig.json` extends from) now uses `"moduleResolution": "bundler"` (which is recommended by the TypeScript team, as it properly resolves types from packages with an `exports` map in package.json) and `verbatimModuleSyntax` (which replaces the existing `importsNotUsedAsValues ` and `preserveValueImports` flags — if you have those in your `tsconfig.json`, remove them. `svelte-migrate` will do this for you).
-
-SvelteKit 2 uses ES2022 features, which are supported in all modern browsers.

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -645,7 +645,7 @@ async function kit({ svelte_config }) {
 							preserveEntrySignatures: 'strict'
 						},
 						ssrEmitAssets: true,
-						target: ssr ? 'node18.13' : 'es2022'
+						target: ssr ? 'node18.13' : undefined
 					},
 					publicDir: kit.files.assets,
 					worker: {


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/11658

please review the question in https://github.com/sveltejs/kit/issues/11658#issuecomment-1900722813 while deciding whether this is safe