### PR TITLE
chore: use svelte v5 in create-svelte templates

### DIFF
--- a/.changeset/soft-bags-admire.md
+++ b/.changeset/soft-bags-admire.md
@@ -1,0 +1,5 @@
+---
+'create-svelte': patch
+---
+
+chore: use svelte v5 in create-svelte templates

--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
+import * as p from '@clack/prompts';
+import { bold, cyan, grey, yellow } from 'kleur/colors';
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
-import * as p from '@clack/prompts';
-import { bold, cyan, grey, yellow } from 'kleur/colors';
 import { create } from './index.js';
 import { dist, package_manager } from './utils.js';
 
@@ -99,10 +99,6 @@ const options = await p.group(
 					{
 						value: 'vitest',
 						label: 'Add Vitest for unit testing'
-					},
-					{
-						value: 'svelte5',
-						label: 'Try the Svelte 5 preview (unstable!)'
 					}
 				]
 			})
@@ -117,8 +113,7 @@ await create(cwd, {
 	prettier: options.features.includes('prettier'),
 	eslint: options.features.includes('eslint'),
 	playwright: options.features.includes('playwright'),
-	vitest: options.features.includes('vitest'),
-	svelte5: options.features.includes('svelte5')
+	vitest: options.features.includes('vitest')
 });
 
 p.outro('Your project is ready!');

--- a/packages/create-svelte/scripts/update-template-repo-contents.js
+++ b/packages/create-svelte/scripts/update-template-repo-contents.js
@@ -21,8 +21,7 @@ await create(repo, {
 	types: 'checkjs',
 	prettier: true,
 	playwright: false,
-	vitest: false,
-	svelte5: false
+	vitest: false
 });
 
 // Remove the Sverdle from the template because it doesn't work within Stackblitz (cookies not set)

--- a/packages/create-svelte/shared/+eslint+svelte5/package.json
+++ b/packages/create-svelte/shared/+eslint+svelte5/package.json
@@ -1,5 +1,0 @@
-{
-	"devDependencies": {
-		"eslint-plugin-svelte": "^2.36.0"
-	}
-}

--- a/packages/create-svelte/shared/+skeletonlib+svelte5/package.json
+++ b/packages/create-svelte/shared/+skeletonlib+svelte5/package.json
@@ -1,8 +1,0 @@
-{
-	"peerDependencies": {
-		"svelte": "^5.0.0-next.1"
-	},
-	"devDependencies": {
-		"svelte": "^5.0.0-next.1"
-	}
-}

--- a/packages/create-svelte/shared/+svelte5/package.json
+++ b/packages/create-svelte/shared/+svelte5/package.json
@@ -1,6 +1,0 @@
-{
-	"devDependencies": {
-		"@sveltejs/vite-plugin-svelte": "^4.0.0-next.6",
-		"svelte": "^5.0.0-next.1"
-	}
-}

--- a/packages/create-svelte/templates/default/package.template.json
+++ b/packages/create-svelte/templates/default/package.template.json
@@ -11,8 +11,8 @@
 		"@neoconfetti/svelte": "^2.0.0",
 		"@sveltejs/adapter-auto": "^3.0.0",
 		"@sveltejs/kit": "^2.0.0",
-		"@sveltejs/vite-plugin-svelte": "^3.0.0",
-		"svelte": "^4.2.7",
+		"@sveltejs/vite-plugin-svelte": "^4.0.0",
+		"svelte": "^5.0.2",
 		"vite": "^5.0.3"
 	},
 	"type": "module"

--- a/packages/create-svelte/templates/skeleton/package.template.json
+++ b/packages/create-svelte/templates/skeleton/package.template.json
@@ -10,8 +10,8 @@
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^3.0.0",
 		"@sveltejs/kit": "^2.0.0",
-		"@sveltejs/vite-plugin-svelte": "^3.0.0",
-		"svelte": "^4.2.7",
+		"@sveltejs/vite-plugin-svelte": "^4.0.0",
+		"svelte": "^5.0.2",
 		"vite": "^5.0.3"
 	},
 	"type": "module"

