### PR TITLE
fix: correctly notify page store subscribers

### DIFF
--- a/.changeset/dirty-bees-act.md
+++ b/.changeset/dirty-bees-act.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly notify page store subscribers

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2688,11 +2688,11 @@ function create_navigation(current, intent, url, type) {
 
 /**
  * TODO: remove this in 3.0 when the page store is also removed
- * 
+ *
  * We need to assign a new page object so that subscribers are correctly notified.
  * However, spreading `{ ...page }` returns an empty object so we manually
  * assign to each property instead.
- * 
+ *
  * @param {import('@sveltejs/kit').Page} page
  */
 function clone_page(page) {

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -520,7 +520,17 @@ function get_navigation_result_from_branch({ url, params, branch, status, error,
 		props: {
 			// @ts-ignore Somehow it's getting SvelteComponent and SvelteComponentDev mixed up
 			constructors: compact(branch).map((branch_node) => branch_node.node.component),
-			page
+			// we need to assign a new page object so that subscribers are correctly notified
+			page: {
+				data: page.data,
+				error: page.error,
+				form: page.form,
+				params: page.params,
+				route: page.route,
+				state: page.state,
+				status: page.status,
+				url: page.url
+			}
 		}
 	};
 
@@ -848,7 +858,20 @@ function preload_error({ error, url, route, params }) {
 			params,
 			branch: []
 		},
-		props: { page, constructors: [] }
+		props: {
+			// we need to assign a new page object so that subscribers are correctly notified
+			page: {
+				data: page.data,
+				error: page.error,
+				form: page.form,
+				params: page.params,
+				route: page.route,
+				state: page.state,
+				status: page.status,
+				url: page.url
+			},
+			constructors: []
+		}
 	};
 }
 
@@ -1909,7 +1932,19 @@ export function pushState(url, state) {
 	has_navigated = true;
 
 	page.state = state;
-	root.$set({ page });
+	root.$set({
+		// we need to assign a new page object so that subscribers are correctly notified
+		page: {
+			data: page.data,
+			error: page.error,
+			form: page.form,
+			params: page.params,
+			route: page.route,
+			state: page.state,
+			status: page.status,
+			url: page.url
+		}
+	});
 
 	clear_onward_history(current_history_index, current_navigation_index);
 }
@@ -1950,7 +1985,19 @@ export function replaceState(url, state) {
 	history.replaceState(opts, '', resolve_url(url));
 
 	page.state = state;
-	root.$set({ page });
+	root.$set({
+		// we need to assign a new page object so that subscribers are correctly notified
+		page: {
+			data: page.data,
+			error: page.error,
+			form: page.form,
+			params: page.params,
+			route: page.route,
+			state: page.state,
+			status: page.status,
+			url: page.url
+		}
+	});
 }
 
 /**
@@ -2001,7 +2048,17 @@ export async function applyAction(result) {
 			// this brings Svelte's view of the world in line with SvelteKit's
 			// after use:enhance reset the form....
 			form: null,
-			page
+			// we need to assign a new page object so that subscribers are correctly notified
+			page: {
+				data: page.data,
+				error: page.error,
+				form: page.form,
+				params: page.params,
+				route: page.route,
+				state: page.state,
+				status: page.status,
+				url: page.url
+			}
 		});
 
 		// ...so that setting the `form` prop takes effect and isn't ignored
@@ -2253,15 +2310,14 @@ function _start_router() {
 				// This happens with hash links and `pushState`/`replaceState`. The
 				// exception is if we haven't navigated yet, since we could have
 				// got here after a modal navigation then a reload
+				if (state !== page.state) {
+					page.state = state;
+				}
+
 				update_url(url);
 
 				scroll_positions[current_history_index] = scroll_state();
 				if (scroll) scrollTo(scroll.x, scroll.y);
-
-				if (state !== page.state) {
-					page.state = state;
-					root.$set({ page });
-				}
 
 				current_history_index = history_index;
 				return;

--- a/packages/kit/test/apps/basics/src/routes/store/subscribe/+layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/store/subscribe/+layout.svelte
@@ -1,0 +1,48 @@
+<script>
+	import { page } from '$app/stores';
+	import { goto, pushState, replaceState, invalidate } from '$app/navigation';
+	import { applyAction } from '$app/forms';
+
+	let { children } = $props();
+
+	let count = $state(0);
+
+	page.subscribe(() => {
+    console.log('$page notified')
+		count += 1;
+	});
+</script>
+
+<p>{count}</p>
+
+<button
+	onclick={() => {
+    invalidate('/state/subscribe')
+	}}>invalidate</button
+>
+
+<button
+	onclick={() => {
+		replaceState(`/store/subscribe`, { active: true });
+	}}>replaceState</button
+>
+
+<button
+	onclick={() => {
+		pushState(`/store/subscribe`, { active: false });
+	}}>pushState</button
+>
+
+<button
+	onclick={() => {
+		goto(`/store/subscribe`);
+	}}>goto</button
+>
+
+<button
+	onclick={() => {
+		applyAction({ type: 'success', status: 200 });
+	}}>applyAction</button
+>
+
+{@render children()}

--- a/packages/kit/test/apps/basics/src/routes/store/subscribe/+layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/store/subscribe/+layout.svelte
@@ -8,7 +8,6 @@
 	let count = $state(0);
 
 	page.subscribe(() => {
-    console.log('$page notified')
 		count += 1;
 	});
 </script>
@@ -17,7 +16,7 @@
 
 <button
 	onclick={() => {
-    invalidate('/state/subscribe')
+		invalidate('/state/subscribe');
 	}}>invalidate</button
 >
 

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -394,6 +394,60 @@ test.describe('$app/stores', () => {
 		await app.goto('/store/data/store-update/same-keys');
 		await expect(page.locator('p')).toHaveText('$page.data was updated 1 time(s)');
 	});
+
+	test('page subscribers are notified when invalidate is called', async ({ page }) => {
+		await page.goto('/store/subscribe');
+		await expect(page.locator('p')).toHaveText('1');
+		await page.locator('button', { hasText: 'invalidate' }).click();
+		await expect(page.locator('p')).toHaveText('2');
+		await page.locator('button', { hasText: 'invalidate' }).click();
+		await expect(page.locator('p')).toHaveText('3');
+	});
+
+	test('page subscribers are notified when replaceState is called', async ({ page }) => {
+		await page.goto('/store/subscribe');
+		await expect(page.locator('p')).toHaveText('1');
+		await page.locator('button', { hasText: 'replaceState' }).click();
+		await expect(page.locator('p')).toHaveText('2');
+		await page.locator('button', { hasText: 'replaceState' }).click();
+		await expect(page.locator('p')).toHaveText('3');
+	});
+
+	test('page subscribers are notified when pushState is called', async ({ page }) => {
+		await page.goto('/store/subscribe');
+		await expect(page.locator('p')).toHaveText('1');
+		await page.locator('button', { hasText: 'pushState' }).click();
+		await expect(page.locator('p')).toHaveText('2');
+		await page.locator('button', { hasText: 'pushState' }).click();
+		await expect(page.locator('p')).toHaveText('3');
+	});
+
+	test('page subscribers are notified when goto is called', async ({ page }) => {
+		await page.goto('/store/subscribe');
+		await expect(page.locator('p')).toHaveText('1');
+		await page.locator('button', { hasText: 'goto' }).click();
+		await expect(page.locator('p')).toHaveText('2');
+		await page.locator('button', { hasText: 'goto' }).click();
+		await expect(page.locator('p')).toHaveText('3');
+	});
+
+	test('page subscribers are notified when applyAction is called', async ({ page }) => {
+		await page.goto('/store/subscribe');
+		await expect(page.locator('p')).toHaveText('1');
+		await page.locator('button', { hasText: 'applyAction' }).click();
+		await expect(page.locator('p')).toHaveText('2');
+		await page.locator('button', { hasText: 'applyAction' }).click();
+		await expect(page.locator('p')).toHaveText('3');
+	});
+
+	test('page subscribers are notified only once after popstate', async ({ page }) => {
+		await page.goto('/store/subscribe');
+		await expect(page.locator('p')).toHaveText('1');
+		await page.locator('button', { hasText: 'pushState' }).click();
+		await expect(page.locator('p')).toHaveText('2');
+		await page.goBack();
+		await expect(page.locator('p')).toHaveText('3');
+	});
 });
 
 test.describe('$app/state', () => {


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13200

This PR ensures page store subscribers are correctly notified by creating a new object whenever we update the page store. I'm not sure why but when the same page object is used, it doesn't notify subscribers.

There was also another bug where a popstate event would cause subscribers to get notified twice because we were calling `root.$set({ page })` in addition to `stores.page.notify()` when updating the URL.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
