### PR TITLE
chore: refactor load_config function to support multiple config files

### DIFF
--- a/.changeset/lazy-cobras-tell.md
+++ b/.changeset/lazy-cobras-tell.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": minor
+---
+
+chore: refactor load_config function to support .mjs and .cjs config files

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -61,12 +61,21 @@ export function load_error_page(config) {
  * @returns {Promise<import('types').ValidatedConfig>}
  */
 export async function load_config({ cwd = process.cwd() } = {}) {
-	const config_file = path.join(cwd, 'svelte.config.js');
+	const config_files = ['svelte.config.js', 'svelte.config.mjs', 'svelte.config.cjs']
+		.map((file) => path.join(cwd, file))
+		.filter((file) => fs.existsSync(file));
 
-	if (!fs.existsSync(config_file)) {
+	if (config_files.length > 1) {
+		throw new Error(
+			`Found multiple config files: ${config_files.join(
+				', '
+			)}. Please keep only one of these files.`
+		);
+	} else if (config_files.length === 0) {
 		return process_config({}, { cwd });
 	}
 
+	const config_file = config_files[0];
 	const config = await import(`${url.pathToFileURL(config_file).href}?ts=${Date.now()}`);
 
 	try {


### PR DESCRIPTION
The load_config function in the `index.js` file has been refactored to support multiple config files. Previously, it only checked for the existence of a single `svelte.config.js` file. Now, it checks for three possible files: `svelte.config.js`, `svelte.config.mjs`, and `svelte.config.cjs`. If multiple config files are found, an error is thrown. If no config file is found, the function returns an empty config object.

This change improves the flexibility of the configuration loading process and ensures that only one config file is used.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
This PR solves the Problem of not having the explicit power to set the type of the config. With this PR you can decide yourself if the svelte.config.js is a .mjs or .cjs file and it will automatically detect them. 
I personally ran into issues trying to get sveltekit running together with other packages like electron, which both want either "commonJS" or "ES Module". 

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
- Tests did not even work in clean repository Clone


### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [X] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
