### PR TITLE
fix: correctly resolve hooks entry file when directory exists

### DIFF
--- a/.changeset/brown-bats-mate.md
+++ b/.changeset/brown-bats-mate.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly resolves hooks when similarly named directory exists

--- a/.changeset/brown-bats-mate.md
+++ b/.changeset/brown-bats-mate.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: correctly resolves hooks when similarly named directory exists
+fix: correctly resolve hooks file when a similarly named directory exists

--- a/packages/kit/src/utils/filesystem.js
+++ b/packages/kit/src/utils/filesystem.js
@@ -169,8 +169,9 @@ export function from_fs(str) {
 export function resolve_entry(entry) {
 	if (fs.existsSync(entry)) {
 		const stats = fs.statSync(entry);
-		if (stats.isDirectory()) {
-			return resolve_entry(path.join(entry, 'index'));
+		const index = path.join(entry, 'index');
+		if (stats.isDirectory() && fs.existsSync(index)) {
+			return resolve_entry(index);
 		}
 
 		return entry;

--- a/packages/kit/src/utils/filesystem.spec.js
+++ b/packages/kit/src/utils/filesystem.spec.js
@@ -105,3 +105,10 @@ test('ignores hooks.server folder when resolving hooks', () => {
 
 	expect(resolve_entry(source_dir + '/hooks')).null;
 });
+
+test('ignores hooks folder that has no index file when resolving hooks', () => {
+	write('hooks/not-index.js', '');
+	write('hooks.js', '');
+
+	expect(resolve_entry(source_dir + '/hooks')).toBe(source_dir + '/hooks');
+});


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13100

This PR adds a check to see if an index file exists in the related directory before resolving to that path. Directories without an index file should correctly fallback to the non-directory path.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
