### PR TITLE
fix: always decode asset URLs

### DIFF
--- a/.changeset/tough-actors-hope.md
+++ b/.changeset/tough-actors-hope.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: always decode asset URLs

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -53,7 +53,9 @@ export function read(asset) {
 		});
 	}
 
-	const file = decodeURIComponent(DEV && asset.startsWith('/@fs') ? asset : asset.slice(base.length + 1));
+	const file = decodeURIComponent(
+		DEV && asset.startsWith('/@fs') ? asset : asset.slice(base.length + 1)
+	);
 
 	if (file in manifest._.server_assets) {
 		const length = manifest._.server_assets[file];

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -53,9 +53,7 @@ export function read(asset) {
 		});
 	}
 
-	const file = DEV
-		? decodeURIComponent(asset.startsWith('/@fs') ? asset : asset.slice(base.length + 1))
-		: asset.slice(base.length + 1);
+	const file = decodeURIComponent(DEV && asset.startsWith('/@fs') ? asset : asset.slice(base.length + 1));
 
 	if (file in manifest._.server_assets) {
 		const length = manifest._.server_assets[file];


### PR DESCRIPTION
I was wrong in #12341 — it _is_ necessary to decode asset URLs in prod, because files can be emitted with e.g. spaces in them. No test because it'd be finicky and annoying and I'm tired, but this has been tested locally and is very unlikely to regress

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
