### PR TITLE
fix: prerender data when there's no server load but `trailingSlash` option is set from the server

### DIFF
--- a/.changeset/gold-tips-cover.md
+++ b/.changeset/gold-tips-cover.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: prerender data when `trailingSlash` option is set from the server
+fix: prerender data when there is no server load but the `trailingSlash` option is set from the server

--- a/.changeset/gold-tips-cover.md
+++ b/.changeset/gold-tips-cover.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prerender data when `trailingSlash` option is set from the server

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -70,7 +70,9 @@ export async function render_page(event, page, options, manifest, state, resolve
 			}
 		}
 
-		const should_prerender_data = nodes.some((node) => node?.server?.load);
+		const should_prerender_data = nodes.some(
+			(node) => node?.server?.load || node?.server?.trailingSlash !== undefined
+		);
 		const data_pathname = add_data_suffix(event.url.pathname);
 
 		// it's crucial that we do this before returning the non-SSR response, otherwise

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -71,6 +71,7 @@ export async function render_page(event, page, options, manifest, state, resolve
 		}
 
 		const should_prerender_data = nodes.some(
+			// prerender in case of trailingSlash because the client retrieves that value from the server
 			(node) => node?.server?.load || node?.server?.trailingSlash !== undefined
 		);
 		const data_pathname = add_data_suffix(event.url.pathname);

--- a/packages/kit/test/apps/options-2/src/routes/trailing-slash-server/+page.svelte
+++ b/packages/kit/test/apps/options-2/src/routes/trailing-slash-server/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { base } from '$app/paths';
+</script>
+
+<a href="{base}/trailing-slash-server/prerender">{base}/trailing-slash-server/prerender</a>

--- a/packages/kit/test/apps/options-2/src/routes/trailing-slash-server/prerender/+page.server.js
+++ b/packages/kit/test/apps/options-2/src/routes/trailing-slash-server/prerender/+page.server.js
@@ -1,0 +1,2 @@
+export const trailingSlash = 'always';
+export const prerender = true;

--- a/packages/kit/test/apps/options-2/src/routes/trailing-slash-server/prerender/+page.svelte
+++ b/packages/kit/test/apps/options-2/src/routes/trailing-slash-server/prerender/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { page } from '$app/state';
+</script>
+
+<h2>{page.url.pathname}</h2>

--- a/packages/kit/test/apps/options-2/test/test.js
+++ b/packages/kit/test/apps/options-2/test/test.js
@@ -55,6 +55,23 @@ test.describe('paths', () => {
 	});
 });
 
+test.describe('trailing slash', () => {
+	if (!process.env.DEV) {
+		test('trailing slash server prerendered without server load', async ({
+			page,
+			clicknav,
+			javaScriptEnabled
+		}) => {
+			if (!javaScriptEnabled) return;
+
+			await page.goto('/basepath/trailing-slash-server');
+
+			await clicknav('a[href="/basepath/trailing-slash-server/prerender"]');
+			expect(await page.textContent('h2')).toBe('/basepath/trailing-slash-server/prerender/');
+		});
+	}
+});
+
 test.describe('Service worker', () => {
 	if (process.env.DEV) return;
 


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13255

This PR ensures that the `__data.json` file is prerendered when the `trailingSlash` option is set from a `+page.server` or `+layout.server` file although no server load exists. The data file is needed because the client relies on the server data to get the `trailingSlash` option value.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
