### PR TITLE
Forced cookie path change breaks re-use of CookieSerializeOptions #11799

### DIFF
--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -236,7 +236,8 @@ export interface Cookies {
 	set(
 		name: string,
 		value: string,
-		opts: import('cookie').CookieSerializeOptions & { path: string }
+		opts: import('../runtime/server/page/types.d.ts').CustomCookieSerializeOptions
+
 	): void;
 
 	/**
@@ -246,7 +247,7 @@ export interface Cookies {
 	 * @param name the name of the cookie
 	 * @param opts the options, passed directly to `cookie.serialize`. The `path` must match the path of the cookie you want to delete. See documentation [here](https://github.com/jshttp/cookie#cookieserializename-value-options)
 	 */
-	delete(name: string, opts: import('cookie').CookieSerializeOptions & { path: string }): void;
+	delete(name: string, opts: import('../runtime/server/page/types.d.ts').CustomCookieSerializeOptions): void;
 
 	/**
 	 * Serialize a cookie name-value pair into a `Set-Cookie` header string, but don't apply it to the response.
@@ -262,7 +263,7 @@ export interface Cookies {
 	serialize(
 		name: string,
 		value: string,
-		opts: import('cookie').CookieSerializeOptions & { path: string }
+		opts: import('../runtime/server/page/types.d.ts').CustomCookieSerializeOptions
 	): string;
 }
 

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -36,7 +36,7 @@ export function get_cookies(request, url, trailing_slash) {
 	/** @type {Record<string, import('./page/types.js').Cookie>} */
 	const new_cookies = {};
 
-	/** @type {import('cookie').CookieSerializeOptions} */
+	/** @type {import('./page/types.js').CustomCookieSerializeOptions}*/
 	const defaults = {
 		httpOnly: true,
 		sameSite: 'lax',

--- a/packages/kit/src/runtime/server/page/types.d.ts
+++ b/packages/kit/src/runtime/server/page/types.d.ts
@@ -32,5 +32,5 @@ export interface CspOpts {
 export interface Cookie {
 	name: string;
 	value: string;
-	options: CookieSerializeOptions & { path: string };
+	options: CookieSerializeOptions & { path: string | undefined };
 }

--- a/packages/kit/src/runtime/server/page/types.d.ts
+++ b/packages/kit/src/runtime/server/page/types.d.ts
@@ -29,8 +29,12 @@ export interface CspOpts {
 	prerender: boolean;
 }
 
+export interface CustomCookieSerializeOptions extends CookieSerializeOptions {
+	path: string;
+}
+
 export interface Cookie {
 	name: string;
 	value: string;
-	options: CookieSerializeOptions & { path: string | undefined };
+	options: CustomCookieSerializeOptions;
 }

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -218,7 +218,7 @@ declare module '@sveltejs/kit' {
 		set(
 			name: string,
 			value: string,
-			opts: import('cookie').CookieSerializeOptions & { path: string }
+			opts: import('cookie').CookieSerializeOptions & { path: string | undefined}
 		): void;
 
 		/**
@@ -228,7 +228,7 @@ declare module '@sveltejs/kit' {
 		 * @param name the name of the cookie
 		 * @param opts the options, passed directly to `cookie.serialize`. The `path` must match the path of the cookie you want to delete. See documentation [here](https://github.com/jshttp/cookie#cookieserializename-value-options)
 		 */
-		delete(name: string, opts: import('cookie').CookieSerializeOptions & { path: string }): void;
+		delete(name: string, opts: import('cookie').CookieSerializeOptions & { path: string | undefined}): void;
 
 		/**
 		 * Serialize a cookie name-value pair into a `Set-Cookie` header string, but don't apply it to the response.
@@ -244,7 +244,7 @@ declare module '@sveltejs/kit' {
 		serialize(
 			name: string,
 			value: string,
-			opts: import('cookie').CookieSerializeOptions & { path: string }
+			opts: import('cookie').CookieSerializeOptions & { path: string | undefined}
 		): string;
 	}
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -218,7 +218,7 @@ declare module '@sveltejs/kit' {
 		set(
 			name: string,
 			value: string,
-			opts: import('cookie').CookieSerializeOptions & { path: string | undefined}
+			opts: import('../src/runtime/server/page/types').CustomCookieSerializeOptions
 		): void;
 
 		/**
@@ -228,7 +228,7 @@ declare module '@sveltejs/kit' {
 		 * @param name the name of the cookie
 		 * @param opts the options, passed directly to `cookie.serialize`. The `path` must match the path of the cookie you want to delete. See documentation [here](https://github.com/jshttp/cookie#cookieserializename-value-options)
 		 */
-		delete(name: string, opts: import('cookie').CookieSerializeOptions & { path: string | undefined}): void;
+		delete(name: string, opts: import('../src/runtime/server/page/types').CustomCookieSerializeOptions): void;
 
 		/**
 		 * Serialize a cookie name-value pair into a `Set-Cookie` header string, but don't apply it to the response.
@@ -244,7 +244,7 @@ declare module '@sveltejs/kit' {
 		serialize(
 			name: string,
 			value: string,
-			opts: import('cookie').CookieSerializeOptions & { path: string | undefined}
+			opts: import('../src/runtime/server/page/types').CustomCookieSerializeOptions
 		): string;
 	}
 


### PR DESCRIPTION
Creates and exports a custom CustomCookieSerializeOptions type for issue #11799, edited in the following files:

- types.d.ts
- cookie.js
- public.d.ts
- index.d.ts

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
