### PR TITLE
fix cloudflare docs

### DIFF
--- a/documentation/docs/25-build-and-deploy/60-adapter-cloudflare.md
+++ b/documentation/docs/25-build-and-deploy/60-adapter-cloudflare.md
@@ -86,6 +86,8 @@ To include type declarations for your bindings, reference them in your `src/app.
 
 ```ts
 /// file: src/app.d.ts
+import { KVNamespace, DurableObjectNamespace } from '@cloudflare/workers-types';
+
 declare global {
 	namespace App {
 		interface Platform {

--- a/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
+++ b/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
@@ -107,6 +107,8 @@ To include type declarations for your bindings, reference them in your `src/app.
 
 ```ts
 /// file: src/app.d.ts
+import { KVNamespace, DurableObjectNamespace } from '@cloudflare/workers-types';
+
 declare global {
 	namespace App {
 		interface Platform {


### PR DESCRIPTION
#12991 caused the docs to fail to deploy — not quite sure why the preview link in that PR succeeded. This _should_ fix it, according to my local testing (though will need to be accompanied by a change on svelte.dev installing `@cloudflare/workers-types`)