### PR TITLE
fix: resolve side effect imports

### DIFF
--- a/.changeset/heavy-ties-worry.md
+++ b/.changeset/heavy-ties-worry.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/package": patch
+---
+
+fix: resolve side effect imports

--- a/packages/package/src/utils.js
+++ b/packages/package/src/utils.js
@@ -30,7 +30,7 @@ export function resolve_aliases(input, file, content, aliases) {
 		return match;
 	};
 
-	content = content.replace(/from\s+('|")([^"';,]+?)\1/g, replace_import_path);
+	content = content.replace(/(?:import|from)\s*('|")([^"';,]+?)\1/g, replace_import_path);
 	content = content.replace(/import\s*\(\s*('|")([^"';,]+?)\1\s*\)/g, replace_import_path);
 	return content;
 }

--- a/packages/package/test/fixtures/resolve-alias/expected/Test.svelte
+++ b/packages/package/test/fixtures/resolve-alias/expected/Test.svelte
@@ -1,4 +1,5 @@
 <script>
+    import './css/global.css';
     import { foo } from './sub/foo';
 		import { util } from './utils';
     export let bar = foo;

--- a/packages/package/test/fixtures/resolve-alias/expected/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/resolve-alias/expected/Test.svelte.d.ts
@@ -1,4 +1,5 @@
 import { SvelteComponent } from 'svelte';
+import './css/global.css';
 declare const __propDef: {
 	props: {
 		bar?: import('./sub/foo').Foo;

--- a/packages/package/test/fixtures/resolve-alias/expected/css/global.css
+++ b/packages/package/test/fixtures/resolve-alias/expected/css/global.css
@@ -1,0 +1,1 @@
+/* some css to test if side effect imports are resolved */

--- a/packages/package/test/fixtures/resolve-alias/src/lib/Test.svelte
+++ b/packages/package/test/fixtures/resolve-alias/src/lib/Test.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import '$lib/css/global.css';
+
 	import { foo } from '$lib/sub/foo';
 	import { util } from '$utils';
 

--- a/packages/package/test/fixtures/resolve-alias/src/lib/css/global.css
+++ b/packages/package/test/fixtures/resolve-alias/src/lib/css/global.css
@@ -1,0 +1,1 @@
+/* some css to test if side effect imports are resolved */


### PR DESCRIPTION
`@sveltejs/package` does not resolve aliases for side effect imports. This is annoying when you have global CSS in your library and want to import that in Svelte components. With this PR side effect imports are now also resolved.

I have added tests for this, but the behaviour for the .d.ts file is weird. When using the currently published version, the CSS import is stripped from .d.ts file, but for the tests it is still there.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
