### PR TITLE
fix: ensure prettier doesn't process build output or test results

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -23,6 +23,7 @@
 				"**/CHANGELOG.md",
 				"**/vite.config.js.timestamp-*",
 				"**/.svelte-kit/**",
+				"**/test-results/**",
 				"documentation/**/*.md",
 				"packages/package/test/fixtures/**/expected/**/*",
 				"packages/package/test/watch/expected/**/*",
@@ -30,7 +31,7 @@
 				"packages/kit/src/core/postbuild/fixtures/**/*"
 			],
 			"options": {
-				"requirePragma": true
+				"rangeEnd": 0
 			}
 		}
 	]

--- a/packages/kit/.prettierignore
+++ b/packages/kit/.prettierignore
@@ -1,3 +1,6 @@
 test/build-errors/apps/syntax-error/src/routes/+page.svelte
 /types
 src/runtime/components/svelte-5/layout.svelte
+.svelte-kit
+test-results
+/test/apps/basics/test/errors.json


### PR DESCRIPTION
 of test apps


this saves time on ecosystem-ci and also on user machines if they ran tests and then format.

`rangeEnd: 0` is a better hack than `requirePragma` because that prevents prettier from reading the file looking for the pragma

<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
