### PR TITLE
feat: make TypeScript the default for apps

### DIFF
--- a/.changeset/twelve-singers-bake.md
+++ b/.changeset/twelve-singers-bake.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": minor
+---
+
+feat: make TypeScript the default for apps

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -60,18 +60,20 @@ const options = await p.group(
 				})
 			}),
 
-		types: () =>
+		types: ({ results }) =>
 			p.select({
 				message: 'Add type checking with TypeScript?',
-				initialValue: /** @type {'checkjs' | 'typescript' | null} */ ('checkjs'),
+				initialValue: /** @type {'checkjs' | 'typescript' | null} */ (
+					results.template === 'skeletonlib' ? 'checkjs' : 'typescript'
+				),
 				options: [
-					{
-						label: 'Yes, using JavaScript with JSDoc comments',
-						value: 'checkjs'
-					},
 					{
 						label: 'Yes, using TypeScript syntax',
 						value: 'typescript'
+					},
+					{
+						label: 'Yes, using JavaScript with JSDoc comments',
+						value: 'checkjs'
 					},
 					{ label: 'No', value: null }
 				]
@@ -111,7 +113,7 @@ const options = await p.group(
 await create(cwd, {
 	name: path.basename(path.resolve(cwd)),
 	template: /** @type {'default' | 'skeleton' | 'skeletonlib'} */ (options.template),
-	types: options.types,
+	types: /** @type {'checkjs' | 'typescript' | null} */ (options.types),
 	prettier: options.features.includes('prettier'),
 	eslint: options.features.includes('eslint'),
 	playwright: options.features.includes('playwright'),


### PR DESCRIPTION
I don't think we ever really meant to make JSDoc the default or didn't put much thought into having it be the default. We've said that JSDoc is nice for libraries to avoid shipping sourcemaps, etc. But the calculus for applications is different and we should probably have TypeScript be the default there.