### PR TITLE
docs: add report uri directive to CSP example

### DIFF
--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -332,7 +332,7 @@ export interface KitConfig {
 	 *       directives: {
 	 *         'script-src': ['self']
 	 *       },
-	 *       // must be specified with either `report-uri` or `report-to` directives, or both
+	 *       // must be specified with either the `report-uri` or `report-to` directives, or both
 	 *       reportOnly: {
 	 *         'script-src': ['self'],
 	 *         'report-uri': ['/']

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -332,9 +332,9 @@ export interface KitConfig {
 	 *       directives: {
 	 *         'script-src': ['self']
 	 *       },
+	 *       // must be specified with either `report-uri` or `report-to` directives, or both
 	 *       reportOnly: {
 	 *         'script-src': ['self'],
-	 *         // must be specified with either `report-uri` or `report-to` directives, or both
 	 *         'report-uri': ['/']
 	 *       }
 	 *     }

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -333,7 +333,9 @@ export interface KitConfig {
 	 *         'script-src': ['self']
 	 *       },
 	 *       reportOnly: {
-	 *         'script-src': ['self']
+	 *         'script-src': ['self'],
+	 *         // must be specified with either `report-uri` or `report-to` directives, or both
+	 *         'report-uri': ['/']
 	 *       }
 	 *     }
 	 *   }

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -314,7 +314,7 @@ declare module '@sveltejs/kit' {
 		 *       directives: {
 		 *         'script-src': ['self']
 		 *       },
-		 *       // must be specified with either `report-uri` or `report-to` directives, or both
+		 *       // must be specified with either the `report-uri` or `report-to` directives, or both
 		 *       reportOnly: {
 		 *         'script-src': ['self'],
 		 *         'report-uri': ['/']

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -315,7 +315,9 @@ declare module '@sveltejs/kit' {
 		 *         'script-src': ['self']
 		 *       },
 		 *       reportOnly: {
-		 *         'script-src': ['self']
+		 *         'script-src': ['self'],
+		 *         // must be specified with either `report-uri` or `report-to` directives, or both
+		 *         'report-uri': ['/']
 		 *       }
 		 *     }
 		 *   }

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -314,9 +314,9 @@ declare module '@sveltejs/kit' {
 		 *       directives: {
 		 *         'script-src': ['self']
 		 *       },
+		 *       // must be specified with either `report-uri` or `report-to` directives, or both
 		 *       reportOnly: {
 		 *         'script-src': ['self'],
-		 *         // must be specified with either `report-uri` or `report-to` directives, or both
 		 *         'report-uri': ['/']
 		 *       }
 		 *     }


### PR DESCRIPTION
Adds an example to the CSP documentation of the `report-uri` directive which is required and found similarly in our own kit test app. Currently, using the [example provided by the docs](https://kit.svelte.dev/docs/configuration#csp), gives this error message:

```sh
Error: `content-security-policy-report-only` must be specified with either the `report-to` or `report-uri` directives, or both
    at new CspReportOnlyProvider (/home/chewteeming/my-app/node_modules/.pnpm/@sveltejs+kit@2.6.4_@sveltejs+vite-plugin-svelte@3.1.2_svelte@4.2.19_vite@5.4.8__svelte@4.2.19_vite@5.4.8/node_modules/@sveltejs/kit/src/runtime/server/page/csp.js:319:11)
    at new Csp (/home/chewteeming/my-app/node_modules/.pnpm/@sveltejs+kit@2.6.4_@sveltejs+vite-plugin-svelte@3.1.2_svelte@4.2.19_vite@5.4.8__svelte@4.2.19_vite@5.4.8/node_modules/@sveltejs/kit/src/runtime/server/page/csp.js:344:31)
    at Module.render_response (/home/chewteeming/my-app/node_modules/.pnpm/@sveltejs+kit@2.6.4_@sveltejs+vite-plugin-svelte@3.1.2_svelte@4.2.19_vite@5.4.8__svelte@4.2.19_vite@5.4.8/node_modules/@sveltejs/kit/src/runtime/server/page/render.js:200:14)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Module.respond_with_error (/home/chewteeming/my-app/node_modules/.pnpm/@sveltejs+kit@2.6.4_@sveltejs+vite-plugin-svelte@3.1.2_svelte@4.2.19_vite@5.4.8__svelte@4.2.19_vite@5.4.8/node_modules/@sveltejs/kit/src/runtime/server/page/respond_with_error.js:85:10)
    at async resolve (/home/chewteeming/my-app/node_modules/.pnpm/@sveltejs+kit@2.6.4_@sveltejs+vite-plugin-svelte@3.1.2_svelte@4.2.19_vite@5.4.8__svelte@4.2.19_vite@5.4.8/node_modules/@sveltejs/kit/src/runtime/server/respond.js:524:12)
    at async Module.respond (/home/chewteeming/my-app/node_modules/.pnpm/@sveltejs+kit@2.6.4_@sveltejs+vite-plugin-svelte@3.1.2_svelte@4.2.19_vite@5.4.8__svelte@4.2.19_vite@5.4.8/node_modules/@sveltejs/kit/src/runtime/server/respond.js:327:20)
    at async file:///home/chewteeming/my-app/node_modules/.pnpm/@sveltejs+kit@2.6.4_@sveltejs+vite-plugin-svelte@3.1.2_svelte@4.2.19_vite@5.4.8__svelte@4.2.19_vite@5.4.8/node_modules/@sveltejs/kit/src/exports/vite/dev/index.js:521:22
```

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
