### PR TITLE
feat: add self-closing-tags migration

### DIFF
--- a/.changeset/sixty-walls-act.md
+++ b/.changeset/sixty-walls-act.md
@@ -1,0 +1,5 @@
+---
+"svelte-migrate": minor
+---
+
+feat: add self-closing-tags migration

--- a/packages/create-svelte/templates/default/src/routes/sverdle/+page.svelte
+++ b/packages/create-svelte/templates/default/src/routes/sverdle/+page.svelte
@@ -200,7 +200,7 @@
 			stageHeight: window.innerHeight,
 			colors: ['#ff3e00', '#40b3ff', '#676778']
 		}}
-	/>
+	></div>
 {/if}
 
 <style>

--- a/packages/kit/test/apps/basics/src/routes/anchor-with-manual-scroll/anchor-afternavigate/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/anchor-with-manual-scroll/anchor-afternavigate/+page.svelte
@@ -12,6 +12,6 @@
 	<p id="go-to-element">The browser scrolls to me</p>
 </div>
 <p id="abcde" style="height: 180vh; background-color: hotpink;">I take precedence</p>
-<div />
+<div></div>
 
 <a href="/anchor-with-manual-scroll/anchor-afternavigate?x=y#go-to-element">reload me</a>

--- a/packages/kit/test/apps/basics/src/routes/anchor-with-manual-scroll/anchor-onmount/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/anchor-with-manual-scroll/anchor-onmount/+page.svelte
@@ -13,4 +13,4 @@
 	<p id="go-to-element">The browser scrolls to me</p>
 </div>
 <p id="abcde" style="height: 180vh; background-color: hotpink;">I take precedence</p>
-<div />
+<div></div>

--- a/packages/kit/test/apps/basics/src/routes/data-sveltekit/noscroll/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/data-sveltekit/noscroll/+page.svelte
@@ -1,4 +1,4 @@
-<div style="height: 2000px; background: palegoldenrod" />
+<div style="height: 2000px; background: palegoldenrod"></div>
 
 <a id="one" href="/data-sveltekit/noscroll/target" data-sveltekit-noscroll>one</a>
 

--- a/packages/kit/test/apps/basics/src/routes/data-sveltekit/noscroll/target/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/data-sveltekit/noscroll/target/+page.svelte
@@ -1,3 +1,3 @@
-<div style="height: 2000px; background: palegoldenrod" />
+<div style="height: 2000px; background: palegoldenrod"></div>
 
 <h1>target</h1>

--- a/packages/kit/test/apps/basics/src/routes/iframes/nested/parent/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/iframes/nested/parent/+page.svelte
@@ -1,1 +1,1 @@
-<iframe title="Child content" src="./child" />
+<iframe title="Child content" src="./child"></iframe>

--- a/packages/kit/test/apps/basics/src/routes/no-ssr/margin/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/no-ssr/margin/+page.svelte
@@ -1,6 +1,6 @@
 <div class="container">
 	<span> ^this is not the top of the screen</span>
-	<div class="spacer" />
+	<div class="spacer"></div>
 </div>
 
 <style>

--- a/packages/kit/test/apps/basics/src/routes/routing/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/+page.svelte
@@ -12,4 +12,4 @@
 
 <a href="/routing/b" data-sveltekit-reload>b</a>
 
-<div class="hydrate-test" />
+<div class="hydrate-test"></div>

--- a/packages/kit/test/apps/basics/src/routes/scroll/cross-document/a/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/scroll/cross-document/a/+page.svelte
@@ -1,5 +1,5 @@
 <h1>a</h1>
 
-<div style="height: 200vh; background: teal" />
+<div style="height: 200vh; background: teal"></div>
 
 <a data-sveltekit-reload href="/scroll/cross-document/b">b</a>

