### PR TITLE
fix: remove unnecessary `tslib` dependency

### DIFF
--- a/.changeset/slow-beans-develop.md
+++ b/.changeset/slow-beans-develop.md
@@ -1,0 +1,5 @@
+---
+"create-svelte": patch
+---
+
+fix: remove unnecessary `tslib` dependency

--- a/packages/create-svelte/shared/+typescript/package.json
+++ b/packages/create-svelte/shared/+typescript/package.json
@@ -5,7 +5,6 @@
 	},
 	"devDependencies": {
 		"typescript": "^5.0.0",
-		"tslib": "^2.4.1",
 		"svelte-check": "^3.6.0"
 	}
 }

--- a/packages/create-svelte/templates/skeletonlib/package.template.json
+++ b/packages/create-svelte/templates/skeletonlib/package.template.json
@@ -25,7 +25,6 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
 		"publint": "^0.1.9",
 		"svelte": "^4.2.7",
-		"tslib": "^2.4.1",
 		"typescript": "^5.3.2",
 		"vite": "^5.0.11"
 	},


### PR DESCRIPTION
[`tslib`](https://github.com/Microsoft/tslib) was added to the Svelte codebase in https://github.com/sveltejs/svelte/pull/920 but the [`--importHelpers`](https://www.typescriptlang.org/tsconfig/#importHelpers) option since disappeared from the `tsconfig` during the split in https://github.com/sveltejs/svelte/pull/2994. This option as well as [downlevelling](https://www.typescriptlang.org/tsconfig/#downlevelIteration) are also not set by `create-svelte`. 

So this library is unused, and there is no need to keep it. This PR removes it.  

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
