### PR TITLE
chore: separate expected output for svelte 4 and 5

### DIFF
--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -31,6 +31,7 @@
 		"@types/node": "^18.19.48",
 		"@types/semver": "^7.5.6",
 		"prettier": "^3.1.1",
+		"semver": "^7.6.3",
 		"svelte": "^5.2.9",
 		"svelte-preprocess": "^6.0.0",
 		"typescript": "^5.3.3",

--- a/packages/package/test/fixtures/javascript/expected ^5/Test.svelte
+++ b/packages/package/test/fixtures/javascript/expected ^5/Test.svelte
@@ -1,0 +1,12 @@
+<script>
+	import { createEventDispatcher } from 'svelte';
+	/**
+	 * @type {string}
+	 */
+	export const astring = 'potato';
+
+	const dispatch = createEventDispatcher();
+	dispatch('event', true);
+</script>
+
+<slot {astring} />

--- a/packages/package/test/fixtures/javascript/expected ^5/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/javascript/expected ^5/Test.svelte.d.ts
@@ -1,0 +1,55 @@
+export default Test;
+type Test = SvelteComponent<$$__sveltets_2_PropsWithChildren<{
+    astring?: string;
+}, {
+    default: {
+        astring: string;
+    };
+}>, {
+    event: CustomEvent<any>;
+} & {
+    [evt: string]: CustomEvent<any>;
+}, {
+    default: {
+        astring: string;
+    };
+}> & {
+    $$bindings?: string;
+} & {
+    astring: string;
+};
+declare const Test: $$__sveltets_2_IsomorphicComponent<$$__sveltets_2_PropsWithChildren<{
+    astring?: string;
+}, {
+    default: {
+        astring: string;
+    };
+}>, {
+    event: CustomEvent<any>;
+} & {
+    [evt: string]: CustomEvent<any>;
+}, {
+    default: {
+        astring: string;
+    };
+}, {
+    astring: string;
+}, string>;
+type $$__sveltets_2_PropsWithChildren<Props, Slots> = Props & (Slots extends {
+    default: any;
+} ? Props extends Record<string, never> ? any : {
+    children?: any;
+} : {});
+interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
+    new (options: import("svelte").ComponentConstructorOptions<Props>): import("svelte").SvelteComponent<Props, Events, Slots> & {
+        $$bindings?: Bindings;
+    } & Exports;
+    (internal: unknown, props: Props & {
+        $$events?: Events;
+        $$slots?: Slots;
+    }): Exports & {
+        $set?: any;
+        $on?: any;
+    };
+    z_$$bindings?: Bindings;
+}

--- a/packages/package/test/fixtures/javascript/expected ^5/Test2.svelte
+++ b/packages/package/test/fixtures/javascript/expected ^5/Test2.svelte
@@ -1,0 +1,6 @@
+<script>
+	/**
+	 * @type {import('./foo').Foo}
+	 */
+	export let foo;
+</script>

--- a/packages/package/test/fixtures/javascript/expected ^5/Test2.svelte.d.ts
+++ b/packages/package/test/fixtures/javascript/expected ^5/Test2.svelte.d.ts
@@ -1,0 +1,26 @@
+export default Test2;
+type Test2 = SvelteComponent<{
+    foo: boolean;
+}, {
+    [evt: string]: CustomEvent<any>;
+}, {}> & {
+    $$bindings?: string;
+};
+declare const Test2: $$__sveltets_2_IsomorphicComponent<{
+    foo: import("./foo").Foo;
+}, {
+    [evt: string]: CustomEvent<any>;
+}, {}, {}, string>;
+interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
+    new (options: import("svelte").ComponentConstructorOptions<Props>): import("svelte").SvelteComponent<Props, Events, Slots> & {
+        $$bindings?: Bindings;
+    } & Exports;
+    (internal: unknown, props: Props & {
+        $$events?: Events;
+        $$slots?: Slots;
+    }): Exports & {
+        $set?: any;
+        $on?: any;
+    };
+    z_$$bindings?: Bindings;
+}

--- a/packages/package/test/fixtures/javascript/expected ^5/foo.d.ts
+++ b/packages/package/test/fixtures/javascript/expected ^5/foo.d.ts
@@ -1,0 +1,1 @@
+export type Foo = boolean;

--- a/packages/package/test/fixtures/javascript/expected ^5/index.d.ts
+++ b/packages/package/test/fixtures/javascript/expected ^5/index.d.ts
@@ -1,0 +1,2 @@
+export { default as Test } from './Test.svelte';
+export { default as Internal } from './internal/Test.svelte';

--- a/packages/package/test/fixtures/javascript/expected ^5/index.js
+++ b/packages/package/test/fixtures/javascript/expected ^5/index.js
@@ -1,0 +1,2 @@
+export { default as Test } from './Test.svelte';
+export { default as Internal } from './internal/Test.svelte';

--- a/packages/package/test/fixtures/javascript/expected ^5/internal/Test.svelte
+++ b/packages/package/test/fixtures/javascript/expected ^5/internal/Test.svelte
@@ -1,0 +1,6 @@
+<script>
+	/**
+	 * @type {import('./foo').Foo}
+	 */
+	export let foo;
+</script>

--- a/packages/package/test/fixtures/javascript/expected ^5/internal/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/javascript/expected ^5/internal/Test.svelte.d.ts
@@ -1,0 +1,26 @@
+export default Test;
+type Test = SvelteComponent<{
+    foo: boolean;
+}, {
+    [evt: string]: CustomEvent<any>;
+}, {}> & {
+    $$bindings?: string;
+};
+declare const Test: $$__sveltets_2_IsomorphicComponent<{
+    foo: import("./foo").Foo;
+}, {
+    [evt: string]: CustomEvent<any>;
+}, {}, {}, string>;
+interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
+    new (options: import("svelte").ComponentConstructorOptions<Props>): import("svelte").SvelteComponent<Props, Events, Slots> & {
+        $$bindings?: Bindings;
+    } & Exports;
+    (internal: unknown, props: Props & {
+        $$events?: Events;
+        $$slots?: Slots;
+    }): Exports & {
+        $set?: any;
+        $on?: any;
+    };
+    z_$$bindings?: Bindings;
+}

