### PR TITLE
chore: update Vercel, Cloudflare, and Netlify adapter versions

### DIFF
--- a/.changeset/selfish-lamps-joke.md
+++ b/.changeset/selfish-lamps-joke.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-auto': major
+---
+
+feat: update Vercel, Cloudflare Pages, and Netlify adapter major versions

--- a/packages/adapter-auto/adapters.js
+++ b/packages/adapter-auto/adapters.js
@@ -7,19 +7,19 @@ export const adapters = [
 		name: 'Vercel',
 		test: () => !!process.env.VERCEL,
 		module: '@sveltejs/adapter-vercel',
-		version: '4'
+		version: '5'
 	},
 	{
 		name: 'Cloudflare Pages',
 		test: () => !!process.env.CF_PAGES,
 		module: '@sveltejs/adapter-cloudflare',
-		version: '3'
+		version: '4'
 	},
 	{
 		name: 'Netlify',
 		test: () => !!process.env.NETLIFY,
 		module: '@sveltejs/adapter-netlify',
-		version: '3'
+		version: '4'
 	},
 	{
 		name: 'Azure Static Web Apps',


### PR DESCRIPTION
This PR updates the installed versions of the Vercel, Cloudflare, and Netlify adapters so that a fresh project created by `pnpx sv create` doesn't fail on Vercel, which uses Node 22 to build but installs adapter-vercel 4 instead of 5 which is incompatible with Node 22.

I wasn't sure what changeset version or message to write for this one. Please feel free to correct it.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
