### PR TITLE
docs: fix links

### DIFF
--- a/documentation/docs/10-getting-started/10-introduction.md
+++ b/documentation/docs/10-getting-started/10-introduction.md
@@ -4,7 +4,7 @@ title: Introduction
 
 ## Before we begin
 
-> [!NOTE] If you're new to Svelte or SvelteKit we recommend checking out the [interactive tutorial](../tutorial/kit).
+> [!NOTE] If you're new to Svelte or SvelteKit we recommend checking out the [interactive tutorial](/tutorial/kit).
 >
 > If you get stuck, reach out for help in the [Discord chatroom](https://svelte.dev/chat).
 

--- a/documentation/docs/20-core-concepts/10-routing.md
+++ b/documentation/docs/20-core-concepts/10-routing.md
@@ -394,6 +394,6 @@ If components and modules are needed by multiple routes, it's a good idea to put
 
 ## Further reading
 
-- [Tutorial: Routing](../tutorial/kit/pages)
-- [Tutorial: API routes](../tutorial/kit/get-handlers)
+- [Tutorial: Routing](/tutorial/kit/pages)
+- [Tutorial: API routes](/tutorial/kit/get-handlers)
 - [Docs: Advanced routing](advanced-routing)

--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -693,6 +693,6 @@ Putting an auth guard in `+layout.server.js` requires all child pages to call `a
 
 ## Further reading
 
-- [Tutorial: Loading data](../tutorial/kit/page-data)
-- [Tutorial: Errors and redirects](../tutorial/kit/error-basics)
-- [Tutorial: Advanced loading](../tutorial/kit/await-parent)
+- [Tutorial: Loading data](/tutorial/kit/page-data)
+- [Tutorial: Errors and redirects](/tutorial/kit/error-basics)
+- [Tutorial: Advanced loading](/tutorial/kit/await-parent)

--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -518,4 +518,4 @@ Submitting this form will navigate to `/search?q=...` and invoke your load funct
 
 ## Further reading
 
-- [Tutorial: Forms](../tutorial/kit/the-form-element)
+- [Tutorial: Forms](/tutorial/kit/the-form-element)

--- a/documentation/docs/20-core-concepts/40-page-options.md
+++ b/documentation/docs/20-core-concepts/40-page-options.md
@@ -219,4 +219,4 @@ export const config = {
 
 ## Further reading
 
-- [Tutorial: Page options](../tutorial/kit/page-options)
+- [Tutorial: Page options](/tutorial/kit/page-options)

--- a/documentation/docs/20-core-concepts/50-state-management.md
+++ b/documentation/docs/20-core-concepts/50-state-management.md
@@ -82,7 +82,7 @@ If you're not using SSR, then there's no risk of accidentally exposing one user'
 
 ## Using stores with context
 
-You might wonder how we're able to use `$page.data` and other [app stores]($app-stores) if we can't use our own stores. The answer is that app stores on the server use Svelte's [context API](../tutorial/svelte/context-api) — the store is attached to the component tree with `setContext`, and when you subscribe you retrieve it with `getContext`. We can do the same thing with our own stores:
+You might wonder how we're able to use `$page.data` and other [app stores]($app-stores) if we can't use our own stores. The answer is that app stores on the server use Svelte's [context API](/tutorial/svelte/context-api) — the store is attached to the component tree with `setContext`, and when you subscribe you retrieve it with `getContext`. We can do the same thing with our own stores:
 
 ```svelte
 <!--- file: src/routes/+layout.svelte --->
@@ -143,7 +143,7 @@ When you navigate around your application, SvelteKit reuses existing layout and 
 
 ...then navigating from `/blog/my-short-post` to `/blog/my-long-post` won't cause the layout, page and any other components within to be destroyed and recreated. Instead the `data` prop (and by extension `data.title` and `data.content`) will update (as it would with any other Svelte component) and, because the code isn't rerunning, lifecycle methods like `onMount` and `onDestroy` won't rerun and `estimatedReadingTime` won't be recalculated.
 
-Instead, we need to make the value [_reactive_](../tutorial/svelte/state):
+Instead, we need to make the value [_reactive_](/tutorial/svelte/state):
 
 ```svelte
 /// file: src/routes/blog/[slug]/+page.svelte

--- a/documentation/docs/30-advanced/10-advanced-routing.md
+++ b/documentation/docs/30-advanced/10-advanced-routing.md
@@ -287,4 +287,4 @@ export function load(event) {
 
 ## Further reading
 
-- [Tutorial: Advanced Routing](../tutorial/kit/optional-params)
+- [Tutorial: Advanced Routing](/tutorial/kit/optional-params)

--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -270,4 +270,4 @@ Using `reroute` will _not_ change the contents of the browser's address bar, or 
 
 ## Further reading
 
-- [Tutorial: Hooks](../tutorial/kit/handle)
+- [Tutorial: Hooks](/tutorial/kit/handle)

--- a/documentation/docs/30-advanced/25-errors.md
+++ b/documentation/docs/30-advanced/25-errors.md
@@ -144,5 +144,5 @@ This interface always includes a `message: string` property.
 
 ## Further reading
 
-- [Tutorial: Errors and redirects](../tutorial/kit/error-basics)
-- [Tutorial: Hooks](../tutorial/kit/handle)
+- [Tutorial: Errors and redirects](/tutorial/kit/error-basics)
+- [Tutorial: Hooks](/tutorial/kit/handle)

--- a/documentation/docs/30-advanced/50-server-only-modules.md
+++ b/documentation/docs/30-advanced/50-server-only-modules.md
@@ -61,4 +61,4 @@ This feature also works with dynamic imports, even interpolated ones like ``awai
 
 ## Further reading
 
-- [Tutorial: Environment variables](../tutorial/kit/env-static-private)
+- [Tutorial: Environment variables](/tutorial/kit/env-static-private)


### PR DESCRIPTION
6c6e86df4ece3eb18e29782ea55400b6946a8908 (and maybe others, not sure) broke some links. This PR fixes some of them, but not all — not sure how many are still broken just yet because of #12859 