### PR TITLE
fix: remove `images` from route-level config

### DIFF
--- a/.changeset/stupid-lies-remain.md
+++ b/.changeset/stupid-lies-remain.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/adapter-vercel': major
+'@sveltejs/adapter-vercel': patch
 ---
 
 fix: remove `images` from route-level config

--- a/.changeset/stupid-lies-remain.md
+++ b/.changeset/stupid-lies-remain.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-vercel': major
 ---
 
-breaking: remove `images` from route-level config
+fix: remove `images` from route-level config

--- a/.changeset/stupid-lies-remain.md
+++ b/.changeset/stupid-lies-remain.md
@@ -1,5 +1,5 @@
 ---
-"@sveltejs/adapter-vercel": patch
+'@sveltejs/adapter-vercel': major
 ---
 
-fix: add images to edge config types
+breaking: remove `images` from route-level config

--- a/.changeset/stupid-lies-remain.md
+++ b/.changeset/stupid-lies-remain.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-vercel": patch
+---
+
+fix: add images to edge config types

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -98,6 +98,10 @@ export interface EdgeConfig {
 	 * If `true`, this route will always be deployed as its own separate function
 	 */
 	split?: boolean;
+	/**
+	 * https://vercel.com/docs/build-output-api/v3/configuration#images
+	 */
+	images?: ImagesConfig;
 }
 
 export type Config = EdgeConfig | ServerlessConfig;

