### PR TITLE
Support wrangler.json configuration file in adapter-cloudflare-workers

### DIFF
--- a/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
+++ b/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
@@ -34,7 +34,7 @@ export default {
 
 ### config
 
-Path to your custom `wrangler.toml` config file.
+Path to your custom `wrangler.toml` or `wrangler.json` config file.
 
 ### platformProxy
 

--- a/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
+++ b/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
@@ -42,7 +42,7 @@ Preferences for the emulated `platform.env` local bindings. See the [getPlatform
 
 ## Basic Configuration
 
-This adapter expects to find a [wrangler.toml](https://developers.cloudflare.com/workers/platform/sites/configuration) file in the project root. It should look something like this:
+This adapter expects to find a [wrangler.toml/wrangler.json](https://developers.cloudflare.com/workers/platform/sites/configuration) file in the project root. It should look something like this:
 
 ```toml
 /// file: wrangler.toml

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -186,7 +186,7 @@ export default function ({ config = 'wrangler.toml', platformProxy = {} } = {}) 
  */
 function validate_config(builder, config_file) {
 	if (!existsSync(config_file) && config_file === 'wrangler.toml' && existsSync('wrangler.json')) {
-		builder.log.minor('Default wrangler.toml not existed. Using wrangler.json.');
+		builder.log.minor('Default wrangler.toml does not exist. Using wrangler.json.');
 		config_file = 'wrangler.json';
 	}
 	if (existsSync(config_file)) {

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -185,6 +185,10 @@ export default function ({ config = 'wrangler.toml', platformProxy = {} } = {}) 
  * @returns {WranglerConfig}
  */
 function validate_config(builder, config_file) {
+	if (!existsSync(config_file) && config_file === 'wrangler.toml' && existsSync('wrangler.json')) {
+		builder.log.minor('Default wrangler.toml not existed. Using wrangler.json.');
+		config_file = 'wrangler.json';
+	}
 	if (existsSync(config_file)) {
 		/** @type {WranglerConfig} */
 		let wrangler_config;

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -190,9 +190,15 @@ function validate_config(builder, config_file) {
 		let wrangler_config;
 
 		try {
-			wrangler_config = /** @type {WranglerConfig} */ (
-				toml.parse(readFileSync(config_file, 'utf-8'))
-			);
+			if (config_file.endsWith('.json')) {
+				wrangler_config = /** @type {WranglerConfig} */ (
+					JSON.parse(readFileSync(config_file, 'utf-8'))
+				);
+			} else {
+				wrangler_config = /** @type {WranglerConfig} */ (
+					toml.parse(readFileSync(config_file, 'utf-8'))
+				);
+			}
 		} catch (err) {
 			err.message = `Error parsing ${config_file}: ${err.message}`;
 			throw err;


### PR DESCRIPTION
closes #13121

The behavior in this PR is a little different from the code in the issue.
Here, the adapter will now also attempt to use `wrangler.json` if:
 * The `wrangler.json` file exists.
  * The `config` is set to default (`wrangler.toml`).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
