### PR TITLE
feat: Add Prefered Code Editor/IDE option to create-svelte

### DIFF
--- a/.changeset/tame-dryers-jog.md
+++ b/.changeset/tame-dryers-jog.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+Add Option to choose preferred code editor/IDE

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -104,6 +104,23 @@ const options = await p.group(
 						label: 'Try the Svelte 5 preview (unstable!)'
 					}
 				]
+			}),
+		editor: () =>
+			p.select({
+				message:
+					'Would you like to add reccomended configuration files for your preferred code editor?',
+				/** @type {'vscode' | null } */
+				initialValue: null,
+				options: [
+					{
+						value: 'vscode',
+						label: 'Yes, Visual Studio Code'
+					},
+					{
+						value: null,
+						label: 'No'
+					}
+				]
 			})
 	},
 	{ onCancel: () => process.exit(1) }
@@ -117,7 +134,8 @@ await create(cwd, {
 	eslint: options.features.includes('eslint'),
 	playwright: options.features.includes('playwright'),
 	vitest: options.features.includes('vitest'),
-	svelte5: options.features.includes('svelte5')
+	svelte5: options.features.includes('svelte5'),
+	editor: /** @type {'vscode' | null } */ (options.editor)
 });
 
 p.outro('Your project is ready!');

--- a/packages/create-svelte/index.js
+++ b/packages/create-svelte/index.js
@@ -53,7 +53,7 @@ function write_common_files(cwd, options, name) {
 	sort_files(files).forEach((file) => {
 		const include = file.include.every((condition) => matches_condition(condition, options));
 		const exclude = file.exclude.some((condition) => matches_condition(condition, options));
-
+	
 		if (exclude || !include) return;
 
 		if (file.name === 'package.json') {
@@ -84,6 +84,9 @@ function matches_condition(condition, options) {
 	}
 	if (condition === 'typescript' || condition === 'checkjs') {
 		return options.types === condition;
+	}
+	if (condition === 'vscode') {
+		return options.editor === condition;
 	}
 	return !!options[condition];
 }

--- a/packages/create-svelte/index.js
+++ b/packages/create-svelte/index.js
@@ -53,7 +53,7 @@ function write_common_files(cwd, options, name) {
 	sort_files(files).forEach((file) => {
 		const include = file.include.every((condition) => matches_condition(condition, options));
 		const exclude = file.exclude.some((condition) => matches_condition(condition, options));
-	
+
 		if (exclude || !include) return;
 
 		if (file.name === 'package.json') {

--- a/packages/create-svelte/scripts/update-template-repo-contents.js
+++ b/packages/create-svelte/scripts/update-template-repo-contents.js
@@ -21,7 +21,8 @@ await create(repo, {
 	prettier: true,
 	playwright: false,
 	vitest: false,
-	svelte5: false
+	svelte5: false,
+	editor: null
 });
 
 // Remove the Sverdle from the template because it doesn't work within Stackblitz (cookies not set)

--- a/packages/create-svelte/shared/+typescript+vscode/.vscode/extensions.json
+++ b/packages/create-svelte/shared/+typescript+vscode/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["svelte.svelte-vscode"]
+}

--- a/packages/create-svelte/shared/+typescript+vscode/.vscode/settings.json
+++ b/packages/create-svelte/shared/+typescript+vscode/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+	"[svelte]": {
+		"editor.defaultFormatter": "svelte.svelte-vscode"
+	},
+	"svelte.enable-ts-plugin": true,
+	"svelte.plugin.svelte.defaultScriptLanguage": "ts"
+}

--- a/packages/create-svelte/shared/+vscode+eslint+typescript/extensions.json
+++ b/packages/create-svelte/shared/+vscode+eslint+typescript/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["svelte.svelte-vscode", "dbaeumer.vscode-eslint"]
+}

--- a/packages/create-svelte/shared/+vscode+eslint+typescript/settings.json
+++ b/packages/create-svelte/shared/+vscode+eslint+typescript/settings.json
@@ -1,0 +1,6 @@
+{
+	"eslint.validate": ["javascript", "javascriptreact", "typescript", "svelte"],
+	"[svelte]": {
+		"editor.defaultFormatter": "svelte.svelte-vscode"
+	}
+}

--- a/packages/create-svelte/shared/+vscode+eslint-typescript/.vscode/extensions.json
+++ b/packages/create-svelte/shared/+vscode+eslint-typescript/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["svelte.svelte-vscode", "dbaeumer.vscode-eslint"]
+}

--- a/packages/create-svelte/shared/+vscode+eslint-typescript/.vscode/settings.json
+++ b/packages/create-svelte/shared/+vscode+eslint-typescript/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+	"eslint.validate": ["javascript", "javascriptreact", "svelte"],
+	"[svelte]": {
+		"editor.defaultFormatter": "svelte.svelte-vscode"
+	}
+}

--- a/packages/create-svelte/shared/+vscode/.vscode/extensions.json
+++ b/packages/create-svelte/shared/+vscode/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["svelte.svelte-vscode"]
+}

--- a/packages/create-svelte/shared/+vscode/.vscode/settings.json
+++ b/packages/create-svelte/shared/+vscode/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+	"[svelte]": {
+		"editor.defaultFormatter": "svelte.svelte-vscode"
+	}
+}

