### PR TITLE
fix: only disallow body with GET/HEAD requests

### DIFF
--- a/.changeset/four-insects-play.md
+++ b/.changeset/four-insects-play.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: only disallow body with GET/HEAD

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -110,9 +110,9 @@ export async function getRequest({ request, base, bodySizeLimit }) {
 		method: request.method,
 		headers: /** @type {Record<string, string>} */ (request.headers),
 		body:
-			request.method === 'POST' || request.method === 'PUT' || request.method === 'PATCH'
-				? get_raw_body(request, bodySizeLimit)
-				: undefined
+			request.method === 'GET' || request.method === 'HEAD'
+				? undefined
+				: get_raw_body(request, bodySizeLimit)
 	});
 }
 


### PR DESCRIPTION
Apparently people are sending bodies with their `DELETE` requests, and #11708 was a breaking change as a result. This changes it to just ignore bodies for `GET` and `HEAD`, since that's what causes Undici to lose its cool.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
