### PR TITLE
chore: bump publint to v0.2

### DIFF
--- a/.changeset/serious-eyes-rule.md
+++ b/.changeset/serious-eyes-rule.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+chore: bump publint to v0.2

--- a/packages/create-svelte/templates/skeletonlib/package.template.json
+++ b/packages/create-svelte/templates/skeletonlib/package.template.json
@@ -23,7 +23,7 @@
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/package": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
-		"publint": "^0.1.9",
+		"publint": "^0.2.0",
 		"svelte": "^4.2.7",
 		"typescript": "^5.3.2",
 		"vite": "^5.0.11"


### PR DESCRIPTION
<!-- Your PR description here -->

The library template is still using publint v0.1.

There is not CLI breaking changes from v0.1 to v0.2.

https://github.com/bluwy/publint/releases/tag/v0.2.0

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
