### PR TITLE
docs: add note to vercel isr on prerender page options conflict

### DIFF
--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -125,7 +125,7 @@ export const config = {
 
 The `expiration` property is required; all others are optional.
 
-> Do not specify [prerender page options](/docs/page-options#prerender) on ISR routes as they take precedence over ISR configuration.
+> Pages that are  [prerendered](/docs/page-options#prerender) will ignore ISR configuration.
 
 ## Environment variables
 

--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -125,6 +125,8 @@ export const config = {
 
 The `expiration` property is required; all others are optional.
 
+> Do not specify [prerender page options](/docs/page-options#prerender) on ISR routes as they take precedence over ISR configuration.
+
 ## Environment variables
 
 Vercel makes a set of [deployment-specific environment variables](https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables) available. Like other environment variables, these are accessible from `$env/static/private` and `$env/dynamic/private` (sometimes — more on that later), and inaccessible from their public counterparts. To access one of these variables from the client:


### PR DESCRIPTION
Added note to the Vercel page to make it explicit that page render options cannot be used with Vercel ISR config.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
