### PR TITLE
feat: support specifying the tsconfig in svelte-package

### DIFF
--- a/.changeset/clean-dots-switch.md
+++ b/.changeset/clean-dots-switch.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/package": minor
+---
+
+feat: add option to specify the tsconfig/jsconfig

--- a/documentation/docs/30-advanced/70-packaging.md
+++ b/documentation/docs/30-advanced/70-packaging.md
@@ -197,6 +197,7 @@ You should think carefully about whether or not the changes you make to your pac
 - `-i`/`--input` — the input directory which contains all the files of the package. Defaults to `src/lib`
 - `-o`/`--o` — the output directory where the processed files are written to. Your `package.json`'s `exports` should point to files inside there, and the `files` array should include that folder. Defaults to `dist`
 - `-t`/`--types` — whether or not to create type definitions (`d.ts` files). We strongly recommend doing this as it fosters ecosystem library quality. Defaults to `true`
+- `--tsconfig` - the path to a tsconfig or jsconfig. When not provided, searches for the next upper tsconfig/jsconfig in the workspace path.
 
 ## Publishing
 

--- a/packages/package/src/cli.js
+++ b/packages/package/src/cli.js
@@ -24,6 +24,10 @@ prog
 	.option('-o, --output', 'Output directory', 'dist')
 	.option('-t, --types', 'Emit type declarations', true)
 	.option('-w, --watch', 'Rerun when files change', false)
+	.option(
+		'--tsconfig',
+		'A path to a tsconfig or jsconfig file. When not provided, searches for the next upper tsconfig/jsconfig in the workspace path.'
+	)
 	.action(async (args) => {
 		try {
 			const config = await load_config();
@@ -42,6 +46,7 @@ prog
 				cwd: process.cwd(),
 				input: args.input ?? config.kit?.files?.lib ?? 'src/lib',
 				output: args.output,
+				tsconfig: args.tsconfig,
 				types: args.types,
 				config
 			};

--- a/packages/package/src/types.d.ts
+++ b/packages/package/src/types.d.ts
@@ -5,6 +5,7 @@ export interface Options {
 	input: string;
 	output: string;
 	types: boolean;
+	tsconfig?: string;
 	config: {
 		extensions?: string[];
 		kit?: {

--- a/packages/package/test/fixtures/tsconfig-specified/expected/runes.svelte.d.ts
+++ b/packages/package/test/fixtures/tsconfig-specified/expected/runes.svelte.d.ts
@@ -1,0 +1,1 @@
+export declare const x = true;

--- a/packages/package/test/fixtures/tsconfig-specified/expected/runes.svelte.js
+++ b/packages/package/test/fixtures/tsconfig-specified/expected/runes.svelte.js
@@ -1,0 +1,1 @@
+export const x = true;

--- a/packages/package/test/fixtures/tsconfig-specified/package.json
+++ b/packages/package/test/fixtures/tsconfig-specified/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "typescript",
+	"private": true,
+	"version": "1.0.0",
+	"description": "typescript package using esnext",
+	"type": "module",
+	"peerDependencies": {
+		"svelte": "^4.0.0"
+	},
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"svelte": "./dist/index.js"
+		}
+	}
+}

--- a/packages/package/test/fixtures/tsconfig-specified/src/lib/runes.svelte.ts
+++ b/packages/package/test/fixtures/tsconfig-specified/src/lib/runes.svelte.ts
@@ -1,0 +1,2 @@
+// a comment to delete
+export const x = true;

--- a/packages/package/test/fixtures/tsconfig-specified/svelte.config.js
+++ b/packages/package/test/fixtures/tsconfig-specified/svelte.config.js
@@ -1,0 +1,7 @@
+import preprocess from 'svelte-preprocess';
+
+export default {
+	preprocess: preprocess({
+		preserve: ['ld+json']
+	})
+};

--- a/packages/package/test/fixtures/tsconfig-specified/tsconfig.build.json
+++ b/packages/package/test/fixtures/tsconfig-specified/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"removeComments": true
+	}
+}

--- a/packages/package/test/fixtures/tsconfig-specified/tsconfig.json
+++ b/packages/package/test/fixtures/tsconfig-specified/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext"
+	}
+}

--- a/packages/package/test/index.js
+++ b/packages/package/test/index.js
@@ -151,6 +151,10 @@ test('SvelteKit interop', async () => {
 	await test_make_package('svelte-kit');
 });
 
+test('create package with tsconfig specified', async () => {
+	await test_make_package('tsconfig-specified', { tsconfig: 'tsconfig.build.json' });
+});
+
 // chokidar doesn't fire events in github actions :shrug:
 if (!process.env.CI) {
 	test('watches for changes', async () => {


### PR DESCRIPTION
<!-- Your PR description here -->

closes #9373

Adds the option `tsconfig` to svelte-package, allowing to specify which tsconfig / jsconfig to use during the packaging.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
