### PR TITLE
fix: allow `enhanced` to be first query parameter

### DIFF
--- a/packages/enhanced-img/types/ambient.d.ts
+++ b/packages/enhanced-img/types/ambient.d.ts
@@ -4,3 +4,10 @@ declare module '*?enhanced' {
 	const value: Picture;
 	export default value;
 }
+
+declare module '*&enhanced' {
+	import type { Picture } from 'vite-imagetools';
+
+	const value: Picture;
+	export default value;
+}


### PR DESCRIPTION
Add `&enhanced`

Currently, the following throws an error:
```
import MyImage from './path/to/your/image.jpg?quality=80&tint=#ffaa22&enhanced;
```

Ideally, we would also be able to put the `enhanced` query at the beginning, but I'm not TS fluent enough to know how to do that.
```
// Doesn't work
import MyImage from './path/to/your/image.jpg?enhanced&quality=80&tint=#ffaa22;
```

Fix https://github.com/sveltejs/kit/issues/12608
Thanks to https://github.com/vvnsrzn for the solution.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
