### PR TITLE
fix: use resolve_symlinks for node.universal and node.server

### DIFF
--- a/.changeset/great-badgers-sing.md
+++ b/.changeset/great-badgers-sing.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Fix symlinks handling for routes
+fix: resolve symlinks when handling routes

--- a/.changeset/great-badgers-sing.md
+++ b/.changeset/great-badgers-sing.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix symlinks handling for routes

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -58,17 +58,19 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 		}
 
 		if (node.universal) {
-			imports.push(`import * as universal from '../${
-				resolve_symlinks(server_manifest, node.universal).chunk.file
-			}';`);
+			imports.push(
+				`import * as universal from '../${
+					resolve_symlinks(server_manifest, node.universal).chunk.file
+				}';`
+			);
 			exports.push('export { universal };');
 			exports.push(`export const universal_id = ${s(node.universal)};`);
 		}
 
 		if (node.server) {
-			imports.push(`import * as server from '../${
-				resolve_symlinks(server_manifest, node.server).chunk.file
-			}';`);
+			imports.push(
+				`import * as server from '../${resolve_symlinks(server_manifest, node.server).chunk.file}';`
+			);
 			exports.push('export { server };');
 			exports.push(`export const server_id = ${s(node.server)};`);
 		}

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -58,13 +58,17 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 		}
 
 		if (node.universal) {
-			imports.push(`import * as universal from '../${server_manifest[node.universal].file}';`);
+			imports.push(`import * as universal from '../${
+				resolve_symlinks(server_manifest, node.universal).chunk.file
+			}';`);
 			exports.push('export { universal };');
 			exports.push(`export const universal_id = ${s(node.universal)};`);
 		}
 
 		if (node.server) {
-			imports.push(`import * as server from '../${server_manifest[node.server].file}';`);
+			imports.push(`import * as server from '../${
+				resolve_symlinks(server_manifest, node.server).chunk.file
+			}';`);
 			exports.push('export { server };');
 			exports.push(`export const server_id = ${s(node.server)};`);
 		}


### PR DESCRIPTION
This PR seems to fix following issue with symbolic links in the routes https://github.com/sveltejs/kit/issues/8100
Minimal issue reproduction is available here: https://github.com/yukipastelcat/sveltekit-symlinks
Symbolic links in the reproduction repository will be created automatically during build, but my plugin is flaky, so you might need to run `npm run build` for the second time to reproduce the issue.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

`pnpm test` command does not exist, so I ran `pnpm test:kit` instead, some tests are failing, but they also do it in the `main` branch.

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
