### PR TITLE
chore: enable Vercel speed insights on site

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1281,6 +1281,9 @@ importers:
       '@types/node':
         specifier: ^18.19.3
         version: 18.19.31
+      '@vercel/speed-insights':
+        specifier: ^1.0.0
+        version: 1.0.11(@sveltejs/kit@packages+kit)(svelte@4.2.14)
       browserslist:
         specifier: ^4.22.2
         version: 4.23.0
@@ -2358,6 +2361,29 @@ packages:
     resolution: {integrity: sha512-j4jCOOXke2t8cHZCIxu1dzKLHLcFmYzC3yqAK6MfZznOL1QIJKd0xcFsXK3zcqzU7ScsE2zWkiMMNHGMHgp+FA==}
     engines: {node: '>=16'}
     hasBin: true
+
+  '@vercel/speed-insights@1.0.11':
+    resolution: {integrity: sha512-l9hzSNmJvb2Yqpgd/BzpiT0J0aQDdtqxOf3Xm+iW4PICxVvhY1ef7Otdx4GXI+88dVkws57qMzXiShz19gXzSQ==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19
+      svelte: ^4
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitest/expect@1.5.0':
     resolution: {integrity: sha512-0pzuCI6KYi2SIC3LQezmxujU9RK/vwC1U9R0rLuGlNGcOuDWxqWKu6nUdFsX9tH1WU0SXtAxToOsEjeUn1s3hA==}
@@ -5983,6 +6009,11 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@vercel/speed-insights@1.0.11(@sveltejs/kit@packages+kit)(svelte@4.2.14)':
+    optionalDependencies:
+      '@sveltejs/kit': link:packages/kit
+      svelte: 4.2.14
 
   '@vitest/expect@1.5.0':
     dependencies:

--- a/sites/kit.svelte.dev/package.json
+++ b/sites/kit.svelte.dev/package.json
@@ -21,6 +21,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"@types/d3-geo": "^3.1.0",
 		"@types/node": "^18.19.3",
+		"@vercel/speed-insights": "^1.0.0",
 		"browserslist": "^4.22.2",
 		"flexsearch": "^0.7.31",
 		"lightningcss": "^1.22.1",

--- a/sites/kit.svelte.dev/src/routes/+layout.svelte
+++ b/sites/kit.svelte.dev/src/routes/+layout.svelte
@@ -6,6 +6,9 @@
 	import { Banners, Icon, Shell } from '@sveltejs/site-kit/components';
 	import { Nav, Separator } from '@sveltejs/site-kit/nav';
 	import { Search, SearchBox } from '@sveltejs/site-kit/search';
+	import { injectSpeedInsights } from '@vercel/speed-insights/sveltekit';
+
+	injectSpeedInsights();
 
 	export let data;
 


### PR DESCRIPTION
privacy-compliant way to track performance metrics on our sites
