### PR TITLE
fix: yield main thread before navigating

### DIFF
--- a/.changeset/pink-tigers-whisper.md
+++ b/.changeset/pink-tigers-whisper.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: yield main thread before navigating

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2122,7 +2122,7 @@ function _start_router() {
 
 		// allow the browser to repaint before navigating —
 		// this prevents INP scores being penalised
-		new Promise((fulfil) => {
+		await new Promise((fulfil) => {
 			requestAnimationFrame(() => {
 				setTimeout(fulfil, 0);
 			});

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2027,7 +2027,7 @@ function _start_router() {
 	}
 
 	/** @param {MouseEvent} event */
-	container.addEventListener('click', (event) => {
+	container.addEventListener('click', async (event) => {
 		// Adapted from https://github.com/visionmedia/page.js
 		// MIT license https://github.com/visionmedia/page.js#license
 		if (event.button || event.which !== 1) return;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2120,6 +2120,16 @@ function _start_router() {
 
 		event.preventDefault();
 
+		// allow the browser to repaint before navigating —
+		// this prevents INP scores being penalised
+		new Promise((fulfil) => {
+			requestAnimationFrame(() => {
+				setTimeout(fulfil, 0);
+			});
+
+			setTimeout(fulfil, 100); // fallback for edge case where rAF doesn't fire because e.g. tab was backgrounded
+		});
+
 		navigate({
 			type: 'link',
 			url,

--- a/packages/kit/test/apps/basics/src/routes/routing/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/+page.svelte
@@ -6,6 +6,7 @@
 
 <a href="/routing/a">a</a>
 <a href="/routing/ambiguous/ok.json" rel="external">ok</a>
+<a href="/routing/next-paint">next-paint</a>
 <a href="/routing/symlink-from">symlinked</a>
 <a href="http://localhost:{$page.url.searchParams.get('port')}">elsewhere</a>
 <a href="/static.json">static.json</a>

--- a/packages/kit/test/apps/basics/src/routes/routing/next-paint/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/next-paint/+page.svelte
@@ -1,0 +1,1 @@
+<p>next-paint</p>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1163,3 +1163,32 @@ test.describe('reroute', () => {
 		expect(await page.textContent('h1')).toContain('Full Navigation');
 	});
 });
+
+test.describe('INP', () => {
+	test('does not block next paint', async ({ page }) => {
+		// Thanks to https://publishing-project.rivendellweb.net/measuring-performance-tasks-with-playwright/#interaction-to-next-paint-inp
+		async function measureInteractionToPaint(selector) {
+			return page.evaluate(async (selector) => {
+				return new Promise((resolve) => {
+					const startTime = performance.now();
+					document.querySelector(selector).click();
+					requestAnimationFrame(() => {
+						const endTime = performance.now();
+						resolve(endTime - startTime);
+					});
+				});
+			}, selector);
+		}
+
+		await page.goto('/routing');
+
+		const client = await page.context().newCDPSession(page);
+		await client.send('Emulation.setCPUThrottlingRate', { rate: 100 });
+
+		const time = await measureInteractionToPaint('a[href="/routing/next-paint"]');
+
+		// we may need to tweak this number, and the `rate` above,
+		// depending on if this proves flaky
+		expect(time).toBeLessThan(200);
+	});
+});

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1189,6 +1189,6 @@ test.describe('INP', () => {
 
 		// we may need to tweak this number, and the `rate` above,
 		// depending on if this proves flaky
-		expect(time).toBeLessThan(200);
+		expect(time).toBeLessThan(400);
 	});
 });


### PR DESCRIPTION
By default, SvelteKit preloads the data and code needed to navigate when you touch or hover over a link. As a consequence, it's often the case that navigation can occur immediately following a click event, with no delay for network activity.

Ironically, this means that navigation becomes _less_ responsive, not more, because the browser doesn't get a chance to repaint before the navigation occurs and the page is re-rendered, which can cause dropped frames on slower devices. Because of this, the Interaction to Next Paint (INP) metric suffers, which harms the Core Web Vitals (CWV) score of SvelteKit apps.

This PR adds a tiny pause inside the `click` handler before navigation. The combination of `requestAnimationFrame` and `setTimeout` allows the browser to repaint, but without creating a user-noticeable delay.

No tests because I'm not sure how you _would_ test for this.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
