### PR TITLE
feat: atomic builds in `adapter-cloudflare`

### DIFF
--- a/.changeset/fair-apricots-change.md
+++ b/.changeset/fair-apricots-change.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-cloudflare": minor
+---
+
+feat: adapter-cloudflare uses atomic builds


### PR DESCRIPTION
Before this PR, when building `adapter-cloudflare` first removes the build directory, then initiates a build.

When using [workers-sdk](https://github.com/cloudflare/workers-sdk) alongside sveltekit this leads to lots of error messages when watching and rebuilding, first due to files not existing, and then due to incomplete builds. This creates lots of output of transient errors in the console confusing the development process (especially for beginners), and also hides any real issues behind a wall of non-errors.

This PR updates the build behaviour to leave the existing build in place while building to a new temporary build location. When the build finishes, the final build destination is removed and the temporary build directory is renamed to take the place of the final build destination.

This fixes all of the transient error outputs during rebuilds. I'm working on fixes to workers-sdk as well which should further smooth the integration between these two projects.

Let me know if you have any questions or feedback, I'm all ears!

Magnus

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
