### PR TITLE
docs: add keywords to selective loading docs

### DIFF
--- a/documentation/docs/40-best-practices/05-performance.md
+++ b/documentation/docs/40-best-practices/05-performance.md
@@ -71,7 +71,7 @@ To run third party scripts in a web worker (which avoids blocking the main threa
 
 ### Selective loading
 
-Code imported with static `import` declarations will be automatically bundled with the rest of your page. If there is a piece of code you need only when some condition is met, use the dynamic `import(...)` form to lazy-load the component.
+Code imported with static `import` declarations will be automatically bundled with the rest of your page. If there is a piece of code you need only when some condition is met, use the dynamic `import(...)` form to selectively lazy-load the component.
 
 ## Navigation
 


### PR DESCRIPTION
Should hopefully help with this:

>TIL we can lazy load components in Svelte too. I searched our docs but I don't think we have anything on them. I only first got familiar with the concept when going through the React / Next.js docs where they use a dynamic import with  lazy() or dynamic() .
>
>EDIT: found something briefly mentioned in Kit docs https://kit.svelte.dev/docs/performance#reducing-code-size-selective-loading but it didn't turn up when searching "lazy loading" or "dynamic import"