### PR TITLE
fix: include importer in illegal import error message

### DIFF
--- a/.changeset/dry-cows-smash.md
+++ b/.changeset/dry-cows-smash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: include importer in illegal import error message

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -352,8 +352,8 @@ async function kit({ svelte_config }) {
 		}
 	};
 
-	/** @type {string | undefined}} */
-	let illegal_importer;
+	/** @type {Map<string, string>} */
+	let import_map = new Map();
 
 	/** @type {import('vite').Plugin} */
 	const plugin_virtual_modules = {
@@ -376,9 +376,7 @@ async function kit({ svelte_config }) {
 					);
 				}
 
-				if (id.startsWith('$env/')) {
-					illegal_importer = importer;
-				}
+				import_map.set(id, importer);
 			}
 
 			// treat $env/static/[public|private] as virtual
@@ -408,9 +406,10 @@ async function kit({ svelte_config }) {
 
 					const illegal_module = strip_virtual_prefix(relative);
 
-					if (illegal_module.startsWith('$env/') && illegal_importer) {
+					if (illegal_module.startsWith('$env/') && import_map.has(illegal_module)) {
+						const importer = path.relative(cwd, /** @type {string} */ (import_map.get(illegal_module)));
 						throw new Error(
-							`Cannot import ${illegal_module} into client-side code: ${path.relative(cwd, illegal_importer)}`
+							`Cannot import ${illegal_module} into client-side code: ${importer}`
 						);
 					}
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -406,7 +406,7 @@ async function kit({ svelte_config }) {
 
 					const illegal_module = strip_virtual_prefix(relative);
 
-					if (illegal_module.startsWith('$env/') && import_map.has(illegal_module)) {
+					if (import_map.has(illegal_module)) {
 						const importer = path.relative(
 							cwd,
 							/** @type {string} */ (import_map.get(illegal_module))

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -353,7 +353,7 @@ async function kit({ svelte_config }) {
 	};
 
 	/** @type {Map<string, string>} */
-	let import_map = new Map();
+	const import_map = new Map();
 
 	/** @type {import('vite').Plugin} */
 	const plugin_virtual_modules = {
@@ -407,10 +407,11 @@ async function kit({ svelte_config }) {
 					const illegal_module = strip_virtual_prefix(relative);
 
 					if (illegal_module.startsWith('$env/') && import_map.has(illegal_module)) {
-						const importer = path.relative(cwd, /** @type {string} */ (import_map.get(illegal_module)));
-						throw new Error(
-							`Cannot import ${illegal_module} into client-side code: ${importer}`
+						const importer = path.relative(
+							cwd,
+							/** @type {string} */ (import_map.get(illegal_module))
 						);
+						throw new Error(`Cannot import ${illegal_module} into client-side code: ${importer}`);
 					}
 
 					throw new Error(`Cannot import ${illegal_module} into client-side code`);

--- a/packages/kit/test/apps/dev-only/test/test.js
+++ b/packages/kit/test/apps/dev-only/test/test.js
@@ -17,7 +17,7 @@ test.describe.serial('Illegal imports', () => {
 			wait_for_started: false
 		});
 		expect(await page.textContent('.message-body')).toBe(
-			'Cannot import $env/dynamic/private into client-side code'
+			'Cannot import $env/dynamic/private into client-side code: src/routes/illegal-imports/env/dynamic-private/+page.svelte'
 		);
 	});
 
@@ -26,7 +26,7 @@ test.describe.serial('Illegal imports', () => {
 			wait_for_started: false
 		});
 		expect(await page.textContent('.message-body')).toBe(
-			'Cannot import $env/dynamic/private into client-side code'
+			'Cannot import $env/dynamic/private into client-side code: src/routes/illegal-imports/env/dynamic-private-dynamic-import/+page.svelte'
 		);
 	});
 
@@ -35,7 +35,7 @@ test.describe.serial('Illegal imports', () => {
 			wait_for_started: false
 		});
 		expect(await page.textContent('.message-body')).toBe(
-			'Cannot import $env/static/private into client-side code'
+			'Cannot import $env/static/private into client-side code: src/routes/illegal-imports/env/static-private/+page.svelte'
 		);
 	});
 
@@ -44,7 +44,7 @@ test.describe.serial('Illegal imports', () => {
 			wait_for_started: false
 		});
 		expect(await page.textContent('.message-body')).toBe(
-			'Cannot import $env/static/private into client-side code'
+			'Cannot import $env/static/private into client-side code: src/routes/illegal-imports/env/static-private-dynamic-import/+page.svelte'
 		);
 	});
 


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/12550

Uses the `resolveId` hook to get the importer name before including it in the error message when loading the illegal import in the `load` hook.

However, I couldn't figure how to get this working for server only imports since those don't trigger the `resolveId` hook. (at least when I was running console logs to see if it did trigger it).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
