### PR TITLE
fix: `@sveltejs/enhanced-img` allow the usage of variables / template literals for the src attribute

### DIFF
--- a/packages/enhanced-img/src/preprocessor.js
+++ b/packages/enhanced-img/src/preprocessor.js
@@ -46,8 +46,9 @@ export function image(opts) {
 			 * @returns {Promise<void>}
 			 */
 			async function update_element(node, src_attribute) {
+				const { expression } = src_attribute;
 				// TODO: this will become ExpressionTag in Svelte 5
-				if (src_attribute.type === 'MustacheTag') {
+				if (src_attribute.type === 'MustacheTag' && expression.type !== 'Literal' && expression.type !== 'TemplateLiteral') {
 					const src_var_name = content
 						.substring(src_attribute.start + 1, src_attribute.end - 1)
 						.trim();
@@ -55,7 +56,17 @@ export function image(opts) {
 					return;
 				}
 
-				const original_url = src_attribute.raw.trim();
+				let original_url = '';
+				if (src_attribute.type === 'Text') {
+					original_url = src_attribute.raw.trim();
+				} else if (expression.type === 'Literal') {
+					original_url = expression.value.trim();
+				} else if (expression.type === 'TemplateLiteral') {
+					throw new Error(`Template literals are not supported in src attributes. Please use a string literal or a dynamically imported image.`);
+				} else {
+					throw new Error(`Could not locate image. Please ensure that the src attribute contains a dynamically imported image or a string literal pointing to one.`);
+				}
+
 				let url = original_url;
 
 				const sizes = get_attr_value(node, 'sizes');

--- a/packages/enhanced-img/test/Input.svelte
+++ b/packages/enhanced-img/test/Input.svelte
@@ -5,6 +5,9 @@
 	const images = [manual_image1, manual_image2];
 
 	let foo: string = 'bar';
+	let imagePath: string = './foo.png';
+	let imageName: string = 'foo';
+	let imageExt: string = 'png';
 </script>
 
 {foo}
@@ -12,6 +15,15 @@
 <img src="./foo.png" alt="non-enhanced test" />
 
 <enhanced:img src="./foo.png" alt="basic test" />
+
+<enhanced:img src={'./foo.png'} alt="basic test passing src as literal" />
+
+<enhanced:img src={imagePath} alt="basic test passing src by variable" />
+
+<enhanced:img
+	src={`./${imageName}.${imageExt}`}
+	alt="basic test passing src using template literal"
+/>
 
 <enhanced:img src="./foo.png" width="5" height="10" alt="dimensions test" />
 

--- a/packages/enhanced-img/test/Output.svelte
+++ b/packages/enhanced-img/test/Output.svelte
@@ -8,6 +8,7 @@
 	const images = [manual_image1, manual_image2];
 
 	let foo: string = 'bar';
+	let imagePath: string = './foo.png';
 </script>
 
 {foo}
@@ -15,6 +16,12 @@
 <img src="./foo.png" alt="non-enhanced test" />
 
 <picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src="/7" alt="basic test" width=1440 height=1440 /></picture>
+
+<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src="/7" alt="basic test passing src as literal" width=1440 height=1440 /></picture>
+
+<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src="/7" alt="basic test passing src by variable" width=1440 height=1440 /></picture>
+
+<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src="/7" alt="basic test passing src using template literal" width=1440 height=1440 /></picture>
 
 <picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src="/7" width="5" height="10" alt="dimensions test" width=1440 height=1440 /></picture>
 


### PR DESCRIPTION
I noticed that it's not possible to pass a variable or a template literal to the `src` property of the `enhanced:img` component. There's already an issue addressing this: #11535 

I created a [repository](https://github.com/flippbit/sveltekit-enhanced-img-issues/blob/40736b71b8c76a1a6dc96415cf331001cb628146/src/routes/%2Bpage.svelte) with some use cases, which are currently not working:

```svelte
<script lang="ts">
    import svelteLogo from '../images/svelte-logo-square.png?enhanced';
    const fileName = "svelte-logo-square";
    const fileExtension = "png";
    const pathToFileTemplate = `../images/${fileName}.${fileExtension}`;
    const pathToFile = '../images/svelte-logo-square.png';
</script>

<div>
    <!-- these work fine -->
    <enhanced:img src={svelteLogo} alt="" />
    <enhanced:img src='../images/svelte-logo-square.png' alt="" />
    
    <!-- these don't work -->
    <enhanced:img src={'../images/svelte-logo-square.png'} alt="" />
    <enhanced:img src={`../images/${fileName}.${fileExtension}`} alt="" />
    <enhanced:img src={pathToFileTemplate} alt="" />
    <enhanced:img src={pathToFile} alt="" />
</div>
```

I identified the `update_element` function as the culprit ([for reference](https://github.com/sveltejs/kit/blob/3d82b9c4fafa5c191c586b5ebe4fe41d3e0b72cc/packages/enhanced-img/src/preprocessor.js#L48)). The function is not considering all possible src types. [I added some logic to handle literals correctly](https://github.com/flippbit/sveltekit/blob/23de1f26c1ff187e683e23465133159cf5c7a7f5/packages/enhanced-img/src/preprocessor.js#L48), but I'm struggling to find a way to handle the other cases as well. I added some additional errors for now, so it's clear which cases are missing right now.

This pull request currently fixes this case:

```svelte
    <enhanced:img src={'../images/svelte-logo-square.png'} alt="" />
```

I'm looking for input on how to handle the other cases. For example, if I were to use a template literal like this:

```svelte
<script lang="ts">
	const fileName = 'thumbnail.png';
</script>

<enhanced:img src={`./${fileName}`} />
```

The content of `src_attribute` inside the `update_element` handler looks like this:
<details>

  ```json
  {
    "start": 418,
    "end": 435,
    "type": "MustacheTag",
    "expression": {
      "type": "TemplateLiteral",
      "start": 419,
      "end": 434,
      "loc": {
        "start": { "line": 11, "column": 19 },
        "end": { "line": 11, "column": 34 }
      },
      "expressions": [
        {
          "type": "Identifier",
          "start": 424,
          "end": 432,
          "loc": {
            "start": { "line": 11, "column": 24 },
            "end": { "line": 11, "column": 32 }
          },
          "name": "fileName"
        }
      ],
      "quasis": [
        {
          "type": "TemplateElement",
          "start": 420,
          "end": 422,
          "loc": {
            "start": { "line": 11, "column": 20 },
            "end": { "line": 11, "column": 22 }
          },
          "value": { "raw": "./", "cooked": "./" },
          "tail": false
        },
        {
          "type": "TemplateElement",
          "start": 433,
          "end": 433,
          "loc": {
            "start": { "line": 11, "column": 33 },
            "end": { "line": 11, "column": 33 }
          },
          "value": { "raw": "", "cooked": "" },
          "tail": true
        }
      ]
    }
  }
  
  ```
</details>

Extracting the values of those variables from the actual component now seems a little bit hacky.

I appreciate any input!

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
