### PR TITLE
fix: do not create more than one shutdown timeout

### DIFF
--- a/.changeset/cuddly-mails-argue.md
+++ b/.changeset/cuddly-mails-argue.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-node": minor
+---
+
+fix: do not create more than one shutdown timeout

--- a/.changeset/cuddly-mails-argue.md
+++ b/.changeset/cuddly-mails-argue.md
@@ -1,5 +1,5 @@
 ---
-"@sveltejs/adapter-node": minor
+"@sveltejs/adapter-node": patch
 ---
 
 fix: do not create more than one shutdown timeout

--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -56,10 +56,10 @@ function graceful_shutdown(reason) {
 		if (error) return;
 
 		if (shutdown_timeout_id) {
-			shutdown_timeout_id = clearTimeout(shutdown_timeout_id);
+			clearTimeout(shutdown_timeout_id);
 		}
 		if (idle_timeout_id) {
-			idle_timeout_id = clearTimeout(idle_timeout_id);
+			clearTimeout(idle_timeout_id);
 		}
 
 		// @ts-expect-error custom events cannot be typed


### PR DESCRIPTION
Because the timer IDs are always cleaned up and set to `undefined` while the custom cleanup hook is running, it can happen that a shutdown timeout is created twice.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
