### PR TITLE
chore(deps): upgrade and unpin undici

### DIFF
--- a/.changeset/large-meals-speak.md
+++ b/.changeset/large-meals-speak.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+chore(deps): upgrade and unpin undici

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -23,7 +23,7 @@
 		"set-cookie-parser": "^2.6.0",
 		"sirv": "^2.0.2",
 		"tiny-glob": "^0.2.9",
-		"undici": "~5.26.2"
+		"undici": "^5.28.3"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,8 +432,8 @@ importers:
         specifier: ^0.2.9
         version: 0.2.9
       undici:
-        specifier: ~5.26.2
-        version: 5.26.3
+        specifier: ^5.28.3
+        version: 5.28.3
     devDependencies:
       '@playwright/test':
         specifier: 1.30.0
@@ -6237,8 +6237,8 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
-  /undici@5.26.3:
-    resolution: {integrity: sha512-H7n2zmKEWgOllKkIUkLvFmsJQj062lSm3uA4EYApG8gLuiOM0/go9bIoC3HVaSnfg4xunowDE2i9p8drkXuvDw==}
+  /undici@5.28.3:
+    resolution: {integrity: sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==}
     engines: {node: '>=14.0'}
     dependencies:
       '@fastify/busboy': 2.0.0


### PR DESCRIPTION
This is against the `version-1` branch. It will stop users still on v1 from getting pinged by security audit tools. See https://github.com/advisories/GHSA-3787-6prv-h9w3

SvelteKit v2 is unaffected as it does not depend on `undici` directly. Instead users should make sure they're using a patched version of Node.js.