### PR TITLE
docs: add tip when mixing universal and server load

### DIFF
--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -216,6 +216,8 @@ export async function load({ data }) {
 }
 ```
 
+> It's important to not modify `data` to include any non-serializable objects since it will be processed by the **server** `load` after the **universal** `load` returns.
+
 ## Using URL data
 
 Often the `load` function depends on the URL in one way or another. For this, the `load` function provides you with `url`, `route` and `params`.


### PR DESCRIPTION
Relates to #11458

- Since modifying `data` to include non-serializable POJOs (such as components) will throw an error, this change provides a hint for users not to do that.

I came across an issue on Discord where someone tried using dynamic `import()` to load a component and pass it to `data` in the universal load:

```js
export async function load({ data }) {
  data.component = (await import('$lib/components/Button.svelte')).default
  return data
  //     ^ error
}
```

This threw an error along the lines of "cannot return non-serializable POJOs" since `data` was being returned by the server `load` in `+page.server.js`. Hopefully my contribution to the docs helps point out this lesser-known nuance.

I see this as a nice-to-have, so I'll understand if you don't wish to merge it.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
