### PR TITLE
chore: add sync request workflow

### DIFF
--- a/.github/workflows/sync-request.yml
+++ b/.github/workflows/sync-request.yml
@@ -1,0 +1,21 @@
+name: Sync request
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.SYNC_REQUEST_TOKEN }}
+          repository: sveltejs/svelte.dev
+          event-type: sync-request
+          client-payload: |-
+            {
+              "package": "kit"
+            }


### PR DESCRIPTION
this means that merges to `main` will trigger docs PRs on svelte.dev