### PR TITLE
fix: change page.url when calling pushState(...) with a new url

### DIFF
--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1958,17 +1958,22 @@ export function pushState(url, state) {
 	}
 
 	update_scroll_positions(current_history_index);
+	url = resolve_url(url);
+	const change = page.url.href !== url.href ? 1 : 0;
 
 	const opts = {
 		[HISTORY_INDEX]: (current_history_index += 1),
-		[NAVIGATION_INDEX]: current_navigation_index,
-		[PAGE_URL_KEY]: page.url.href,
+		[NAVIGATION_INDEX]: (current_navigation_index += change),
+		[PAGE_URL_KEY]: url.href,
 		[STATES_KEY]: state
 	};
 
-	history.pushState(opts, '', resolve_url(url));
+	history.pushState(opts, '', url);
 	has_navigated = true;
 
+	if (change) {
+		page.url = url;
+	}
 	page.state = state;
 	root.$set({ page });
 

--- a/packages/kit/test/apps/basics/src/routes/state/url/[slug]/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/state/url/[slug]/+page.svelte
@@ -1,0 +1,32 @@
+<script>
+	import { pushState } from '$app/navigation';
+	import { page } from '$app/state';
+	import { untrack } from 'svelte';
+
+	let count = $state(0);
+
+	$effect(() => {
+		page.url;
+		untrack(() => {
+			count += 1;
+		});
+	});
+</script>
+
+<button
+	type="button"
+	class="before"
+	onclick={() => {
+		pushState('', { s: 'test' });
+	}}>slug = before</button
+>
+<button
+	type="button"
+	class="after"
+	onclick={() => {
+		pushState('/state/url/after', { s: 'test' });
+	}}>slug = after</button
+>
+
+<h1>{page.url.pathname}</h1>
+<h2>page.url was updated {count} time(s)</h2>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -428,6 +428,25 @@ test.describe('$app/state', () => {
 		await page.locator('button').click();
 		await expect(page.locator('p')).toHaveText('test');
 	});
+
+	test('page.url does update when used with pushState', async ({ page }) => {
+		await page.goto('/state/url/before');
+
+		await expect(page.locator('h1')).toHaveText('/state/url/before');
+		await expect(page.locator('h2')).toHaveText('page.url was updated 1 time(s)');
+
+		await page.locator('button.before').click();
+		await expect(page.locator('h1')).toHaveText('/state/url/before');
+		await expect(page.locator('h2')).toHaveText('page.url was updated 1 time(s)');
+
+		await page.locator('button.after').click();
+		await expect(page.locator('h1')).toHaveText('/state/url/after');
+		await expect(page.locator('h2')).toHaveText('page.url was updated 2 time(s)');
+
+		await page.locator('button.after').click();
+		await expect(page.locator('h1')).toHaveText('/state/url/after');
+		await expect(page.locator('h2')).toHaveText('page.url was updated 2 time(s)');
+	});
 });
 
 test.describe('Invalidation', () => {
@@ -1113,7 +1132,7 @@ test.describe('Shallow routing', () => {
 
 		await page.goForward();
 		expect(page.url()).toBe(`${baseURL}/shallow-routing/push-state/a`);
-		await expect(page.locator('h1')).toHaveText('parent');
+		await expect(page.locator('h1')).toHaveText('a');
 		await expect(page.locator('p')).toHaveText('active: true');
 	});
 


### PR DESCRIPTION
Recently @Rich-Harris fixed the first part of [the bug, that I reported](https://github.com/sveltejs/kit/issues/12742) in https://github.com/sveltejs/kit/pull/13196. However the second bug related to `pushState` is still a problem.

Basically when doing `pushState('/new-url', { foo: 'bar' })` you end up with real browser url and `page.url` being out of sync. The weird part is that some of the tests are explicitly ensuring current behavior, which makes me unsure if that's an accident or I am missing something.

Some tests are failing because their existence made me unsure about the change and I am opening this PR to validate it.

That's my first contribution. I've tried to match the code and logic written around, but am not sure how well I've done that. Happy to incorporate any feedback.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
