### PR TITLE
fix: add CSP hashes/nonces to inline styles when using

### DIFF
--- a/.changeset/angry-geckos-dream.md
+++ b/.changeset/angry-geckos-dream.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: add CSP hashes/nonces to inline styles when using `bundleStrategy: 'inline'`

--- a/packages/kit/src/runtime/server/page/csp.js
+++ b/packages/kit/src/runtime/server/page/csp.js
@@ -186,10 +186,6 @@ class BaseProvider {
 			this.#style_src.push(source);
 		}
 
-		if (this.#style_src_needs_csp) {
-			this.#style_src.push(source);
-		}
-
 		if (this.#style_src_attr_needs_csp) {
 			this.#style_src_attr.push(source);
 		}

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -228,19 +228,18 @@ export async function render_response({
 		return `${assets}/${path}`;
 	};
 
-	if (client.inline?.style) {
-		head += `\n\t<style>${client.inline.style}</style>`;
-	}
+	// inline styles can come from `bundleStrategy: 'inline'` or `inlineStyleThreshold`
+	const style = client.inline
+		? client.inline?.style
+		: Array.from(inline_styles.values()).join('\n');
 
-	if (inline_styles.size > 0) {
-		const content = Array.from(inline_styles.values()).join('\n');
-
+	if (style) {
 		const attributes = __SVELTEKIT_DEV__ ? [' data-sveltekit'] : [];
 		if (csp.style_needs_nonce) attributes.push(` nonce="${csp.nonce}"`);
 
-		csp.add_style(content);
+		csp.add_style(style);
 
-		head += `\n\t<style${attributes.join('')}>${content}</style>`;
+		head += `\n\t<style${attributes.join('')}>${style}</style>`;
 	}
 
 	for (const dep of stylesheets) {


### PR DESCRIPTION
I forgot to account for CSP when adding inline styles for `bundleStrategy: 'inline'`.

No test in this PR because there are no tests for `bundleStrategy: 'inline'` anyway, and life is too short to worry about such things during the Christmas break

Also, hashes were being printed twice, inexplicably (if harmlessly) — this fixes that

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
