### PR TITLE
fix: update `pushState` function to reflect the new url in the `page` store

### DIFF
--- a/.changeset/rich-dryers-design.md
+++ b/.changeset/rich-dryers-design.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: update `page` store when `pushState` or `replaceState` is called

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1876,10 +1876,12 @@ export function pushState(url, state) {
 		[STATES_KEY]: state
 	};
 
-	history.pushState(opts, '', resolve_url(url));
+	const url_object = resolve_url(url);
+
+	history.pushState(opts, '', url_object);
 	has_navigated = true;
 
-	page = { ...page, state };
+	page = { ...page, state, url: url_object, route: { id: url_object.pathname } };
 	root.$set({ page });
 
 	clear_onward_history(current_history_index, current_navigation_index);

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1916,9 +1916,11 @@ export function replaceState(url, state) {
 		[STATES_KEY]: state
 	};
 
-	history.replaceState(opts, '', resolve_url(url));
+	const url_object = resolve_url(url);
 
-	page = { ...page, state };
+	history.replaceState(opts, '', url_object);
+
+	page = { ...page, state, url: url_object, route: { id: url_object.pathname } };
 	root.$set({ page });
 }
 

--- a/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/+page.svelte
@@ -20,4 +20,5 @@
 <button data-id="invalidate" on:click={invalidateAll}>invalidate all</button>
 
 <p>active: {$page.state.active ?? false}</p>
+<div class="route_id">route.id: {$page.route.id}</div>
 <span>{data.now}</span>

--- a/packages/kit/test/apps/basics/src/routes/shallow-routing/replace-state/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shallow-routing/replace-state/+page.svelte
@@ -17,3 +17,4 @@
 <button data-id="two" on:click={two}>replace state on child page</button>
 
 <p>active: {$page.state.active ?? false}</p>
+<div class="route_id">route.id: {$page.route.id}</div>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1119,8 +1119,14 @@ test.describe('Shallow routing', () => {
 		await page.goto('/shallow-routing/replace-state/b');
 		await clicknav('[href="/shallow-routing/replace-state"]');
 
+		await expect(page.locator('div.route_id')).toHaveText(
+			'route.id: /shallow-routing/replace-state'
+		);
 		await page.locator('[data-id="two"]').click();
 		await expect(page.locator('p')).toHaveText('active: true');
+		await expect(page.locator('div.route_id')).toHaveText(
+			'route.id: /shallow-routing/replace-state/a'
+		);
 
 		await page.goBack();
 		expect(page.url()).toBe(`${baseURL}/shallow-routing/replace-state/b`);

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1045,11 +1045,15 @@ test.describe('Shallow routing', () => {
 	test('Pushes state to a new URL', async ({ baseURL, page }) => {
 		await page.goto('/shallow-routing/push-state');
 		await expect(page.locator('p')).toHaveText('active: false');
+		await expect(page.locator('div.route_id')).toHaveText('route.id: /shallow-routing/push-state');
 
 		await page.locator('[data-id="two"]').click();
 		expect(page.url()).toBe(`${baseURL}/shallow-routing/push-state/a`);
 		await expect(page.locator('h1')).toHaveText('parent');
 		await expect(page.locator('p')).toHaveText('active: true');
+		await expect(page.locator('div.route_id')).toHaveText(
+			'route.id: /shallow-routing/push-state/a'
+		);
 
 		await page.reload();
 		await expect(page.locator('h1')).toHaveText('a');


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/11492

The `pushState` function was not updating the built-in `page` store properties (`$pages.url` and `$pages.route`) even though the actual URL in the browser was changed. This causes changes to not reflected on the UI if a component depends on any of those `page` store properties.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