--- a/packages/package/test/fixtures/javascript/expected ^5/internal/foo.d.ts
+++ b/packages/package/test/fixtures/javascript/expected ^5/internal/foo.d.ts
@@ -1,0 +1,1 @@
+export type Foo = boolean;

--- a/packages/package/test/fixtures/javascript/expected ^5/internal/index.d.ts
+++ b/packages/package/test/fixtures/javascript/expected ^5/internal/index.d.ts
@@ -1,0 +1,2 @@
+export const foo: 'bar';
+export { x } from "./runes.svelte.js";

--- a/packages/package/test/fixtures/javascript/expected ^5/internal/index.js
+++ b/packages/package/test/fixtures/javascript/expected ^5/internal/index.js
@@ -1,0 +1,2 @@
+export const foo = 'bar';
+export { x } from './runes.svelte.js';

--- a/packages/package/test/fixtures/javascript/expected ^5/internal/runes.svelte.d.ts
+++ b/packages/package/test/fixtures/javascript/expected ^5/internal/runes.svelte.d.ts
@@ -1,0 +1,1 @@
+export const x: true;

--- a/packages/package/test/fixtures/javascript/expected ^5/internal/runes.svelte.js
+++ b/packages/package/test/fixtures/javascript/expected ^5/internal/runes.svelte.js
@@ -1,0 +1,1 @@
+export const x = true;

--- a/packages/package/test/fixtures/javascript/expected/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/javascript/expected/Test.svelte.d.ts
@@ -1,55 +1,42 @@
-export default Test;
-type Test = SvelteComponent<$$__sveltets_2_PropsWithChildren<{
-    astring?: string;
-}, {
-    default: {
-        astring: string;
-    };
-}>, {
-    event: CustomEvent<any>;
-} & {
-    [evt: string]: CustomEvent<any>;
-}, {
-    default: {
-        astring: string;
-    };
-}> & {
-    $$bindings?: string;
-} & {
-    astring: string;
-};
-declare const Test: $$__sveltets_2_IsomorphicComponent<$$__sveltets_2_PropsWithChildren<{
-    astring?: string;
-}, {
-    default: {
-        astring: string;
-    };
-}>, {
-    event: CustomEvent<any>;
-} & {
-    [evt: string]: CustomEvent<any>;
-}, {
-    default: {
-        astring: string;
-    };
-}, {
-    astring: string;
-}, string>;
-type $$__sveltets_2_PropsWithChildren<Props, Slots> = Props & (Slots extends {
-    default: any;
-} ? Props extends Record<string, never> ? any : {
-    children?: any;
-} : {});
-interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
-    new (options: import("svelte").ComponentConstructorOptions<Props>): import("svelte").SvelteComponent<Props, Events, Slots> & {
-        $$bindings?: Bindings;
-    } & Exports;
-    (internal: unknown, props: Props & {
-        $$events?: Events;
-        $$slots?: Slots;
-    }): Exports & {
-        $set?: any;
-        $on?: any;
-    };
-    z_$$bindings?: Bindings;
+/** @typedef {typeof __propDef.props}  TestProps */
+/** @typedef {typeof __propDef.events}  TestEvents */
+/** @typedef {typeof __propDef.slots}  TestSlots */
+export default class Test extends SvelteComponent<
+	{
+		astring?: string;
+	},
+	{
+		event: CustomEvent<any>;
+	} & {
+		[evt: string]: CustomEvent<any>;
+	},
+	{
+		default: {
+			astring: string;
+		};
+	}
+> {
+	get astring(): string;
 }
+export type TestProps = typeof __propDef.props;
+export type TestEvents = typeof __propDef.events;
+export type TestSlots = typeof __propDef.slots;
+import { SvelteComponent } from 'svelte';
+declare const __propDef: {
+	props: {
+		astring?: string;
+	};
+	events: {
+		event: CustomEvent<any>;
+	} & {
+		[evt: string]: CustomEvent<any>;
+	};
+	slots: {
+		default: {
+			astring: string;
+		};
+	};
+	exports?: {};
+	bindings?: string;
+};
+export {};

--- a/packages/package/test/fixtures/javascript/expected/Test2.svelte.d.ts
+++ b/packages/package/test/fixtures/javascript/expected/Test2.svelte.d.ts
@@ -1,26 +1,28 @@
-export default Test2;
-type Test2 = SvelteComponent<{
-    foo: boolean;
-}, {
-    [evt: string]: CustomEvent<any>;
-}, {}> & {
-    $$bindings?: string;
+/** @typedef {typeof __propDef.props}  Test2Props */
+/** @typedef {typeof __propDef.events}  Test2Events */
+/** @typedef {typeof __propDef.slots}  Test2Slots */
+export default class Test2 extends SvelteComponent<
+	{
+		foo: import('./foo').Foo;
+	},
+	{
+		[evt: string]: CustomEvent<any>;
+	},
+	{}
+> {}
+export type Test2Props = typeof __propDef.props;
+export type Test2Events = typeof __propDef.events;
+export type Test2Slots = typeof __propDef.slots;
+import { SvelteComponent } from 'svelte';
+declare const __propDef: {
+	props: {
+		foo: import('./foo').Foo;
+	};
+	events: {
+		[evt: string]: CustomEvent<any>;
+	};
+	slots: {};
+	exports?: {};
+	bindings?: string;
 };
-declare const Test2: $$__sveltets_2_IsomorphicComponent<{
-    foo: import("./foo").Foo;
-}, {
-    [evt: string]: CustomEvent<any>;
-}, {}, {}, string>;
-interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
-    new (options: import("svelte").ComponentConstructorOptions<Props>): import("svelte").SvelteComponent<Props, Events, Slots> & {
-        $$bindings?: Bindings;
-    } & Exports;
-    (internal: unknown, props: Props & {
-        $$events?: Events;
-        $$slots?: Slots;
-    }): Exports & {
-        $set?: any;
-        $on?: any;
-    };
-    z_$$bindings?: Bindings;
-}
+export {};

