### PR TITLE
docs: address TypeScript issue in migration guide

### DIFF
--- a/documentation/docs/60-appendix/30-migrating-to-sveltekit-2.md
+++ b/documentation/docs/60-appendix/30-migrating-to-sveltekit-2.md
@@ -68,7 +68,7 @@ export function load({ fetch }) {
 
 ## goto(...) changes
 
-`goto(...)` no longer accepts external URLs. To navigate to an external URL, use `window.location = url`. The `state` object now determines `$page.state` and must adhere to the `App.PageState` interface, if declared. See [shallow routing](shallow-routing) for more details.
+`goto(...)` no longer accepts external URLs. To navigate to an external URL, use `window.location.href = url`. The `state` object now determines `$page.state` and must adhere to the `App.PageState` interface, if declared. See [shallow routing](shallow-routing) for more details.
 
 ## paths are now relative by default
 


### PR DESCRIPTION
https://stackoverflow.com/questions/75194714/window-location-type-string-is-not-assignable-to-type-location-stri