### PR TITLE
feat: add `load` function to `handle` hook to control css loading

### DIFF
--- a/packages/kit/src/exports/hooks/sequence.js
+++ b/packages/kit/src/exports/hooks/sequence.js
@@ -106,13 +106,22 @@ export function sequence(...handlers) {
 					/** @type {import('@sveltejs/kit').ResolveOptions['preload']} */
 					const preload = parent_options?.preload ?? options?.preload;
 
+					/** @type {import('@sveltejs/kit').ResolveOptions['load']} */
+					const load = parent_options?.load ?? options?.load;
+
 					return i < length - 1
 						? apply_handle(i + 1, event, {
 								transformPageChunk,
 								filterSerializedResponseHeaders,
-								preload
+								preload,
+								load
 							})
-						: resolve(event, { transformPageChunk, filterSerializedResponseHeaders, preload });
+						: resolve(event, {
+								transformPageChunk,
+								filterSerializedResponseHeaders,
+								preload,
+								load
+							});
 				}
 			});
 		}

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1153,6 +1153,13 @@ export interface ResolveOptions {
 	 * @param input the type of the file and its path
 	 */
 	preload?(input: { type: 'font' | 'css' | 'js' | 'asset'; path: string }): boolean;
+
+	/**
+	 * Determines what should be added to the `<head>` tag to load it.
+	 * By default, `js` and `css` files will be preloaded.
+	 * @param input the type of the file and its path
+	 */
+	load?(input: { type: 'font' | 'css' | 'js' | 'asset'; path: string }): boolean;
 }
 
 export interface RouteDefinition<Config = any> {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -213,6 +213,16 @@ export async function render_response({
 	};
 
 	if (inline_styles.size > 0) {
+		for (const dep of inline_styles.keys()) {
+			const path = prefixed(dep);
+
+			if (!resolve_opts.load({ type: 'css', path })) {
+				inline_styles.delete(dep);
+			}
+		}
+	}
+
+	if (inline_styles.size > 0) {
 		const content = Array.from(inline_styles.values()).join('\n');
 
 		const attributes = __SVELTEKIT_DEV__ ? [' data-sveltekit'] : [];
@@ -225,6 +235,10 @@ export async function render_response({
 
 	for (const dep of stylesheets) {
 		const path = prefixed(dep);
+
+		if (!resolve_opts.load({ type: 'css', path })) {
+			continue;
+		}
 
 		const attributes = ['rel="stylesheet"'];
 

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -45,6 +45,9 @@ const default_filter = () => false;
 /** @type {import('types').RequiredResolveOptions['preload']} */
 const default_preload = ({ type }) => type === 'js' || type === 'css';
 
+/** @type {import('types').RequiredResolveOptions['load']} */
+const default_load = ({ type }) => type === 'js' || type === 'css';
+
 const page_methods = new Set(['GET', 'HEAD', 'POST']);
 
 const allowed_page_methods = new Set(['GET', 'HEAD', 'OPTIONS']);
@@ -211,7 +214,8 @@ export async function respond(request, options, manifest, state) {
 	let resolve_opts = {
 		transformPageChunk: default_transform,
 		filterSerializedResponseHeaders: default_filter,
-		preload: default_preload
+		preload: default_preload,
+		load: default_load
 	};
 
 	try {
@@ -412,7 +416,8 @@ export async function respond(request, options, manifest, state) {
 				resolve_opts = {
 					transformPageChunk: opts.transformPageChunk || default_transform,
 					filterSerializedResponseHeaders: opts.filterSerializedResponseHeaders || default_filter,
-					preload: opts.preload || default_preload
+					preload: opts.preload || default_preload,
+					load: opts.load || default_load
 				};
 			}
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1135,6 +1135,13 @@ declare module '@sveltejs/kit' {
 		 * @param input the type of the file and its path
 		 */
 		preload?(input: { type: 'font' | 'css' | 'js' | 'asset'; path: string }): boolean;
+
+		/**
+		 * Determines what should be added to the `<head>` tag to load it.
+		 * By default, `js` and `css` files will be preloaded.
+		 * @param input the type of the file and its path
+		 */
+		load?(input: { type: 'font' | 'css' | 'js' | 'asset'; path: string }): boolean;
 	}
 
 	export interface RouteDefinition<Config = any> {


### PR DESCRIPTION
This PR introduces an additional `handle` hook function, similar to [preload](https://kit.svelte.dev/docs/hooks#server-hooks). The purpose of this function is to control which CSS assets should be loaded for a specific page or route.

This functionality is necessary for [dynamic component use case](https://github.com/sveltejs/kit/issues/9775)  implemented using a combination of +page.server.js and +page.js. In the current version of SvelteKit, the CSS assets of all dynamically imported components are loaded on the page, regardless of whether or not they are actually used.

It is possible to remove unwanted css by redacting the html output using `transformPageChunk` but this feels more like a hack. It also does not work with `inlineStyleThreshold` configuration property.

The new function will allow SvelteKit users who use dynamic component imports to control which CSS assets should be loaded.

I'll address the items in the list below once I receive initial feedback on the solution. Thanks 🙏🏻

TODO:
- [ ] Naming
- [ ] Test
- [ ] Docs
- [ ] Changeset
---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.

### P.S. 
Huge thank you to everyone involved in Svelte and SvelteKit projects ❤️ 