--- a/packages/package/test/fixtures/javascript/expected/internal/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/javascript/expected/internal/Test.svelte.d.ts
@@ -1,26 +1,28 @@
-export default Test;
-type Test = SvelteComponent<{
-    foo: boolean;
-}, {
-    [evt: string]: CustomEvent<any>;
-}, {}> & {
-    $$bindings?: string;
+/** @typedef {typeof __propDef.props}  TestProps */
+/** @typedef {typeof __propDef.events}  TestEvents */
+/** @typedef {typeof __propDef.slots}  TestSlots */
+export default class Test extends SvelteComponent<
+	{
+		foo: import('./foo').Foo;
+	},
+	{
+		[evt: string]: CustomEvent<any>;
+	},
+	{}
+> {}
+export type TestProps = typeof __propDef.props;
+export type TestEvents = typeof __propDef.events;
+export type TestSlots = typeof __propDef.slots;
+import { SvelteComponent } from 'svelte';
+declare const __propDef: {
+	props: {
+		foo: import('./foo').Foo;
+	};
+	events: {
+		[evt: string]: CustomEvent<any>;
+	};
+	slots: {};
+	exports?: {};
+	bindings?: string;
 };
-declare const Test: $$__sveltets_2_IsomorphicComponent<{
-    foo: import("./foo").Foo;
-}, {
-    [evt: string]: CustomEvent<any>;
-}, {}, {}, string>;
-interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
-    new (options: import("svelte").ComponentConstructorOptions<Props>): import("svelte").SvelteComponent<Props, Events, Slots> & {
-        $$bindings?: Bindings;
-    } & Exports;
-    (internal: unknown, props: Props & {
-        $$events?: Events;
-        $$slots?: Slots;
-    }): Exports & {
-        $set?: any;
-        $on?: any;
-    };
-    z_$$bindings?: Bindings;
-}
+export {};

--- a/packages/package/test/fixtures/resolve-alias/expected ^5/Test.svelte
+++ b/packages/package/test/fixtures/resolve-alias/expected ^5/Test.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import { foo } from './sub/foo';
+	import { util } from './utils';
+
+	export let bar = foo;
+
+	util();
+</script>

--- a/packages/package/test/fixtures/resolve-alias/expected ^5/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/resolve-alias/expected ^5/Test.svelte.d.ts
@@ -1,0 +1,20 @@
+interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
+	new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & {
+			$$bindings?: Bindings;
+	} & Exports;
+	(internal: unknown, props: Props & {
+			$$events?: Events;
+			$$slots?: Slots;
+	}): Exports & {
+			$set?: any;
+			$on?: any;
+	};
+	z_$$bindings?: Bindings;
+}
+declare const Test: $$__sveltets_2_IsomorphicComponent<{
+	bar?: import("./sub/foo").Foo;
+}, {
+	[evt: string]: CustomEvent<any>;
+}, {}, {}, string>;
+type Test = InstanceType<typeof Test>;
+export default Test;

--- a/packages/package/test/fixtures/resolve-alias/expected ^5/baz.d.ts
+++ b/packages/package/test/fixtures/resolve-alias/expected ^5/baz.d.ts
@@ -1,0 +1,4 @@
+export interface Baz {
+	baz: string;
+}
+export declare const baz: Baz;

--- a/packages/package/test/fixtures/resolve-alias/expected ^5/baz.js
+++ b/packages/package/test/fixtures/resolve-alias/expected ^5/baz.js
@@ -1,0 +1,1 @@
+export const baz = { baz: 'baz' };

--- a/packages/package/test/fixtures/resolve-alias/expected ^5/index.d.ts
+++ b/packages/package/test/fixtures/resolve-alias/expected ^5/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Test } from './Test.svelte';

--- a/packages/package/test/fixtures/resolve-alias/expected ^5/index.js
+++ b/packages/package/test/fixtures/resolve-alias/expected ^5/index.js
@@ -1,0 +1,1 @@
+export { default as Test } from './Test.svelte';

--- a/packages/package/test/fixtures/resolve-alias/expected ^5/sub/bar.d.ts
+++ b/packages/package/test/fixtures/resolve-alias/expected ^5/sub/bar.d.ts
@@ -1,0 +1,2 @@
+export declare const bar1: import('./foo').Foo;
+export declare const bar2: import('../baz').Baz;

--- a/packages/package/test/fixtures/resolve-alias/expected ^5/sub/bar.js
+++ b/packages/package/test/fixtures/resolve-alias/expected ^5/sub/bar.js
@@ -1,0 +1,4 @@
+import { baz } from '../baz';
+import { foo } from './foo';
+export const bar1 = foo;
+export const bar2 = baz;

--- a/packages/package/test/fixtures/resolve-alias/expected ^5/sub/foo.d.ts
+++ b/packages/package/test/fixtures/resolve-alias/expected ^5/sub/foo.d.ts
@@ -1,0 +1,4 @@
+export interface Foo {
+	foo: string;
+}
+export declare const foo: Foo;

--- a/packages/package/test/fixtures/resolve-alias/expected ^5/sub/foo.js
+++ b/packages/package/test/fixtures/resolve-alias/expected ^5/sub/foo.js
@@ -1,0 +1,1 @@
+export const foo = { foo: 'foo' };

--- a/packages/package/test/fixtures/resolve-alias/expected ^5/utils/index.d.ts
+++ b/packages/package/test/fixtures/resolve-alias/expected ^5/utils/index.d.ts
@@ -1,0 +1,1 @@
+export declare const util: () => void;

--- a/packages/package/test/fixtures/resolve-alias/expected ^5/utils/index.js
+++ b/packages/package/test/fixtures/resolve-alias/expected ^5/utils/index.js
@@ -1,0 +1,1 @@
+export const util = () => { };

