### PR TITLE
fix: set no-op proxy config to get Vite HTTPS working

### DIFF
--- a/.changeset/unlucky-walls-drum.md
+++ b/.changeset/unlucky-walls-drum.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: strip HTTP/2 pseudo-headers and symbol request header keys to get Vite HTTPS working again

--- a/.changeset/unlucky-walls-drum.md
+++ b/.changeset/unlucky-walls-drum.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: set a no-op proxy config to force Vite to downgrade to TLS-only so that Vite HTTPS works
+fix: set a no-op proxy config so that Vite HTTPS works

--- a/.changeset/unlucky-walls-drum.md
+++ b/.changeset/unlucky-walls-drum.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: strip HTTP/2 pseudo-headers and symbol request header keys to get Vite HTTPS working again
+fix: set a no-op proxy config to force Vite to downgrade to TLS-only so that Vite HTTPS works

--- a/.changeset/unlucky-walls-drum.md
+++ b/.changeset/unlucky-walls-drum.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: set a no-op proxy config so that Vite HTTPS works
+fix: when using `@vitejs/plugin-basic-ssl`, set a no-op proxy config to downgrade from HTTP/2 to TLS since `undici` does not yet enable HTTP/2 by default

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -106,11 +106,21 @@ function get_raw_body(req, body_size_limit) {
 // TODO 3.0 make the signature synchronous?
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function getRequest({ request, base, bodySizeLimit }) {
+	const headers = /** @type {Record<string, string>} */ (
+		Object.fromEntries(
+			Object.entries(request.headers).filter(([key]) => {
+				// strip HTTP/2 pseudo-headers and symbol keys which the `Headers`
+				// implementation doesn't like
+				return key[0] !== ':' && typeof key !== 'symbol';
+			})
+		)
+	);
+
 	return new Request(base + request.url, {
 		// @ts-expect-error
 		duplex: 'half',
 		method: request.method,
-		headers: /** @type {Record<string, string>} */ (request.headers),
+		headers,
 		body:
 			request.method === 'GET' || request.method === 'HEAD'
 				? undefined

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -106,7 +106,7 @@ function get_raw_body(req, body_size_limit) {
 // TODO 3.0 make the signature synchronous?
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function getRequest({ request, base, bodySizeLimit }) {
-	// strip out symbol keys which Request doesn't like
+	// strip out symbol keys because the `Request` implementation doesn't like them
 	const headers = /** @type {Record<string, string>} */ (
 		Object.fromEntries(Object.entries(request.headers))
 	);

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -106,26 +106,11 @@ function get_raw_body(req, body_size_limit) {
 // TODO 3.0 make the signature synchronous?
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function getRequest({ request, base, bodySizeLimit }) {
-	// strip out symbol keys because the `Request` implementation doesn't like them
-	const headers = /** @type {Record<string, string>} */ (
-		Object.fromEntries(Object.entries(request.headers))
-	);
-
-	if (request.httpVersionMajor === 2) {
-		// strip out the HTTP/2 pseudo-headers because the `Headers`
-		// implementation doesn't like them
-		delete headers[':method'];
-		delete headers[':path'];
-		delete headers[':authority'];
-		delete headers[':scheme'];
-		delete headers[':status'];
-	}
-
 	return new Request(base + request.url, {
 		// @ts-expect-error
 		duplex: 'half',
 		method: request.method,
-		headers,
+		headers: /** @type {Record<string, string>} */ (request.headers),
 		body:
 			request.method === 'GET' || request.method === 'HEAD'
 				? undefined

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -106,15 +106,20 @@ function get_raw_body(req, body_size_limit) {
 // TODO 3.0 make the signature synchronous?
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function getRequest({ request, base, bodySizeLimit }) {
+	// strip out symbol keys which Request doesn't like
 	const headers = /** @type {Record<string, string>} */ (
-		Object.fromEntries(
-			Object.entries(request.headers).filter(([key]) => {
-				// strip HTTP/2 pseudo-headers and symbol keys which the `Headers`
-				// implementation doesn't like
-				return key[0] !== ':' && typeof key !== 'symbol';
-			})
-		)
+		Object.fromEntries(Object.entries(request.headers))
 	);
+
+	if (request.httpVersionMajor === 2) {
+		// strip out the HTTP/2 pseudo-headers because the `Headers`
+		// implementation doesn't like them
+		delete headers[':method'];
+		delete headers[':path'];
+		delete headers[':authority'];
+		delete headers[':scheme'];
+		delete headers[':status'];
+	}
 
 	return new Request(base + request.url, {
 		// @ts-expect-error

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -353,7 +353,7 @@ async function kit({ svelte_config }) {
 			const vite_basic_ssl = config.plugins.find(({ name }) => name === 'vite:basic-ssl');
 
 			// by default, when enabling HTTPS in Vite, it also enables HTTP/2
-			// however, undici's Headers implementation does not like the HTTP/2 headers
+			// however, undici has not yet enabled HTTP/2 by default: https://github.com/nodejs/undici/issues/2750
 			// we set a no-op proxy config to force Vite to downgrade to TLS-only
 			// see https://vitejs.dev/config/#server-https
 			if ((config.server.https || vite_basic_ssl) && !config.server.proxy) {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -348,6 +348,22 @@ async function kit({ svelte_config }) {
 		 * Stores the final config.
 		 */
 		configResolved(config) {
+			// we search for this plugin by name because we can't detect it
+			// since it doesn't directly modify the https config
+			const vite_basic_ssl = config.plugins.find(({ name }) => name === 'vite:basic-ssl');
+
+			// by default, when enabling HTTPS in Vite, it also enables HTTP/2
+			// however, undici's Request implementation does not like the HTTP/2 headers
+			// we set a no-op proxy config to force Vite to downgrade to TLS-only
+			// see https://vitejs.dev/config/#server-https
+			if ((config.server.https || vite_basic_ssl) && !config.server.proxy) {
+				config.server.proxy = {};
+			}
+
+			if ((config.preview.https || vite_basic_ssl) && !config.preview.proxy) {
+				config.preview.proxy = {};
+			}
+
 			vite_config = config;
 		}
 	};

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -349,7 +349,7 @@ async function kit({ svelte_config }) {
 		 */
 		configResolved(config) {
 			// we search for this plugin by name because we can't detect it
-			// since it doesn't directly modify the https config unlike mkcert
+			// since it doesn't directly modify the https config unlike the mkcert plugin
 			const vite_basic_ssl = config.plugins.find(({ name }) => name === 'vite:basic-ssl');
 
 			// by default, when enabling HTTPS in Vite, it also enables HTTP/2

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -353,7 +353,7 @@ async function kit({ svelte_config }) {
 			const vite_basic_ssl = config.plugins.find(({ name }) => name === 'vite:basic-ssl');
 
 			// by default, when enabling HTTPS in Vite, it also enables HTTP/2
-			// however, undici's Request implementation does not like the HTTP/2 headers
+			// however, undici's Headers implementation does not like the HTTP/2 headers
 			// we set a no-op proxy config to force Vite to downgrade to TLS-only
 			// see https://vitejs.dev/config/#server-https
 			if ((config.server.https || vite_basic_ssl) && !config.server.proxy) {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -349,7 +349,7 @@ async function kit({ svelte_config }) {
 		 */
 		configResolved(config) {
 			// we search for this plugin by name because we can't detect it
-			// since it doesn't directly modify the https config
+			// since it doesn't directly modify the https config unlike mkcert
 			const vite_basic_ssl = config.plugins.find(({ name }) => name === 'vite:basic-ssl');
 
 			// by default, when enabling HTTPS in Vite, it also enables HTTP/2


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/11365

cc: @Conduitry @benmccann 

This PR gets the Vite HTTPS working again by filtering out two types of keys from the incoming request headers object before we pass it to a new `Request` object. Doing so prevents the two errors we currently encounter as shown below.

1. When there's a symbol key in the request headers:

```sh
TypeError: Request constructor: init.headers is a symbol, which cannot be converted to a DOMString.
    at webidl.errors.exception (node:internal/deps/undici/undici:3384:14)
    at webidl.converters.DOMString (node:internal/deps/undici/undici:3650:29)
    at webidl.converters.ByteString (node:internal/deps/undici/undici:3658:35)
    at Object.record<ByteString, ByteString> (node:internal/deps/undici/undici:3567:30)
    at webidl.converters.HeadersInit (node:internal/deps/undici/undici:8715:67)
    at Object.RequestInit (node:internal/deps/undici/undici:3624:21)
    at new Request (node:internal/deps/undici/undici:9267:34)
    at getRequest (file:///home/chewteeming/my-app/node_modules/.pnpm/@sveltejs+kit@2.7.3_@sveltejs+vite-plugin-svelte@4.0.0_svelte@5.1.4_vite@5.4.10__svelte@5.1.4_vite@5.4.10/node_modules/@sveltejs/kit/src/exports/node/index.js:122:9)
    at file:///home/chewteeming/my-app/node_modules/.pnpm/@sveltejs+kit@2.7.3_@sveltejs+vite-plugin-svelte@4.0.0_svelte@5.1.4_vite@5.4.10__svelte@5.1.4_vite@5.4.10/node_modules/@sveltejs/kit/src/exports/vite/dev/index.js:497:27
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

2. When there's HTTP/2 pseudo-headers in the request headers (partially reimplements https://github.com/sveltejs/kit/pull/3572/files):

```sh
TypeError: Headers.append: ":method" is an invalid header name.
    at webidl.errors.exception (node:internal/deps/undici/undici:3384:14)
    at webidl.errors.invalidArgument (node:internal/deps/undici/undici:3395:28)
    at appendHeader (node:internal/deps/undici/undici:8339:29)
    at fill (node:internal/deps/undici/undici:8325:11)
    at new Request (node:internal/deps/undici/undici:9490:13)
    at getRequest (file:///home/chewteeming/my-app/node_modules/.pnpm/@sveltejs+kit@2.7.3_@sveltejs+vite-plugin-svelte@4.0.0_svelte@5.1.4_vite@5.4.10__svelte@5.1.4_vite@5.4.10/node_modules/@sveltejs/kit/src/exports/node/index.js:118:9)
    at file:///home/chewteeming/my-app/node_modules/.pnpm/@sveltejs+kit@2.7.3_@sveltejs+vite-plugin-svelte@4.0.0_svelte@5.1.4_vite@5.4.10__svelte@5.1.4_vite@5.4.10/node_modules/@sveltejs/kit/src/exports/vite/dev/index.js:497:27
```

Open to suggestions for a better way to do this.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
