### PR TITLE
fix: crawl hrefs that start with `config.prerender.origin`

### DIFF
--- a/.changeset/rude-hairs-roll.md
+++ b/.changeset/rude-hairs-roll.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: hrefs that start with `config.prerender.origin` are now crawled

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -276,7 +276,18 @@ async function prerender({ out, manifest_path, metadata, verbose, env }) {
 
 			actual_hashlinks.set(decoded, ids);
 
-			for (const href of hrefs) {
+			/** @param {string} href */
+			const removePrerenderOrigin = (href) => {
+				if (href.startsWith(config.prerender.origin)) {
+					if (href === config.prerender.origin) return '/';
+					if (href.at(config.prerender.origin.length) !== '/') return href;
+					return href.slice(config.prerender.origin.length);
+				} else {
+					return href;
+				}
+			};
+
+			for (const href of hrefs.map(removePrerenderOrigin)) {
 				if (!is_root_relative(href)) continue;
 
 				const { pathname, search, hash } = new URL(href, 'http://localhost');

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -282,9 +282,8 @@ async function prerender({ out, manifest_path, metadata, verbose, env }) {
 					if (href === config.prerender.origin) return '/';
 					if (href.at(config.prerender.origin.length) !== '/') return href;
 					return href.slice(config.prerender.origin.length);
-				} else {
-					return href;
 				}
+				return href;
 			};
 
 			for (const href of hrefs.map(removePrerenderOrigin)) {

--- a/packages/kit/test/prerendering/basics/src/routes/prerender-origin/+page.svelte
+++ b/packages/kit/test/prerendering/basics/src/routes/prerender-origin/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	import { page } from '$app/stores';
+	const href = new URL('/prerender-origin/dynamic', $page.url.origin).href;
+</script>
+
+<a {href}>Please crawl this</a>

--- a/packages/kit/test/prerendering/basics/src/routes/prerender-origin/[dynamic]/+page.svelte
+++ b/packages/kit/test/prerendering/basics/src/routes/prerender-origin/[dynamic]/+page.svelte
@@ -1,0 +1,4 @@
+<h1>
+	This page will only be discovered if full hrefs that start with config.prerender.origin are
+	crawled
+</h1>

--- a/packages/kit/test/prerendering/basics/svelte.config.js
+++ b/packages/kit/test/prerendering/basics/svelte.config.js
@@ -7,7 +7,7 @@ const config = {
 
 		prerender: {
 			handleHttpError: 'warn',
-			origin: 'http://example.com'
+			origin: 'http://prerender.origin'
 		}
 	}
 };

--- a/packages/kit/test/prerendering/basics/test/tests.spec.js
+++ b/packages/kit/test/prerendering/basics/test/tests.spec.js
@@ -203,7 +203,7 @@ test('fetches data from local endpoint', () => {
 
 test('respects config.prerender.origin', () => {
 	const content = read('origin.html');
-	expect(content).toMatch('<h2>http://example.com</h2>');
+	expect(content).toMatch('<h2>http://prerender.origin</h2>');
 });
 
 test('$env - includes environment variables', () => {
@@ -252,4 +252,9 @@ test('prerenders responses with immutable Headers', () => {
 test('prerenders paths with optional parameters with empty values', () => {
 	const content = read('optional-params.html');
 	expect(content).includes('Path with Value');
+});
+
+test('crawls links that start with config.prerender.origin', () => {
+	const content = read('prerender-origin/dynamic.html');
+	expect(content).toBeTruthy();
 });


### PR DESCRIPTION
Closes #12271 

Until now the crawler would not recoginze links that start with the value of `config.prerender.origin` as internal links & would not crawl them. This PR fixes that. 

For example: A link `<a href="https://my-site/base/some-page"` would not be crawled, even if `prerender.origin` was set to `https://my-site` in `svelte.config.js`. 

This is important since `<link rel="alternate"` requires links to be absolute URIs that include the protocol, so until now it was impossible for the crawler to discover pages that were linked to in valid `<link rel="alternate"` links. 

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
