### PR TITLE
fix: Use default cookie decoder instead of bare native

### DIFF
--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -67,8 +67,8 @@ export function get_cookies(request, url, trailing_slash) {
 				return c.value;
 			}
 
-			const decoder = opts?.decode || decodeURIComponent;
-			const req_cookies = parse(header, { decode: decoder });
+			// `parse` uses default decoder if `opts.decode` is undefined
+			const req_cookies = parse(header, { decode: opts?.decode });
 			const cookie = req_cookies[name]; // the decoded string or undefined
 
 			// in development, if the cookie was set during this session with `cookies.set`,
@@ -95,8 +95,8 @@ export function get_cookies(request, url, trailing_slash) {
 		 * @param {import('cookie').CookieParseOptions} opts
 		 */
 		getAll(opts) {
-			const decoder = opts?.decode || decodeURIComponent;
-			const cookies = parse(header, { decode: decoder });
+			// `parse` uses default decoder if `opts.decode` is undefined
+			const cookies = parse(header, { decode: opts?.decode });
 
 			for (const c of Object.values(new_cookies)) {
 				if (


### PR DESCRIPTION
SvelteKit currently depends on cookie@0.6.0 which has known security vulnerability. User can create an override if they do not need to keep the backward compatibility.

cookie@0.6.0 wraps the passed decoder in try..catch but the new version does not. If user overrides the cookie library, `cookies.get` and `cookies.getAll` throw if called with a cookie value that contains malformed content.

In both cases (cookie@0.6.0 and higher) the default `decode` implementation of `cookie` library has performance optimization to skip calling `decodeURIComponent` if the string does not contain `"%"`.

Removing the passing of default decoder: `decodeURIComponent` does not harm but helps both cases.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
