### PR TITLE
chore: remove noisy output and update text about svelte-add

### DIFF
--- a/.changeset/old-jars-work.md
+++ b/.changeset/old-jars-work.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+chore: update text about svelte-add

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -156,8 +156,8 @@ if (options.features.includes('vitest')) {
 	console.log(cyan('  https://vitest.dev\n'));
 }
 
-console.log('Install community-maintained integrations:');
-console.log(cyan('  https://github.com/svelte-add/svelte-add'));
+console.log('Install more integrations with:');
+console.log(bold(cyan('  npx svelte-add')));
 
 console.log('\nNext steps:');
 let i = 1;

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -122,38 +122,11 @@ await create(cwd, {
 
 p.outro('Your project is ready!');
 
-if (options.types === 'typescript') {
-	console.log(bold('✔ Typescript'));
-	console.log('  Inside Svelte components, use <script lang="ts">\n');
-} else if (options.types === 'checkjs') {
-	console.log(bold('✔ Type-checked JavaScript'));
-	console.log(cyan('  https://www.typescriptlang.org/tsconfig#checkJs\n'));
-} else if (options.template === 'skeletonlib') {
+if (!options.types && options.template === 'skeletonlib') {
 	const warning = yellow('▲');
 	console.log(
 		`${warning} You chose to not add type checking, but TypeScript will still be installed in order to generate type definitions when building the library\n`
 	);
-}
-
-if (options.features.includes('eslint')) {
-	console.log(bold('✔ ESLint'));
-	console.log(cyan('  https://github.com/sveltejs/eslint-plugin-svelte\n'));
-}
-
-if (options.features.includes('prettier')) {
-	console.log(bold('✔ Prettier'));
-	console.log(cyan('  https://prettier.io/docs/en/options.html'));
-	console.log(cyan('  https://github.com/sveltejs/prettier-plugin-svelte#options\n'));
-}
-
-if (options.features.includes('playwright')) {
-	console.log(bold('✔ Playwright'));
-	console.log(cyan('  https://playwright.dev\n'));
-}
-
-if (options.features.includes('vitest')) {
-	console.log(bold('✔ Vitest'));
-	console.log(cyan('  https://vitest.dev\n'));
 }
 
 console.log('Install more integrations with:');


### PR DESCRIPTION
Rather than telling people about a web page, we should try to help them remember what the command is

It also removes the noisy output, which just buries the info we want people to see. People aren't going to remember those URLs when they want to find the docs. They'll just google it.

