### PR TITLE
chore: add `svelte-eslint-parser` to list of migratable dependencies

### DIFF
--- a/.changeset/curvy-bugs-wait.md
+++ b/.changeset/curvy-bugs-wait.md
@@ -1,0 +1,5 @@
+---
+"svelte-migrate": patch
+---
+
+chore: add `svelte-eslint-parser` to list of migratable dependencies

--- a/packages/migrate/migrations/svelte-5/migrate.js
+++ b/packages/migrate/migrations/svelte-5/migrate.js
@@ -29,6 +29,7 @@ export function update_pkg_json_content(content) {
 		['prettier', '^3.1.0'],
 		['prettier-plugin-svelte', '^3.2.6'],
 		['eslint-plugin-svelte', '^2.43.0'],
+		['svelte-eslint-parser', '^0.42.0'],
 		[
 			'eslint-plugin-svelte3',
 			'^4.0.0',

--- a/packages/migrate/migrations/svelte-5/migrate.js
+++ b/packages/migrate/migrations/svelte-5/migrate.js
@@ -28,7 +28,7 @@ export function update_pkg_json_content(content) {
 		['rollup-plugin-svelte', '^7.2.2'],
 		['prettier', '^3.1.0'],
 		['prettier-plugin-svelte', '^3.2.6'],
-		['eslint-plugin-svelte', '^2.43.0'],
+		['eslint-plugin-svelte', '^2.45.1'],
 		['svelte-eslint-parser', '^0.42.0'],
 		[
 			'eslint-plugin-svelte3',

--- a/packages/migrate/migrations/svelte-5/migrate.spec.js
+++ b/packages/migrate/migrations/svelte-5/migrate.spec.js
@@ -80,7 +80,8 @@ test('Update package.json', () => {
 	"devDependencies": {
 		"svelte": "^4.0.0",
 		"svelte-check": "^3.0.0",
-		"svelte-preprocess": "^5.0.0"
+		"svelte-preprocess": "^5.0.0",
+		"svelte-eslint-parser": "^0.41.1"
 	},
 	"dependencies": {
 		"@sveltejs/kit": "^2.0.0"
@@ -94,7 +95,8 @@ test('Update package.json', () => {
 	"devDependencies": {
 		"svelte": "^5.0.0-next.0",
 		"svelte-check": "^4.0.0",
-		"svelte-preprocess": "^6.0.0"
+		"svelte-preprocess": "^6.0.0",
+		"svelte-eslint-parser": "^0.42.0"
 	},
 	"dependencies": {
 		"@sveltejs/kit": "^2.5.27"


### PR DESCRIPTION
Adds `svelte-eslint-parser` to the list of migratable dependencies. One of the problem we might face is that people are just using this in the eslint config transitively but i guess it's still better have it than not.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
