### PR TITLE
feat: configure error reporting when routes marked as prerendable wer…

### DIFF
--- a/.changeset/gentle-llamas-yawn.md
+++ b/.changeset/gentle-llamas-yawn.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": minor
+---
+
+feat: configure error reporting when routes marked as prerendable were not prerendered

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -239,6 +239,20 @@ const options = object(
 					}
 				),
 
+				handleNotPrerenderedRoutes: validate(
+					(/** @type {any} */ { message }) => {
+						throw new Error(
+							message +
+								'\nTo suppress or handle this error, implement `handleNotPrerenderedRoutes` in https://kit.svelte.dev/docs/configuration#prerender'
+						);
+					},
+					(input, keypath) => {
+						if (typeof input === 'function') return input;
+						if (['fail', 'warn', 'ignore'].includes(input)) return input;
+						throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
+					}
+				),
+
 				origin: validate('http://sveltekit-prerender', (input, keypath) => {
 					assert_string(input, keypath);
 

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -132,6 +132,15 @@ async function prerender({ out, manifest_path, metadata, verbose, env }) {
 		}
 	);
 
+	const handle_not_prerendered_route = normalise_error_handler(
+		log,
+		config.prerender.handleNotPrerenderedRoutes,
+		({ notPrerenderedRoutes }) => {
+			const list = notPrerenderedRoutes.map((id) => `  - ${id}`).join('\n');
+			return `The following routes were marked as prerenderable, but were not prerendered because they were not found while crawling your app:\n${list}\n\nSee https://kit.svelte.dev/docs/page-options#prerender-troubleshooting for info on how to solve this`;
+		}
+	);
+
 	const q = queue(config.prerender.concurrency);
 
 	/**
@@ -487,11 +496,7 @@ async function prerender({ out, manifest_path, metadata, verbose, env }) {
 	}
 
 	if (not_prerendered.length > 0) {
-		const list = not_prerendered.map((id) => `  - ${id}`).join('\n');
-
-		throw new Error(
-			`The following routes were marked as prerenderable, but were not prerendered because they were not found while crawling your app:\n${list}\n\nSee https://kit.svelte.dev/docs/page-options#prerender-troubleshooting for info on how to solve this`
-		);
+		handle_not_prerendered_route({ notPrerenderedRoutes: not_prerendered });
 	}
 
 	return { prerendered, prerender_map };

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -13,6 +13,7 @@ import {
 	PrerenderEntryGeneratorMismatchHandlerValue,
 	PrerenderHttpErrorHandlerValue,
 	PrerenderMissingIdHandlerValue,
+	PrerenderMissingRoutesHandlerValue,
 	PrerenderOption,
 	RequestOptions,
 	RouteSegment
@@ -583,6 +584,18 @@ export interface KitConfig {
 		 * @since 1.16.0
 		 */
 		handleEntryGeneratorMismatch?: PrerenderEntryGeneratorMismatchHandlerValue;
+		/**
+		 * How to respond when a route is marked as prerenderable but has not been prerendered.
+		 *
+		 * - `'fail'` — fail the build
+		 * - `'ignore'` - silently ignore the failure and continue
+		 * - `'warn'` — continue, but print a warning
+		 * - `(details) => void` — a custom error handler that takes a `details` object with `notPrerenderedRoutes` property. If you `throw` from this function, the build will fail
+		 *
+		 * @default "fail"
+		 * @since 2.5.0
+		 */
+		handleNotPrerenderedRoutes?: PrerenderMissingRoutesHandlerValue;
 		/**
 		 * The value of `url.origin` during prerendering; useful if it is included in rendered content.
 		 * @default "http://sveltekit-prerender"

--- a/packages/kit/src/types/private.d.ts
+++ b/packages/kit/src/types/private.d.ts
@@ -209,8 +209,17 @@ export interface PrerenderEntryGeneratorMismatchHandler {
 	(details: { generatedFromId: string; entry: string; matchedId: string; message: string }): void;
 }
 
+export interface PrerenderEntryMissingRoutesHandler {
+	(details: { notPrerenderedRoutes: string[]; message: string }): void;
+}
+
 export type PrerenderHttpErrorHandlerValue = 'fail' | 'warn' | 'ignore' | PrerenderHttpErrorHandler;
 export type PrerenderMissingIdHandlerValue = 'fail' | 'warn' | 'ignore' | PrerenderMissingIdHandler;
+export type PrerenderMissingRoutesHandlerValue =
+	| 'fail'
+	| 'warn'
+	| 'ignore'
+	| PrerenderEntryMissingRoutesHandler;
 export type PrerenderEntryGeneratorMismatchHandlerValue =
 	| 'fail'
 	| 'warn'

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -566,6 +566,18 @@ declare module '@sveltejs/kit' {
 			 */
 			handleEntryGeneratorMismatch?: PrerenderEntryGeneratorMismatchHandlerValue;
 			/**
+			 * How to respond when a route is marked as prerenderable but has not been prerendered.
+			 *
+			 * - `'fail'` — fail the build
+			 * - `'ignore'` - silently ignore the failure and continue
+			 * - `'warn'` — continue, but print a warning
+			 * - `(details) => void` — a custom error handler that takes a `details` object with `notPrerenderedRoutes` property. If you `throw` from this function, the build will fail
+			 *
+			 * @default "fail"
+			 * @since 2.5.0
+			 */
+			handleNotPrerenderedRoutes?: PrerenderMissingRoutesHandlerValue;
+			/**
 			 * The value of `url.origin` during prerendering; useful if it is included in rendered content.
 			 * @default "http://sveltekit-prerender"
 			 */
@@ -1538,8 +1550,17 @@ declare module '@sveltejs/kit' {
 		(details: { generatedFromId: string; entry: string; matchedId: string; message: string }): void;
 	}
 
+	interface PrerenderEntryMissingRoutesHandler {
+		(details: { notPrerenderedRoutes: string[]; message: string }): void;
+	}
+
 	type PrerenderHttpErrorHandlerValue = 'fail' | 'warn' | 'ignore' | PrerenderHttpErrorHandler;
 	type PrerenderMissingIdHandlerValue = 'fail' | 'warn' | 'ignore' | PrerenderMissingIdHandler;
+	type PrerenderMissingRoutesHandlerValue =
+		| 'fail'
+		| 'warn'
+		| 'ignore'
+		| PrerenderEntryMissingRoutesHandler;
 	type PrerenderEntryGeneratorMismatchHandlerValue =
 		| 'fail'
 		| 'warn'


### PR DESCRIPTION
Closes #11697 

Add a prerender option `handleNotPrerenderedRoutes` to be able to configure the error reporting when routes were marked as prerenderable, but were not prerendered.

<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
