### PR TITLE
fix: prefer pages over endpoints when prerendering

### DIFF
--- a/.changeset/silver-nails-move.md
+++ b/.changeset/silver-nails-move.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prefer pages over endpoints when prerendering

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -208,6 +208,8 @@ async function prerender({ out, manifest_path, metadata, verbose, env }) {
 		const response = await server.respond(
 			new Request(config.prerender.origin + encoded, {
 				headers: {
+					// we need to specify text/html or else content negotiation
+					// will prefer any +server file over +page for the same route
 					accept: 'text/html,*/*'
 				}
 			}),


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/10735

This PR adds an `Accept` header to the prerender requests, preferring `text/html` first then whatever with `*/*`. Previously, it would[ always end up as `*/*` during content negotiation](https://github.com/sveltejs/kit/blob/435984bf61b047d1e1a8efe88354ca7ac4e9109f/packages/kit/src/runtime/server/endpoint.js#L91-L92), which invokes the endpoint handler, causing a `405 method not allowed` if the GET handler doesn't exist.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
No test because it would break the prerender app build.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
