### PR TITLE
chore: fix ecosystem CI

### DIFF
--- a/packages/kit/test/apps/amp/package.json
+++ b/packages/kit/test/apps/amp/package.json
@@ -19,7 +19,7 @@
 		"dropcss": "^1.0.16",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/apps/basics/package.json
+++ b/packages/kit/test/apps/basics/package.json
@@ -19,7 +19,7 @@
 		"cross-env": "^7.0.3",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/apps/basics/src/routes/cookies/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/cookies/+page.svelte
@@ -3,4 +3,4 @@
 	export let data;
 </script>
 
-Cookie: <span id="cookie-value">{data.cookie ?? 'undefined'}</span>
+Cookie: <span id="cookie-value">{`${data.cookie}`}</span>

--- a/packages/kit/test/apps/basics/src/routes/cookies/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/cookies/+page.svelte
@@ -3,4 +3,4 @@
 	export let data;
 </script>
 
-Cookie: <span id="cookie-value">{data.cookie}</span>
+Cookie: <span id="cookie-value">{data.cookie ?? 'undefined'}</span>

--- a/packages/kit/test/apps/basics/src/routes/cookies/enhanced/basic/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/cookies/enhanced/basic/+page.svelte
@@ -6,7 +6,7 @@
 </script>
 
 Cookie: <span id="cookie-value">
-	{data.cookie}
+	{data.cookie ?? 'undefined'}
 </span>
 
 <form method="post" action="?/setTeapot" use:enhance>

--- a/packages/kit/test/apps/basics/src/routes/cookies/enhanced/basic/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/cookies/enhanced/basic/+page.svelte
@@ -5,9 +5,7 @@
 	export let data;
 </script>
 
-Cookie: <span id="cookie-value">
-	{`${data.cookie}`}
-</span>
+Cookie: <span id="cookie-value">{`${data.cookie}`}</span>
 
 <form method="post" action="?/setTeapot" use:enhance>
 	<button id="teapot">Set cookie to "teapot"</button>

--- a/packages/kit/test/apps/basics/src/routes/cookies/enhanced/basic/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/cookies/enhanced/basic/+page.svelte
@@ -6,7 +6,7 @@
 </script>
 
 Cookie: <span id="cookie-value">
-	{data.cookie ?? 'undefined'}
+	{`${data.cookie}`}
 </span>
 
 <form method="post" action="?/setTeapot" use:enhance>

--- a/packages/kit/test/apps/basics/src/routes/cookies/nested/a/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/cookies/nested/a/+page.svelte
@@ -3,4 +3,4 @@
 	export let data;
 </script>
 
-Cookie: <span id="cookie-value">{data.cookie ?? 'undefined'}</span>
+Cookie: <span id="cookie-value">{`${data.cookie}`}</span>

--- a/packages/kit/test/apps/basics/src/routes/cookies/nested/a/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/cookies/nested/a/+page.svelte
@@ -3,4 +3,4 @@
 	export let data;
 </script>
 
-Cookie: <span id="cookie-value">{data.cookie}</span>
+Cookie: <span id="cookie-value">{data.cookie ?? 'undefined'}</span>

--- a/packages/kit/test/apps/basics/src/routes/cookies/nested/b/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/cookies/nested/b/+page.svelte
@@ -3,4 +3,4 @@
 	export let data;
 </script>
 
-Cookie: <span id="cookie-value">{data.cookie ?? 'undefined'}</span>
+Cookie: <span id="cookie-value">{`${data.cookie}`}</span>

--- a/packages/kit/test/apps/basics/src/routes/cookies/nested/b/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/cookies/nested/b/+page.svelte
@@ -3,4 +3,4 @@
 	export let data;
 </script>
 
-Cookie: <span id="cookie-value">{data.cookie}</span>
+Cookie: <span id="cookie-value">{data.cookie ?? 'undefined'}</span>

--- a/packages/kit/test/apps/basics/src/routes/load/url-hash/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/url-hash/+page.js
@@ -1,6 +1,3 @@
-// TODO: remove this when Svelte 5 hydration is fixed. See https://github.com/sveltejs/svelte/issues/14437
-export const ssr = false;
-
 export const load = ({ url }) => {
 	const hash = url.hash;
 	return { hash };

--- a/packages/kit/test/apps/basics/src/routes/load/url-hash/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/url-hash/+page.js
@@ -1,3 +1,6 @@
+// TODO: remove this when Svelte 5 hydration is fixed. See https://github.com/sveltejs/svelte/issues/14437
+export const ssr = false;
+
 export const load = ({ url }) => {
 	const hash = url.hash;
 	return { hash };

--- a/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/after-navigate/a/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/after-navigate/a/+page.svelte
@@ -13,5 +13,5 @@
 	});
 </script>
 
-<h1>{from?.url.pathname  ?? 'undefined'} -> {to?.url.pathname  ?? 'undefined'}</h1>
+<h1>{from?.url.pathname ?? 'undefined'} -> {to?.url.pathname ?? 'undefined'}</h1>
 <a href="/navigation-lifecycle/after-navigate/b">/b</a>

--- a/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/after-navigate/a/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/after-navigate/a/+page.svelte
@@ -13,5 +13,5 @@
 	});
 </script>
 
