### PR TITLE
fix: @sveltejs/enhanced-img broken behavior on client navigation

### DIFF
--- a/.changeset/twenty-rats-shake.md
+++ b/.changeset/twenty-rats-shake.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/enhanced-img": patch
+---
+
+fix: ensure `src` attribute is properly formed on client navigation

--- a/packages/enhanced-img/src/preprocessor.js
+++ b/packages/enhanced-img/src/preprocessor.js
@@ -220,7 +220,7 @@ function get_attr_value(node, attr) {
  *   height: string | number
  * }} details
  */
-function img_attributes_to_markdown(content, attributes, details) {
+function serialize_img_attributes(content, attributes, details) {
 	const attribute_strings = attributes.map((attribute) => {
 		if (attribute.name === 'src') {
 			return `src={${details.src}}`;
@@ -288,7 +288,7 @@ function img_to_picture(content, node, image) {
 		image.img.src.startsWith('"+') && image.img.src.endsWith('+"')
 			? `{"${image.img.src.substring(2, image.img.src.length - 2)}"}`
 			: `"${image.img.src}"`;
-	res += `<img ${img_attributes_to_markdown(content, attributes, {
+	res += `<img ${serialize_img_attributes(content, attributes, {
 		src,
 		width: image.img.w,
 		height: image.img.h
@@ -320,13 +320,13 @@ function dynamic_img_to_picture(content, node, src_var_name) {
 	};
 
 	return `{#if typeof ${src_var_name} === 'string'}
-	<img ${img_attributes_to_markdown(content, node.attributes, details)} />
+	<img ${serialize_img_attributes(content, node.attributes, details)} />
 {:else}
 	<picture>
 		{#each Object.entries(${src_var_name}.sources) as [format, srcset]}
 			<source {srcset}${sizes_string} type={'image/' + format} />
 		{/each}
-		<img ${img_attributes_to_markdown(content, attributes, details)} />
+		<img ${serialize_img_attributes(content, attributes, details)} />
 	</picture>
 {/if}`;
 }

--- a/packages/enhanced-img/src/preprocessor.js
+++ b/packages/enhanced-img/src/preprocessor.js
@@ -223,7 +223,7 @@ function get_attr_value(node, attr) {
 function serialize_img_attributes(content, attributes, details) {
 	const attribute_strings = attributes.map((attribute) => {
 		if (attribute.name === 'src') {
-			return `src={${details.src}}`;
+			return `src={"${details.src}"}`;
 		}
 		return content.substring(attribute.start, attribute.end);
 	});
@@ -286,8 +286,8 @@ function img_to_picture(content, node, image) {
 	// See https://github.com/vitejs/vite/blob/b93dfe3e08f56cafe2e549efd80285a12a3dc2f0/packages/vite/src/node/plugins/asset.ts#L132
 	const src =
 		image.img.src.startsWith('"+') && image.img.src.endsWith('+"')
-			? `{"${image.img.src.substring(2, image.img.src.length - 2)}"}`
-			: `"${image.img.src}"`;
+			? image.img.src.substring(2, image.img.src.length - 2)
+			: image.img.src;
 	res += `<img ${serialize_img_attributes(content, attributes, {
 		src,
 		width: image.img.w,

--- a/packages/enhanced-img/src/preprocessor.js
+++ b/packages/enhanced-img/src/preprocessor.js
@@ -223,7 +223,7 @@ function get_attr_value(node, attr) {
 function img_attributes_to_markdown(content, attributes, details) {
 	const attribute_strings = attributes.map((attribute) => {
 		if (attribute.name === 'src') {
-			return `src=${details.src}`;
+			return `src={${details.src}}`;
 		}
 		return content.substring(attribute.start, attribute.end);
 	});

--- a/packages/enhanced-img/test/Output.svelte
+++ b/packages/enhanced-img/test/Output.svelte
@@ -32,13 +32,13 @@
 <picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src={"/7"} alt="absolute path test" width=1440 height=1440 /></picture>
 
 {#if typeof src === 'string'}
-	<img src={{src.img.src}} alt="attribute shorthand test" width={src.img.w} height={src.img.h} />
+	<img src={"{src.img.src}"} alt="attribute shorthand test" width={src.img.w} height={src.img.h} />
 {:else}
 	<picture>
 		{#each Object.entries(src.sources) as [format, srcset]}
 			<source {srcset} type={'image/' + format} />
 		{/each}
-		<img src={{src.img.src}} alt="attribute shorthand test" width={src.img.w} height={src.img.h} />
+		<img src={"{src.img.src}"} alt="attribute shorthand test" width={src.img.w} height={src.img.h} />
 	</picture>
 {/if}
 
@@ -46,13 +46,13 @@
 
 {#each images as image}
 	{#if typeof image === 'string'}
-	<img src={{image.img.src}} alt="opt-in test" width={image.img.w} height={image.img.h} />
+	<img src={"{image.img.src}"} alt="opt-in test" width={image.img.w} height={image.img.h} />
 {:else}
 	<picture>
 		{#each Object.entries(image.sources) as [format, srcset]}
 			<source {srcset} type={'image/' + format} />
 		{/each}
-		<img src={{image.img.src}} alt="opt-in test" width={image.img.w} height={image.img.h} />
+		<img src={"{image.img.src}"} alt="opt-in test" width={image.img.w} height={image.img.h} />
 	</picture>
 {/if}
 {/each}

--- a/packages/enhanced-img/test/Output.svelte
+++ b/packages/enhanced-img/test/Output.svelte
@@ -15,30 +15,30 @@
 
 <img src="./foo.png" alt="non-enhanced test" />
 
-<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src="/7" alt="basic test" width=1440 height=1440 /></picture>
+<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src={"/7"} alt="basic test" width=1440 height=1440 /></picture>
 
-<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src="/7" width="5" height="10" alt="dimensions test" width=1440 height=1440 /></picture>
+<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src={"/7"} width="5" height="10" alt="dimensions test" width=1440 height=1440 /></picture>
 
-<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src="/7" alt="directive test" width=1440 height=1440 /></picture>
+<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src={"/7"} alt="directive test" width=1440 height=1440 /></picture>
 
-<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src="/7" {...{ foo }} alt="spread attributes test" width=1440 height=1440 /></picture>
+<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src={"/7"} {...{ foo }} alt="spread attributes test" width=1440 height=1440 /></picture>
 
-<picture><source srcset={"/1 1440w, /2 960w"} sizes="(min-width: 60rem) 80vw, (min-width: 40rem) 90vw, 100vw" type="image/avif" /><source srcset={"/3 1440w, /4 960w"} sizes="(min-width: 60rem) 80vw, (min-width: 40rem) 90vw, 100vw" type="image/webp" /><source srcset={"5 1440w, /6 960w"} sizes="(min-width: 60rem) 80vw, (min-width: 40rem) 90vw, 100vw" type="image/png" /><img src="/7" alt="sizes test" width=1440 height=1440 /></picture>
+<picture><source srcset={"/1 1440w, /2 960w"} sizes="(min-width: 60rem) 80vw, (min-width: 40rem) 90vw, 100vw" type="image/avif" /><source srcset={"/3 1440w, /4 960w"} sizes="(min-width: 60rem) 80vw, (min-width: 40rem) 90vw, 100vw" type="image/webp" /><source srcset={"5 1440w, /6 960w"} sizes="(min-width: 60rem) 80vw, (min-width: 40rem) 90vw, 100vw" type="image/png" /><img src={"/7"} alt="sizes test" width=1440 height=1440 /></picture>
 
-<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src="/7" on:click={(foo = 'clicked an image!')} alt="event handler test" width=1440 height=1440 /></picture>
+<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src={"/7"} on:click={(foo = 'clicked an image!')} alt="event handler test" width=1440 height=1440 /></picture>
 
-<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src="/7" alt="alias test" width=1440 height=1440 /></picture>
+<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src={"/7"} alt="alias test" width=1440 height=1440 /></picture>
 
-<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src="/7" alt="absolute path test" width=1440 height=1440 /></picture>
+<picture><source srcset={"/1 1440w, /2 960w"} type="image/avif" /><source srcset={"/3 1440w, /4 960w"} type="image/webp" /><source srcset={"5 1440w, /6 960w"} type="image/png" /><img src={"/7"} alt="absolute path test" width=1440 height=1440 /></picture>
 
 {#if typeof src === 'string'}
-	<img src={src.img.src} alt="attribute shorthand test" width={src.img.w} height={src.img.h} />
+	<img src={{src.img.src}} alt="attribute shorthand test" width={src.img.w} height={src.img.h} />
 {:else}
 	<picture>
 		{#each Object.entries(src.sources) as [format, srcset]}
 			<source {srcset} type={'image/' + format} />
 		{/each}
-		<img src={src.img.src} alt="attribute shorthand test" width={src.img.w} height={src.img.h} />
+		<img src={{src.img.src}} alt="attribute shorthand test" width={src.img.w} height={src.img.h} />
 	</picture>
 {/if}
 
@@ -46,13 +46,13 @@
 
 {#each images as image}
 	{#if typeof image === 'string'}
-	<img src={image.img.src} alt="opt-in test" width={image.img.w} height={image.img.h} />
+	<img src={{image.img.src}} alt="opt-in test" width={image.img.w} height={image.img.h} />
 {:else}
 	<picture>
 		{#each Object.entries(image.sources) as [format, srcset]}
 			<source {srcset} type={'image/' + format} />
 		{/each}
-		<img src={image.img.src} alt="opt-in test" width={image.img.w} height={image.img.h} />
+		<img src={{image.img.src}} alt="opt-in test" width={image.img.w} height={image.img.h} />
 	</picture>
 {/if}
 {/each}


### PR DESCRIPTION
This small fix was crucial because, without it, the package was unusable. The original behavior caused the src attributes of images to be replaced with "import.meta.url" + ... on any client navigation.

By adding escaping brackets, the package now functions as expected.


---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
