### PR TITLE
fix: read non-encoded data URIs

### DIFF
--- a/.changeset/clever-penguins-reflect.md
+++ b/.changeset/clever-penguins-reflect.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: read non-encoded data URIs

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -27,12 +27,12 @@ export function read(asset) {
 	}
 
 	// handle inline assets internally
-	if (asset.startsWith('data:')) {
-		const [prelude, data] = asset.split(';');
-		const type = prelude.slice(5) || 'application/octet-stream';
+	const match = /^data:(.+?)?(;base64)?,(.*)$/.exec(asset);
+	if (match) {
+		const type = match[1] ?? 'application/octet-stream';
 
-		if (data.startsWith('base64,')) {
-			const decoded = b64_decode(data.slice(7));
+		if (match[2] !== undefined) {
+			const decoded = b64_decode(match[3]);
 
 			return new Response(decoded, {
 				headers: {
@@ -42,7 +42,7 @@ export function read(asset) {
 			});
 		}
 
-		const decoded = decodeURIComponent(data);
+		const decoded = decodeURIComponent(match[3]);
 
 		return new Response(decoded, {
 			headers: {

--- a/packages/kit/test/apps/basics/src/routes/read-file/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/read-file/+page.server.js
@@ -23,7 +23,8 @@ export async function load() {
 	return {
 		auto: await read(auto).text(),
 		url: await read(url).text(),
-		local_glob: await read(Object.values(local_glob)[0].default).text(),
-		external_glob: await read(Object.values(external_glob)[0].default).text()
+		local_glob: await read(local_glob['./assets/[file].txt'].default).text(),
+		external_glob: await read(Object.values(external_glob)[0].default).text(),
+		svg: await read(local_glob['./assets/icon.svg'].default).text()
 	};
 }

--- a/packages/kit/test/apps/basics/src/routes/read-file/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/read-file/+page.svelte
@@ -6,3 +6,4 @@
 <p data-testid="url">{data.url}</p>
 <p data-testid="local_glob">{data.local_glob}</p>
 <p data-testid="external_glob">{data.external_glob}</p>
+<div data-testid="svg">{@html data.svg}</div>

--- a/packages/kit/test/apps/basics/src/routes/read-file/assets/icon.svg
+++ b/packages/kit/test/apps/basics/src/routes/read-file/assets/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+	<rect width="24" height="24" rx="2" fill="#ff3e00"/>
+</svg>

--- a/packages/kit/test/apps/basics/test/cross-platform/test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/test.js
@@ -1042,6 +1042,7 @@ test.describe('$app/server', () => {
 		const url = await page.textContent('[data-testid="url"]');
 		const local_glob = await page.textContent('[data-testid="local_glob"]');
 		const external_glob = await page.textContent('[data-testid="external_glob"]');
+		const svg = await page.innerHTML('[data-testid="svg"]');
 
 		// the emoji is there to check that base64 decoding works correctly
 		expect(auto.trim()).toBe('Imported without ?url 😎');
@@ -1050,5 +1051,6 @@ test.describe('$app/server', () => {
 		expect(external_glob.trim()).toBe(
 			'Imported with url glob from the read-file test in basics. Placed here outside the app folder to force a /@fs prefix 😎'
 		);
+		expect(svg).toContain('<rect width="24" height="24" rx="2" fill="#ff3e00"></rect>');
 	});
 });


### PR DESCRIPTION
`read` assumes that data URIs (which Vite generates by default for assets below a specific threshold) are base-64 encoded, which isn't true for (for example) SVGs. This fixes it

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x]  Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
