### PR TITLE
fix: svelte should find other package on yarn pnp

### DIFF
--- a/.changeset/famous-colts-grin.md
+++ b/.changeset/famous-colts-grin.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: svelte should find other package on yarn pnp ([#12563](https://github.com/sveltejs/kit/pull/12563))

--- a/packages/kit/src/utils/import.js
+++ b/packages/kit/src/utils/import.js
@@ -10,7 +10,7 @@ export function resolve_peer_dependency(dependency) {
 	const [major, minor] = process.versions.node.split('.').map(Number);
 	try {
 		const resolved = (() => {
-			if (major >= 20 && minor >= 6) {
+			if (major > 20 || (major == 20 && minor >= 6)) {
 				// @ts-expect-error the types are wrong
 				return import.meta.resolve(dependency);
 			}

--- a/packages/kit/src/utils/import.js
+++ b/packages/kit/src/utils/import.js
@@ -7,9 +7,17 @@ import { pathToFileURL } from 'node:url';
  * @param {string} dependency
  */
 export function resolve_peer_dependency(dependency) {
+	const [major, minor] = process.versions.node.split('.').map(Number);
 	try {
+		const resolved = (() => {
+			if (major >= 20 && minor >= 6) {
+				// @ts-expect-error the types are wrong
+				return import.meta.resolve(dependency);
+			}
+			// @ts-expect-error the types are wrong
+			return imr.resolve(dependency, pathToFileURL(process.cwd() + '/dummy.js'));
+		})();
 		// @ts-expect-error the types are wrong
-		const resolved = imr.resolve(dependency, pathToFileURL(process.cwd() + '/dummy.js'));
 		return import(resolved);
 	} catch {
 		throw new Error(

--- a/packages/kit/src/utils/import.js
+++ b/packages/kit/src/utils/import.js
@@ -10,7 +10,7 @@ export function resolve_peer_dependency(dependency) {
 	const [major, minor] = process.versions.node.split('.').map(Number);
 	try {
 		const resolved = (() => {
-			if (major > 20 || (major == 20 && minor >= 6)) {
+			if (major > 20 || (major === 20 && minor >= 6) || (major === 18 && minor >= 19)) {
 				// @ts-expect-error the types are wrong
 				return import.meta.resolve(dependency);
 			}


### PR DESCRIPTION
<!-- Your PR description here -->

fix resolve_peer_dependency function for yarn pnp

### description
As you can see from #5353, the problem is bothering yarn pnp users.

This is PR that I hope that the yarn pnp users can enjoy Svelte under certain conditions.

### detail

https://github.com/wooorm/import-meta-resolve/issues/10#issuecomment-1968831154

The author of the import-meta-resolve in question is not interested in the yarn pnp issue, will not be, and talked as below.

"Then there would be significant differences between when the actual import.meta.resolve is available and when not. As in, Yarn PnP wouldn’t work on old Node. At that point, just use import.meta.resolve?"

I modified the node version to call import.meta.resolve accordingly.

#### import meta resolve

https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/import.meta
![image](https://github.com/user-attachments/assets/5de44d65-3485-4d9a-82bb-e26f95003231)


---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
