### PR TITLE
chore: fixed typo in all svelte configs of create-svelte

### DIFF
--- a/packages/create-svelte/shared/+default+checkjs/svelte.config.js
+++ b/packages/create-svelte/shared/+default+checkjs/svelte.config.js
@@ -9,7 +9,7 @@ const config = {
 
 	kit: {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
-		// If your environment is not supported or you settled on a specific environment, switch out the adapter.
+		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
 		adapter: adapter()
 	}

--- a/packages/create-svelte/shared/+default+typescript/svelte.config.js
+++ b/packages/create-svelte/shared/+default+typescript/svelte.config.js
@@ -9,7 +9,7 @@ const config = {
 
 	kit: {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
-		// If your environment is not supported or you settled on a specific environment, switch out the adapter.
+		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
 		adapter: adapter()
 	}

--- a/packages/create-svelte/shared/+default-typescript/svelte.config.js
+++ b/packages/create-svelte/shared/+default-typescript/svelte.config.js
@@ -4,7 +4,7 @@ import adapter from '@sveltejs/adapter-auto';
 const config = {
 	kit: {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
-		// If your environment is not supported or you settled on a specific environment, switch out the adapter.
+		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
 		adapter: adapter()
 	}

--- a/packages/create-svelte/shared/+typescript/svelte.config.js
+++ b/packages/create-svelte/shared/+typescript/svelte.config.js
@@ -9,7 +9,7 @@ const config = {
 
 	kit: {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
-		// If your environment is not supported or you settled on a specific environment, switch out the adapter.
+		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
 		adapter: adapter()
 	}

--- a/packages/create-svelte/shared/-typescript/svelte.config.js
+++ b/packages/create-svelte/shared/-typescript/svelte.config.js
@@ -4,7 +4,7 @@ import adapter from '@sveltejs/adapter-auto';
 const config = {
 	kit: {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
-		// If your environment is not supported or you settled on a specific environment, switch out the adapter.
+		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
 		adapter: adapter()
 	}


### PR DESCRIPTION
WebStorm notified me of a typo in the `svelte.config.js` file after creating a new project with `create-svelte`. I also cross-checked with languagetool.org and they both said that a comma was missing, so I added it :)
A very dumb PR but I hope it's enough.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [X] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
