### PR TITLE
perf: directly inline values since Svelte no longer inlines

### DIFF
--- a/.changeset/wild-flies-run.md
+++ b/.changeset/wild-flies-run.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/enhanced-img': patch
+---
+
+perf: directly inline values since Svelte no longer inlines variables into template

--- a/packages/enhanced-img/test/Output.svelte
+++ b/packages/enhanced-img/test/Output.svelte
@@ -1,11 +1,6 @@
-<script module>	
+<script lang="ts">	
 	import __IMPORTED_ASSET_0__ from "./foo.svg";
-	const __DECLARED_ASSET_0__ = "__VITE_ASSET__2AM7_y_a__ 1440w, __VITE_ASSET__2AM7_y_b__ 960w";
-	const __DECLARED_ASSET_1__ = "__VITE_ASSET__2AM7_y_c__ 1440w, __VITE_ASSET__2AM7_y_d__ 960w";
-	const __DECLARED_ASSET_2__ = "__VITE_ASSET__2AM7_y_e__ 1440w, __VITE_ASSET__2AM7_y_f__ 960w";
-	const __DECLARED_ASSET_3__ = "__VITE_ASSET__2AM7_y_g__";
-</script>
-<script lang="ts">
+
 	
 	import manual_image1 from './no.png';
 	
@@ -28,7 +23,7 @@
 	<picture><source srcset="/1 1440w, /2 960w" type="image/avif" /><source srcset="/3 1440w, /4 960w" type="image/webp" /><source srcset="5 1440w, /6 960w" type="image/png" /><img src="/7" alt="nested test" width=1440 height=1440 /></picture>
 </div>
 
-<picture><source srcset={__DECLARED_ASSET_0__} type="image/avif" /><source srcset={__DECLARED_ASSET_1__} type="image/webp" /><source srcset={__DECLARED_ASSET_2__} type="image/png" /><img src={__DECLARED_ASSET_3__} alt="production test" width=1440 height=1440 /></picture>
+<picture><source srcset={"__VITE_ASSET__2AM7_y_a__ 1440w, __VITE_ASSET__2AM7_y_b__ 960w"} type="image/avif" /><source srcset={"__VITE_ASSET__2AM7_y_c__ 1440w, __VITE_ASSET__2AM7_y_d__ 960w"} type="image/webp" /><source srcset={"__VITE_ASSET__2AM7_y_e__ 1440w, __VITE_ASSET__2AM7_y_f__ 960w"} type="image/png" /><img src={"__VITE_ASSET__2AM7_y_g__"} alt="production test" width=1440 height=1440 /></picture>
 
 <picture><source srcset="/1 1440w, /2 960w" type="image/avif" /><source srcset="/3 1440w, /4 960w" type="image/webp" /><source srcset="5 1440w, /6 960w" type="image/png" /><img src="/7" width="5" height="10" alt="dimensions test" /></picture>
 


### PR DESCRIPTION
See https://github.com/sveltejs/svelte/pull/14374 released in 5.2.6: https://github.com/sveltejs/svelte/blob/main/packages/svelte/CHANGELOG.md#526

Also removes Svelte 4 support since we already bumped the peer dep version to Svelte 5

This simplifies the code a bit and results in smaller output when absolute URLs are used. However, SvelteKit uses relative URLs by default and it doesn't help there