### PR TITLE
fix: correctly remove navigation callbacks when returning function in onNavigate

### DIFF
--- a/.changeset/sixty-rabbits-smell.md
+++ b/.changeset/sixty-rabbits-smell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly remove navigation callbacks when returning function in onNavigate

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -191,14 +191,18 @@ const components = [];
 /** @type {{id: string, token: {}, promise: Promise<import('./types.js').NavigationResult>} | null} */
 let load_cache = null;
 
-/** @type {Array<(navigation: import('@sveltejs/kit').BeforeNavigate) => void>} */
-const before_navigate_callbacks = [];
+/**
+ * Note on before_navigate_callbacks, on_navigate_callbacks and after_navigate_callbacks:
+ * do not re-assign as some closures keep references to these Sets
+ */
+/** @type {Set<(navigation: import('@sveltejs/kit').BeforeNavigate) => void>} */
+const before_navigate_callbacks = new Set();
 
-/** @type {Array<(navigation: import('@sveltejs/kit').OnNavigate) => import('types').MaybePromise<(() => void) | void>>} */
-const on_navigate_callbacks = [];
+/** @type {Set<(navigation: import('@sveltejs/kit').OnNavigate) => import('types').MaybePromise<(() => void) | void>>} */
+const on_navigate_callbacks = new Set();
 
-/** @type {Array<(navigation: import('@sveltejs/kit').AfterNavigate) => void>} */
-let after_navigate_callbacks = [];
+/** @type {Set<(navigation: import('@sveltejs/kit').AfterNavigate) => void>} */
+const after_navigate_callbacks = new Set();
 
 /** @type {import('./types.js').NavigationState} */
 let current = {
@@ -1460,7 +1464,7 @@ async function navigate({
 
 		const after_navigate = (
 			await Promise.all(
-				on_navigate_callbacks.map((fn) =>
+				Array.from(on_navigate_callbacks, (fn) =>
 					fn(/** @type {import('@sveltejs/kit').OnNavigate} */ (nav.navigation))
 				)
 			)
@@ -1468,14 +1472,16 @@ async function navigate({
 
 		if (after_navigate.length > 0) {
 			function cleanup() {
-				after_navigate_callbacks = after_navigate_callbacks.filter(
-					// @ts-ignore
-					(fn) => !after_navigate.includes(fn)
-				);
+				after_navigate.forEach((fn) => {
+					after_navigate_callbacks.delete(fn);
+				});
 			}
 
 			after_navigate.push(cleanup);
-			after_navigate_callbacks.push(...after_navigate);
+
+			after_navigate.forEach((fn) => {
+				after_navigate_callbacks.add(fn);
+			});
 		}
 
 		root.$set(navigation_result.props);
@@ -1677,7 +1683,7 @@ function setup_preload() {
 		}
 	}
 
-	after_navigate_callbacks.push(after_navigate);
+	after_navigate_callbacks.add(after_navigate);
 	after_navigate();
 }
 
@@ -1706,16 +1712,15 @@ function handle_error(error, event) {
 
 /**
  * @template {Function} T
- * @param {T[]} callbacks
+ * @param {Set<T>} callbacks
  * @param {T} callback
  */
 function add_navigation_callback(callbacks, callback) {
 	onMount(() => {
-		callbacks.push(callback);
+		callbacks.add(callback);
 
 		return () => {
-			const i = callbacks.indexOf(callback);
-			callbacks.splice(i, 1);
+			callbacks.delete(callback);
 		};
 	});
 }

--- a/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/after-navigate-properly-removed/+layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/after-navigate-properly-removed/+layout.svelte
@@ -1,0 +1,10 @@
+<script>
+	import { onNavigate } from '$app/navigation';
+	let { children } = $props();
+
+	onNavigate(() => {
+		return () => {};
+	});
+</script>
+
+{@render children()}

--- a/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/after-navigate-properly-removed/a/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/after-navigate-properly-removed/a/+page.svelte
@@ -1,0 +1,20 @@
+<script>
+	import { afterNavigate } from '$app/navigation';
+
+	afterNavigate(() => {
+		console.log('after navigate called');
+
+		/**
+		 * @type {HTMLElement}
+		 */
+		const el = document.querySelector('.nav-lifecycle-after-nav-removed-test-target');
+
+		if (el) {
+			el.innerText = 'true';
+		}
+	});
+</script>
+
+<h1>/A</h1>
+<a href="/navigation-lifecycle/after-navigate-properly-removed/a">/a</a>
+<a href="/navigation-lifecycle/after-navigate-properly-removed/b">/b</a>

--- a/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/after-navigate-properly-removed/b/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/navigation-lifecycle/after-navigate-properly-removed/b/+page.svelte
@@ -1,0 +1,7 @@
+<h1>/B</h1>
+<div>
+	was called:
+	<span class="nav-lifecycle-after-nav-removed-test-target">false</span>
+</div>
+<a href="/navigation-lifecycle/after-navigate-properly-removed/a">/a</a>
+<a href="/navigation-lifecycle/after-navigate-properly-removed/b">/b</a>

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -256,6 +256,14 @@ test.describe('Navigation lifecycle functions', () => {
 			'/navigation-lifecycle/on-navigate/a -> /navigation-lifecycle/on-navigate/b (link) true'
 		);
 	});
+
+	test('afterNavigate properly removed', async ({ page, clicknav }) => {
+		await page.goto('/navigation-lifecycle/after-navigate-properly-removed/b');
+		await clicknav('[href="/navigation-lifecycle/after-navigate-properly-removed/a"]');
+		await clicknav('[href="/navigation-lifecycle/after-navigate-properly-removed/b"]');
+
+		expect(await page.textContent('.nav-lifecycle-after-nav-removed-test-target')).toBe('false');
+	});
 });
 
 test.describe('Scrolling', () => {


### PR DESCRIPTION
<!-- Your PR description here -->

closes #13240

the callbacks of `afterNavigate` do in fact get removed, just from the wrong array.

[here](https://github.com/sveltejs/kit/blob/619c00e0798d1fe2434e36cf4b0a800ade8112d6/packages/kit/src/runtime/client/client.js#L1471) `after_navigate_callbacks` gets re-assigned a new array, but [here](https://github.com/sveltejs/kit/blob/619c00e0798d1fe2434e36cf4b0a800ade8112d6/packages/kit/src/runtime/client/client.js#L1718) the `splice()` is done on an old reference.

to fix this i switched to a `Set`, and also changed to `const` to warn any future change. Sets keep the insertion order.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