-<h1>{from?.url.pathname ?? 'undefined'} -> {to?.url.pathname ?? 'undefined'}</h1>
+<h1>{`${from?.url.pathname} -> ${to?.url.pathname}`}</h1>
 <a href="/navigation-lifecycle/after-navigate/b">/b</a>

--- a/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/after-navigate/a/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/after-navigate/a/+page.svelte
@@ -13,5 +13,5 @@
 	});
 </script>
 
-<h1>{from?.url.pathname} -> {to?.url.pathname}</h1>
+<h1>{from?.url.pathname  ?? 'undefined'} -> {to?.url.pathname  ?? 'undefined'}</h1>
 <a href="/navigation-lifecycle/after-navigate/b">/b</a>

--- a/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/before-navigate/prevent-navigation/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/before-navigate/prevent-navigation/+page.svelte
@@ -3,7 +3,7 @@
 
 	let times_triggered = 0;
 	let unload = false;
-	let navigation_type = 'undefined';
+	let navigation_type;
 	beforeNavigate(({ cancel, type, willUnload, to }) => {
 		times_triggered++;
 		unload = willUnload;
@@ -22,4 +22,4 @@
 <a href="https://google.de">external</a>
 <!-- svelte-ignore a11y-invalid-attribute -->
 <a download href="">external</a>
-<pre>{times_triggered} {unload} {navigation_type}</pre>
+<pre>{times_triggered} {unload} {`${navigation_type}`}</pre>

--- a/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/before-navigate/prevent-navigation/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/before-navigate/prevent-navigation/+page.svelte
@@ -3,7 +3,7 @@
 
 	let times_triggered = 0;
 	let unload = false;
-	let navigation_type;
+	let navigation_type = 'undefined';
 	beforeNavigate(({ cancel, type, willUnload, to }) => {
 		times_triggered++;
 		unload = willUnload;

--- a/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/on-navigate/[x]/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/on-navigate/[x]/+page.svelte
@@ -25,7 +25,5 @@
 	});
 </script>
 
-<h1>
-	{`${from?.url.pathname} -> ${to?.url.pathname}`} ({type ?? '...'}) {called_return}
-</h1>
+<h1>{`${from?.url.pathname} -> ${to?.url.pathname}`} ({type ?? '...'}) {called_return}</h1>
 <a href="/navigation-lifecycle/on-navigate/b">/b</a>

--- a/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/on-navigate/[x]/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/on-navigate/[x]/+page.svelte
@@ -26,6 +26,6 @@
 </script>
 
 <h1>
-	{from?.url.pathname ?? 'undefined'} -> {to?.url.pathname ?? 'undefined'} ({type ?? '...'}) {called_return}
+	{`${from?.url.pathname} -> ${to?.url.pathname}`} ({type ?? '...'}) {called_return}
 </h1>
 <a href="/navigation-lifecycle/on-navigate/b">/b</a>

--- a/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/on-navigate/[x]/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/on-navigate/[x]/+page.svelte
@@ -25,5 +25,7 @@
 	});
 </script>
 
-<h1>{from?.url.pathname ?? 'undefined'} -> {to?.url.pathname ?? 'undefined'} ({type ?? '...'}) {called_return}</h1>
+<h1>
+	{from?.url.pathname ?? 'undefined'} -> {to?.url.pathname ?? 'undefined'} ({type ?? '...'}) {called_return}
+</h1>
 <a href="/navigation-lifecycle/on-navigate/b">/b</a>

--- a/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/on-navigate/[x]/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/on-navigate/[x]/+page.svelte
@@ -25,5 +25,5 @@
 	});
 </script>
 
-<h1>{from?.url.pathname} -> {to?.url.pathname} ({type ?? '...'}) {called_return}</h1>
+<h1>{from?.url.pathname ?? 'undefined'} -> {to?.url.pathname ?? 'undefined'} ({type ?? '...'}) {called_return}</h1>
 <a href="/navigation-lifecycle/on-navigate/b">/b</a>

--- a/packages/kit/test/apps/basics/src/routes/store/client-access/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/store/client-access/+page.svelte
@@ -1,10 +1,10 @@
 <script>
 	import { getStores } from '$app/stores';
 
-	let pathname = 'undefined';
+	let pathname;
 </script>
 
