### PR TITLE
fix: use `node:` imports in adapter-node to support Deno

### DIFF
--- a/.changeset/breezy-poems-act.md
+++ b/.changeset/breezy-poems-act.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+fix: use `node:` imports to support Deno

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -3,6 +3,16 @@ import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import { builtinModules } from 'node:module';
 
+function prefixBuiltinModules() {
+	return {
+		resolveId(source) {
+			if (builtinModules.includes(source)) {
+				return { id: 'node:' + source, external: true };
+			}
+		}
+	};
+}
+
 export default [
 	{
 		input: 'src/index.js',
@@ -10,8 +20,8 @@ export default [
 			file: 'files/index.js',
 			format: 'esm'
 		},
-		plugins: [nodeResolve({ preferBuiltins: true }), commonjs(), json()],
-		external: ['ENV', 'HANDLER', ...builtinModules]
+		plugins: [nodeResolve({ preferBuiltins: true }), commonjs(), json(), prefixBuiltinModules()],
+		external: ['ENV', 'HANDLER']
 	},
 	{
 		input: 'src/env.js',
@@ -19,8 +29,8 @@ export default [
 			file: 'files/env.js',
 			format: 'esm'
 		},
-		plugins: [nodeResolve(), commonjs(), json()],
-		external: ['HANDLER', ...builtinModules]
+		plugins: [nodeResolve(), commonjs(), json(), prefixBuiltinModules()],
+		external: ['HANDLER']
 	},
 	{
 		input: 'src/handler.js',
@@ -29,8 +39,8 @@ export default [
 			format: 'esm',
 			inlineDynamicImports: true
 		},
-		plugins: [nodeResolve(), commonjs(), json()],
-		external: ['ENV', 'MANIFEST', 'SERVER', 'SHIMS', ...builtinModules]
+		plugins: [nodeResolve(), commonjs(), json(), prefixBuiltinModules()],
+		external: ['ENV', 'MANIFEST', 'SERVER', 'SHIMS']
 	},
 	{
 		input: 'src/shims.js',
@@ -38,7 +48,6 @@ export default [
 			file: 'files/shims.js',
 			format: 'esm'
 		},
-		plugins: [nodeResolve(), commonjs()],
-		external: builtinModules
+		plugins: [nodeResolve(), commonjs(), prefixBuiltinModules()]
 	}
 ];


### PR DESCRIPTION
This adjusts the bundling of the Node adapter so that imports from bundled dependencies (sirv, totalist) are converted into their `node:` versions, without needing code changes in those libraries. Fixes #12783.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
