### PR TITLE
fix: add `node:` prefix and import instead of using globals

### DIFF
--- a/.changeset/smart-buttons-provide.md
+++ b/.changeset/smart-buttons-provide.md
@@ -1,0 +1,12 @@
+---
+"@sveltejs/adapter-auto": patch
+"@sveltejs/adapter-netlify": patch
+"@sveltejs/adapter-node": patch
+"@sveltejs/adapter-static": patch
+"@sveltejs/adapter-vercel": patch
+"create-svelte": patch
+"@sveltejs/enhanced-img": patch
+"@sveltejs/kit": patch
+---
+
+fix: import `node:process` instead of using globals

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ export default [
 	...svelte_config,
 	{
 		rules: {
-			'no-undef': 'off'
+			'no-undef': 'off',
 		}
 	},
 	{
@@ -14,7 +14,7 @@ export default [
 			'packages/adapter-static/test/apps/*/build',
 			'packages/adapter-cloudflare/files',
 			'packages/adapter-netlify/files',
-			'packages/adapter-node/files',
+			'packages/adapter-node/files'
 		]
 	},
 	{
@@ -27,6 +27,7 @@ export default [
 			'@typescript-eslint/await-thenable': 'error',
 			'@typescript-eslint/no-unused-expressions': 'off',
 			'@typescript-eslint/require-await': 'error',
+			'n/prefer-global/process': ['error', 'never']
 		},
 		ignores: [
 			'packages/adapter-node/rollup.config.js',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ export default [
 	...svelte_config,
 	{
 		rules: {
-			'no-undef': 'off',
+			'no-undef': 'off'
 		}
 	},
 	{

--- a/packages/adapter-auto/adapters.js
+++ b/packages/adapter-auto/adapters.js
@@ -1,3 +1,5 @@
+import process from 'node:process';
+
 // List of adapters to check for. `version` is used to pin the installed adapter version and should point
 // to the latest version of the adapter that is compatible with adapter-auto's current peerDependency version of SvelteKit.
 export const adapters = [

--- a/packages/adapter-auto/index.js
+++ b/packages/adapter-auto/index.js
@@ -4,6 +4,7 @@ import { resolve } from 'import-meta-resolve';
 import { adapters } from './adapters.js';
 import { dirname, join } from 'node:path';
 import { existsSync } from 'node:fs';
+import process from 'node:process';
 
 /** @type {Record<string, (name: string, version: string) => string>} */
 const commands = {

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -2,6 +2,7 @@ import { appendFileSync, existsSync, readdirSync, readFileSync, writeFileSync } 
 import { dirname, join, resolve, posix } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { builtinModules } from 'node:module';
+import process from 'node:process';
 import esbuild from 'esbuild';
 import toml from '@iarna/toml';
 

--- a/packages/adapter-netlify/src/serverless.js
+++ b/packages/adapter-netlify/src/serverless.js
@@ -2,6 +2,7 @@ import './shims';
 import { Server } from '0SERVER';
 import { split_headers } from './headers.js';
 import { createReadableStream } from '@sveltejs/kit/node';
+import process from 'node:process';
 
 /**
  * @param {import('@sveltejs/kit').SSRManifest} manifest

--- a/packages/adapter-node/src/env.js
+++ b/packages/adapter-node/src/env.js
@@ -1,4 +1,5 @@
 /* global ENV_PREFIX */
+import process from 'node:process';
 
 const expected = new Set([
 	'SOCKET_PATH',

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -1,6 +1,7 @@
 import 'SHIMS';
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import sirv from 'sirv';
 import { fileURLToPath } from 'node:url';
 import { parse as polka_url_parser } from '@polka/url';

--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import { handler } from 'HANDLER';
 import { env } from 'ENV';
 import polka from 'polka';

--- a/packages/adapter-static/platforms.js
+++ b/packages/adapter-static/platforms.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import process from 'node:process';
 
 /**
  * @typedef {{

--- a/packages/adapter-static/test/utils.js
+++ b/packages/adapter-static/test/utils.js
@@ -1,4 +1,5 @@
 import { devices } from '@playwright/test';
+import process from 'node:process';
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 export const config = {

--- a/packages/adapter-vercel/files/edge.js
+++ b/packages/adapter-vercel/files/edge.js
@@ -1,6 +1,7 @@
+/* eslint-disable n/prefer-global/process --
+ Vercel Edge Runtime does not support node:process */
 import { Server } from 'SERVER';
 import { manifest } from 'MANIFEST';
-import process from 'node:process';
 
 const server = new Server(manifest);
 const initialized = server.init({

--- a/packages/adapter-vercel/files/edge.js
+++ b/packages/adapter-vercel/files/edge.js
@@ -1,5 +1,6 @@
 import { Server } from 'SERVER';
 import { manifest } from 'MANIFEST';
+import process from 'node:process';
 
 const server = new Server(manifest);
 const initialized = server.init({

--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -2,6 +2,7 @@ import { installPolyfills } from '@sveltejs/kit/node/polyfills';
 import { getRequest, setResponse, createReadableStream } from '@sveltejs/kit/node';
 import { Server } from 'SERVER';
 import { manifest } from 'MANIFEST';
+import process from 'node:process';
 
 installPolyfills();
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { nodeFileTrace } from '@vercel/nft';
 import esbuild from 'esbuild';

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import * as p from '@clack/prompts';
 import { bold, cyan, grey, yellow } from 'kleur/colors';
 import { create } from './index.js';

--- a/packages/create-svelte/scripts/update-template-repo-contents.js
+++ b/packages/create-svelte/scripts/update-template-repo-contents.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import { create } from '../index.js';
 
 const repo = process.argv[2];

--- a/packages/create-svelte/utils.js
+++ b/packages/create-svelte/utils.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 /** @param {string} dir */

--- a/packages/enhanced-img/src/index.js
+++ b/packages/enhanced-img/src/index.js
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import process from 'node:process';
 import { imagetools } from 'vite-imagetools';
 import { image } from './preprocessor.js';
 

--- a/packages/kit/postinstall.js
+++ b/packages/kit/postinstall.js
@@ -1,6 +1,7 @@
 import { load_config } from './src/core/config/index.js';
 import glob from 'tiny-glob/sync.js';
 import fs from 'node:fs';
+import process from 'node:process';
 
 try {
 	const cwd = process.env.INIT_CWD ?? process.cwd();

--- a/packages/kit/scripts/cp.js
+++ b/packages/kit/scripts/cp.js
@@ -1,4 +1,5 @@
 import { copy } from '../src/utils/filesystem.js';
+import process from 'node:process';
 
 const [src, dest] = process.argv.slice(2);
 

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import colors from 'kleur';
 import sade from 'sade';
 import { load_config } from './core/config/index.js';

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import * as url from 'node:url';
 import options from './options.js';
 

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { assert, expect, test } from 'vitest';
 import { validate_config, load_config } from './index.js';
+import process from 'node:process';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = join(__filename, '..');

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import process from 'node:process';
 
 /** @typedef {import('./types.js').Validator} Validator */
 

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import colors from 'kleur';
 import { lookup } from 'mrmime';
 import { list_files, runtime_directory } from '../../utils.js';

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import process from 'node:process';
 import { hash } from '../../runtime/hash.js';
 import { posixify, resolve_entry } from '../../utils/filesystem.js';
 import { s } from '../../utils/misc.js';

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import colors from 'kleur';
 import { posixify } from '../../utils/filesystem.js';
 import { write_if_changed } from './utils.js';

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import MagicString from 'magic-string';
 import { posixify, rimraf, walk } from '../../../utils/filesystem.js';
 import { compact } from '../../../utils/array.js';

--- a/packages/kit/src/core/utils.js
+++ b/packages/kit/src/core/utils.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import colors from 'kleur';
 import { posixify, to_fs } from '../utils/filesystem.js';

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import { URL } from 'node:url';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import colors from 'kleur';

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 
 import colors from 'kleur';
 

--- a/packages/kit/src/utils/fork.js
+++ b/packages/kit/src/utils/fork.js
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import { Worker, parentPort } from 'node:worker_threads';
+import process from 'node:process';
 
 /**
  * Runs a task in a subprocess so any dangling stuff gets killed upon completion.

--- a/packages/kit/src/utils/import.js
+++ b/packages/kit/src/utils/import.js
@@ -1,4 +1,5 @@
 import * as imr from 'import-meta-resolve';
+import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 
 /**

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import http from 'node:http';
 import path from 'node:path';
+import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { test as base, devices } from '@playwright/test';
 

--- a/packages/migrate/bin.js
+++ b/packages/migrate/bin.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
+import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import colors from 'kleur';
 

--- a/packages/migrate/migrations/package/index.js
+++ b/packages/migrate/migrations/package/index.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import colors from 'kleur';
 import path from 'node:path';
+import process from 'node:process';
 import prompts from 'prompts';
 import { pathToFileURL } from 'node:url';
 import { bail, check_git } from '../../utils.js';

--- a/packages/migrate/migrations/routes/index.js
+++ b/packages/migrate/migrations/routes/index.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import colors from 'kleur';
 import path from 'node:path';
+import process from 'node:process';
 import prompts from 'prompts';
 import glob from 'tiny-glob/sync.js';
 import { pathToFileURL } from 'node:url';

--- a/packages/migrate/migrations/self-closing-tags/index.js
+++ b/packages/migrate/migrations/self-closing-tags/index.js
@@ -1,5 +1,6 @@
 import colors from 'kleur';
 import fs from 'node:fs';
+import process from 'node:process';
 import prompts from 'prompts';
 import glob from 'tiny-glob/sync.js';
 import { remove_self_closing_tags } from './migrate.js';

--- a/packages/migrate/migrations/svelte-4/index.js
+++ b/packages/migrate/migrations/svelte-4/index.js
@@ -1,5 +1,6 @@
 import colors from 'kleur';
 import fs from 'node:fs';
+import process from 'node:process';
 import prompts from 'prompts';
 import glob from 'tiny-glob/sync.js';
 import { bail, check_git, update_js_file, update_svelte_file } from '../../utils.js';

--- a/packages/migrate/migrations/sveltekit-2/index.js
+++ b/packages/migrate/migrations/sveltekit-2/index.js
@@ -1,5 +1,6 @@
 import colors from 'kleur';
 import fs from 'node:fs';
+import process from 'node:process';
 import prompts from 'prompts';
 import semver from 'semver';
 import glob from 'tiny-glob/sync.js';

--- a/packages/migrate/utils.js
+++ b/packages/migrate/utils.js
@@ -3,6 +3,7 @@ import MagicString from 'magic-string';
 import { execFileSync, execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import semver from 'semver';
 import ts from 'typescript';
 

--- a/packages/package/src/cli.js
+++ b/packages/package/src/cli.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import process from 'node:process';
 import colors from 'kleur';
 import sade from 'sade';
 import { load_config } from './config.js';

--- a/packages/package/src/config.js
+++ b/packages/package/src/config.js
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import process from 'node:process';
 import fs from 'node:fs';
 import url from 'node:url';
 

--- a/packages/package/test/index.js
+++ b/packages/package/test/index.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import process from 'node:process';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 


### PR DESCRIPTION
see https://github.com/denoland/deno/issues/17248#issuecomment-2325128835

Specifically imports `node:process` instead of relying on the `process` global.

TODO:
- [x] add `node:` prefix to polka imports
- [x] add imports to polka instead of relying on globals
- [x] add eslint rule to explicitly import node globals

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
