### PR TITLE
fix: prevent `hooks.server` code being imported into client during build

### DIFF
--- a/.changeset/slimy-eyes-pull.md
+++ b/.changeset/slimy-eyes-pull.md
@@ -2,4 +2,4 @@
 "@sveltejs/kit": patch
 ---
 
-fix hooks.server code triggering a client import error
+fix: prevent client import error when a `hooks.server` file imports a private environment variable

--- a/.changeset/slimy-eyes-pull.md
+++ b/.changeset/slimy-eyes-pull.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix hooks.server code triggering a client import error

--- a/packages/kit/src/utils/filesystem.js
+++ b/packages/kit/src/utils/filesystem.js
@@ -181,7 +181,7 @@ export function resolve_entry(entry) {
 			const base = path.basename(entry);
 			const files = fs.readdirSync(dir);
 
-			const found = files.find((file) => file.replace(/\.[^.]+$/, '') === base);
+			const found = files.find((file) => file.replace(/\.(js|ts)$/, '') === base);
 
 			if (found) return path.join(dir, found);
 		}

--- a/packages/kit/src/utils/filesystem.spec.js
+++ b/packages/kit/src/utils/filesystem.spec.js
@@ -2,7 +2,7 @@ import { mkdtempSync, writeFileSync, readdirSync, mkdirSync, readFileSync } from
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { assert, expect, beforeEach, test } from 'vitest';
-import { copy, mkdirp } from './filesystem.js';
+import { copy, mkdirp, resolve_entry } from './filesystem.js';
 
 /** @type {string} */
 let source_dir;
@@ -98,4 +98,10 @@ test('replaces strings', () => {
 		readFileSync(join(dest_dir, 'foo.md'), 'utf8'),
 		'the quick brown fox jumps over the lazy dog'
 	);
+});
+
+test('ignores hooks.server folder when resolving hooks', () => {
+	write('hooks.server/index.js', '');
+
+	expect(resolve_entry(source_dir + '/hooks')).null;
 });


### PR DESCRIPTION
Server side code inside a `src/hooks.server` folder can result in the build trying to import the code into client side code, usually causing the build to break.

Reproduction: https://www.sveltelab.dev/egkmtnbmy05petz (execute `npm run build`)

It's due to the file suffix being stripped off so `hooks.server` matches a search for `hooks` when the code is looking for universal hooks. This makes the suffix matching stricter to only strip `.js` or `.ts` (AFAICT, those are the only things that should ever be matched with this fn).

Fixes: https://github.com/sveltejs/kit/issues/11754

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [X] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
