### PR TITLE
Disable caching of 404s  for immutable assets in vercel-adapter

### DIFF
--- a/.changeset/stale-turkeys-battle.md
+++ b/.changeset/stale-turkeys-battle.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-vercel': patch
 ---
 
-no-store cache-control for immmutable assets without 200 response.
+fix: ensure immutable assets without 200 response are not cached

--- a/.changeset/stale-turkeys-battle.md
+++ b/.changeset/stale-turkeys-battle.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': minor
+---
+
+no-store cache-control for immmutable assets without 200 response.

--- a/.changeset/stale-turkeys-battle.md
+++ b/.changeset/stale-turkeys-battle.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/adapter-vercel': minor
+'@sveltejs/adapter-vercel': patch
 ---
 
 no-store cache-control for immmutable assets without 200 response.

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -42,24 +42,12 @@ export default async (req, res) => {
 		}
 	});
 
-	// Check if the response status is 404
-	if (response.status === 404) {
-		// Modify the Cache-Control header for 404 responses
-		const newHeaders = new Headers(response.headers);
-		newHeaders.set('cache-control', 'no-store');
-		
-		// Create a new response object with modified headers
-		const modifiedResponse = new Response(response.body, {
-			status: response.status,
-			statusText: response.statusText,
-			headers: newHeaders
-		});
-		
-		// Set the modified response
-		setResponse(res, modifiedResponse);
-	} else {
-		// Set the response normally if not 404
-		setResponse(res, response);
+	// Only apply cache headers to 200 responses
+	if (pathname?.startsWith(`/${manifest.appPath}/immutable/`) && response.statusCode === 200) {
+		response.headers.set('cache-control', 'public,max-age=31536000,immutable');
 	}
+	
+	// Set the response normally if not 404
+	setResponse(res, response);
 
 };

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -53,11 +53,9 @@ export default async (req, res) => {
 		console.log("IMMUTABLE");
 		if (response.status === 200) {
 			response.headers.set('cache-control', 'public,max-age=31536000,immutable');
-			response.setHeader('cache-control', 'public,max-age=31536000,immutable');
 			console.warn("setting headers for 200")
 		} else if (response.status === 404) {
 			response.headers.set('cache-control', 'no-store');
-			response.setHeader('cache-control', 'no-store');
 			console.warn("404 response")
 		}
 	}

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -43,9 +43,8 @@ export default async (req, res) => {
 	});
 
 	if (req.url?.startsWith(`/${manifest.appPath}/immutable/`) && response.status !== 200) {
-			response.headers.set('cache-control', 'no-store');
+		response.headers.set('cache-control', 'no-store');
 	}
 
 	setResponse(res, response);
