### PR TITLE
fix: support custom servers using HTTP/2 in production

### DIFF
--- a/.changeset/shy-needles-warn.md
+++ b/.changeset/shy-needles-warn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: support custom servers using HTTP/2 in production

--- a/.changeset/shy-needles-warn.md
+++ b/.changeset/shy-needles-warn.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: support custom servers using HTTP/2 in production
+fix: support HTTP/2 in dev and production. Revert the changes from [#12907](https://github.com/sveltejs/kit/pull/12907) to downgrade HTTP/2 to TLS as now being unnecessary

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -106,11 +106,29 @@ function get_raw_body(req, body_size_limit) {
 // TODO 3.0 make the signature synchronous?
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function getRequest({ request, base, bodySizeLimit }) {
+	// the Request constructor rejects headers with ':' in the name
+	const headers = {
+		.../** @type {Record<string, string>} */ (request.headers)
+	};
+	if (headers[':method']) {
+		if (!headers.method) {
+			headers.method = headers[':method'];
+		}
+		delete headers[':method'];
+	}
+	if (headers[':authority']) {
+		if (!headers.host) {
+			headers.host = headers[':authority'];
+		}
+		delete headers[':authority'];
+	}
+	delete headers[':path'];
+	delete headers[':scheme'];
 	return new Request(base + request.url, {
 		// @ts-expect-error
 		duplex: 'half',
 		method: request.method,
-		headers: /** @type {Record<string, string>} */ (request.headers),
+		headers,
 		body:
 			request.method === 'GET' || request.method === 'HEAD'
 				? undefined

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -124,7 +124,7 @@ export async function getRequest({ request, base, bodySizeLimit }) {
 		// @ts-expect-error
 		duplex: 'half',
 		method: request.method,
-		headers,
+		headers: Object.entries(headers),
 		body:
 			request.method === 'GET' || request.method === 'HEAD'
 				? undefined

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -110,18 +110,13 @@ export async function getRequest({ request, base, bodySizeLimit }) {
 	if (request.httpVersionMajor >= 2) {
 		// the Request constructor rejects headers with ':' in the name
 		headers = Object.assign({}, headers);
-		if (headers[':method']) {
-			if (!headers.method) {
-				headers.method = headers[':method'];
-			}
-			delete headers[':method'];
-		}
 		if (headers[':authority']) {
 			if (!headers.host) {
 				headers.host = headers[':authority'];
 			}
 			delete headers[':authority'];
 		}
+		delete headers[':method'];
 		delete headers[':path'];
 		delete headers[':scheme'];
 	}

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -110,12 +110,11 @@ export async function getRequest({ request, base, bodySizeLimit }) {
 	if (request.httpVersionMajor >= 2) {
 		// the Request constructor rejects headers with ':' in the name
 		headers = Object.assign({}, headers);
+		// https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3.1-2.3.5
 		if (headers[':authority']) {
-			if (!headers.host) {
-				headers.host = headers[':authority'];
-			}
-			delete headers[':authority'];
+			headers.host = headers[':authority'];
 		}
+		delete headers[':authority'];
 		delete headers[':method'];
 		delete headers[':path'];
 		delete headers[':scheme'];

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -106,24 +106,26 @@ function get_raw_body(req, body_size_limit) {
 // TODO 3.0 make the signature synchronous?
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function getRequest({ request, base, bodySizeLimit }) {
-	// the Request constructor rejects headers with ':' in the name
-	const headers = {
-		.../** @type {Record<string, string>} */ (request.headers)
-	};
-	if (headers[':method']) {
-		if (!headers.method) {
-			headers.method = headers[':method'];
+	let headers = /** @type {Record<string, string>} */ (request.headers);
+	if (request.httpVersionMajor >= 2) {
+		// the Request constructor rejects headers with ':' in the name
+		headers = Object.assign({}, headers);
+		if (headers[':method']) {
+			if (!headers.method) {
+				headers.method = headers[':method'];
+			}
+			delete headers[':method'];
 		}
-		delete headers[':method'];
-	}
-	if (headers[':authority']) {
-		if (!headers.host) {
-			headers.host = headers[':authority'];
+		if (headers[':authority']) {
+			if (!headers.host) {
+				headers.host = headers[':authority'];
+			}
+			delete headers[':authority'];
 		}
-		delete headers[':authority'];
+		delete headers[':path'];
+		delete headers[':scheme'];
 	}
-	delete headers[':path'];
-	delete headers[':scheme'];
+
 	return new Request(base + request.url, {
 		// @ts-expect-error
 		duplex: 'half',

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -349,22 +349,6 @@ async function kit({ svelte_config }) {
 		 * Stores the final config.
 		 */
 		configResolved(config) {
-			// we search for this plugin by name because we can't detect it
-			// since it doesn't directly modify the https config unlike the mkcert plugin
-			const vite_basic_ssl = config.plugins.find(({ name }) => name === 'vite:basic-ssl');
-
-			// by default, when enabling HTTPS in Vite, it also enables HTTP/2
-			// however, undici has not yet enabled HTTP/2 by default: https://github.com/nodejs/undici/issues/2750
-			// we set a no-op proxy config to force Vite to downgrade to TLS-only
-			// see https://vitejs.dev/config/#server-https
-			if ((config.server.https || vite_basic_ssl) && !config.server.proxy) {
-				config.server.proxy = {};
-			}
-
-			if ((config.preview.https || vite_basic_ssl) && !config.preview.proxy) {
-				config.preview.proxy = {};
-			}
-
 			vite_config = config;
 		}
 	};

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -185,7 +185,7 @@ export async function preview(vite, vite_config, svelte_config) {
 
 		// SSR
 		vite.middlewares.use(async (req, res) => {
-			const host = req.headers['host'];
+			const host = req.headers[':authority'] || req.headers.host;
 
 			const request = await getRequest({
 				base: `${protocol}://${host}`,


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/11365