### PR TITLE
fix: fall back to importing dynamic dependencies relative to SvelteKit package

### DIFF
--- a/.changeset/tricky-books-study.md
+++ b/.changeset/tricky-books-study.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: fall back to importing dynamic dependencies relative to SvelteKit package

--- a/packages/kit/src/core/sync/utils.js
+++ b/packages/kit/src/core/sync/utils.js
@@ -3,15 +3,8 @@ import path from 'node:path';
 import { mkdirp } from '../../utils/filesystem.js';
 import { resolve_peer_dependency } from '../../utils/import.js';
 
-/** @type {string} */
-let VERSION;
-
-try {
-	({ VERSION } = await resolve_peer_dependency('svelte/compiler'));
-} catch {
-	// we can end up here from e.g. unit tests. this is the simplest fix
-	({ VERSION } = await import('svelte/compiler'));
-}
+/** @type {{ VERSION: string }} */
+const { VERSION } = await resolve_peer_dependency('svelte/compiler');
 
 /** @type {Map<string, string>} */
 const previous_contents = new Map();

--- a/packages/kit/src/utils/import.js
+++ b/packages/kit/src/utils/import.js
@@ -3,17 +3,22 @@ import { pathToFileURL } from 'node:url';
 
 /**
  * Resolve a dependency relative to the current working directory,
- * rather than relative to this package
+ * rather than relative to this package (but falls back to trying that, if necessary)
  * @param {string} dependency
  */
-export function resolve_peer_dependency(dependency) {
+export async function resolve_peer_dependency(dependency) {
 	try {
 		// @ts-expect-error the types are wrong
 		const resolved = imr.resolve(dependency, pathToFileURL(process.cwd() + '/dummy.js'));
-		return import(resolved);
+		return await import(resolved);
 	} catch {
-		throw new Error(
-			`Could not resolve peer dependency "${dependency}" relative to your project — please install it and try again.`
-		);
+		// fall back to import relative to this package
+		try {
+			return await import(dependency);
+		} catch {
+			throw new Error(
+				`Could not resolve peer dependency "${dependency}" relative to your project — please install it and try again.`
+			);
+		}
 	}
 }

--- a/packages/kit/src/utils/import.js
+++ b/packages/kit/src/utils/import.js
@@ -10,7 +10,7 @@ export async function resolve_peer_dependency(dependency) {
 	try {
 		// @ts-expect-error the types are wrong
 		const resolved = imr.resolve(dependency, pathToFileURL(process.cwd() + '/dummy.js'));
-		return await import(resolved);
+		return await import(resolved).catch(() => import(dependency));
 	} catch {
 		// fall back to import relative to this package
 		try {

--- a/packages/kit/src/utils/import.js
+++ b/packages/kit/src/utils/import.js
@@ -12,13 +12,8 @@ export async function resolve_peer_dependency(dependency) {
 		const resolved = imr.resolve(dependency, pathToFileURL(process.cwd() + '/dummy.js'));
 		return await import(resolved).catch(() => import(dependency));
 	} catch {
-		// fall back to import relative to this package
-		try {
-			return await import(dependency);
-		} catch {
-			throw new Error(
-				`Could not resolve peer dependency "${dependency}" relative to your project — please install it and try again.`
-			);
-		}
+		throw new Error(
+			`Could not resolve peer dependency "${dependency}" relative to your project — please install it and try again.`
+		);
 	}
 }


### PR DESCRIPTION
Simplifies code a bit around usage locations in our own code, and solves some issues people may have with their setups closes #11578


---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
