### PR TITLE
feat: throw error if routes are configured in _routes.json

### DIFF
--- a/.changeset/angry-spies-rule.md
+++ b/.changeset/angry-spies-rule.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-cloudflare": patch
+---
+
+chore: throw an error if `_routes.json` is detected

--- a/.changeset/angry-spies-rule.md
+++ b/.changeset/angry-spies-rule.md
@@ -1,5 +1,5 @@
 ---
-"@sveltejs/adapter-cloudflare": patch
+"@sveltejs/adapter-cloudflare": minor
 ---
 
-chore: throw an error if `_routes.json` is detected
+feat: validate that no `_routes.json` is present to avoid overwriting it

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -24,12 +24,9 @@ export default function (options = {}) {
 	return {
 		name: '@sveltejs/adapter-cloudflare',
 		async adapt(builder) {
-			const has_routes_json = existsSync('_routes.json');
-
-			// if there are no routes inside svelte config, and _routes.json exists, user is expecting to configure cloudflare routes in the wrong way.
-			if (!options.routes && has_routes_json) {
+			if (!options.routes && existsSync('_routes.json')) {
 				throw new Error(
-					'Cloudflare routes should be configured inside svelte config, not in _routes.json'
+					'Cloudflare routes should be configured in svelte.config.js rather than _routes.json'
 				);
 			}
 

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -1,4 +1,4 @@
-import { writeFileSync } from 'node:fs';
+import { existsSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as esbuild from 'esbuild';
@@ -24,6 +24,15 @@ export default function (options = {}) {
 	return {
 		name: '@sveltejs/adapter-cloudflare',
 		async adapt(builder) {
+			const has_routes_json = existsSync('_routes.json');
+
+			// if there are no routes inside svelte config, and _routes.json exists, user is expecting to configure cloudflare routes in the wrong way.
+			if (!options.routes && has_routes_json) {
+				throw new Error(
+					'Cloudflare routes should be configured inside svelte config, not in _routes.json'
+				);
+			}
+
 			const files = fileURLToPath(new URL('./files', import.meta.url).href);
 			const dest = builder.getBuildDirectory('cloudflare');
 			const tmp = builder.getBuildDirectory('cloudflare-tmp');

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -24,7 +24,7 @@ export default function (options = {}) {
 	return {
 		name: '@sveltejs/adapter-cloudflare',
 		async adapt(builder) {
-			if (!options.routes && existsSync('_routes.json')) {
+			if (existsSync('_routes.json')) {
 				throw new Error(
 					'Cloudflare routes should be configured in svelte.config.js rather than _routes.json'
 				);


### PR DESCRIPTION
Close #12321 

I don't know if it was the best choice, but I opted for throw error only if `_routes.json` exists and there are no configured routes in svelte.config.

Let me know if you think Changelogs should be generated.

I don't think it's related, but `pnpm test` fails on
```diff
Watching src/lib for changes...

✘ • • • •   (14 / 15)

FAIL  "watches for changes"
Expected values to be deeply equal:  (equal)

Actual:
--<script·lang="ts">export·let·answer:·number</script>
Expected:
++<script>export·let·answer;
++</script>
        
@sveltejs/package@2.3.2 test: `uvu test "^index.js$"
```

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