--- a/packages/adapter-vercel/index.d.ts
+++ b/packages/adapter-vercel/index.d.ts
@@ -30,11 +30,6 @@ export interface ServerlessConfig {
 	split?: boolean;
 
 	/**
-	 * https://vercel.com/docs/build-output-api/v3/configuration#images
-	 */
-	images?: ImagesConfig;
-
-	/**
 	 * [Incremental Static Regeneration](https://vercel.com/docs/concepts/incremental-static-regeneration/overview) configuration.
 	 * Serverless only.
 	 */
@@ -98,13 +93,14 @@ export interface EdgeConfig {
 	 * If `true`, this route will always be deployed as its own separate function
 	 */
 	split?: boolean;
+}
+
+export type Config = (EdgeConfig | ServerlessConfig) & {
 	/**
 	 * https://vercel.com/docs/build-output-api/v3/configuration#images
 	 */
 	images?: ImagesConfig;
-}
-
-export type Config = EdgeConfig | ServerlessConfig;
+};
 
 // we copy the RequestContext interface from `@vercel/edge` because that package can't co-exist with `@types/node`.
 // see https://github.com/sveltejs/kit/pull/9280#issuecomment-1452110035

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -22,7 +22,7 @@ const get_default_runtime = () => {
 // https://vercel.com/docs/functions/edge-functions/edge-runtime#compatible-node.js-modules
 const compatible_node_modules = ['async_hooks', 'events', 'buffer', 'assert', 'util'];
 
-/** @type {import('index.js').default} **/
+/** @type {import('./index.js').default} **/
 const plugin = function (defaults = {}) {
 	if ('edge' in defaults) {
 		throw new Error("{ edge: true } has been removed in favour of { runtime: 'edge' }");
@@ -69,8 +69,8 @@ const plugin = function (defaults = {}) {
 
 			/**
 			 * @param {string} name
-			 * @param {import('index.js').ServerlessConfig} config
-			 * @param {import('@sveltejs/kit').RouteDefinition<import('index.js').Config>[]} routes
+			 * @param {import('./index.js').ServerlessConfig} config
+			 * @param {import('@sveltejs/kit').RouteDefinition<import('./index.js').Config>[]} routes
 			 */
 			async function generate_serverless_function(name, config, routes) {
 				const dir = `${dirs.functions}/${name}.func`;
@@ -99,8 +99,8 @@ const plugin = function (defaults = {}) {
 
 			/**
 			 * @param {string} name
-			 * @param {import('index.js').EdgeConfig} config
-			 * @param {import('@sveltejs/kit').RouteDefinition<import('index.js').EdgeConfig>[]} routes
+			 * @param {import('./index.js').EdgeConfig} config
+			 * @param {import('@sveltejs/kit').RouteDefinition<import('./index.js').EdgeConfig>[]} routes
 			 */
 			async function generate_edge_function(name, config, routes) {
 				const tmp = builder.getBuildDirectory(`vercel-tmp/${name}`);
@@ -193,7 +193,7 @@ const plugin = function (defaults = {}) {
 				);
 			}
 
-			/** @type {Map<string, { i: number, config: import('index.js').Config, routes: import('@sveltejs/kit').RouteDefinition<import('index.js').Config>[] }>} */
+			/** @type {Map<string, { i: number, config: import('./index.js').Config, routes: import('@sveltejs/kit').RouteDefinition<import('./index.js').Config>[] }>} */
 			const groups = new Map();
 
 			/** @type {Map<string, { hash: string, route_id: string }>} */
@@ -202,7 +202,7 @@ const plugin = function (defaults = {}) {
 			/** @type {Map<string, string>} */
 			const functions = new Map();
 
-			/** @type {Map<import('@sveltejs/kit').RouteDefinition<import('index.js').Config>, { expiration: number | false, bypassToken: string | undefined, allowQuery: string[], group: number, passQuery: true }>} */
+			/** @type {Map<import('@sveltejs/kit').RouteDefinition<import('./index.js').Config>, { expiration: number | false, bypassToken: string | undefined, allowQuery: string[], group: number, passQuery: true }>} */
 			const isr_config = new Map();
 
 			/** @type {Set<string>} */
@@ -396,7 +396,7 @@ const plugin = function (defaults = {}) {
 	};
 };
 
-/** @param {import('index.js').EdgeConfig & import('index.js').ServerlessConfig} config */
+/** @param {import('./index.js').EdgeConfig & import('./index.js').ServerlessConfig} config */
 function hash_config(config) {
 	return [
 		config.runtime ?? '',
@@ -425,7 +425,7 @@ function write(file, data) {
 // This function is duplicated in adapter-static
 /**
  * @param {import('@sveltejs/kit').Builder} builder
- * @param {import('index.js').Config} config
+ * @param {import('./index.js').Config} config
  * @param {string} dir
  */
 function static_vercel_config(builder, config, dir) {
@@ -532,7 +532,7 @@ function static_vercel_config(builder, config, dir) {
  * @param {import('@sveltejs/kit').Builder} builder
  * @param {string} entry
  * @param {string} dir
- * @param {import('index.js').ServerlessConfig} config
+ * @param {import('./index.js').ServerlessConfig} config
  */
 async function create_function_bundle(builder, entry, dir, config) {
 	fs.rmSync(dir, { force: true, recursive: true });

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -210,6 +210,14 @@ const plugin = function (defaults = {}) {
 
 			// group routes by config
 			for (const route of builder.routes) {
+				if (route.config?.images) {
+					// we need this because previous versions incorrectly put `images` on `ServerlessConfig` —
+					// it's unlikely anyone actually used it that way, but belt and braces
+					throw new Error(
+						`\`images\` configuration can only be specified in your adapter options, not in individual routes (${route.id})`
+					);
+				}
+
 				const runtime = route.config?.runtime ?? defaults?.runtime ?? get_default_runtime();
 				const config = { runtime, ...defaults, ...route.config };
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -22,7 +22,7 @@ const get_default_runtime = () => {
 // https://vercel.com/docs/functions/edge-functions/edge-runtime#compatible-node.js-modules
 const compatible_node_modules = ['async_hooks', 'events', 'buffer', 'assert', 'util'];
 
-/** @type {import('.').default} **/
+/** @type {import('index.js').default} **/
 const plugin = function (defaults = {}) {
 	if ('edge' in defaults) {
 		throw new Error("{ edge: true } has been removed in favour of { runtime: 'edge' }");
@@ -69,8 +69,8 @@ const plugin = function (defaults = {}) {
 
 			/**
 			 * @param {string} name
-			 * @param {import('.').ServerlessConfig} config
-			 * @param {import('@sveltejs/kit').RouteDefinition<import('.').Config>[]} routes
+			 * @param {import('index.js').ServerlessConfig} config
+			 * @param {import('@sveltejs/kit').RouteDefinition<import('index.js').Config>[]} routes
 			 */
 			async function generate_serverless_function(name, config, routes) {
 				const dir = `${dirs.functions}/${name}.func`;
@@ -99,8 +99,8 @@ const plugin = function (defaults = {}) {
 
 			/**
 			 * @param {string} name
-			 * @param {import('.').EdgeConfig} config
-			 * @param {import('@sveltejs/kit').RouteDefinition<import('.').EdgeConfig>[]} routes
+			 * @param {import('index.js').EdgeConfig} config
+			 * @param {import('@sveltejs/kit').RouteDefinition<import('index.js').EdgeConfig>[]} routes
 			 */
 			async function generate_edge_function(name, config, routes) {
 				const tmp = builder.getBuildDirectory(`vercel-tmp/${name}`);
@@ -146,7 +146,8 @@ const plugin = function (defaults = {}) {
 
 						console.error(formatted.join('\n'));
 					}
-				} catch (error) {
+				} catch (err) {
+					const error = /** @type {import('esbuild').BuildFailure} */ (err);
 					for (const e of error.errors) {
 						for (const node of e.notes) {
 							const match =
@@ -192,7 +193,7 @@ const plugin = function (defaults = {}) {
 				);
 			}
 
-			/** @type {Map<string, { i: number, config: import('.').Config, routes: import('@sveltejs/kit').RouteDefinition<import('.').Config>[] }>} */
+			/** @type {Map<string, { i: number, config: import('index.js').Config, routes: import('@sveltejs/kit').RouteDefinition<import('index.js').Config>[] }>} */
 			const groups = new Map();
 
 			/** @type {Map<string, { hash: string, route_id: string }>} */
@@ -201,7 +202,7 @@ const plugin = function (defaults = {}) {
 			/** @type {Map<string, string>} */
 			const functions = new Map();
 
-			/** @type {Map<import('@sveltejs/kit').RouteDefinition<import('.').Config>, { expiration: number | false, bypassToken: string | undefined, allowQuery: string[], group: number, passQuery: true }>} */
+			/** @type {Map<import('@sveltejs/kit').RouteDefinition<import('index.js').Config>, { expiration: number | false, bypassToken: string | undefined, allowQuery: string[], group: number, passQuery: true }>} */
 			const isr_config = new Map();
 
 			/** @type {Set<string>} */
@@ -220,7 +221,7 @@ const plugin = function (defaults = {}) {
 				}
 
 				const node_runtime = /nodejs([0-9]+)\.x/.exec(runtime);
-				if (runtime !== 'edge' && (!node_runtime || node_runtime[1] < 18)) {
+				if (runtime !== 'edge' && (!node_runtime || parseInt(node_runtime[1]) < 18)) {
 					throw new Error(
 						`Invalid runtime '${runtime}' for route ${route.id}. Valid runtimes are 'edge' and 'nodejs18.x' or higher ` +
 							'(see the Node.js Version section in your Vercel project settings for info on the currently supported versions).'
@@ -395,7 +396,7 @@ const plugin = function (defaults = {}) {
 	};
 };
 
-/** @param {import('.').EdgeConfig & import('.').ServerlessConfig} config */
+/** @param {import('index.js').EdgeConfig & import('index.js').ServerlessConfig} config */
 function hash_config(config) {
 	return [
 		config.runtime ?? '',
@@ -424,7 +425,7 @@ function write(file, data) {
 // This function is duplicated in adapter-static
 /**
  * @param {import('@sveltejs/kit').Builder} builder
- * @param {import('.').Config} config
+ * @param {import('index.js').Config} config
  * @param {string} dir
  */
 function static_vercel_config(builder, config, dir) {
@@ -434,7 +435,7 @@ function static_vercel_config(builder, config, dir) {
 	/** @type {Record<string, { path: string }>} */
 	const overrides = {};
 
-	/** @type {import('./index').ImagesConfig} */
+	/** @type {import('./index.js').ImagesConfig | undefined} */
 	const images = config.images;
 
 	for (const [src, redirect] of builder.prerendered.redirects) {
@@ -531,7 +532,7 @@ function static_vercel_config(builder, config, dir) {
  * @param {import('@sveltejs/kit').Builder} builder
  * @param {string} entry
  * @param {string} dir
- * @param {import('.').ServerlessConfig} config
+ * @param {import('index.js').ServerlessConfig} config
  */
 async function create_function_bundle(builder, entry, dir, config) {
 	fs.rmSync(dir, { force: true, recursive: true });

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -210,14 +210,6 @@ const plugin = function (defaults = {}) {
 
 			// group routes by config
 			for (const route of builder.routes) {
-				if (route.config?.images) {
-					// we need this because previous versions incorrectly put `images` on `ServerlessConfig` —
-					// it's unlikely anyone actually used it that way, but belt and braces
-					throw new Error(
-						`\`images\` configuration can only be specified in your adapter options, not in individual routes (${route.id})`
-					);
-				}
-
 				const runtime = route.config?.runtime ?? defaults?.runtime ?? get_default_runtime();
 				const config = { runtime, ...defaults, ...route.config };
 

--- a/packages/adapter-vercel/tsconfig.json
+++ b/packages/adapter-vercel/tsconfig.json
@@ -13,6 +13,5 @@
 		"paths": {
 			"@sveltejs/kit": ["../kit/types/index"]
 		}
-	},
-	"include": ["**/*.js", "index.d.ts", "internal.d.ts"]
+	}
 }


### PR DESCRIPTION
The `include` in the `tsconfig.json` was causing the index file in `adapter-vercel` not to be type checked. I removed it to type check all files. I added `images` to the edge config to get it to pass. @dummdidumm could you verify if that's correct?