### PR TITLE
fix: export `init` hook from `get_hooks`

### DIFF
--- a/.changeset/sour-pigs-talk.md
+++ b/.changeset/sour-pigs-talk.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: export `init` hook from `get_hooks`

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -67,6 +67,7 @@ export async function get_hooks() {
 	let handle;
 	let handleFetch;
 	let handleError;
+	let init;
 	${server_hooks ? `({ handle, handleFetch, handleError, init } = await import(${s(server_hooks)}));` : ''}
 
 	let reroute;

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -67,7 +67,7 @@ export async function get_hooks() {
 	let handle;
 	let handleFetch;
 	let handleError;
-	${server_hooks ? `({ handle, handleFetch, handleError } = await import(${s(server_hooks)}));` : ''}
+	${server_hooks ? `({ handle, handleFetch, handleError, init } = await import(${s(server_hooks)}));` : ''}
 
 	let reroute;
 	${universal_hooks ? `({ reroute } = await import(${s(universal_hooks)}));` : ''}
@@ -77,6 +77,7 @@ export async function get_hooks() {
 		handleFetch,
 		handleError,
 		reroute,
+		init,
 	};
 }
 


### PR DESCRIPTION
Follow-up to #13103 ...after #13104 was merged the `init` hook was not exported from `get_hooks` anymore. This fixes it.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
