### PR TITLE
fix: allow mutation of data and form props in Svelte 5

### DIFF
--- a/.changeset/selfish-seas-change.md
+++ b/.changeset/selfish-seas-change.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: allow mutation of data and form props in Svelte 5

--- a/packages/kit/src/core/sync/write_root.js
+++ b/packages/kit/src/core/sync/write_root.js
@@ -21,16 +21,22 @@ export function write_root(manifest_data, output) {
 
 	let l = max_depth;
 
-	let pyramid = `<svelte:component this={constructors[${l}]} bind:this={components[${l}]} data={data_${l}} {form} />`;
+	let pyramid = `<svelte:component this={constructors[${l}]} bind:this={components[${l}]} ${
+		isSvelte5Plus() ? `bind:data={data_${l}} bind:form` : `data={data_${l}} {form}`
+	} />`;
 
 	while (l--) {
 		pyramid = dedent`
 			{#if constructors[${l + 1}]}
-				<svelte:component this={constructors[${l}]} bind:this={components[${l}]} data={data_${l}}>
+				<svelte:component this={constructors[${l}]} bind:this={components[${l}]} ${
+					isSvelte5Plus() ? `bind:data={data_${l}}` : `data={data_${l}}`
+				}>
 					${pyramid}
 				</svelte:component>
 			{:else}
-				<svelte:component this={constructors[${l}]} bind:this={components[${l}]} data={data_${l}} {form} />
+				<svelte:component this={constructors[${l}]} bind:this={components[${l}]} ${
+					isSvelte5Plus() ? `bind:data={data_${l}} bind:form` : `data={data_${l}} {form}`
+				} />
 			{/if}
 		`;
 	}


### PR DESCRIPTION
By doing `bind:data/form`, the layout/child components are allowed to mutate those properties
Related https://github.com/sveltejs/svelte/issues/9905 / https://github.com/sveltejs/svelte/issues/10084

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
