### PR TITLE
fix: use arrow function types over bound functions

### DIFF
--- a/.changeset/wet-dancers-kneel.md
+++ b/.changeset/wet-dancers-kneel.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: use arrow function types over bound funcs

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -34,7 +34,7 @@ export interface Adapter {
 	 * This function is called after SvelteKit has built your app.
 	 * @param builder An object provided by SvelteKit that contains methods for adapting the app
 	 */
-	adapt(builder: Builder): MaybePromise<void>;
+	adapt: (builder: Builder) => MaybePromise<void>;
 	/**
 	 * Checks called during dev and build to determine whether specific features will work in production with this adapter
 	 */
@@ -49,7 +49,7 @@ export interface Adapter {
 	 * Creates an `Emulator`, which allows the adapter to influence the environment
 	 * during dev, build and prerendering
 	 */
-	emulate?(): MaybePromise<Emulator>;
+	emulate?: () => MaybePromise<Emulator>;
 }
 
 export type LoadProperties<input extends Record<string, any> | void> = input extends void
@@ -685,7 +685,7 @@ export interface KitConfig {
  */
 export type Handle = (input: {
 	event: RequestEvent;
-	resolve(event: RequestEvent, opts?: ResolveOptions): MaybePromise<Response>;
+	resolve: (event: RequestEvent, opts?: ResolveOptions) => MaybePromise<Response>;
 }) => MaybePromise<Response>;
 
 /**
@@ -791,14 +791,14 @@ export interface LoadEvent<
 	 *
 	 * `setHeaders` has no effect when a `load` function runs in the browser.
 	 */
-	setHeaders(headers: Record<string, string>): void;
+	setHeaders: (headers: Record<string, string>) => void;
 	/**
 	 * `await parent()` returns data from parent `+layout.js` `load` functions.
 	 * Implicitly, a missing `+layout.js` is treated as a `({ data }) => data` function, meaning that it will return and forward data from parent `+layout.server.js` files.
 	 *
 	 * Be careful not to introduce accidental waterfalls when using `await parent()`. If for example you only want to merge parent data into the returned output, call it _after_ fetching your other data.
 	 */
-	parent(): Promise<ParentData>;
+	parent: () => Promise<ParentData>;
 	/**
 	 * This function declares that the `load` function has a _dependency_ on one or more URLs or custom identifiers, which can subsequently be used with [`invalidate()`](https://svelte.dev/docs/kit/$app-navigation#invalidate) to cause `load` to rerun.
 	 *
@@ -836,7 +836,7 @@ export interface LoadEvent<
 	 * <button on:click={increase}>Increase Count</button>
 	 * ```
 	 */
-	depends(...deps: Array<`${string}:${string}`>): void;
+	depends: (...deps: Array<`${string}:${string}`>) => void;
 	/**
 	 * Use this function to opt out of dependency tracking for everything that is synchronously called within the callback. Example:
 	 *
@@ -850,7 +850,7 @@ export interface LoadEvent<
 	 * }
 	 * ```
 	 */
-	untrack<T>(fn: () => T): T;
+	untrack: <T>(fn: () => T) => T;
 }
 
 export interface NavigationEvent<
@@ -1059,7 +1059,7 @@ export interface RequestEvent<
 	/**
 	 * The client's IP address, set by the adapter.
 	 */
-	getClientAddress(): string;
+	getClientAddress: () => string;
 	/**
 	 * Contains custom data that was added to the request within the [`server handle hook`](https://svelte.dev/docs/kit/hooks#Server-hooks-handle).
 	 */
@@ -1107,7 +1107,7 @@ export interface RequestEvent<
 	 *
 	 * You cannot add a `set-cookie` header with `setHeaders` — use the [`cookies`](https://svelte.dev/docs/kit/@sveltejs-kit#Cookies) API instead.
 	 */
-	setHeaders(headers: Record<string, string>): void;
+	setHeaders: (headers: Record<string, string>) => void;
 	/**
 	 * The requested URL.
 	 */
@@ -1140,20 +1140,20 @@ export interface ResolveOptions {
 	 * but they will always be split at sensible boundaries such as `%sveltekit.head%` or layout/page components.
 	 * @param input the html chunk and the info if this is the last chunk
 	 */
-	transformPageChunk?(input: { html: string; done: boolean }): MaybePromise<string | undefined>;
+	transformPageChunk?: (input: { html: string; done: boolean }) => MaybePromise<string | undefined>;
 	/**
 	 * Determines which headers should be included in serialized responses when a `load` function loads a resource with `fetch`.
 	 * By default, none will be included.
 	 * @param name header name
 	 * @param value header value
 	 */
-	filterSerializedResponseHeaders?(name: string, value: string): boolean;
+	filterSerializedResponseHeaders?: (name: string, value: string) => boolean;
 	/**
 	 * Determines what should be added to the `<head>` tag to preload it.
 	 * By default, `js` and `css` files will be preloaded.
 	 * @param input the type of the file and its path
 	 */
-	preload?(input: { type: 'font' | 'css' | 'js' | 'asset'; path: string }): boolean;
+	preload?: (input: { type: 'font' | 'css' | 'js' | 'asset'; path: string }) => boolean;
 }
 
 export interface RouteDefinition<Config = any> {
@@ -1222,7 +1222,7 @@ export interface ServerLoadEvent<
 	 *
 	 * Be careful not to introduce accidental waterfalls when using `await parent()`. If for example you only want to merge parent data into the returned output, call it _after_ fetching your other data.
 	 */
-	parent(): Promise<ParentData>;
+	parent: () => Promise<ParentData>;
 	/**
 	 * This function declares that the `load` function has a _dependency_ on one or more URLs or custom identifiers, which can subsequently be used with [`invalidate()`](https://svelte.dev/docs/kit/$app-navigation#invalidate) to cause `load` to rerun.
 	 *
@@ -1260,7 +1260,7 @@ export interface ServerLoadEvent<
 	 * <button on:click={increase}>Increase Count</button>
 	 * ```
 	 */
-	depends(...deps: string[]): void;
+	depends: (...deps: string[]) => void;
 	/**
 	 * Use this function to opt out of dependency tracking for everything that is synchronously called within the callback. Example:
 	 *
@@ -1274,7 +1274,7 @@ export interface ServerLoadEvent<
 	 * }
 	 * ```
 	 */
-	untrack<T>(fn: () => T): T;
+	untrack: <T>(fn: () => T) => T;
 }
 
 /**
@@ -1345,7 +1345,7 @@ export type SubmitFunction<
 	formElement: HTMLFormElement;
 	controller: AbortController;
 	submitter: HTMLElement | null;
-	cancel(): void;
+	cancel: () => void;
 }) => MaybePromise<
 	| void
 	| ((opts: {
@@ -1358,7 +1358,7 @@ export type SubmitFunction<
 			 * @param options Set `reset: false` if you don't want the `<form>` values to be reset after a successful submission.
 			 * @param invalidateAll Set `invalidateAll: false` if you don't want the action to call `invalidateAll` after submission.
 			 */
-			update(options?: { reset?: boolean; invalidateAll?: boolean }): Promise<void>;
+			update: (options?: { reset?: boolean; invalidateAll?: boolean }) => Promise<void>;
 	  }) => void)
 >;
 

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -93,9 +93,9 @@ export interface Builder {
 	/** Print messages to the console. `log.info` and `log.minor` are silent unless Vite's `logLevel` is `info`. */
 	log: Logger;
 	/** Remove `dir` and all its contents. */
-	rimraf(dir: string): void;
+	rimraf: (dir: string) => void;
 	/** Create `dir` and any required parent directories. */
-	mkdirp(dir: string): void;
+	mkdirp: (dir: string) => void;
 
 	/** The fully resolved `svelte.config.js`. */
 	config: ValidatedConfig;
@@ -110,59 +110,59 @@ export interface Builder {
 	 * @param fn A function that groups a set of routes into an entry point
 	 * @deprecated Use `builder.routes` instead
 	 */
-	createEntries(fn: (route: RouteDefinition) => AdapterEntry): Promise<void>;
+	createEntries: (fn: (route: RouteDefinition) => AdapterEntry) => Promise<void>;
 
 	/**
 	 * Find all the assets imported by server files belonging to `routes`
 	 */
-	findServerAssets(routes: RouteDefinition[]): string[];
+	findServerAssets: (routes: RouteDefinition[]) => string[];
 
 	/**
 	 * Generate a fallback page for a static webserver to use when no route is matched. Useful for single-page apps.
 	 */
-	generateFallback(dest: string): Promise<void>;
+	generateFallback: (dest: string) => Promise<void>;
 
 	/**
 	 * Generate a module exposing build-time environment variables as `$env/dynamic/public`.
 	 */
-	generateEnvModule(): void;
+	generateEnvModule: () => void;
 
 	/**
 	 * Generate a server-side manifest to initialise the SvelteKit [server](https://svelte.dev/docs/kit/@sveltejs-kit#Server) with.
 	 * @param opts a relative path to the base directory of the app and optionally in which format (esm or cjs) the manifest should be generated
 	 */
-	generateManifest(opts: { relativePath: string; routes?: RouteDefinition[] }): string;
+	generateManifest: (opts: { relativePath: string; routes?: RouteDefinition[] }) => string;
 
 	/**
 	 * Resolve a path to the `name` directory inside `outDir`, e.g. `/path/to/.svelte-kit/my-adapter`.
 	 * @param name path to the file, relative to the build directory
 	 */
-	getBuildDirectory(name: string): string;
+	getBuildDirectory: (name: string) => string;
 	/** Get the fully resolved path to the directory containing client-side assets, including the contents of your `static` directory. */
-	getClientDirectory(): string;
+	getClientDirectory: () => string;
 	/** Get the fully resolved path to the directory containing server-side code. */
-	getServerDirectory(): string;
+	getServerDirectory: () => string;
 	/** Get the application path including any configured `base` path, e.g. `my-base-path/_app`. */
-	getAppPath(): string;
+	getAppPath: () => string;
 
 	/**
 	 * Write client assets to `dest`.
 	 * @param dest the destination folder
 	 * @returns an array of files written to `dest`
 	 */
-	writeClient(dest: string): string[];
+	writeClient: (dest: string) => string[];
 	/**
 	 * Write prerendered files to `dest`.
 	 * @param dest the destination folder
 	 * @returns an array of files written to `dest`
 	 */
-	writePrerendered(dest: string): string[];
+	writePrerendered: (dest: string) => string[];
 	/**
 	 * Write server-side code to `dest`.
 	 * @param dest the destination folder
 	 * @returns an array of files written to `dest`
 	 */
-	writeServer(dest: string): string[];
+	writeServer: (dest: string) => string[];
 	/**
 	 * Copy a file or directory.
 	 * @param from the source file or directory
@@ -171,20 +171,20 @@ export interface Builder {
 	 * @param opts.replace a map of strings to replace
 	 * @returns an array of files that were copied
 	 */
-	copy(
+	copy: (
 		from: string,
 		to: string,
 		opts?: {
 			filter?(basename: string): boolean;
 			replace?: Record<string, string>;
 		}
-	): string[];
+	) => string[];
 
 	/**
 	 * Compress files in `directory` with gzip and brotli, where appropriate. Generates `.gz` and `.br` files alongside the originals.
 	 * @param {string} directory The directory containing the files to be compressed
 	 */
-	compress(directory: string): Promise<void>;
+	compress: (directory: string) => Promise<void>;
 }
 
 export interface Config {
@@ -214,13 +214,13 @@ export interface Cookies {
 	 * @param name the name of the cookie
 	 * @param opts the options, passed directly to `cookie.parse`. See documentation [here](https://github.com/jshttp/cookie#cookieparsestr-options)
 	 */
-	get(name: string, opts?: import('cookie').CookieParseOptions): string | undefined;
+	get: (name: string, opts?: import('cookie').CookieParseOptions) => string | undefined;
 
 	/**
 	 * Gets all cookies that were previously set with `cookies.set`, or from the request headers.
 	 * @param opts the options, passed directly to `cookie.parse`. See documentation [here](https://github.com/jshttp/cookie#cookieparsestr-options)
 	 */
-	getAll(opts?: import('cookie').CookieParseOptions): Array<{ name: string; value: string }>;
+	getAll: (opts?: import('cookie').CookieParseOptions) => Array<{ name: string; value: string }>;
 
 	/**
 	 * Sets a cookie. This will add a `set-cookie` header to the response, but also make the cookie available via `cookies.get` or `cookies.getAll` during the current request.
@@ -232,11 +232,11 @@ export interface Cookies {
 	 * @param value the cookie value
 	 * @param opts the options, passed directly to `cookie.serialize`. See documentation [here](https://github.com/jshttp/cookie#cookieserializename-value-options)
 	 */
-	set(
+	set: (
 		name: string,
 		value: string,
 		opts: import('cookie').CookieSerializeOptions & { path: string }
-	): void;
+	) => void;
 
 	/**
 	 * Deletes a cookie by setting its value to an empty string and setting the expiry date in the past.
@@ -245,7 +245,7 @@ export interface Cookies {
 	 * @param name the name of the cookie
 	 * @param opts the options, passed directly to `cookie.serialize`. The `path` must match the path of the cookie you want to delete. See documentation [here](https://github.com/jshttp/cookie#cookieserializename-value-options)
 	 */
-	delete(name: string, opts: import('cookie').CookieSerializeOptions & { path: string }): void;
+	delete: (name: string, opts: import('cookie').CookieSerializeOptions & { path: string }) => void;
 
 	/**
 	 * Serialize a cookie name-value pair into a `Set-Cookie` header string, but don't apply it to the response.
@@ -258,11 +258,11 @@ export interface Cookies {
 	 * @param value the cookie value
 	 * @param opts the options, passed directly to `cookie.serialize`. See documentation [here](https://github.com/jshttp/cookie#cookieserializename-value-options)
 	 */
-	serialize(
+	serialize: (
 		name: string,
 		value: string,
 		opts: import('cookie').CookieSerializeOptions & { path: string }
-	): string;
+	) => string;
 }
 
 /**
@@ -945,7 +945,7 @@ export interface BeforeNavigate extends Navigation {
 	/**
 	 * Call this to prevent the navigation from starting.
 	 */
-	cancel(): void;
+	cancel: () => void;
 }
 
 /**
@@ -1195,7 +1195,7 @@ export interface SSRManifest {
 		client: NonNullable<BuildData['client']>;
 		nodes: SSRNodeLoader[];
 		routes: SSRRoute[];
-		matchers(): Promise<Record<string, ParamMatcher>>;
+		matchers: () => Promise<Record<string, ParamMatcher>>;
 		/** A `[file]: size` map of all assets imported by server code */
 		server_assets: Record<string, number>;
 	};

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -52,7 +52,7 @@ export function get_cookies(request, url, trailing_slash) {
 
 		/**
 		 * @param {string} name
-		 * @param {import('cookie').CookieParseOptions} opts
+		 * @param {import('cookie').CookieParseOptions} [opts]
 		 */
 		get(name, opts) {
 			const c = new_cookies[name];
@@ -89,7 +89,7 @@ export function get_cookies(request, url, trailing_slash) {
 		},
 
 		/**
-		 * @param {import('cookie').CookieParseOptions} opts
+		 * @param {import('cookie').CookieParseOptions} [opts]
 		 */
 		getAll(opts) {
 			const decoder = opts?.decode || decodeURIComponent;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -75,9 +75,9 @@ declare module '@sveltejs/kit' {
 		/** Print messages to the console. `log.info` and `log.minor` are silent unless Vite's `logLevel` is `info`. */
 		log: Logger;
 		/** Remove `dir` and all its contents. */
-		rimraf(dir: string): void;
+		rimraf: (dir: string) => void;
 		/** Create `dir` and any required parent directories. */
-		mkdirp(dir: string): void;
+		mkdirp: (dir: string) => void;
 
 		/** The fully resolved `svelte.config.js`. */
 		config: ValidatedConfig;
@@ -92,59 +92,59 @@ declare module '@sveltejs/kit' {
 		 * @param fn A function that groups a set of routes into an entry point
 		 * @deprecated Use `builder.routes` instead
 		 */
-		createEntries(fn: (route: RouteDefinition) => AdapterEntry): Promise<void>;
+		createEntries: (fn: (route: RouteDefinition) => AdapterEntry) => Promise<void>;
 
 		/**
 		 * Find all the assets imported by server files belonging to `routes`
 		 */
-		findServerAssets(routes: RouteDefinition[]): string[];
+		findServerAssets: (routes: RouteDefinition[]) => string[];
 
 		/**
 		 * Generate a fallback page for a static webserver to use when no route is matched. Useful for single-page apps.
 		 */
-		generateFallback(dest: string): Promise<void>;
+		generateFallback: (dest: string) => Promise<void>;
 
 		/**
 		 * Generate a module exposing build-time environment variables as `$env/dynamic/public`.
 		 */
-		generateEnvModule(): void;
+		generateEnvModule: () => void;
 
 		/**
 		 * Generate a server-side manifest to initialise the SvelteKit [server](https://svelte.dev/docs/kit/@sveltejs-kit#Server) with.
 		 * @param opts a relative path to the base directory of the app and optionally in which format (esm or cjs) the manifest should be generated
 		 */
-		generateManifest(opts: { relativePath: string; routes?: RouteDefinition[] }): string;
+		generateManifest: (opts: { relativePath: string; routes?: RouteDefinition[] }) => string;
 
 		/**
 		 * Resolve a path to the `name` directory inside `outDir`, e.g. `/path/to/.svelte-kit/my-adapter`.
 		 * @param name path to the file, relative to the build directory
 		 */
-		getBuildDirectory(name: string): string;
+		getBuildDirectory: (name: string) => string;
 		/** Get the fully resolved path to the directory containing client-side assets, including the contents of your `static` directory. */
-		getClientDirectory(): string;
+		getClientDirectory: () => string;
 		/** Get the fully resolved path to the directory containing server-side code. */
-		getServerDirectory(): string;
+		getServerDirectory: () => string;
 		/** Get the application path including any configured `base` path, e.g. `my-base-path/_app`. */
-		getAppPath(): string;
+		getAppPath: () => string;
 
 		/**
 		 * Write client assets to `dest`.
 		 * @param dest the destination folder
 		 * @returns an array of files written to `dest`
 		 */
-		writeClient(dest: string): string[];
+		writeClient: (dest: string) => string[];
 		/**
 		 * Write prerendered files to `dest`.
 		 * @param dest the destination folder
 		 * @returns an array of files written to `dest`
 		 */
-		writePrerendered(dest: string): string[];
+		writePrerendered: (dest: string) => string[];
 		/**
 		 * Write server-side code to `dest`.
 		 * @param dest the destination folder
 		 * @returns an array of files written to `dest`
 		 */
-		writeServer(dest: string): string[];
+		writeServer: (dest: string) => string[];
 		/**
 		 * Copy a file or directory.
 		 * @param from the source file or directory
@@ -153,20 +153,20 @@ declare module '@sveltejs/kit' {
 		 * @param opts.replace a map of strings to replace
 		 * @returns an array of files that were copied
 		 */
-		copy(
+		copy: (
 			from: string,
 			to: string,
 			opts?: {
 				filter?(basename: string): boolean;
 				replace?: Record<string, string>;
 			}
-		): string[];
+		) => string[];
 
 		/**
 		 * Compress files in `directory` with gzip and brotli, where appropriate. Generates `.gz` and `.br` files alongside the originals.
 		 * @param directory The directory containing the files to be compressed
 		 */
-		compress(directory: string): Promise<void>;
+		compress: (directory: string) => Promise<void>;
 	}
 
 	export interface Config {
@@ -196,13 +196,13 @@ declare module '@sveltejs/kit' {
 		 * @param name the name of the cookie
 		 * @param opts the options, passed directly to `cookie.parse`. See documentation [here](https://github.com/jshttp/cookie#cookieparsestr-options)
 		 */
-		get(name: string, opts?: import('cookie').CookieParseOptions): string | undefined;
+		get: (name: string, opts?: import('cookie').CookieParseOptions) => string | undefined;
 
 		/**
 		 * Gets all cookies that were previously set with `cookies.set`, or from the request headers.
 		 * @param opts the options, passed directly to `cookie.parse`. See documentation [here](https://github.com/jshttp/cookie#cookieparsestr-options)
 		 */
-		getAll(opts?: import('cookie').CookieParseOptions): Array<{ name: string; value: string }>;
+		getAll: (opts?: import('cookie').CookieParseOptions) => Array<{ name: string; value: string }>;
 
 		/**
 		 * Sets a cookie. This will add a `set-cookie` header to the response, but also make the cookie available via `cookies.get` or `cookies.getAll` during the current request.
@@ -214,11 +214,11 @@ declare module '@sveltejs/kit' {
 		 * @param value the cookie value
 		 * @param opts the options, passed directly to `cookie.serialize`. See documentation [here](https://github.com/jshttp/cookie#cookieserializename-value-options)
 		 */
-		set(
+		set: (
 			name: string,
 			value: string,
 			opts: import('cookie').CookieSerializeOptions & { path: string }
-		): void;
+		) => void;
 
 		/**
 		 * Deletes a cookie by setting its value to an empty string and setting the expiry date in the past.
@@ -227,7 +227,7 @@ declare module '@sveltejs/kit' {
 		 * @param name the name of the cookie
 		 * @param opts the options, passed directly to `cookie.serialize`. The `path` must match the path of the cookie you want to delete. See documentation [here](https://github.com/jshttp/cookie#cookieserializename-value-options)
 		 */
-		delete(name: string, opts: import('cookie').CookieSerializeOptions & { path: string }): void;
+		delete: (name: string, opts: import('cookie').CookieSerializeOptions & { path: string }) => void;
 
 		/**
 		 * Serialize a cookie name-value pair into a `Set-Cookie` header string, but don't apply it to the response.
@@ -240,11 +240,11 @@ declare module '@sveltejs/kit' {
 		 * @param value the cookie value
 		 * @param opts the options, passed directly to `cookie.serialize`. See documentation [here](https://github.com/jshttp/cookie#cookieserializename-value-options)
 		 */
-		serialize(
+		serialize: (
 			name: string,
 			value: string,
 			opts: import('cookie').CookieSerializeOptions & { path: string }
-		): string;
+		) => string;
 	}
 
 	/**
@@ -927,7 +927,7 @@ declare module '@sveltejs/kit' {
 		/**
 		 * Call this to prevent the navigation from starting.
 		 */
-		cancel(): void;
+		cancel: () => void;
 	}
 
 	/**
@@ -1177,7 +1177,7 @@ declare module '@sveltejs/kit' {
 			client: NonNullable<BuildData['client']>;
 			nodes: SSRNodeLoader[];
 			routes: SSRRoute[];
-			matchers(): Promise<Record<string, ParamMatcher>>;
+			matchers: () => Promise<Record<string, ParamMatcher>>;
 			/** A `[file]: size` map of all assets imported by server code */
 			server_assets: Record<string, number>;
 		};

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -16,7 +16,7 @@ declare module '@sveltejs/kit' {
 		 * This function is called after SvelteKit has built your app.
 		 * @param builder An object provided by SvelteKit that contains methods for adapting the app
 		 */
-		adapt(builder: Builder): MaybePromise<void>;
+		adapt: (builder: Builder) => MaybePromise<void>;
 		/**
 		 * Checks called during dev and build to determine whether specific features will work in production with this adapter
 		 */
@@ -31,7 +31,7 @@ declare module '@sveltejs/kit' {
 		 * Creates an `Emulator`, which allows the adapter to influence the environment
 		 * during dev, build and prerendering
 		 */
-		emulate?(): MaybePromise<Emulator>;
+		emulate?: () => MaybePromise<Emulator>;
 	}
 
 	export type LoadProperties<input extends Record<string, any> | void> = input extends void
@@ -667,7 +667,7 @@ declare module '@sveltejs/kit' {
 	 */
 	export type Handle = (input: {
 		event: RequestEvent;
-		resolve(event: RequestEvent, opts?: ResolveOptions): MaybePromise<Response>;
+		resolve: (event: RequestEvent, opts?: ResolveOptions) => MaybePromise<Response>;
 	}) => MaybePromise<Response>;
 
 	/**
@@ -773,14 +773,14 @@ declare module '@sveltejs/kit' {
 		 *
 		 * `setHeaders` has no effect when a `load` function runs in the browser.
 		 */
-		setHeaders(headers: Record<string, string>): void;
+		setHeaders: (headers: Record<string, string>) => void;
 		/**
 		 * `await parent()` returns data from parent `+layout.js` `load` functions.
 		 * Implicitly, a missing `+layout.js` is treated as a `({ data }) => data` function, meaning that it will return and forward data from parent `+layout.server.js` files.
 		 *
 		 * Be careful not to introduce accidental waterfalls when using `await parent()`. If for example you only want to merge parent data into the returned output, call it _after_ fetching your other data.
 		 */
-		parent(): Promise<ParentData>;
+		parent: () => Promise<ParentData>;
 		/**
 		 * This function declares that the `load` function has a _dependency_ on one or more URLs or custom identifiers, which can subsequently be used with [`invalidate()`](https://svelte.dev/docs/kit/$app-navigation#invalidate) to cause `load` to rerun.
 		 *
@@ -818,7 +818,7 @@ declare module '@sveltejs/kit' {
 		 * <button on:click={increase}>Increase Count</button>
 		 * ```
 		 */
-		depends(...deps: Array<`${string}:${string}`>): void;
+		depends: (...deps: Array<`${string}:${string}`>) => void;
 		/**
 		 * Use this function to opt out of dependency tracking for everything that is synchronously called within the callback. Example:
 		 *
@@ -832,7 +832,7 @@ declare module '@sveltejs/kit' {
 		 * }
 		 * ```
 		 */
-		untrack<T>(fn: () => T): T;
+		untrack: <T>(fn: () => T) => T;
 	}
 
 	export interface NavigationEvent<
@@ -1041,7 +1041,7 @@ declare module '@sveltejs/kit' {
 		/**
 		 * The client's IP address, set by the adapter.
 		 */
-		getClientAddress(): string;
+		getClientAddress: () => string;
 		/**
 		 * Contains custom data that was added to the request within the [`server handle hook`](https://svelte.dev/docs/kit/hooks#Server-hooks-handle).
 		 */
@@ -1089,7 +1089,7 @@ declare module '@sveltejs/kit' {
 		 *
 		 * You cannot add a `set-cookie` header with `setHeaders` — use the [`cookies`](https://svelte.dev/docs/kit/@sveltejs-kit#Cookies) API instead.
 		 */
-		setHeaders(headers: Record<string, string>): void;
+		setHeaders: (headers: Record<string, string>) => void;
 		/**
 		 * The requested URL.
 		 */
@@ -1122,20 +1122,20 @@ declare module '@sveltejs/kit' {
 		 * but they will always be split at sensible boundaries such as `%sveltekit.head%` or layout/page components.
 		 * @param input the html chunk and the info if this is the last chunk
 		 */
-		transformPageChunk?(input: { html: string; done: boolean }): MaybePromise<string | undefined>;
+		transformPageChunk?: (input: { html: string; done: boolean }) => MaybePromise<string | undefined>;
 		/**
 		 * Determines which headers should be included in serialized responses when a `load` function loads a resource with `fetch`.
 		 * By default, none will be included.
 		 * @param name header name
 		 * @param value header value
 		 */
-		filterSerializedResponseHeaders?(name: string, value: string): boolean;
+		filterSerializedResponseHeaders?: (name: string, value: string) => boolean;
 		/**
 		 * Determines what should be added to the `<head>` tag to preload it.
 		 * By default, `js` and `css` files will be preloaded.
 		 * @param input the type of the file and its path
 		 */
-		preload?(input: { type: 'font' | 'css' | 'js' | 'asset'; path: string }): boolean;
+		preload?: (input: { type: 'font' | 'css' | 'js' | 'asset'; path: string }) => boolean;
 	}
 
 	export interface RouteDefinition<Config = any> {
@@ -1204,7 +1204,7 @@ declare module '@sveltejs/kit' {
 		 *
 		 * Be careful not to introduce accidental waterfalls when using `await parent()`. If for example you only want to merge parent data into the returned output, call it _after_ fetching your other data.
 		 */
-		parent(): Promise<ParentData>;
+		parent: () => Promise<ParentData>;
 		/**
 		 * This function declares that the `load` function has a _dependency_ on one or more URLs or custom identifiers, which can subsequently be used with [`invalidate()`](https://svelte.dev/docs/kit/$app-navigation#invalidate) to cause `load` to rerun.
 		 *
@@ -1242,7 +1242,7 @@ declare module '@sveltejs/kit' {
 		 * <button on:click={increase}>Increase Count</button>
 		 * ```
 		 */
-		depends(...deps: string[]): void;
+		depends: (...deps: string[]) => void;
 		/**
 		 * Use this function to opt out of dependency tracking for everything that is synchronously called within the callback. Example:
 		 *
@@ -1256,7 +1256,7 @@ declare module '@sveltejs/kit' {
 		 * }
 		 * ```
 		 */
-		untrack<T>(fn: () => T): T;
+		untrack: <T>(fn: () => T) => T;
 	}
 
 	/**
@@ -1327,7 +1327,7 @@ declare module '@sveltejs/kit' {
 		formElement: HTMLFormElement;
 		controller: AbortController;
 		submitter: HTMLElement | null;
-		cancel(): void;
+		cancel: () => void;
 	}) => MaybePromise<
 		| void
 		| ((opts: {
@@ -1340,7 +1340,7 @@ declare module '@sveltejs/kit' {
 				 * @param options Set `reset: false` if you don't want the `<form>` values to be reset after a successful submission.
 				 * @param invalidateAll Set `invalidateAll: false` if you don't want the action to call `invalidateAll` after submission.
 				 */
-				update(options?: { reset?: boolean; invalidateAll?: boolean }): Promise<void>;
+				update: (options?: { reset?: boolean; invalidateAll?: boolean }) => Promise<void>;
 		  }) => void)
 	>;
 


### PR DESCRIPTION
Using class method function types causes SvelteKit users to get TypeScript ESLint errors if they're using the [@typescript-eslint/unbound-method][1] rule (included by default in the `recommended-type-checked` config).

For example:

```
/home/projects/stackblitz-starters-1y7qpk/src/routes/sum/+layout.ts
  3:42  error  Avoid referencing unbound methods which may cause unintentional scoping of `this`.
If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead  @typescript-eslint/unbound-method
```

Switching SvelteKit's public types to arrow functions fixes https://github.com/sveltejs/kit/issues/12622.

### Implementation decisions

I haven't enabled the `@typescript-eslint/unbound-method` rule in this PR. However, I've got a separate PR (https://github.com/sveltejs/kit/pull/12915) where we enable this rule and we fix internal types as well.

I kept the following types in `public.d.ts` using non-arrow functions, since:

- These types are for user inputs, which might rely on these functions being bound, and so it might be a breaking change to change these types:
  - [`Emulator['platform']`][2]
  - functions in `KitConfig`
- Class methods that rely on `this`:
  - [`Server`][3]

I also had to make some changes to `packages/kit/src/runtime/server/cookie.js` to make TypeScript happy.

[1]: https://typescript-eslint.io/rules/unbound-method/
[2]: https://github.com/sveltejs/kit/blob/b25f2d052bbf22e832ac57cbf9e12c48ac922f96/packages/kit/src/exports/public.d.ts#L272-L276
[3]: https://github.com/sveltejs/kit/blob/b25f2d052bbf22e832ac57cbf9e12c48ac922f96/packages/kit/src/exports/public.d.ts#L1174-L1178

<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
  - Fixes https://github.com/sveltejs/kit/issues/12622
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
  - No tests, however https://github.com/sveltejs/kit/pull/12915 enables the [@typescript-eslint/unbound-method][1] rule as well and does test this.
    However, I've split it up on the advice of @benmccann (see https://github.com/sveltejs/kit/pull/12915#issuecomment-2455481039)

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
