### PR TITLE
Add %sveltekit.version% placeholder for template interpolation

### DIFF
--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -51,6 +51,7 @@ export const options = {
 			.replace('%sveltekit.body%', '" + body + "')
 			.replace(/%sveltekit\.assets%/g, '" + assets + "')
 			.replace(/%sveltekit\.nonce%/g, '" + nonce + "')
+			.replace(/%sveltekit\.version%/g, config.kit.version.name)
 			.replace(
 				/%sveltekit\.env\.([^%]+)%/g,
 				(_match, capture) => `" + (env[${s(capture)}] ?? "") + "`

--- a/playgrounds/basic/src/app.html
+++ b/playgrounds/basic/src/app.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="version" content="%sveltekit.version%" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/playgrounds/basic/svelte.config.js
+++ b/playgrounds/basic/svelte.config.js
@@ -3,7 +3,10 @@ import adapter from '@sveltejs/adapter-auto';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter()
+		adapter: adapter(),
+		version: {
+			name: 'playground'
+		}
 	}
 };
 


### PR DESCRIPTION
Allow `app.html` to interpolate the `version` string passed to `kit.version.name` in `svelte.config.js`. This makes it easier for static `<head>` includes for third-party scripts to be passed the current app version, e.g.

```html
<script>
  GenericAnalytics.init({
    token: "abc123",
    application: "web",
    version: "%sveltekit.version%",
  });
</script>
```

This is nice ergonomic improvement, but there are several available workarounds:

* set a variable using a globally included `%sveltekit.head%`
* duplicate the version string to an env variable and use `%sveltekit.env.PUBLIC_VERSION%`
* do your own pre-templating of `app.html` in `hooks.server`

This PR resolves https://github.com/sveltejs/kit/issues/12130.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