--- a/packages/create-svelte/test/check.js
+++ b/packages/create-svelte/test/check.js
@@ -117,7 +117,8 @@ for (const template of templates) {
 			eslint: true,
 			playwright: false,
 			vitest: false,
-			svelte5: false
+			svelte5: false,
+			editor: null
 		});
 
 		const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf-8'));

--- a/packages/create-svelte/types/internal.d.ts
+++ b/packages/create-svelte/types/internal.d.ts
@@ -7,6 +7,7 @@ export type Options = {
 	playwright: boolean;
 	vitest: boolean;
 	svelte5?: boolean; // optional to not introduce a breaking change to the `create` API
+	editor: null | 'vscode';
 };
 
 export type File = {
@@ -24,7 +25,8 @@ export type Condition =
 	| 'skeleton'
 	| 'default'
 	| 'skeletonlib'
-	| 'svelte5';
+	| 'svelte5'
+	| 'vscode';
 
 export type Common = {
 	files: Array<{


### PR DESCRIPTION
# Add Prefered Code Editor/IDE option to create-svelte

I made this PR more to spark a discussion, and hopefully help the Svelte ecosystem. 

## Problem
Setting up your preferred IDE for Svelte is kind of frustrating. There have been a lot of changes to Svelte's VSCode Plugins throughout its lifespan with recommended settings and plugins changing multiple times as evidenced by the official plugins setup section in the [docs.](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode) 

Also there are a few hidden gotchas when setting up ESLint like opting in to svelte file [checking](https://sveltejs.github.io/eslint-plugin-svelte/user-guide/#visual-studio-code)

I also have a multitude of other problems which are more frustrating because I am unsure if it is me not configuring correctly or bugs within the plugins themselves. 

Most people will use VSCode when coding with Svelte. Especially since it also [Svelte's recommended IDE ](https://sveltejs.github.io/eslint-plugin-svelte/user-guide/#visual-studio-code) . When most people setup a Svelte project they probably don't want to be scanning through a ton of docs to figure out how to set up their IDE, and instead just want to get started coding Svelte. I think this is one small thing that hurts the DX & the ecosystem that can be easily fixed with this package. Allowing maintainers of IDE plugins to more effectively communicate their recommended setup to the community & new users, and drastically improve the DX of Svelte overall. 

## Fix

I added an option to add default setup files for your prefered IDE. With only vscode so far but, more IDEs might be able to be added later.  I added the settings I have found best with my VSCode setup so far, but I would definitely like input from people who are more involved with these plugins. As I still have some annoyances and it would be great to have it clarified that I am  following the recommended setup by the people who know more than me. 

## Conclusion 

The DX of Svelte is great, I just think the IDE setup was one small thing missed that causes frustration and harms DX. I think this change allows us to easily fix that by allowing the community & maintainers of the plugins themselves to communicate their recommended IDE setups through official Svelte channels. 

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [X] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
