### PR TITLE
chore: remove duck typing check

### DIFF
--- a/packages/kit/src/utils/error.js
+++ b/packages/kit/src/utils/error.js
@@ -5,10 +5,7 @@ import { HttpError, SvelteKitError } from '../runtime/control.js';
  * @return {Error}
  */
 export function coalesce_to_error(err) {
-	return err instanceof Error ||
-		(err && /** @type {any} */ (err).name && /** @type {any} */ (err).message)
-		? /** @type {Error} */ (err)
-		: new Error(JSON.stringify(err));
+	return err instanceof Error ? /** @type {Error} */ (err) : new Error(JSON.stringify(err));
 }
 
 /**


### PR DESCRIPTION
Why do we need `(err && /** @type {any} */ (err).name && /** @type {any} */ (err).message)`? All the tests pass without it. I suspect it's leftover code