### PR TITLE
fix: truncated comment when running create-svelte

### DIFF
--- a/.changeset/sweet-weeks-pretend.md
+++ b/.changeset/sweet-weeks-pretend.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+docs: update comment about path aliases

--- a/packages/create-svelte/shared/+checkjs/jsconfig.json
+++ b/packages/create-svelte/shared/+checkjs/jsconfig.json
@@ -11,7 +11,8 @@
 		"strict": true,
 		"moduleResolution": "bundler"
 	}
-	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias and https://kit.svelte.dev/docs/configuration#files
+	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
+	// except $lib which is handled by https://kit.svelte.dev/docs/configuration#files
 	//
 	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
 	// from the referenced tsconfig.json - TypeScript does not merge them in

--- a/packages/create-svelte/shared/+typescript/tsconfig.json
+++ b/packages/create-svelte/shared/+typescript/tsconfig.json
@@ -11,7 +11,8 @@
 		"strict": true,
 		"moduleResolution": "bundler"
 	}
-	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias and https://kit.svelte.dev/docs/configuration#files
+	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
+	// except $lib which is handled by https://kit.svelte.dev/docs/configuration#files
 	//
 	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
 	// from the referenced tsconfig.json - TypeScript does not merge them in

--- a/packages/create-svelte/shared/+typescript/tsconfig.json
+++ b/packages/create-svelte/shared/+typescript/tsconfig.json
@@ -11,7 +11,7 @@
 		"strict": true,
 		"moduleResolution": "bundler"
 	}
-	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
+	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias and https://kit.svelte.dev/docs/configuration#files
 	//
 	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
 	// from the referenced tsconfig.json - TypeScript does not merge them in


### PR DESCRIPTION
When running create-svelte, I noticed that the Typescript generated project had a comment truncated compared to an identical JSDoc generated project. I've added the truncated portion as there's no indication that this was intention in the original commit, 9b24b9c. I've included a screenshot of that commit to make it clear (you can see how the jsconfig has both links, but the tsconfig has only the one.)

<img width="1084" alt="Screenshot 2024-02-02 at 1 43 26 PM" src="https://github.com/sveltejs/kit/assets/1836017/d48d73c9-d630-4141-aaee-0fe51f7927c8">

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
