### PR TITLE
fix: prevent hooks exported from `hooks.js` from overwriting hooks in `hooks.server.js`

### DIFF
--- a/.changeset/mean-bottles-wash.md
+++ b/.changeset/mean-bottles-wash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prevent hooks exported from `hooks.js` from overwriting hooks in `hooks.server.js`

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -64,9 +64,19 @@ export const options = {
 };
 
 export async function get_hooks() {
+	let handle;
+	let handleFetch;
+	let handleError;
+	${server_hooks ? `({ handle, handleFetch, handleError } = await import(${s(server_hooks)}));` : ''}
+
+	let reroute;
+	${universal_hooks ? `({ reroute } = await import(${s(universal_hooks)}));` : ''}
+
 	return {
-		${server_hooks ? `...(await import(${s(server_hooks)})),` : ''}
-		${universal_hooks ? `...(await import(${s(universal_hooks)})),` : ''}
+		handle,
+		handleFetch,
+		handleError,
+		reroute,
 	};
 }
 


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/12065

Instead of spreading the imported functions from the server hooks file and universal hooks file, this PR changes it to specifically import and return each hook. This prevents hooks exported from `hook.js` from overwriting hooks from `hook.server.js`

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
