### PR TITLE
fix: Continue traversing a non-self-closing element's children

### DIFF
--- a/.changeset/smart-donkeys-destroy.md
+++ b/.changeset/smart-donkeys-destroy.md
@@ -1,0 +1,5 @@
+---
+'svelte-migrate': patch
+---
+
+fix: continue traversing the children of non-self-closing elements

--- a/packages/migrate/migrations/self-closing-tags/migrate.js
+++ b/packages/migrate/migrations/self-closing-tags/migrate.js
@@ -164,6 +164,7 @@ export async function remove_self_closing_tags({ preprocess, parse }, source) {
 					SVGElements.includes(node.name) ||
 					!/^[a-z0-9_-]+$/.test(node.name)
 				) {
+					next();
 					return;
 				}
 

--- a/packages/migrate/migrations/self-closing-tags/migrate.spec.js
+++ b/packages/migrate/migrations/self-closing-tags/migrate.spec.js
@@ -20,7 +20,8 @@ const tests = {
 	'<svelte:options namespace="foreign" /><foo />': '<svelte:options namespace="foreign" /><foo />',
 	'<script>console.log("<div />")</script>': '<script>console.log("<div />")</script>',
 	'<script lang="ts">let a: string = ""</script><div />':
-		'<script lang="ts">let a: string = ""</script><div></div>'
+		'<script lang="ts">let a: string = ""</script><div></div>',
+	'<div><i /><div>': '<div><i /><div>'
 };
 
 for (const input in tests) {

--- a/packages/migrate/migrations/self-closing-tags/migrate.spec.js
+++ b/packages/migrate/migrations/self-closing-tags/migrate.spec.js
@@ -21,7 +21,7 @@ const tests = {
 	'<script>console.log("<div />")</script>': '<script>console.log("<div />")</script>',
 	'<script lang="ts">let a: string = ""</script><div />':
 		'<script lang="ts">let a: string = ""</script><div></div>',
-	'<div><i /><div>': '<div><i /><div>'
+	'<div><i/></div>': '<div><i></i></div>'
 };
 
 for (const input in tests) {


### PR DESCRIPTION
Fixes an issue where a non-self-closing element would have their children skipped when running the `svelte-migrate self-closing-tags` migration script.

for example:
```svelte
<div>
<!-- 👇 doesn't get fixed by the migration script -->
	<i /> 
</div>
```

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