-<h1>{pathname}</h1>
+<h1>{`${pathname}`}</h1>
 
 <button
 	on:click={() => {

--- a/packages/kit/test/apps/basics/src/routes/store/client-access/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/store/client-access/+page.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { getStores } from '$app/stores';
 
-	let pathname;
+	let pathname = 'undefined';
 </script>
 
 <h1>{pathname}</h1>

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -50,10 +50,10 @@ test.describe('a11y', () => {
 			expect(has_live_region).toBeTruthy();
 
 			// live region should exist, but be empty
-			expect(await page.innerHTML('[aria-live]')).toBe('');
+			expect(await page.innerText('[aria-live]')).toBe('');
 
 			await clicknav('[href="/accessibility/b"]');
-			expect(await page.innerHTML('[aria-live]')).toBe('b'); // TODO i18n
+			expect(await page.innerText('[aria-live]')).toBe('b'); // TODO i18n
 		} else {
 			expect(has_live_region).toBeFalsy();
 		}

--- a/packages/kit/test/apps/dev-only/package.json
+++ b/packages/kit/test/apps/dev-only/package.json
@@ -25,7 +25,7 @@
 		"e2e-test-dep-server": "file:./_test_dependencies/cjs-only",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/apps/embed/package.json
+++ b/packages/kit/test/apps/embed/package.json
@@ -17,7 +17,7 @@
 		"cross-env": "^7.0.3",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/apps/no-ssr/package.json
+++ b/packages/kit/test/apps/no-ssr/package.json
@@ -17,7 +17,7 @@
 		"cross-env": "^7.0.3",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/apps/options-2/package.json
+++ b/packages/kit/test/apps/options-2/package.json
@@ -18,7 +18,7 @@
 		"cross-env": "^7.0.3",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/apps/options/package.json
+++ b/packages/kit/test/apps/options/package.json
@@ -17,7 +17,7 @@
 		"cross-env": "^7.0.3",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/apps/options/source/pages/+layout.svelte
+++ b/packages/kit/test/apps/options/source/pages/+layout.svelte
@@ -1,7 +1,20 @@
 <script>
+	import { onMount } from 'svelte';
 	import { setup } from '../../../../setup.js';
 
 	setup();
+
+	// TODO: remove this when Svelte 5 addresses this issue https://github.com/sveltejs/svelte/issues/14438
+	onMount(() => {
+		// @ts-expect-error trustedTypes is a limited availability global
+		// see https://developer.mozilla.org/en-US/docs/Web/API/Window/trustedTypes
+		if (window.trustedTypes && trustedTypes.createPolicy) {
+			// @ts-expect-error
+			trustedTypes.createPolicy('default', {
+				createHTML: (/** @type {string} */ str) => str
+			});
+		}
+	});
 </script>
 
 <slot />

--- a/packages/kit/test/apps/writes/package.json
+++ b/packages/kit/test/apps/writes/package.json
@@ -17,7 +17,7 @@
 		"cross-env": "^7.0.3",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/package.json
+++ b/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/package.json
+++ b/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/package.json
+++ b/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/build-errors/apps/private-dynamic-env-dynamic-import/package.json
+++ b/packages/kit/test/build-errors/apps/private-dynamic-env-dynamic-import/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/build-errors/apps/private-dynamic-env/package.json
+++ b/packages/kit/test/build-errors/apps/private-dynamic-env/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/build-errors/apps/private-static-env-dynamic-import/package.json
+++ b/packages/kit/test/build-errors/apps/private-static-env-dynamic-import/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/build-errors/apps/private-static-env/package.json
+++ b/packages/kit/test/build-errors/apps/private-static-env/package.json
@@ -15,7 +15,7 @@
 		"cross-env": "^7.0.3",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/build-errors/apps/server-only-folder-dynamic-import/package.json
+++ b/packages/kit/test/build-errors/apps/server-only-folder-dynamic-import/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/build-errors/apps/server-only-folder/package.json
+++ b/packages/kit/test/build-errors/apps/server-only-folder/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/build-errors/apps/server-only-module-dynamic-import/package.json
+++ b/packages/kit/test/build-errors/apps/server-only-module-dynamic-import/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/build-errors/apps/server-only-module/package.json
+++ b/packages/kit/test/build-errors/apps/server-only-module/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/build-errors/apps/service-worker-dynamic-public-env/package.json
+++ b/packages/kit/test/build-errors/apps/service-worker-dynamic-public-env/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/build-errors/apps/service-worker-private-env/package.json
+++ b/packages/kit/test/build-errors/apps/service-worker-private-env/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/build-errors/apps/syntax-error/package.json
+++ b/packages/kit/test/build-errors/apps/syntax-error/package.json
@@ -12,7 +12,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2"
 	},
 	"type": "module"

--- a/packages/kit/test/prerendering/basics/package.json
+++ b/packages/kit/test/prerendering/basics/package.json
@@ -15,7 +15,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2",
 		"vitest": "^2.0.1"
 	},

--- a/packages/kit/test/prerendering/options/package.json
+++ b/packages/kit/test/prerendering/options/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2",
 		"vitest": "^2.0.1"
 	},

--- a/packages/kit/test/prerendering/paths-base/package.json
+++ b/packages/kit/test/prerendering/paths-base/package.json
@@ -14,7 +14,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"svelte": "^4.2.10",
 		"svelte-check": "^4.0.1",
-		"typescript": "^5.3.3",
+		"typescript": "^5.5.4",
 		"vite": "^5.3.2",
 		"vitest": "^2.0.1"
 	},

--- a/playgrounds/basic/package.json
+++ b/playgrounds/basic/package.json
@@ -28,7 +28,7 @@
 		"prettier": "^3.3.2",
 		"prettier-plugin-svelte": "^3.2.6",
 		"publint": "^0.2.0",
-		"svelte": "^5.2.8",
+		"svelte": "^5.1.13",
 		"svelte-check": "^4.0.1",
 		"typescript": "^5.5.0",
 		"vite": "^5.4.4"

