### PR TITLE
fix: only preload link if the URL differs from current page

### DIFF
--- a/.changeset/calm-fireants-hug.md
+++ b/.changeset/calm-fireants-hug.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: only preload links that have a different URL than the current page

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1543,7 +1543,10 @@ function setup_preload() {
 
 		const options = get_router_options(a);
 
-		if (!options.reload) {
+		// we don't want to preload data for a page we're already on
+		const same_url = url && current.url.pathname + current.url.search === url.pathname + url.search;
+
+		if (!options.reload && !same_url) {
 			if (priority <= options.preload_data) {
 				const intent = get_navigation_intent(url, false);
 				if (intent) {

--- a/packages/kit/test/apps/basics/src/routes/routing/hashes/a/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/routing/hashes/a/+page.svelte
@@ -2,3 +2,6 @@
 <a href="#hash-target">hash link</a>
 <a href="/routing/hashes/b">b</a>
 <a href="#replace-state" data-sveltekit-replacestate>replace state</a>
+
+<a data-sveltekit-preload-data href="/routing/hashes/a">/routing/hashes/a</a>
+<a data-sveltekit-preload-data href="#preload">#preload</a>

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -615,6 +615,19 @@ test.describe('Prefetching', () => {
 		await expect(page.locator('h1')).not.toHaveText('Oopsie');
 	});
 
+	test('same route hash links work more than once', async ({ page, clicknav, baseURL }) => {
+		await page.goto('/routing/hashes/a');
+
+		await clicknav('[href="#preload"]');
+		await expect(page.url()).toBe(`${baseURL}/routing/hashes/a#preload`);
+
+		await clicknav('[href="/routing/hashes/a"]');
+		await expect(page.url()).toBe(`${baseURL}/routing/hashes/a`);
+
+		await clicknav('[href="#preload"]');
+		await expect(page.url()).toBe(`${baseURL}/routing/hashes/a#preload`);
+	});
+
 	test('does not rerun load on calls to duplicate preload hash route', async ({ app, page }) => {
 		await page.goto('/routing/a');
 


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/10234

By avoiding preloading pages where the URL pathname and search params (the load ID) are unchanged, we also avoid mistakenly caching navigation results for hash URLs. Currently, these are ID'd the same as URLs without hashes, causing navigation to lose track of the current URL (hence the original issue).

This should be a good solution because:
1. if we're on already on the page we don't need new load results for it.
2. even if the load results are suppose to be different for the same URL, clicking on a link that leads to the exact same URL already does nothing.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
