### PR TITLE
fix: correctly resolve `$app/state` on the server with Vite 5

### DIFF
--- a/.changeset/thin-suns-fail.md
+++ b/.changeset/thin-suns-fail.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly resolve `$app/state` on the server with Vite 5

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -308,7 +308,10 @@ async function kit({ svelte_config }) {
 						'@sveltejs/kit'
 					],
 					resolve: {
-						conditions: ['module', 'node', 'development|production'],
+						// This is default value in Vite 6 but not Vite 5. We need it so that
+						// importing $app/state correctly resolves to the default conditional export
+						// instead of the browser condition.
+						conditions: ['module', 'node', 'development|production']
 					}
 				}
 			};

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -308,10 +308,10 @@ async function kit({ svelte_config }) {
 						'@sveltejs/kit'
 					],
 					resolve: {
-						// This is default value in Vite 6 but not Vite 5. We need it so that
-						// importing $app/state correctly resolves to the default conditional export
-						// instead of the browser condition.
-						conditions: ['module', 'node', 'development|production']
+						// We need this so that importing $app/state correctly
+						// resolves to the default conditional export instead of
+						// the browser condition on the server.
+						conditions: ['module', 'node']
 					}
 				}
 			};

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -306,7 +306,10 @@ async function kit({ svelte_config }) {
 						//    See https://github.com/sveltejs/kit/pull/9172
 						//    and https://vitest.dev/config/#deps-registernodeloader
 						'@sveltejs/kit'
-					]
+					],
+					resolve: {
+						conditions: ['module', 'node', 'development|production'],
+					}
 				}
 			};
 


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13179

This PR backports the default value for Vite 6's `ssr.resolve.conditions` options so that it doesn't fallback to `resolve.conditions` which seemingly causes it to resolve to the browser conditional export.

- [Vite 5 ssr.resolve.conditions](https://v5.vite.dev/config/ssr-options.html#ssr-resolve-conditions)
- [Vite 5 resolve.conditions](https://v5.vite.dev/config/shared-options.html#resolve-conditions)
- [Vite 6 ssr.resolve.conditions](https://vite.dev/config/ssr-options.html#ssr-resolve-conditions)

However, I'm not sure if these condition values are right. @dominikg probably knows better.
- Should we also include 'svelte' as a ssr resolve condition here? I noticed it's included when using vite-plugin-svelte 5 while 4 only includes it in the root resolve condition (which we are falling back to by having ssr.config.resolve as undefined?).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

No test because it only happens on Vite 5 and our test suite is on Vite 6.

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
