### PR TITLE
feat: validate values for `cache-control` and `content-type` headers in dev mode

### DIFF
--- a/.changeset/rich-pants-beam.md
+++ b/.changeset/rich-pants-beam.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: validate values for `cache-control` and `content-type` headers in dev mode

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -33,8 +33,10 @@ import { INVALIDATED_PARAM, TRAILING_SLASH_PARAM } from '../shared.js';
 import { get_public_env } from './env_module.js';
 import { load_page_nodes } from './page/load_page_nodes.js';
 import { get_page_config } from '../../utils/route_config.js';
+import { validateHeaders } from './validate-headers.js';
 
 /* global __SVELTEKIT_ADAPTER_NAME__ */
+/* global __SVELTEKIT_DEV__ */
 
 /** @type {import('types').RequiredResolveOptions['transformPageChunk']} */
 const default_transform = ({ html }) => html;
@@ -186,6 +188,10 @@ export async function respond(request, options, manifest, state) {
 		request,
 		route: { id: route?.id ?? null },
 		setHeaders: (new_headers) => {
+			if (__SVELTEKIT_DEV__) {
+				validateHeaders(new_headers);
+			}
+
 			for (const key in new_headers) {
 				const lower = key.toLowerCase();
 				const value = new_headers[key];

--- a/packages/kit/src/runtime/server/validate-headers.js
+++ b/packages/kit/src/runtime/server/validate-headers.js
@@ -23,24 +23,26 @@ const CONTENT_TYPE_PATTERN =
 /** @type {Record<string, (value: string) => void>} */
 const HEADER_VALIDATORS = {
 	'cache-control': (value) => {
-		const parts = value.split(',');
-		if (parts.some((part) => !part.trim())) {
-			throw new Error('cache-control header contains empty directives');
+		const error_suffix = `(While parsing "${value}".)`;
+		const parts = value.split(',').map((part) => part.trim());
+		if (parts.some((part) => !part)) {
+			throw new Error(`\`cache-control\` header contains empty directives. ${error_suffix}`);
 		}
 
-		const directives = parts.map((part) => part.trim().split('=')[0].toLowerCase());
+		const directives = parts.map((part) => part.split('=')[0].toLowerCase());
 		const invalid = directives.find((directive) => !VALID_CACHE_CONTROL_DIRECTIVES.has(directive));
 		if (invalid) {
 			throw new Error(
-				`Invalid cache-control directive "${invalid}". Did you mean one of: ${[...VALID_CACHE_CONTROL_DIRECTIVES].join(', ')}`
+				`Invalid cache-control directive "${invalid}". Did you mean one of: ${[...VALID_CACHE_CONTROL_DIRECTIVES].join(', ')}? ${error_suffix}`
 			);
 		}
 	},
 
 	'content-type': (value) => {
 		const type = value.split(';')[0].trim();
+		const error_suffix = `(While parsing "${value}".)`;
 		if (!CONTENT_TYPE_PATTERN.test(type)) {
-			throw new Error(`Invalid content-type value "${type}"`);
+			throw new Error(`Invalid content-type value "${type}". ${error_suffix}`);
 		}
 	}
 };

--- a/packages/kit/src/runtime/server/validate-headers.js
+++ b/packages/kit/src/runtime/server/validate-headers.js
@@ -18,7 +18,7 @@ const VALID_CACHE_CONTROL_DIRECTIVES = new Set([
 ]);
 
 const CONTENT_TYPE_PATTERN =
-	/^(application|audio|font|image|model|text|video|x-[a-z]+)\/[-+.\w]+$/i;
+	/^(application|audio|example|font|haptics|image|message|model|multipart|text|video|x-[a-z]+)\/[-+.\w]+$/i;
 
 /** @type {Record<string, (value: string) => void>} */
 const HEADER_VALIDATORS = {

--- a/packages/kit/src/runtime/server/validate-headers.js
+++ b/packages/kit/src/runtime/server/validate-headers.js
@@ -1,0 +1,62 @@
+/** @type {Set<string>} */
+const VALID_CACHE_CONTROL_DIRECTIVES = new Set([
+	'max-age',
+	'public',
+	'private',
+	'no-cache',
+	'no-store',
+	'must-revalidate',
+	'proxy-revalidate',
+	's-maxage',
+	'immutable',
+	'stale-while-revalidate',
+	'stale-if-error',
+	'no-transform',
+	'only-if-cached',
+	'max-stale',
+	'min-fresh'
+]);
+
+const CONTENT_TYPE_PATTERN =
+	/^(application|audio|font|image|model|text|video|x-[a-z]+)\/[-+.\w]+$/i;
+
+/** @type {Record<string, (value: string) => void>} */
+const HEADER_VALIDATORS = {
+	'cache-control': (value) => {
+		const parts = value.split(',');
+		if (parts.some((part) => !part.trim())) {
+			throw new Error('cache-control header contains empty directives');
+		}
+
+		const directives = parts.map((part) => part.trim().split('=')[0].toLowerCase());
+		const invalid = directives.find((directive) => !VALID_CACHE_CONTROL_DIRECTIVES.has(directive));
+		if (invalid) {
+			throw new Error(
+				`Invalid cache-control directive "${invalid}". Did you mean one of: ${[...VALID_CACHE_CONTROL_DIRECTIVES].join(', ')}`
+			);
+		}
+	},
+
+	'content-type': (value) => {
+		const type = value.split(';')[0].trim();
+		if (!CONTENT_TYPE_PATTERN.test(type)) {
+			throw new Error(`Invalid content-type value "${type}"`);
+		}
+	}
+};
+
+/**
+ * @param {Record<string, string>} headers
+ */
+export function validateHeaders(headers) {
+	for (const [key, value] of Object.entries(headers)) {
+		const validator = HEADER_VALIDATORS[key.toLowerCase()];
+		try {
+			validator?.(value);
+		} catch (error) {
+			if (error instanceof Error) {
+				console.warn(`[SvelteKit] ${error.message}`);
+			}
+		}
+	}
+}

--- a/packages/kit/src/runtime/server/validate-headers.spec.js
+++ b/packages/kit/src/runtime/server/validate-headers.spec.js
@@ -1,0 +1,98 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+describe('validateHeaders', () => {
+	/** @type {typeof console.warn} */
+	let console_warn;
+
+	/** @type {(headers: Record<string, string>) => void} */
+	let validateHeaders;
+
+	beforeAll(() => {
+		console_warn = console.warn;
+		// @ts-expect-error
+		globalThis.__SVELTEKIT_DEV__ = false;
+	});
+
+	afterAll(() => {
+		console.warn = console_warn;
+		vi.unstubAllGlobals();
+	});
+
+	beforeEach(async () => {
+		console.warn = vi.fn();
+		// @ts-expect-error
+		globalThis.__SVELTEKIT_DEV__ = true;
+		const module = await import('./validate-headers.js');
+		validateHeaders = module.validateHeaders;
+	});
+
+	describe('cache-control header', () => {
+		test('accepts valid directives', () => {
+			validateHeaders({ 'cache-control': 'public, max-age=3600' });
+			expect(console.warn).not.toHaveBeenCalled();
+		});
+
+		test('rejects invalid directives', () => {
+			validateHeaders({ 'cache-control': 'public, maxage=3600' });
+			expect(console.warn).toHaveBeenCalledWith(
+				expect.stringContaining('Invalid cache-control directive "maxage"')
+			);
+		});
+
+		test('rejects empty directives', () => {
+			validateHeaders({ 'cache-control': 'public,, max-age=3600' });
+			expect(console.warn).toHaveBeenCalledWith(
+				expect.stringContaining('cache-control header contains empty directives')
+			);
+
+			validateHeaders({ 'cache-control': 'public, , max-age=3600' });
+			expect(console.warn).toHaveBeenCalledWith(
+				expect.stringContaining('cache-control header contains empty directives')
+			);
+		});
+	});
+
+	describe('content-type header', () => {
+		test('accepts standard content types', () => {
+			validateHeaders({ 'content-type': 'application/json' });
+			expect(console.warn).not.toHaveBeenCalled();
+		});
+
+		test('accepts content types with parameters', () => {
+			validateHeaders({ 'content-type': 'text/html; charset=utf-8' });
+			expect(console.warn).not.toHaveBeenCalled();
+
+			validateHeaders({ 'content-type': 'application/javascript; charset=utf-8' });
+			expect(console.warn).not.toHaveBeenCalled();
+		});
+
+		test('accepts vendor-specific content types', () => {
+			validateHeaders({ 'content-type': 'x-custom/whatever' });
+			expect(console.warn).not.toHaveBeenCalled();
+		});
+
+		test('rejects malformed content types', () => {
+			validateHeaders({ 'content-type': 'invalid-content-type' });
+			expect(console.warn).toHaveBeenCalledWith(
+				expect.stringContaining('Invalid content-type value "invalid-content-type"')
+			);
+		});
+
+		test('rejects invalid content type categories', () => {
+			validateHeaders({ 'content-type': 'invalid/type; invalid=param' });
+			expect(console.warn).toHaveBeenCalledWith(
+				expect.stringContaining('Invalid content-type value "invalid/type"')
+			);
+
+			validateHeaders({ 'content-type': 'bad/type; charset=utf-8' });
+			expect(console.warn).toHaveBeenCalledWith(
+				expect.stringContaining('Invalid content-type value "bad/type"')
+			);
+		});
+	});
+
+	test('allows unknown headers', () => {
+		validateHeaders({ 'x-custom-header': 'some-value' });
+		expect(console.warn).not.toHaveBeenCalled();
+	});
+});

--- a/packages/kit/src/runtime/server/validate-headers.spec.js
+++ b/packages/kit/src/runtime/server/validate-headers.spec.js
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest';
-import {validateHeaders} from './validate-headers.js';
+import { validateHeaders } from './validate-headers.js';
 
 describe('validateHeaders', () => {
 	const console_warn_spy = vi.spyOn(console, 'warn');

--- a/packages/kit/src/runtime/server/validate-headers.spec.js
+++ b/packages/kit/src/runtime/server/validate-headers.spec.js
@@ -50,6 +50,11 @@ describe('validateHeaders', () => {
 				expect.stringContaining('cache-control header contains empty directives')
 			);
 		});
+
+		test('accepts multiple cache-control values', () => {
+			validateHeaders({ 'cache-control': 'max-age=3600, s-maxage=7200' });
+			expect(console.warn).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('content-type header', () => {
@@ -89,10 +94,24 @@ describe('validateHeaders', () => {
 				expect.stringContaining('Invalid content-type value "bad/type"')
 			);
 		});
+
+		test('handles case-insensitive content-types', () => {
+			validateHeaders({ 'content-type': 'TEXT/HTML; charset=utf-8' });
+			expect(console.warn).not.toHaveBeenCalled();
+		});
 	});
 
 	test('allows unknown headers', () => {
 		validateHeaders({ 'x-custom-header': 'some-value' });
+		expect(console.warn).not.toHaveBeenCalled();
+	});
+
+	test('handles multiple headers simultaneously', () => {
+		validateHeaders({
+			'cache-control': 'max-age=3600',
+			'content-type': 'text/html',
+			'x-custom': 'value'
+		});
 		expect(console.warn).not.toHaveBeenCalled();
 	});
 });

--- a/packages/kit/src/runtime/server/validate-headers.spec.js
+++ b/packages/kit/src/runtime/server/validate-headers.spec.js
@@ -1,109 +1,91 @@
-import { describe, test, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import {validateHeaders} from './validate-headers.js';
 
 describe('validateHeaders', () => {
-	/** @type {typeof console.warn} */
-	let console_warn;
+	const console_warn_spy = vi.spyOn(console, 'warn');
 
-	/** @type {(headers: Record<string, string>) => void} */
-	let validateHeaders;
-
-	beforeAll(() => {
-		console_warn = console.warn;
-		// @ts-expect-error
-		globalThis.__SVELTEKIT_DEV__ = false;
-	});
-
-	afterAll(() => {
-		console.warn = console_warn;
-		vi.unstubAllGlobals();
-	});
-
-	beforeEach(async () => {
-		console.warn = vi.fn();
-		// @ts-expect-error
-		globalThis.__SVELTEKIT_DEV__ = true;
-		const module = await import('./validate-headers.js');
-		validateHeaders = module.validateHeaders;
+	beforeEach(() => {
+		vi.resetAllMocks();
 	});
 
 	describe('cache-control header', () => {
 		test('accepts valid directives', () => {
 			validateHeaders({ 'cache-control': 'public, max-age=3600' });
-			expect(console.warn).not.toHaveBeenCalled();
+			expect(console_warn_spy).not.toHaveBeenCalled();
 		});
 
 		test('rejects invalid directives', () => {
 			validateHeaders({ 'cache-control': 'public, maxage=3600' });
-			expect(console.warn).toHaveBeenCalledWith(
+			expect(console_warn_spy).toHaveBeenCalledWith(
 				expect.stringContaining('Invalid cache-control directive "maxage"')
 			);
 		});
 
 		test('rejects empty directives', () => {
 			validateHeaders({ 'cache-control': 'public,, max-age=3600' });
-			expect(console.warn).toHaveBeenCalledWith(
-				expect.stringContaining('cache-control header contains empty directives')
+			expect(console_warn_spy).toHaveBeenCalledWith(
+				expect.stringContaining('`cache-control` header contains empty directives')
 			);
 
 			validateHeaders({ 'cache-control': 'public, , max-age=3600' });
-			expect(console.warn).toHaveBeenCalledWith(
-				expect.stringContaining('cache-control header contains empty directives')
+			expect(console_warn_spy).toHaveBeenCalledWith(
+				expect.stringContaining('`cache-control` header contains empty directives')
 			);
 		});
 
 		test('accepts multiple cache-control values', () => {
 			validateHeaders({ 'cache-control': 'max-age=3600, s-maxage=7200' });
-			expect(console.warn).not.toHaveBeenCalled();
+			expect(console_warn_spy).not.toHaveBeenCalled();
 		});
 	});
 
 	describe('content-type header', () => {
 		test('accepts standard content types', () => {
 			validateHeaders({ 'content-type': 'application/json' });
-			expect(console.warn).not.toHaveBeenCalled();
+			expect(console_warn_spy).not.toHaveBeenCalled();
 		});
 
 		test('accepts content types with parameters', () => {
 			validateHeaders({ 'content-type': 'text/html; charset=utf-8' });
-			expect(console.warn).not.toHaveBeenCalled();
+			expect(console_warn_spy).not.toHaveBeenCalled();
 
 			validateHeaders({ 'content-type': 'application/javascript; charset=utf-8' });
-			expect(console.warn).not.toHaveBeenCalled();
+			expect(console_warn_spy).not.toHaveBeenCalled();
 		});
 
 		test('accepts vendor-specific content types', () => {
 			validateHeaders({ 'content-type': 'x-custom/whatever' });
-			expect(console.warn).not.toHaveBeenCalled();
+			expect(console_warn_spy).not.toHaveBeenCalled();
 		});
 
 		test('rejects malformed content types', () => {
 			validateHeaders({ 'content-type': 'invalid-content-type' });
-			expect(console.warn).toHaveBeenCalledWith(
+			expect(console_warn_spy).toHaveBeenCalledWith(
 				expect.stringContaining('Invalid content-type value "invalid-content-type"')
 			);
 		});
 
 		test('rejects invalid content type categories', () => {
 			validateHeaders({ 'content-type': 'invalid/type; invalid=param' });
-			expect(console.warn).toHaveBeenCalledWith(
+			expect(console_warn_spy).toHaveBeenCalledWith(
 				expect.stringContaining('Invalid content-type value "invalid/type"')
 			);
 
 			validateHeaders({ 'content-type': 'bad/type; charset=utf-8' });
-			expect(console.warn).toHaveBeenCalledWith(
+			expect(console_warn_spy).toHaveBeenCalledWith(
 				expect.stringContaining('Invalid content-type value "bad/type"')
 			);
 		});
 
 		test('handles case-insensitive content-types', () => {
 			validateHeaders({ 'content-type': 'TEXT/HTML; charset=utf-8' });
-			expect(console.warn).not.toHaveBeenCalled();
+			expect(console_warn_spy).not.toHaveBeenCalled();
 		});
 	});
 
 	test('allows unknown headers', () => {
 		validateHeaders({ 'x-custom-header': 'some-value' });
-		expect(console.warn).not.toHaveBeenCalled();
+		expect(console_warn_spy).not.toHaveBeenCalled();
 	});
 
 	test('handles multiple headers simultaneously', () => {
@@ -112,6 +94,6 @@ describe('validateHeaders', () => {
 			'content-type': 'text/html',
 			'x-custom': 'value'
 		});
-		expect(console.warn).not.toHaveBeenCalled();
+		expect(console_warn_spy).not.toHaveBeenCalled();
 	});
 });

--- a/packages/kit/test/apps/dev-only/src/routes/headers/invalid/+server.js
+++ b/packages/kit/test/apps/dev-only/src/routes/headers/invalid/+server.js
@@ -1,0 +1,9 @@
+/** @type {import("@sveltejs/kit").RequestHandler} */
+export function GET({ setHeaders }) {
+	setHeaders({
+		'cache-control': 'totally-invalid',
+		'content-type': 'not-a-real-type'
+	});
+
+	return new Response('Testing invalid headers');
+}


### PR DESCRIPTION
Fix for [#12784](https://github.com/sveltejs/kit/issues/12784)

Adds validation for common HTTP headers in dev mode to help catch invalid values early:
- Validates cache-control directives against standard values
- Validates content-type format
- Only active in dev mode

run `pnpm dev` from `test/apps/basics` and navigate to [http://localhost:5173/headers/invalid](http://localhost:5173/headers/invalid). In your console you'll see:
```
[SvelteKit] Invalid cache-control directive "totally-invalid". Did you mean one of: max-age, public, private, no-cache, no-store, must-revalidate, proxy-revalidate, s-maxage, immutable, stale-while-revalidate, stale-if-error, no-transform, only-if-cached, max-stale, min-fresh
[SvelteKit] Invalid content-type value "not-a-real-type"
```

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
