### PR TITLE
docs: overhual integrations page

### DIFF
--- a/documentation/docs/60-appendix/20-integrations.md
+++ b/documentation/docs/60-appendix/20-integrations.md
@@ -17,7 +17,11 @@ export default {
 
 ## Adders
 
-Run `npx svelte-add` to setup many different complex integrations like Tailwind, Bootstrap, Storybook, mdsvex (i.e. markdown), and more with a single command.
+Run `npx svelte-add` to setup many different complex integrations with a single command including:
+- CSS - Tailwind, Bootstrap, Bulma
+- database - Drizzle ORM
+- markdown - mdsvex
+- Storybook
 
 ## Directory
 

--- a/documentation/docs/60-appendix/20-integrations.md
+++ b/documentation/docs/60-appendix/20-integrations.md
@@ -2,13 +2,9 @@
 title: Integrations
 ---
 
-## Preprocessors
+## `vitePreprocess`
 
-Preprocessors transform your `.svelte` files before passing them to the compiler. For example, if your `.svelte` file uses TypeScript and PostCSS, it must first be transformed into JavaScript and CSS so that the Svelte compiler can handle it. There are many [available preprocessors](https://sveltesociety.dev/packages?category=preprocessors). The Svelte team maintains two official ones discussed below.
-
-### `vitePreprocess`
-
-`vite-plugin-svelte` offers a [`vitePreprocess`](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/preprocess.md) feature which utilizes Vite for preprocessing. It is capable of handling the language flavors Vite handles: TypeScript, PostCSS, SCSS, Less, Stylus, and SugarSS. If you set your project up with TypeScript it will be included by default:
+Including [`vitePreprocess`](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/preprocess.md) in your project will allow you to use the various flavors of JS and CSS that Vite supports: TypeScript, PostCSS, SCSS, Less, Stylus, and SugarSS. If you set your project up with TypeScript it will be included by default:
 
 ```js
 // svelte.config.js
@@ -19,19 +15,25 @@ export default {
 };
 ```
 
+## Adders
+
+Run `npx svelte-add` to setup many different complex integrations like Tailwind, Bootstrap, Storybook, mdsvex (i.e. markdown), and more with a single command.
+
+## Directory
+
+See [sveltesociety.dev](https://sveltesociety.dev/) for a full listing of [packages](https://sveltesociety.dev/packages) and [templates](https://sveltesociety.dev/templates) available for use with Svelte and SvelteKit.
+
+## Additional integrations
+
 ### `svelte-preprocess`
 
 `svelte-preprocess` has some additional functionality not found in `vitePreprocess` such as support for Pug, Babel, and global styles. However, `vitePreprocess` may be faster and require less configuration, so it is used by default. Note that CoffeeScript is [not supported](https://github.com/sveltejs/kit/issues/2920#issuecomment-996469815) by SvelteKit.
 
 You will need to install `svelte-preprocess` with `npm install --save-dev svelte-preprocess` and [add it to your `svelte.config.js`](https://github.com/sveltejs/svelte-preprocess/blob/main/docs/usage.md#with-svelte-config). After that, you will often need to [install the corresponding library](https://github.com/sveltejs/svelte-preprocess/blob/main/docs/getting-started.md) such as `npm install -D sass` or `npm install -D less`.
 
-## Adders
-
-[Svelte Adders](https://sveltesociety.dev/templates?category=svelte-add) allow you to setup many different complex integrations like Tailwind, PostCSS, Storybook, Firebase, GraphQL, mdsvex, and more with a single command. Please see [sveltesociety.dev](https://sveltesociety.dev/) for a full listing of templates, components, and tools available for use with Svelte and SvelteKit.
-
 ## Vite plugins
 
-Since SvelteKit projects are built with Vite, you can use Vite plugins to enhance your project. See a list of available plugins at [`vitejs/awesome-vite`](https://github.com/vitejs/awesome-vite).
+Since SvelteKit projects are built with Vite, you can use Vite plugins to enhance your project. See a list of available plugins at [`vitejs/awesome-vite`](https://github.com/vitejs/awesome-vite?tab=readme-ov-file#plugins).
 
 ## Integration FAQs
 


### PR DESCRIPTION
- Separate into the most used integrations and "Additional integrations"
- List `svelte-add` command directly on page
- Remove link to svelte add directory (https://github.com/svelte-society/sveltesociety.dev/commit/c549e9cd5708aa9045e994c451507eea5045b9ce)
- Remove explanation of what preprocessor is. It's too much info and the important info on the page gets lost. We can add a better explanation on svelte.dev and link there in the future. For now I just rewrote the vitePreprocess description to be understandable without that intro paragraph