### PR TITLE
perf: shorten file names

### DIFF
--- a/.changeset/blue-foxes-clean.md
+++ b/.changeset/blue-foxes-clean.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+perf: shorten file names

--- a/.changeset/blue-foxes-clean.md
+++ b/.changeset/blue-foxes-clean.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-perf: shorten file names
+perf: shorten chunk file names

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -640,8 +640,8 @@ async function kit({ svelte_config }) {
 							output: {
 								format: 'esm',
 								entryFileNames: ssr ? '[name].js' : `${prefix}/[name].[hash].${ext}`,
-								chunkFileNames: ssr ? 'chunks/[name].js' : `${prefix}/chunks/[name].[hash].${ext}`,
-								assetFileNames: `${prefix}/assets/[name].[hash][extname]`,
+								chunkFileNames: ssr ? 'chunks/[name].js' : `${prefix}/chunks/[hash].${ext}`,
+								assetFileNames: `${prefix}/assets/[hash][extname]`,
 								hoistTransitiveImports: false,
 								sourcemapIgnoreList
 							},
@@ -655,8 +655,8 @@ async function kit({ svelte_config }) {
 						rollupOptions: {
 							output: {
 								entryFileNames: `${prefix}/workers/[name]-[hash].js`,
-								chunkFileNames: `${prefix}/workers/chunks/[name]-[hash].js`,
-								assetFileNames: `${prefix}/workers/assets/[name]-[hash][extname]`,
+								chunkFileNames: `${prefix}/workers/chunks/[hash].js`,
+								assetFileNames: `${prefix}/workers/assets/[hash][extname]`,
 								hoistTransitiveImports: false
 							}
 						}

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -641,7 +641,7 @@ async function kit({ svelte_config }) {
 								format: 'esm',
 								entryFileNames: ssr ? '[name].js' : `${prefix}/[name].[hash].${ext}`,
 								chunkFileNames: ssr ? 'chunks/[name].js' : `${prefix}/chunks/[hash].${ext}`,
-								assetFileNames: `${prefix}/assets/[hash][extname]`,
+								assetFileNames: `${prefix}/assets/[name].[hash][extname]`,
 								hoistTransitiveImports: false,
 								sourcemapIgnoreList
 							},
@@ -656,7 +656,7 @@ async function kit({ svelte_config }) {
 							output: {
 								entryFileNames: `${prefix}/workers/[name]-[hash].js`,
 								chunkFileNames: `${prefix}/workers/chunks/[hash].js`,
-								assetFileNames: `${prefix}/workers/assets/[hash][extname]`,
+								assetFileNames: `${prefix}/workers/assets/[name]-[hash][extname]`,
 								hoistTransitiveImports: false
 							}
 						}

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -50,7 +50,7 @@ test.describe('Imports', () => {
 			]);
 		} else {
 			expect(sources[0].startsWith('data:image/png;base64,')).toBeTruthy();
-			expect(sources[1]).toMatch(/\/_app\/immutable\/assets\/large\.[\w-]+\.jpg/);
+			expect(sources[1]).toMatch(/\/_app\/immutable\/assets\/[\w-]+\.jpg/);
 		}
 	});
 });

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -50,7 +50,7 @@ test.describe('Imports', () => {
 			]);
 		} else {
 			expect(sources[0].startsWith('data:image/png;base64,')).toBeTruthy();
-			expect(sources[1]).toMatch(/\/_app\/immutable\/assets\/[\w-]+\.jpg/);
+			expect(sources[1]).toMatch(/\/_app\/immutable\/assets\/large\.[\w-]+\.jpg/);
 		}
 	});
 });


### PR DESCRIPTION
This shortens references to JS files in SSR, JS, and HTTP headers. Less bytes referring to these files. Also, the chunks often pick combine multiple files and pick the name of one individual file to use for the chunk, which can be misleading

Reducing the size of asset names reduced the size of the JS on my image-heavy page by 6.5% after brotli compression, but we couldn't come to agreement to shorten those