--- a/packages/create-svelte/templates/skeletonlib/package.template.json
+++ b/packages/create-svelte/templates/skeletonlib/package.template.json
@@ -23,9 +23,9 @@
 		"@sveltejs/adapter-auto": "^3.0.0",
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/package": "^2.0.0",
-		"@sveltejs/vite-plugin-svelte": "^3.0.0",
+		"@sveltejs/vite-plugin-svelte": "^4.0.0",
 		"publint": "^0.2.0",
-		"svelte": "^4.2.7",
+		"svelte": "^5.0.2",
 		"typescript": "^5.3.2",
 		"vite": "^5.0.11"
 	},

--- a/packages/create-svelte/test/check.js
+++ b/packages/create-svelte/test/check.js
@@ -106,39 +106,36 @@ for (const template of templates) {
 	if (template[0] === '.') continue;
 
 	for (const types of /** @type {const} */ (['checkjs', 'typescript'])) {
-		for (const svelteVersion of /** @type {const} */ (['svelte4', 'svelte5'])) {
-			const test_id = `${template}-${types}-${svelteVersion}`;
-			const cwd = path.join(test_workspace_dir, test_id);
-			fs.rmSync(cwd, { recursive: true, force: true });
+		const test_id = `${template}-${types}`;
+		const cwd = path.join(test_workspace_dir, test_id);
+		fs.rmSync(cwd, { recursive: true, force: true });
 
-			create(cwd, {
-				name: `create-svelte-test-${test_id}`,
-				template,
-				types,
-				prettier: true,
-				eslint: true,
-				playwright: false,
-				vitest: false,
-				svelte5: svelteVersion === 'svelte5'
-			});
+		create(cwd, {
+			name: `create-svelte-test-${test_id}`,
+			template,
+			types,
+			prettier: true,
+			eslint: true,
+			playwright: false,
+			vitest: false
+		});
 
-			const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf-8'));
-			patch_package_json(pkg);
+		const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf-8'));
+		patch_package_json(pkg);
 
-			fs.writeFileSync(path.join(cwd, 'package.json'), JSON.stringify(pkg, null, '\t') + '\n');
+		fs.writeFileSync(path.join(cwd, 'package.json'), JSON.stringify(pkg, null, '\t') + '\n');
 
-			// run provided scripts that are non-blocking. All of them should exit with 0
-			// package script requires lib dir
-			// TODO: lint should run before format
-			const scripts_to_test = ['format', 'lint', 'check', 'build', 'package'].filter(
-				(s) => s in pkg.scripts
-			);
+		// run provided scripts that are non-blocking. All of them should exit with 0
+		// package script requires lib dir
+		// TODO: lint should run before format
+		const scripts_to_test = ['format', 'lint', 'check', 'build', 'package'].filter(
+			(s) => s in pkg.scripts
+		);
 
-			for (const script of scripts_to_test) {
-				const tests = script_test_map.get(script) ?? [];
-				tests.push([test_id, () => exec_async(`pnpm ${script}`, { cwd })]);
-				script_test_map.set(script, tests);
-			}
+		for (const script of scripts_to_test) {
+			const tests = script_test_map.get(script) ?? [];
+			tests.push([test_id, () => exec_async(`pnpm ${script}`, { cwd })]);
+			script_test_map.set(script, tests);
 		}
 	}
 }

--- a/packages/create-svelte/types/internal.d.ts
+++ b/packages/create-svelte/types/internal.d.ts
@@ -6,7 +6,6 @@ export type Options = {
 	eslint: boolean;
 	playwright: boolean;
 	vitest: boolean;
-	svelte5?: boolean; // optional to not introduce a breaking change to the `create` API
 };
 
 export type File = {
@@ -23,8 +22,7 @@ export type Condition =
 	| 'vitest'
 	| 'skeleton'
 	| 'default'
-	| 'skeletonlib'
-	| 'svelte5';
+	| 'skeletonlib';
 
 export type Common = {
 	files: Array<{


### PR DESCRIPTION
<!-- Your PR description here -->

Use Svelte v5 as default in `create-svelte` package.

Would `create-svelte` be deprecated and replaced with `sv`?

> No, the new CLI replaces "npm create svelte" and "npx svelte-add". You will still use Vite everywhere it was used before

https://twitter.com/BenjaminMcCann/status/1847780400053309761

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