--- a/packages/package/test/fixtures/resolve-alias/expected/Test.svelte
+++ b/packages/package/test/fixtures/resolve-alias/expected/Test.svelte
@@ -1,8 +1,6 @@
-<script lang="ts">
-	import { foo } from './sub/foo';
-	import { util } from './utils';
-
-	export let bar = foo;
-
-	util();
+<script>
+  import { foo } from './sub/foo';
+  import { util } from './utils';
+  export let bar = foo;
+  util();
 </script>

--- a/packages/package/test/fixtures/resolve-alias/expected/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/resolve-alias/expected/Test.svelte.d.ts
@@ -1,20 +1,17 @@
-interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
-	new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & {
-			$$bindings?: Bindings;
-	} & Exports;
-	(internal: unknown, props: Props & {
-			$$events?: Events;
-			$$slots?: Slots;
-	}): Exports & {
-			$set?: any;
-			$on?: any;
+import { SvelteComponent } from 'svelte';
+declare const __propDef: {
+	props: {
+		bar?: import('./sub/foo').Foo;
 	};
-	z_$$bindings?: Bindings;
-}
-declare const Test: $$__sveltets_2_IsomorphicComponent<{
-	bar?: import("./sub/foo").Foo;
-}, {
-	[evt: string]: CustomEvent<any>;
-}, {}, {}, string>;
-type Test = InstanceType<typeof Test>;
-export default Test;
+	events: {
+		[evt: string]: CustomEvent<any>;
+	};
+	slots: {};
+	exports?: {};
+	bindings?: string;
+};
+export type TestProps = typeof __propDef.props;
+export type TestEvents = typeof __propDef.events;
+export type TestSlots = typeof __propDef.slots;
+export default class Test extends SvelteComponent<TestProps, TestEvents, TestSlots> {}
+export {};

--- a/packages/package/test/fixtures/svelte-3-types/expected ^5/Test.svelte
+++ b/packages/package/test/fixtures/svelte-3-types/expected ^5/Test.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import { createEventDispatcher } from 'svelte';
+export const astring = 'potato';
+const dispatch = createEventDispatcher();
+dispatch('event', true);
+</script>
+
+<slot {astring} />

--- a/packages/package/test/fixtures/svelte-3-types/expected ^5/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/svelte-3-types/expected ^5/Test.svelte.d.ts
@@ -1,0 +1,23 @@
+import { SvelteComponentTyped } from 'svelte';
+declare const __propDef: {
+	props: {
+		astring?: string;
+	};
+	events: {
+		event: CustomEvent<boolean>;
+	} & {
+		[evt: string]: CustomEvent<any>;
+	};
+	slots: {
+		default: {
+			astring: string;
+		};
+	};
+};
+export type TestProps = typeof __propDef.props;
+export type TestEvents = typeof __propDef.events;
+export type TestSlots = typeof __propDef.slots;
+export default class Test extends SvelteComponentTyped<TestProps, TestEvents, TestSlots> {
+	get astring(): string;
+}
+export {};

--- a/packages/package/test/fixtures/svelte-3-types/expected ^5/index.d.ts
+++ b/packages/package/test/fixtures/svelte-3-types/expected ^5/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Test } from './Test.svelte';

--- a/packages/package/test/fixtures/svelte-3-types/expected ^5/index.js
+++ b/packages/package/test/fixtures/svelte-3-types/expected ^5/index.js
@@ -1,0 +1,1 @@
+export { default as Test } from './Test.svelte';

--- a/packages/package/test/fixtures/svelte-3-types/expected/Test.svelte
+++ b/packages/package/test/fixtures/svelte-3-types/expected/Test.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script>
 import { createEventDispatcher } from 'svelte';
 export const astring = 'potato';
 const dispatch = createEventDispatcher();

--- a/packages/package/test/fixtures/svelte-kit/expected ^5/Test.svelte
+++ b/packages/package/test/fixtures/svelte-kit/expected ^5/Test.svelte
@@ -1,0 +1,12 @@
+<script>
+	import { createEventDispatcher } from 'svelte';
+	/**
+	 * @type {string}
+	 */
+	export const astring = 'potato';
+
+	const dispatch = createEventDispatcher();
+	dispatch('event', true);
+</script>
+
+<slot {astring} />

--- a/packages/package/test/fixtures/svelte-kit/expected ^5/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/svelte-kit/expected ^5/Test.svelte.d.ts
@@ -1,0 +1,55 @@
+export default Test;
+type Test = SvelteComponent<$$__sveltets_2_PropsWithChildren<{
+    astring?: string;
+}, {
+    default: {
+        astring: string;
+    };
+}>, {
+    event: CustomEvent<any>;
+} & {
+    [evt: string]: CustomEvent<any>;
+}, {
+    default: {
+        astring: string;
+    };
+}> & {
+    $$bindings?: string;
+} & {
+    astring: string;
+};
+declare const Test: $$__sveltets_2_IsomorphicComponent<$$__sveltets_2_PropsWithChildren<{
+    astring?: string;
+}, {
+    default: {
+        astring: string;
+    };
+}>, {
+    event: CustomEvent<any>;
+} & {
+    [evt: string]: CustomEvent<any>;
+}, {
+    default: {
+        astring: string;
+    };
+}, {
+    astring: string;
+}, string>;
+type $$__sveltets_2_PropsWithChildren<Props, Slots> = Props & (Slots extends {
+    default: any;
+} ? Props extends Record<string, never> ? any : {
+    children?: any;
+} : {});
+interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
+    new (options: import("svelte").ComponentConstructorOptions<Props>): import("svelte").SvelteComponent<Props, Events, Slots> & {
+        $$bindings?: Bindings;
+    } & Exports;
+    (internal: unknown, props: Props & {
+        $$events?: Events;
+        $$slots?: Slots;
+    }): Exports & {
+        $set?: any;
+        $on?: any;
+    };
+    z_$$bindings?: Bindings;
+}