--- a/packages/migrate/migrations/self-closing-tags/index.js
+++ b/packages/migrate/migrations/self-closing-tags/index.js
@@ -1,0 +1,38 @@
+import colors from 'kleur';
+import fs from 'node:fs';
+import prompts from 'prompts';
+import glob from 'tiny-glob/sync.js';
+import { remove_self_closing_tags } from './migrate.js';
+
+export async function migrate() {
+	console.log(
+		colors.bold().yellow('\nThis will update .svelte files inside the current directory\n')
+	);
+
+	const response = await prompts({
+		type: 'confirm',
+		name: 'value',
+		message: 'Continue?',
+		initial: false
+	});
+
+	if (!response.value) {
+		process.exit(1);
+	}
+
+	const files = glob('**/*.svelte')
+		.map((file) => file.replace(/\\/g, '/'))
+		.filter((file) => !file.includes('/node_modules/'));
+
+	for (const file of files) {
+		try {
+			const code = await remove_self_closing_tags(fs.readFileSync(file, 'utf-8'));
+			fs.writeFileSync(file, code);
+		} catch (e) {
+			// continue
+		}
+	}
+
+	console.log(colors.bold().green('✔ Your project has been updated'));
+	console.log('  If using Prettier, please upgrade to the latest prettier-plugin-svelte version');
+}

--- a/packages/migrate/migrations/self-closing-tags/migrate.js
+++ b/packages/migrate/migrations/self-closing-tags/migrate.js
@@ -1,0 +1,184 @@
+import MagicString from 'magic-string';
+import { parse, preprocess, walk } from 'svelte/compiler';
+
+const VoidElements = [
+	'area',
+	'base',
+	'br',
+	'col',
+	'embed',
+	'hr',
+	'img',
+	'input',
+	'keygen',
+	'link',
+	'menuitem',
+	'meta',
+	'param',
+	'source',
+	'track',
+	'wbr'
+];
+
+const SVGElements = [
+	'altGlyph',
+	'altGlyphDef',
+	'altGlyphItem',
+	'animate',
+	'animateColor',
+	'animateMotion',
+	'animateTransform',
+	'circle',
+	'clipPath',
+	'color-profile',
+	'cursor',
+	'defs',
+	'desc',
+	'discard',
+	'ellipse',
+	'feBlend',
+	'feColorMatrix',
+	'feComponentTransfer',
+	'feComposite',
+	'feConvolveMatrix',
+	'feDiffuseLighting',
+	'feDisplacementMap',
+	'feDistantLight',
+	'feDropShadow',
+	'feFlood',
+	'feFuncA',
+	'feFuncB',
+	'feFuncG',
+	'feFuncR',
+	'feGaussianBlur',
+	'feImage',
+	'feMerge',
+	'feMergeNode',
+	'feMorphology',
+	'feOffset',
+	'fePointLight',
+	'feSpecularLighting',
+	'feSpotLight',
+	'feTile',
+	'feTurbulence',
+	'filter',
+	'font',
+	'font-face',
+	'font-face-format',
+	'font-face-name',
+	'font-face-src',
+	'font-face-uri',
+	'foreignObject',
+	'g',
+	'glyph',
+	'glyphRef',
+	'hatch',
+	'hatchpath',
+	'hkern',
+	'image',
+	'line',
+	'linearGradient',
+	'marker',
+	'mask',
+	'mesh',
+	'meshgradient',
+	'meshpatch',
+	'meshrow',
+	'metadata',
+	'missing-glyph',
+	'mpath',
+	'path',
+	'pattern',
+	'polygon',
+	'polyline',
+	'radialGradient',
+	'rect',
+	'set',
+	'solidcolor',
+	'stop',
+	'svg',
+	'switch',
+	'symbol',
+	'text',
+	'textPath',
+	'tref',
+	'tspan',
+	'unknown',
+	'use',
+	'view',
+	'vkern'
+];
+
+/** @param {string} source */
+export async function remove_self_closing_tags(source) {
+	const preprocessed = await preprocess(source, {
+		script: ({ content }) => ({
+			code: content
+				.split('\n')
+				.map((line) => ' '.repeat(line.length))
+				.join('\n')
+		}),
+		style: ({ content }) => ({
+			code: content
+				.split('\n')
+				.map((line) => ' '.repeat(line.length))
+				.join('\n')
+		})
+	});
+	const ast = parse(preprocessed.code);
+	const ms = new MagicString(source);
+	/** @type {Array<() => void>} */
+	const updates = [];
+	let is_foreign = false;
+	let is_custom_element = false;
+
+	walk(/** @type {any} */ (ast.html), {
+		/** @param {Record<string, any>} node */
+		enter(node) {
+			if (node.type === 'Options') {
+				const namespace = node.attributes.find(
+					/** @param {any} a */
+					(a) => a.type === 'Attribute' && a.name === 'namespace'
+				);
+				if (namespace?.value[0].data === 'foreign') {
+					is_foreign = true;
+					return;
+				}
+
+				is_custom_element = node.attributes.some(
+					/** @param {any} a */
+					(a) => a.type === 'Attribute' && (a.name === 'customElement' || a.name === 'tag')
+				);
+			}
+
+			if (node.type === 'Element' || node.type === 'Slot') {
+				const is_self_closing = source[node.end - 2] === '/';
+				if (
+					!is_self_closing ||
+					VoidElements.includes(node.name) ||
+					SVGElements.includes(node.name) ||
+					!/^[a-z0-9_-]+$/.test(node.name)
+				) {
+					return;
+				}
+
+				let start = node.end - 2;
+				if (source[start - 1] === ' ') {
+					start--;
+				}
+				updates.push(() => {
+					if (node.type === 'Element' || is_custom_element) {
+						ms.update(start, node.end, `></${node.name}>`);
+					}
+				});
+			}
+		}
+	});
+
+	if (is_foreign) {
+		return source;
+	}
+
+	updates.forEach((update) => update());
+	return ms.toString();
+}

