### PR TITLE
fix: don't error on dynamic routes with `prerender = false`

### DIFF
--- a/.changeset/funny-squids-hear.md
+++ b/.changeset/funny-squids-hear.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-static': patch
+---
+
+fix: ignore dynamic pages which have `prerender = false` set

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -8,7 +8,7 @@ export default function (options) {
 
 		async adapt(builder) {
 			if (!options?.fallback) {
-				const dynamic_routes = builder.routes.filter((route) => route.prerender !== true);
+				const dynamic_routes = builder.routes.filter((route) => route.prerender === undefined);
 				if (dynamic_routes.length > 0 && options?.strict !== false) {
 					const prefix = path.relative('.', builder.config.kit.files.routes);
 					const has_param_routes = builder.routes.some((route) => route.id.includes('['));

--- a/packages/adapter-static/index.js
+++ b/packages/adapter-static/index.js
@@ -30,7 +30,7 @@ You have the following options:
   - add \`export const prerender = true\` to your root \`+layout.js/.ts\` or \`+layout.server.js/.ts\` file. This will try to prerender all pages.
   - add \`export const prerender = true\` to any \`+server.js/ts\` files that are not fetched by page \`load\` functions.
 ${config_option}
-  - pass \`strict: false\` to \`adapter-static\` to ignore this error. Only do this if you are sure you don't need the routes in question in your final app, as they will be unavailable. See https://github.com/sveltejs/kit/tree/main/packages/adapter-static#strict for more info.
+  - add \`export const prerender = false\` to any files that should not be prerendered or pass \`strict: false\` to \`adapter-static\` to ignore this error for all files. Only do this if you are sure you don't need the routes in question in your final app, as they will be unavailable. See https://github.com/sveltejs/kit/tree/main/packages/adapter-static#strict for more info.
 
 If this doesn't help, you may need to use a different adapter. @sveltejs/adapter-static can only be used for sites that don't need a server for dynamic rendering, and can run on just a static file server.
 See https://kit.svelte.dev/docs/page-options#prerender for more details`


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/10332

Instead of always erroring on dynamic routes generated with the static adapter, we only error if the prerender option was not explicitly set. This allows users to have dynamic pages in the project but choose to ignore them, which is useful if they have multiple builds that may use a different adapter.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
