### PR TITLE
fix: @sveltejs/enhanced-img allow the usage of variables / template literals for the src attribute

### DIFF
--- a/packages/enhanced-img/src/preprocessor.js
+++ b/packages/enhanced-img/src/preprocessor.js
@@ -46,8 +46,9 @@ export function image(opts) {
 			 * @returns {Promise<void>}
 			 */
 			async function update_element(node, src_attribute) {
+				const { expression } = src_attribute;
 				// TODO: this will become ExpressionTag in Svelte 5
-				if (src_attribute.type === 'MustacheTag') {
+				if (src_attribute.type === 'MustacheTag' && expression.type !== 'Literal' && expression.type !== 'TemplateLiteral') {
 					const src_var_name = content
 						.substring(src_attribute.start + 1, src_attribute.end - 1)
 						.trim();
@@ -55,7 +56,17 @@ export function image(opts) {
 					return;
 				}
 
-				const original_url = src_attribute.raw.trim();
+				let original_url = '';
+				if (src_attribute.type === 'Text') {
+					original_url = src_attribute.raw.trim();
+				} else if (expression.type === 'Literal') {
+					original_url = expression.value.trim();
+				} else if (expression.type === 'TemplateLiteral') {
+					throw new Error(`Template literals are not supported in src attributes. Please use a string literal or a dynamically imported image.`);
+				} else {
+					throw new Error(`Could not locate image. Please ensure that the src attribute contains a dynamically imported image or a string literal pointing to one.`);
+				}
+
 				let url = original_url;
 
 				const sizes = get_attr_value(node, 'sizes');

--- a/packages/enhanced-img/test/Input.svelte
+++ b/packages/enhanced-img/test/Input.svelte
@@ -5,6 +5,9 @@
 	const images = [manual_image1, manual_image2];
 
 	let foo: string = 'bar';
+	let imagePath: string = './foo.png';
+	let imageName: string = 'foo';
+	let imageExt: string = 'png';
 </script>
 
 {foo}
@@ -12,6 +15,15 @@
 <img src="./foo.png" alt="non-enhanced test" />
 
 <enhanced:img src="./foo.png" alt="basic test" />
+
+<enhanced:img src={'./foo.png'} alt="basic test passing src as literal" />
+
+<enhanced:img src={imagePath} alt="basic test passing src by variable" />
+
+<enhanced:img
+	src={`./${imageName}.${imageExt}`}
+	alt="basic test passing src using template literal"
+/>
 
 <enhanced:img src="./foo.png" width="5" height="10" alt="dimensions test" />
 

--- a/packages/enhanced-img/test/Output.svelte
+++ b/packages/enhanced-img/test/Output.svelte
@@ -8,6 +8,7 @@
 	const images = [manual_image1, manual_image2];
 
 	let foo: string = 'bar';
+	let imagePath: string = './foo.png';
 </script>
 
 {foo}
@@ -15,6 +16,12 @@
 <img src="./foo.png" alt="non-enhanced test" />
 
 <picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src="/7" alt="basic test" width=1440 height=1440 /></picture>
+
+<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src="/7" alt="basic test passing src as literal" width=1440 height=1440 /></picture>
+
+<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src="/7" alt="basic test passing src by variable" width=1440 height=1440 /></picture>
+
+<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src="/7" alt="basic test passing src using template literal" width=1440 height=1440 /></picture>
 
 <picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src="/7" width="5" height="10" alt="dimensions test" width=1440 height=1440 /></picture>
 


### PR DESCRIPTION
This idea was discussed in this issue: https://github.com/sveltejs/kit/issues/11535 and first started by @flippbit in this PR: https://github.com/sveltejs/kit/pull/11840

As reported by @fliippbit, this scenario was not working, and now all of them are functional.

```js
<script lang="ts">
    import svelteLogo from '../images/svelte-logo-square.png?enhanced';
    const fileName = "svelte-logo-square";
    const fileExtension = "png";
    const pathToFileTemplate = `../images/${fileName}.${fileExtension}`;
    const pathToFile = '../images/svelte-logo-square.png';
</script>

<div>
    <!-- these work fine -->
    <enhanced:img src={svelteLogo} alt="" />
    <enhanced:img src='../images/svelte-logo-square.png' alt="" />
    
    <!-- these don't work in current version, but now they do -->
    <enhanced:img src={'../images/svelte-logo-square.png'} alt="" />
    <enhanced:img src={`../images/${fileName}.${fileExtension}`} alt="" />
    <enhanced:img src={pathToFileTemplate} alt="" />
    <enhanced:img src={pathToFile} alt="" />
</div>
```

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
