### PR TITLE
feat: add option for css preloads when prerendering

### DIFF
--- a/.changeset/sixty-planets-love.md
+++ b/.changeset/sixty-planets-love.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": minor
+---
+
+feat: add option for css preloads when prerendering

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -106,6 +106,7 @@ const get_defaults = (prefix = '') => ({
 			concurrency: 1,
 			crawl: true,
 			entries: ['*'],
+			generateCssPreloadTags: false,
 			origin: 'http://sveltekit-prerender'
 		},
 		version: {

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -197,6 +197,7 @@ const options = object(
 					return input;
 				}),
 
+				generateCssPreloadTags: boolean(false),
 				handleHttpError: validate(
 					(/** @type {any} */ { message }) => {
 						throw new Error(

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -41,6 +41,7 @@ export const options = {
 	embedded: ${config.kit.embedded},
 	env_public_prefix: '${config.kit.env.publicPrefix}',
 	env_private_prefix: '${config.kit.env.privatePrefix}',
+	generate_css_preload_tags: ${config.kit.prerender.generateCssPreloadTags},
 	hooks: null, // added lazily, via \`get_hooks\`
 	preload_strategy: ${s(config.kit.output.preloadStrategy)},
 	root,

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -545,6 +545,13 @@ export interface KitConfig {
 		 */
 		entries?: Array<'*' | `/${string}`>;
 		/**
+		 * Whether SvelteKit should generate `<link rel="preload">` tags for stylesheets.
+		 * This is useful for Cloudflare Pages's [Early Hints](https://developers.cloudflare.com/pages/configuration/early-hints/) feature, which looks for these tags to automatically generate Link headers.
+		 *
+		 * @default false
+		 */
+		generateCssPreloadTags?: boolean;
+		/**
 		 * How to respond to HTTP errors encountered while prerendering the app.
 		 *
 		 * - `'fail'` — fail the build

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -236,6 +236,9 @@ export async function render_response({
 			if (resolve_opts.preload({ type: 'css', path })) {
 				const preload_atts = ['rel="preload"', 'as="style"'];
 				link_header_preloads.add(`<${encodeURI(path)}>; ${preload_atts.join(';')}; nopush`);
+				if (options.generate_css_preload_tags && state.prerendering) {
+					head += `\n\t\t<link href="${path}" ${preload_atts.join(' ')}>`;
+				}
 			}
 		}
 

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -360,6 +360,7 @@ export interface SSROptions {
 	embedded: boolean;
 	env_public_prefix: string;
 	env_private_prefix: string;
+	generate_css_preload_tags: boolean;
 	hooks: ServerHooks;
 	preload_strategy: ValidatedConfig['kit']['output']['preloadStrategy'];
 	root: SSRComponent['default'];

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -527,6 +527,13 @@ declare module '@sveltejs/kit' {
 			 */
 			entries?: Array<'*' | `/${string}`>;
 			/**
+			 * Whether SvelteKit should generate `<link rel="preload">` tags for stylesheets.
+			 * This is useful for Cloudflare Pages's [Early Hints](https://developers.cloudflare.com/pages/configuration/early-hints/) feature, which looks for these tags to automatically generate Link headers.
+			 *
+			 * @default false
+			 */
+			generateCssPreloadTags?: boolean;
+			/**
 			 * How to respond to HTTP errors encountered while prerendering the app.
 			 *
 			 * - `'fail'` — fail the build


### PR DESCRIPTION
Adding a `<link rel="preload">` tag to prerendering for stylesheets is helpful for static page rendering. This is especially useful when deploying to Cloudflare, which looks for preload tags with its [Early Hints](https://developers.cloudflare.com/pages/configuration/early-hints/) feature.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
