### PR TITLE
fix: tsconfig includes should cover svelte.config.js

### DIFF
--- a/.changeset/sixty-files-lay.md
+++ b/.changeset/sixty-files-lay.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: tsconfig includes should cover svelte.config.js

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -58,6 +58,7 @@ export function get_tsconfig(kit) {
 		'ambient.d.ts',
 		'non-ambient.d.ts',
 		'./types/**/$types.d.ts',
+		config_relative('svelte.config.js'),
 		config_relative('vite.config.js'),
 		config_relative('vite.config.ts')
 	]);

--- a/packages/kit/src/core/sync/write_tsconfig.spec.js
+++ b/packages/kit/src/core/sync/write_tsconfig.spec.js
@@ -77,6 +77,7 @@ test('Creates tsconfig include from kit.files', () => {
 		'ambient.d.ts',
 		'non-ambient.d.ts',
 		'./types/**/$types.d.ts',
+		'../svelte.config.js',
 		'../vite.config.js',
 		'../vite.config.ts',
 		'../app/**/*.js',


### PR DESCRIPTION
I was unable to setup https://typescript-eslint.io/rules/no-misused-promises/ in a SvelteKit project without this. I might have been able to tweak the esconfig settings to get it to work, but either way it seemed like the `svelte.config.js` should be there if the `vite.config.js` is there