### PR TITLE
fix: avoid errors when constructing the base path in certain edge cases

### DIFF
--- a/.changeset/yellow-bags-deliver.md
+++ b/.changeset/yellow-bags-deliver.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: avoid errors when constructing the base path in certain edge cases

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -102,14 +102,15 @@ export async function render_response({
 			base = segments.map(() => '..').join('/') || '.';
 
 			// resolve e.g. '../..' against current location, then remove trailing slash
-			base_expression = `new URL(${s(base)}, location).pathname.slice(0, -1)`;
+			base_expression = `['about:', 'data:'].includes(location.protocol) ? ${s(base)} : new URL(${s(base)}, location).pathname.slice(0, -1)`;
 
 			if (!paths.assets || (paths.assets[0] === '/' && paths.assets !== SVELTE_KIT_ASSETS)) {
 				assets = base;
 			}
 		} else if (options.hash_routing) {
 			// we have to assume that we're in the right place
-			base_expression = "new URL('.', location).pathname.slice(0, -1)";
+			base_expression =
+				"['about:', 'data:'].includes(location.protocol) ? '' : new URL('.', location).pathname.slice(0, -1)";
 		}
 	}
 


### PR DESCRIPTION
In specific edge cases, `new URL(..., location)` may fail, such as when using an `<iframe>` with `srcdoc` set to the HTML of a SvelteKit page.

This pull request adds a condition to check if the protocol is `about:` or `data:` and handle the base URL resolution accordingly.

- Resolves #13226

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
