### PR TITLE
fix: determine local Svelte version more reliably

### DIFF
--- a/.changeset/lovely-dancers-search.md
+++ b/.changeset/lovely-dancers-search.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: determine local Svelte version more reliably

--- a/packages/kit/postinstall.js
+++ b/packages/kit/postinstall.js
@@ -1,5 +1,4 @@
 import { load_config } from './src/core/config/index.js';
-import * as sync from './src/core/sync/sync.js';
 import glob from 'tiny-glob/sync.js';
 import fs from 'node:fs';
 
@@ -37,6 +36,9 @@ try {
 
 			const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 			if (!pkg.dependencies?.['@sveltejs/kit'] && !pkg.devDependencies?.['@sveltejs/kit']) continue;
+
+			// defer import until after the chdir so that peer dependency resolves correctly
+			const sync = await import('./src/core/sync/sync.js');
 
 			try {
 				const config = await load_config();

--- a/packages/kit/src/core/sync/utils.js
+++ b/packages/kit/src/core/sync/utils.js
@@ -9,6 +9,7 @@ let VERSION;
 try {
 	({ VERSION } = await resolve_peer_dependency('svelte/compiler'));
 } catch {
+	// we can end up here from e.g. unit tests. this is the simplest fix
 	({ VERSION } = await import('svelte/compiler'));
 }
 

--- a/packages/kit/src/core/sync/utils.js
+++ b/packages/kit/src/core/sync/utils.js
@@ -1,15 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
-import * as imr from 'import-meta-resolve';
 import { mkdirp } from '../../utils/filesystem.js';
+import { resolve_peer_dependency } from '../../utils/import.js';
 
-// ensure that we load the peer dependency rather than the dev dependency,
-// even when SvelteKit is linked rather than locally installed in the current project
-const { VERSION } = await import(
-	// @ts-expect-error the types are wrong
-	imr.resolve('svelte/compiler', pathToFileURL(process.cwd() + '/dummy.js'))
-);
+const { VERSION } = await resolve_peer_dependency('svelte/compiler');
 
 /** @type {Map<string, string>} */
 const previous_contents = new Map();

--- a/packages/kit/src/core/sync/utils.js
+++ b/packages/kit/src/core/sync/utils.js
@@ -1,7 +1,15 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { VERSION } from 'svelte/compiler';
+import { pathToFileURL } from 'node:url';
+import * as imr from 'import-meta-resolve';
 import { mkdirp } from '../../utils/filesystem.js';
+
+// ensure that we load the peer dependency rather than the dev dependency,
+// even when SvelteKit is linked rather than locally installed in the current project
+const { VERSION } = await import(
+	// @ts-expect-error the types are wrong
+	imr.resolve('svelte/compiler', pathToFileURL(process.cwd() + '/dummy.js'))
+);
 
 /** @type {Map<string, string>} */
 const previous_contents = new Map();

--- a/packages/kit/src/core/sync/utils.js
+++ b/packages/kit/src/core/sync/utils.js
@@ -3,7 +3,14 @@ import path from 'node:path';
 import { mkdirp } from '../../utils/filesystem.js';
 import { resolve_peer_dependency } from '../../utils/import.js';
 
-const { VERSION } = await resolve_peer_dependency('svelte/compiler');
+/** @type {string} */
+let VERSION;
+
+try {
+	({ VERSION } = await resolve_peer_dependency('svelte/compiler'));
+} catch {
+	({ VERSION } = await import('svelte/compiler'));
+}
 
 /** @type {Map<string, string>} */
 const previous_contents = new Map();

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -128,7 +128,7 @@ const warning_preprocessor = {
  * rather than relative to this package
  * @param {string} dependency
  */
-async function resolve_peer_dependency(dependency) {
+function resolve_peer_dependency(dependency) {
 	try {
 		// @ts-expect-error the types are wrong
 		const resolved = imr.resolve(dependency, pathToFileURL(process.cwd() + '/dummy.js'));

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import * as imr from 'import-meta-resolve';
 import colors from 'kleur';
 
 import { copy, mkdirp, posixify, read, resolve_entry, rimraf } from '../../utils/filesystem.js';
@@ -34,7 +33,6 @@ import {
 	sveltekit_paths,
 	sveltekit_server
 } from './module_ids.js';
-import { pathToFileURL } from 'node:url';
 import { resolve_peer_dependency } from '../../utils/import.js';
 
 const cwd = process.cwd();

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -35,6 +35,7 @@ import {
 	sveltekit_server
 } from './module_ids.js';
 import { pathToFileURL } from 'node:url';
+import { resolve_peer_dependency } from '../../utils/import.js';
 
 const cwd = process.cwd();
 
@@ -122,23 +123,6 @@ const warning_preprocessor = {
 		}
 	}
 };
-
-/**
- * Resolve a dependency relative to the current working directory,
- * rather than relative to this package
- * @param {string} dependency
- */
-function resolve_peer_dependency(dependency) {
-	try {
-		// @ts-expect-error the types are wrong
-		const resolved = imr.resolve(dependency, pathToFileURL(process.cwd() + '/dummy.js'));
-		return import(resolved);
-	} catch {
-		throw new Error(
-			`Could not resolve peer dependency "${dependency}" relative to your project — please install it and try again.`
-		);
-	}
-}
 
 /**
  * Returns the SvelteKit Vite plugins.

--- a/packages/kit/src/utils/import.js
+++ b/packages/kit/src/utils/import.js
@@ -1,3 +1,6 @@
+import * as imr from 'import-meta-resolve';
+import { pathToFileURL } from 'url';
+
 /**
  * Resolve a dependency relative to the current working directory,
  * rather than relative to this package

--- a/packages/kit/src/utils/import.js
+++ b/packages/kit/src/utils/import.js
@@ -1,5 +1,5 @@
 import * as imr from 'import-meta-resolve';
-import { pathToFileURL } from 'url';
+import { pathToFileURL } from 'node:url';
 
 /**
  * Resolve a dependency relative to the current working directory,

--- a/packages/kit/src/utils/import.js
+++ b/packages/kit/src/utils/import.js
@@ -1,0 +1,16 @@
+/**
+ * Resolve a dependency relative to the current working directory,
+ * rather than relative to this package
+ * @param {string} dependency
+ */
+export function resolve_peer_dependency(dependency) {
+	try {
+		// @ts-expect-error the types are wrong
+		const resolved = imr.resolve(dependency, pathToFileURL(process.cwd() + '/dummy.js'));
+		return import(resolved);
+	} catch {
+		throw new Error(
+			`Could not resolve peer dependency "${dependency}" relative to your project — please install it and try again.`
+		);
+	}
+}

--- a/scripts/sync-all.js
+++ b/scripts/sync-all.js
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import * as sync from '../packages/kit/src/core/sync/sync.js';
 import { load_config } from '../packages/kit/src/core/config/index.js';
 
 // This isn't strictly necessary, but it eliminates some annoying warnings in CI
@@ -13,10 +12,15 @@ for (const directories of [
 	for (const dir of fs.readdirSync(directories)) {
 		const cwd = path.join(directories, dir);
 
-		if (!fs.existsSync(path.join(cwd, 'svelte.config.js'))) {
+		if (!fs.existsSync('svelte.config.js')) {
 			continue;
 		}
 
+		process.chdir(cwd);
+
+		// we defer this import so that we don't try and resolve `svelte` from
+		// the root via `isSvelte5Plus`, which would blow up
+		const sync = await import('../packages/kit/src/core/sync/sync.js');
 		await sync.all(await load_config({ cwd }), 'development');
 	}
 }


### PR DESCRIPTION
It's currently impossible to develop a Svelte 5 project with a linked SvelteKit installation, because the `sync` script wrongly believes it's dealing with Svelte 4 (which is a dev dependency inside SvelteKit). This fixes it.

I added a changeset because it's a change, but it doesn't actually require a release since the problem it solves only arises when you're working with the repo directly.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
