### PR TITLE
chore: replace `-prefetch` with `-preload-code` in tests

### DIFF
--- a/packages/kit/src/core/postbuild/fixtures/base/input.html
+++ b/packages/kit/src/core/postbuild/fixtures/base/input.html
@@ -8,8 +8,8 @@
 	<body>
 		<a href="https://external.com">https://external.com</a>
 		<a href="wheee">/wheee</a>
-		<a data-sveltekit-prefetch href="wheee2">/wheee</a>
-		<a href="wheee3" data-sveltekit-prefetch>/wheee</a>
+		<a data-sveltekit-preload-data href="wheee2">/wheee</a>
+		<a href="wheee3" data-sveltekit-preload-data/wheee</a>
 		<a href="wheee4">/wheee</a>
 	</body>
 </html>

--- a/packages/kit/src/core/postbuild/fixtures/basic-href/input.html
+++ b/packages/kit/src/core/postbuild/fixtures/basic-href/input.html
@@ -7,8 +7,8 @@
 	<body>
 		<a href="https://external.com">https://external.com</a>
 		<a href="/wheee">/wheee</a>
-		<a data-sveltekit-prefetch href="/wheee2">/wheee</a>
-		<a href="/wheee3" data-sveltekit-prefetch>/wheee</a>
+		<a data-sveltekit-preload-data href="/wheee2">/wheee</a>
+		<a href="/wheee3" data-sveltekit-preload-data>/wheee</a>
 		<a href="/wheee4">/wheee</a>
 	</body>
 </html>


### PR DESCRIPTION
Replaces the old `data-sveltekit-prefetch` attribute with `data-sveltekit-preload-code` in certain tests. This removes all mention of the attribute from the repository. (other than changelogs, of course)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
