### PR TITLE
fix: update default playwright test case for lib-project

### DIFF
--- a/.changeset/sixty-dingos-invent.md
+++ b/.changeset/sixty-dingos-invent.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+fix: update default playwright test case for lib-project

--- a/packages/create-svelte/shared/+playwright+default/tests/test.ts
+++ b/packages/create-svelte/shared/+playwright+default/tests/test.ts
@@ -1,6 +1,0 @@
-import { expect, test } from '@playwright/test';
-
-test('about page has expected h1', async ({ page }) => {
-	await page.goto('/about');
-	await expect(page.getByRole('heading', { name: 'About this app' })).toBeVisible();
-});

--- a/packages/create-svelte/shared/+playwright+skeleton/tests/test.ts
+++ b/packages/create-svelte/shared/+playwright+skeleton/tests/test.ts
@@ -1,6 +1,0 @@
-import { expect, test } from '@playwright/test';
-
-test('index page has expected h1', async ({ page }) => {
-	await page.goto('/');
-	await expect(page.getByRole('heading', { name: 'Welcome to SvelteKit' })).toBeVisible();
-});

--- a/packages/create-svelte/shared/+playwright+skeletonlib/tests/test.ts
+++ b/packages/create-svelte/shared/+playwright+skeletonlib/tests/test.ts
@@ -2,5 +2,5 @@ import { expect, test } from '@playwright/test';
 
 test('index page has expected h1', async ({ page }) => {
 	await page.goto('/');
-	await expect(page.getByRole('heading', { name: 'Welcome to SvelteKit' })).toBeVisible();
+	await expect(page.getByRole('heading', { name: 'Welcome to your library project' })).toBeVisible();
 });

--- a/packages/create-svelte/shared/+playwright+skeletonlib/tests/test.ts
+++ b/packages/create-svelte/shared/+playwright+skeletonlib/tests/test.ts
@@ -2,5 +2,7 @@ import { expect, test } from '@playwright/test';
 
 test('index page has expected h1', async ({ page }) => {
 	await page.goto('/');
-	await expect(page.getByRole('heading', { name: 'Welcome to your library project' })).toBeVisible();
+	await expect(
+		page.getByRole('heading', { name: 'Welcome to your library project' })
+	).toBeVisible();
 });

--- a/packages/create-svelte/shared/+playwright+skeletonlib/tests/test.ts
+++ b/packages/create-svelte/shared/+playwright+skeletonlib/tests/test.ts
@@ -1,8 +1,0 @@
-import { expect, test } from '@playwright/test';
-
-test('index page has expected h1', async ({ page }) => {
-	await page.goto('/');
-	await expect(
-		page.getByRole('heading', { name: 'Welcome to your library project' })
-	).toBeVisible();
-});

--- a/packages/create-svelte/shared/+playwright/tests/test.ts
+++ b/packages/create-svelte/shared/+playwright/tests/test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from '@playwright/test';
+
+test('home page has expected h1', async ({ page }) => {
+	await page.goto('/');
+	await expect(page.locator('h1')).toBeVisible();
+});


### PR DESCRIPTION
## Summary

When you create a `Library project` with `playwrite` using `create-svelte`,  the default test case fails because the content of the H1 in a new `Library project` is different.


---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
