### PR TITLE
fix: revert tsconfig change, fix types

### DIFF
--- a/.changeset/afraid-ghosts-yell.md
+++ b/.changeset/afraid-ghosts-yell.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: revert tsconfig change that includes svelte.config.js

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -58,7 +58,6 @@ export function get_tsconfig(kit) {
 		'ambient.d.ts',
 		'non-ambient.d.ts',
 		'./types/**/$types.d.ts',
-		config_relative('svelte.config.js'),
 		config_relative('vite.config.js'),
 		config_relative('vite.config.ts')
 	]);

--- a/packages/kit/src/core/sync/write_tsconfig.spec.js
+++ b/packages/kit/src/core/sync/write_tsconfig.spec.js
@@ -77,7 +77,6 @@ test('Creates tsconfig include from kit.files', () => {
 		'ambient.d.ts',
 		'non-ambient.d.ts',
 		'./types/**/$types.d.ts',
-		'../svelte.config.js',
 		'../vite.config.js',
 		'../vite.config.ts',
 		'../app/**/*.js',

--- a/packages/kit/src/types/private.d.ts
+++ b/packages/kit/src/types/private.d.ts
@@ -73,7 +73,6 @@ export namespace Csp {
 	type SchemeSource = 'http:' | 'https:' | 'data:' | 'mediastream:' | 'blob:' | 'filesystem:';
 	type Source = HostSource | SchemeSource | CryptoSource | BaseSource;
 	type Sources = Source[];
-	type UriPath = `${HttpDelineator}${string}`;
 }
 
 export interface CspDirectives {
@@ -113,7 +112,7 @@ export interface CspDirectives {
 	'form-action'?: Array<Csp.Source | Csp.ActionSource>;
 	'frame-ancestors'?: Array<Csp.HostSource | Csp.SchemeSource | Csp.FrameSource>;
 	'navigate-to'?: Array<Csp.Source | Csp.ActionSource>;
-	'report-uri'?: Csp.UriPath[];
+	'report-uri'?: string[];
 	'report-to'?: string[];
 
 	'require-trusted-types-for'?: Array<'script'>;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1419,7 +1419,6 @@ declare module '@sveltejs/kit' {
 		type SchemeSource = 'http:' | 'https:' | 'data:' | 'mediastream:' | 'blob:' | 'filesystem:';
 		type Source = HostSource | SchemeSource | CryptoSource | BaseSource;
 		type Sources = Source[];
-		type UriPath = `${HttpDelineator}${string}`;
 	}
 
 	interface CspDirectives {
@@ -1459,7 +1458,7 @@ declare module '@sveltejs/kit' {
 		'form-action'?: Array<Csp.Source | Csp.ActionSource>;
 		'frame-ancestors'?: Array<Csp.HostSource | Csp.SchemeSource | Csp.FrameSource>;
 		'navigate-to'?: Array<Csp.Source | Csp.ActionSource>;
-		'report-uri'?: Csp.UriPath[];
+		'report-uri'?: string[];
 		'report-to'?: string[];
 
 		'require-trusted-types-for'?: Array<'script'>;


### PR DESCRIPTION
The inclusion of `svelte.config.js` is a breaking change since it's type-checked now and that can break projects which did type-check without errors previously
closes #11906

Also relaxes the report-uri types, fully qualified urls are also ok
closes #11905

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
