### PR TITLE
docs: update requirements for generated types

### DIFF
--- a/documentation/docs/50-reference/40-types.md
+++ b/documentation/docs/50-reference/40-types.md
@@ -96,7 +96,7 @@ export async function load({ params, fetch }) {
 }
 ```
 
-> For this to work, your own `tsconfig.json` or `jsconfig.json` should extend from the generated `.svelte-kit/tsconfig.json` (where `.svelte-kit` is your [`outDir`](configuration#outdir)):
+> For this to work, your own `tsconfig.json` or `jsconfig.json` should extend from the generated `.svelte-kit/tsconfig.json` (where `.svelte-kit` is your [`outDir`](configuration#outdir)) and TypeScript should be installed as a dependency:
 >
 > `{ "extends": "./.svelte-kit/tsconfig.json" }`
 


### PR DESCRIPTION
Clarifies that Typescript is required as a dependency for generated types to be created. When the dependency is missing they are silently omitted. This requirement may not be obvious to those who are running a vanilla JavaScript project and have not used the scaffolding script (e.g. because they migrated from an earlier version of SvelteKit).

I came across this issue because I migrated from an alpha version and spent a while scratching my head before realising why the new generated types were not working for me.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
