### PR TITLE
chore: error during development when using `use:enhance` with `+server`

### DIFF
--- a/.changeset/nine-parrots-smoke.md
+++ b/.changeset/nine-parrots-smoke.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: error during development when using `use:enhance` with `+server`

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -13,7 +13,7 @@ import { method_not_allowed } from './utils.js';
 export async function render_endpoint(event, mod, state) {
 	if (DEV && event.request.headers.get('x-sveltekit-action') === 'true') {
 		throw new Error(
-			'Methods from $app/forms such as use:enhance and deserialize should only be used with SvelteKit form actions'
+			'use:enhance should only be used with SvelteKit form actions'
 		);
 	}
 

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -1,3 +1,4 @@
+import { DEV } from 'esm-env';
 import { ENDPOINT_METHODS, PAGE_METHODS } from '../../constants.js';
 import { negotiate } from '../../utils/http.js';
 import { Redirect } from '../control.js';
@@ -10,6 +11,12 @@ import { method_not_allowed } from './utils.js';
  * @returns {Promise<Response>}
  */
 export async function render_endpoint(event, mod, state) {
+	if (DEV && event.request.headers.get('x-sveltekit-action') === 'true') {
+		throw new Error(
+			'Methods from $app/forms such as use:enhance and deserialize should only be used with SvelteKit form actions'
+		);
+	}
+
 	const method = /** @type {import('types').HttpMethod} */ (event.request.method);
 
 	let handler = mod[method] || mod.fallback;

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -12,9 +12,7 @@ import { method_not_allowed } from './utils.js';
  */
 export async function render_endpoint(event, mod, state) {
 	if (DEV && event.request.headers.get('x-sveltekit-action') === 'true') {
-		throw new Error(
-			'use:enhance should only be used with SvelteKit form actions'
-		);
+		throw new Error('use:enhance should only be used with SvelteKit form actions');
 	}
 
 	const method = /** @type {import('types').HttpMethod} */ (event.request.method);


### PR DESCRIPTION
Related to https://github.com/sveltejs/kit/issues/10855 (If we have no plans to extend `use:enhance` to work with non-SvelteKit form actions then this closes that issue entirely).

This PR adds an dev-only error if someone uses an enhanced form and POSTs to an internal API handler. It makes it more obvious they shouldn't be used together compared to "Unexpected end of JSON input" when it fails to parse a response body.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