--- a/playgrounds/basic/package.json
+++ b/playgrounds/basic/package.json
@@ -28,7 +28,7 @@
 		"prettier": "^3.3.2",
 		"prettier-plugin-svelte": "^3.2.6",
 		"publint": "^0.2.0",
-		"svelte": "^5.1.13",
+		"svelte": "^5.2.8",
 		"svelte-check": "^4.0.1",
 		"typescript": "^5.5.0",
 		"vite": "^5.4.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 2.27.8
       '@sveltejs/eslint-config':
         specifier: ^8.1.0
-        version: 8.1.0(@stylistic/eslint-plugin-js@2.1.0(eslint@9.6.0))(eslint-config-prettier@9.1.0(eslint@9.6.0))(eslint-plugin-n@17.9.0(eslint@9.6.0))(eslint-plugin-svelte@2.41.0(eslint@9.6.0)(svelte@5.1.13))(eslint@9.6.0)(typescript-eslint@8.4.0(eslint@9.6.0)(typescript@5.6.3))(typescript@5.6.3)
+        version: 8.1.0(@stylistic/eslint-plugin-js@2.1.0(eslint@9.6.0))(eslint-config-prettier@9.1.0(eslint@9.6.0))(eslint-plugin-n@17.9.0(eslint@9.6.0))(eslint-plugin-svelte@2.41.0(eslint@9.6.0)(svelte@5.2.8))(eslint@9.6.0)(typescript-eslint@8.4.0(eslint@9.6.0)(typescript@5.6.3))(typescript@5.6.3)
       '@svitejs/changesets-changelog-github-compact':
         specifier: ^1.1.0
         version: 1.1.0
@@ -28,7 +28,7 @@ importers:
         version: 3.1.1
       prettier-plugin-svelte:
         specifier: ^3.1.2
-        version: 3.1.2(prettier@3.1.1)(svelte@5.1.13)
+        version: 3.1.2(prettier@3.1.1)(svelte@5.2.8)
       typescript-eslint:
         specifier: ^8.0.0
         version: 8.4.0(eslint@9.6.0)(typescript@5.6.3)
@@ -44,7 +44,7 @@ importers:
         version: link:../kit
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.1
-        version: 3.1.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+        version: 3.1.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       '@types/node':
         specifier: ^18.19.48
         version: 18.19.50
@@ -137,7 +137,7 @@ importers:
         version: link:../kit
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.1
-        version: 3.1.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+        version: 3.1.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       '@types/node':
         specifier: ^18.19.48
         version: 18.19.50
@@ -177,7 +177,7 @@ importers:
         version: link:../kit
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.1
-        version: 3.1.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+        version: 3.1.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       '@types/node':
         specifier: ^18.19.48
         version: 18.19.50
@@ -274,7 +274,7 @@ importers:
         version: link:../kit
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.1
-        version: 3.1.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+        version: 3.1.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       '@types/node':
         specifier: ^18.19.48
         version: 18.19.50
@@ -289,7 +289,7 @@ importers:
     dependencies:
       '@sveltejs/kit':
         specifier: ^1.0.0 || ^2.0.0
-        version: 2.7.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+        version: 2.7.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
     devDependencies:
       typescript:
         specifier: ^5.3.3
@@ -1102,22 +1102,22 @@ importers:
         version: link:../../packages/package
       '@sveltejs/vite-plugin-svelte':
         specifier: ^4.0.0
-        version: 4.0.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+        version: 4.0.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       prettier:
         specifier: ^3.3.2
         version: 3.3.3
       prettier-plugin-svelte:
         specifier: ^3.2.6
-        version: 3.2.7(prettier@3.3.3)(svelte@5.1.13)
+        version: 3.2.7(prettier@3.3.3)(svelte@5.2.8)
       publint:
         specifier: ^0.2.0
         version: 0.2.7
       svelte:
-        specifier: ^5.1.13
-        version: 5.1.13
+        specifier: ^5.2.8
+        version: 5.2.8
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@5.1.13)(typescript@5.6.3)
+        version: 4.0.1(picomatch@4.0.2)(svelte@5.2.8)(typescript@5.6.3)
       typescript:
         specifier: ^5.5.0
         version: 5.6.3
@@ -2752,6 +2752,9 @@ packages:
   is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
 
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3549,6 +3552,10 @@ packages:
 
   svelte@5.1.13:
     resolution: {integrity: sha512-xVNk8yLsZNfkyqWzVg8+nfU9ewiSjVW0S4qyTxfKa6Y7P5ZBhA+LDsh2cHWIXJQMltikQAk6W3sqGdQZSH58PA==}
+    engines: {node: '>=18'}
+
+  svelte@5.2.8:
+    resolution: {integrity: sha512-VU7a01XwnFi6wXVkH5QY3FYXRZWrhsWZhaE8AYU6UeYZdslE3TFgQq6+HLrbMjOLkVhdKt74NGHYbhFeErQQ6g==}
     engines: {node: '>=18'}
 
   tapable@2.2.1:
@@ -4503,20 +4510,20 @@ snapshots:
       eslint-visitor-keys: 4.1.0
       espree: 10.2.0
 
