### PR TITLE
fix: prevent stale values after invalidation

### DIFF
--- a/.changeset/angry-gorillas-peel.md
+++ b/.changeset/angry-gorillas-peel.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: prevent stale values after invalidation

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -312,16 +312,16 @@ async function _invalidate() {
 
 	if (navigation_result) {
 		if (navigation_result.type === 'redirect') {
-			await _goto(new URL(navigation_result.location, current.url).href, {}, 1, nav_token);
-		} else {
-			if (navigation_result.props.page !== undefined) {
-				page = navigation_result.props.page;
-			}
-			root.$set(navigation_result.props);
+			return _goto(new URL(navigation_result.location, current.url).href, {}, 1, nav_token);
 		}
-	}
 
-	invalidated.length = 0;
+		if (navigation_result.props.page) {
+			page = navigation_result.props.page;
+		}
+		current = navigation_result.state;
+		invalidated.length = 0;
+		root.$set(navigation_result.props);
+	}
 }
 
 /** @param {number} index */

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -308,20 +308,18 @@ async function _invalidate() {
 
 	const nav_token = (token = {});
 	const navigation_result = intent && (await load_route(intent));
-	if (nav_token !== token) return;
+	if (!navigation_result || nav_token !== token) return;
 
-	if (navigation_result) {
-		if (navigation_result.type === 'redirect') {
-			return _goto(new URL(navigation_result.location, current.url).href, {}, 1, nav_token);
-		}
-
-		if (navigation_result.props.page) {
-			page = navigation_result.props.page;
-		}
-		current = navigation_result.state;
-		reset_invalidation();
-		root.$set(navigation_result.props);
+	if (navigation_result.type === 'redirect') {
+		return _goto(new URL(navigation_result.location, current.url).href, {}, 1, nav_token);
 	}
+
+	if (navigation_result.props.page) {
+		page = navigation_result.props.page;
+	}
+	current = navigation_result.state;
+	reset_invalidation();
+	root.$set(navigation_result.props);
 }
 
 function reset_invalidation() {

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -320,6 +320,7 @@ async function _invalidate() {
 		}
 		current = navigation_result.state;
 		invalidated.length = 0;
+		force_invalidation = false;
 		root.$set(navigation_result.props);
 	}
 }

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1095,6 +1095,9 @@ async function load_root_error_page({ status, error, url, route }) {
 }
 
 /**
+ * Resolve the full info (which route, params, etc.) for a client-side navigation from the URL,
+ * taking the reroute hook into account. If this isn't a client-side-navigation (or the URL is undefined),
+ * returns undefined.
  * @param {URL | undefined} url
  * @param {boolean} invalidating
  */

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -319,10 +319,14 @@ async function _invalidate() {
 			page = navigation_result.props.page;
 		}
 		current = navigation_result.state;
-		invalidated.length = 0;
-		force_invalidation = false;
+		reset_invalidation();
 		root.$set(navigation_result.props);
 	}
+}
+
+function reset_invalidation() {
+	invalidated.length = 0;
+	force_invalidation = false;
 }
 
 /** @param {number} index */
@@ -1282,8 +1286,7 @@ async function navigate({
 
 	// reset invalidation only after a finished navigation. If there are redirects or
 	// additional invalidations, they should get the same invalidation treatment
-	invalidated.length = 0;
-	force_invalidation = false;
+	reset_invalidation();
 
 	updating = true;
 

--- a/packages/kit/test/apps/basics/src/routes/load/invalidation/invalidate-then-goto/+layout.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/invalidation/invalidate-then-goto/+layout.server.js
@@ -1,4 +1,4 @@
-/** @type {import('./$types').PageLoad} */
+/** @type {import('./$types').LayoutServerLoad} */
 export function load({ depends }) {
 	depends('invalidate-depends:goto');
 	return {

--- a/packages/kit/test/apps/basics/src/routes/load/invalidation/invalidate-then-goto/+layout.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/invalidation/invalidate-then-goto/+layout.server.js
@@ -1,0 +1,7 @@
+/** @type {import('./$types').PageLoad} */
+export function load({ depends }) {
+	depends('invalidate-depends:goto');
+	return {
+		layoutDate: new Date().getTime()
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/invalidation/invalidate-then-goto/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/invalidation/invalidate-then-goto/+page.server.js
@@ -1,0 +1,7 @@
+/** @type {import('./$types').PageLoad} */
+export function load({ url }) {
+	url.searchParams.get('x');
+	return {
+		pageDate: new Date().getTime()
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/invalidation/invalidate-then-goto/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/invalidation/invalidate-then-goto/+page.server.js
@@ -1,4 +1,4 @@
-/** @type {import('./$types').PageLoad} */
+/** @type {import('./$types').PageServerLoad} */
 export function load({ url }) {
 	url.searchParams.get('x');
 	return {

--- a/packages/kit/test/apps/basics/src/routes/load/invalidation/invalidate-then-goto/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/invalidation/invalidate-then-goto/+page.svelte
@@ -1,0 +1,23 @@
+<script>
+	import { invalidate, goto } from '$app/navigation';
+
+	/** @type {import('./$types').PageData} */
+	export let data;
+</script>
+
+<p class="layout">{data.layoutDate}</p>
+<p class="page">{data.pageDate}</p>
+<button
+	type="button"
+	class="invalidate"
+	on:click={() => (window.promise = invalidate('invalidate-depends:goto'))}
+>
+	invalidate
+</button>
+<button
+	type="button"
+	class="goto"
+	on:click={() => (window.promise = goto('/load/invalidation/invalidate-then-goto?x'))}
+>
+	goto
+</button>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -614,7 +614,6 @@ test.describe('Invalidation', () => {
 		const next_layout_2 = await page.textContent('p.layout');
 		const next_page_2 = await page.textContent('p.page');
 		expect(next_layout_2).toBe(next_layout_1);
-		expect(next_layout_2).not.toBe(layout);
 		expect(next_page_2).not.toBe(next_page_1);
 	});
 });

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -594,6 +594,29 @@ test.describe('Invalidation', () => {
 		await page.locator('button').click();
 		await expect(page.getByText('updated')).toBeVisible();
 	});
+
+	test('goto after invalidation does not reset state', async ({ page }) => {
+		await page.goto('/load/invalidation/invalidate-then-goto');
+		const layout = await page.textContent('p.layout');
+		const _page = await page.textContent('p.page');
+		expect(layout).toBeDefined();
+		expect(_page).toBeDefined();
+
+		await page.click('button.invalidate');
+		await page.evaluate(() => window.promise);
+		const next_layout_1 = await page.textContent('p.layout');
+		const next_page_1 = await page.textContent('p.page');
+		expect(next_layout_1).not.toBe(layout);
+		expect(next_page_1).toBe(_page);
+
+		await page.click('button.goto');
+		await page.evaluate(() => window.promise);
+		const next_layout_2 = await page.textContent('p.layout');
+		const next_page_2 = await page.textContent('p.page');
+		expect(next_layout_2).toBe(next_layout_1);
+		expect(next_layout_2).not.toBe(layout);
+		expect(next_page_2).not.toBe(next_page_1);
+	});
 });
 
 test.describe('data-sveltekit attributes', () => {


### PR DESCRIPTION
Current was not updated after invalidation, which resulted in the previous values getting used on next navigation
fixes #11446
We also didn't set `force_invalidate` back to `false`
fixes #10123

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
