### PR TITLE
fix: path missing in first item of "On this page" component for Docs site

### DIFF
--- a/sites/kit.svelte.dev/src/lib/server/docs/index.js
+++ b/sites/kit.svelte.dev/src/lib/server/docs/index.js
@@ -63,6 +63,8 @@ for (const [file, asset] of Object.entries(markdown)) {
 		category: category.title,
 		title,
 		file: `${category_dir}/${basename}`,
+		slug,
+		path: slug,
 		sections: await get_sections(body),
 		body
 	};
@@ -78,6 +80,8 @@ export async function get_parsed_docs(slug) {
 		category: page.category,
 		title: page.title,
 		file: page.file,
+		path: page.path,
+		slug: page.slug,
 		sections: page.sections,
 		content: await render_content(page.file, page.body)
 	};


### PR DESCRIPTION

Add some missing properties for the correct creation of href for the first items of "On this page" component of the [Sveltekit Docs](https://kit.svelte.dev/docs/introduction). Currently doesn't create that reference in the first item and prevent navigation to the top of the page.

More info on [issue](https://github.com/sveltejs/kit/issues/11830)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
Only affects website

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

🥹Junior dev PR
> I'm not sure how to do that. I've done it manually and I hope is done properly.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
