### PR TITLE
feat: implement prototype of safe server stores

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -28,7 +28,7 @@
 		"@playwright/test": "^1.41.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"@types/connect": "^3.4.38",
-		"@types/node": "^18.19.3",
+		"@types/node": "^18.19.33",
 		"@types/sade": "^1.7.8",
 		"@types/set-cookie-parser": "^2.4.7",
 		"dts-buddy": "0.4.6",

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1828,7 +1828,7 @@ declare module '@sveltejs/kit' {
 	export type NumericRange<TStart extends number, TEnd extends number> = Exclude<TEnd | LessThan<TEnd>, LessThan<TStart>>;
 	export const VERSION: string;
 	class HttpError_1 {
-		
+
 		constructor(status: number, body: {
 			message: string;
 		} extends App.Error ? (App.Error | string | undefined) : App.Error);
@@ -1837,7 +1837,7 @@ declare module '@sveltejs/kit' {
 		toString(): string;
 	}
 	class Redirect_1 {
-		
+
 		constructor(status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308, location: string);
 		status: 301 | 302 | 303 | 307 | 308 | 300 | 304 | 305 | 306;
 		location: string;
@@ -2180,11 +2180,11 @@ declare module '$app/server' {
 
 declare module '$app/stores' {
 	export function getStores(): {
-		
+
 		page: typeof page;
-		
+
 		navigating: typeof navigating;
-		
+
 		updated: typeof updated;
 	};
 	/**
@@ -2210,6 +2210,8 @@ declare module '$app/stores' {
 	export const updated: import('svelte/store').Readable<boolean> & {
 		check(): Promise<boolean>;
 	};
+
+	export const unshared_writable: (initialValue: any) => import('svelte/store').Writable<any>;
 }/**
  * It's possible to tell SvelteKit how to type objects inside your app by declaring the `App` namespace. By default, a new project will have a file called `src/app.d.ts` containing the following:
  *

--- a/playgrounds/basic/src/lib/global_store.js
+++ b/playgrounds/basic/src/lib/global_store.js
@@ -1,0 +1,5 @@
+// import { writable } from 'svelte/store';
+
+import { unshared_writable } from '$app/stores';
+
+export const global_counter = unshared_writable(0);

--- a/playgrounds/basic/src/routes/+page.svelte
+++ b/playgrounds/basic/src/routes/+page.svelte
@@ -1,2 +1,10 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation</p>
+<script>
+import { global_counter } from '$lib/global_store';
+
+global_counter.subscribe(count => console.log("counter updated", count));
+
+</script>
+<h1>{$global_counter}</h1>
+
+<button on:click={() => global_counter.set(1)}>set</button>
+<button on:click={() => global_counter.update((count) => count + 1)}>update</button>

--- a/playgrounds/basic/src/routes/+page.ts
+++ b/playgrounds/basic/src/routes/+page.ts
@@ -1,0 +1,9 @@
+import { global_counter } from '$lib/global_store';
+import { get } from 'svelte/store';
+
+export async function load() {
+    global_counter.update((count) => count + 1);
+    const v = get(global_counter);
+
+    console.log('load', v);
+}

--- a/playgrounds/basic/src/routes/+page.ts
+++ b/playgrounds/basic/src/routes/+page.ts
@@ -1,9 +1,6 @@
 import { global_counter } from '$lib/global_store';
-import { get } from 'svelte/store';
 
 export async function load() {
+    // increment the counter on every page load, but it will always stay at 1 because requests are isolated
     global_counter.update((count) => count + 1);
-    const v = get(global_counter);
-
-    console.log('load', v);
 }


### PR DESCRIPTION
## Context

The unsafe behavior of global variables during SSR (particularly global stores) has been one of the most persistently complained about issues with SvelteKit (#4339).

![Screenshot 2024-05-13 at 2 58 04 pm](https://github.com/sveltejs/kit/assets/17972275/e2908071-0968-431b-8902-7e391044f257)

The way stores are currently implemented result in state being leaked across requests which presents a very high security risk especially for users that are unaware of this difference of behavior in client-side vs server-side apps.

## Solution
Using `AsyncLocalStorage` allows us to isolate the stores between server-side requests in Svelte.

**Docs:** https://nodejs.org/api/async_context.html

**Clarification**: This is only a server-side feature, and is not necessary on the browser side of things as the client is naturally isolated from other clients - web support for `AsyncLocalStorage` is not required

## Benefits
- Ability to use declare and use globally accessible stores in normal JS/TS files, including within `hooks`
- No more `Cannot access 'x' before initialization`
- Request-level isolation
- No security worries with data leakage between requests 

## My thoughts
- I have temporarily implemented a custom `unshared_writable` function inside of the Kit repository, but this behavior should be implemented in the Svelte repository itself, with a way for the server to replace the `getStore` function with another function which uses `AsyncLocalStorage.getStore()` from the server `index.js` code
- Currently, the `initialValue` is reused in a shallow way (so only primitive types are isolated). we could implement behavior to do a deep clone with [structuredClone](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone), alternatively, the syntax of `writable` could be `writable(() => initial_value)` such that it is a function that returns a fresh object, but this would change the syntax and be a breaking change with the existing store functions in `svelte/store`
- Currently, the global stores aren't transferred to the client-side, so we'll need a way to serialize and serialize the existing state onto the client-side which shouldn't be too difficult to implement

## Support
This appears to be supported by all major server runtimes:

- [Cloudflare](https://developers.cloudflare.com/workers/runtime-apis/nodejs/asynclocalstorage/) as `node:async_hooks`
- [Node](https://nodejs.org/api/async_context.html) as `node:async_hooks`
- [Bun](https://github.com/oven-sh/bun/pull/3089) as `node:async_hooks`
- [Vercel](https://vercel.com/docs/functions/runtimes/edge-runtime#compatible-node.js-modules) as `node:async_hooks`
- [Deno](https://docs.deno.com/runtime/manual/node/compatibility) as `node:async_hooks`

I believe they all use the same import module 