### PR TITLE
fix: copy `.eot`, `.otf`, `.ttf`, `.woff`, and `woff2` font files when bundling

### DIFF
--- a/.changeset/silver-bears-melt.md
+++ b/.changeset/silver-bears-melt.md
@@ -5,4 +5,4 @@
 '@sveltejs/adapter-vercel': patch
 ---
 
-fix: copy `.woff` and `.ttf` font files when bundling
+fix: copy `.woff`, `woff2`, and `.ttf` font files when bundling

--- a/.changeset/silver-bears-melt.md
+++ b/.changeset/silver-bears-melt.md
@@ -5,4 +5,4 @@
 '@sveltejs/adapter-vercel': patch
 ---
 
-fix: copy `.woff`, `woff2`, and `.ttf` font files when bundling
+fix: copy `.eof`, `.otf`, `.ttf`, `.woff`, and `woff2` font files when bundling

--- a/.changeset/silver-bears-melt.md
+++ b/.changeset/silver-bears-melt.md
@@ -5,4 +5,4 @@
 '@sveltejs/adapter-vercel': patch
 ---
 
-fix: copy `.eof`, `.otf`, `.ttf`, `.woff`, and `woff2` font files when bundling
+fix: copy `.eot`, `.otf`, `.ttf`, `.woff`, and `woff2` font files when bundling

--- a/.changeset/silver-bears-melt.md
+++ b/.changeset/silver-bears-melt.md
@@ -1,0 +1,8 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-cloudflare': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-vercel': patch
+---
+
+fix: copy `.woff` and `.ttf` font files when bundling

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -101,7 +101,7 @@ export default function ({ config = 'wrangler.toml', platformProxy = {} } = {}) 
 						'.woff': 'copy',
 						'.woff2': 'copy',
 						'.ttf': 'copy',
-						'.eof': 'copy',
+						'.eot': 'copy',
 						'.otf': 'copy'
 					},
 					logLevel: 'silent'

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -101,7 +101,6 @@ export default function ({ config = 'wrangler.toml', platformProxy = {} } = {}) 
 						'.woff': 'copy',
 						'.ttf': 'copy'
 					},
-					assetNames: '[name]',
 					logLevel: 'silent'
 				});
 

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -100,7 +100,9 @@ export default function ({ config = 'wrangler.toml', platformProxy = {} } = {}) 
 						'.wasm': 'copy',
 						'.woff': 'copy',
 						'.woff2': 'copy',
-						'.ttf': 'copy'
+						'.ttf': 'copy',
+						'.eof': 'copy',
+						'.otf': 'copy'
 					},
 					logLevel: 'silent'
 				});

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -97,8 +97,11 @@ export default function ({ config = 'wrangler.toml', platformProxy = {} } = {}) 
 					alias: Object.fromEntries(compatible_node_modules.map((id) => [id, `node:${id}`])),
 					format: 'esm',
 					loader: {
-						'.wasm': 'copy'
+						'.wasm': 'copy',
+						'.woff': 'copy',
+						'.ttf': 'copy'
 					},
