### PR TITLE
fix: add node custom inspect for `URL.searchParams`

### DIFF
--- a/.changeset/rude-shirts-raise.md
+++ b/.changeset/rude-shirts-raise.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prevent crash when logging URL search params in a server load function

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -144,6 +144,11 @@ export function make_trackable(url, callback, search_params_callback) {
 		tracked[Symbol.for('nodejs.util.inspect.custom')] = (depth, opts, inspect) => {
 			return inspect(url, opts);
 		};
+
+		// @ts-ignore
+		tracked.searchParams[Symbol.for('nodejs.util.inspect.custom')] = (depth, opts, inspect) => {
+			return inspect(url.searchParams, opts);
+		};
 	}
 
 	if (DEV || !BROWSER) {


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/11482

Since `URL.searchParams` is an object too, we needed to make the tracked property loggable, similar to the `URL` object itself. This prevents the crashing when logging it in the server load.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
