### PR TITLE
chore: bump @types/eslint to v9

### DIFF
--- a/.changeset/yellow-queens-shop.md
+++ b/.changeset/yellow-queens-shop.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+chore: bump @types/eslint to v9

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,6 @@
 import svelte_config from '@sveltejs/eslint-config';
 
-/** @type {import('eslint').Linter.FlatConfig[]} */
+/** @type {import('eslint').Linter.Config[]} */
 export default [
 	...svelte_config,
 	{

--- a/packages/create-svelte/shared/+eslint+prettier+typescript/eslint.config.js
+++ b/packages/create-svelte/shared/+eslint+prettier+typescript/eslint.config.js
@@ -4,7 +4,7 @@ import svelte from 'eslint-plugin-svelte';
 import prettier from 'eslint-config-prettier';
 import globals from 'globals';
 
-/** @type {import('eslint').Linter.FlatConfig[]} */
+/** @type {import('eslint').Linter.Config[]} */
 export default [
 	js.configs.recommended,
 	...ts.configs.recommended,

--- a/packages/create-svelte/shared/+eslint+prettier-typescript/eslint.config.js
+++ b/packages/create-svelte/shared/+eslint+prettier-typescript/eslint.config.js
@@ -3,7 +3,7 @@ import svelte from 'eslint-plugin-svelte';
 import prettier from 'eslint-config-prettier';
 import globals from 'globals';
 
-/** @type {import('eslint').Linter.FlatConfig[]} */
+/** @type {import('eslint').Linter.Config[]} */
 export default [
 	js.configs.recommended,
 	...svelte.configs['flat/recommended'],

--- a/packages/create-svelte/shared/+eslint+typescript/eslint.config.js
+++ b/packages/create-svelte/shared/+eslint+typescript/eslint.config.js
@@ -3,7 +3,7 @@ import ts from 'typescript-eslint';
 import svelte from 'eslint-plugin-svelte';
 import globals from 'globals';
 
-/** @type {import('eslint').Linter.FlatConfig[]} */
+/** @type {import('eslint').Linter.Config[]} */
 export default [
 	js.configs.recommended,
 	...ts.configs.recommended,

--- a/packages/create-svelte/shared/+eslint-typescript/eslint.config.js
+++ b/packages/create-svelte/shared/+eslint-typescript/eslint.config.js
@@ -2,7 +2,7 @@ import js from '@eslint/js';
 import svelte from 'eslint-plugin-svelte';
 import globals from 'globals';
 
-/** @type {import('eslint').Linter.FlatConfig[]} */
+/** @type {import('eslint').Linter.Config[]} */
 export default [
 	js.configs.recommended,
 	...svelte.configs['flat/recommended'],

--- a/packages/create-svelte/shared/+eslint/package.json
+++ b/packages/create-svelte/shared/+eslint/package.json
@@ -1,6 +1,6 @@
 {
 	"devDependencies": {
-		"@types/eslint": "^8.56.7",
+		"@types/eslint": "^9.6.0",
 		"eslint": "^9.0.0",
 		"eslint-plugin-svelte": "^2.36.0",
 		"globals": "^15.0.0"


### PR DESCRIPTION
Fixes https://github.com/sveltejs/kit/issues/12109

`@types/eslint` v9 has been released.

The `FlatConfig` type is [deprecated](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/23fde1f04766f759428a6302a9ee107200391429/types/eslint/index.d.ts#L1280-L1281
).


```ts
/** @deprecated  Use `Config` instead of `FlatConfig` */
type FlatConfig = Config;
```

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
