### PR TITLE
fix: migrate `svelte` and `vite-plugin-svelte` to latest

### DIFF
--- a/.changeset/eighty-starfishes-rule.md
+++ b/.changeset/eighty-starfishes-rule.md
@@ -1,0 +1,5 @@
+---
+'svelte-migrate': patch
+---
+
+fix: migrate `svelte` and `vite-plugin-svelte` to latest

--- a/packages/migrate/migrations/svelte-5/index.js
+++ b/packages/migrate/migrations/svelte-5/index.js
@@ -62,8 +62,7 @@ export async function migrate() {
 			({ migrate } = await import_from_cwd('svelte/compiler'));
 			if (!migrate) throw new Error('found Svelte 4');
 		} catch {
-			// TODO replace with svelte@5 once it's released
-			execSync('npm install svelte@next --no-save', {
+			execSync('npm install svelte@^5.0.0 --no-save', {
 				stdio: 'inherit',
 				cwd: dirname(fileURLToPath(import.meta.url))
 			});

--- a/packages/migrate/migrations/svelte-5/migrate.js
+++ b/packages/migrate/migrations/svelte-5/migrate.js
@@ -14,12 +14,12 @@ export function update_pkg_json() {
  */
 export function update_pkg_json_content(content) {
 	return update_pkg(content, [
-		['svelte', '^5.0.0-next.0'],
+		['svelte', '^5.0.0'],
 		['svelte-check', '^4.0.0'],
 		['svelte-preprocess', '^6.0.0'],
 		['@sveltejs/enhanced-img', '^0.3.6'],
 		['@sveltejs/kit', '^2.5.27'],
-		['@sveltejs/vite-plugin-svelte', '^4.0.0-next.0'],
+		['@sveltejs/vite-plugin-svelte', '^4.0.0'],
 		[
 			'svelte-loader',
 			'^3.2.3',

--- a/packages/migrate/migrations/svelte-5/migrate.spec.js
+++ b/packages/migrate/migrations/svelte-5/migrate.spec.js
@@ -92,7 +92,7 @@ test('Update package.json', () => {
 	"name": "svelte-app",
 	"version": "1.0.0",
 	"devDependencies": {
-		"svelte": "^5.0.0-next.0",
+		"svelte": "^5.0.0",
 		"svelte-check": "^4.0.0",
 		"svelte-preprocess": "^6.0.0"
 	},


### PR DESCRIPTION
We can now use latest for `svelte` and `@sveltejs/vite-plugin-svelte` in the migration tool!

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
