### PR TITLE
fix(types): use arrow functions over bound funcs

### DIFF
--- a/.changeset/gentle-feet-kiss.md
+++ b/.changeset/gentle-feet-kiss.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix(types): use arrow functions instead of bound functions

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,7 +26,8 @@ export default [
 		rules: {
 			'@typescript-eslint/await-thenable': 'error',
 			'@typescript-eslint/no-unused-expressions': 'off',
-			'@typescript-eslint/require-await': 'error'
+			'@typescript-eslint/require-await': 'error',
+			'@typescript-eslint/unbound-method': 'error'
 		},
 		ignores: [
 			'packages/adapter-node/rollup.config.js',

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -34,7 +34,7 @@ export interface Adapter {
 	 * This function is called after SvelteKit has built your app.
 	 * @param builder An object provided by SvelteKit that contains methods for adapting the app
 	 */
-	adapt(builder: Builder): MaybePromise<void>;
+	adapt: (builder: Builder) => MaybePromise<void>;
 	/**
 	 * Checks called during dev and build to determine whether specific features will work in production with this adapter
 	 */
@@ -49,7 +49,7 @@ export interface Adapter {
 	 * Creates an `Emulator`, which allows the adapter to influence the environment
 	 * during dev, build and prerendering
 	 */
-	emulate?(): MaybePromise<Emulator>;
+	emulate?: () => MaybePromise<Emulator>;
 }
 
 export type LoadProperties<input extends Record<string, any> | void> = input extends void
@@ -685,7 +685,7 @@ export interface KitConfig {
  */
 export type Handle = (input: {
 	event: RequestEvent;
-	resolve(event: RequestEvent, opts?: ResolveOptions): MaybePromise<Response>;
+	resolve: (event: RequestEvent, opts?: ResolveOptions) => MaybePromise<Response>;
 }) => MaybePromise<Response>;
 
 /**
@@ -791,14 +791,14 @@ export interface LoadEvent<
 	 *
 	 * `setHeaders` has no effect when a `load` function runs in the browser.
 	 */
-	setHeaders(headers: Record<string, string>): void;
+	setHeaders: (headers: Record<string, string>) => void;
 	/**
 	 * `await parent()` returns data from parent `+layout.js` `load` functions.
 	 * Implicitly, a missing `+layout.js` is treated as a `({ data }) => data` function, meaning that it will return and forward data from parent `+layout.server.js` files.
 	 *
 	 * Be careful not to introduce accidental waterfalls when using `await parent()`. If for example you only want to merge parent data into the returned output, call it _after_ fetching your other data.
 	 */
-	parent(): Promise<ParentData>;
+	parent: () => Promise<ParentData>;
 	/**
 	 * This function declares that the `load` function has a _dependency_ on one or more URLs or custom identifiers, which can subsequently be used with [`invalidate()`](https://svelte.dev/docs/kit/$app-navigation#invalidate) to cause `load` to rerun.
 	 *
@@ -836,7 +836,7 @@ export interface LoadEvent<
 	 * <button on:click={increase}>Increase Count</button>
 	 * ```
 	 */
-	depends(...deps: Array<`${string}:${string}`>): void;
+	depends: (...deps: Array<`${string}:${string}`>) => void;
 	/**
 	 * Use this function to opt out of dependency tracking for everything that is synchronously called within the callback. Example:
 	 *
@@ -850,7 +850,7 @@ export interface LoadEvent<
 	 * }
 	 * ```
 	 */
-	untrack<T>(fn: () => T): T;
+	untrack: <T>(fn: () => T) => T;
 }
 
 export interface NavigationEvent<
@@ -1059,7 +1059,7 @@ export interface RequestEvent<
 	/**
 	 * The client's IP address, set by the adapter.
 	 */
-	getClientAddress(): string;
+	getClientAddress: () => string;
 	/**
 	 * Contains custom data that was added to the request within the [`server handle hook`](https://svelte.dev/docs/kit/hooks#Server-hooks-handle).
 	 */
@@ -1107,7 +1107,7 @@ export interface RequestEvent<
 	 *
 	 * You cannot add a `set-cookie` header with `setHeaders` — use the [`cookies`](https://svelte.dev/docs/kit/@sveltejs-kit#Cookies) API instead.
 	 */
-	setHeaders(headers: Record<string, string>): void;
+	setHeaders: (headers: Record<string, string>) => void;
 	/**
 	 * The requested URL.
 	 */
@@ -1140,20 +1140,20 @@ export interface ResolveOptions {
 	 * but they will always be split at sensible boundaries such as `%sveltekit.head%` or layout/page components.
 	 * @param input the html chunk and the info if this is the last chunk
 	 */
-	transformPageChunk?(input: { html: string; done: boolean }): MaybePromise<string | undefined>;
+	transformPageChunk?: (input: { html: string; done: boolean }) => MaybePromise<string | undefined>;
 	/**
 	 * Determines which headers should be included in serialized responses when a `load` function loads a resource with `fetch`.
 	 * By default, none will be included.
 	 * @param name header name
 	 * @param value header value
 	 */
-	filterSerializedResponseHeaders?(name: string, value: string): boolean;
+	filterSerializedResponseHeaders?: (name: string, value: string) => boolean;
 	/**
 	 * Determines what should be added to the `<head>` tag to preload it.
 	 * By default, `js` and `css` files will be preloaded.
 	 * @param input the type of the file and its path
 	 */
-	preload?(input: { type: 'font' | 'css' | 'js' | 'asset'; path: string }): boolean;
+	preload?: (input: { type: 'font' | 'css' | 'js' | 'asset'; path: string }) => boolean;
 }
 
 export interface RouteDefinition<Config = any> {
@@ -1222,7 +1222,7 @@ export interface ServerLoadEvent<
 	 *
 	 * Be careful not to introduce accidental waterfalls when using `await parent()`. If for example you only want to merge parent data into the returned output, call it _after_ fetching your other data.
 	 */
-	parent(): Promise<ParentData>;
+	parent: () => Promise<ParentData>;
 	/**
 	 * This function declares that the `load` function has a _dependency_ on one or more URLs or custom identifiers, which can subsequently be used with [`invalidate()`](https://svelte.dev/docs/kit/$app-navigation#invalidate) to cause `load` to rerun.
 	 *
@@ -1260,7 +1260,7 @@ export interface ServerLoadEvent<
 	 * <button on:click={increase}>Increase Count</button>
 	 * ```
 	 */
-	depends(...deps: string[]): void;
+	depends: (...deps: string[]) => void;
 	/**
 	 * Use this function to opt out of dependency tracking for everything that is synchronously called within the callback. Example:
 	 *
@@ -1274,7 +1274,7 @@ export interface ServerLoadEvent<
 	 * }
 	 * ```
 	 */
-	untrack<T>(fn: () => T): T;
+	untrack: <T>(fn: () => T) => T;
 }
 
 /**
@@ -1345,7 +1345,7 @@ export type SubmitFunction<
 	formElement: HTMLFormElement;
 	controller: AbortController;
 	submitter: HTMLElement | null;
-	cancel(): void;
+	cancel: () => void;
 }) => MaybePromise<
 	| void
 	| ((opts: {
@@ -1358,7 +1358,7 @@ export type SubmitFunction<
 			 * @param options Set `reset: false` if you don't want the `<form>` values to be reset after a successful submission.
 			 * @param invalidateAll Set `invalidateAll: false` if you don't want the action to call `invalidateAll` after submission.
 			 */
-			update(options?: { reset?: boolean; invalidateAll?: boolean }): Promise<void>;
+			update: (options?: { reset?: boolean; invalidateAll?: boolean }) => Promise<void>;
 	  }) => void)
 >;
 

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -384,6 +384,7 @@ export async function dev(vite, vite_config, svelte_config) {
 		});
 	}
 	align_exports();
