### PR TITLE
fix: set revalidate cache header on 404'd static assets

### DIFF
--- a/.changeset/light-pears-help.md
+++ b/.changeset/light-pears-help.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: set revalidate cache header on 404'd static assets

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -116,6 +116,9 @@ export async function respond(request, options, manifest, state) {
 	}
 
 	if (decoded.startsWith(`/${options.app_dir}`)) {
+		// Ensure that 404'd static assets are not cached - some adapters might apply caching by default
+		const headers = new Headers();
+		headers.set('cache-control', 'public, max-age=0, must-revalidate');
 		return text('Not found', { status: 404 });
 	}
 


### PR DESCRIPTION
Some adapters (like Vercel) apply a immutable cache header by default to static assets. They respect explicitly set headers though. Therefore apply a "must immediately revalidate" cache header to the 404 response of static assets in the SvelteKit runtime

related to #9089

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
