### PR TITLE
chore: change error helpers to use public interface types

### DIFF
--- a/.changeset/light-singers-lie.md
+++ b/.changeset/light-singers-lie.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+fix: change `error`, `isHttpError`, `redirect`, and `isRedirect` to refer to public type instead of internal class

--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -33,7 +33,7 @@ export { VERSION } from '../version.js';
  * @param {number} status
  * @param {App.Error} body
  * @return {never}
- * @throws {HttpError} This error instructs SvelteKit to initiate HTTP error handling.
+ * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
  * @throws {Error} If the provided status is invalid (not between 400 and 599).
  */
 /**
@@ -47,7 +47,7 @@ export { VERSION } from '../version.js';
  * @param {number} status
  * @param {{ message: string } extends App.Error ? App.Error | string | undefined : never} [body]
  * @return {never}
- * @throws {HttpError} This error instructs SvelteKit to initiate HTTP error handling.
+ * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
  * @throws {Error} If the provided status is invalid (not between 400 and 599).
  */
 /**
@@ -58,7 +58,7 @@ export { VERSION } from '../version.js';
  * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
  * @param {{ message: string } extends App.Error ? App.Error | string | undefined : never} body An object that conforms to the App.Error type. If a string is passed, it will be used as the message property.
  * @return {never}
- * @throws {HttpError} This error instructs SvelteKit to initiate HTTP error handling.
+ * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
  * @throws {Error} If the provided status is invalid (not between 400 and 599).
  */
 export function error(status, body) {
@@ -74,7 +74,7 @@ export function error(status, body) {
  * @template {number} T
  * @param {unknown} e
  * @param {T} [status] The status to filter for.
- * @return {e is (HttpError & { status: T extends undefined ? never : T })}
+ * @return {e is (import('./public.js').HttpError & { status: T extends undefined ? never : T })}
  */
 export function isHttpError(e, status) {
 	if (!(e instanceof HttpError)) return false;
@@ -86,7 +86,7 @@ export function isHttpError(e, status) {
  * Make sure you're not catching the thrown redirect, which would prevent SvelteKit from handling it.
  * @param {300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308 | ({} & number)} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages). Must be in the range 300-308.
  * @param {string | URL} location The location to redirect to.
- * @throws {Redirect} This error instructs SvelteKit to redirect to the specified location.
+ * @throws {import('./public.js').Redirect} This error instructs SvelteKit to redirect to the specified location.
  * @throws {Error} If the provided status is invalid.
  * @return {never}
  */
@@ -105,7 +105,7 @@ export function redirect(status, location) {
 /**
  * Checks whether this is a redirect thrown by {@link redirect}.
  * @param {unknown} e The object to check.
- * @return {e is Redirect}
+ * @return {e is import('./public.js').Redirect}
  */
 export function isRedirect(e) {
 	return e instanceof Redirect;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1765,7 +1765,7 @@ declare module '@sveltejs/kit' {
 	 * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
 	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
 	 * @param body An object that conforms to the App.Error type. If a string is passed, it will be used as the message property.
-	 * @throws {HttpError} This error instructs SvelteKit to initiate HTTP error handling.
+	 * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
 	 * @throws {Error} If the provided status is invalid (not between 400 and 599).
 	 */
 	export function error(status: number, body: App.Error): never;
@@ -1776,7 +1776,7 @@ declare module '@sveltejs/kit' {
 	 * Make sure you're not catching the thrown error, which would prevent SvelteKit from handling it.
 	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
 	 * @param body An object that conforms to the App.Error type. If a string is passed, it will be used as the message property.
-	 * @throws {HttpError} This error instructs SvelteKit to initiate HTTP error handling.
+	 * @throws {import('./public.js').HttpError} This error instructs SvelteKit to initiate HTTP error handling.
 	 * @throws {Error} If the provided status is invalid (not between 400 and 599).
 	 */
 	export function error(status: number, body?: {
@@ -1786,7 +1786,7 @@ declare module '@sveltejs/kit' {
 	 * Checks whether this is an error thrown by {@link error}.
 	 * @param status The status to filter for.
 	 * */
-	export function isHttpError<T extends number>(e: unknown, status?: T | undefined): e is HttpError_1 & {
+	export function isHttpError<T extends number>(e: unknown, status?: T | undefined): e is HttpError & {
 		status: T extends undefined ? never : T;
 	};
 	/**
@@ -1794,7 +1794,7 @@ declare module '@sveltejs/kit' {
 	 * Make sure you're not catching the thrown redirect, which would prevent SvelteKit from handling it.
 	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages). Must be in the range 300-308.
 	 * @param location The location to redirect to.
-	 * @throws {Redirect} This error instructs SvelteKit to redirect to the specified location.
+	 * @throws {import('./public.js').Redirect} This error instructs SvelteKit to redirect to the specified location.
 	 * @throws {Error} If the provided status is invalid.
 	 * */
 	export function redirect(status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308 | ({} & number), location: string | URL): never;
@@ -1802,7 +1802,7 @@ declare module '@sveltejs/kit' {
 	 * Checks whether this is a redirect thrown by {@link redirect}.
 	 * @param e The object to check.
 	 * */
-	export function isRedirect(e: unknown): e is Redirect_1;
+	export function isRedirect(e: unknown): e is Redirect;
 	/**
 	 * Create a JSON `Response` object from the supplied data.
 	 * @param data The value that will be serialized as JSON.
@@ -1834,21 +1834,6 @@ declare module '@sveltejs/kit' {
 	export type LessThan<TNumber extends number, TArray extends any[] = []> = TNumber extends TArray['length'] ? TArray[number] : LessThan<TNumber, [...TArray, TArray['length']]>;
 	export type NumericRange<TStart extends number, TEnd extends number> = Exclude<TEnd | LessThan<TEnd>, LessThan<TStart>>;
 	export const VERSION: string;
-	class HttpError_1 {
-		
-		constructor(status: number, body: {
-			message: string;
-		} extends App.Error ? (App.Error | string | undefined) : App.Error);
-		status: number;
-		body: App.Error;
-		toString(): string;
-	}
-	class Redirect_1 {
-		
-		constructor(status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308, location: string);
-		status: 301 | 302 | 303 | 307 | 308 | 300 | 304 | 305 | 306;
-		location: string;
-	}
 
 	export {};
 }


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/12986

This PR changes the `error`, `isHttpError`, `redirect`, and `isRedirect` functions to use the public interface version of the `HttpError` and `Redirect` errors instead of our internal classes.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
