### PR TITLE
fix: fix nested images in enhanced-img

### DIFF
--- a/.changeset/stale-moons-walk.md
+++ b/.changeset/stale-moons-walk.md
@@ -2,4 +2,4 @@
 '@sveltejs/enhanced-img': patch
 ---
 
-fix: Fix nested <enhanced:img /> elements
+fix: correctly handle `<enhanced:img />` elements nested in other DOM elements

--- a/.changeset/stale-moons-walk.md
+++ b/.changeset/stale-moons-walk.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/enhanced-img': patch
+---
+
+Fix nested <enhanced:img /> elements

--- a/.changeset/stale-moons-walk.md
+++ b/.changeset/stale-moons-walk.md
@@ -2,4 +2,4 @@
 '@sveltejs/enhanced-img': patch
 ---
 
-Fix nested <enhanced:img /> elements
+fix: Fix nested <enhanced:img /> elements

--- a/packages/enhanced-img/src/preprocessor.js
+++ b/packages/enhanced-img/src/preprocessor.js
@@ -131,7 +131,6 @@ export function image(opts) {
 			 * @type {Array<ReturnType<typeof update_element>>}
 			 */
 			const pending_ast_updates = [];
-			// TODO: switch to zimmerframe with Svelte 5
 
 			walk(
 				/** @type {import('svelte/compiler').AST.Root} */ (ast),
@@ -142,7 +141,7 @@ export function image(opts) {
 					},
 					/** @param {import('svelte/compiler').AST.RegularElement} node */
 					// @ts-ignore
-					RegularElement(node) {
+					RegularElement(node, { next }) {
 						if ('name' in node && node.name === 'enhanced:img') {
 							// Compare node tag match
 							const src = get_attr_value(node, 'src');
@@ -150,7 +149,11 @@ export function image(opts) {
 							if (!src || typeof src === 'boolean') return;
 
 							pending_ast_updates.push(update_element(node, src));
+
+							return;
 						}
+
+						next();
 					}
 				}
 			);

--- a/packages/enhanced-img/test/Input.svelte
+++ b/packages/enhanced-img/test/Input.svelte
@@ -15,6 +15,10 @@
 
 <enhanced:img src="./dev.png" alt="dev test" />
 
+<div>
+	<enhanced:img src="./dev.png" alt="nested test" />
+</div>
+
 <enhanced:img src="./prod.png" alt="production test" />
 
 <enhanced:img src="./dev.png" width="5" height="10" alt="dimensions test" />

--- a/packages/enhanced-img/test/Output.svelte
+++ b/packages/enhanced-img/test/Output.svelte
@@ -24,6 +24,10 @@
 
 <picture><source srcset="/1 1440w, /2 960w" type="image/avif" /><source srcset="/3 1440w, /4 960w" type="image/webp" /><source srcset="5 1440w, /6 960w" type="image/png" /><img src="/7" alt="dev test" width=1440 height=1440 /></picture>
 
+<div>
+	<picture><source srcset="/1 1440w, /2 960w" type="image/avif" /><source srcset="/3 1440w, /4 960w" type="image/webp" /><source srcset="5 1440w, /6 960w" type="image/png" /><img src="/7" alt="nested test" width=1440 height=1440 /></picture>
+</div>
+
 <picture><source srcset={__DECLARED_ASSET_0__} type="image/avif" /><source srcset={__DECLARED_ASSET_1__} type="image/webp" /><source srcset={__DECLARED_ASSET_2__} type="image/png" /><img src={__DECLARED_ASSET_3__} alt="production test" width=1440 height=1440 /></picture>
 
 <picture><source srcset="/1 1440w, /2 960w" type="image/avif" /><source srcset="/3 1440w, /4 960w" type="image/webp" /><source srcset="5 1440w, /6 960w" type="image/png" /><img src="/7" width="5" height="10" alt="dimensions test" /></picture>


### PR DESCRIPTION
New enhanced-img update does not traverse into RegularElement AST nodes, completely breaking all `<enhanced:img />` elements not at the top level. This fixes that.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
