### PR TITLE
feat: support for Vercel Images in enhanced-img

### DIFF
--- a/packages/enhanced-img/types/index.d.ts
+++ b/packages/enhanced-img/types/index.d.ts
@@ -9,4 +9,4 @@ declare module 'svelte/elements' {
 	}
 }
 
-export function enhancedImages(): Promise<Plugin[]>;
+export function enhancedImages(options: { vercel_sizes: number[] }): Promise<Plugin[]>;

--- a/sites/kit.svelte.dev/src/routes/home/Hero.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Hero.svelte
@@ -16,7 +16,7 @@
 
 		<div class="hero-image-wrapper">
 			<enhanced:img
-				src="./svelte-kit-machine.webp?w=1440;1080;768;640"
+				src="./svelte-kit-machine.webp?cdn=vercel&tint=ffaa22"
 				sizes="(min-width: 768px) min(100vw, 108rem), 64rem"
 				class="hero-image"
 				alt="SvelteKit illustration"

--- a/sites/kit.svelte.dev/svelte.config.js
+++ b/sites/kit.svelte.dev/svelte.config.js
@@ -4,7 +4,13 @@ import adapter from '@sveltejs/adapter-vercel';
 const config = {
 	kit: {
 		adapter: adapter({
-			runtime: 'edge'
+			runtime: 'edge',
+			images: {
+			  minimumCacheTTL: 300,
+			  formats: ['image/avif', 'image/webp'],
+			  sizes: [480, 1024, 1920, 2560],
+			  domains: []
+			}
 		}),
 
 		paths: {

--- a/sites/kit.svelte.dev/vite.config.js
+++ b/sites/kit.svelte.dev/vite.config.js
@@ -19,7 +19,9 @@ const config = {
 		cssMinify: 'lightningcss'
 	},
 
-	plugins: [enhancedImages(), sveltekit()],
+	plugins: [enhancedImages({
+		vercel_sizes: [480, 1024, 1920, 2560]
+	}), sveltekit()],
 
 	ssr: {
 		noExternal: ['@sveltejs/site-kit']


### PR DESCRIPTION
Usage:

https://github.com/sveltejs/kit/blob/7cf670319441b43bdd60791b8260ddfd7715913a/sites/kit.svelte.dev/svelte.config.js#L11

https://github.com/sveltejs/kit/blob/7cf670319441b43bdd60791b8260ddfd7715913a/sites/kit.svelte.dev/vite.config.js#L23

```html
<enhanced:img
  src="./svelte-kit-machine.webp?cdn=vercel&tint=ffaa22"
  sizes="(min-width: 768px) min(100vw, 108rem), 64rem"
  class="hero-image"
  alt="SvelteKit illustration"
/>
```

Notice the `cdn=vercel&tint=ffaa22`.

Output (after `npm run dev`):

```html
<img
 srcset="/@imagetools/dd29267694d95adde023ac14c36bec9956893809 480w, /@imagetools/dd29267694d95adde023ac14c36bec9956893809 1024w, /@imagetools/dd29267694d95adde023ac14c36bec9956893809 1920w, /@imagetools/dd29267694d95adde023ac14c36bec9956893809 2560w"
 src="/@imagetools/dd29267694d95adde023ac14c36bec9956893809"
 sizes="(min-width: 768px) min(100vw, 108rem), 64rem"
 class="hero-image s-V_4r9JSKzHNM"
 alt="SvelteKit illustration"
 width="1440"
 height="1440"
 title="NOTE(dev mode): The srcset image URLs will be more like /_vercel/image?url=...?w=&amp;q= in production."
>
```

![image](https://github.com/sveltejs/kit/assets/990216/501c1bdc-eeb8-4a98-8108-20e24341f7ef)

The scope of adding this functionality is kind of large given the different CDN providers.

Not sure how you all would want to go about it, but this is something I wanted for use with Vercel instead of having to use a component.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
