### PR TITLE
fix: bump enhanced-img version to avoid peer dep warning

### DIFF
--- a/.changeset/shy-seals-draw.md
+++ b/.changeset/shy-seals-draw.md
@@ -1,0 +1,5 @@
+---
+'svelte-migrate': patch
+---
+
+fix: bump enhanced-img version to avoid peer dep warning

--- a/packages/migrate/migrations/svelte-5/migrate.js
+++ b/packages/migrate/migrations/svelte-5/migrate.js
@@ -17,7 +17,7 @@ export function update_pkg_json_content(content) {
 		['svelte', '^5.0.0'],
 		['svelte-check', '^4.0.0'],
 		['svelte-preprocess', '^6.0.0'],
-		['@sveltejs/enhanced-img', '^0.3.6'],
+		['@sveltejs/enhanced-img', '^0.3.9'],
 		['@sveltejs/kit', '^2.5.27'],
 		['@sveltejs/vite-plugin-svelte', '^4.0.0'],
 		[


### PR DESCRIPTION
I just ran the migration tool on my small site and this was the only issue I encountered :smile: 