### PR TITLE
docs: whitespace in cloudflare worker adapter docs

### DIFF
--- a/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
+++ b/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
@@ -18,14 +18,14 @@ import adapter from '@sveltejs/adapter-cloudflare-workers';
 export default {
 	kit: {
 		adapter: adapter({
-      config: 'wrangler.toml',
+			config: 'wrangler.toml',
 			platformProxy: {
 				configPath: 'wrangler.toml',
 				environment: undefined,
 				experimentalJsonConfig: false,
 				persist: false
 			}
-    })
+		})
 	}
 };
 ```


### PR DESCRIPTION
<!-- Your PR description here -->

Fixed a very slight indentation problem with the Cloudflare Worker adapter docs, where spaces were used for indentation instead of tabs. Previously, two lines of the example configuration were mis-aligned.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
