### PR TITLE
fix: don't hydrate when falling back to error page

### DIFF
--- a/.changeset/funny-lies-beam.md
+++ b/.changeset/funny-lies-beam.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't hydrate when falling back to error page

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2358,6 +2358,7 @@ async function _hydrate(
 
 	/** @type {import('./types.js').NavigationFinished | undefined} */
 	let result;
+	let hydrate = true;
 
 	try {
 		const branch_promises = node_ids.map(async (n, i) => {
@@ -2422,13 +2423,16 @@ async function _hydrate(
 			url,
 			route
 		});
+
+		target.textContent = '';
+		hydrate = false;
 	}
 
 	if (result.props.page) {
 		result.props.page.state = {};
 	}
 
-	initialize(result, target, true);
+	initialize(result, target, hydrate);
 }
 
 /**


### PR DESCRIPTION
When we encouter an error while rerunning the loaders on hydration, we need to remove the contents that were server-rendered and start fresh with the root error page. Else Svelte 5 (which is more strict with this) will fail because it tries to walk an entirely different DOM tree. Svelte 4 didn't suffer from this because it just threw away the old code, but it was still wrong to have to do it in the first place.

Fixes https://github.com/sveltejs/svelte/issues/14437
