### PR TITLE
fix: set peerDependencies based on chosen Svelte version

### DIFF
--- a/.changeset/tall-goats-warn.md
+++ b/.changeset/tall-goats-warn.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+fix: set peerDependencies based on chosen Svelte version

--- a/packages/create-svelte/shared/+skeletonlib+svelte5/package.json
+++ b/packages/create-svelte/shared/+skeletonlib+svelte5/package.json
@@ -1,0 +1,8 @@
+{
+	"peerDependencies": {
+		"svelte": "^5.0.0-next.1"
+	},
+	"devDependencies": {
+		"svelte": "^5.0.0-next.1"
+	}
+}

--- a/packages/create-svelte/shared/+skeletonlib+svelte5/package.json
+++ b/packages/create-svelte/shared/+skeletonlib+svelte5/package.json
@@ -1,8 +1,8 @@
 {
 	"peerDependencies": {
-		"svelte": "^5.0.0-next.1"
+		"svelte": "^5.0.0-next.0"
 	},
 	"devDependencies": {
-		"svelte": "^5.0.0-next.1"
+		"svelte": "^5.0.0-next.0"
 	}
 }

--- a/packages/create-svelte/shared/+skeletonlib+svelte5/package.json
+++ b/packages/create-svelte/shared/+skeletonlib+svelte5/package.json
@@ -1,8 +1,8 @@
 {
 	"peerDependencies": {
-		"svelte": "^5.0.0-next.0"
+		"svelte": "^5.0.0-next.1"
 	},
 	"devDependencies": {
-		"svelte": "^5.0.0-next.0"
+		"svelte": "^5.0.0-next.1"
 	}
 }


### PR DESCRIPTION
If you create a library with Svelte 5 today, it still has Svelte 4 as a peer dependency