### PR TITLE
fix: `headers.get()` does not throw in csr

### DIFF
--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -347,9 +347,11 @@ export function create_universal_fetch(event, state, fetched, csr, resolve_opts)
 				if (value && !lower.startsWith('x-sveltekit-')) {
 					const included = resolve_opts.filterSerializedResponseHeaders(lower, value);
 					if (!included) {
-						throw new Error(
+						console.error(
 							`Failed to get response header "${lower}" — it must be included by the \`filterSerializedResponseHeaders\` option: https://kit.svelte.dev/docs/hooks#server-hooks-handle (at ${event.route.id})`
 						);
+
+						return null;
 					}
 				}
 

--- a/packages/kit/src/runtime/server/page/load_data.spec.js
+++ b/packages/kit/src/runtime/server/page/load_data.spec.js
@@ -56,11 +56,8 @@ test('errors when no acao header present on cors', async () => {
 	);
 });
 
-test('errors when trying to access non-serialized request headers on the server', async () => {
+test('returns null when trying to access non-serialized request headers on the server', async () => {
 	const fetch = create_fetch({});
 	const response = await fetch('https://domain-a.com');
-	assert.throws(
-		() => response.headers.get('content-type'),
-		/Failed to get response header "content-type" — it must be included by the `filterSerializedResponseHeaders` option/
-	);
+	assert.equal(response.headers.get('content-type'), null);
 });


### PR DESCRIPTION
[Headers.get](https://developer.mozilla.org/en-US/docs/Web/API/Headers/get) is not allowed to throw if the header is missing / not allowed to be used. It should return `null`. 

The design of this feature is also incredibly bad, as libraries like [`supabase/auth-js`](https://github.com/supabase/auth-js) which use a custom header `x-supabase-api-version` to negotiate responses and behavior is impossible to be used within Sveltekit. Why was this design chosen, is beyond this PR.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
