### PR TITLE
fix: ignore bodies sent with non-PUT/PATCH/POST requests 

### DIFF
--- a/.changeset/smooth-kids-cover.md
+++ b/.changeset/smooth-kids-cover.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: ignore bodies sent with non-PUT/PATCH/POST requests

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -95,8 +95,6 @@ function get_raw_body(req, body_size_limit) {
 	});
 }
 
-const can_have_body = ['POST', 'PUT', 'PATCH'];
-
 /**
  * @param {{
  *   request: import('http').IncomingMessage;
@@ -111,9 +109,10 @@ export async function getRequest({ request, base, bodySizeLimit }) {
 		duplex: 'half',
 		method: request.method,
 		headers: /** @type {Record<string, string>} */ (request.headers),
-		body: can_have_body.includes(request.method ?? '')
-			? get_raw_body(request, bodySizeLimit)
-			: undefined
+		body:
+			request.method === 'POST' || request.method === 'PUT' || request.method === 'PATCH'
+				? get_raw_body(request, bodySizeLimit)
+				: undefined
 	});
 }
 

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -95,6 +95,8 @@ function get_raw_body(req, body_size_limit) {
 	});
 }
 
+const can_have_body = ['POST', 'PUT', 'PATCH'];
+
 /**
  * @param {{
  *   request: import('http').IncomingMessage;
@@ -109,7 +111,9 @@ export async function getRequest({ request, base, bodySizeLimit }) {
 		duplex: 'half',
 		method: request.method,
 		headers: /** @type {Record<string, string>} */ (request.headers),
-		body: get_raw_body(request, bodySizeLimit)
+		body: can_have_body.includes(request.method ?? '')
+			? get_raw_body(request, bodySizeLimit)
+			: undefined
 	});
 }
 


### PR DESCRIPTION
Right now, it's possible to crash a Node server by including a body with a `GET` request. This fixes it

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
