### PR TITLE
fix: decode URI when previewing prerendered pages

### DIFF
--- a/.changeset/eleven-turkeys-jump.md
+++ b/.changeset/eleven-turkeys-jump.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: decode non-latin characters when previewing prerendered pages

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -128,9 +128,9 @@ export async function preview(vite, vite_config, svelte_config) {
 
 				const { pathname, search } = new URL(/** @type {string} */ (req.url), 'http://dummy');
 
-				let filename = normalizePath(
+				let filename = decodeURI(normalizePath(
 					join(svelte_config.kit.outDir, 'output/prerendered/pages' + pathname)
-				);
+				));
 				let prerendered = is_file(filename);
 
 				if (!prerendered) {


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/12865

The issue only affected the preview server as we weren't decoding the URI before checking if the prerendered file existed or not.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
