### PR TITLE
feat: add option to configure rollup externals

### DIFF
--- a/.changeset/rude-meals-push.md
+++ b/.changeset/rude-meals-push.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': minor
+---
+
+feat: add option to configure rollup externals

--- a/packages/adapter-node/index.d.ts
+++ b/packages/adapter-node/index.d.ts
@@ -9,6 +9,11 @@ interface AdapterOptions {
 	out?: string;
 	precompress?: boolean;
 	envPrefix?: string;
+	external?:
+		| (string | RegExp)[]
+		| RegExp
+		| string
+		| ((id: string, parentId: string, isResolved: boolean) => boolean);
 }
 
 export default function plugin(options?: AdapterOptions): Adapter;


### PR DESCRIPTION
Add `external` as an option to the node-adapter. This allows the rollup externals to be configured if you have a use case where the default is not desirable. 
