### PR TITLE
fix: silence dev/prod warning during sync

### DIFF
--- a/.changeset/clever-phones-reply.md
+++ b/.changeset/clever-phones-reply.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: silence dev/prod warning during sync

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -1,4 +1,5 @@
-import { BROWSER } from 'esm-env';
+// @ts-ignore - need to publish types for sub-package imports
+import BROWSER from 'esm-env/browser';
 
 const param_pattern = /^(\[)?(\.\.\.)?(\w+)(?:=(\w+))?(\])?$/;
 


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/13238

this avoids loading the dev check so it doesn't care if we tell it we're in dev or prod mode