### PR TITLE
chore: await async functions in tests

### DIFF
--- a/packages/enhanced-img/test/preprocessor.spec.js
+++ b/packages/enhanced-img/test/preprocessor.spec.js
@@ -32,7 +32,7 @@ it('Image preprocess snapshot test', async () => {
 	// Make imports readable
 	const ouput = processed.code.replace(/import/g, '\n\timport');
 
-	expect(ouput).toMatchFileSnapshot('./Output.svelte');
+	await expect(ouput).toMatchFileSnapshot('./Output.svelte');
 });
 
 it('parses a minimized object', () => {

--- a/packages/kit/src/core/postbuild/queue.spec.js
+++ b/packages/kit/src/core/postbuild/queue.spec.js
@@ -76,9 +76,8 @@ test('starts tasks in sequence', async () => {
 
 test('q.add fails if queue is already finished', async () => {
 	const q = queue(1);
-	q.add(() => {});
-
 	await q.done();
+
 	expect(() => q.add(() => {})).throws(/Cannot add tasks to a queue that has ended/);
 });
 

--- a/packages/kit/src/runtime/server/page/load_data.spec.js
+++ b/packages/kit/src/runtime/server/page/load_data.spec.js
@@ -47,10 +47,10 @@ test('succeeds when acao header present on cors', async () => {
 	assert.equal(text, 'foo');
 });
 
-test('errors when no acao header present on cors', () => {
+test('errors when no acao header present on cors', async () => {
 	const fetch = create_fetch({});
 
-	expect(async () => {
+	await expect(async () => {
 		const response = await fetch('https://domain-b.com');
 		await response.text();
 	}).rejects.toThrowError(


### PR DESCRIPTION
It's probably not strictly necessary, but I do think it's a bit nicer and it removes an unnecessary line that doesn't do anything