### PR TITLE
breaking: precompress by default

### DIFF
--- a/.changeset/strong-rocks-perform.md
+++ b/.changeset/strong-rocks-perform.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-node": major
+---
+
+breaking: change default value of `precompress` option to true to serve precompressed assets by default

--- a/documentation/docs/25-build-and-deploy/40-adapter-node.md
+++ b/documentation/docs/25-build-and-deploy/40-adapter-node.md
@@ -132,7 +132,7 @@ export default {
 		adapter: adapter({
 			// default options are shown
 			out: 'build',
-			precompress: false,
+			precompress: true,
 			envPrefix: ''
 		})
 	}
@@ -145,7 +145,7 @@ The directory to build the server to. It defaults to `build` — i.e. `node buil
 
 ### precompress
 
-Enables precompressing using gzip and brotli for assets and prerendered pages. It defaults to `false`.
+Enables precompressing using gzip and brotli for assets and prerendered pages. It defaults to `true`.
 
 ### envPrefix
 

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -9,7 +9,7 @@ const files = fileURLToPath(new URL('./files', import.meta.url).href);
 
 /** @type {import('./index.js').default} */
 export default function (opts = {}) {
-	const { out = 'build', precompress, envPrefix = '' } = opts;
+	const { out = 'build', precompress = true, envPrefix = '' } = opts;
 
 	return {
 		name: '@sveltejs/adapter-node',


### PR DESCRIPTION
I'd like to merge this together with https://github.com/sveltejs/kit/pull/11653 where we're already doing a major version bump in `adapter-node`.

I was looking at a major SvelteKit project and they were just using the default options and not precompressing assets, which would have made their site much faster. It made me wonder why we weren't doing it by default as I believe we should have our defaults align with making sites fast. This feature was originally introduced in https://github.com/sveltejs/kit/pull/1693. It was made `false` by default there as they were worried about adding to build time. I tried building the site with both `true` and `false` and there was minimal if any difference in speed, so I don't think we should let that block us

Should we just remove the option and always do it by default? I don't really see why you'd want to be able to disable it. There are potentially other options you'd want to be able to set though (https://github.com/sveltejs/kit/issues/10789). Removing the option would free up space for new options. Or perhaps we should make it `precompress.enabled` as another way of freeing up the namespace