### PR TITLE
feat: add `@zeabur/svelte-adapter` support in `adapter-auto`

### DIFF
--- a/.changeset/neat-taxis-type.md
+++ b/.changeset/neat-taxis-type.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-auto": minor
+---
+
+feat: add Zeabur adapter support

--- a/packages/adapter-auto/adapters.js
+++ b/packages/adapter-auto/adapters.js
@@ -30,5 +30,11 @@ export const adapters = [
 		test: () => !!process.env.SST,
 		module: 'svelte-kit-sst',
 		version: '2'
+	},
+	{
+		name: 'Zeabur',
+		test: () => !!process.env.ZEABUR,
+		module: '@zeabur/svelte-adapter',
+		version: '1'
 	}
 ];


### PR DESCRIPTION
<!-- Your PR description here -->

Introduce support for [`@zeabur/svelte-adapter`](https://www.npmjs.com/package/@zeabur/svelte-adapter) in `adapter-auto`.

This PR simplifies the deployment process for developers aiming to host their Svelte applications on [Zeabur](https://zeabur.com).

It eliminates the need for manual installation and configuration updates, as outlined in the Zeabur documentation (https://zeabur.com/docs/guides/nodejs/svelte-kit#step-2-set-up-zeabursvelte-adapter).

Example Svelte Kit website deployed on Zeabur with `@zeabur/svelte-adapter`: https://svelte-kit.zeabur.app/

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
