### PR TITLE
fix: revert using server read for load function fetch

### DIFF
--- a/.changeset/eight-insects-live.md
+++ b/.changeset/eight-insects-live.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: revert reading assets directly when using the load function's fetch

--- a/.changeset/eight-insects-live.md
+++ b/.changeset/eight-insects-live.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: revert reading assets directly when using the load function's fetch
+fix: don't try reading assets directly that aren't present

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -1,6 +1,7 @@
 import * as set_cookie_parser from 'set-cookie-parser';
 import { respond } from './respond.js';
 import * as paths from '__sveltekit/paths';
+import { read_implementation } from '__sveltekit/server';
 
 /**
  * @param {{
@@ -95,6 +96,16 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 
 						return new Response(state.read(file), {
 							headers: type ? { 'content-type': type } : {}
+						});
+					} else if (read_implementation && file in manifest._.server_assets) {
+						const length = manifest._.server_assets[file];
+						const type = manifest.mimeTypes[file.slice(file.lastIndexOf('.'))];
+
+						return new Response(read_implementation(file), {
+							headers: {
+								'Content-Length': '' + length,
+								'Content-Type': type
+							}
 						});
 					}
 

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -1,7 +1,6 @@
 import * as set_cookie_parser from 'set-cookie-parser';
 import { respond } from './respond.js';
 import * as paths from '__sveltekit/paths';
-import { read_implementation } from '__sveltekit/server';
 
 /**
  * @param {{
@@ -96,16 +95,6 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 
 						return new Response(state.read(file), {
 							headers: type ? { 'content-type': type } : {}
-						});
-					} else if (read_implementation) {
-						const length = manifest._.server_assets[file];
-						const type = manifest.mimeTypes[file.slice(file.lastIndexOf('.'))];
-
-						return new Response(read_implementation(file), {
-							headers: {
-								'Content-Length': '' + length,
-								'Content-Type': type
-							}
 						});
 					}
 


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/12868

This PR reverts a part of the change from https://github.com/sveltejs/kit/pull/12113. The issue is caused by the `read` implementation trying to read the static asset from the server during a `fetch`, but it doesn't work since the static asset isn't packaged with the serverless function. I think having the distinction between `fetch` and `read` is good here.
https://github.com/sveltejs/kit/blob/dcbe4222a194c5f90cfc0fc020cf065f7a4e4c46/packages/kit/src/runtime/server/fetch.js#L100-L110

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
