### PR TITLE
fix: use dynamic components in `root.svelte` instead of `svelte:component` for svelte 5

### DIFF
--- a/.changeset/cyan-hounds-refuse.md
+++ b/.changeset/cyan-hounds-refuse.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: use dynamic components in `root.svelte` instead of `svelte:component` for svelte 5

--- a/packages/kit/src/core/sync/write_root.js
+++ b/packages/kit/src/core/sync/write_root.js
@@ -25,7 +25,7 @@ export function write_root(manifest_data, output) {
 	${
 		isSvelte5Plus()
 			? `<!-- svelte-ignore binding_property_non_reactive -->
-		<Piramid_${l} bind:this={components[${l}]} data={data_${l}} {form} />`
+		<Pyramid_${l} bind:this={components[${l}]} data={data_${l}} {form} />`
 			: `<svelte:component this={constructors[${l}]} bind:this={components[${l}]} data={data_${l}} {form} />`
 	}`;
 
@@ -34,11 +34,11 @@ export function write_root(manifest_data, output) {
 			{#if constructors[${l + 1}]}
 				${
 					isSvelte5Plus()
-						? dedent`{@const Piramid_${l} = constructors[${l}]}
+						? dedent`{@const Pyramid_${l} = constructors[${l}]}
 						<!-- svelte-ignore binding_property_non_reactive -->
-						<Piramid_${l} bind:this={components[${l}]} data={data_${l}} {form}>
+						<Pyramid_${l} bind:this={components[${l}]} data={data_${l}} {form}>
 							${pyramid}
-						</Piramid_${l}>`
+						</Pyramid_${l}>`
 						: dedent`<svelte:component this={constructors[${l}]} bind:this={components[${l}]} data={data_${l}}>
 					${pyramid}
 				</svelte:component>`
@@ -48,9 +48,9 @@ export function write_root(manifest_data, output) {
 				${
 					isSvelte5Plus()
 						? dedent`
-					{@const Piramid_${l} = constructors[${l}]}
+					{@const Pyramid_${l} = constructors[${l}]}
 					<!-- svelte-ignore binding_property_non_reactive -->
-					<Piramid_${l} bind:this={components[${l}]} data={data_${l}} {form} />
+					<Pyramid_${l} bind:this={components[${l}]} data={data_${l}} {form} />
 					`
 						: dedent`<svelte:component this={constructors[${l}]} bind:this={components[${l}]} data={data_${l}} {form} />`
 				}
@@ -131,7 +131,7 @@ export function write_root(manifest_data, output) {
 					return unsubscribe;
 				});
 
-				${isSvelte5Plus() ? `const Piramid_${max_depth}=$derived(constructors[${max_depth}])` : ''}
+				${isSvelte5Plus() ? `const Pyramid_${max_depth}=$derived(constructors[${max_depth}])` : ''}
 			</script>
 
 			${pyramid}

--- a/packages/kit/src/core/sync/write_root.js
+++ b/packages/kit/src/core/sync/write_root.js
@@ -22,20 +22,39 @@ export function write_root(manifest_data, output) {
 	let l = max_depth;
 
 	let pyramid = dedent`
-	${isSvelte5Plus() ? '<!-- svelte-ignore binding_property_non_reactive -->' : ''}
-	<svelte:component this={constructors[${l}]} bind:this={components[${l}]} data={data_${l}} {form} />
-	`;
+	${
+		isSvelte5Plus()
+			? `<!-- svelte-ignore binding_property_non_reactive -->
+		<Piramid_${l} bind:this={components[${l}]} data={data_${l}} {form} />`
+			: `<svelte:component this={constructors[${l}]} bind:this={components[${l}]} data={data_${l}} {form} />`
+	}`;
 
 	while (l--) {
 		pyramid = dedent`
 			{#if constructors[${l + 1}]}
-				${isSvelte5Plus() ? '<!-- svelte-ignore binding_property_non_reactive -->' : ''}
-				<svelte:component this={constructors[${l}]} bind:this={components[${l}]} data={data_${l}}>
+				${
+					isSvelte5Plus()
+						? dedent`{@const Piramid_${l} = constructors[${l}]}
+						<!-- svelte-ignore binding_property_non_reactive -->
+						<Piramid_${l} bind:this={components[${l}]} data={data_${l}} {form}>
+							${pyramid}
+						</Piramid_${l}>`
+						: dedent`<svelte:component this={constructors[${l}]} bind:this={components[${l}]} data={data_${l}}>
 					${pyramid}
-				</svelte:component>
+				</svelte:component>`
+				}
+				
 			{:else}
-				${isSvelte5Plus() ? '<!-- svelte-ignore binding_property_non_reactive -->' : ''}
-				<svelte:component this={constructors[${l}]} bind:this={components[${l}]} data={data_${l}} {form} />
+				${
+					isSvelte5Plus()
+						? dedent`
+					{@const Piramid_${l} = constructors[${l}]}
+					<!-- svelte-ignore binding_property_non_reactive -->
+					<Piramid_${l} bind:this={components[${l}]} data={data_${l}} {form} />
+					`
+						: dedent`<svelte:component this={constructors[${l}]} bind:this={components[${l}]} data={data_${l}} {form} />`
+				}
+				
 			{/if}
 		`;
 	}
@@ -111,6 +130,8 @@ export function write_root(manifest_data, output) {
 					mounted = true;
 					return unsubscribe;
 				});
+
+				${isSvelte5Plus() ? `const Piramid_${max_depth}=$derived(constructors[${max_depth}])` : ''}
 			</script>
 
 			${pyramid}


### PR DESCRIPTION
Closes #12573

Again i'm not really sure if and where i should add a test for this. Also for the moment i did not rename `constructors` to something else in svelte 5 because there was still the possibility to share some code but i'm willing to completely split the two branches if we feel like.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