+	// eslint-disable-next-line @typescript-eslint/unbound-method -- We'll pass `this` back to it later
 	const ws_send = vite.ws.send;
 	/** @param {any} args */
 	vite.ws.send = function (...args) {

--- a/packages/kit/src/runtime/app/stores.js
+++ b/packages/kit/src/runtime/app/stores.js
@@ -56,7 +56,7 @@ export const navigating = {
  * A readable store whose initial value is `false`. If [`version.pollInterval`](https://svelte.dev/docs/kit/configuration#version) is a non-zero value, SvelteKit will poll for new versions of the app and update the store value to `true` when it detects one. `updated.check()` will force an immediate check, regardless of polling.
  *
  * On the server, this store can only be subscribed to during component initialization. In the browser, it can be subscribed to at any time.
- * @type {import('svelte/store').Readable<boolean> & { check(): Promise<boolean> }}
+ * @type {import('svelte/store').Readable<boolean> & { check: () => Promise<boolean> }}
  */
 export const updated = {
 	subscribe(fn) {

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -88,12 +88,14 @@ if (DEV && BROWSER) {
 		);
 	};
 
+	// eslint-disable-next-line @typescript-eslint/unbound-method -- We'll pass `history` as `this`
 	const push_state = history.pushState;
 	history.pushState = (...args) => {
 		warn();
 		return push_state.apply(history, args);
 	};
 
+	// eslint-disable-next-line @typescript-eslint/unbound-method -- We'll pass `history` as `this`
 	const replace_state = history.replaceState;
 	history.replaceState = (...args) => {
 		warn();
@@ -1374,6 +1376,7 @@ async function navigate({
 			[STATES_KEY]: state
 		};
 
+		// eslint-disable-next-line @typescript-eslint/unbound-method -- We'll pass `history` as `this`
 		const fn = replace_state ? history.replaceState : history.pushState;
 		fn.call(history, entry, '', url);
 

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -64,6 +64,7 @@ export function get_cookies(request, url, trailing_slash) {
 				return c.value;
 			}
 
+			// eslint-disable-next-line @typescript-eslint/unbound-method -- Fixed in `cookie@1.0.0`'s types
 			const decoder = opts?.decode || decodeURIComponent;
 			const req_cookies = parse(header, { decode: decoder });
 			const cookie = req_cookies[name]; // the decoded string or undefined
@@ -92,6 +93,7 @@ export function get_cookies(request, url, trailing_slash) {
 		 * @param {import('cookie').CookieParseOptions} opts
 		 */
 		getAll(opts) {
+			// eslint-disable-next-line @typescript-eslint/unbound-method -- Fixed in `cookie@1.0.0`'s types
 			const decoder = opts?.decode || decodeURIComponent;
 			const cookies = parse(header, { decode: decoder });
 
@@ -161,6 +163,7 @@ export function get_cookies(request, url, trailing_slash) {
 			if (!domain_matches(destination.hostname, cookie.options.domain)) continue;
 			if (!path_matches(destination.pathname, cookie.options.path)) continue;
 
+			// eslint-disable-next-line @typescript-eslint/unbound-method -- Fixed in `cookie@1.0.0`'s types
 			const encoder = cookie.options.encode || encodeURIComponent;
 			combined_cookies[cookie.name] = encoder(cookie.value);
 		}

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -340,6 +340,7 @@ export function create_universal_fetch(event, state, fetched, csr, resolve_opts)
 
 		if (csr) {
 			// ensure that excluded headers can't be read
+			// eslint-disable-next-line @typescript-eslint/unbound-method -- We'll pass `response.headers` as `this`
 			const get = response.headers.get;
 			response.headers.get = (key) => {
 				const lower = key.toLowerCase();

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -32,16 +32,16 @@ export interface ServerModule {
 }
 
 export interface ServerInternalModule {
-	set_assets(path: string): void;
-	set_building(): void;
-	set_manifest(manifest: SSRManifest): void;
-	set_prerendering(): void;
-	set_private_env(environment: Record<string, string>): void;
-	set_public_env(environment: Record<string, string>): void;
-	set_read_implementation(implementation: (path: string) => ReadableStream): void;
-	set_safe_public_env(environment: Record<string, string>): void;
-	set_version(version: string): void;
-	set_fix_stack_trace(fix_stack_trace: (error: unknown) => string): void;
+	set_assets: (path: string) => void;
+	set_building: () => void;
+	set_manifest: (manifest: SSRManifest) => void;
+	set_prerendering: () => void;
+	set_private_env: (environment: Record<string, string>) => void;
+	set_public_env: (environment: Record<string, string>) => void;
+	set_read_implementation: (implementation: (path: string) => ReadableStream) => void;
+	set_safe_public_env: (environment: Record<string, string>) => void;
+	set_version: (version: string) => void;
+	set_fix_stack_trace: (fix_stack_trace: (error: unknown) => string) => void;
 }
 
 export interface Asset {
@@ -404,7 +404,7 @@ export interface SSRRoute {
 
 export interface SSRState {
 	fallback?: string;
-	getClientAddress(): string;
+	getClientAddress: () => string;
 	/**
 	 * True if we're currently attempting to render an error page
 	 */

--- a/packages/kit/src/types/private.d.ts
+++ b/packages/kit/src/types/private.d.ts
@@ -20,13 +20,15 @@ export interface AdapterEntry {
 	 * - Fallback pages: `/foo/[c]` is a fallback for `/foo/a-[b]`, and `/[...catchall]` is a fallback for all routes
 	 * - Grouping routes that share a common `config`: `/foo` should be deployed to the edge, `/bar` and `/baz` should be deployed to a serverless function
 	 */
-	filter(route: RouteDefinition): boolean;
+	filter: (route: RouteDefinition) => boolean;
 
 	/**
 	 * A function that is invoked once the entry has been created. This is where you
 	 * should write the function to the filesystem and generate redirect manifests.
 	 */
-	complete(entry: { generateManifest(opts: { relativePath: string }): string }): MaybePromise<void>;
+	complete: (entry: {
+		generateManifest(opts: { relativePath: string }): string;
+	}) => MaybePromise<void>;
 }
 
 // Based on https://github.com/josh-hemphill/csp-typed-directives/blob/latest/src/csp.types.ts

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -16,7 +16,7 @@ declare module '@sveltejs/kit' {
 		 * This function is called after SvelteKit has built your app.
 		 * @param builder An object provided by SvelteKit that contains methods for adapting the app
 		 */
-		adapt(builder: Builder): MaybePromise<void>;
+		adapt: (builder: Builder) => MaybePromise<void>;
 		/**
 		 * Checks called during dev and build to determine whether specific features will work in production with this adapter
 		 */
@@ -31,7 +31,7 @@ declare module '@sveltejs/kit' {
 		 * Creates an `Emulator`, which allows the adapter to influence the environment
 		 * during dev, build and prerendering
 		 */
-		emulate?(): MaybePromise<Emulator>;
+		emulate?: () => MaybePromise<Emulator>;
 	}
 
 	export type LoadProperties<input extends Record<string, any> | void> = input extends void
@@ -667,7 +667,7 @@ declare module '@sveltejs/kit' {
 	 */
 	export type Handle = (input: {
 		event: RequestEvent;
-		resolve(event: RequestEvent, opts?: ResolveOptions): MaybePromise<Response>;
+		resolve: (event: RequestEvent, opts?: ResolveOptions) => MaybePromise<Response>;
 	}) => MaybePromise<Response>;
 
 	/**
@@ -773,14 +773,14 @@ declare module '@sveltejs/kit' {
 		 *
 		 * `setHeaders` has no effect when a `load` function runs in the browser.
 		 */
-		setHeaders(headers: Record<string, string>): void;
+		setHeaders: (headers: Record<string, string>) => void;
 		/**
 		 * `await parent()` returns data from parent `+layout.js` `load` functions.
 		 * Implicitly, a missing `+layout.js` is treated as a `({ data }) => data` function, meaning that it will return and forward data from parent `+layout.server.js` files.
 		 *
 		 * Be careful not to introduce accidental waterfalls when using `await parent()`. If for example you only want to merge parent data into the returned output, call it _after_ fetching your other data.
 		 */
-		parent(): Promise<ParentData>;
+		parent: () => Promise<ParentData>;
 		/**
 		 * This function declares that the `load` function has a _dependency_ on one or more URLs or custom identifiers, which can subsequently be used with [`invalidate()`](https://svelte.dev/docs/kit/$app-navigation#invalidate) to cause `load` to rerun.
 		 *
@@ -818,7 +818,7 @@ declare module '@sveltejs/kit' {
 		 * <button on:click={increase}>Increase Count</button>
 		 * ```
 		 */
-		depends(...deps: Array<`${string}:${string}`>): void;
+		depends: (...deps: Array<`${string}:${string}`>) => void;
 		/**
 		 * Use this function to opt out of dependency tracking for everything that is synchronously called within the callback. Example:
 		 *
@@ -832,7 +832,7 @@ declare module '@sveltejs/kit' {
 		 * }
 		 * ```
 		 */
-		untrack<T>(fn: () => T): T;
+		untrack: <T>(fn: () => T) => T;
 	}
 
 	export interface NavigationEvent<
@@ -1041,7 +1041,7 @@ declare module '@sveltejs/kit' {
 		/**
 		 * The client's IP address, set by the adapter.
 		 */
-		getClientAddress(): string;
+		getClientAddress: () => string;
 		/**
 		 * Contains custom data that was added to the request within the [`server handle hook`](https://svelte.dev/docs/kit/hooks#Server-hooks-handle).
 		 */
@@ -1089,7 +1089,7 @@ declare module '@sveltejs/kit' {
 		 *
 		 * You cannot add a `set-cookie` header with `setHeaders` — use the [`cookies`](https://svelte.dev/docs/kit/@sveltejs-kit#Cookies) API instead.
 		 */
-		setHeaders(headers: Record<string, string>): void;
+		setHeaders: (headers: Record<string, string>) => void;
 		/**
 		 * The requested URL.
 		 */
@@ -1122,20 +1122,20 @@ declare module '@sveltejs/kit' {
 		 * but they will always be split at sensible boundaries such as `%sveltekit.head%` or layout/page components.
 		 * @param input the html chunk and the info if this is the last chunk
 		 */
-		transformPageChunk?(input: { html: string; done: boolean }): MaybePromise<string | undefined>;
+		transformPageChunk?: (input: { html: string; done: boolean }) => MaybePromise<string | undefined>;
 		/**
 		 * Determines which headers should be included in serialized responses when a `load` function loads a resource with `fetch`.
 		 * By default, none will be included.
 		 * @param name header name
 		 * @param value header value
 		 */
-		filterSerializedResponseHeaders?(name: string, value: string): boolean;
+		filterSerializedResponseHeaders?: (name: string, value: string) => boolean;
 		/**
 		 * Determines what should be added to the `<head>` tag to preload it.
 		 * By default, `js` and `css` files will be preloaded.
 		 * @param input the type of the file and its path
 		 */
-		preload?(input: { type: 'font' | 'css' | 'js' | 'asset'; path: string }): boolean;
+		preload?: (input: { type: 'font' | 'css' | 'js' | 'asset'; path: string }) => boolean;
 	}
 
 	export interface RouteDefinition<Config = any> {
@@ -1204,7 +1204,7 @@ declare module '@sveltejs/kit' {
 		 *
 		 * Be careful not to introduce accidental waterfalls when using `await parent()`. If for example you only want to merge parent data into the returned output, call it _after_ fetching your other data.
 		 */
-		parent(): Promise<ParentData>;
+		parent: () => Promise<ParentData>;
 		/**
 		 * This function declares that the `load` function has a _dependency_ on one or more URLs or custom identifiers, which can subsequently be used with [`invalidate()`](https://svelte.dev/docs/kit/$app-navigation#invalidate) to cause `load` to rerun.
 		 *
@@ -1242,7 +1242,7 @@ declare module '@sveltejs/kit' {
 		 * <button on:click={increase}>Increase Count</button>
 		 * ```
 		 */
-		depends(...deps: string[]): void;
+		depends: (...deps: string[]) => void;
 		/**
 		 * Use this function to opt out of dependency tracking for everything that is synchronously called within the callback. Example:
 		 *
@@ -1256,7 +1256,7 @@ declare module '@sveltejs/kit' {
 		 * }
 		 * ```
 		 */
-		untrack<T>(fn: () => T): T;
+		untrack: <T>(fn: () => T) => T;
 	}
 
 	/**
@@ -1327,7 +1327,7 @@ declare module '@sveltejs/kit' {
 		formElement: HTMLFormElement;
 		controller: AbortController;
 		submitter: HTMLElement | null;
-		cancel(): void;
+		cancel: () => void;
 	}) => MaybePromise<
 		| void
 		| ((opts: {
@@ -1340,7 +1340,7 @@ declare module '@sveltejs/kit' {
 				 * @param options Set `reset: false` if you don't want the `<form>` values to be reset after a successful submission.
 				 * @param invalidateAll Set `invalidateAll: false` if you don't want the action to call `invalidateAll` after submission.
 				 */
-				update(options?: { reset?: boolean; invalidateAll?: boolean }): Promise<void>;
+				update: (options?: { reset?: boolean; invalidateAll?: boolean }) => Promise<void>;
 		  }) => void)
 	>;
 
@@ -1367,13 +1367,15 @@ declare module '@sveltejs/kit' {
 		 * - Fallback pages: `/foo/[c]` is a fallback for `/foo/a-[b]`, and `/[...catchall]` is a fallback for all routes
 		 * - Grouping routes that share a common `config`: `/foo` should be deployed to the edge, `/bar` and `/baz` should be deployed to a serverless function
 		 */
-		filter(route: RouteDefinition): boolean;
+		filter: (route: RouteDefinition) => boolean;
 
 		/**
 		 * A function that is invoked once the entry has been created. This is where you
 		 * should write the function to the filesystem and generate redirect manifests.
 		 */
-		complete(entry: { generateManifest(opts: { relativePath: string }): string }): MaybePromise<void>;
+		complete: (entry: {
+			generateManifest(opts: { relativePath: string }): string;
+		}) => MaybePromise<void>;
 	}
 
 	// Based on https://github.com/josh-hemphill/csp-typed-directives/blob/latest/src/csp.types.ts
@@ -2235,7 +2237,7 @@ declare module '$app/stores' {
 	 * On the server, this store can only be subscribed to during component initialization. In the browser, it can be subscribed to at any time.
 	 * */
 	export const updated: import('svelte/store').Readable<boolean> & {
-		check(): Promise<boolean>;
+		check: () => Promise<boolean>;
 	};
 
 	export {};

--- a/packages/package/src/typescript.js
+++ b/packages/package/src/typescript.js
@@ -132,7 +132,9 @@ function load_tsconfig(tsconfig, filename, ts) {
 		throw new Error('Failed to locate tsconfig or jsconfig');
 	}
 
-	const { error, config } = ts.readConfigFile(config_filename, ts.sys.readFile);
+	const { error, config } = ts.readConfigFile(config_filename, (...args) =>
+		ts.sys.readFile(...args)
+	);
 
 	if (error) {
 		throw new Error('Malformed tsconfig\n' + JSON.stringify(error, null, 2));

--- a/packages/package/src/validate.js
+++ b/packages/package/src/validate.js
@@ -14,10 +14,10 @@ export function create_validator(options) {
 		 * @param {string} name
 		 * @param {string} content
 		 */
-		analyse_code(name, content) {
+		analyse_code: (name, content) => {
 			analyse_code(name, content);
 		},
-		validate() {
+		validate: () => {
 			/** @type {Record<string, any>} */
 			const pkg = JSON.parse(readFileSync(join(options.cwd, 'package.json'), 'utf-8'));
 			const warnings = validate(pkg);


### PR DESCRIPTION
Enable the [ESLint `@typescript-eslint/unbound-method-error` rule][1] and fix/ignore all the errors it throws at us.

Basically, this rule warns us from unbinding a function (e.g. doing `const {x} = {x() { /* etc */}}` that doesn't explicitly have `this: void`.

I've replaced these types with arrow functions when possible, to avoid users of the SvelteKit library from facing the same ESLint issues.

There are some instances where ESLint throws an error when we are purposely doing this (e.g. we'd later call `func.apply(originalThis,` or `func.call(originalThis,`, but since they're rare, I've just added ``// eslint-disable-next-line @typescript-eslint/unbound-method -- We'll pass `xxxxx` as `this` `` comments there to ignore the error.

https://github.com/sveltejs/kit/blob/b84e4dc8117b6ce90c6ee8eeb3f3e08151a251b6/packages/kit/src/runtime/client/client.js#L91-L95

I've also manually fixed some types in `packages/kit/src/exports/public.d.ts` that weren't caught by the `@typescript-eslint/unbound-method-error` rule, since they're only destructured in `packages/kit/test/apps`, which is ignored by our ESLint config. However, this manual change should fix https://github.com/sveltejs/kit/issues/12622.

[1]: https://typescript-eslint.io/rules/unbound-method/


<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
  - Fixes https://github.com/sveltejs/kit/issues/12622 for me, but since the `@typescript-eslint/*` rules ignore `packages/kit/test/apps/**`, it's possible that I've missed some issues. 
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
  - ESLint fails before most of these changes.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
  - The changes in the `packages/package` should be internal only, so we don't need to make a changeset for it.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