-  '@sveltejs/eslint-config@8.1.0(@stylistic/eslint-plugin-js@2.1.0(eslint@9.6.0))(eslint-config-prettier@9.1.0(eslint@9.6.0))(eslint-plugin-n@17.9.0(eslint@9.6.0))(eslint-plugin-svelte@2.41.0(eslint@9.6.0)(svelte@5.1.13))(eslint@9.6.0)(typescript-eslint@8.4.0(eslint@9.6.0)(typescript@5.6.3))(typescript@5.6.3)':
+  '@sveltejs/eslint-config@8.1.0(@stylistic/eslint-plugin-js@2.1.0(eslint@9.6.0))(eslint-config-prettier@9.1.0(eslint@9.6.0))(eslint-plugin-n@17.9.0(eslint@9.6.0))(eslint-plugin-svelte@2.41.0(eslint@9.6.0)(svelte@5.2.8))(eslint@9.6.0)(typescript-eslint@8.4.0(eslint@9.6.0)(typescript@5.6.3))(typescript@5.6.3)':
     dependencies:
       '@stylistic/eslint-plugin-js': 2.1.0(eslint@9.6.0)
       eslint: 9.6.0
       eslint-config-prettier: 9.1.0(eslint@9.6.0)
       eslint-plugin-n: 17.9.0(eslint@9.6.0)
-      eslint-plugin-svelte: 2.41.0(eslint@9.6.0)(svelte@5.1.13)
+      eslint-plugin-svelte: 2.41.0(eslint@9.6.0)(svelte@5.2.8)
       globals: 15.10.0
       typescript: 5.6.3
       typescript-eslint: 8.4.0(eslint@9.6.0)(typescript@5.6.3)
 
-  '@sveltejs/kit@2.7.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
+  '@sveltejs/kit@2.7.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.0
@@ -4528,7 +4535,7 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 3.0.0
-      svelte: 5.1.13
+      svelte: 5.2.8
       tiny-glob: 0.2.9
       vite: 5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)
 
@@ -4550,20 +4557,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       debug: 4.3.5
-      svelte: 5.1.13
+      svelte: 5.2.8
       vite: 5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       debug: 4.3.7
-      svelte: 5.1.13
+      svelte: 5.2.8
       vite: 5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)
     transitivePeerDependencies:
       - supports-color
@@ -4596,28 +4603,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
+  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       debug: 4.3.5
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.11
-      svelte: 5.1.13
-      svelte-hmr: 0.16.0(svelte@5.1.13)
+      svelte: 5.2.8
+      svelte-hmr: 0.16.0(svelte@5.2.8)
       vite: 5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)
       vitefu: 0.2.5(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
+  '@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       debug: 4.3.7
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.12
-      svelte: 5.1.13
+      svelte: 5.2.8
       vite: 5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)
       vitefu: 1.0.3(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
     transitivePeerDependencies:
@@ -5162,7 +5169,7 @@ snapshots:
       minimatch: 9.0.5
       semver: 7.6.3
 
-  eslint-plugin-svelte@2.41.0(eslint@9.6.0)(svelte@5.1.13):
+  eslint-plugin-svelte@2.41.0(eslint@9.6.0)(svelte@5.2.8):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.6.0)
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -5175,9 +5182,9 @@ snapshots:
       postcss-safe-parser: 6.0.0(postcss@8.4.47)
       postcss-selector-parser: 6.1.2
       semver: 7.6.3
-      svelte-eslint-parser: 0.39.2(svelte@5.1.13)
+      svelte-eslint-parser: 0.39.2(svelte@5.2.8)
     optionalDependencies:
-      svelte: 5.1.13
+      svelte: 5.2.8
     transitivePeerDependencies:
       - ts-node
 
@@ -5531,6 +5538,10 @@ snapshots:
       '@types/estree': 1.0.6
 
   is-reference@3.0.2:
+    dependencies:
+      '@types/estree': 1.0.6
+
+  is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.6
 
@@ -5916,15 +5927,15 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.1.2(prettier@3.1.1)(svelte@5.1.13):
+  prettier-plugin-svelte@3.1.2(prettier@3.1.1)(svelte@5.2.8):
     dependencies:
       prettier: 3.1.1
-      svelte: 5.1.13
+      svelte: 5.2.8
 
-  prettier-plugin-svelte@3.2.7(prettier@3.3.3)(svelte@5.1.13):
+  prettier-plugin-svelte@3.2.7(prettier@3.3.3)(svelte@5.2.8):
     dependencies:
       prettier: 3.3.3
-      svelte: 5.1.13
+      svelte: 5.2.8
 
   prettier@2.8.8: {}
 
@@ -6193,19 +6204,19 @@ snapshots:
     transitivePeerDependencies:
       - picomatch
 
