### PR TITLE
feat: add support for svelte.config.ts

### DIFF
--- a/.changeset/tall-adults-film.md
+++ b/.changeset/tall-adults-film.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+add support for svelte.config.ts

--- a/packages/kit/src/core/config/fixtures/typescript/svelte.config.ts
+++ b/packages/kit/src/core/config/fixtures/typescript/svelte.config.ts
@@ -1,0 +1,5 @@
+export default {
+	preprocess: [],
+	extensions: ['.svelte'],
+	kit: {}
+};

--- a/packages/kit/src/core/config/fixtures/typescript/svelte.config.ts
+++ b/packages/kit/src/core/config/fixtures/typescript/svelte.config.ts
@@ -1,5 +1,1 @@
-export default {
-	preprocess: [],
-	extensions: ['.svelte'],
-	kit: {}
-};
+export default {};

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -2,7 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import * as url from 'node:url';
 import options from './options.js';
-import { transpileModule } from 'typescript';
+import pkg from 'typescript';
+const { transpileModule } = pkg;
 
 /**
  * Loads the template (src/app.html by default) and validates that it has the

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -72,8 +72,7 @@ export async function load_config({ cwd = process.cwd() } = {}) {
 
 	if (fs.existsSync(ts_config_file)) {
 		const config = await load_ts_config(ts_config_file);
-		console.log(config);
-		return process_config(config, { cwd });
+		return process_config(config.default, { cwd });
 	}
 
 	return process_config({}, { cwd });
@@ -94,7 +93,7 @@ async function load_ts_config(ts_config_file) {
 		const config = await import(
 			`data:text/javascript;base64,${Buffer.from(js_code).toString('base64')}`
 		);
-		return config.default;
+		return config;
 	} catch (e) {
 		const error = /** @type {Error} */ (e);
 

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -360,6 +360,18 @@ test('load default config (esm)', async () => {
 	expect(config).toEqual(defaults);
 });
 
+test('load default typescript config (esm)', async () => {
+	const cwd = join(__dirname, 'fixtures/typescript');
+
+	const config = await load_config({ cwd });
+	remove_keys(config, ([, v]) => typeof v === 'function');
+
+	const defaults = get_defaults(cwd + '/');
+	defaults.kit.version.name = config.kit.version.name;
+
+	expect(config).toEqual(defaults);
+});
+
 test('errors on loading config with incorrect default export', async () => {
 	let message = null;
 
@@ -372,6 +384,6 @@ test('errors on loading config with incorrect default export', async () => {
 
 	assert.equal(
 		message,
-		'svelte.config.js must have a configuration object as its default export. See https://kit.svelte.dev/docs/configuration'
+		'svelte.config.js or svelte.config.ts must have a configuration object as its default export. See https://kit.svelte.dev/docs/configuration'
 	);
 });

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1840,7 +1840,7 @@ declare module '@sveltejs/kit' {
 	class Redirect_1 {
 		
 		constructor(status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308, location: string);
-		status: 301 | 302 | 303 | 307 | 308 | 300 | 304 | 305 | 306;
+		status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308;
 		location: string;
 	}
 }


### PR DESCRIPTION
This added support for `svelte.config.ts` with minimal changes and independent. This does not provide types support, however, now we could run `svelte.config.ts` out-of-the-box.

![Screenshot 2024-07-10 092107](https://github.com/sveltejs/kit/assets/50759463/44de458f-5270-4286-9229-220e0b38cfd5)

Closes #2576

Note that, `svelte.config.js` is prioritized by default.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
