### PR TITLE
fix: wrap project name in quotes for CLI tool create-svelte (#12843)

### DIFF
--- a/packages/create-svelte/bin.js
+++ b/packages/create-svelte/bin.js
@@ -138,7 +138,7 @@ let i = 1;
 
 const relative = path.relative(process.cwd(), cwd);
 if (relative !== '') {
-	console.log(`  ${i++}: ${bold(cyan(`cd ${relative}`))}`);
+	console.log(`  ${i++}: ${bold(cyan(`cd "${relative}"`))}`);
 }
 
 console.log(`  ${i++}: ${bold(cyan(`${package_manager} install`))}`);


### PR DESCRIPTION
This commit updates the instructions given by the CLI tool that scaffolds the sveltKit project. it wraps the project name in double quotes. This prevents errors when navigating into directories with spaces in their names.

<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