-  svelte-check@4.0.1(picomatch@4.0.2)(svelte@5.1.13)(typescript@5.6.3):
+  svelte-check@4.0.1(picomatch@4.0.2)(svelte@5.2.8)(typescript@5.6.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.6.0
       fdir: 6.3.0(picomatch@4.0.2)
       picocolors: 1.1.0
       sade: 1.8.1
-      svelte: 5.1.13
+      svelte: 5.2.8
       typescript: 5.6.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@0.39.2(svelte@5.1.13):
+  svelte-eslint-parser@0.39.2(svelte@5.2.8):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -6213,15 +6224,15 @@ snapshots:
       postcss: 8.4.47
       postcss-scss: 4.0.9(postcss@8.4.47)
     optionalDependencies:
-      svelte: 5.1.13
+      svelte: 5.2.8
 
   svelte-hmr@0.16.0(svelte@4.2.19):
     dependencies:
       svelte: 4.2.19
 
-  svelte-hmr@0.16.0(svelte@5.1.13):
+  svelte-hmr@0.16.0(svelte@5.2.8):
     dependencies:
-      svelte: 5.1.13
+      svelte: 5.2.8
 
   svelte-parse-markup@0.1.5(svelte@5.1.13):
     dependencies:
@@ -6275,6 +6286,22 @@ snapshots:
       is-reference: 3.0.2
       locate-character: 3.0.0
       magic-string: 0.30.11
+      zimmerframe: 1.1.2
+
+  svelte@5.2.8:
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@jridgewell/sourcemap-codec': 1.5.0
+      '@types/estree': 1.0.6
+      acorn: 8.12.1
+      acorn-typescript: 1.4.13(acorn@8.12.1)
+      aria-query: 5.3.2
+      axobject-query: 4.1.0
+      esm-env: 1.0.0
+      esrap: 1.2.2
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.12
       zimmerframe: 1.1.2
 
   tapable@2.2.1: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 2.27.8
       '@sveltejs/eslint-config':
         specifier: ^8.1.0
-        version: 8.1.0(@stylistic/eslint-plugin-js@2.1.0(eslint@9.6.0))(eslint-config-prettier@9.1.0(eslint@9.6.0))(eslint-plugin-n@17.9.0(eslint@9.6.0))(eslint-plugin-svelte@2.41.0(eslint@9.6.0)(svelte@5.2.8))(eslint@9.6.0)(typescript-eslint@8.4.0(eslint@9.6.0)(typescript@5.6.3))(typescript@5.6.3)
+        version: 8.1.0(@stylistic/eslint-plugin-js@2.1.0(eslint@9.6.0))(eslint-config-prettier@9.1.0(eslint@9.6.0))(eslint-plugin-n@17.9.0(eslint@9.6.0))(eslint-plugin-svelte@2.41.0(eslint@9.6.0)(svelte@5.1.13))(eslint@9.6.0)(typescript-eslint@8.4.0(eslint@9.6.0)(typescript@5.6.3))(typescript@5.6.3)
       '@svitejs/changesets-changelog-github-compact':
         specifier: ^1.1.0
         version: 1.1.0
@@ -28,7 +28,7 @@ importers:
         version: 3.1.1
       prettier-plugin-svelte:
         specifier: ^3.1.2
-        version: 3.1.2(prettier@3.1.1)(svelte@5.2.8)
+        version: 3.1.2(prettier@3.1.1)(svelte@5.1.13)
       typescript-eslint:
         specifier: ^8.0.0
         version: 8.4.0(eslint@9.6.0)(typescript@5.6.3)
@@ -44,7 +44,7 @@ importers:
         version: link:../kit
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.1
-        version: 3.1.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+        version: 3.1.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       '@types/node':
         specifier: ^18.19.48
         version: 18.19.50
@@ -137,7 +137,7 @@ importers:
         version: link:../kit
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.1
-        version: 3.1.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+        version: 3.1.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       '@types/node':
         specifier: ^18.19.48
         version: 18.19.50
@@ -177,7 +177,7 @@ importers:
         version: link:../kit
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.1
-        version: 3.1.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+        version: 3.1.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       '@types/node':
         specifier: ^18.19.48
         version: 18.19.50
@@ -274,7 +274,7 @@ importers:
         version: link:../kit
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.1
-        version: 3.1.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+        version: 3.1.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       '@types/node':
         specifier: ^18.19.48
         version: 18.19.50
@@ -289,7 +289,7 @@ importers:
     dependencies:
       '@sveltejs/kit':
         specifier: ^1.0.0 || ^2.0.0
-        version: 2.7.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+        version: 2.7.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
     devDependencies:
       typescript:
         specifier: ^5.3.3
@@ -1102,22 +1102,22 @@ importers:
         version: link:../../packages/package
       '@sveltejs/vite-plugin-svelte':
         specifier: ^4.0.0
-        version: 4.0.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+        version: 4.0.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       prettier:
         specifier: ^3.3.2
         version: 3.3.3
       prettier-plugin-svelte:
         specifier: ^3.2.6
-        version: 3.2.7(prettier@3.3.3)(svelte@5.2.8)
+        version: 3.2.7(prettier@3.3.3)(svelte@5.1.13)
       publint:
         specifier: ^0.2.0
         version: 0.2.7
       svelte:
-        specifier: ^5.2.8
-        version: 5.2.8
+        specifier: ^5.1.13
+        version: 5.1.13
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@5.2.8)(typescript@5.6.3)
+        version: 4.0.1(picomatch@4.0.2)(svelte@5.1.13)(typescript@5.6.3)
       typescript:
         specifier: ^5.5.0
         version: 5.6.3
@@ -2752,9 +2752,6 @@ packages:
   is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
 
