### PR TITLE
fix: adhere to Vite `build.minify` setting when building service worker

### DIFF
--- a/.changeset/rotten-cheetahs-complain.md
+++ b/.changeset/rotten-cheetahs-complain.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: adhere to Vite config minify setting when building service worker

--- a/.changeset/rotten-cheetahs-complain.md
+++ b/.changeset/rotten-cheetahs-complain.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: adhere to Vite config minify setting when building service worker
+fix: adhere to Vite `build.minify` setting when building the service worker

--- a/packages/kit/src/exports/vite/build/build_service_worker.js
+++ b/packages/kit/src/exports/vite/build/build_service_worker.js
@@ -105,7 +105,8 @@ export async function build_service_worker(
 				}
 			},
 			outDir: `${out}/client`,
-			emptyOutDir: false
+			emptyOutDir: false,
+			minify: vite_config.build.minify
 		},
 		configFile: false,
 		define: vite_config.define,

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -886,7 +886,13 @@ async function kit({ svelte_config }) {
 					await build_service_worker(
 						out,
 						kit,
-						vite_config,
+						{
+							...vite_config,
+							build: {
+								...vite_config.build,
+								minify: initial_config.build?.minify ?? 'esbuild',
+							}
+						},
 						manifest_data,
 						service_worker_entry_file,
 						prerendered,

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -890,7 +890,7 @@ async function kit({ svelte_config }) {
 							...vite_config,
 							build: {
 								...vite_config.build,
-								minify: initial_config.build?.minify ?? 'esbuild',
+								minify: initial_config.build?.minify ?? 'esbuild'
 							}
 						},
 						manifest_data,


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/11790

This PR passes the user's Vite `build.minify` config value to the Vite build for the service worker.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
