### PR TITLE
fix: set the correct for the ESLint config ignores

### DIFF
--- a/.changeset/chilly-wombats-roll.md
+++ b/.changeset/chilly-wombats-roll.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+fix: set the correct for the ESLint config ignores

--- a/packages/create-svelte/shared/+eslint+prettier+typescript/eslint.config.js
+++ b/packages/create-svelte/shared/+eslint+prettier+typescript/eslint.config.js
@@ -28,6 +28,6 @@ export default [
 		}
 	},
 	{
-		ignores: ['build/', '.svelte-kit/', 'package/']
+		ignores: ['build/', '.svelte-kit/', 'dist/']
 	}
 ];

--- a/packages/create-svelte/shared/+eslint+prettier-typescript/eslint.config.js
+++ b/packages/create-svelte/shared/+eslint+prettier-typescript/eslint.config.js
@@ -18,6 +18,6 @@ export default [
 		}
 	},
 	{
-		ignores: ['build/', '.svelte-kit/', 'package/']
+		ignores: ['build/', '.svelte-kit/', 'dist/']
 	}
 ];

--- a/packages/create-svelte/shared/+eslint+typescript/eslint.config.js
+++ b/packages/create-svelte/shared/+eslint+typescript/eslint.config.js
@@ -25,6 +25,6 @@ export default [
 		}
 	},
 	{
-		ignores: ['build/', '.svelte-kit/', 'package/']
+		ignores: ['build/', '.svelte-kit/', 'dist/']
 	}
 ];

--- a/packages/create-svelte/shared/+eslint-typescript/eslint.config.js
+++ b/packages/create-svelte/shared/+eslint-typescript/eslint.config.js
@@ -15,6 +15,6 @@ export default [
 		}
 	},
 	{
-		ignores: ['build/', '.svelte-kit/', 'package/']
+		ignores: ['build/', '.svelte-kit/', 'dist/']
 	}
 ];


### PR DESCRIPTION
By default, `svelte-package` creates a directory that is not `package` but `dist`, so we need to change it.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
