### PR TITLE
fix: adjust create-svelte templates

### DIFF
--- a/.changeset/fifty-experts-thank.md
+++ b/.changeset/fifty-experts-thank.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+fix: set template package version to 1.0.0

--- a/packages/create-svelte/templates/default/package.template.json
+++ b/packages/create-svelte/templates/default/package.template.json
@@ -1,6 +1,6 @@
 {
 	"name": "~TODO~",
-	"version": "0.0.1",
+	"version": "1.0.0",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/packages/create-svelte/templates/skeleton/package.template.json
+++ b/packages/create-svelte/templates/skeleton/package.template.json
@@ -1,6 +1,6 @@
 {
 	"name": "~TODO~",
-	"version": "0.0.1",
+	"version": "1.0.0",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",

--- a/packages/create-svelte/templates/skeletonlib/package.template.json
+++ b/packages/create-svelte/templates/skeletonlib/package.template.json
@@ -1,6 +1,6 @@
 {
 	"name": "~TODO~",
-	"version": "0.0.1",
+	"version": "1.0.0",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run package",


### PR DESCRIPTION
- Start package.json version at 1.0.0 (no related tickets)
- Note; unit tests were failing before this change

I noticed many Svelte packages in the ecosystem start at version `0.0.1`, and I believe this template is part of the reason why. To help encourage better semantic versioning, I've set templates to begin at `1.0.0`.

If a package maintainer wishes to signal something is in beta, they're welcome to start at `0.1.0` or use prereleases.

<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
