### PR TITLE
fix: add warning for form action responses lost without SSR

### DIFF
--- a/.changeset/many-cats-breathe.md
+++ b/.changeset/many-cats-breathe.md
@@ -2,4 +2,4 @@
 "@sveltejs/kit": patch
 ---
 
-fix: Add warning for form action responses lost without SSR
+fix: warn when form action responses are lost because SSR is off

--- a/.changeset/many-cats-breathe.md
+++ b/.changeset/many-cats-breathe.md
@@ -2,4 +2,4 @@
 "@sveltejs/kit": patch
 ---
 
-Add warning for form action responses lost without SSR
+fix: Add warning for form action responses lost without SSR

--- a/.changeset/many-cats-breathe.md
+++ b/.changeset/many-cats-breathe.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+Add warning for form action responses lost without SSR

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -100,8 +100,8 @@ export async function render_page(event, page, options, manifest, state, resolve
 		// no server data to prerender. As a result, the load functions and rendering
 		// only occur client-side.
 		if (get_option(nodes, 'ssr') === false && !(state.prerendering && should_prerender_data)) {
-			// if SSR is turned off, and the user makes a request through a non-enhanced form,
-			// the returned value is lost because neither the server nor the client will handle it
+			// if the user makes a request through a non-enhanced form, the returned value is lost
+			// because there is no SSR or client-side handling of the response
 			if (DEV) {
 				const no_enhance = !event.request.headers.has('x-sveltekit-action');
 

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -100,8 +100,8 @@ export async function render_page(event, page, options, manifest, state, resolve
 		// no server data to prerender. As a result, the load functions and rendering
 		// only occur client-side.
 		if (get_option(nodes, 'ssr') === false && !(state.prerendering && should_prerender_data)) {
-			// if SSR is turned off, and the user makes a request through a non-enhanced form, the action that
-			// returns a value is lost because neither the server nor the client will handle it
+			// if SSR is turned off, and the user makes a request through a non-enhanced form,
+			// the returned value is lost because neither the server nor the client will handle it
 			if (DEV) {
 				const no_enhance = !event.request.headers.has('x-sveltekit-action');
 

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -100,9 +100,8 @@ export async function render_page(event, page, options, manifest, state, resolve
 		// no server data to prerender. As a result, the load functions and rendering
 		// only occur client-side.
 		if (get_option(nodes, 'ssr') === false && !(state.prerendering && should_prerender_data)) {
-			// if SSR is turned off, and user makes a request through non-enhanced form and the action returns a value
-			// the returned value gets "lost", because neither the server nor the client will handle it
-			// so we warn the user about this
+			// if SSR is turned off, and the user makes a request through a non-enhanced form, the action that
+			// returns a value is lost because neither the server nor the client will handle it
 			if (DEV) {
 				const no_enhance = !event.request.headers.has('x-sveltekit-action');
 

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -102,23 +102,16 @@ export async function render_page(event, page, options, manifest, state, resolve
 		if (get_option(nodes, 'ssr') === false && !(state.prerendering && should_prerender_data)) {
 			// if the user makes a request through a non-enhanced form, the returned value is lost
 			// because there is no SSR or client-side handling of the response
-			if (DEV) {
-				const no_enhance = !event.request.headers.has('x-sveltekit-action');
-
-				if (action_result && no_enhance) {
-					if (action_result.type === 'error') {
-						console.warn(
-							"The form action returned an error, but +error.svelte wasn't rendered because SSR is off. To get the error page with CSR, enhance your form with `use:enhance`. See https://kit.svelte.dev/docs/form-actions#progressive-enhancement-use-enhance"
-						);
-					}
-					// for type: 'success' and type: 'failure'
-					else if (action_result.data) {
-						/// case: lost data
-						console.warn(
-							"The form action returned a value, but it isn't available in `$page.form`, because SSR is off. To handle the returned value in CSR, enhance your form with `use:enhance`. See https://kit.svelte.dev/docs/form-actions#progressive-enhancement-use-enhance"
-						);
-					}
-					// type 'redirect' is returned immediately, so we don't need to handle it here
+			if (DEV && action_result && !event.request.headers.has('x-sveltekit-action')) {
+				if (action_result.type === 'error') {
+					console.warn(
+						"The form action returned an error, but +error.svelte wasn't rendered because SSR is off. To get the error page with CSR, enhance your form with `use:enhance`. See https://kit.svelte.dev/docs/form-actions#progressive-enhancement-use-enhance"
+					);
+				} else if (action_result.data) {
+					/// case: lost data
+					console.warn(
+						"The form action returned a value, but it isn't available in `$page.form`, because SSR is off. To handle the returned value in CSR, enhance your form with `use:enhance`. See https://kit.svelte.dev/docs/form-actions#progressive-enhancement-use-enhance"
+					);
 				}
 			}
 


### PR DESCRIPTION
Fixes #11757.

As described in #11757, when SSR is disabled the values / errors returned from form actions get lost, because the CSR shell is always empty.

This behaviour is correct but can be confusing, if one forgets `use:enhance` on the form (been there, done that).

As proposed in https://github.com/sveltejs/kit/issues/11757#issuecomment-2013135714, I've added warnings that explain why the desired behaviour didn't occur and how to fix it.

I'm also not sure if such warning needs a test, if yes, I'll try to add it. :)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
