### PR TITLE
feat: `adapter-auto` support `bun add`

### DIFF
--- a/.changeset/serious-geckos-itch.md
+++ b/.changeset/serious-geckos-itch.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-auto': minor
 ---
 
-feat: adds support for Bun package manager
+feat: add support for Bun package manager

--- a/.changeset/serious-geckos-itch.md
+++ b/.changeset/serious-geckos-itch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-auto': minor
+---
+
+feat: adds support for Bun package manager

--- a/packages/adapter-auto/index.js
+++ b/packages/adapter-auto/index.js
@@ -10,7 +10,8 @@ import process from 'node:process';
 const commands = {
 	npm: (name, version) => `npm install -D ${name}@${version}`,
 	pnpm: (name, version) => `pnpm add -D ${name}@${version}`,
-	yarn: (name, version) => `yarn add -D ${name}@${version}`
+	yarn: (name, version) => `yarn add -D ${name}@${version}`,
+	bun: (name, version) => `bun add -D ${name}@${version}`
 };
 
 function detect_lockfile() {
@@ -20,6 +21,7 @@ function detect_lockfile() {
 		if (existsSync(join(dir, 'pnpm-lock.yaml'))) return 'pnpm';
 		if (existsSync(join(dir, 'yarn.lock'))) return 'yarn';
 		if (existsSync(join(dir, 'package-lock.json'))) return 'npm';
+		if (existsSync(join(dir, 'bun.lockb')) || existsSync(join(dir, 'bun.lock'))) return 'bun';
 	} while (dir !== (dir = dirname(dir)));
 
 	return 'npm';


### PR DESCRIPTION
<!-- Your PR description here -->

Adds support for Bun package manager with `@sveltejs/adapter-auto`. 

Initially, I considered adding `svelte-adapter-bun` to the plugin list, but since Bun works seamlessly with Node.js, it wasn't necessary!

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
