### PR TITLE
fix: handling 404 when redirect from +layout.ts in SPA mode

### DIFF
--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1069,10 +1069,7 @@ async function load_root_error_page({ status, error, url, route }) {
 		data: null
 	};
 
-	const branch = [];
-	if (Object.keys(params).length == 0) {
-		branch.push(root_error);
-	} else {
+	try {
 		const root_layout = await load_node({
 			loader: default_layout_loader,
 			url,
@@ -1082,17 +1079,24 @@ async function load_root_error_page({ status, error, url, route }) {
 			server_data_node: create_data_node(server_data_node)
 		});
 
-		branch.push(root_layout, root_error);
+		return await get_navigation_result_from_branch({
+			url,
+			params,
+			branch: [root_layout, root_error],
+			status,
+			error,
+			route: null
+		});
+	} catch (err) {
+		return await get_navigation_result_from_branch({
+			url,
+			params,
+			branch: [root_error],
+			status,
+			error,
+			route: null
+		});
 	}
-
-	return await get_navigation_result_from_branch({
-		url,
-		params,
-		branch,
-		status,
-		error,
-		route: null
-	});
 }
 
 /**

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1060,15 +1060,6 @@ async function load_root_error_page({ status, error, url, route }) {
 		}
 	}
 
-	const root_layout = await load_node({
-		loader: default_layout_loader,
-		url,
-		params,
-		route,
-		parent: () => Promise.resolve({}),
-		server_data_node: create_data_node(server_data_node)
-	});
-
 	/** @type {import('./types.js').BranchNode} */
 	const root_error = {
 		node: await default_error_loader(),
@@ -1078,10 +1069,26 @@ async function load_root_error_page({ status, error, url, route }) {
 		data: null
 	};
 
+	const branch = [];
+	if (Object.keys(params).length == 0) {
+		branch.push(root_error);
+	} else {
+		const root_layout = await load_node({
+			loader: default_layout_loader,
+			url,
+			params,
+			route,
+			parent: () => Promise.resolve({}),
+			server_data_node: create_data_node(server_data_node)
+		});
+
+		branch.push(root_layout, root_error);
+	}
+
 	return await get_navigation_result_from_branch({
 		url,
 		params,
-		branch: [root_layout, root_error],
+		branch,
 		status,
 		error,
 		route: null

--- a/packages/kit/test/apps/no-ssr/src/routes/+layout.js
+++ b/packages/kit/test/apps/no-ssr/src/routes/+layout.js
@@ -1,1 +1,10 @@
+import { redirect } from '@sveltejs/kit';
+
 export const ssr = false;
+
+export async function load({ route }) {
+	//@ts-ignore
+	if (route.id == '/bad-route' || route.id == '/good-route') {
+		throw redirect(302, '/');
+	}
+}

--- a/packages/kit/test/apps/no-ssr/test/test.js
+++ b/packages/kit/test/apps/no-ssr/test/test.js
@@ -13,3 +13,12 @@ test('navigating to a non-existent route renders the default error page', async 
 	await page.waitForLoadState('networkidle');
 	expect(await page.textContent('h1')).toBe('404');
 });
+
+test('error occur in load function at root layout renders the default error page', async ({
+	page
+}) => {
+	test.setTimeout(3000);
+	await page.goto('/bad-route');
+	await page.waitForLoadState('networkidle');
+	expect(await page.textContent('h1')).toBe('404');
+});


### PR DESCRIPTION
<!-- Your PR description here -->
fixes  #11099

When redirect to an unknow route in SPA mode, which has a root load function in `+layout.ts`, it will fallback to the root `+error.svelte` instead of a blank page.
Issue #11494 seems to be releated 

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
