### PR TITLE
chore: upgrade to ts-morph 23

### DIFF
--- a/.changeset/kind-rabbits-talk.md
+++ b/.changeset/kind-rabbits-talk.md
@@ -1,0 +1,5 @@
+---
+'svelte-migrate': patch
+---
+
+chore: upgrade to ts-morph 23

--- a/packages/migrate/migrations/svelte-4/migrate.js
+++ b/packages/migrate/migrations/svelte-4/migrate.js
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { Project, ts, Node } from 'ts-morph';
+import { Project, ts, Node, SyntaxKind } from 'ts-morph';
 import { log_migration, log_on_ts_modification, update_pkg } from '../../utils.js';
 
 export function update_pkg_json() {
@@ -201,7 +201,12 @@ function update_imports(source, is_ts) {
 		return (
 			(Node.isImportSpecifier(parent) &&
 				!parent.getAliasNode() &&
-				parent.getParent().getParent().getParent().getModuleSpecifier().getText() === 'svelte') ||
+				parent
+					.getParent()
+					.getParent()
+					.getParentIfKind(SyntaxKind.ImportDeclaration)
+					?.getModuleSpecifier()
+					.getText() === 'svelte') ||
 			!is_declaration(parent)
 		);
 	});

--- a/packages/migrate/migrations/sveltekit-2/migrate.js
+++ b/packages/migrate/migrations/sveltekit-2/migrate.js
@@ -108,8 +108,8 @@ export function update_svelte_config_content(code) {
 		namedImport
 			.getParent()
 			.getParent()
-			.getParent()
-			.setModuleSpecifier('@sveltejs/vite-plugin-svelte');
+			.getParentIfKind(SyntaxKind.ImportDeclaration)
+			?.setModuleSpecifier('@sveltejs/vite-plugin-svelte');
 	} else {
 		namedImport.remove();
 		const vps = source.getImportDeclaration(

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -34,7 +34,7 @@
 		"prompts": "^2.4.2",
 		"semver": "^7.5.4",
 		"tiny-glob": "^0.2.9",
-		"ts-morph": "^22.0.0",
+		"ts-morph": "^23.0.0",
 		"typescript": "^5.3.3",
 		"zimmerframe": "^1.1.2"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1114,8 +1114,8 @@ importers:
         specifier: ^0.2.9
         version: 0.2.9
       ts-morph:
-        specifier: ^22.0.0
-        version: 22.0.0
+        specifier: ^23.0.0
+        version: 23.0.0
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -2119,8 +2119,8 @@ packages:
     resolution: {integrity: sha512-qhUGGDHcpbY2zpjW3SwqchuW8J/5EzlPFud7xNntHKA7f3a/mx5+g+ruJKFHSAiVZYo30PALt+AyhmPUNKH/Og==}
     engines: {node: ^14.13.1 || ^16.0.0 || >=18}
 
-  '@ts-morph/common@0.23.0':
-    resolution: {integrity: sha512-m7Lllj9n/S6sOkCkRftpM7L24uvmfXQFedlW/4hENcuJH1HHm9u5EgxZb9uVjQSCGrbBWBkOGgcTxNg36r6ywA==}
+  '@ts-morph/common@0.24.0':
+    resolution: {integrity: sha512-c1xMmNHWpNselmpIqursHeOHHBTIsJLbB+NuovbTTRCNiTLEr/U9dbJ8qy0jd/O2x5pc3seWuOUN5R2IoOTp8A==}
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
@@ -4080,8 +4080,8 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  ts-morph@22.0.0:
-    resolution: {integrity: sha512-M9MqFGZREyeb5fTl6gNHKZLqBQA0TjA1lea+CR48R8EBTDuWrNqW6ccC5QvjNR4s6wDumD3LTCjOFSp9iwlzaw==}
+  ts-morph@23.0.0:
+    resolution: {integrity: sha512-FcvFx7a9E8TUe6T3ShihXJLiJOiqyafzFKUO4aqIHDUCIvADdGNShcbc2W5PMr3LerXRv7mafvFZ9lRENxJmug==}
 
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
@@ -5049,7 +5049,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@ts-morph/common@0.23.0':
+  '@ts-morph/common@0.24.0':
     dependencies:
       fast-glob: 3.3.2
       minimatch: 9.0.5
@@ -6991,9 +6991,9 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-morph@22.0.0:
+  ts-morph@23.0.0:
     dependencies:
-      '@ts-morph/common': 0.23.0
+      '@ts-morph/common': 0.24.0
       code-block-writer: 13.0.1
 
   tslib@2.6.2: {}


### PR DESCRIPTION
The error made it seem like `.getParent()` started returning ImportDeclaration or JSDoc, so I'm checking if it's returning an ImportDeclaration. I don't know if this is right and VS Code was only showing the ImportDeclaraction being returned and not the JSDoc so please check if this is the correct fix