### PR TITLE
feat: allow to opt-out of use:enhance for forms

### DIFF
--- a/.changeset/spotty-queens-beam.md
+++ b/.changeset/spotty-queens-beam.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+Allow to do opt out of enhancing forms with `data-sveltekit-reload` on the form element or button

--- a/.changeset/spotty-queens-beam.md
+++ b/.changeset/spotty-queens-beam.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': minor
 ---
 
-Allow to do opt out of enhancing forms with `data-sveltekit-reload` on the form element or button
+feat: allow opting out of `use:enhance` with `data-sveltekit-reload` on the form element or submit button

--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -359,7 +359,7 @@ Without an argument, `use:enhance` will emulate the browser-native behaviour, ju
 - render the nearest `+error` boundary if an error occurs
 - [reset focus](accessibility#Focus-management) to the appropriate element
 
-You can add the [`data-sveltekit-reload`](link-options#data-sveltekit-reload) attribute on the `<form>` or the `<button>` to opt-out of this behavior and instead let the browser handle the form submission.
+You can add the [`data-sveltekit-reload`](link-options#data-sveltekit-reload) attribute on the `<form>` or the `<button>` (or a parent element) to opt-out of this behavior and instead let the browser handle the form submission.
 
 ### Customising use:enhance
 

--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -359,6 +359,8 @@ Without an argument, `use:enhance` will emulate the browser-native behaviour, ju
 - render the nearest `+error` boundary if an error occurs
 - [reset focus](accessibility#Focus-management) to the appropriate element
 
+You can add the [`data-sveltekit-reload`](link-options#data-sveltekit-reload) attribute on the `<form>` or the `<button>` to opt-out of this behavior and instead let the browser handle the form submission.
+
 ### Customising use:enhance
 
 To customise the behaviour, you can provide a `SubmitFunction` that runs immediately before the form is submitted, and (optionally) returns a callback that runs with the `ActionResult`. Note that if you return a callback, the default behavior mentioned above is not triggered. To get it back, call `update`.

--- a/documentation/docs/30-advanced/30-link-options.md
+++ b/documentation/docs/30-advanced/30-link-options.md
@@ -68,6 +68,8 @@ Occasionally, we need to tell SvelteKit not to handle a link, but allow the brow
 
 Links with a `rel="external"` attribute will receive the same treatment. In addition, they will be ignored during [prerendering](page-options#prerender).
 
+Forms with the `use:enhance` action can skip using the enhanced behavior by adding a `data-sveltekit-reload` attribute to the form element or the submit button.
+
 ## data-sveltekit-replacestate
 
 Sometimes you don't want navigation to create a new entry in the browser's session history. Adding a `data-sveltekit-replacestate` attribute to a link...

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -2,6 +2,7 @@ import * as devalue from 'devalue';
 import { DEV } from 'esm-env';
 import { invalidateAll } from './navigation.js';
 import { app, applyAction } from '../client/client.js';
+import { link_option } from '../client/utils.js';
 
 export { applyAction };
 
@@ -117,10 +118,15 @@ export function enhance(form_element, submit = () => {}) {
 			: clone(form_element).method;
 		if (method !== 'post') return;
 
-		const skip =
-			event.submitter?.getAttribute('data-sveltekit-reload') ??
-			form_element.getAttribute('data-sveltekit-reload');
-		if (skip === 'true') return;
+		/** @type {import('../client/utils.js').ValidLinkOptions<'reload'> | null} */
+		let reload = null;
+		if (event.submitter) {
+			reload = link_option(event.submitter, 'reload');
+		}
+		if (reload === null) {
+			reload = link_option(form_element, 'reload');
+		}
+		if (reload === '' || reload === 'true') return;
 
 		event.preventDefault();
 

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -2,7 +2,7 @@ import * as devalue from 'devalue';
 import { DEV } from 'esm-env';
 import { invalidateAll } from './navigation.js';
 import { app, applyAction } from '../client/client.js';
-import { link_option } from '../client/utils.js';
+import { get_router_options } from '../client/utils.js';
 
 export { applyAction };
 
@@ -118,15 +118,15 @@ export function enhance(form_element, submit = () => {}) {
 			: clone(form_element).method;
 		if (method !== 'post') return;
 
-		/** @type {import('../client/utils.js').ValidLinkOptions<'reload'> | null} */
-		let reload = null;
+		/** @type {boolean | undefined} */
+		let reload;
 		if (event.submitter) {
-			reload = link_option(event.submitter, 'reload');
+			reload = get_router_options(/** @type {HTMLButtonElement} */ (event.submitter)).reload;
 		}
-		if (reload === null) {
-			reload = link_option(form_element, 'reload');
+		if (reload === undefined) {
+			reload = get_router_options(form_element).reload;
 		}
-		if (reload === '' || reload === 'true') return;
+		if (reload) return;
 
 		event.preventDefault();
 

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -117,6 +117,11 @@ export function enhance(form_element, submit = () => {}) {
 			: clone(form_element).method;
 		if (method !== 'post') return;
 
+		const skip =
+			event.submitter?.getAttribute('data-sveltekit-reload') ??
+			form_element.getAttribute('data-sveltekit-reload');
+		if (skip === 'true') return;
+
 		event.preventDefault();
 
 		const action = new URL(

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -52,7 +52,7 @@ const valid_link_options = /** @type {const} */ ({
  * @param {Element} element
  * @param {T} name
  */
-export function link_option(element, name) {
+function link_option(element, name) {
 	const value = /** @type {ValidLinkOptions<T> | null} */ (
 		element.getAttribute(`data-sveltekit-${name}`)
 	);
@@ -146,7 +146,7 @@ export function get_link_info(a, base, uses_hash_router) {
 }
 
 /**
- * @param {HTMLFormElement | HTMLAnchorElement | SVGAElement} element
+ * @param {HTMLFormElement | HTMLAnchorElement | HTMLButtonElement | SVGAElement} element
  */
 export function get_router_options(element) {
 	/** @type {ValidLinkOptions<'keepfocus'> | null} */

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -52,7 +52,7 @@ const valid_link_options = /** @type {const} */ ({
  * @param {Element} element
  * @param {T} name
  */
-function link_option(element, name) {
+export function link_option(element, name) {
 	const value = /** @type {ValidLinkOptions<T> | null} */ (
 		element.getAttribute(`data-sveltekit-${name}`)
 	);


### PR DESCRIPTION
fix #13180 

I reused the `data-sveltekit-reload` attribute to opt-out of `use:enhance`. The attribute can be present either on the form element or the form button.

More details of the reasoning in the linked issue but tl;dr: I need to post to an endpoint in a new tab from the same form that is used for formactions and `use:enhance`.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
