### PR TITLE
chore: fix flaky download test

### DIFF
--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -220,26 +220,22 @@ test.describe('Navigation lifecycle functions', () => {
 		expect(await page.innerHTML('pre')).toBe('2 false goto');
 	});
 
-	test('beforeNavigate is triggered after clicking a download link', async ({
-		page,
-		baseURL,
-	}) => {
+	test('beforeNavigate is triggered after clicking a download link', async ({ page, baseURL }) => {
 		const pathname = '/navigation-lifecycle/before-navigate/prevent-navigation';
+		const current_url = baseURL + pathname;
 
 		await page.goto(pathname);
 
 		const download = page.waitForEvent('download');
 		await page.locator('a[download]').click();
+		await page.waitForURL(current_url);
 		await (await download).cancel();
 
-		const current_url = baseURL + pathname;
-
-		expect(page.url()).toBe(current_url);
 		expect(await page.locator('pre').innerText()).toBe('0 false undefined');
 
 		await page.locator('a[href="/navigation-lifecycle/before-navigate/a"]').click();
+		await page.waitForURL(current_url);
 
-		expect(page.url()).toBe(current_url);
 		expect(await page.locator('pre').innerText()).toBe('1 false link');
 	});
 

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -223,13 +223,20 @@ test.describe('Navigation lifecycle functions', () => {
 	test('beforeNavigate is triggered after clicking a download link', async ({ page, baseURL }) => {
 		await page.goto('/navigation-lifecycle/before-navigate/prevent-navigation');
 
-		await page.click('a[download]');
-		expect(await page.innerHTML('pre')).toBe('0 false undefined');
+		const download = page.waitForEvent('download', { timeout: 3000 });
+		await page.locator('a[download]').click();
+		await (await download).cancel();
+
+		const current_url = baseURL + '/navigation-lifecycle/before-navigate/prevent-navigation';
+
+		expect(page.url()).toBe(current_url);
+		expect(await page.locator('pre').innerText()).toBe('0 false undefined');
 
 		await page.click('a[href="/navigation-lifecycle/before-navigate/a"]');
+		await page.waitForLoadState('networkidle');
 
-		expect(page.url()).toBe(baseURL + '/navigation-lifecycle/before-navigate/prevent-navigation');
-		expect(await page.innerHTML('pre')).toBe('1 false link');
+		expect(page.url()).toBe(current_url);
+		expect(await page.locator('pre').innerText()).toBe('1 false link');
 	});
 
 	test('afterNavigate calls callback', async ({ page, clicknav }) => {

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -220,13 +220,17 @@ test.describe('Navigation lifecycle functions', () => {
 		expect(await page.innerHTML('pre')).toBe('2 false goto');
 	});
 
-	test('beforeNavigate is triggered after clicking a download link', async ({ page, baseURL }) => {
+	test('beforeNavigate is triggered after clicking a download link', async ({
+		page,
+		baseURL,
+		clicknav
+	}) => {
 		const pathname = '/navigation-lifecycle/before-navigate/prevent-navigation';
 
 		await page.goto(pathname);
 
 		const download = page.waitForEvent('download');
-		await page.locator('a[download]').click();
+		await clicknav('a[download]');
 		await (await download).cancel();
 
 		const current_url = baseURL + pathname;
@@ -234,8 +238,7 @@ test.describe('Navigation lifecycle functions', () => {
 		expect(page.url()).toBe(current_url);
 		expect(await page.locator('pre').innerText()).toBe('0 false undefined');
 
-		await page.click('a[href="/navigation-lifecycle/before-navigate/a"]');
-		await page.waitForLoadState('networkidle');
+		await clicknav('a[href="/navigation-lifecycle/before-navigate/a"]');
 
 		expect(page.url()).toBe(current_url);
 		expect(await page.locator('pre').innerText()).toBe('1 false link');

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -230,7 +230,7 @@ test.describe('Navigation lifecycle functions', () => {
 		await page.goto(pathname);
 
 		const download = page.waitForEvent('download');
-		await clicknav('a[download]');
+		await page.locator('a[download]').click();
 		await (await download).cancel();
 
 		const current_url = baseURL + pathname;

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -220,23 +220,18 @@ test.describe('Navigation lifecycle functions', () => {
 		expect(await page.innerHTML('pre')).toBe('2 false goto');
 	});
 
-	test('beforeNavigate is triggered after clicking a download link', async ({ page, baseURL }) => {
-		const pathname = '/navigation-lifecycle/before-navigate/prevent-navigation';
-		const current_url = baseURL + pathname;
-
-		await page.goto(pathname);
+	test('beforeNavigate is triggered after clicking a download link', async ({ page }) => {
+		await page.goto('/navigation-lifecycle/before-navigate/prevent-navigation');
 
 		const download = page.waitForEvent('download');
 		await page.locator('a[download]').click();
-		await page.waitForURL(current_url);
 		await (await download).cancel();
 
-		expect(await page.locator('pre').innerText()).toBe('0 false undefined');
+		await expect(page.locator('pre')).toHaveText('0 false undefined');
 
 		await page.locator('a[href="/navigation-lifecycle/before-navigate/a"]').click();
-		await page.waitForURL(current_url);
 
-		expect(await page.locator('pre').innerText()).toBe('1 false link');
+		await expect(page.locator('pre')).toHaveText('1 false link');
 	});
 
 	test('afterNavigate calls callback', async ({ page, clicknav }) => {

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -225,7 +225,7 @@ test.describe('Navigation lifecycle functions', () => {
 
 		await page.goto(pathname);
 
-		const download = page.waitForEvent('download', { timeout: 3000 });
+		const download = page.waitForEvent('download');
 		await page.locator('a[download]').click();
 		await (await download).cancel();
 

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -223,7 +223,6 @@ test.describe('Navigation lifecycle functions', () => {
 	test('beforeNavigate is triggered after clicking a download link', async ({
 		page,
 		baseURL,
-		clicknav
 	}) => {
 		const pathname = '/navigation-lifecycle/before-navigate/prevent-navigation';
 
@@ -238,7 +237,7 @@ test.describe('Navigation lifecycle functions', () => {
 		expect(page.url()).toBe(current_url);
 		expect(await page.locator('pre').innerText()).toBe('0 false undefined');
 
-		await clicknav('a[href="/navigation-lifecycle/before-navigate/a"]');
+		await page.locator('a[href="/navigation-lifecycle/before-navigate/a"]').click();
 
 		expect(page.url()).toBe(current_url);
 		expect(await page.locator('pre').innerText()).toBe('1 false link');

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -221,13 +221,15 @@ test.describe('Navigation lifecycle functions', () => {
 	});
 
 	test('beforeNavigate is triggered after clicking a download link', async ({ page, baseURL }) => {
-		await page.goto('/navigation-lifecycle/before-navigate/prevent-navigation');
+		const pathname = '/navigation-lifecycle/before-navigate/prevent-navigation';
+
+		await page.goto(pathname);
 
 		const download = page.waitForEvent('download', { timeout: 3000 });
 		await page.locator('a[download]').click();
 		await (await download).cancel();
 
-		const current_url = baseURL + '/navigation-lifecycle/before-navigate/prevent-navigation';
+		const current_url = baseURL + pathname;
 
 		expect(page.url()).toBe(current_url);
 		expect(await page.locator('pre').innerText()).toBe('0 false undefined');


### PR DESCRIPTION
Let's see if waiting for the download event makes it less flaky.

EDIT: seems less flaky? will try re-running the CI a couple of times. Seems to only error on other flaky tests.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
