### PR TITLE
fix: allow whitespace in legacy onMount check

### DIFF
--- a/.changeset/cuddly-melons-taste.md
+++ b/.changeset/cuddly-melons-taste.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow whitespace in legacy onMount check

--- a/packages/kit/src/runtime/client/state.svelte.js
+++ b/packages/kit/src/runtime/client/state.svelte.js
@@ -12,7 +12,7 @@ export let updated;
 
 // this is a bootleg way to tell if we're in old svelte or new svelte
 const is_legacy =
-	onMount.toString().includes('$$') || /function \w+\(\) \{\}/.test(onMount.toString());
+	onMount.toString().includes('$$') || /function \w+\(\) \{\s?\}/.test(onMount.toString());
 
 if (is_legacy) {
 	page = {


### PR DESCRIPTION
I have an application using `svelte@4.2.19` alongside `@sveltejs/kit@2.15.1`, it seems like the `is_legacy` check introduced in https://github.com/sveltejs/kit/pull/13140 is failing (assuming legacy refers to <= Svelte 4) as the result of `onMount.toString()` includes a linebreak in the function body.

This PR modifies the regex to account for whitespace within the curly braces.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
