### PR TITLE
fix: exclude service worker directory from tsconfig

### DIFF
--- a/.changeset/red-ladybugs-press.md
+++ b/.changeset/red-ladybugs-press.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: exclude service worker directory from tsconfig

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -87,8 +87,11 @@ export function get_tsconfig(kit) {
 		exclude.push(config_relative(kit.files.serviceWorker));
 	} else {
 		exclude.push(config_relative(`${kit.files.serviceWorker}.js`));
+		exclude.push(config_relative(`${kit.files.serviceWorker}/**/*.js`));
 		exclude.push(config_relative(`${kit.files.serviceWorker}.ts`));
+		exclude.push(config_relative(`${kit.files.serviceWorker}/**/*.ts`));
 		exclude.push(config_relative(`${kit.files.serviceWorker}.d.ts`));
+		exclude.push(config_relative(`${kit.files.serviceWorker}/**/*.d.ts`));
 	}
 
 	const config = {


### PR DESCRIPTION
The [docs](https://kit.svelte.dev/docs/service-workers) state that the service worker can be located at `src/service-worker.js` or as an `index.js` file within the `src/service-worker` directory.

Without this fix users who place the file within the directory run into Typescript errors like [#11721](https://github.com/sveltejs/kit/issues/11721)

Follow up to [#11727](https://github.com/sveltejs/kit/pull/11727)

Question for maintainers: Should all js/ts files in the `service-worker` directory be excluded or only `index.js|ts|d.ts`? 

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
