### PR TITLE
fix: don't strip `lang="ts"` tag in Svelte 5

### DIFF
--- a/.changeset/loud-pens-mate.md
+++ b/.changeset/loud-pens-mate.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/package": patch
+---
+
+fix: don't strip `lang="ts"` tag in Svelte 5

--- a/packages/package/src/utils.js
+++ b/packages/package/src/utils.js
@@ -51,10 +51,10 @@ export function strip_lang_tags(content) {
 			// Things like application/ld+json should be kept as-is. Preprocessed languages are "ts" etc.
 			// Svelte 5 deals with TypeScript natively, and in the template, too, therefore keep it in.
 			// Not removing it would mean Svelte parses without its TS plugin and then runs into errors.
-			(match, s1, s2, _, s4) =>
-				s4?.startsWith('application/') || (is_svelte_5_plus && s4 === 'ts')
+			(match, comment, tag_open, _, type) =>
+				type?.startsWith('application/') || (is_svelte_5_plus && type === 'ts')
 					? match
-					: (s1 ?? '') + (s2 ?? '')
+					: (comment ?? '') + (tag_open ?? '')
 		)
 		.replace(/(<!--[^]*?-->)|(<style[^>]*?)\s(?:type|lang)=(["']).*?\3/g, '$1$2');
 }

--- a/packages/package/src/utils.js
+++ b/packages/package/src/utils.js
@@ -1,6 +1,9 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { VERSION } from 'svelte/compiler';
 import { posixify, mkdirp, walk } from './filesystem.js';
+
+const is_svelte_5_plus = Number(VERSION.split('.')[0]) >= 5;
 
 /**
  * Resolves aliases
@@ -45,8 +48,13 @@ export function strip_lang_tags(content) {
 	return content
 		.replace(
 			/(<!--[^]*?-->)|(<script[^>]*?)\s(?:type|lang)=(["'])(.*?)\3/g,
-			// things like application/ld+json should be kept as-is. Preprocessed languages are "ts" etc
-			(match, s1, s2, _, s4) => (s4?.startsWith('application/') ? match : (s1 ?? '') + (s2 ?? ''))
+			// Things like application/ld+json should be kept as-is. Preprocessed languages are "ts" etc.
+			// Svelte 5 deals with TypeScript natively, and in the template, too, therefore keep it in.
+			// Not removing it would mean Svelte parses without its TS plugin and then runs into errors.
+			(match, s1, s2, _, s4) =>
+				s4?.startsWith('application/') || (is_svelte_5_plus && s4 === 'ts')
+					? match
+					: (s1 ?? '') + (s2 ?? '')
 		)
 		.replace(/(<!--[^]*?-->)|(<style[^>]*?)\s(?:type|lang)=(["']).*?\3/g, '$1$2');
 }


### PR DESCRIPTION
closes https://github.com/sveltejs/svelte/issues/10766

no test because this needs Svelte 5 to work, which we don't use in this repo yet.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
