### PR TITLE
breaking: apply `@polka/compression` middleware

### DIFF
--- a/.changeset/chatty-mirrors-repair.md
+++ b/.changeset/chatty-mirrors-repair.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-node": major
+---
+
+breaking: apply `@polka/compression` middleware

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -33,12 +33,13 @@
 		"prepublishOnly": "pnpm build"
 	},
 	"devDependencies": {
-		"@polka/url": "1.0.0-next.24",
+		"@polka/compression": "1.0.0-next.25",
+		"@polka/url": "1.0.0-next.25",
 		"@sveltejs/kit": "workspace:^",
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"@types/node": "^18.19.3",
 		"c8": "^9.0.0",
-		"polka": "1.0.0-next.24",
+		"polka": "1.0.0-next.25",
 		"sirv": "^2.0.4",
 		"typescript": "^5.3.3",
 		"vitest": "^1.2.0"

--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -1,12 +1,13 @@
 import { handler } from 'HANDLER';
 import { env } from 'ENV';
+import compression from '@polka/compression';
 import polka from 'polka';
 
 export const path = env('SOCKET_PATH', false);
 export const host = env('HOST', '0.0.0.0');
 export const port = env('PORT', !path && '3000');
 
-const server = polka().use(handler);
+const server = polka().use(compression(), handler);
 
 server.listen({ path, host, port }, () => {
 	console.log(`Listening on ${path ? path : host + ':' + port}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,9 +166,12 @@ importers:
         specifier: ^4.9.5
         version: 4.9.6
     devDependencies:
+      '@polka/compression':
+        specifier: 1.0.0-next.25
+        version: 1.0.0-next.25
       '@polka/url':
-        specifier: 1.0.0-next.24
-        version: 1.0.0-next.24
+        specifier: 1.0.0-next.25
+        version: 1.0.0-next.25
       '@sveltejs/kit':
         specifier: workspace:^
         version: link:../kit
@@ -182,8 +185,8 @@ importers:
         specifier: ^9.0.0
         version: 9.1.0
       polka:
-        specifier: 1.0.0-next.24
-        version: 1.0.0-next.24
+        specifier: 1.0.0-next.25
+        version: 1.0.0-next.25
       sirv:
         specifier: ^2.0.4
         version: 2.0.4
@@ -2139,8 +2142,13 @@ packages:
       playwright: 1.41.2
     dev: true
 
-  /@polka/url@1.0.0-next.24:
-    resolution: {integrity: sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==}
+  /@polka/compression@1.0.0-next.25:
+    resolution: {integrity: sha512-UlVkoSGRig87riHSn8QOxd2DzGhadRpNSj5Ukqj+Bt7WTE4Es+sE3ju3OYbe8SiV2OwA+8tDcSuHWUh5S3jCBQ==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /@polka/url@1.0.0-next.25:
+    resolution: {integrity: sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==}
 
   /@rollup/plugin-commonjs@25.0.7(rollup@4.9.6):
     resolution: {integrity: sha512-nEvcR+LRjEjsaSsc4x3XZfCCvZIaSMenZu/OiwOKGN2UhQpAYI7ru7czFvyWbErlpoGjnSX3D5Ch5FcMA3kRWQ==}
@@ -5288,11 +5296,11 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /polka@1.0.0-next.24:
-    resolution: {integrity: sha512-i0EB3KPaALOLBC8K27UhPzzDyhsrn6KxDu0+agIz6ZgA2oNqqQjxBn+z9w2Ba4obV/PoqEJtyfzBkYgqKEJYiA==}
+  /polka@1.0.0-next.25:
+    resolution: {integrity: sha512-LBgDEGL73aeb/5yAwO9JWsqCuqPdvEdwA/n25Y38F4kv6jqFaLbgIWVuZfsv9Sc9O052eoWWrAjGB75oCQvELw==}
     engines: {node: '>=8'}
     dependencies:
-      '@polka/url': 1.0.0-next.24
+      '@polka/url': 1.0.0-next.25
       trouter: 4.0.0
     dev: true
 
@@ -5808,7 +5816,7 @@ packages:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
     dependencies:
-      '@polka/url': 1.0.0-next.24
+      '@polka/url': 1.0.0-next.25
       mrmime: 2.0.0
       totalist: 3.0.1
 


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/9593

We used to apply the `compression` middleware. However, that middleware is incompatible with streaming and has blocked users from filing issues or sending PRs to the repo. The newly available `@polka/compression` middleware addresses those concerns

This could be merged together with https://github.com/sveltejs/kit/pull/11945 and https://github.com/sveltejs/kit/pull/11653 as part of a new major release for `adapter-node`