### PR TITLE
chore: fix flaky scroll test

### DIFF
--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -452,6 +452,8 @@ test.describe('Scrolling', () => {
 
 		await page.goto('/anchor');
 		await page.evaluate(() => window.scrollTo(0, 1000));
+		// wait for the scroll to be processed before jumping to the next page
+		await page.waitForTimeout(1000);
 		await app.goto('/anchor/anchor');
 		await page.evaluate(() => window.scrollTo(0, 1000));
 


### PR DESCRIPTION
This PR adds a timeout to ensure the initial scroll has occurred in the browser. It should help with the consistent failures when running the test in vite-ecosystem-ci where the test is too quick and the initial scroll is skipped.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
