### PR TITLE
Revert "fix: replace version in generateBundle (#12700)"

### DIFF
--- a/.changeset/large-planes-tan.md
+++ b/.changeset/large-planes-tan.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: revert change to replace version in generateBundle

--- a/packages/kit/src/constants.js
+++ b/packages/kit/src/constants.js
@@ -9,15 +9,3 @@ export const GENERATED_COMMENT = '// this file is generated — do not edit it\n
 export const ENDPOINT_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'];
 
 export const PAGE_METHODS = ['GET', 'POST', 'HEAD'];
-
-/**
- * Placeholders for the hash of the app version.
- * Later replaced in the generateBundle hook to avoid affecting the chunk hash.
- */
-export const APP_VERSION_HASH_PLACEHOLDER_BASE = '__SVELTEKIT_APP_VERSION_HASH__';
-
-/**
- * Placeholder for the app version.
- * Later replaced in the generateBundle hook to avoid affecting the chunk hash.
- */
-export const APP_VERSION_PLACEHOLDER_BASE = '__SVELTEKIT_APP_VERSION__';


### PR DESCRIPTION
This reverts commit 3591411e880ed5337123c66365433afe8c2f747b.

#12700 did introduce a bug where the file name stays the same, but the contents of a file can change because of a changed version. Revert for now and take another look at tackling this later.

Fixes #12771
Reopens #12260
