### PR TITLE
fix: correctly resolve no hooks file when a similarly named directory exists

### DIFF
--- a/.changeset/empty-mugs-press.md
+++ b/.changeset/empty-mugs-press.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly resolve no hooks file when a similarly named directory exists

--- a/packages/kit/src/utils/filesystem.js
+++ b/packages/kit/src/utils/filesystem.js
@@ -170,22 +170,24 @@ export function resolve_entry(entry) {
 	if (fs.existsSync(entry)) {
 		const stats = fs.statSync(entry);
 		const index = path.join(entry, 'index');
-		if (stats.isDirectory() && fs.existsSync(index)) {
+
+		if (stats.isFile()) {
+			return entry;
+		} else if (fs.existsSync(index)) {
 			return resolve_entry(index);
 		}
+	}
 
-		return entry;
-	} else {
-		const dir = path.dirname(entry);
+	const dir = path.dirname(entry);
 
-		if (fs.existsSync(dir)) {
-			const base = path.basename(entry);
-			const files = fs.readdirSync(dir);
+	if (fs.existsSync(dir)) {
+		const base = path.basename(entry);
+		const files = fs.readdirSync(dir, { withFileTypes: true });
+		const found = files.find((file) => {
+			return file.isFile() && file.name.replace(/\.(js|ts)$/, '') === base;
+		});
 
-			const found = files.find((file) => file.replace(/\.(js|ts)$/, '') === base);
-
-			if (found) return path.join(dir, found);
-		}
+		if (found) return path.join(dir, found.name);
 	}
 
 	return null;

--- a/packages/kit/src/utils/filesystem.js
+++ b/packages/kit/src/utils/filesystem.js
@@ -182,12 +182,12 @@ export function resolve_entry(entry) {
 
 	if (fs.existsSync(dir)) {
 		const base = path.basename(entry);
-		const files = fs.readdirSync(dir, { withFileTypes: true });
+		const files = fs.readdirSync(dir);
 		const found = files.find((file) => {
-			return file.isFile() && file.name.replace(/\.(js|ts)$/, '') === base;
+			return file.replace(/\.(js|ts)$/, '') === base && fs.statSync(path.join(dir, file)).isFile();
 		});
 
-		if (found) return path.join(dir, found.name);
+		if (found) return path.join(dir, found);
 	}
 
 	return null;

--- a/packages/kit/src/utils/filesystem.spec.js
+++ b/packages/kit/src/utils/filesystem.spec.js
@@ -110,5 +110,17 @@ test('ignores hooks folder that has no index file when resolving hooks', () => {
 	write('hooks/not-index.js', '');
 	write('hooks.js', '');
 
-	expect(resolve_entry(source_dir + '/hooks')).toBe(source_dir + '/hooks');
+	expect(resolve_entry(source_dir + '/hooks')).toBe(source_dir + '/hooks.js');
+});
+
+test('ignores hooks folder when resolving universal hooks', () => {
+	write('hooks/hooks.server.js', '');
+
+	expect(resolve_entry(source_dir + '/hooks')).null;
+});
+
+test('resolves entries that have an extension', () => {
+	write('hooks.js', '');
+
+	expect(resolve_entry(source_dir + '/hooks.js')).toBe(source_dir + '/hooks.js');
 });

--- a/packages/kit/src/utils/filesystem.spec.js
+++ b/packages/kit/src/utils/filesystem.spec.js
@@ -1,6 +1,6 @@
 import { mkdtempSync, writeFileSync, readdirSync, mkdirSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import path, { dirname, join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { assert, expect, beforeEach, test } from 'vitest';
 import { copy, mkdirp, resolve_entry } from './filesystem.js';
 
@@ -101,20 +101,20 @@ test('replaces strings', () => {
 });
 
 test('ignores hooks.server folder when resolving hooks', () => {
-	write('hooks.server/index.js', '');
+	write(join('hooks.server', 'index.js'), '');
 
 	expect(resolve_entry(source_dir + '/hooks')).null;
 });
 
 test('ignores hooks folder that has no index file when resolving hooks', () => {
-	write('hooks/not-index.js', '');
+	write(join('hooks', 'not-index.js'), '');
 	write('hooks.js', '');
 
-	expect(resolve_entry(source_dir + '/hooks')).toBe(path.join(source_dir, 'hooks.js'));
+	expect(resolve_entry(source_dir + '/hooks')).toBe(join(source_dir, 'hooks.js'));
 });
 
 test('ignores hooks folder when resolving universal hooks', () => {
-	write('hooks/hooks.server.js', '');
+	write(join('hooks', 'hooks.server.js'), '');
 
 	expect(resolve_entry(source_dir + '/hooks')).null;
 });
@@ -122,5 +122,5 @@ test('ignores hooks folder when resolving universal hooks', () => {
 test('resolves entries that have an extension', () => {
 	write('hooks.js', '');
 
-	expect(resolve_entry(source_dir + '/hooks.js')).toBe(path.join(source_dir, 'hooks.js'));
+	expect(resolve_entry(source_dir + '/hooks.js')).toBe(join(source_dir, '/hooks.js'));
 });

--- a/packages/kit/src/utils/filesystem.spec.js
+++ b/packages/kit/src/utils/filesystem.spec.js
@@ -101,26 +101,20 @@ test('replaces strings', () => {
 });
 
 test('ignores hooks.server folder when resolving hooks', () => {
-	write(join('hooks.server', 'index.js'), '');
+	write('hooks.server/index.js', '');
 
 	expect(resolve_entry(source_dir + '/hooks')).null;
 });
 
 test('ignores hooks folder that has no index file when resolving hooks', () => {
-	write(join('hooks', 'not-index.js'), '');
+	write('hooks/not-index.js', '');
 	write('hooks.js', '');
 
-	expect(resolve_entry(source_dir + '/hooks')).toBe(join(source_dir, 'hooks.js'));
+	expect(resolve_entry(source_dir + '/hooks')).toBe(source_dir + '/hooks.js');
 });
 
 test('ignores hooks folder when resolving universal hooks', () => {
-	write(join('hooks', 'hooks.server.js'), '');
+	write('hooks/hooks.server.js', '');
 
 	expect(resolve_entry(source_dir + '/hooks')).null;
-});
-
-test('resolves entries that have an extension', () => {
-	write('hooks.js', '');
-
-	expect(resolve_entry(source_dir + '/hooks.js')).toBe(join(source_dir, '/hooks.js'));
 });

--- a/packages/kit/src/utils/filesystem.spec.js
+++ b/packages/kit/src/utils/filesystem.spec.js
@@ -1,6 +1,6 @@
 import { mkdtempSync, writeFileSync, readdirSync, mkdirSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import path, { dirname, join } from 'node:path';
 import { assert, expect, beforeEach, test } from 'vitest';
 import { copy, mkdirp, resolve_entry } from './filesystem.js';
 
@@ -110,7 +110,7 @@ test('ignores hooks folder that has no index file when resolving hooks', () => {
 	write('hooks/not-index.js', '');
 	write('hooks.js', '');
 
-	expect(resolve_entry(source_dir + '/hooks')).toBe(source_dir + '/hooks.js');
+	expect(resolve_entry(source_dir + '/hooks')).toBe(path.join(source_dir, 'hooks.js'));
 });
 
 test('ignores hooks folder when resolving universal hooks', () => {
@@ -122,5 +122,5 @@ test('ignores hooks folder when resolving universal hooks', () => {
 test('resolves entries that have an extension', () => {
 	write('hooks.js', '');
 
-	expect(resolve_entry(source_dir + '/hooks.js')).toBe(source_dir + '/hooks.js');
+	expect(resolve_entry(source_dir + '/hooks.js')).toBe(path.join(source_dir, 'hooks.js'));
 });

--- a/packages/kit/src/utils/filesystem.spec.js
+++ b/packages/kit/src/utils/filesystem.spec.js
@@ -110,7 +110,7 @@ test('ignores hooks folder that has no index file when resolving hooks', () => {
 	write(join('hooks', 'not-index.js'), '');
 	write('hooks.js', '');
 
-	expect(resolve_entry(source_dir + '/hooks')).toBe(join(source_dir, '/hooks.js'));
+	expect(resolve_entry(source_dir + '/hooks')).toBe(join(source_dir, 'hooks.js'));
 });
 
 test('ignores hooks folder when resolving universal hooks', () => {
@@ -122,5 +122,5 @@ test('ignores hooks folder when resolving universal hooks', () => {
 test('resolves entries that have an extension', () => {
 	write('hooks.js', '');
 
-	expect(resolve_entry(source_dir + '/hooks.js')).toBe(join(source_dir, '/hooks.js'));
+	expect(resolve_entry(join(source_dir, 'hooks.js'))).toBe(join(source_dir, 'hooks.js'));
 });

--- a/packages/kit/src/utils/filesystem.spec.js
+++ b/packages/kit/src/utils/filesystem.spec.js
@@ -118,3 +118,9 @@ test('ignores hooks folder when resolving universal hooks', () => {
 
 	expect(resolve_entry(source_dir + '/hooks')).null;
 });
+
+test('resolves entries that have an extension', () => {
+	write('hooks.js', '');
+
+	expect(resolve_entry(source_dir + '/hooks.js')).toBe(source_dir + '/hooks.js');
+});

--- a/packages/kit/src/utils/filesystem.spec.js
+++ b/packages/kit/src/utils/filesystem.spec.js
@@ -101,20 +101,20 @@ test('replaces strings', () => {
 });
 
 test('ignores hooks.server folder when resolving hooks', () => {
-	write('hooks.server/index.js', '');
+	write(join('hooks.server', 'index.js'), '');
 
 	expect(resolve_entry(source_dir + '/hooks')).null;
 });
 
 test('ignores hooks folder that has no index file when resolving hooks', () => {
-	write('hooks/not-index.js', '');
+	write(join('hooks', 'not-index.js'), '');
 	write('hooks.js', '');
 
-	expect(resolve_entry(source_dir + '/hooks')).toBe(source_dir + '/hooks.js');
+	expect(resolve_entry(source_dir + '/hooks')).toBe(join(source_dir, '/hooks.js'));
 });
 
 test('ignores hooks folder when resolving universal hooks', () => {
-	write('hooks/hooks.server.js', '');
+	write(join('hooks', 'hooks.server.js'), '');
 
 	expect(resolve_entry(source_dir + '/hooks')).null;
 });
@@ -122,5 +122,5 @@ test('ignores hooks folder when resolving universal hooks', () => {
 test('resolves entries that have an extension', () => {
 	write('hooks.js', '');
 
-	expect(resolve_entry(source_dir + '/hooks.js')).toBe(source_dir + '/hooks.js');
+	expect(resolve_entry(source_dir + '/hooks.js')).toBe(join(source_dir, '/hooks.js'));
 });


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13184

https://github.com/sveltejs/kit/pull/13144 caused a regression where it incorrectly resolved to the directory name when the `hooks.js file` doesn't exist. This happened because it couldn't distinguish between file names and directory names when looking for a matching file without the .js / .ts extension (`hooks/` and `hooks.js` would both equal to `hooks`, but `hooks/` would return first).

This didn't happen before https://github.com/sveltejs/kit/pull/13144 because we'd return early whenever a directory name matched. Therefore, the file name search would only contains files, not files and directory names.

This PR fixes that by only checking for file names again.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
