### PR TITLE
chore: upgrade to @fontsource/fira-mono v5 and @neoconfetti/svelte v2

### DIFF
--- a/.changeset/lemon-pugs-film.md
+++ b/.changeset/lemon-pugs-film.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+chore: upgrade to @fontsource/fira-mono v5 and @neoconfetti/svelte v2

--- a/packages/create-svelte/templates/default/package.json
+++ b/packages/create-svelte/templates/default/package.json
@@ -8,6 +8,7 @@
 		"preview": "vite preview"
 	},
 	"devDependencies": {
+		"@fontsource/fira-mono": "^5.0.0",
 		"@neoconfetti/svelte": "^2.0.0",
 		"@sveltejs/adapter-auto": "workspace:*",
 		"@sveltejs/kit": "workspace:*",
@@ -16,8 +17,5 @@
 		"typescript": "^5.3.3",
 		"vite": "^5.3.2"
 	},
-	"type": "module",
-	"dependencies": {
-		"@fontsource/fira-mono": "^5.0.0"
-	}
+	"type": "module"
 }

--- a/packages/create-svelte/templates/default/package.json
+++ b/packages/create-svelte/templates/default/package.json
@@ -8,7 +8,7 @@
 		"preview": "vite preview"
 	},
 	"devDependencies": {
-		"@neoconfetti/svelte": "^1.0.0",
+		"@neoconfetti/svelte": "^2.0.0",
 		"@sveltejs/adapter-auto": "workspace:*",
 		"@sveltejs/kit": "workspace:*",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
@@ -18,6 +18,6 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@fontsource/fira-mono": "^5.0.8"
+		"@fontsource/fira-mono": "^5.0.0"
 	}
 }

--- a/packages/create-svelte/templates/default/package.template.json
+++ b/packages/create-svelte/templates/default/package.template.json
@@ -7,8 +7,8 @@
 		"preview": "vite preview"
 	},
 	"devDependencies": {
-		"@fontsource/fira-mono": "^4.5.10",
-		"@neoconfetti/svelte": "^1.0.0",
+		"@fontsource/fira-mono": "^5.0.0",
+		"@neoconfetti/svelte": "^2.0.0",
 		"@sveltejs/adapter-auto": "^3.0.0",
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,11 +330,10 @@ importers:
         version: 2.0.1(@types/node@18.19.31)(lightningcss@1.24.1)
 
   packages/create-svelte/templates/default:
-    dependencies:
+    devDependencies:
       '@fontsource/fira-mono':
         specifier: ^5.0.0
         version: 5.0.12
-    devDependencies:
       '@neoconfetti/svelte':
         specifier: ^2.0.0
         version: 2.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,12 +332,12 @@ importers:
   packages/create-svelte/templates/default:
     dependencies:
       '@fontsource/fira-mono':
-        specifier: ^5.0.8
+        specifier: ^5.0.0
         version: 5.0.12
     devDependencies:
       '@neoconfetti/svelte':
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^2.0.0
+        version: 2.2.1
       '@sveltejs/adapter-auto':
         specifier: workspace:*
         version: link:../../../adapter-auto
@@ -1916,8 +1916,8 @@ packages:
     resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
     hasBin: true
 
-  '@neoconfetti/svelte@1.0.0':
-    resolution: {integrity: sha512-SmksyaJAdSlMa9cTidVSIqYo1qti+WTsviNDwgjNVm+KQ3DRP2Df9umDIzC4vCcpEYY+chQe0i2IKnLw03AT8Q==}
+  '@neoconfetti/svelte@2.2.1':
+    resolution: {integrity: sha512-2Ts0Rxaf6clW2qG+AKhTwpl01AAyZEAe03XeuQ7Vp+qYIaM3ycuI94j546fmEkUxwACwGI3Zl2cZ/pncTuNcJg==}
 
   '@netlify/functions@2.6.0':
     resolution: {integrity: sha512-vU20tij0fb4nRGACqb+5SQvKd50JYyTyEhQetCMHdakcJFzjLDivvRR16u1G2Oy4A7xNAtGJF1uz8reeOtTVcQ==}
@@ -4869,7 +4869,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@neoconfetti/svelte@1.0.0': {}
+  '@neoconfetti/svelte@2.2.1': {}
 
   '@netlify/functions@2.6.0':
     dependencies:


### PR DESCRIPTION
I don't really understand why we need the dependency in both `package.json` and `package.template.json`?