+					assetNames: '[name]',
 					logLevel: 'silent'
 				});
 

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -99,6 +99,7 @@ export default function ({ config = 'wrangler.toml', platformProxy = {} } = {}) 
 					loader: {
 						'.wasm': 'copy',
 						'.woff': 'copy',
+						'.woff2': 'copy',
 						'.ttf': 'copy'
 					},
 					logLevel: 'silent'

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -92,6 +92,7 @@ export default function (options = {}) {
 					loader: {
 						'.wasm': 'copy',
 						'.woff': 'copy',
+						'.woff2': 'copy',
 						'.ttf': 'copy'
 					},
 					external,

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -90,8 +90,11 @@ export default function (options = {}) {
 					format: 'esm',
 					bundle: true,
 					loader: {
-						'.wasm': 'copy'
+						'.wasm': 'copy',
+						'.woff': 'copy',
+						'.ttf': 'copy'
 					},
+					assetNames: '[name]',
 					external,
 					alias: Object.fromEntries(compatible_node_modules.map((id) => [id, `node:${id}`])),
 					logLevel: 'silent'

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -93,7 +93,9 @@ export default function (options = {}) {
 						'.wasm': 'copy',
 						'.woff': 'copy',
 						'.woff2': 'copy',
-						'.ttf': 'copy'
+						'.ttf': 'copy',
+						'.eof': 'copy',
+						'.otf': 'copy'
 					},
 					external,
 					alias: Object.fromEntries(compatible_node_modules.map((id) => [id, `node:${id}`])),

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -94,7 +94,6 @@ export default function (options = {}) {
 						'.woff': 'copy',
 						'.ttf': 'copy'
 					},
-					assetNames: '[name]',
 					external,
 					alias: Object.fromEntries(compatible_node_modules.map((id) => [id, `node:${id}`])),
 					logLevel: 'silent'

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -94,7 +94,7 @@ export default function (options = {}) {
 						'.woff': 'copy',
 						'.woff2': 'copy',
 						'.ttf': 'copy',
-						'.eof': 'copy',
+						'.eot': 'copy',
 						'.otf': 'copy'
 					},
 					external,

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -171,7 +171,9 @@ async function generate_edge_functions({ builder }) {
 			'.wasm': 'copy',
 			'.woff': 'copy',
 			'.woff2': 'copy',
-			'.ttf': 'copy'
+			'.ttf': 'copy',
+			'.eof': 'copy',
+			'.otf': 'copy'
 		},
 		// Node built-ins are allowed, but must be prefixed with `node:`
 		// https://docs.netlify.com/edge-functions/api/#runtime-environment

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -172,7 +172,7 @@ async function generate_edge_functions({ builder }) {
 			'.woff': 'copy',
 			'.woff2': 'copy',
 			'.ttf': 'copy',
-			'.eof': 'copy',
+			'.eot': 'copy',
 			'.otf': 'copy'
 		},
 		// Node built-ins are allowed, but must be prefixed with `node:`

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -167,7 +167,12 @@ async function generate_edge_functions({ builder }) {
 		platform: 'browser',
 		sourcemap: 'linked',
 		target: 'es2020',
-
+		loader: {
+			'.wasm': 'copy',
+			'.woff': 'copy',
+			'.ttf': 'copy'
+		},
+		assetNames: '[name]',
 		// Node built-ins are allowed, but must be prefixed with `node:`
 		// https://docs.netlify.com/edge-functions/api/#runtime-environment
 		external: builtinModules.map((id) => `node:${id}`),

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -172,7 +172,6 @@ async function generate_edge_functions({ builder }) {
 			'.woff': 'copy',
 			'.ttf': 'copy'
 		},
-		assetNames: '[name]',
 		// Node built-ins are allowed, but must be prefixed with `node:`
 		// https://docs.netlify.com/edge-functions/api/#runtime-environment
 		external: builtinModules.map((id) => `node:${id}`),

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -170,6 +170,7 @@ async function generate_edge_functions({ builder }) {
 		loader: {
 			'.wasm': 'copy',
 			'.woff': 'copy',
+			'.woff2': 'copy',
 			'.ttf': 'copy'
 		},
 		// Node built-ins are allowed, but must be prefixed with `node:`

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -137,7 +137,9 @@ const plugin = function (defaults = {}) {
 							'.wasm': 'copy',
 							'.woff': 'copy',
 							'.woff2': 'copy',
-							'.ttf': 'copy'
+							'.ttf': 'copy',
+							'.eof': 'copy',
+							'.otf': 'copy'
 						}
 					});
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -136,6 +136,7 @@ const plugin = function (defaults = {}) {
 						loader: {
 							'.wasm': 'copy',
 							'.woff': 'copy',
+							'.woff2': 'copy',
 							'.ttf': 'copy'
 						}
 					});

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -134,8 +134,11 @@ const plugin = function (defaults = {}) {
 						sourcemap: 'linked',
 						banner: { js: 'globalThis.global = globalThis;' },
 						loader: {
-							'.wasm': 'copy'
-						}
+							'.wasm': 'copy',
+							'.woff': 'copy',
+							'.ttf': 'copy'
+						},
+						assetNames: '[name]'
 					});
 
 					if (result.warnings.length > 0) {

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -138,7 +138,7 @@ const plugin = function (defaults = {}) {
 							'.woff': 'copy',
 							'.woff2': 'copy',
 							'.ttf': 'copy',
-							'.eof': 'copy',
+							'.eot': 'copy',
 							'.otf': 'copy'
 						}
 					});

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -137,8 +137,7 @@ const plugin = function (defaults = {}) {
 							'.wasm': 'copy',
 							'.woff': 'copy',
 							'.ttf': 'copy'
-						},
-						assetNames: '[name]'
+						}
 					});
 
 					if (result.warnings.length > 0) {


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/pull/11219
fixes https://github.com/sveltejs/kit/issues/11220

Copies `.ttf` and `.woff` font files when bundling edge functions since those are the most common font files included with packages. Alternatively, we could use the same list of assets as [Vite](https://github.com/vitejs/vite/blob/22b299429599834bf1855b53264a28ae5ff8f888/packages/vite/src/node/optimizer/esbuildDepPlugin.ts#L25-L48).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
