### PR TITLE
fix: await applyAction and goto

### DIFF
--- a/.changeset/clean-panthers-bake.md
+++ b/.changeset/clean-panthers-bake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: await applyAction and goto

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -104,7 +104,7 @@ export function enhance(form_element, submit = () => {}) {
 			result.type === 'redirect' ||
 			result.type === 'error'
 		) {
-			applyAction(result);
+			await applyAction(result);
 		}
 	};
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1983,7 +1983,7 @@ export async function applyAction(result) {
 			tick().then(reset_focus);
 		}
 	} else if (result.type === 'redirect') {
-		_goto(result.location, { invalidateAll: true }, 0);
+		await _goto(result.location, { invalidateAll: true }, 0);
 	} else {
 		/** @type {Record<string, any>} */
 		root.$set({


### PR DESCRIPTION
Here is a simple form with a button that gets disabled while the form is being submitted:
```ts
<form
  method="post"
  use:enhance={() => {
    sending = true;
    return async ({ update }) => {
      await update();
      sending = false;
    };
  }}
>
  <div>
    <button disabled={sending}>{sending ? "Sending..." : "Send"}</button>
  </div>
</form>
```

If the server responds with a redirect, I expect the button to stay on "Sending..." until the other page shows up. Unfortunately, this is not what happens right now: ![video](https://github.com/user-attachments/assets/e230ca7d-1079-414a-900e-f2cdde39c391).

And here is what it looks like after these changes: ![video](https://github.com/user-attachments/assets/93d8e7e2-6041-4a89-85ce-323f5cb500f4).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
