### PR TITLE
Enhanced Image: Support {AttributeShorthand} syntax

### DIFF
--- a/.changeset/good-parrots-act.md
+++ b/.changeset/good-parrots-act.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/enhanced-img": patch
+---
+
+fix: support attribute shorthand syntax on `<enhanced:img {src} />`

--- a/packages/enhanced-img/src/preprocessor.js
+++ b/packages/enhanced-img/src/preprocessor.js
@@ -53,6 +53,10 @@ export function image(opts) {
 						.trim();
 					s.update(node.start, node.end, dynamic_img_to_picture(content, node, src_var_name));
 					return;
+				} else if (src_attribute.type === 'AttributeShorthand') {
+					const src_var_name = content.substring(src_attribute.start, src_attribute.end).trim();
+					s.update(node.start, node.end, dynamic_img_to_picture(content, node, src_var_name));
+					return;
 				}
 
 				const original_url = src_attribute.raw.trim();

--- a/packages/enhanced-img/test/Input.svelte
+++ b/packages/enhanced-img/test/Input.svelte
@@ -42,3 +42,7 @@
 	<source srcset="./foo.avif 500v ./bar.avif 100v" />
 	<source srcset="./foo.avif, ./bar.avif 1v" />
 </picture>
+
+{#each images as src}
+	<enhanced:img {src} alt="opt-in test" />
+{/each}

--- a/packages/enhanced-img/test/Output.svelte
+++ b/packages/enhanced-img/test/Output.svelte
@@ -50,3 +50,16 @@
 	<source srcset="./foo.avif 500v ./bar.avif 100v" />
 	<source srcset="./foo.avif, ./bar.avif 1v" />
 </picture>
+
+{#each images as src}
+	{#if typeof src === 'string'}
+	<img src={src.img.src} alt="opt-in test" width={src.img.w} height={src.img.h} />
+{:else}
+	<picture>
+		{#each Object.entries(src.sources) as [format, srcset]}
+			<source {srcset} type={'image/' + format} />
+		{/each}
+		<img src={src.img.src} alt="opt-in test" width={src.img.w} height={src.img.h} />
+	</picture>
+{/if}
+{/each}


### PR DESCRIPTION
This PR adds support for the Attribute shorthand syntax on `<enhanced:img` components.
It is now possible to write the following code:

```svelte
<script>
  import src from "$lib/myImage.png?enhanced"
</script>

<enhanced:img {src} />
```

Previously this would error

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
