### PR TITLE
chore: bump typescript-eslint to v7

### DIFF
--- a/.changeset/mighty-radios-know.md
+++ b/.changeset/mighty-radios-know.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+chore: bump typescript-eslint to v7

--- a/packages/create-svelte/shared/+eslint+typescript/package.json
+++ b/packages/create-svelte/shared/+eslint+typescript/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"@typescript-eslint/eslint-plugin": "^6.0.0",
-		"@typescript-eslint/parser": "^6.0.0"
+		"@typescript-eslint/eslint-plugin": "^7.0.0",
+		"@typescript-eslint/parser": "^7.0.0"
 	}
 }

--- a/packages/create-svelte/shared/+eslint/package.json
+++ b/packages/create-svelte/shared/+eslint/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"@types/eslint": "8.56.0",
+		"@types/eslint": "^8.56.0",
 		"eslint": "^8.56.0",
 		"eslint-plugin-svelte": "^2.35.1"
 	}


### PR DESCRIPTION
[typescript-eslint v7](https://typescript-eslint.io/blog/announcing-typescript-eslint-v7/) has been released.

1. This will bump the required Node.js version to `^18.18.0`, beyond the SvelteKit's current `>=18.13`
2. In https://github.com/sveltejs/kit/pull/11453, the `@types/eslint` package's version was set to exact. Caret has been added.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
