### PR TITLE
fix: explain why `json()` cannot be used in form actions

### DIFF
--- a/.changeset/healthy-planets-dance.md
+++ b/.changeset/healthy-planets-dance.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: explain why `json()` cannot be used in form actions
+fix: better error message when a `Result` is returned from a form action

--- a/.changeset/healthy-planets-dance.md
+++ b/.changeset/healthy-planets-dance.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: explain why `json()` cannot be used in form actions

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -287,7 +287,7 @@ function try_deserialize(data, fn, route_id) {
 			);
 		}
 
-		// if devalue could not serialize the data
+		// if devalue could not serialize a property on the object, etc.
 		if ('path' in error) {
 			let message = `Data returned from action inside ${route_id} is not serializable: ${error.message}`;
 			if (error.path !== '') message += ` (data.${error.path})`;

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -287,6 +287,7 @@ function try_deserialize(data, fn, route_id) {
 			);
 		}
 
+		// if devalue could not serialize the data
 		if ('path' in error) {
 			let message = `Data returned from action inside ${route_id} is not serializable: ${error.message}`;
 			if (error.path !== '') message += ` (data.${error.path})`;

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -280,6 +280,13 @@ function try_deserialize(data, fn, route_id) {
 		// If we're here, the data could not be serialized with devalue
 		const error = /** @type {any} */ (e);
 
+		// if someone tries to use `json()` in their action
+		if (data instanceof Response) {
+			throw new Error(
+				`Data returned from action inside ${route_id} is not serializable. Form actions need to return objects directly or fail(). e.g. return { success: true } or return fail(400, { message: "invalid" });`
+			);
+		}
+
 		if ('path' in error) {
 			let message = `Data returned from action inside ${route_id} is not serializable: ${error.message}`;
 			if (error.path !== '') message += ` (data.${error.path})`;

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -283,7 +283,7 @@ function try_deserialize(data, fn, route_id) {
 		// if someone tries to use `json()` in their action
 		if (data instanceof Response) {
 			throw new Error(
-				`Data returned from action inside ${route_id} is not serializable. Form actions need to return plain objects or fail(). e.g. return { success: true } or return fail(400, { message: "invalid" });`
+				`Data returned from action inside ${route_id} is not serializable. Form actions need to return plain objects or fail(). E.g. return { success: true } or return fail(400, { message: "invalid" });`
 			);
 		}
 

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -283,7 +283,7 @@ function try_deserialize(data, fn, route_id) {
 		// if someone tries to use `json()` in their action
 		if (data instanceof Response) {
 			throw new Error(
-				`Data returned from action inside ${route_id} is not serializable. Form actions need to return objects directly or fail(). e.g. return { success: true } or return fail(400, { message: "invalid" });`
+				`Data returned from action inside ${route_id} is not serializable. Form actions need to return plain objects or fail(). e.g. return { success: true } or return fail(400, { message: "invalid" });`
 			);
 		}
 


### PR DESCRIPTION
closes #12787

Adds a check to see if the data being returned is a `Response` object (such as with the helper method `json()`), then replies with a more helpful error message.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
