### PR TITLE
fix: correctly match route groups preceding optional parameters

### DIFF
--- a/.changeset/fifty-cars-lie.md
+++ b/.changeset/fifty-cars-lie.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly match route groups preceding optional parameters

--- a/packages/kit/src/core/sync/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.spec.js
@@ -427,7 +427,7 @@ test('optional parameters', () => {
 		default_layout,
 		{
 			component: 'samples/optional-group/[[optional]]/(group)/+page.svelte'
-		},
+		}
 	]);
 
 	expect(routes.map(simplify_route)).toEqual([
@@ -442,7 +442,9 @@ test('optional parameters', () => {
 				layouts: [0],
 				errors: [1],
 				// see above, linux/windows difference -> find the index dynamically
-				leaf: nodes.findIndex((node) => node.component?.includes('optional-group/[[optional]]/(group)'))
+				leaf: nodes.findIndex((node) =>
+					node.component?.includes('optional-group/[[optional]]/(group)')
+				)
 			}
 		},
 		{

--- a/packages/kit/src/core/sync/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.spec.js
@@ -412,7 +412,7 @@ test('nested optionals', () => {
 	]);
 });
 
-test('optional parameters', () => {
+test('group preceding optional parameters', () => {
 	const { nodes, routes } = create('samples/optional-group');
 
 	expect(

--- a/packages/kit/src/core/sync/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.spec.js
@@ -412,6 +412,46 @@ test('nested optionals', () => {
 	]);
 });
 
+test('optional parameters', () => {
+	const { nodes, routes } = create('samples/optional-group');
+
+	expect(
+		nodes
+			.map(simplify_node)
+			// for some reason linux and windows have a different order, which is why
+			// we need sort the nodes using a sort function (doesn't work either without),
+			// resulting in the following expected node order
+			.sort((a, b) => a.component?.localeCompare(b.component ?? '') ?? 1)
+	).toEqual([
+		default_error,
+		default_layout,
+		{
+			component: 'samples/optional-group/[[optional]]/(group)/+page.svelte'
+		},
+	]);
+
+	expect(routes.map(simplify_route)).toEqual([
+		{
+			id: '/',
+			pattern: '/^/$/'
+		},
+		{
+			id: '/[[optional]]/(group)',
+			pattern: '/^(?:/([^/]+))?/?$/',
+			page: {
+				layouts: [0],
+				errors: [1],
+				// see above, linux/windows difference -> find the index dynamically
+				leaf: nodes.findIndex((node) => node.component?.includes('optional-group/[[optional]]/(group)'))
+			}
+		},
+		{
+			id: '/[[optional]]',
+			pattern: '/^(?:/([^/]+))?/?$/'
+		}
+	]);
+});
+
 test('ignores files and directories with leading underscores', () => {
 	const { routes } = create('samples/hidden-underscore');
 

--- a/packages/kit/src/core/sync/create_manifest_data/sort.js
+++ b/packages/kit/src/core/sync/create_manifest_data/sort.js
@@ -136,7 +136,8 @@ function split_route_id(id) {
 	return get_route_segments(
 		id
 			// remove all [[optional]] parts unless they're at the very end
-			.replace(/\[\[[^\]]+\]\](?!$)/g, '')
+			// or it ends with a route group
+			.replace(/\[\[[^\]]+\]\](?!(?:\/\([^/]+\))*$)/g, '')
 	).filter(Boolean);
 }
 


### PR DESCRIPTION
fixes #13095

This PR changes the RegExp to ensure that routes such as `/[[optional]]/(group)` are treated the same as `[[optional]]`. Previously, `/[[optional]]/(group)` was being treated the same as `/` which is incorrect since it has an optional segment. It wasn't recognised as `/[[optional]]` because the RegExp didn't consider the route group preceding it (it only looked for the end of the string).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
