### PR TITLE
fix: prevent vitest from hanging

### DIFF
--- a/.changeset/six-goats-ring.md
+++ b/.changeset/six-goats-ring.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+fix: prevent vitest from hanging

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -150,6 +150,7 @@ export default function ({ config = 'wrangler.toml', platformProxy = {} } = {}) 
 		},
 
 		emulate() {
+			// we want to invoke `getPlatformProxy` only once and await it only when it is accessed
 			const getting_platform = (async () => {
 				const proxy = await getPlatformProxy(platformProxy);
 				const platform = /** @type {App.Platform} */ ({

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -149,29 +149,33 @@ export default function ({ config = 'wrangler.toml', platformProxy = {} } = {}) 
 			builder.writePrerendered(bucket_dir);
 		},
 
-		async emulate() {
-			const proxy = await getPlatformProxy(platformProxy);
-			const platform = /** @type {App.Platform} */ ({
-				env: proxy.env,
-				context: proxy.ctx,
-				caches: proxy.caches,
-				cf: proxy.cf
-			});
-
-			/** @type {Record<string, any>} */
-			const env = {};
-			const prerender_platform = /** @type {App.Platform} */ (/** @type {unknown} */ ({ env }));
-
-			for (const key in proxy.env) {
-				Object.defineProperty(env, key, {
-					get: () => {
-						throw new Error(`Cannot access platform.env.${key} in a prerenderable route`);
-					}
+		emulate() {
+			const getting_platform = (async () => {
+				const proxy = await getPlatformProxy(platformProxy);
+				const platform = /** @type {App.Platform} */ ({
+					env: proxy.env,
+					context: proxy.ctx,
+					caches: proxy.caches,
+					cf: proxy.cf
 				});
-			}
+
+				/** @type {Record<string, any>} */
+				const env = {};
+				const prerender_platform = /** @type {App.Platform} */ (/** @type {unknown} */ ({ env }));
+
+				for (const key in proxy.env) {
+					Object.defineProperty(env, key, {
+						get: () => {
+							throw new Error(`Cannot access platform.env.${key} in a prerenderable route`);
+						}
+					});
+				}
+				return { platform, prerender_platform };
+			})();
 
 			return {
-				platform: ({ prerender }) => {
+				platform: async ({ prerender }) => {
+					const { platform, prerender_platform } = await getting_platform;
 					return prerender ? prerender_platform : platform;
 				}
 			};

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -150,7 +150,8 @@ export default function ({ config = 'wrangler.toml', platformProxy = {} } = {}) 
 		},
 
 		emulate() {
-			// we want to invoke `getPlatformProxy` only once and await it only when it is accessed
+			// we want to invoke `getPlatformProxy` only once, but await it only when it is accessed.
+			// If we would await it here, it would hang indefinitely because the platform proxy only resolves once a request happens
 			const getting_platform = (async () => {
 				const proxy = await getPlatformProxy(platformProxy);
 				const platform = /** @type {App.Platform} */ ({

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -145,6 +145,7 @@ export default function (options = {}) {
 			}
 		},
 		emulate() {
+			// we want to invoke `getPlatformProxy` only once and await it only when it is accessed
 			const getting_platform = (async () => {
 				const proxy = await getPlatformProxy(options.platformProxy);
 				const platform = /** @type {App.Platform} */ ({

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -144,29 +144,33 @@ export default function (options = {}) {
 				);
 			}
 		},
-		async emulate() {
-			const proxy = await getPlatformProxy(options.platformProxy);
-			const platform = /** @type {App.Platform} */ ({
-				env: proxy.env,
-				context: proxy.ctx,
-				caches: proxy.caches,
-				cf: proxy.cf
-			});
-
-			/** @type {Record<string, any>} */
-			const env = {};
-			const prerender_platform = /** @type {App.Platform} */ (/** @type {unknown} */ ({ env }));
-
-			for (const key in proxy.env) {
-				Object.defineProperty(env, key, {
-					get: () => {
-						throw new Error(`Cannot access platform.env.${key} in a prerenderable route`);
-					}
+		emulate() {
+			const getting_platform = (async () => {
+				const proxy = await getPlatformProxy(options.platformProxy);
+				const platform = /** @type {App.Platform} */ ({
+					env: proxy.env,
+					context: proxy.ctx,
+					caches: proxy.caches,
+					cf: proxy.cf
 				});
-			}
+
+				/** @type {Record<string, any>} */
+				const env = {};
+				const prerender_platform = /** @type {App.Platform} */ (/** @type {unknown} */ ({ env }));
+
+				for (const key in proxy.env) {
+					Object.defineProperty(env, key, {
+						get: () => {
+							throw new Error(`Cannot access platform.env.${key} in a prerenderable route`);
+						}
+					});
+				}
+				return { platform, prerender_platform };
+			})();
 
 			return {
-				platform: ({ prerender }) => {
+				platform: async ({ prerender }) => {
+					const { platform, prerender_platform } = await getting_platform;
 					return prerender ? prerender_platform : platform;
 				}
 			};

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -145,7 +145,8 @@ export default function (options = {}) {
 			}
 		},
 		emulate() {
-			// we want to invoke `getPlatformProxy` only once and await it only when it is accessed
+			// we want to invoke `getPlatformProxy` only once, but await it only when it is accessed.
+			// If we would await it here, it would hang indefinitely because the platform proxy only resolves once a request happens
 			const getting_platform = (async () => {
 				const proxy = await getPlatformProxy(options.platformProxy);
 				const platform = /** @type {App.Platform} */ ({


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/12305
closes https://github.com/sveltejs/kit/pull/12306

This is an alternative to https://github.com/sveltejs/kit/pull/12306 . Instead of creating the emulator every time the Vite dev and preview middlewares are invoked, we await Cloudflare's platform proxy only when the adapter emulated platform is accessed, rather than much earlier when `adapter.adapt` is invoked.

We could still use the newly added test from https://github.com/sveltejs/kit/pull/12306

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