-
 };

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -44,16 +44,24 @@ export default async (req, res) => {
 
 	// Only apply cache headers to 200 responses
 	console.warn('Response Object:', response);
-	console.warn(req.url)
-	console.warn(manifest.appPath)
-	console.warn(response.statusCode)
-	console.warn(response.status)
-	console.warn("CALLED")
-	if (req.url?.startsWith(`/${manifest.appPath}/immutable/`) && response.status === 200) {
-		response.headers.set('cache-control', 'public,max-age=31536000,immutable');
-		response.setHeader('cache-control', 'public,max-age=31536000,immutable');
-		console.warn("setting headers")
+	console.warn(req.url);
+	console.warn(manifest.appPath);
+	console.warn(response.statusCode);
+	console.warn(response.status);
+	console.warn("CALLED");
+	if (req.url?.startsWith(`/${manifest.appPath}/immutable/`)) {
+		console.log("IMMUTABLE");
+		if (response.status === 200) {
+			response.headers.set('cache-control', 'public,max-age=31536000,immutable');
+			response.setHeader('cache-control', 'public,max-age=31536000,immutable');
+			console.warn("setting headers for 200")
+		} else if (response.status === 404) {
+			response.headers.set('cache-control', 'no-store');
+			response.setHeader('cache-control', 'no-store');
+			console.warn("404 response")
+		}
 	}
+	console.log("Response Headers:", response.headers);
 	// Set the response normally if not 404
 	setResponse(res, response);
 

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -43,10 +43,9 @@ export default async (req, res) => {
 	});
 
 	// Only apply cache headers to 200 responses
-	if (pathname?.startsWith(`/${manifest.appPath}/immutable/`) && response.statusCode === 200) {
+	if (req.url?.startsWith(`/${manifest.appPath}/immutable/`) && response.statusCode === 200) {
 		response.headers.set('cache-control', 'public,max-age=31536000,immutable');
 	}
-	
 	// Set the response normally if not 404
 	setResponse(res, response);
 

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -43,8 +43,14 @@ export default async (req, res) => {
 	});
 
 	// Only apply cache headers to 200 responses
+	console.warn(req.url)
+	console.warn(manifest.appPath)
+	console.warn(response.statusCode)
+	console.warn("CALLED")
 	if (req.url?.startsWith(`/${manifest.appPath}/immutable/`) && response.statusCode === 200) {
 		response.headers.set('cache-control', 'public,max-age=31536000,immutable');
+		response.setHeader('cache-control', 'public,max-age=31536000,immutable');
+		console.warn("setting headers")
 	}
 	// Set the response normally if not 404
 	setResponse(res, response);

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -42,25 +42,34 @@ export default async (req, res) => {
 		}
 	});
 
-	// Only apply cache headers to 200 responses
-	console.warn('Response Object:', response);
-	console.warn(req.url);
-	console.warn(manifest.appPath);
-	console.warn(response.statusCode);
-	console.warn(response.status);
-	console.warn("CALLED");
-	if (req.url?.startsWith(`/${manifest.appPath}/immutable/`)) {
-		console.log("IMMUTABLE");
-		if (response.status === 200) {
-			response.headers.set('cache-control', 'public,max-age=31536000,immutable');
-			console.warn("setting headers for 200")
-		} else if (response.status === 404) {
+	if (req.url?.startsWith(`/${manifest.appPath}/immutable/`) && response.status !== 200) {
 			response.headers.set('cache-control', 'no-store');
-			console.warn("404 response")
-		}
 	}
-	console.log("Response Headers:", response.headers);
-	// Set the response normally if not 404
+
 	setResponse(res, response);
 
 };
+
+
+// Check if the response status is 404
+if (pathname.startsWith(`/${manifest.appPath}/immutable/`) && res.statusCode === 200) {
+	res.setHeader('cache-control', 'public,max-age=31536000,immutable');
+}
+if (pathname.startsWith()response.status === 404) {
+// Modify the Cache-Control header for 404 responses
+const newHeaders = new Headers(response.headers);
+newHeaders.set('cache-control', 'no-store');
+
+// Create a new response object with modified headers
+const modifiedResponse = new Response(response.body, {
+status: response.status,
+statusText: response.statusText,
+headers: newHeaders
+});
+
+// Set the modified response
+setResponse(res, modifiedResponse);
+} else {
+// Set the response normally if not 404
+setResponse(res, response);
+}

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -49,27 +49,3 @@ export default async (req, res) => {
 	setResponse(res, response);
 
 };
-
-
-// Check if the response status is 404
-if (pathname.startsWith(`/${manifest.appPath}/immutable/`) && res.statusCode === 200) {
-	res.setHeader('cache-control', 'public,max-age=31536000,immutable');
-}
-if (pathname.startsWith()response.status === 404) {
-// Modify the Cache-Control header for 404 responses
-const newHeaders = new Headers(response.headers);
-newHeaders.set('cache-control', 'no-store');
-
-// Create a new response object with modified headers
-const modifiedResponse = new Response(response.body, {
-status: response.status,
-statusText: response.statusText,
-headers: newHeaders
-});
-
-// Set the modified response
-setResponse(res, modifiedResponse);
-} else {
-// Set the response normally if not 404
-setResponse(res, response);
-}

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -43,11 +43,13 @@ export default async (req, res) => {
 	});
 
 	// Only apply cache headers to 200 responses
