### PR TITLE
fix: strip `/@fs` prefix correctly on Windows when invoking `read()` in dev mode

### DIFF
--- a/.changeset/fresh-points-smoke.md
+++ b/.changeset/fresh-points-smoke.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: strip `/@fs` prefix correctly on Windows when invoking `read()` in dev mode

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -8,7 +8,7 @@ import { isCSSRequest, loadEnv, buildErrorMessage } from 'vite';
 import { createReadableStream, getRequest, setResponse } from '../../../exports/node/index.js';
 import { installPolyfills } from '../../../exports/node/polyfills.js';
 import { coalesce_to_error } from '../../../utils/error.js';
-import { posixify, resolve_entry, to_fs } from '../../../utils/filesystem.js';
+import { from_fs, posixify, resolve_entry, to_fs } from '../../../utils/filesystem.js';
 import { load_error_page } from '../../../core/config/index.js';
 import { SVELTE_KIT_ASSETS } from '../../../constants.js';
 import * as sync from '../../../core/sync/sync.js';
@@ -87,7 +87,7 @@ export async function dev(vite, vite_config, svelte_config) {
 
 	/** @param {string} id */
 	async function resolve(id) {
-		const url = id.startsWith('..') ? `/@fs${path.posix.resolve(id)}` : `/${id}`;
+		const url = id.startsWith('..') ? to_fs(path.posix.resolve(id)) : `/${id}`;
 
 		const module = await loud_ssr_load_module(url);
 
@@ -137,8 +137,8 @@ export async function dev(vite, vite_config, svelte_config) {
 				server_assets: new Proxy(
 					{},
 					{
-						has: (_, /** @type {string} */ file) => fs.existsSync(file.replace(/^\/@fs/, '')),
-						get: (_, /** @type {string} */ file) => fs.statSync(file.replace(/^\/@fs/, '')).size
+						has: (_, /** @type {string} */ file) => fs.existsSync(from_fs(file)),
+						get: (_, /** @type {string} */ file) => fs.statSync(from_fs(file)).size
 					}
 				),
 				nodes: manifest_data.nodes.map((node, index) => {
@@ -490,7 +490,7 @@ export async function dev(vite, vite_config, svelte_config) {
 
 				await server.init({
 					env,
-					read: (file) => createReadableStream(file.replace(/^\/@fs/, ''))
+					read: (file) => createReadableStream(from_fs(file))
 				});
 
 				const request = await getRequest({

--- a/packages/kit/src/utils/filesystem.js
+++ b/packages/kit/src/utils/filesystem.js
@@ -149,6 +149,19 @@ export function to_fs(str) {
 }
 
 /**
+ * Removes `/@fs` prefix from given path and posixifies it
+ * @param {string} str
+ */
+export function from_fs(str) {
+	str = posixify(str);
+	if (!str.startsWith('/@fs')) return str;
+
+	str = str.slice(4);
+	// Windows/Linux separation - Windows starts with a drive letter, we need to strip the additional / here
+	return str[2] === ':' && /[A-Z]/.test(str[1]) ? str.slice(1) : str;
+}
+
+/**
  * Given an entry point like [cwd]/src/hooks, returns a filename like [cwd]/src/hooks.js or [cwd]/src/hooks/index.js
  * @param {string} entry
  * @returns {string|null}

--- a/packages/kit/test/apps/basics/src/routes/read-file/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/read-file/+page.server.js
@@ -3,6 +3,11 @@ import { read } from '$app/server';
 import auto from './auto.txt';
 import url from './url.txt?url';
 
+const glob = import.meta.glob('../../../../read-file-test.txt', {
+	as: 'url',
+	eager: true
+});
+
 export async function load() {
 	if (!dev && !auto.startsWith('data:')) {
 		throw new Error('expected auto.txt to be inlined');
@@ -10,6 +15,7 @@ export async function load() {
 
 	return {
 		auto: await read(auto).text(),
-		url: await read(url).text()
+		url: await read(url).text(),
+		glob: await read(Object.values(glob)[0]).text()
 	};
 }

--- a/packages/kit/test/apps/basics/src/routes/read-file/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/read-file/+page.svelte
@@ -4,3 +4,4 @@
 
 <p data-testid="auto">{data.auto}</p>
 <p data-testid="url">{data.url}</p>
+<p data-testid="glob">{data.glob}</p>

--- a/packages/kit/test/apps/basics/test/cross-platform/test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/test.js
@@ -1033,3 +1033,20 @@ test.describe('XSS', () => {
 		);
 	});
 });
+
+test.describe('$app/server', () => {
+	test('can read a file', async ({ page }) => {
+		await page.goto('/read-file');
+
+		const auto = await page.textContent('[data-testid="auto"]');
+		const url = await page.textContent('[data-testid="url"]');
+		const glob = await page.textContent('[data-testid="glob"]');
+
+		// the emoji is there to check that base64 decoding works correctly
+		expect(auto.trim()).toBe('Imported without ?url 😎');
+		expect(url.trim()).toBe('Imported with ?url 😎');
+		expect(glob.trim()).toBe(
+			'Imported with url glob from the read-file test in basics. Placed here outside the app folder to force a /@fs prefix 😎'
+		);
+	});
+});

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -706,19 +706,6 @@ test.describe('$app/paths', () => {
 	});
 });
 
-test.describe('$app/server', () => {
-	test('can read a file', async ({ page }) => {
-		await page.goto('/read-file');
-
-		const auto = await page.textContent('[data-testid="auto"]');
-		const url = await page.textContent('[data-testid="url"]');
-
-		// the emoji is there to check that base64 decoding works correctly
-		expect(auto.trim()).toBe('Imported without ?url 😎');
-		expect(url.trim()).toBe('Imported with ?url 😎');
-	});
-});
-
 test.describe('$app/stores', () => {
 	test('can access page.url', async ({ baseURL, page }) => {
 		await page.goto('/origin');

--- a/packages/kit/test/apps/read-file-test.txt
+++ b/packages/kit/test/apps/read-file-test.txt
@@ -1,0 +1,1 @@
+Imported with url glob from the read-file test in basics. Placed here outside the app folder to force a /@fs prefix 😎


### PR DESCRIPTION
Windows absolute paths look like `/@fs/C:/..` - when stripping the fs prefix, we need to remove the additional slash after the fs

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
