### PR TITLE
fix: avoid importing component code in server nodes that have SSR disabled

### DIFF
--- a/.changeset/pink-islands-fry.md
+++ b/.changeset/pink-islands-fry.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: avoid importing component code in server nodes with SSR disabled

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -139,7 +139,8 @@ async function analyse({
 			config: route_config,
 			methods: Array.from(new Set([...page_methods, ...api_methods])),
 			page: {
-				methods: page_methods
+				methods: page_methods,
+				ssr: !!page?.ssr
 			},
 			api: {
 				methods: api_methods
@@ -208,7 +209,8 @@ function analyse_page(layouts, leaf) {
 		config: get_page_config([...layouts, leaf]),
 		entries: leaf.universal?.entries ?? leaf.server?.entries,
 		methods,
-		prerender: get_option([...layouts, leaf], 'prerender') ?? false
+		prerender: get_option([...layouts, leaf], 'prerender') ?? false,
+		ssr: get_option([...layouts, leaf], 'ssr') ?? true
 	};
 }
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -793,7 +793,8 @@ async function kit({ svelte_config }) {
 					server_manifest,
 					null,
 					null,
-					svelte_config.output
+					svelte_config.output,
+					null
 				);
 
 				const metadata = await analyse({
@@ -913,7 +914,8 @@ async function kit({ svelte_config }) {
 					server_manifest,
 					client_manifest,
 					css,
-					svelte_config.kit.output
+					svelte_config.kit.output,
+					metadata
 				);
 
 				// ...and prerender

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -297,6 +297,7 @@ export interface ServerMetadataRoute {
 	};
 	page: {
 		methods: Array<'GET' | 'POST'>;
+		ssr: boolean;
 	};
 	methods: Array<HttpMethod | '*'>;
 	prerender: PrerenderOption | undefined;


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/12578

This PR makes it so that component code is only imported in nodes that have SSR enabled. It should make bundle sizes smaller for edge deployed apps since the component code and its dependencies will no longer be bundled for nodes with SSR disabled.

Do we need to add a test that checks if the component is exported from the node?

EDIT: In hindsight, this will error if the ssr option is false during building but true during production

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
