### PR TITLE
fix: prefix node builtins for bundled files

### DIFF
--- a/.changeset/early-maps-battle.md
+++ b/.changeset/early-maps-battle.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+fix: prefix builtin node imports of transitive dependencies with `node:*`

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -59,7 +59,7 @@ function prefix_node_builtins() {
 					const chunk = file;
 					chunk.code = chunk.code.replace(
 						node_builtin_regex,
-						(match, moduleName) => `from 'node:${moduleName}'`
+						(match, module_name) => `from 'node:${module_name}'`
 					);
 				}
 			}

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -43,7 +43,7 @@ export default [
 	}
 ];
 
-const node_builtin_regex = new RegExp(`from (['"])(${[...builtinModules].join('|')})(['"])`, 'g');
+const node_builtin_regex = new RegExp(`from '(${[...builtinModules].join('|')})'`, 'g');
 
 /**
  * @returns {import('rollup').Plugin}
@@ -59,7 +59,7 @@ function prefix_node_builtins() {
 					const chunk = file;
 					chunk.code = chunk.code.replace(
 						node_builtin_regex,
-						(match, quote, moduleName) => `from ${quote}node:${moduleName}${quote}`
+						(match, moduleName) => `from 'node:${moduleName}'`
 					);
 				}
 			}

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -43,6 +43,8 @@ export default [
 	}
 ];
 
+const node_builtin_regex = new RegExp(`from (['"])(${[...builtinModules].join('|')})(['"])`, 'g');
+
 /**
  * @returns {import('rollup').Plugin}
  */
@@ -56,8 +58,8 @@ function prefix_node_builtins() {
 					/** @type {import('rollup').OutputChunk} */
 					const chunk = file;
 					chunk.code = chunk.code.replace(
-						new RegExp(`(['"])(${[...builtinModules].join('|')})(['"])`, 'g'),
-						(match, quote, moduleName) => `${quote}node:${moduleName}${quote}`
+						node_builtin_regex,
+						(match, quote, moduleName) => `from ${quote}node:${moduleName}${quote}`
 					);
 				}
 			}

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -43,7 +43,14 @@ export default [
 	}
 ];
 
-const node_builtin_regex = new RegExp(`from (['"])(${[...builtinModules].join('|')})(['"])`, 'g');
+const node_builtin_regex = new RegExp(
+	`(?:from|import)\\s*(['"])(${[...builtinModules].join('|')})(['"])`,
+	'g'
+);
+const dynamic_import_regex = new RegExp(
+	`import\\s*\\(\\s*(['"])(${[...builtinModules].join('|')})(['"])\\s*\\)`,
+	'g'
+);
 
 /**
  * @returns {import('rollup').Plugin}
@@ -57,10 +64,17 @@ function prefix_node_builtins() {
 				if (file.type === 'chunk') {
 					/** @type {import('rollup').OutputChunk} */
 					const chunk = file;
-					chunk.code = chunk.code.replace(
-						node_builtin_regex,
-						(match, quote, moduleName) => `from ${quote}node:${moduleName}${quote}`
-					);
+					chunk.code = chunk.code
+						.replace(
+							node_builtin_regex,
+							(match, quote, moduleName, endQuote) =>
+								`${match.startsWith('from') ? 'from' : 'import'} ${quote}node:${moduleName}${endQuote}`
+						)
+						.replace(
+							dynamic_import_regex,
+							(match, quote, moduleName, endQuote) =>
+								`import(${quote}node:${moduleName}${endQuote})`
+						);
 				}
 			}
 		}

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -43,14 +43,7 @@ export default [
 	}
 ];
 
-const node_builtin_regex = new RegExp(
-	`(?:from|import)\\s*(['"])(${[...builtinModules].join('|')})(['"])`,
-	'g'
-);
-const dynamic_import_regex = new RegExp(
-	`import\\s*\\(\\s*(['"])(${[...builtinModules].join('|')})(['"])\\s*\\)`,
-	'g'
-);
+const node_builtin_regex = new RegExp(`from (['"])(${[...builtinModules].join('|')})(['"])`, 'g');
 
 /**
  * @returns {import('rollup').Plugin}
@@ -64,17 +57,10 @@ function prefix_node_builtins() {
 				if (file.type === 'chunk') {
 					/** @type {import('rollup').OutputChunk} */
 					const chunk = file;
-					chunk.code = chunk.code
-						.replace(
-							node_builtin_regex,
-							(match, quote, moduleName, endQuote) =>
-								`${match.startsWith('from') ? 'from' : 'import'} ${quote}node:${moduleName}${endQuote}`
-						)
-						.replace(
-							dynamic_import_regex,
-							(match, quote, moduleName, endQuote) =>
-								`import(${quote}node:${moduleName}${endQuote})`
-						);
+					chunk.code = chunk.code.replace(
+						node_builtin_regex,
+						(match, quote, moduleName) => `from ${quote}node:${moduleName}${quote}`
+					);
 				}
 			}
 		}

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -50,8 +50,8 @@ function prefix_node_builtins() {
 	return {
 		name: 'prefix-node-builtins-in-bundle',
 		generateBundle(options, bundle) {
-			for (const fileName of Object.keys(bundle)) {
-				const file = bundle[fileName];
+			for (const file_name of Object.keys(bundle)) {
+				const file = bundle[file_name];
 				if (file.type === 'chunk') {
 					/** @type {import('rollup').OutputChunk} */
 					const chunk = file;


### PR DESCRIPTION
Adds a rollup plugin to prefix all builtin node imports (including transitive dependencies). ChatGPT helped with this one so I'm sure it can be improved. Additionally, for some reason, it makes the build faster by a few ms (I thought an additional plugin would make it slower).

This solves the issue of current and potentially future transitive imports from not having the node: prefix.

Before:

![build results before plugin](https://github.com/user-attachments/assets/05582839-2b7c-49a4-af55-357a9b20bed1)

After:

![build results after plugin](https://github.com/user-attachments/assets/31d94429-5fdd-4dc4-b0cd-e838daf2ffff)


---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
