### PR TITLE
fix: allow native form submission for `<form target="_blank">` and `<button formtarget="_blank">` 

### DIFF
--- a/.changeset/great-cooks-hunt.md
+++ b/.changeset/great-cooks-hunt.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: open a new tab for `<form target="_blank">` and `<button formtarget="_blank"> submissions

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2086,7 +2086,7 @@ function _start_router() {
 
 		const submitter = /** @type {HTMLButtonElement | HTMLInputElement | null} */ (event.submitter);
 
-		const target = (submitter?.hasAttribute('formtarget') && submitter?.formTarget) || form.target;
+		const target = submitter?.formTarget || form.target;
 
 		if (target === '_blank') return;
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2086,6 +2086,10 @@ function _start_router() {
 
 		const submitter = /** @type {HTMLButtonElement | HTMLInputElement | null} */ (event.submitter);
 
+		const target = (submitter?.hasAttribute('formtarget') && submitter?.formTarget) || form.target;
+
+		if (target === '_blank') return;
+
 		const method = submitter?.formMethod || form.method;
 
 		if (method !== 'get') return;

--- a/packages/kit/test/apps/basics/src/routes/routing/form-target-blank/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/form-target-blank/+page.svelte
@@ -1,0 +1,7 @@
+<form target="_blank">
+	<button>Inside form</button>
+</form>
+
+<form id="my-form"></form>
+
+<button formtarget="_blank" form="my-form">Outside form</button>

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -769,7 +769,7 @@ test.describe('Routing', () => {
 		let tabs = page.context().pages();
 		expect(tabs.length === 1);
 
-		const new_tab = page.waitForEvent('popup', { timeout: 100 });
+		const new_tab = page.waitForEvent('popup', { timeout: 200 });
 		await page.locator('button', { hasText: 'Inside form' }).click();
 		await new_tab;
 
@@ -783,7 +783,7 @@ test.describe('Routing', () => {
 		let tabs = page.context().pages();
 		expect(tabs.length === 1);
 
-		const new_tab = page.waitForEvent('popup', { timeout: 100 });
+		const new_tab = page.waitForEvent('popup', { timeout: 200 });
 		await page.locator('button', { hasText: 'Outside form' }).click();
 		await new_tab;
 

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -763,6 +763,34 @@ test.describe('Routing', () => {
 		expect(await page.textContent('h3')).toBe('bar');
 	});
 
+	test('responds to <form target="_blank"> submission with new tab', async ({ page }) => {
+		await page.goto('/routing/form-target-blank');
+
+		let tabs = page.context().pages();
+		expect(tabs.length === 1);
+
+		const new_tab = page.waitForEvent('popup', { timeout: 100 });
+		await page.locator('button', { hasText: 'Inside form' }).click();
+		await new_tab;
+
+		tabs = page.context().pages();
+		expect(tabs.length > 1);
+	});
+
+	test('responds to <button formtarget="_blank" submission with new tab', async ({ page }) => {
+		await page.goto('/routing/form-target-blank');
+
+		let tabs = page.context().pages();
+		expect(tabs.length === 1);
+
+		const new_tab = page.waitForEvent('popup', { timeout: 100 });
+		await page.locator('button', { hasText: 'Outside form' }).click();
+		await new_tab;
+
+		tabs = page.context().pages();
+		expect(tabs.length > 1);
+	});
+
 	test('ignores links with no href', async ({ page }) => {
 		await page.goto('/routing/missing-href');
 		const selector = '[data-testid="count"]';

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -769,7 +769,7 @@ test.describe('Routing', () => {
 		let tabs = page.context().pages();
 		expect(tabs.length === 1);
 
-		const new_tab = page.waitForEvent('popup', { timeout: 500 });
+		const new_tab = page.waitForEvent('popup', { timeout: 1000 });
 		await page.locator('button', { hasText: 'Inside form' }).click();
 		await new_tab;
 
@@ -783,7 +783,7 @@ test.describe('Routing', () => {
 		let tabs = page.context().pages();
 		expect(tabs.length === 1);
 
-		const new_tab = page.waitForEvent('popup', { timeout: 500 });
+		const new_tab = page.waitForEvent('popup', { timeout: 1000 });
 		await page.locator('button', { hasText: 'Outside form' }).click();
 		await new_tab;
 

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -769,7 +769,7 @@ test.describe('Routing', () => {
 		let tabs = page.context().pages();
 		expect(tabs.length === 1);
 
-		const new_tab = page.waitForEvent('popup', { timeout: 200 });
+		const new_tab = page.waitForEvent('popup', { timeout: 500 });
 		await page.locator('button', { hasText: 'Inside form' }).click();
 		await new_tab;
 
@@ -783,7 +783,7 @@ test.describe('Routing', () => {
 		let tabs = page.context().pages();
 		expect(tabs.length === 1);
 
-		const new_tab = page.waitForEvent('popup', { timeout: 200 });
+		const new_tab = page.waitForEvent('popup', { timeout: 500 });
 		await page.locator('button', { hasText: 'Outside form' }).click();
 		await new_tab;
 


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/11931

This PR ensures that our client submit event listener allows the browser to make a native form submission to open a new tab if a form or button has the `target="_blank"` or `formtarget="_blank"` attribute. This should open the form response in a new tab for both GET and POST submissions.

Afaik the other `target` values such as `_parent` and `_top` should function similarly to `_self` where we just want to update the current page without refreshing (even if Kit is in an iframe).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
