### PR TITLE
fix: allow missing MIME type in data URI

### DIFF
--- a/.changeset/metal-moles-beam.md
+++ b/.changeset/metal-moles-beam.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow missing MIME type from data URI

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -27,7 +27,7 @@ export function read(asset) {
 	}
 
 	// handle inline assets internally
-	const match = /^data:([^;,]+)?(;base64)?,/.exec(asset);
+	const match = /^data:([^;,*?)?(;base64)?,/.exec(asset);
 	if (match) {
 		const type = match[1] ?? 'application/octet-stream';
 		const data = asset.slice(match[0].length);


### PR DESCRIPTION
this is a belt-and-braces thing as I'm pretty sure Vite will always add a MIME type (hence no test), but just in case we end up copying this regex somewhere else it makes sense to fix it. Means that things like `data:,Hello%2C%20World%21` will match.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
