### PR TITLE
fix: catch stack trace fixing errors thrown in web containers

### DIFF
--- a/.changeset/polite-games-smash.md
+++ b/.changeset/polite-games-smash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: catch stack trace fixing errors thrown in web containers

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -270,7 +270,9 @@ export async function dev(vite, vite_config, svelte_config) {
 
 	/** @param {Error} error */
 	function fix_stack_trace(error) {
-		vite.ssrFixStacktrace(error);
+		try {
+			vite.ssrFixStacktrace(error);
+		} catch {}
 		return error.stack;
 	}
 

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -162,17 +162,3 @@ export function stringify_uses(node) {
 
 	return `"uses":{${uses.join(',')}}`;
 }
-
-/**
- * @param {string} message
- * @param {number} offset
- */
-export function warn_with_callsite(message, offset = 0) {
-	if (DEV) {
-		const stack = fix_stack_trace(new Error()).split('\n');
-		const line = stack.at(3 + offset);
-		message += `\n${line}`;
-	}
-
-	console.warn(message);
-}


### PR DESCRIPTION
@paoloricciuti 's solution in https://github.com/sveltejs/kit/pull/10638 helps catch the anonymous Vite error (shown below) that appears in web containers such as stackblitz, sveltekit.new , etc. Instead, it returns the original unfixed stack trace in the event that it is unable to fix the stack trace.
```
Error: `line` must be greater than 0 (lines start at line 1)
```

Although, the returned stack trace line number reported is unfixed, it's better than not having any useful errors reported.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
