### PR TITLE
fix: fix `popState` race-condition when not using SSR

### DIFF
--- a/.changeset/angry-months-speak.md
+++ b/.changeset/angry-months-speak.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: fix race-condition when not using SSR when pressing back before initial load

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2231,7 +2231,7 @@ function _start_router() {
 			const state = event.state[STATES_KEY] ?? {};
 			const url = new URL(event.state[PAGE_URL_KEY] ?? location.href);
 			const navigation_index = event.state[NAVIGATION_INDEX];
-			const is_hash_change = strip_hash(location) === strip_hash(current.url);
+			const is_hash_change = current.url ? strip_hash(location) === strip_hash(current.url) : false;
 			const shallow =
 				navigation_index === current_navigation_index && (has_navigated || is_hash_change);
 


### PR DESCRIPTION
When loading a non-SSR page and pressing the browser's back button while the page is still loading, it's possible for `current.url` to still be the default value of `null`, which then causes the `popState` function to throw the following uncaught error:

```
Uncaught (in promise) TypeError: Cannot destructure property 'href' of 'object null' as it is null.
    at strip_hash (url.js?v=3a24e001:84:30)
    at client.js?v=3a24e001:2227:52
```

This is from
https://github.com/sveltejs/kit/blob/e41a8e24b71cb9e9ee249ddfe732a3d0721d40bf/packages/kit/src/runtime/client/client.js#L2234

See #12924 for a reproduction/example videos.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
  - Fixes #12924
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
  - I'm struggling to write an E2E test for this, so I might skip this if that's okay.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
