### PR TITLE
fix: correctly match asset filenames if base path is set

### DIFF
--- a/.changeset/dry-mirrors-shout.md
+++ b/.changeset/dry-mirrors-shout.md
@@ -1,0 +1,6 @@
+---
+"@sveltejs/adapter-cloudflare-workers": patch
+"@sveltejs/adapter-cloudflare": patch
+---
+
+fix: correctly return static assets if base path is set

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -57,8 +57,7 @@ export default {
 		const filename = stripped_pathname.slice(base_path.length + 1);
 		if (filename) {
 			is_static_asset =
-				manifest.assets.has(filename) ||
-				manifest.assets.has(filename + '/index.html');
+				manifest.assets.has(filename) || manifest.assets.has(filename + '/index.html');
 		}
 
 		let location = pathname.at(-1) === '/' ? stripped_pathname : pathname + '/';

--- a/packages/adapter-cloudflare-workers/files/entry.js
+++ b/packages/adapter-cloudflare-workers/files/entry.js
@@ -1,5 +1,5 @@
 import { Server } from 'SERVER';
-import { manifest, prerendered } from 'MANIFEST';
+import { manifest, prerendered, base_path } from 'MANIFEST';
 import { getAssetFromKV, mapRequestToAsset } from '@cloudflare/kv-asset-handler';
 import static_asset_manifest_json from '__STATIC_CONTENT_MANIFEST';
 const static_asset_manifest = JSON.parse(static_asset_manifest_json);
@@ -54,10 +54,11 @@ export default {
 
 		// prerendered pages and /static files
 		let is_static_asset = false;
-		const filename = stripped_pathname.substring(1);
+		const filename = stripped_pathname.slice(base_path.length + 1);
 		if (filename) {
 			is_static_asset =
-				manifest.assets.has(filename) || manifest.assets.has(filename + '/index.html');
+				manifest.assets.has(filename) ||
+				manifest.assets.has(filename + '/index.html');
 		}
 
 		let location = pathname.at(-1) === '/' ? stripped_pathname : pathname + '/';

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -73,9 +73,9 @@ export default function ({ config = 'wrangler.toml' } = {}) {
 
 			writeFileSync(
 				`${tmp}/manifest.js`,
-				`export const manifest = ${builder.generateManifest({
-					relativePath
-				})};\n\nexport const prerendered = new Map(${JSON.stringify(prerendered_entries)});\n`
+				`export const manifest = ${builder.generateManifest({ relativePath })};\n\n` +
+					`export const prerendered = new Map(${JSON.stringify(prerendered_entries)});\n\n` +
+					`export const base_path = ${JSON.stringify(builder.config.kit.paths.base)};\n`
 			);
 
 			const external = ['__STATIC_CONTENT_MANIFEST', 'cloudflare:*'];

--- a/packages/adapter-cloudflare-workers/placeholders.d.ts
+++ b/packages/adapter-cloudflare-workers/placeholders.d.ts
@@ -7,6 +7,7 @@ declare module 'MANIFEST' {
 
 	export const manifest: SSRManifest;
 	export const prerendered: Map<string, { file: string }>;
+	export const base_path: string;
 }
 
 declare module '__STATIC_CONTENT_MANIFEST' {

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -52,7 +52,7 @@ export default function (options = {}) {
 				`${tmp}/manifest.js`,
 				`export const manifest = ${builder.generateManifest({ relativePath })};\n\n` +
 					`export const prerendered = new Set(${JSON.stringify(builder.prerendered.paths)});\n\n` +
-					`export const app_path = ${JSON.stringify(builder.getAppPath())};\n`
+					`export const base_path = ${JSON.stringify(builder.config.kit.paths.base)};\n`
 			);
 
 			writeFileSync(
@@ -193,7 +193,7 @@ function get_routes_json(builder, assets, { include = ['/*'], exclude = ['<all>'
 								file === '_redirects'
 							)
 					)
-					.map((file) => `/${file}`);
+					.map((file) => `${builder.config.kit.paths.base}/${file}`);
 			}
 
 			if (rule === '<prerendered>') {

--- a/packages/adapter-cloudflare/placeholders.d.ts
+++ b/packages/adapter-cloudflare/placeholders.d.ts
@@ -8,4 +8,5 @@ declare module 'MANIFEST' {
 	export const manifest: SSRManifest;
 	export const prerendered: Set<string>;
 	export const app_path: string;
+	export const base_path: string;
 }

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -1,11 +1,13 @@
 import { Server } from 'SERVER';
-import { manifest, prerendered, app_path } from 'MANIFEST';
+import { manifest, prerendered, base_path } from 'MANIFEST';
 import * as Cache from 'worktop/cfw.cache';
 
 const server = new Server(manifest);
 
-const immutable = `/${app_path}/immutable/`;
-const version_file = `/${app_path}/version.json`;
+const app_path = `/${manifest.appPath}`;
+
+const immutable = `${app_path}/immutable/`;
+const version_file = `${app_path}/version.json`;
 
 /** @type {import('worktop/cfw').Module.Worker<{ ASSETS: import('worktop/cfw.durable').Durable.Object }>} */
 const worker = {
@@ -28,7 +30,7 @@ const worker = {
 
 		// prerendered pages and /static files
 		let is_static_asset = false;
-		const filename = stripped_pathname.substring(1);
+		const filename = stripped_pathname.slice(base_path.length + 1);
 		if (filename) {
 			is_static_asset =
 				manifest.assets.has(filename) || manifest.assets.has(filename + '/index.html');


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/12060

Exports the base path of the project so we can remove the base path from the request URL pathname when matching against the static asset filenames in the manifest that are saved without the base path.

might add some tests later just because the path matching has proven to be error prone

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
