### PR TITLE
fix: emulate `event.platform` during development even if route is undefined

### DIFF
--- a/.changeset/shiny-suns-scream.md
+++ b/.changeset/shiny-suns-scream.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-In dev, emulate event.platform even if route is undefined
+fix: emulate `event.platform` during development even if route is undefined

--- a/.changeset/shiny-suns-scream.md
+++ b/.changeset/shiny-suns-scream.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: emulate `event.platform` during development even if route is undefined
+fix: emulate `event.platform` even when the route does not exist

--- a/.changeset/shiny-suns-scream.md
+++ b/.changeset/shiny-suns-scream.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+In dev, emulate event.platform even if route is undefined

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -297,7 +297,7 @@ export async function respond(request, options, manifest, state) {
 			}
 		}
 
-		if (!event.platform && DEV && state.emulator?.platform) {
+ else if (state.emulator?.platform) {
 			event.platform = await state.emulator.platform({ config: {}, prerender: false });
 		}
 

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -295,9 +295,7 @@ export async function respond(request, options, manifest, state) {
 					event.platform = await state.emulator.platform({ config, prerender });
 				}
 			}
-		}
-
- else if (state.emulator?.platform) {
+		} else if (state.emulator?.platform) {
 			event.platform = await state.emulator.platform({
 				config: {},
 				prerender: !!state.prerendering?.fallback

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -297,6 +297,10 @@ export async function respond(request, options, manifest, state) {
 			}
 		}
 
+		if (!event.platform && DEV && state.emulator?.platform) {
+			event.platform = await state.emulator.platform({ config: {}, prerender: false });
+		}
+
 		const { cookies, new_cookies, get_cookie_header, set_internal } = get_cookies(
 			request,
 			url,

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -298,7 +298,10 @@ export async function respond(request, options, manifest, state) {
 		}
 
  else if (state.emulator?.platform) {
-			event.platform = await state.emulator.platform({ config: {}, prerender: false });
+			event.platform = await state.emulator.platform({
+				config: {},
+				prerender: !!state.prerendering?.fallback
+			});
 		}
 
 		const { cookies, new_cookies, get_cookie_header, set_internal } = get_cookies(


### PR DESCRIPTION
This ought to fix #11996

Only if `DEV`, config is an empty object and prerender is set to `false` so that `event.platform` can be emulated.
I believe this will improve the development experience by preventing 500 errors and allowing development to occur in a more local development environment similar to the production environment.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
