### PR TITLE
Use .toString() to serialize URL instead of JSON.stringify

### DIFF
--- a/.changeset/many-spies-dream.md
+++ b/.changeset/many-spies-dream.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: cache key serialization error on iOS Chrome

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -154,7 +154,9 @@ function dev_fetch(resource, opts) {
  * @param {RequestInit} [opts]
  */
 function build_selector(resource, opts) {
-	const url = JSON.stringify(resource instanceof Request ? resource.url : resource);
+	let url = resource instanceof Request ? resource.url : resource;
+	if (url instanceof URL) url = url.toString();
+	url = JSON.stringify(url);
 
 	let selector = `script[data-sveltekit-fetched][data-url=${url}]`;
 


### PR DESCRIPTION
<!-- Your PR description here -->

This changes the stringification method for building cache keys to avoid circular references inside the searchParams of URL objects.

In Chrome on iOS, URLSearchParams can contain a reference to their enclosing url object:

```javascript
url = {
  ...,
  searchParams: {
    _url: // this references the containing url
  }
}
```

Attempting to serialize a URL object in Chrome on iOS results in `Unhandled Promise Rejection: TypeError: JSON.stringify cannot serialize cyclic structures`

Fixes: https://github.com/sveltejs/kit/issues/12826

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
