### PR TITLE
fix: use correct type for '*?enhanced' imports

### DIFF
--- a/.changeset/cool-grapes-remain.md
+++ b/.changeset/cool-grapes-remain.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/enhanced-img": patch
+---
+
+Use correct type for '\*?enhanced' imports

--- a/.changeset/cool-grapes-remain.md
+++ b/.changeset/cool-grapes-remain.md
@@ -1,5 +1,5 @@
 ---
-"@sveltejs/enhanced-img": patch
+'@sveltejs/enhanced-img': patch
 ---
 
-Use correct type for '\*?enhanced' imports
+fix: use correct type for `*?enhanced` imports

--- a/packages/enhanced-img/types/ambient.d.ts
+++ b/packages/enhanced-img/types/ambient.d.ts
@@ -1,4 +1,5 @@
 import type { Picture } from 'vite-imagetools';
+
 declare module '*?enhanced' {
 	const value: Picture;
 	export default value;

--- a/packages/enhanced-img/types/ambient.d.ts
+++ b/packages/enhanced-img/types/ambient.d.ts
@@ -1,4 +1,5 @@
+import type { Picture } from 'vite-imagetools';
 declare module '*?enhanced' {
-	const value: string;
+	const value: Picture;
 	export default value;
 }

--- a/packages/enhanced-img/types/index.d.ts
+++ b/packages/enhanced-img/types/index.d.ts
@@ -1,14 +1,14 @@
-import 'svelte/elements';
+import type { HTMLImgAttributes } from 'svelte/elements';
 import type { Plugin } from 'vite';
 import type { Picture } from 'vite-imagetools';
 import './ambient.js';
 
+type EnhancedImgAttributes = Omit<HTMLImgAttributes, 'src'> & { src: string | Picture };
+
 // https://svelte.dev/docs/typescript#enhancing-built-in-dom-types
 declare module 'svelte/elements' {
 	export interface SvelteHTMLElements {
-		'enhanced:img': Omit<HTMLImgAttributes, 'src'> & {
-			src: string | Picture;
-		};
+		'enhanced:img': EnhancedImgAttributes;
 	}
 }
 

--- a/packages/enhanced-img/types/index.d.ts
+++ b/packages/enhanced-img/types/index.d.ts
@@ -1,11 +1,14 @@
+import 'svelte/elements';
 import type { Plugin } from 'vite';
+import type { Picture } from 'vite-imagetools';
 import './ambient.js';
-import { HTMLImgAttributes } from 'svelte/elements';
 
 // https://svelte.dev/docs/typescript#enhancing-built-in-dom-types
 declare module 'svelte/elements' {
 	export interface SvelteHTMLElements {
-		'enhanced:img': HTMLImgAttributes;
+		'enhanced:img': Omit<HTMLImgAttributes, 'src'> & {
+			src: string | Picture;
+		};
 	}
 }
 


### PR DESCRIPTION
<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.

Currently the type of an enhanced import is `string`, which is wrong. You can easily verify by logging the imported value. The correct type is `Picture`.