### PR TITLE
chore: support building with Node 22

### DIFF
--- a/.changeset/long-rivers-stare.md
+++ b/.changeset/long-rivers-stare.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+chore: support building with Node 22

--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -44,13 +44,13 @@ export const config = {
 /// file: admin/+layout.js
 /** @type {import('@sveltejs/adapter-vercel').Config} */
 export const config = {
-	runtime: 'nodejs18.x'
+	runtime: 'nodejs22.x'
 };
 ```
 
 The following options apply to all functions:
 
-- `runtime`: `'edge'`, `'nodejs18.x'` or `'nodejs20.x'`. By default, the adapter will select the `'nodejs<version>.x'` corresponding to the Node version your project is configured to use on the Vercel dashboard
+- `runtime`: `'edge'`, `'nodejs18.x'`, `'nodejs20.x'` or `'nodejs22.x'`. By default, the adapter will select the `'nodejs<version>.x'` corresponding to the Node version your project is configured to use on the Vercel dashboard
 - `regions`: an array of [edge network regions](https://vercel.com/docs/concepts/edge-network/regions) (defaulting to `["iad1"]` for serverless functions) or `'all'` if `runtime` is `edge` (its default). Note that multiple regions for serverless functions are only supported on Enterprise plans
 - `split`: if `true`, causes a route to be deployed as an individual function. If `split` is set to `true` at the adapter level, all routes will be deployed as individual functions
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -11,13 +11,26 @@ const name = '@sveltejs/adapter-vercel';
 const DEFAULT_FUNCTION_NAME = 'fn';
 
 const get_default_runtime = () => {
-	const major = process.version.slice(1).split('.')[0];
-	if (major === '18') return 'nodejs18.x';
-	if (major === '20') return 'nodejs20.x';
+	const major = Number(process.version.slice(1).split('.')[0]);
 
-	throw new Error(
-		`Unsupported Node.js version: ${process.version}. Please use Node 18 or Node 20 to build your project, or explicitly specify a runtime in your adapter configuration.`
-	);
+	// If we're building on Vercel, we know that the version will be fine. Also means
+	// we're not on the hook for updating the adapter every time a new Node version is
+	// added to Vercel.
+	if (!process.env.VERCEL) {
+		if (major < 18 || major > 22) {
+			throw new Error(
+				`Building locally with unsupported Node.js version: ${process.version}. Please use Node 18, 20 or 22 to build your project, or explicitly specify a runtime in your adapter configuration.`
+			);
+		}
+
+		if (major % 2 !== 0) {
+			throw new Error(
+				`Unsupported Node.js version: ${process.version}. Please use an even-numbered Node version to build your project, or explicitly specify a runtime in your adapter configuration.`
+			);
+		}
+	}
+
+	return `nodejs${major}.x`;
 };
 
 // https://vercel.com/docs/functions/edge-functions/edge-runtime#compatible-node.js-modules

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -13,9 +13,10 @@ const DEFAULT_FUNCTION_NAME = 'fn';
 const get_default_runtime = () => {
 	const major = Number(process.version.slice(1).split('.')[0]);
 
-	// If we're building on Vercel, we know that the version will be fine. Also means
-	// we're not on the hook for updating the adapter every time a new Node version is
-	// added to Vercel.
+	// If we're building on Vercel, we know that the version will be fine because Vercel
+	// provides Node (and Vercel won't provide something it doesn't support).
+	// Also means we're not on the hook for updating the adapter every time a new Node
+	// version is added to Vercel.
 	if (!process.env.VERCEL) {
 		if (major < 18 || major > 22) {
 			throw new Error(


### PR DESCRIPTION
Also adjust the validation logic to not care at all when building on Vercel, to not have to update the adapter each time right away. Closes #13040
