### PR TITLE
chore: reduce number of eslint global ignores

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,15 +4,7 @@ import svelte_config from '@sveltejs/eslint-config';
 export default [
 	...svelte_config,
 	{
-		languageOptions: {
-			parserOptions: {
-				project: true
-			}
-		},
 		rules: {
-			'@typescript-eslint/await-thenable': 'error',
-			'@typescript-eslint/no-unused-expressions': 'off',
-			'@typescript-eslint/require-await': 'error',
 			'no-undef': 'off'
 		}
 	},
@@ -23,18 +15,31 @@ export default [
 			'packages/adapter-cloudflare/files',
 			'packages/adapter-netlify/files',
 			'packages/adapter-node/files',
-			// TODO: figure out if we can ignore these only for @typescript-eslint
+		]
+	},
+	{
+		languageOptions: {
+			parserOptions: {
+				project: true
+			}
+		},
+		rules: {
+			'@typescript-eslint/await-thenable': 'error',
+			'@typescript-eslint/no-unused-expressions': 'off',
+			'@typescript-eslint/require-await': 'error',
+		},
+		ignores: [
 			'packages/adapter-node/rollup.config.js',
 			'packages/adapter-node/tests/smoke.spec.js',
-			'packages/adapter-static/test/apps',
-			'packages/create-svelte/shared',
-			'packages/create-svelte/templates',
-			'packages/kit/src/core/sync/create_manifest_data/test/samples',
-			'packages/kit/test/apps',
-			'packages/kit/test/build-errors',
-			'packages/kit/test/prerendering',
-			'packages/package/test/errors',
-			'packages/package/test/fixtures'
+			'packages/adapter-static/test/apps/**/*',
+			'packages/create-svelte/shared/**/*',
+			'packages/create-svelte/templates/**/*',
+			'packages/kit/src/core/sync/create_manifest_data/test/samples/**/*',
+			'packages/kit/test/apps/**/*',
+			'packages/kit/test/build-errors/**/*',
+			'packages/kit/test/prerendering/**/*',
+			'packages/package/test/errors/**/*',
+			'packages/package/test/fixtures/**/*'
 		]
 	}
 ];

--- a/packages/kit/test/apps/amp/playwright.config.js
+++ b/packages/kit/test/apps/amp/playwright.config.js
@@ -1,6 +1,11 @@
 import { config } from '../../utils.js';
 
-config.webServer && (config.webServer.timeout = 45000); // AMP validator needs a long time to get moving
+if (config.webServer) {
+	if (config.webServer instanceof Array) {
+		throw new Error('Expected a single web server');
+	}
+	config.webServer.timeout = 45000; // AMP validator needs a long time to get moving
+}
 
 // remove any projects with javaScriptEnabled
 const projects = config.projects || [];

--- a/packages/kit/test/apps/basics/src/routes/errors/init-error-endpoint/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/errors/init-error-endpoint/+server.js
@@ -3,6 +3,7 @@ import { json } from '@sveltejs/kit';
 
 if (!building) {
 	// @ts-expect-error
+	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 	thisvariableisnotdefined;
 }
 

--- a/packages/kit/test/apps/basics/src/routes/untrack/server/[x]/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/untrack/server/[x]/+page.server.js
@@ -1,8 +1,11 @@
 export function load({ params, parent, url, untrack }) {
 	untrack(() => {
+		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 		params.x;
 		parent();
+		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 		url.pathname;
+		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 		url.search;
 	});
 

--- a/packages/kit/test/apps/basics/src/routes/untrack/universal/[x]/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/untrack/universal/[x]/+page.js
@@ -1,8 +1,11 @@
 export function load({ params, parent, url, untrack }) {
 	untrack(() => {
+		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 		params.x;
 		parent();
+		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 		url.pathname;
+		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 		url.search;
 	});
 


### PR DESCRIPTION
Turns out that eslint non-global ignores need a trailing `/**/*` while global ignores don't. Not the most intuitive API...