### PR TITLE
fix: prevent false positive `history.pushState` warnings

### DIFF
--- a/.changeset/loud-kangaroos-leave.md
+++ b/.changeset/loud-kangaroos-leave.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: prevent false positive `history.pushState` and `history.replaceState` warnings

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -78,7 +78,7 @@ if (DEV && BROWSER) {
 		if (!stack) return;
 		if (!stack[0].includes('https:') && !stack[0].includes('http:')) stack = stack.slice(1); // Chrome includes the error message in the stack
 		stack = stack.slice(2); // remove `warn` and the place where `warn` was called
-		if (!stack[0] || stack[0].includes(current_module_url)) return;
+		if (stack[0]?.includes(current_module_url)) return;
 
 		warned = true;
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -67,6 +67,8 @@ const snapshots = storage.get(SNAPSHOT_KEY) ?? {};
 if (DEV && BROWSER) {
 	let warned = false;
 
+	const current_module_url = import.meta.url.split('?')[0]; // remove query params that Vite adds to the URL
+
 	const warn = () => {
 		if (warned) return;
 
@@ -76,7 +78,7 @@ if (DEV && BROWSER) {
 		if (!stack) return;
 		if (!stack[0].includes('https:') && !stack[0].includes('http:')) stack = stack.slice(1); // Chrome includes the error message in the stack
 		stack = stack.slice(2); // remove `warn` and the place where `warn` was called
-		if (stack[0].includes(import.meta.url)) return;
+		if (stack[0].includes(current_module_url)) return;
 
 		warned = true;
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -78,6 +78,7 @@ if (DEV && BROWSER) {
 		if (!stack) return;
 		if (!stack[0].includes('https:') && !stack[0].includes('http:')) stack = stack.slice(1); // Chrome includes the error message in the stack
 		stack = stack.slice(2); // remove `warn` and the place where `warn` was called
+		// Can be falsy if was called directly from an anonymous function
 		if (stack[0]?.includes(current_module_url)) return;
 
 		warned = true;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -67,7 +67,7 @@ const snapshots = storage.get(SNAPSHOT_KEY) ?? {};
 if (DEV && BROWSER) {
 	let warned = false;
 
-	const current_module_url = import.meta.url.split('?')[0]; // remove query params that Vite adds to the URL
+	const current_module_url = import.meta.url.split('?')[0]; // remove query params that vite adds to the URL when it is loaded from node_modules
 
 	const warn = () => {
 		if (warned) return;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -78,7 +78,7 @@ if (DEV && BROWSER) {
 		if (!stack) return;
 		if (!stack[0].includes('https:') && !stack[0].includes('http:')) stack = stack.slice(1); // Chrome includes the error message in the stack
 		stack = stack.slice(2); // remove `warn` and the place where `warn` was called
-		if (stack[0]?.includes(current_module_url)) return;
+		if (!stack[0] || stack[0].includes(current_module_url)) return;
 
 		warned = true;
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -78,7 +78,7 @@ if (DEV && BROWSER) {
 		if (!stack) return;
 		if (!stack[0].includes('https:') && !stack[0].includes('http:')) stack = stack.slice(1); // Chrome includes the error message in the stack
 		stack = stack.slice(2); // remove `warn` and the place where `warn` was called
-		if (stack[0].includes(current_module_url)) return;
+		if (stack[0]?.includes(current_module_url)) return;
 
 		warned = true;
 


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/11671

The warning currently incorrectly fires when we use `history.pushState()` internally such as clicking on a link. You can test this in a [stackblitz starter project](sveltekit.new). This is because one of the early exit conditions in the warning method is failing incorrectly.

`import.meta.url` returns the `client.js` file with a query parameter when loading it from `node_modules`. This causes the substring search for the module filename in the error stack to always return false (because of the query params that are not present in the error stack) https://github.com/sveltejs/kit/blob/53412fd74120e452f5e538ed142374a462d2419e/packages/kit/src/runtime/client/client.js#L79

The solution is to simply return the URL without the query parameters if any.

No test because so far it's only reproducible when Vite is loading SvelteKit from `node_modules` rather than being linked through the workspace (how it's currently setup in the kit repository).

## Aside

This addresses the original issue of:

> I'm not using history as suggested by the warning. I'm using goto in a couple of places, from $app/navigation. I haven't changed anything. The warning is not present with v2.3.3.
> 
> From a quick test, commenting out all the goto calls still resulted in the warning.

~but it does not address the possibility that `warn` checks the wrong stack entry. This can happen when other scripts also monkey patch `history.pushState` causing our `client.js` to appear earlier or later in the call stack.~

I think we're safe from third-party scripts monkey patching and upsetting the call stack order. I've tested monkey patching it in:

* the <script> of a svelte file
* the html template
* the <svelte:head> of a svelte file

and they get called in that order, but `warn` is always first in the call stack, followed by the `client.js` monkey patch.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
