### PR TITLE
feat: update service worker when new version is detected

### DIFF
--- a/.changeset/unlucky-cars-swim.md
+++ b/.changeset/unlucky-cars-swim.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: update service worker when new version is detected

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -151,7 +151,7 @@ function native_navigation(url) {
  * tries to update it.
  */
 async function update_service_worker() {
-	if (BROWSER && 'serviceWorker' in navigator) {
+	if ('serviceWorker' in navigator) {
 		const registration = await navigator.serviceWorker.getRegistration(base || '/');
 		if (registration) {
 			await registration.update();

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -146,6 +146,19 @@ function native_navigation(url) {
 	return new Promise(() => {});
 }
 
+/**
+ * Checks whether a service worker is registered, and if it is,
+ * tries to update it.
+ */
+async function update_service_worker() {
+	if (BROWSER && 'serviceWorker' in navigator) {
+		const registration = await navigator.serviceWorker.getRegistration(base || '/');
+		if (registration) {
+			await registration.update();
+		}
+	}
+}
+
 function noop() {}
 
 /** @type {import('types').CSRRoute[]} */
@@ -1001,6 +1014,8 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 					// Referenced node could have been removed due to redeploy, check
 					const updated = await stores.updated.check();
 					if (updated) {
+						// Before reloading, try to update the service worker if it exists
+						await update_service_worker();
 						return await native_navigation(url);
 					}
 
@@ -1325,6 +1340,8 @@ async function navigate({
 	} else if (/** @type {number} */ (navigation_result.props.page.status) >= 400) {
 		const updated = await stores.updated.check();
 		if (updated) {
+			// Before reloading, try to update the service worker if it exists
+			await update_service_worker();
 			await native_navigation(url);
 		}
 	}


### PR DESCRIPTION
this patch adds a function that tries to update the service worker (if it exists), and calls it when sveltekit detects that a new version has been deployed.
i'm not sure if this is the right place to put this -- i considered putting it in the body of check(), but it feels wrong to me. if you think it's a good idea, let me know and i'll update it.

closes #3667

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
