### PR TITLE
fix: tsconfig includes should cover svelte.config.js

### DIFF
--- a/.changeset/shaggy-walls-wave.md
+++ b/.changeset/shaggy-walls-wave.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": major
+---
+
+fix: tsconfig includes should cover svelte.config.js

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -58,6 +58,7 @@ export function get_tsconfig(kit) {
 		'ambient.d.ts', // careful: changing this name would be a breaking change, because it's referenced in the service-workers documentation
 		'non-ambient.d.ts',
 		'./types/**/$types.d.ts',
+		config_relative('svelte.config.js'),
 		config_relative('vite.config.js'),
 		config_relative('vite.config.ts')
 	]);

--- a/packages/kit/src/core/sync/write_tsconfig.spec.js
+++ b/packages/kit/src/core/sync/write_tsconfig.spec.js
@@ -77,6 +77,7 @@ test('Creates tsconfig include from kit.files', () => {
 		'ambient.d.ts',
 		'non-ambient.d.ts',
 		'./types/**/$types.d.ts',
+		'../svelte.config.js',
 		'../vite.config.js',
 		'../vite.config.ts',
 		'../app/**/*.js',


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/pull/11731 

While investigating https://github.com/sveltejs/kit/pull/11731 , I found that the ambient types from adapters weren't showing up when I tried installing the cloudflare, vercel, and node adapters in a fresh project and tried to access the autocomplete on `event.platform`.

This PR includes the `svelte.config.js` file in the generated tsconfig so that when the svelte.config.js file imports the adapter, the ambient types are included for the whole project.

We previously did this in https://github.com/sveltejs/kit/pull/11886 but had to revert it in https://github.com/sveltejs/kit/pull/11908 because it was a breaking change. 

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
