### PR TITLE
fix: update inline css url in dev

### DIFF
--- a/.changeset/ninety-dragons-carry.md
+++ b/.changeset/ninety-dragons-carry.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: update inline css url generation for FOUC prevention in dev

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -203,9 +203,8 @@ export async function dev(vite, vite_config, svelte_config) {
 
 							for (const dep of deps) {
 								if (
-									isCSSRequest(dep.url) &&
-									svelte_query_regex.test(dep.url) &&
-									type_css_query_regex.test(dep.url) &&
+									(isCSSRequest(dep.url) ||
+										(svelte_query_regex.test(dep.url) && type_css_query_regex.test(dep.url))) &&
 									!vite_css_query_regex.test(dep.url)
 								) {
 									const inlineCssUrl = dep.url.includes('?')

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -22,8 +22,6 @@ import { check_feature } from '../../../utils/features.js';
 const cwd = process.cwd();
 // vite-specifc queries that we should skip handling for css urls
 const vite_css_query_regex = /(?:\?|&)(?:raw|url|inline)(?:&|$)/;
-const svelte_query_regex = /(?:\?|&)svelte(?:&|$)/;
-const type_css_query_regex = /(?:\?|&)type=css(?:&|$)/;
 
 /**
  * @param {import('vite').ViteDevServer} vite
@@ -202,11 +200,7 @@ export async function dev(vite, vite_config, svelte_config) {
 							const styles = {};
 
 							for (const dep of deps) {
-								if (
-									(isCSSRequest(dep.url) ||
-										(svelte_query_regex.test(dep.url) && type_css_query_regex.test(dep.url))) &&
-									!vite_css_query_regex.test(dep.url)
-								) {
+								if (isCSSRequest(dep.url) && !vite_css_query_regex.test(dep.url)) {
 									const inlineCssUrl = dep.url.includes('?')
 										? dep.url.replace('?', '?inline&')
 										: dep.url + '?inline';


### PR DESCRIPTION
In the logic where SvelteKit loads the CSS to prevent FOUC in dev, it constructs URLs like `/path/Foo.svelte?svelte=&type=css&lang.css=&inline=`, which isn't great for Vite because it checks if a module is CSS via `/\.(css|less|...)(?:$|\?)/`, which wouldn't have matched the constructed URL.

With the Vite quirk aside (which fixing it is probably a separate breaking topic in Vite), this PR updates so it looks like this instead: `/path/Foo.svelte?inline&svelte=&type=css&lang.css`, which Vite will be happy about. This is also what [Astro does](https://github.com/withastro/astro/blob/bde49f186e4d620ce0c926353db38215e33dceef/packages/astro/src/vite-plugin-astro-server/css.ts#L39-L45) which had also worked well.

The reason why it always worked before (and unnoticed) is because `vite-plugin-svelte` was normalizing back to a Vite-happy path: https://github.com/sveltejs/vite-plugin-svelte/blob/da54670065f949c7352597dcafbd51dfa202e638/packages/vite-plugin-svelte/src/index.js#L127-L135. I'm trying to fix some compat for that code for Vite 6 where that will no longer happen, so I figured to fix this here first

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