--- a/packages/migrate/migrations/self-closing-tags/migrate.spec.js
+++ b/packages/migrate/migrations/self-closing-tags/migrate.spec.js
@@ -1,4 +1,5 @@
 import { assert, test } from 'vitest';
+import * as compiler from 'svelte/compiler';
 import { remove_self_closing_tags } from './migrate.js';
 
 /** @type {Record<string, string>} */
@@ -25,6 +26,6 @@ const tests = {
 for (const input in tests) {
 	test(input, async () => {
 		const output = tests[input];
-		assert.equal(await remove_self_closing_tags(input), output);
+		assert.equal(await remove_self_closing_tags(compiler, input), output);
 	});
 }

--- a/packages/migrate/migrations/self-closing-tags/migrate.spec.js
+++ b/packages/migrate/migrations/self-closing-tags/migrate.spec.js
@@ -1,0 +1,30 @@
+import { assert, test } from 'vitest';
+import { remove_self_closing_tags } from './migrate.js';
+
+/** @type {Record<string, string>} */
+const tests = {
+	'<div/>': '<div></div>',
+	'<div />': '<div></div>',
+	'<custom-element />': '<custom-element></custom-element>',
+	'<div class="foo"/>': '<div class="foo"></div>',
+	'<div class="foo" />': '<div class="foo"></div>',
+	'\t<div\n\t\tonclick={blah}\n\t/>': '\t<div\n\t\tonclick={blah}\n\t></div>',
+	'<foo-bar/>': '<foo-bar></foo-bar>',
+	'<link/>': '<link/>',
+	'<link />': '<link />',
+	'<svg><g /></svg>': '<svg><g /></svg>',
+	'<slot />': '<slot />',
+	'<svelte:options customElement="my-element" /><slot />':
+		'<svelte:options customElement="my-element" /><slot></slot>',
+	'<svelte:options namespace="foreign" /><foo />': '<svelte:options namespace="foreign" /><foo />',
+	'<script>console.log("<div />")</script>': '<script>console.log("<div />")</script>',
+	'<script lang="ts">let a: string = ""</script><div />':
+		'<script lang="ts">let a: string = ""</script><div></div>'
+};
+
+for (const input in tests) {
+	test(input, async () => {
+		const output = tests[input];
+		assert.equal(await remove_self_closing_tags(input), output);
+	});
+}

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -24,20 +24,22 @@
 		"!migrations/**/samples.md"
 	],
 	"dependencies": {
+		"import-meta-resolve": "^4.0.0",
 		"kleur": "^4.1.5",
 		"magic-string": "^0.30.5",
 		"prompts": "^2.4.2",
 		"semver": "^7.5.4",
-		"svelte": "^4.0.0",
 		"tiny-glob": "^0.2.9",
 		"ts-morph": "^22.0.0",
-		"typescript": "^5.3.3"
+		"typescript": "^5.3.3",
+		"zimmerframe": "^1.1.2"
 	},
 	"devDependencies": {
 		"@types/node": "^18.19.3",
 		"@types/prompts": "^2.4.9",
 		"@types/semver": "^7.5.6",
 		"prettier": "^3.1.1",
+		"svelte": "^4.2.10",
 		"vitest": "^1.5.0"
 	},
 	"scripts": {

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -28,6 +28,7 @@
 		"magic-string": "^0.30.5",
 		"prompts": "^2.4.2",
 		"semver": "^7.5.4",
+		"svelte": "^4.0.0",
 		"tiny-glob": "^0.2.9",
 		"ts-morph": "^22.0.0",
 		"typescript": "^5.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1089,6 +1089,9 @@ importers:
       semver:
         specifier: ^7.5.4
         version: 7.6.0
+      svelte:
+        specifier: ^4.0.0
+        version: 4.2.14
       tiny-glob:
         specifier: ^0.2.9
         version: 0.2.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,6 +1077,9 @@ importers:
 
   packages/migrate:
     dependencies:
+      import-meta-resolve:
+        specifier: ^4.0.0
+        version: 4.0.0
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
@@ -1089,9 +1092,6 @@ importers:
       semver:
         specifier: ^7.5.4
         version: 7.6.0
-      svelte:
-        specifier: ^4.0.0
-        version: 4.2.14
       tiny-glob:
         specifier: ^0.2.9
         version: 0.2.9
@@ -1101,6 +1101,9 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
+      zimmerframe:
+        specifier: ^1.1.2
+        version: 1.1.2
     devDependencies:
       '@types/node':
         specifier: ^18.19.3
@@ -1114,6 +1117,9 @@ importers:
       prettier:
         specifier: ^3.1.1
         version: 3.2.5
+      svelte:
+        specifier: ^4.2.10
+        version: 4.2.14
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@18.19.31)(lightningcss@1.24.1)
@@ -7458,6 +7464,10 @@ packages:
       cookie: 0.5.0
       mustache: 4.2.0
       stacktracey: 2.1.8
+    dev: false
+
+  /zimmerframe@1.1.2:
+    resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
     dev: false
 
   /zod@3.22.4:

--- a/sites/kit.svelte.dev/src/routes/home/Video.svelte
+++ b/sites/kit.svelte.dev/src/routes/home/Video.svelte
@@ -120,7 +120,7 @@
 	</video>
 
 	{#if d}
-		<div class="progress-bar" style={`width: ${(t / d) * 100}%`} />
+		<div class="progress-bar" style={`width: ${(t / d) * 100}%`}></div>
 	{/if}
 
 	<div class="top-controls">


### PR DESCRIPTION
Companion to sveltejs/svelte#11114. This adds an npx svelte-migrate self-closing-tags migration that replaces all the self-closing non-void elements in your .svelte files.

Alternative to #12102 with the following adjustments:
- doesn't migrate slots that are not real custom element slots (will make diff much less noisy)
- doesn't migrate when namespace is foreign
- leaves tag-like strings inside scripts/styles etc alone

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