--- a/packages/package/test/fixtures/svelte-kit/expected ^5/foo.d.ts
+++ b/packages/package/test/fixtures/svelte-kit/expected ^5/foo.d.ts
@@ -1,0 +1,1 @@
+export type Foo = boolean;

--- a/packages/package/test/fixtures/svelte-kit/expected ^5/index.d.ts
+++ b/packages/package/test/fixtures/svelte-kit/expected ^5/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Test } from './Test.svelte';

--- a/packages/package/test/fixtures/svelte-kit/expected ^5/index.js
+++ b/packages/package/test/fixtures/svelte-kit/expected ^5/index.js
@@ -1,0 +1,1 @@
+export { default as Test } from './Test.svelte';

--- a/packages/package/test/fixtures/svelte-kit/expected/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/svelte-kit/expected/Test.svelte.d.ts
@@ -1,55 +1,42 @@
-export default Test;
-type Test = SvelteComponent<$$__sveltets_2_PropsWithChildren<{
-    astring?: string;
-}, {
-    default: {
-        astring: string;
-    };
-}>, {
-    event: CustomEvent<any>;
-} & {
-    [evt: string]: CustomEvent<any>;
-}, {
-    default: {
-        astring: string;
-    };
-}> & {
-    $$bindings?: string;
-} & {
-    astring: string;
-};
-declare const Test: $$__sveltets_2_IsomorphicComponent<$$__sveltets_2_PropsWithChildren<{
-    astring?: string;
-}, {
-    default: {
-        astring: string;
-    };
-}>, {
-    event: CustomEvent<any>;
-} & {
-    [evt: string]: CustomEvent<any>;
-}, {
-    default: {
-        astring: string;
-    };
-}, {
-    astring: string;
-}, string>;
-type $$__sveltets_2_PropsWithChildren<Props, Slots> = Props & (Slots extends {
-    default: any;
-} ? Props extends Record<string, never> ? any : {
-    children?: any;
-} : {});
-interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
-    new (options: import("svelte").ComponentConstructorOptions<Props>): import("svelte").SvelteComponent<Props, Events, Slots> & {
-        $$bindings?: Bindings;
-    } & Exports;
-    (internal: unknown, props: Props & {
-        $$events?: Events;
-        $$slots?: Slots;
-    }): Exports & {
-        $set?: any;
-        $on?: any;
-    };
-    z_$$bindings?: Bindings;
+/** @typedef {typeof __propDef.props}  TestProps */
+/** @typedef {typeof __propDef.events}  TestEvents */
+/** @typedef {typeof __propDef.slots}  TestSlots */
+export default class Test extends SvelteComponent<
+	{
+		astring?: string;
+	},
+	{
+		event: CustomEvent<any>;
+	} & {
+		[evt: string]: CustomEvent<any>;
+	},
+	{
+		default: {
+			astring: string;
+		};
+	}
+> {
+	get astring(): string;
 }
+export type TestProps = typeof __propDef.props;
+export type TestEvents = typeof __propDef.events;
+export type TestSlots = typeof __propDef.slots;
+import { SvelteComponent } from 'svelte';
+declare const __propDef: {
+	props: {
+		astring?: string;
+	};
+	events: {
+		event: CustomEvent<any>;
+	} & {
+		[evt: string]: CustomEvent<any>;
+	};
+	slots: {
+		default: {
+			astring: string;
+		};
+	};
+	exports?: {};
+	bindings?: string;
+};
+export {};

--- a/packages/package/test/fixtures/typescript-esnext/expected ^5/Plain.svelte
+++ b/packages/package/test/fixtures/typescript-esnext/expected ^5/Plain.svelte
@@ -1,0 +1,17 @@
+<script>
+	/** @type {import('./foo').Foo} */
+	export let foo;
+</script>
+
+<svelte:head>
+  <script type="application/ld+json">
+		{
+			"@context": "http://schema.org",
+			"@type": "Corporation",
+			"name": "Svelte Corp",
+			"description": "Svelte will cybernetically enhance you",
+			"naics": "523910",
+			"url": "https://svelte.dev"
+		}
+	</script>
+</svelte:head>

--- a/packages/package/test/fixtures/typescript-esnext/expected ^5/Plain.svelte.d.ts
+++ b/packages/package/test/fixtures/typescript-esnext/expected ^5/Plain.svelte.d.ts
@@ -1,0 +1,26 @@
+export default Plain;
+type Plain = SvelteComponent<{
+    foo: boolean;
+}, {
+    [evt: string]: CustomEvent<any>;
+}, {}> & {
+    $$bindings?: string;
+};
+declare const Plain: $$__sveltets_2_IsomorphicComponent<{
+    foo: import("./foo").Foo;
+}, {
+    [evt: string]: CustomEvent<any>;
+}, {}, {}, string>;
+interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
+    new (options: import("svelte").ComponentConstructorOptions<Props>): import("svelte").SvelteComponent<Props, Events, Slots> & {
+        $$bindings?: Bindings;
+    } & Exports;
+    (internal: unknown, props: Props & {
+        $$events?: Events;
+        $$slots?: Slots;
+    }): Exports & {
+        $set?: any;
+        $on?: any;
+    };
+    z_$$bindings?: Bindings;
+}

--- a/packages/package/test/fixtures/typescript-esnext/expected ^5/Test.svelte
+++ b/packages/package/test/fixtures/typescript-esnext/expected ^5/Test.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import { createEventDispatcher } from 'svelte';
+export const astring = 'potato';
+const dispatch = createEventDispatcher();
+dispatch('event', true);
+</script>
+
+<slot {astring} />

