### PR TITLE
feat: pass filename to `migrate`

### DIFF
--- a/.changeset/dry-feet-wink.md
+++ b/.changeset/dry-feet-wink.md
@@ -1,0 +1,5 @@
+---
+'svelte-migrate': minor
+---
+
+feat: pass filename to `migrate` to allow for `svelte:self` migration

--- a/packages/migrate/migrations/svelte-5/index.js
+++ b/packages/migrate/migrations/svelte-5/index.js
@@ -143,7 +143,7 @@ export async function migrate() {
 		if (extensions.some((ext) => file.endsWith(ext))) {
 			if (svelte_extensions.some((ext) => file.endsWith(ext))) {
 				update_svelte_file(file, transform_module_code, (code) =>
-					transform_svelte_code(code, migrate)
+					transform_svelte_code(code, migrate, file)
 				);
 			} else {
 				update_js_file(file, transform_module_code);

--- a/packages/migrate/migrations/svelte-5/index.js
+++ b/packages/migrate/migrations/svelte-5/index.js
@@ -143,7 +143,7 @@ export async function migrate() {
 		if (extensions.some((ext) => file.endsWith(ext))) {
 			if (svelte_extensions.some((ext) => file.endsWith(ext))) {
 				update_svelte_file(file, transform_module_code, (code) =>
-					transform_svelte_code(code, migrate, file)
+					transform_svelte_code(code, migrate, { filename: file })
 				);
 			} else {
 				update_js_file(file, transform_module_code);

--- a/packages/migrate/migrations/svelte-5/migrate.js
+++ b/packages/migrate/migrations/svelte-5/migrate.js
@@ -55,11 +55,11 @@ export function transform_module_code(code) {
 
 /**
  * @param {string} code
- * @param {(source: string, filename: string) => { code: string }} transform_code
- * @param {string} filename
+ * @param {(source: string, options: { filename?: string }) => { code: string }} transform_code
+ * @param {{ filename?: string }} options
  */
-export function transform_svelte_code(code, transform_code, filename) {
-	return transform_code(code, filename).code;
+export function transform_svelte_code(code, transform_code, options) {
+	return transform_code(code, options).code;
 }
 
 /**

--- a/packages/migrate/migrations/svelte-5/migrate.js
+++ b/packages/migrate/migrations/svelte-5/migrate.js
@@ -55,10 +55,11 @@ export function transform_module_code(code) {
 
 /**
  * @param {string} code
- * @param {(source: code) => { code: string }} transform_code
+ * @param {(source: string, filename: string) => { code: string }} transform_code
+ * @param {string} filename
  */
-export function transform_svelte_code(code, transform_code) {
-	return transform_code(code).code;
+export function transform_svelte_code(code, transform_code, filename) {
+	return transform_code(code, filename).code;
 }
 
 /**


### PR DESCRIPTION
Companion PR for https://github.com/sveltejs/svelte/pull/13504

if we decide to merge we can pass the filename to allow the migration script to migrate `svelte:self` which is deprecated in svelte 5. I've tested it locally and it seems to work fine but i'm not sure if i should add some proper test (and where.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