-  is-reference@3.0.3:
-    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
-
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3552,10 +3549,6 @@ packages:
 
   svelte@5.1.13:
     resolution: {integrity: sha512-xVNk8yLsZNfkyqWzVg8+nfU9ewiSjVW0S4qyTxfKa6Y7P5ZBhA+LDsh2cHWIXJQMltikQAk6W3sqGdQZSH58PA==}
-    engines: {node: '>=18'}
-
-  svelte@5.2.8:
-    resolution: {integrity: sha512-VU7a01XwnFi6wXVkH5QY3FYXRZWrhsWZhaE8AYU6UeYZdslE3TFgQq6+HLrbMjOLkVhdKt74NGHYbhFeErQQ6g==}
     engines: {node: '>=18'}
 
   tapable@2.2.1:
@@ -4510,20 +4503,20 @@ snapshots:
       eslint-visitor-keys: 4.1.0
       espree: 10.2.0
 
-  '@sveltejs/eslint-config@8.1.0(@stylistic/eslint-plugin-js@2.1.0(eslint@9.6.0))(eslint-config-prettier@9.1.0(eslint@9.6.0))(eslint-plugin-n@17.9.0(eslint@9.6.0))(eslint-plugin-svelte@2.41.0(eslint@9.6.0)(svelte@5.2.8))(eslint@9.6.0)(typescript-eslint@8.4.0(eslint@9.6.0)(typescript@5.6.3))(typescript@5.6.3)':
+  '@sveltejs/eslint-config@8.1.0(@stylistic/eslint-plugin-js@2.1.0(eslint@9.6.0))(eslint-config-prettier@9.1.0(eslint@9.6.0))(eslint-plugin-n@17.9.0(eslint@9.6.0))(eslint-plugin-svelte@2.41.0(eslint@9.6.0)(svelte@5.1.13))(eslint@9.6.0)(typescript-eslint@8.4.0(eslint@9.6.0)(typescript@5.6.3))(typescript@5.6.3)':
     dependencies:
       '@stylistic/eslint-plugin-js': 2.1.0(eslint@9.6.0)
       eslint: 9.6.0
       eslint-config-prettier: 9.1.0(eslint@9.6.0)
       eslint-plugin-n: 17.9.0(eslint@9.6.0)
-      eslint-plugin-svelte: 2.41.0(eslint@9.6.0)(svelte@5.2.8)
+      eslint-plugin-svelte: 2.41.0(eslint@9.6.0)(svelte@5.1.13)
       globals: 15.10.0
       typescript: 5.6.3
       typescript-eslint: 8.4.0(eslint@9.6.0)(typescript@5.6.3)
 
-  '@sveltejs/kit@2.7.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
+  '@sveltejs/kit@2.7.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.0
@@ -4535,7 +4528,7 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 3.0.0
-      svelte: 5.2.8
+      svelte: 5.1.13
       tiny-glob: 0.2.9
       vite: 5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)
 
@@ -4557,20 +4550,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       debug: 4.3.5
-      svelte: 5.2.8
+      svelte: 5.1.13
       vite: 5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       debug: 4.3.7
-      svelte: 5.2.8
+      svelte: 5.1.13
       vite: 5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)
     transitivePeerDependencies:
       - supports-color
@@ -4603,28 +4596,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
+  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       debug: 4.3.5
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.11
-      svelte: 5.2.8
-      svelte-hmr: 0.16.0(svelte@5.2.8)
+      svelte: 5.1.13
+      svelte-hmr: 0.16.0(svelte@5.1.13)
       vite: 5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)
       vitefu: 0.2.5(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
+  '@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.2.8)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.1.13)(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
       debug: 4.3.7
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.12
-      svelte: 5.2.8
+      svelte: 5.1.13
       vite: 5.4.10(@types/node@18.19.50)(lightningcss@1.24.1)
       vitefu: 1.0.3(vite@5.4.10(@types/node@18.19.50)(lightningcss@1.24.1))
     transitivePeerDependencies:
@@ -5169,7 +5162,7 @@ snapshots:
       minimatch: 9.0.5
       semver: 7.6.3
 
-  eslint-plugin-svelte@2.41.0(eslint@9.6.0)(svelte@5.2.8):
+  eslint-plugin-svelte@2.41.0(eslint@9.6.0)(svelte@5.1.13):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.6.0)
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -5182,9 +5175,9 @@ snapshots:
       postcss-safe-parser: 6.0.0(postcss@8.4.47)
       postcss-selector-parser: 6.1.2
       semver: 7.6.3
-      svelte-eslint-parser: 0.39.2(svelte@5.2.8)
+      svelte-eslint-parser: 0.39.2(svelte@5.1.13)
     optionalDependencies:
-      svelte: 5.2.8
+      svelte: 5.1.13
     transitivePeerDependencies:
       - ts-node
 
@@ -5538,10 +5531,6 @@ snapshots:
       '@types/estree': 1.0.6
 
   is-reference@3.0.2:
-    dependencies:
-      '@types/estree': 1.0.6
-
-  is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.6
 
@@ -5927,15 +5916,15 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.1.2(prettier@3.1.1)(svelte@5.2.8):
+  prettier-plugin-svelte@3.1.2(prettier@3.1.1)(svelte@5.1.13):
     dependencies:
       prettier: 3.1.1
