### PR TITLE
fix: handle whitespace in HTTP Accept header

### DIFF
--- a/.changeset/witty-bees-hope.md
+++ b/.changeset/witty-bees-hope.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: handle whitespace in HTTP Accept header

--- a/packages/kit/src/utils/http.js
+++ b/packages/kit/src/utils/http.js
@@ -9,7 +9,7 @@ export function negotiate(accept, types) {
 	const parts = [];
 
 	accept.split(',').forEach((str, i) => {
-		const match = /([^/]+)\/([^;]+)(?:;q=([0-9.]+))?/.exec(str);
+		const match = /([^/ \t]+)\/([^; \t]+)[ \t]*(?:;[ \t]*q=([0-9.]+))?/.exec(str);
 
 		// no match equals invalid header — ignore
 		if (match) {

--- a/packages/kit/src/utils/http.spec.js
+++ b/packages/kit/src/utils/http.spec.js
@@ -6,6 +6,13 @@ test('handle valid accept header value', () => {
 	assert.equal(negotiate(accept, ['text/html']), 'text/html');
 });
 
+test('handle accept values with optional whitespace', () => {
+	// according to RFC 9110, OWS (optional whitespace, aka a space or horizontal tab)
+	// can occur before/after the `,` and the `;`.
+	const accept = 'application/some-thing-else, \tapplication/json \t; q=0.9  ,text/plain;q=0.1';
+	assert.equal(negotiate(accept, ['application/json', 'text/plain']), 'application/json');
+});
+
 test('handle invalid accept header value', () => {
 	const accept = 'text/html,*';
 	assert.equal(negotiate(accept, ['text/html']), 'text/html');


### PR DESCRIPTION
Currently, using something like `Accept: application/my-custom-type,application/json;q=0.9` correctly returns errors as JSON. However, once you add a space to it, e.g. like `Accept: application/my-custom-type, application/json;q=0.9`, any errors messages returned use HTML instead of JSON.

## The HTTP `Accept:` header, according to RFC 9110

According to [RFC 9110][1], in the HTTP Accept header, there can be OWS (optional whitespace, e.g. zero to unlimited SP (space) or HTAB (horizontal tab)) between the `;` and `,` characters.

If you go to [RFC 9110 § 12.5.1 Accept ¶ 3](https://www.rfc-editor.org/rfc/rfc9110#section-12.5.1-3):

> ```
>   Accept = #( media-range [ weight ] )
> 
>   media-range    = ( "*/*"
>                      / ( type "/" "*" )
>                      / ( type "/" subtype )
>                    ) parameters
> ```

Where `#()` is defined as a list, see [RFC 9110 § 5.6.1.2 ¶ 2](https://www.rfc-editor.org/rfc/rfc9110#section-5.6.1.2-2)

> ```
>   #element => [ element ] *( OWS "," OWS [ element ] )
> ```

and where `OWS` is defined in [RFC 9110 § 5.6.3 Whitespace ¶ 7](https://www.rfc-editor.org/rfc/rfc9110#section-5.6.3-7) as:

> ```
>   OWS            = *( SP / HTAB )
>                  ; optional whitespace
> ```

and where `weight` is defined as [RFC 9110 § 12.4.2 Quality Values ¶ 3](https://www.rfc-editor.org/rfc/rfc9110#section-12.4.2-3) as:

> ```
>   weight = OWS ";" OWS "q=" qvalue
>   qvalue = ( "0" [ "." 0*3DIGIT ] )
>          / ( "1" [ "." 0*3("0") ] )
> ```

[1]: https://www.rfc-editor.org/rfc/rfc9110

<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
  - I couldn't find a relevant issue for this, but this bug is pretty minor.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
