### PR TITLE
skip hydrate if ssr: false

### DIFF
--- a/.changeset/sweet-otters-glow.md
+++ b/.changeset/sweet-otters-glow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: only hydrate when page is server-rendered

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -419,8 +419,9 @@ async function _preload_code(pathname) {
 /**
  * @param {import('./types.js').NavigationFinished} result
  * @param {HTMLElement} target
+ * @param {boolean} hydrate
  */
-function initialize(result, target) {
+function initialize(result, target, hydrate) {
 	if (DEV && result.state.error && document.querySelector('vite-error-overlay')) return;
 
 	current = result.state;
@@ -433,7 +434,7 @@ function initialize(result, target) {
 	root = new app.root({
 		target,
 		props: { ...result.props, stores, components },
-		hydrate: true
+		hydrate
 	});
 
 	restore_snapshot(current_navigation_index);
@@ -1406,7 +1407,7 @@ async function navigate({
 		root.$set(navigation_result.props);
 		has_navigated = true;
 	} else {
-		initialize(navigation_result, target);
+		initialize(navigation_result, target, false);
 	}
 
 	const { activeElement } = document;
@@ -2382,7 +2383,7 @@ async function _hydrate(
 		result.props.page.state = {};
 	}
 
-	initialize(result, target);
+	initialize(result, target, true);
 }
 
 /**


### PR DESCRIPTION
Should fix https://github.com/sveltejs/svelte/issues/10929

When using Svelte 5, we're always calling `hydrate(...)` instead of `mount(...)`, even if the landing page was `ssr = false`. This PR fixes it.

Later, we can go a little bit further: by creating two entry points (one that references `hydrate`, one that references `mount`), and serving the `mount` entry point for `ssr = false` pages, we can take advantage of treeshaking to make the client bundle smaller in these cases. But it's probably not worth doing that until Svelte 5 is stable.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