--- a/packages/package/test/fixtures/typescript-esnext/expected ^5/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/typescript-esnext/expected ^5/Test.svelte.d.ts
@@ -1,0 +1,37 @@
+interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
+	new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & {
+			$$bindings?: Bindings;
+	} & Exports;
+	(internal: unknown, props: Props & {
+			$$events?: Events;
+			$$slots?: Slots;
+	}): Exports & {
+			$set?: any;
+			$on?: any;
+	};
+	z_$$bindings?: Bindings;
+}
+type $$__sveltets_2_PropsWithChildren<Props, Slots> = Props & (Slots extends {
+	default: any;
+} ? Props extends Record<string, never> ? any : {
+	children?: any;
+} : {});
+declare const Test: $$__sveltets_2_IsomorphicComponent<$$__sveltets_2_PropsWithChildren<{
+	astring?: string;
+}, {
+	default: {
+			astring: string;
+	};
+}>, {
+	event: CustomEvent<boolean>;
+} & {
+	[evt: string]: CustomEvent<any>;
+}, {
+	default: {
+			astring: string;
+	};
+}, {
+	astring: string;
+}, string>;
+type Test = InstanceType<typeof Test>;
+export default Test;

--- a/packages/package/test/fixtures/typescript-esnext/expected ^5/Test2.svelte
+++ b/packages/package/test/fixtures/typescript-esnext/expected ^5/Test2.svelte
@@ -1,0 +1,3 @@
+<script lang="ts">
+	export let foo;
+</script>

--- a/packages/package/test/fixtures/typescript-esnext/expected ^5/Test2.svelte.d.ts
+++ b/packages/package/test/fixtures/typescript-esnext/expected ^5/Test2.svelte.d.ts
@@ -1,0 +1,21 @@
+import type { Foo } from './foo';
+interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
+    new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & {
+        $$bindings?: Bindings;
+    } & Exports;
+    (internal: unknown, props: Props & {
+        $$events?: Events;
+        $$slots?: Slots;
+    }): Exports & {
+        $set?: any;
+        $on?: any;
+    };
+    z_$$bindings?: Bindings;
+}
+declare const Test2: $$__sveltets_2_IsomorphicComponent<{
+    foo: Foo;
+}, {
+    [evt: string]: CustomEvent<any>;
+}, {}, {}, string>;
+type Test2 = InstanceType<typeof Test2>;
+export default Test2;

--- a/packages/package/test/fixtures/typescript-esnext/expected ^5/foo.d.ts
+++ b/packages/package/test/fixtures/typescript-esnext/expected ^5/foo.d.ts
@@ -1,0 +1,1 @@
+export type Foo = boolean;

--- a/packages/package/test/fixtures/typescript-esnext/expected ^5/index.d.ts
+++ b/packages/package/test/fixtures/typescript-esnext/expected ^5/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Test } from './Test.svelte';

--- a/packages/package/test/fixtures/typescript-esnext/expected ^5/index.js
+++ b/packages/package/test/fixtures/typescript-esnext/expected ^5/index.js
@@ -1,0 +1,1 @@
+export { default as Test } from './Test.svelte';

--- a/packages/package/test/fixtures/typescript-esnext/expected ^5/runes.svelte.d.ts
+++ b/packages/package/test/fixtures/typescript-esnext/expected ^5/runes.svelte.d.ts
@@ -1,0 +1,1 @@
+export declare const x = true;

--- a/packages/package/test/fixtures/typescript-esnext/expected ^5/runes.svelte.js
+++ b/packages/package/test/fixtures/typescript-esnext/expected ^5/runes.svelte.js
@@ -1,0 +1,1 @@
+export const x = true;

--- a/packages/package/test/fixtures/typescript-esnext/expected/Plain.svelte.d.ts
+++ b/packages/package/test/fixtures/typescript-esnext/expected/Plain.svelte.d.ts
@@ -1,26 +1,28 @@
-export default Plain;
-type Plain = SvelteComponent<{
-    foo: boolean;
-}, {
-    [evt: string]: CustomEvent<any>;
-}, {}> & {
-    $$bindings?: string;
+/** @typedef {typeof __propDef.props}  PlainProps */
+/** @typedef {typeof __propDef.events}  PlainEvents */
+/** @typedef {typeof __propDef.slots}  PlainSlots */
+export default class Plain extends SvelteComponent<
+	{
+		foo: import('./foo').Foo;
+	},
+	{
+		[evt: string]: CustomEvent<any>;
+	},
+	{}
+> {}
+export type PlainProps = typeof __propDef.props;
+export type PlainEvents = typeof __propDef.events;
+export type PlainSlots = typeof __propDef.slots;
+import { SvelteComponent } from 'svelte';
+declare const __propDef: {
+	props: {
+		foo: import('./foo').Foo;
+	};
+	events: {
+		[evt: string]: CustomEvent<any>;
+	};
+	slots: {};
+	exports?: {};
+	bindings?: string;
 };
-declare const Plain: $$__sveltets_2_IsomorphicComponent<{
-    foo: import("./foo").Foo;
-}, {
-    [evt: string]: CustomEvent<any>;
-}, {}, {}, string>;
-interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
-    new (options: import("svelte").ComponentConstructorOptions<Props>): import("svelte").SvelteComponent<Props, Events, Slots> & {
-        $$bindings?: Bindings;
-    } & Exports;
-    (internal: unknown, props: Props & {
-        $$events?: Events;
-        $$slots?: Slots;
-    }): Exports & {
-        $set?: any;
-        $on?: any;
-    };
-    z_$$bindings?: Bindings;
-}
+export {};

--- a/packages/package/test/fixtures/typescript-esnext/expected/Test.svelte
+++ b/packages/package/test/fixtures/typescript-esnext/expected/Test.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script>
 import { createEventDispatcher } from 'svelte';
 export const astring = 'potato';
 const dispatch = createEventDispatcher();

