### PR TITLE
feat: enable cwd override for vite plugin

### DIFF
--- a/.changeset/long-buckets-cheer.md
+++ b/.changeset/long-buckets-cheer.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/kit': major
+'@sveltejs/kit': minor
 ---
 
 Enable overriding working dir when using vite plugin

--- a/.changeset/long-buckets-cheer.md
+++ b/.changeset/long-buckets-cheer.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+Enable overriding working dir when using vite plugin

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -933,7 +933,7 @@ function warn_overridden_config(config, resolved_config) {
 	if (overridden.length > 0) {
 		console.error(
 			colors.bold().red('The following Vite config options will be overridden by SvelteKit:') +
-			overridden.map((key) => `\n  - ${key}`).join('')
+				overridden.map((key) => `\n  - ${key}`).join('')
 		);
 	}
 }
@@ -977,9 +977,9 @@ const create_service_worker_module = (config) => dedent`
 	export const build = [];
 	export const files = [
 		${create_assets(config)
-		.filter((asset) => config.kit.serviceWorker.files(asset.file))
-		.map((asset) => `${s(`${config.kit.paths.base}/${asset.file}`)}`)
-		.join(',\n')}
+			.filter((asset) => config.kit.serviceWorker.files(asset.file))
+			.map((asset) => `${s(`${config.kit.paths.base}/${asset.file}`)}`)
+			.join(',\n')}
 	];
 	export const prerendered = [];
 	export const version = ${s(config.kit.version.name)};

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1944,7 +1944,9 @@ declare module '@sveltejs/kit/vite' {
 	/**
 	 * Returns the SvelteKit Vite plugins.
 	 * */
-	export function sveltekit(): Promise<import('vite').Plugin[]>;
+	export function sveltekit({ cwd }?: {
+		cwd?: string | undefined;
+	}): Promise<import('vite').Plugin[]>;
 }
 
 declare module '$app/environment' {


### PR DESCRIPTION
When using SvelteKit in a monorepo, currently you are forced to keep it in the root because the `sveltekit` looks for the `svelte.config.js` in the `process.cwd()`. 

This prevents us from:
- Having multiple sveltekit apps in nested folders
- Which we would be able to build/serve from the root of the monorepo

> Note: Test seems to be failing with unrelated code

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [X] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
