### PR TITLE
feat: enable custom cwd for vite plugin

### DIFF
--- a/.changeset/dry-rice-travel.md
+++ b/.changeset/dry-rice-travel.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: enable custom cwd for vite plugin

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -1,4 +1,4 @@
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { get_option } from '../../utils/options.js';
 import {
@@ -33,13 +33,15 @@ async function analyse({ manifest_path, manifest_data, server_manifest, tracked_
 	/** @type {import('@sveltejs/kit').SSRManifest} */
 	const manifest = (await import(pathToFileURL(manifest_path).href)).manifest;
 
+	const internalPath = join(dirname(manifest_path), 'internal.js');
+
 	/** @type {import('types').ValidatedKitConfig} */
 	const config = (await load_config()).kit;
 
-	const server_root = join(config.outDir, 'output');
+	const server_root = join(dirname(dirname(manifest_path)));
 
 	/** @type {import('types').ServerInternalModule} */
-	const internal = await import(pathToFileURL(`${server_root}/server/internal.js`).href);
+	const internal = await import(pathToFileURL(internalPath).href);
 
 	installPolyfills();
 

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -90,7 +90,11 @@ async function prerender({ out, manifest_path, metadata, verbose, env }) {
 	const prerendered_routes = new Set();
 
 	/** @type {import('types').ValidatedKitConfig} */
-	const config = (await load_config()).kit;
+	const config = (
+		await load_config({
+			cwd: out
+		})
+	).kit;
 
 	const emulator = await config.adapter?.emulate?.();
 
@@ -327,7 +331,7 @@ async function prerender({ out, manifest_path, metadata, verbose, env }) {
 		const is_html = response_type === REDIRECT || type === 'text/html';
 
 		const file = output_filename(decoded, is_html);
-		const dest = `${config.outDir}/output/prerendered/${category}/${file}`;
+		const dest = `${out}/prerendered/${category}/${file}`;
 
 		if (written.has(file)) return;
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -124,10 +124,11 @@ const warning_preprocessor = {
 
 /**
  * Returns the SvelteKit Vite plugins.
+ * @param {{ cwd?: string }} options
  * @returns {Promise<import('vite').Plugin[]>}
  */
-export async function sveltekit() {
-	const svelte_config = await load_config();
+export async function sveltekit(options = {}) {
+	const svelte_config = await load_config(options);
 
 	/** @type {import('@sveltejs/vite-plugin-svelte').Options['preprocess']} */
 	let preprocess = svelte_config.preprocess;
@@ -838,7 +839,6 @@ async function kit({ svelte_config }) {
 
 				// regenerate nodes with the client manifest...
 				build_server_nodes(out, kit, manifest_data, server_manifest, client_manifest, css);
-
 				// ...and prerender
 				const { prerendered, prerender_map } = await prerender({
 					out,

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1944,7 +1944,9 @@ declare module '@sveltejs/kit/vite' {
 	/**
 	 * Returns the SvelteKit Vite plugins.
 	 * */
-	export function sveltekit(): Promise<import('vite').Plugin[]>;
+	export function sveltekit(options?: {
+		cwd?: string;
+	}): Promise<import('vite').Plugin[]>;
 }
 
 declare module '$app/environment' {


### PR DESCRIPTION
## Context
When using sveltekit in a mono-repository context, the build tends to fail with the following error message:
```
src/app.html does not exist
```
The error persists if you change the file location from the svelte config. 

This is due to the file resolutions being made from the current directory instead of the project's root directory. While it works totally fine in a standalone project, it can't work in a monorepository context.

The objective of this pull request is to provide an option that specifies the root of the project in the vite adapter and to base the file resolution on the new option if it is provided while keeping the default `process.cwd()` directory if not provided

### Related issues
- https://github.com/nxext/nx-extensions/issues/1058

*Note that the code still needs a bit of refactoring, failing tests seems unrelated but I'll take a look this week*


---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