--- a/packages/package/test/fixtures/typescript-esnext/expected/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/typescript-esnext/expected/Test.svelte.d.ts
@@ -1,37 +1,25 @@
-interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
-	new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & {
-			$$bindings?: Bindings;
-	} & Exports;
-	(internal: unknown, props: Props & {
-			$$events?: Events;
-			$$slots?: Slots;
-	}): Exports & {
-			$set?: any;
-			$on?: any;
+import { SvelteComponent } from 'svelte';
+declare const __propDef: {
+	props: {
+		astring?: string;
 	};
-	z_$$bindings?: Bindings;
+	events: {
+		event: CustomEvent<boolean>;
+	} & {
+		[evt: string]: CustomEvent<any>;
+	};
+	slots: {
+		default: {
+			astring: string;
+		};
+	};
+	exports?: {};
+	bindings?: string;
+};
+export type TestProps = typeof __propDef.props;
+export type TestEvents = typeof __propDef.events;
+export type TestSlots = typeof __propDef.slots;
+export default class Test extends SvelteComponent<TestProps, TestEvents, TestSlots> {
+	get astring(): string;
 }
-type $$__sveltets_2_PropsWithChildren<Props, Slots> = Props & (Slots extends {
-	default: any;
-} ? Props extends Record<string, never> ? any : {
-	children?: any;
-} : {});
-declare const Test: $$__sveltets_2_IsomorphicComponent<$$__sveltets_2_PropsWithChildren<{
-	astring?: string;
-}, {
-	default: {
-			astring: string;
-	};
-}>, {
-	event: CustomEvent<boolean>;
-} & {
-	[evt: string]: CustomEvent<any>;
-}, {
-	default: {
-			astring: string;
-	};
-}, {
-	astring: string;
-}, string>;
-type Test = InstanceType<typeof Test>;
-export default Test;
+export {};

--- a/packages/package/test/fixtures/typescript-esnext/expected/Test2.svelte
+++ b/packages/package/test/fixtures/typescript-esnext/expected/Test2.svelte
@@ -1,3 +1,3 @@
-<script lang="ts">
+<script>
 	export let foo;
 </script>

--- a/packages/package/test/fixtures/typescript-esnext/expected/Test2.svelte.d.ts
+++ b/packages/package/test/fixtures/typescript-esnext/expected/Test2.svelte.d.ts
@@ -1,21 +1,18 @@
+import { SvelteComponent } from 'svelte';
 import type { Foo } from './foo';
-interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
-    new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & {
-        $$bindings?: Bindings;
-    } & Exports;
-    (internal: unknown, props: Props & {
-        $$events?: Events;
-        $$slots?: Slots;
-    }): Exports & {
-        $set?: any;
-        $on?: any;
-    };
-    z_$$bindings?: Bindings;
-}
-declare const Test2: $$__sveltets_2_IsomorphicComponent<{
-    foo: Foo;
-}, {
-    [evt: string]: CustomEvent<any>;
-}, {}, {}, string>;
-type Test2 = InstanceType<typeof Test2>;
-export default Test2;
+declare const __propDef: {
+	props: {
+		foo: Foo;
+	};
+	events: {
+		[evt: string]: CustomEvent<any>;
+	};
+	slots: {};
+	exports?: {};
+	bindings?: string;
+};
+export type Test2Props = typeof __propDef.props;
+export type Test2Events = typeof __propDef.events;
+export type Test2Slots = typeof __propDef.slots;
+export default class Test2 extends SvelteComponent<Test2Props, Test2Events, Test2Slots> {}
+export {};

--- a/packages/package/test/fixtures/typescript-nodenext/expected ^5/Test.svelte
+++ b/packages/package/test/fixtures/typescript-nodenext/expected ^5/Test.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import { createEventDispatcher } from 'svelte';
+export const astring = 'potato';
+const dispatch = createEventDispatcher();
+dispatch('event', true);
+</script>
+
+<slot {astring} />

--- a/packages/package/test/fixtures/typescript-nodenext/expected ^5/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/typescript-nodenext/expected ^5/Test.svelte.d.ts
@@ -1,0 +1,37 @@
+interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
+	new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & {
+			$$bindings?: Bindings;
+	} & Exports;
+	(internal: unknown, props: Props & {
+			$$events?: Events;
+			$$slots?: Slots;
+	}): Exports & {
+			$set?: any;
+			$on?: any;
+	};
+	z_$$bindings?: Bindings;
+}
+type $$__sveltets_2_PropsWithChildren<Props, Slots> = Props & (Slots extends {
+	default: any;
+} ? Props extends Record<string, never> ? any : {
+	children?: any;
+} : {});
+declare const Test: $$__sveltets_2_IsomorphicComponent<$$__sveltets_2_PropsWithChildren<{
+	astring?: string;
+}, {
+	default: {
+			astring: string;
+	};
+}>, {
+	event: CustomEvent<boolean>;
+} & {
+	[evt: string]: CustomEvent<any>;
+}, {
+	default: {
+			astring: string;
+	};
+}, {
+	astring: string;
+}, string>;
+type Test = InstanceType<typeof Test>;
+export default Test;

--- a/packages/package/test/fixtures/typescript-nodenext/expected ^5/index.d.ts
+++ b/packages/package/test/fixtures/typescript-nodenext/expected ^5/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Test } from './Test.svelte';

--- a/packages/package/test/fixtures/typescript-nodenext/expected ^5/index.js
+++ b/packages/package/test/fixtures/typescript-nodenext/expected ^5/index.js
@@ -1,0 +1,1 @@
+export { default as Test } from './Test.svelte';

--- a/packages/package/test/fixtures/typescript-nodenext/expected ^5/runes.svelte.d.ts
+++ b/packages/package/test/fixtures/typescript-nodenext/expected ^5/runes.svelte.d.ts
@@ -1,0 +1,1 @@
+export declare const x = true;

--- a/packages/package/test/fixtures/typescript-nodenext/expected ^5/runes.svelte.js
+++ b/packages/package/test/fixtures/typescript-nodenext/expected ^5/runes.svelte.js
@@ -1,0 +1,1 @@
+export const x = true;

--- a/packages/package/test/fixtures/typescript-nodenext/expected/Test.svelte
+++ b/packages/package/test/fixtures/typescript-nodenext/expected/Test.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script>
 import { createEventDispatcher } from 'svelte';
 export const astring = 'potato';
 const dispatch = createEventDispatcher();

