### PR TITLE
fix: strip internal data before passing URL to `reroute`

### DIFF
--- a/.changeset/curvy-trains-dress.md
+++ b/.changeset/curvy-trains-dress.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: strip internal data before passing URL to `reroute`

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -82,9 +82,16 @@ export async function respond(request, options, manifest, state) {
 	}
 
 	// reroute could alter the given URL, so we pass a copy
+	const url_copy = new URL(url);
+	if (has_data_suffix(url_copy.pathname)) {
+		url_copy.pathname = strip_data_suffix(url_copy.pathname) || '/';
+		url_copy.searchParams.delete(TRAILING_SLASH_PARAM);
+		url_copy.searchParams.delete(INVALIDATED_PARAM);
+	}
+
 	let rerouted_path;
 	try {
-		rerouted_path = options.hooks.reroute({ url: new URL(url) }) ?? url.pathname;
+		rerouted_path = options.hooks.reroute({ url: url_copy }) ?? url.pathname;
 	} catch {
 		return text('Internal Server Error', {
 			status: 500


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/11625

This PR ensures that the `/__data.json` suffix, `x-sveltekit-trailing-slash`, and `x-sveltekit-invalidated` query param are stripped before passing the URL copy to `reroute` so that the URL can be correctly rerouted instead of causing a 404 due to the `/__data.json` pathname suffix.

If this PR gets merged, we will need a shared solution for the edge middlewares running `reroute` in https://github.com/sveltejs/kit/pull/12296

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
