### PR TITLE
chore: fix flaky test

### DIFF
--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1020,11 +1020,11 @@ test.describe('untrack', () => {
 		expect(await page.textContent('p.id')).toBe(id);
 	});
 
-	test('untracks universal load function', async ({ page }) => {
+	test('untracks universal load function', async ({ page, clicknav }) => {
 		await page.goto('/untrack/universal/1');
 		expect(await page.textContent('p.url')).toBe('/untrack/universal/1');
 		const id = await page.textContent('p.id');
-		await page.click('a[href="/untrack/universal/2"]');
+		await clicknav('a[href="/untrack/universal/2"]');
 		expect(await page.textContent('p.url')).toBe('/untrack/universal/2');
 		expect(await page.textContent('p.id')).toBe(id);
 	});


### PR DESCRIPTION
I think our tests have been flaky ever since https://github.com/sveltejs/kit/pull/11311

It's an easy fix, but I didn't know this test was flaky because GitHub was burying the logs. Thankfully @eltigerchino realized there were other errors in the logs that I didn't see

`page.click` won't wait for the navigation to complete where as `clicknav` will