### PR TITLE
fix: ensure generated tsconfig paths start with `./` if aliasing to `./svelte-kit`

### DIFF
--- a/.changeset/wicked-kangaroos-swim.md
+++ b/.changeset/wicked-kangaroos-swim.md
@@ -2,4 +2,4 @@
 "@sveltejs/kit": patch
 ---
 
-fix: correctly handle aliases to files in the `./svelte-kit` directory
+fix: correctly handle aliases to files in the `.svelte-kit` directory

--- a/.changeset/wicked-kangaroos-swim.md
+++ b/.changeset/wicked-kangaroos-swim.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: correctly handle aliases to files in the `./svelte-kit` directory

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -192,7 +192,7 @@ const value_regex = /^(.*?)((\/\*)|(\.\w+))?$/;
  */
 function get_tsconfig_paths(config) {
 	/** @param {string} file */
-	const config_relative = (file) => posixify(path.relative(config.outDir, file));
+	const config_relative = (file) => posixify('./' + path.relative(config.outDir, file));
 
 	const alias = { ...config.alias };
 	if (fs.existsSync(project_relative(config.files.lib))) {

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -192,7 +192,13 @@ const value_regex = /^(.*?)((\/\*)|(\.\w+))?$/;
  */
 function get_tsconfig_paths(config) {
 	/** @param {string} file */
-	const config_relative = (file) => posixify('./' + path.relative(config.outDir, file));
+	const config_relative = (file) => {
+		let relative_path = path.relative(config.outDir, file);
+		if (!relative_path.startsWith('..')) {
+			relative_path = './' + relative_path;
+		}
+		return posixify(relative_path);
+	};
 
 	const alias = { ...config.alias };
 	if (fs.existsSync(project_relative(config.files.lib))) {

--- a/packages/kit/src/core/sync/write_tsconfig.spec.js
+++ b/packages/kit/src/core/sync/write_tsconfig.spec.js
@@ -9,7 +9,8 @@ test('Creates tsconfig path aliases from kit.alias', () => {
 				simpleKey: 'simple/value',
 				key: 'value',
 				'key/*': 'some/other/value/*',
-				keyToFile: 'path/to/file.ts'
+				keyToFile: 'path/to/file.ts',
+				$routes: '.svelte-kit/types/src/routes'
 			}
 		}
 	});
@@ -23,7 +24,9 @@ test('Creates tsconfig path aliases from kit.alias', () => {
 		'simpleKey/*': ['../simple/value/*'],
 		key: ['../value'],
 		'key/*': ['../some/other/value/*'],
-		keyToFile: ['../path/to/file.ts']
+		keyToFile: ['../path/to/file.ts'],
+		$routes: ['./types/src/routes'],
+		'$routes/*': ['./types/src/routes/*']
 	});
 });
 


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/12169

Appends a `"./"` to the generated tsconfig path so that aliases to files in `.svelte-kit/...` don't cause the user's tsconfig.json to complain about non-relative paths.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