--- a/packages/package/test/fixtures/typescript-nodenext/expected/Test.svelte.d.ts
+++ b/packages/package/test/fixtures/typescript-nodenext/expected/Test.svelte.d.ts
@@ -1,37 +1,25 @@
-interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
-	new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & {
-			$$bindings?: Bindings;
-	} & Exports;
-	(internal: unknown, props: Props & {
-			$$events?: Events;
-			$$slots?: Slots;
-	}): Exports & {
-			$set?: any;
-			$on?: any;
+import { SvelteComponent } from 'svelte';
+declare const __propDef: {
+	props: {
+		astring?: string;
 	};
-	z_$$bindings?: Bindings;
+	events: {
+		event: CustomEvent<boolean>;
+	} & {
+		[evt: string]: CustomEvent<any>;
+	};
+	slots: {
+		default: {
+			astring: string;
+		};
+	};
+	exports?: {};
+	bindings?: string;
+};
+export type TestProps = typeof __propDef.props;
+export type TestEvents = typeof __propDef.events;
+export type TestSlots = typeof __propDef.slots;
+export default class Test extends SvelteComponent<TestProps, TestEvents, TestSlots> {
+	get astring(): string;
 }
-type $$__sveltets_2_PropsWithChildren<Props, Slots> = Props & (Slots extends {
-	default: any;
-} ? Props extends Record<string, never> ? any : {
-	children?: any;
-} : {});
-declare const Test: $$__sveltets_2_IsomorphicComponent<$$__sveltets_2_PropsWithChildren<{
-	astring?: string;
-}, {
-	default: {
-			astring: string;
-	};
-}>, {
-	event: CustomEvent<boolean>;
-} & {
-	[evt: string]: CustomEvent<any>;
-}, {
-	default: {
-			astring: string;
-	};
-}, {
-	astring: string;
-}, string>;
-type Test = InstanceType<typeof Test>;
-export default Test;
+export {};

--- a/packages/package/test/watch/expected ^5/Test.svelte
+++ b/packages/package/test/watch/expected ^5/Test.svelte
@@ -1,0 +1,1 @@
+<script lang="ts">export let answer: number</script>

--- a/packages/package/test/watch/expected ^5/Test.svelte.d.ts
+++ b/packages/package/test/watch/expected ^5/Test.svelte.d.ts
@@ -1,0 +1,20 @@
+interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
+    new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & {
+        $$bindings?: Bindings;
+    } & Exports;
+    (internal: unknown, props: Props & {
+        $$events?: Events;
+        $$slots?: Slots;
+    }): Exports & {
+        $set?: any;
+        $on?: any;
+    };
+    z_$$bindings?: Bindings;
+}
+declare const Test: $$__sveltets_2_IsomorphicComponent<{
+    answer: number;
+}, {
+    [evt: string]: CustomEvent<any>;
+}, {}, {}, string>;
+type Test = InstanceType<typeof Test>;
+export default Test;

--- a/packages/package/test/watch/expected ^5/a.d.ts
+++ b/packages/package/test/watch/expected ^5/a.d.ts
@@ -1,0 +1,1 @@
+export const a: "a";

--- a/packages/package/test/watch/expected ^5/a.js
+++ b/packages/package/test/watch/expected ^5/a.js
@@ -1,0 +1,1 @@
+export const a = 'a';

--- a/packages/package/test/watch/expected ^5/b.d.ts
+++ b/packages/package/test/watch/expected ^5/b.d.ts
@@ -1,0 +1,1 @@
+export declare const b = "b";

--- a/packages/package/test/watch/expected ^5/b.js
+++ b/packages/package/test/watch/expected ^5/b.js
@@ -1,0 +1,1 @@
+export const b = 'b';

--- a/packages/package/test/watch/expected ^5/index.js
+++ b/packages/package/test/watch/expected ^5/index.js
@@ -1,0 +1,1 @@
+console.log('index.js');

--- a/packages/package/test/watch/expected ^5/package.json
+++ b/packages/package/test/watch/expected ^5/package.json
@@ -1,0 +1,9 @@
+{
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    "./Test.svelte": "./Test.svelte",
+    ".": "./index.js"
+  },
+  "svelte": "./index.js"
+}

--- a/packages/package/test/watch/expected ^5/post-error.svelte
+++ b/packages/package/test/watch/expected ^5/post-error.svelte
@@ -1,0 +1,1 @@
+<button on:click={foo}>click me</button>

--- a/packages/package/test/watch/expected/Test.svelte.d.ts
+++ b/packages/package/test/watch/expected/Test.svelte.d.ts
@@ -1,20 +1,18 @@
-interface $$__sveltets_2_IsomorphicComponent<Props extends Record<string, any> = any, Events extends Record<string, any> = any, Slots extends Record<string, any> = any, Exports = {}, Bindings = string> {
-    new (options: import('svelte').ComponentConstructorOptions<Props>): import('svelte').SvelteComponent<Props, Events, Slots> & {
-        $$bindings?: Bindings;
-    } & Exports;
-    (internal: unknown, props: Props & {
-        $$events?: Events;
-        $$slots?: Slots;
-    }): Exports & {
-        $set?: any;
-        $on?: any;
+import { SvelteComponent } from "svelte";
+declare const __propDef: {
+    props: {
+        answer: number;
     };
-    z_$$bindings?: Bindings;
+    events: {
+        [evt: string]: CustomEvent<any>;
+    };
+    slots: {};
+    exports?: {};
+    bindings?: string;
+};
+export type TestProps = typeof __propDef.props;
+export type TestEvents = typeof __propDef.events;
+export type TestSlots = typeof __propDef.slots;
+export default class Test extends SvelteComponent<TestProps, TestEvents, TestSlots> {
 }
-declare const Test: $$__sveltets_2_IsomorphicComponent<{
-    answer: number;
-}, {
-    [evt: string]: CustomEvent<any>;
-}, {}, {}, string>;
-type Test = InstanceType<typeof Test>;
-export default Test;
+export {};


### PR DESCRIPTION
re-adds the expected output of the svelte-package tests for svelte 4. Probably only useful if we have a test matrix / command for svelte 4 too

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
