### PR TITLE
chore: make build script runnable on Windows

### DIFF
--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -33,7 +33,7 @@
 	],
 	"scripts": {
 		"dev": "node -e \"fs.rmSync('files', { force: true, recursive: true })\" && rollup -cw",
-		"build": "node -e \"fs.rmSync('files', { force: true, recursive: true })\" && rollup -c && cp src/edge.js files/edge.js",
+		"build": "node -e \"fs.rmSync('files', { force: true, recursive: true })\" && rollup -c && node -e \"fs.cpSync('src/edge.js', 'files/edge.js')\"",
 		"test": "vitest run",
 		"check": "tsc",
 		"lint": "prettier --check .",


### PR DESCRIPTION
<!-- Your PR description here -->

Hey there 👋 

The build script for the `@sveltejs/adapter-netlify` currently fails on Windows, because of the `cp` command, which is only available in unix shells:

![image](https://github.com/sveltejs/kit/assets/31937175/7bf06a7a-8177-4513-8ec3-2e0e86094582)

Changing `cp` to `fs.cpSync` makes the script cross-platform.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
