### PR TITLE
docs: add `Other Editors` section to debugging documentation

### DIFF
--- a/documentation/docs/60-appendix/25-debugging.md
+++ b/documentation/docs/60-appendix/25-debugging.md
@@ -45,7 +45,7 @@ Further reading: <https://code.visualstudio.com/docs/editor/debugging>.
 
 ## Other Editors
 
-While it's not feasible to provide guides to debugging svelte in other editors here, we've compiled a few community resources that might help if Visual Studio Code is not your preferred IDE:
+If you use a different editor, these community guides might be useful for you:
 
 - [WebStorm Svelte: Debug Your Application](https://www.jetbrains.com/help/webstorm/svelte.html#ws_svelte_debug)
 - [Debugging JavaScript Frameworks in Neovim](https://theosteiner.de/debugging-javascript-frameworks-in-neovim)

--- a/documentation/docs/60-appendix/25-debugging.md
+++ b/documentation/docs/60-appendix/25-debugging.md
@@ -45,7 +45,7 @@ Further reading: <https://code.visualstudio.com/docs/editor/debugging>.
 
 ## Other Editors
 
-While it's not feasible to provide guides to debugging svelte in other editors here, we've compiled a few community resources that might help if vs code is not your preferred IDE:
+While it's not feasible to provide guides to debugging svelte in other editors here, we've compiled a few community resources that might help if Visual Studio Code is not your preferred IDE:
 
 - [WebStorm Svelte: Debug Your Application](https://www.jetbrains.com/help/webstorm/svelte.html#ws_svelte_debug)
 - [Debugging JavaScript Frameworks in Neovim](https://theosteiner.de/debugging-javascript-frameworks-in-neovim)

--- a/documentation/docs/60-appendix/25-debugging.md
+++ b/documentation/docs/60-appendix/25-debugging.md
@@ -43,6 +43,13 @@ Here's an example `launch.json`:
 
 Further reading: <https://code.visualstudio.com/docs/editor/debugging>.
 
+## Other Editors
+
+While it's not feasible to provide guides to debugging svelte in other editors here, we've compiled a few community resources that might help if vs code is not your preferred IDE:
+
+- [WebStorm Svelte: Debug Your Application](https://www.jetbrains.com/help/webstorm/svelte.html#ws_svelte_debug)
+- [Debugging JavaScript Frameworks in Neovim](https://theosteiner.de/debugging-javascript-frameworks-in-neovim)
+
 ## Google Chrome and Microsoft Edge Developer Tools
 
 It's possible to debug Node.js applications using a browser-based debugger.


### PR DESCRIPTION
#12212 added a guide for debugging svelte applications.
while vscode is probably the most used editor and thus deserves an official guide in the documentation, I thought maybe it could be helpful to point users of other editors to helpful community resources that explain how to debug with other IDEs.

I included guides for `webstorm` and `neovim`. (full disclosure: I am the author of the neovim guide, however I think it's the only one out there. hope this doesn't come over as shady self promotion)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ x Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
