### PR TITLE
fix: invalidate parent load functions

### DIFF
--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -318,7 +318,6 @@ async function _invalidate() {
 		}
 	}
 
-	invalidated.length = 0;
 }
 
 /** @param {number} index */
@@ -753,8 +752,10 @@ function has_changed(
 		if (params[param] !== current.params[param]) return true;
 	}
 
-	for (const href of uses.dependencies) {
-		if (invalidated.some((fn) => fn(new URL(href)))) return true;
+	if (!parent_changed) {
+		for (const href of uses.dependencies) {
+			if (invalidated.some((fn) => fn(new URL(href)))) return true;
+		}
 	}
 
 	return false;


### PR DESCRIPTION
Fixes: https://github.com/sveltejs/kit/issues/11696

also probably
https://github.com/sveltejs/kit/issues/11635
https://github.com/sveltejs/kit/issues/11663
https://github.com/sveltejs/kit/issues/11446
https://github.com/sveltejs/kit/issues/10209
https://github.com/sveltejs/kit/issues/10123
https://github.com/sveltejs/kit/issues/10457
https://github.com/sveltejs/kit/issues/10359
https://github.com/sveltejs/kit/issues/11745

See context: https://github.com/sveltejs/kit/pull/11268#issuecomment-1894232508

Most likely https://github.com/sveltejs/kit/pull/11268 introduced this behavior that is a blocker preventing an upgrade to SvelteKit2 for any project using "parent invalidation".

Draft status as it needs 2 tests: 
-  double invalidation (https://github.com/sveltejs/kit/issues/10359), is it technically possible to test this? 
-  parent invalidation synchronization   

I would like to dig into the tests but could someone confirm this PR is on the right tracks? 

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
