### PR TITLE
chore: specify the route ID in the error message during development when making a form action request to a route without form actions

### DIFF
--- a/.changeset/ninety-taxis-bathe.md
+++ b/.changeset/ninety-taxis-bathe.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-chore: improve error message when making a form action request to a route without form actions
+chore: specify the route ID in the error message during development when making a form action request to a route without form actions

--- a/.changeset/ninety-taxis-bathe.md
+++ b/.changeset/ninety-taxis-bathe.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: improve error message when making a form action request to a route without form actions

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -1,4 +1,5 @@
 import * as devalue from 'devalue';
+import { DEV } from 'esm-env';
 import { json } from '../../../exports/index.js';
 import { get_status, normalize_error } from '../../../utils/error.js';
 import { is_form_content_type, negotiate } from '../../../utils/http.js';
@@ -27,8 +28,9 @@ export async function handle_action_json_request(event, options, server) {
 		const no_actions_error = new SvelteKitError(
 			405,
 			'Method Not Allowed',
-			'POST method not allowed. No actions exist for this page'
+			`POST method not allowed. No form actions exist for ${DEV ? `the page at ${event.route.id}` : 'this page'}`
 		);
+
 		return action_json(
 			{
 				type: 'error',
@@ -153,7 +155,7 @@ export async function handle_action_request(event, server) {
 			error: new SvelteKitError(
 				405,
 				'Method Not Allowed',
-				'POST method not allowed. No actions exist for this page'
+				`POST method not allowed. No form actions exist for ${DEV ? `the page at ${event.route.id}` : 'this page'}`
 			)
 		};
 	}

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -373,8 +373,9 @@ test.describe('Errors', () => {
 		expect(await res_json.json()).toEqual({
 			type: 'error',
 			error: {
-				message:
-					'POST method not allowed. No form actions exist for the page at /errors/missing-actions (405 Method Not Allowed)'
+				message: process.env.DEV
+					? 'POST method not allowed. No form actions exist for the page at /errors/missing-actions (405 Method Not Allowed)'
+					: 'POST method not allowed. No form actions exist for this page (405 Method Not Allowed)'
 			}
 		});
 	});

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -373,7 +373,8 @@ test.describe('Errors', () => {
 		expect(await res_json.json()).toEqual({
 			type: 'error',
 			error: {
-				message: 'POST method not allowed. No form actions exist for the page at /errors/missing-actions (405 Method Not Allowed)'
+				message:
+					'POST method not allowed. No form actions exist for the page at /errors/missing-actions (405 Method Not Allowed)'
 			}
 		});
 	});

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -373,7 +373,7 @@ test.describe('Errors', () => {
 		expect(await res_json.json()).toEqual({
 			type: 'error',
 			error: {
-				message: 'POST method not allowed. No actions exist for this page (405 Method Not Allowed)'
+				message: 'POST method not allowed. No form actions exist for the page at /errors/missing-actions (405 Method Not Allowed)'
 			}
 		});
 	});


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/11876

This PR adds the route ID in the error message during development so it's more obvious which route the error means.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