+	console.warn('Response Object:', response);
 	console.warn(req.url)
 	console.warn(manifest.appPath)
 	console.warn(response.statusCode)
+	console.warn(response.status)
 	console.warn("CALLED")
-	if (req.url?.startsWith(`/${manifest.appPath}/immutable/`) && response.statusCode === 200) {
+	if (req.url?.startsWith(`/${manifest.appPath}/immutable/`) && response.status === 200) {
 		response.headers.set('cache-control', 'public,max-age=31536000,immutable');
 		response.setHeader('cache-control', 'public,max-age=31536000,immutable');
 		console.warn("setting headers")

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -476,12 +476,7 @@ function static_vercel_config(builder, config, dir) {
 
 	const routes = [
 		...prerendered_redirects,
-		{
-			src: `/${builder.getAppPath()}/immutable/.+`,
-			headers: {
-				'cache-control': 'public, immutable, max-age=31536000'
-			}
-		}
+		{ src: `/${builder.getAppPath()}/immutable/.+` }
 	];
 
 	// https://vercel.com/docs/deployments/skew-protection

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -479,9 +479,8 @@ function static_vercel_config(builder, config, dir) {
 		{
 			src: `/${builder.getAppPath()}/immutable/.+`,
 			headers: {
-				'Cache-Control': 'public, max-age=31536000, immutable'
-			},
-			continue: true
+				'cache-control': 'public, immutable, max-age=31536000'
+			}
 		}
 	];
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -477,10 +477,7 @@ function static_vercel_config(builder, config, dir) {
 	const routes = [
 		...prerendered_redirects,
 		{
-			src: `/${builder.getAppPath()}/immutable/.+`,
-			headers: {
-				'cache-control': 'public, immutable, max-age=31536000'
-			}
+			src: `/${builder.getAppPath()}/immutable/.+`
 		}
 	];
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -478,10 +478,10 @@ function static_vercel_config(builder, config, dir) {
 		...prerendered_redirects,
 		{
 			src: `/${builder.getAppPath()}/immutable/.+`,
-			status: 200,
 			headers: {
-				'Cache-Control': 'public, max-age=21536000, immutable'
-			}
+				'Cache-Control': 'public, max-age=31536000, immutable'
+			},
+			continue: true
 		}
 	];
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -476,7 +476,12 @@ function static_vercel_config(builder, config, dir) {
 
 	const routes = [
 		...prerendered_redirects,
-		{ src: `/${builder.getAppPath()}/immutable/.+` }
+		{
+			src: `/${builder.getAppPath()}/immutable/.+`,
+			headers: {
+				'cache-control': 'public, immutable, max-age=31536000'
+			}
+		}
 	];
 
 	// https://vercel.com/docs/deployments/skew-protection

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -477,7 +477,11 @@ function static_vercel_config(builder, config, dir) {
 	const routes = [
 		...prerendered_redirects,
 		{
-			src: `/${builder.getAppPath()}/immutable/.+`
+			src: `/${builder.getAppPath()}/immutable/.+`,
+			status: 200,
+			headers: {
+				'Cache-Control': 'public, max-age=6000, immutable'
+			}
 		}
 	];
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -480,7 +480,7 @@ function static_vercel_config(builder, config, dir) {
 			src: `/${builder.getAppPath()}/immutable/.+`,
 			status: 200,
 			headers: {
-				'Cache-Control': 'public, max-age=6000, immutable'
+				'Cache-Control': 'public, max-age=21536000, immutable'
 			}
 		}
 	];


### PR DESCRIPTION
Immutable assets are being cached for 1 year with adapter-vercel, regardless of status code response. Node adapter has a check to only apply the cache-control header when 200. This PR strips the cache-control header for immutable assets and replaces with no-store if not a 200. There may be a better way to do this but wanted to submit to help rectify. No change in tests, hard to test in vercel environment, I have tested using it on vercel with my own project.

https://github.com/sveltejs/kit/issues/9089

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
