### PR TITLE
docs: clarify `use:enhance` compatibility with `method="POST"`

### DIFF
--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -329,6 +329,8 @@ The easiest way to progressively enhance a form is to add the `use:enhance` acti
 +<form method="POST" use:enhance>
 ```
 
+> `use:enhance` can only be used with forms that have `method="POST"`. It will not work with `method="GET"`, which includes forms without a specified method. Attempting to use `use:enhance` on forms without `method="POST"` will result in an error.
+
 > Yes, it's a little confusing that the `enhance` action and `<form action>` are both called 'action'. These docs are action-packed. Sorry.
 
 Without an argument, `use:enhance` will emulate the browser-native behaviour, just without the full-page reloads. It will:

--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -329,7 +329,7 @@ The easiest way to progressively enhance a form is to add the `use:enhance` acti
 +<form method="POST" use:enhance>
 ```
 
-> `use:enhance` can only be used with forms that have `method="POST"`. It will not work with `method="GET"`, which includes forms without a specified method. Attempting to use `use:enhance` on forms without `method="POST"` will result in an error.
+> `use:enhance` can only be used with forms that have `method="POST"`. It will not work with `method="GET"`, which is the default for forms without a specified method. Attempting to use `use:enhance` on forms without `method="POST"` will result in an error.
 
 > Yes, it's a little confusing that the `enhance` action and `<form action>` are both called 'action'. These docs are action-packed. Sorry.
 


### PR DESCRIPTION
<!-- Your PR description here -->

This PR aims to improve the documentation by explicitly stating that `use:enhance` is only compatible with forms using `method="POST"`. Despite the fact that using `use:enhance` with other methods should [throw an error](https://github.com/sveltejs/kit/blob/feb01542edd542366043bc4f3b1994e3fdb46345/packages/kit/src/runtime/app/forms.js#L73), this limitation isn't clearly communicated in the current documentation.

This lack of clarity has led to misuse in several prominent projects, including:

- [storybook](https://github.com/storybookjs/storybook/blob/next/code/frameworks/sveltekit/template/stories_svelte-kit-skeleton-ts/Forms.svelte#L5)
- [sveltekit-superforms](https://github.com/ciscoheat/sveltekit-superforms/blob/429708d579b161a6461c82837f839bef1f1badfc/src/routes/(v2)/v2/spa-action-2/%2Bpage.svelte#L37)

By updating the documentation, we can help prevent similar misunderstandings and improve the developer experience when working with SvelteKit forms.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
