### PR TITLE
Add option to recursively consider `server` dirs in $lib

### DIFF
--- a/.changeset/khaki-moons-appear.md
+++ b/.changeset/khaki-moons-appear.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: add option to recursively consider server dirs in $lib

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -84,6 +84,7 @@ const get_defaults = (prefix = '') => ({
 				universal: join(prefix, 'src/hooks')
 			},
 			lib: join(prefix, 'src/lib'),
+			nestedServerDirs: false,
 			params: join(prefix, 'src/params'),
 			routes: join(prefix, 'src/routes'),
 			serviceWorker: join(prefix, 'src/service-worker'),

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -128,6 +128,7 @@ const options = object(
 					universal: string(join('src', 'hooks'))
 				}),
 				lib: string(join('src', 'lib')),
+				nestedServerDirs: boolean(false),
 				params: string(join('src', 'params')),
 				routes: string(join('src', 'routes')),
 				serviceWorker: string(join('src', 'service-worker')),

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -440,6 +440,12 @@ export interface KitConfig {
 		 */
 		lib?: string;
 		/**
+		 * whether to consider any folder named `server` inside `$lib` as containing server-only modules,
+		 * instead of just one (`$lib/server/`).
+		 * @default false
+		 */
+		nestedServerDirs?: boolean;
+		/**
 		 * a directory containing [parameter matchers](https://kit.svelte.dev/docs/advanced-routing#matching)
 		 * @default "src/params"
 		 */

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -393,8 +393,11 @@ async function kit({ svelte_config }) {
 				if (
 					is_illegal(id, {
 						cwd: normalized_cwd,
+						lib: normalized_lib,
 						node_modules: vite.normalizePath(path.resolve('node_modules')),
-						server: vite.normalizePath(path.join(normalized_lib, 'server'))
+						server:
+							svelte_config.kit.files.nestedServerDirs ||
+							vite.normalizePath(path.join(normalized_lib, 'server'))
 					})
 				) {
 					const relative = normalize_id(id, normalized_lib, normalized_cwd);
@@ -519,10 +522,14 @@ async function kit({ svelte_config }) {
 			handler(_options) {
 				if (vite_config.build.ssr) return;
 
-				const guard = module_guard(this, {
-					cwd: vite.normalizePath(process.cwd()),
-					lib: vite.normalizePath(kit.files.lib)
-				});
+				const guard = module_guard(
+					this,
+					{
+						cwd: vite.normalizePath(process.cwd()),
+						lib: vite.normalizePath(kit.files.lib)
+					},
+					svelte_config.kit.files.nestedServerDirs
+				);
 
 				manifest_data.nodes.forEach((_node, i) => {
 					const id = vite.normalizePath(


### PR DESCRIPTION
Closes #12732

This PR adds a new config option `kit.files.nestedServerDirs` that, when enabled, considers any modules inside any `$lib/**/server/**` directory a server module, rather than just `$lib/server/**`.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
