### PR TITLE
chore(deps): use vite-plugin-svelte 4 in svelte5 template of create-svelte

### DIFF
--- a/.changeset/thick-spies-hope.md
+++ b/.changeset/thick-spies-hope.md
@@ -2,4 +2,4 @@
 'create-svelte': patch
 ---
 
-fix(svelte5): use vite-plugin-svelte prerelease with improved svelte5 support
+fix: use `vite-plugin-svelte` v4 pre-release when Svelte 5 is chosen

--- a/.changeset/thick-spies-hope.md
+++ b/.changeset/thick-spies-hope.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+fix(svelte5): use vite-plugin-svelte prerelease with improved svelte5 support

--- a/packages/create-svelte/shared/+svelte5/package.json
+++ b/packages/create-svelte/shared/+svelte5/package.json
@@ -1,5 +1,6 @@
 {
 	"devDependencies": {
+		"@sveltejs/vite-plugin-svelte": "^4.0.0-next.6",
 		"svelte": "^5.0.0-next.1"
 	}
 }


### PR DESCRIPTION
this helps to avoid a peer warning during npm install where vite-plugin-svelte@3 still depends on svelte-hmr for svelte4 support, but svelte-hmr does not have a peer range supporting svelte5 (it can't, hmr support is built into svelte5 instead).

Also svelte5 users should use vite-plugin-svelte@4 because that has better support.

<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
