### PR TITLE
fix: add aria-labels to create-svelte default template

### DIFF
--- a/.changeset/gorgeous-schools-matter.md
+++ b/.changeset/gorgeous-schools-matter.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+fix: add aria-label to icon buttons

--- a/packages/create-svelte/templates/default/src/routes/Header.svelte
+++ b/packages/create-svelte/templates/default/src/routes/Header.svelte
@@ -6,7 +6,7 @@
 
 <header>
 	<div class="corner">
-		<a href="https://kit.svelte.dev">
+		<a href="https://kit.svelte.dev" aria-label="SvelteKit">
 			<img src={logo} alt="SvelteKit" />
 		</a>
 	</div>
@@ -32,7 +32,7 @@
 	</nav>
 
 	<div class="corner">
-		<a href="https://github.com/sveltejs/kit">
+		<a href="https://github.com/sveltejs/kit" aria-label="GitHub">
 			<img src={github} alt="GitHub" />
 		</a>
 	</div>


### PR DESCRIPTION
fixes the lint errors when using svelte 5 and the default template by adding aria-label to buttons without any text

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