-      svelte: 5.2.8
+      svelte: 5.1.13
 
-  prettier-plugin-svelte@3.2.7(prettier@3.3.3)(svelte@5.2.8):
+  prettier-plugin-svelte@3.2.7(prettier@3.3.3)(svelte@5.1.13):
     dependencies:
       prettier: 3.3.3
-      svelte: 5.2.8
+      svelte: 5.1.13
 
   prettier@2.8.8: {}
 
@@ -6204,19 +6193,19 @@ snapshots:
     transitivePeerDependencies:
       - picomatch
 
-  svelte-check@4.0.1(picomatch@4.0.2)(svelte@5.2.8)(typescript@5.6.3):
+  svelte-check@4.0.1(picomatch@4.0.2)(svelte@5.1.13)(typescript@5.6.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.6.0
       fdir: 6.3.0(picomatch@4.0.2)
       picocolors: 1.1.0
       sade: 1.8.1
-      svelte: 5.2.8
+      svelte: 5.1.13
       typescript: 5.6.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@0.39.2(svelte@5.2.8):
+  svelte-eslint-parser@0.39.2(svelte@5.1.13):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -6224,15 +6213,15 @@ snapshots:
       postcss: 8.4.47
       postcss-scss: 4.0.9(postcss@8.4.47)
     optionalDependencies:
-      svelte: 5.2.8
+      svelte: 5.1.13
 
   svelte-hmr@0.16.0(svelte@4.2.19):
     dependencies:
       svelte: 4.2.19
 
-  svelte-hmr@0.16.0(svelte@5.2.8):
+  svelte-hmr@0.16.0(svelte@5.1.13):
     dependencies:
-      svelte: 5.2.8
+      svelte: 5.1.13
 
   svelte-parse-markup@0.1.5(svelte@5.1.13):
     dependencies:
@@ -6286,22 +6275,6 @@ snapshots:
       is-reference: 3.0.2
       locate-character: 3.0.0
       magic-string: 0.30.11
-      zimmerframe: 1.1.2
-
-  svelte@5.2.8:
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@jridgewell/sourcemap-codec': 1.5.0
-      '@types/estree': 1.0.6
-      acorn: 8.12.1
-      acorn-typescript: 1.4.13(acorn@8.12.1)
-      aria-query: 5.3.2
-      axobject-query: 4.1.0
-      esm-env: 1.0.0
-      esrap: 1.2.2
-      is-reference: 3.0.3
-      locate-character: 3.0.0
-      magic-string: 0.30.12
       zimmerframe: 1.1.2
 
   tapable@2.2.1: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,10 +432,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -456,10 +456,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -510,10 +510,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -534,10 +534,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -558,10 +558,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -582,10 +582,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -609,10 +609,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -633,10 +633,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -663,10 +663,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -687,10 +687,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -711,10 +711,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -732,10 +732,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -753,10 +753,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -777,10 +777,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -798,10 +798,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -819,10 +819,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -840,10 +840,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -861,10 +861,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -882,10 +882,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -903,10 +903,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -924,10 +924,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -945,10 +945,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -966,10 +966,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -990,10 +990,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -1014,10 +1014,10 @@ importers:
         version: 4.2.19
       svelte-check:
         specifier: ^4.0.1
-        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5)
+        version: 4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.6.3
       vite:
         specifier: ^5.3.2
         version: 5.3.6(@types/node@18.19.50)(lightningcss@1.24.1)
@@ -6181,7 +6181,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.4.5):
+  svelte-check@4.0.1(picomatch@4.0.2)(svelte@4.2.19)(typescript@5.6.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.6.0
@@ -6189,7 +6189,7 @@ snapshots:
       picocolors: 1.1.0
       sade: 1.8.1
       svelte: 4.2.19
-      typescript: 5.4.5
+      typescript: 5.6.3
     transitivePeerDependencies:
       - picomatch
 


### PR DESCRIPTION
This PR is meant to get the [ecosystem CI](https://github.com/sveltejs/svelte-ecosystem-ci) passing for SvelteKit, which overrides Svelte 4 with 5 (and vite-plugin-svelte 3 with 4 in my testing). https://github.com/sveltejs/svelte-ecosystem-ci/actions/runs/12026344184/job/33525133268

Changes are:

- update typescript version in test apps to match Svelte 5's so that [ContentVisibilityAutoStateChangeEvent](https://developer.mozilla.org/en-US/docs/Web/API/ContentVisibilityAutoStateChangeEvent) exists in ts lib. This fixes [this CI error](https://github.com/sveltejs/svelte-ecosystem-ci/actions/runs/12003616227/job/33515109128#step:8:1102) where the event type can't be found.
- ~explicitly use the `"undefined"` string in tests in place of `undefined` values~ use string templates for values so that the text is visible ([instead of an empty string which is the new behaviour in Svelte 5](https://svelte.dev/docs/svelte/v5-migration-guide#Other-breaking-changes-null-and-undefined-become-the-empty-string)).
- use `innerText` in place of `innerHTML` for tests when asserting content so that Svelte 5 hydration marker comments `<!-- ->` are not captured.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
