### PR TITLE
chore: clean up emulator types

### DIFF
--- a/packages/kit/src/core/adapt/index.js
+++ b/packages/kit/src/core/adapt/index.js
@@ -19,7 +19,8 @@ export async function adapt(
 	log,
 	vite_config
 ) {
-	const { name, adapt } = config.kit.adapter;
+	// This is only called when adapter is truthy, so the cast is safe
+	const { name, adapt } = /** @type {import('@sveltejs/kit').Adapter} */ (config.kit.adapter);
 
 	console.log(colors.bold().cyan(`\n> Using ${name}`));
 

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -268,7 +268,7 @@ export interface Cookies {
 /**
  * A collection of functions that influence the environment during dev, build and prerendering
  */
-export class Emulator {
+export interface Emulator {
 	/**
 	 * A function that is called with the current route `config` and `prerender` option
 	 * and returns an `App.Platform` object

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -419,8 +419,6 @@ export async function dev(vite, vite_config, svelte_config) {
 	});
 
 	const env = loadEnv(vite_config.mode, svelte_config.kit.env.dir, '');
-
-	// TODO because of `RecursiveRequired`, TypeScript thinks this is guaranteed to exist, but it isn't
 	const emulator = await svelte_config.kit.adapter?.emulate?.();
 
 	return () => {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -164,7 +164,6 @@ export async function sveltekit() {
 		preprocess,
 		onwarn: svelte_config.onwarn,
 		compilerOptions: {
-			// @ts-expect-error SvelteKit requires hydratable true by default
 			hydratable: isSvelte5Plus() ? undefined : true,
 			...svelte_config.compilerOptions
 		},

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -51,7 +51,6 @@ export async function preview(vite, vite_config, svelte_config) {
 		read: (file) => createReadableStream(`${dir}/${file}`)
 	});
 
-	// TODO because of `RecursiveRequired`, TypeScript thinks this is guaranteed to exist, but it isn't
 	const emulator = await svelte_config.kit.adapter?.emulate?.();
 
 	return () => {

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -437,7 +437,7 @@ export interface Uses {
 
 export type ValidatedConfig = Config & {
 	kit: ValidatedKitConfig;
-	extensions: Required<Config['extensions']>;
+	extensions: string[];
 };
 
 export type ValidatedKitConfig = Omit<RecursiveRequired<KitConfig>, 'adapter'> & {

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -16,7 +16,8 @@ import {
 	Reroute,
 	RequestEvent,
 	SSRManifest,
-	Emulator
+	Emulator,
+	Adapter
 } from '@sveltejs/kit';
 import {
 	HttpMethod,
@@ -434,9 +435,11 @@ export interface Uses {
 	search_params: Set<string>;
 }
 
-export type ValidatedConfig = RecursiveRequired<Config>;
+export type ValidatedConfig = Omit<RecursiveRequired<Config>, 'kit'> & { kit: ValidatedKitConfig };
 
-export type ValidatedKitConfig = RecursiveRequired<KitConfig>;
+export type ValidatedKitConfig = Omit<RecursiveRequired<KitConfig>, 'adapter'> & {
+	adapter?: Adapter;
+};
 
 export * from '../exports/index.js';
 export * from './private.js';

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -435,7 +435,10 @@ export interface Uses {
 	search_params: Set<string>;
 }
 
-export type ValidatedConfig = Omit<RecursiveRequired<Config>, 'kit'> & { kit: ValidatedKitConfig };
+export type ValidatedConfig = Config & {
+	kit: ValidatedKitConfig;
+	extensions: Required<Config['extensions']>;
+};
 
 export type ValidatedKitConfig = Omit<RecursiveRequired<KitConfig>, 'adapter'> & {
 	adapter?: Adapter;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1748,7 +1748,10 @@ declare module '@sveltejs/kit' {
 		endpoint_id?: string;
 	}
 
-	type ValidatedConfig = Omit<RecursiveRequired<Config>, 'kit'> & { kit: ValidatedKitConfig };
+	type ValidatedConfig = Config & {
+		kit: ValidatedKitConfig;
+		extensions: Required<Config['extensions']>;
+	};
 
 	type ValidatedKitConfig = Omit<RecursiveRequired<KitConfig>, 'adapter'> & {
 		adapter?: Adapter;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1750,7 +1750,7 @@ declare module '@sveltejs/kit' {
 
 	type ValidatedConfig = Config & {
 		kit: ValidatedKitConfig;
-		extensions: Required<Config['extensions']>;
+		extensions: string[];
 	};
 
 	type ValidatedKitConfig = Omit<RecursiveRequired<KitConfig>, 'adapter'> & {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -250,7 +250,7 @@ declare module '@sveltejs/kit' {
 	/**
 	 * A collection of functions that influence the environment during dev, build and prerendering
 	 */
-	export class Emulator {
+	export interface Emulator {
 		/**
 		 * A function that is called with the current route `config` and `prerender` option
 		 * and returns an `App.Platform` object
@@ -1748,7 +1748,11 @@ declare module '@sveltejs/kit' {
 		endpoint_id?: string;
 	}
 
-	type ValidatedConfig = RecursiveRequired<Config>;
+	type ValidatedConfig = Omit<RecursiveRequired<Config>, 'kit'> & { kit: ValidatedKitConfig };
+
+	type ValidatedKitConfig = Omit<RecursiveRequired<KitConfig>, 'adapter'> & {
+		adapter?: Adapter;
+	};
 	/**
 	 * Throws an error with a HTTP status code and an optional message.
 	 * When called during request handling, this will cause SvelteKit to


### PR DESCRIPTION
- the Emulator type is not a class export
- make validated config types more correct by leaving adapter types as optional

Leftovers from #11730, no changeset because the thing is not released yet.
Through this I noticed that `export class Server` is similarly incorrect; I guess it just doesn't matter really in practise because only adapters use that for their types.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
