### PR TITLE
fix: make param matcher generated type import with a `.js` extension

### DIFF
--- a/.changeset/slimy-cows-listen.md
+++ b/.changeset/slimy-cows-listen.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: make param matchers generated type import end with `.js`

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -585,7 +585,7 @@ function replace_ext_with_js(file_path) {
 function generate_params_type(params, outdir, config) {
 	/** @param {string} matcher */
 	const path_to_matcher = (matcher) =>
-		posixify(path.relative(outdir, path.join(config.kit.files.params, matcher)));
+		posixify(path.relative(outdir, path.join(config.kit.files.params, matcher + '.js')));
 
 	return `{ ${params
 		.map(


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13280

Similar to https://github.com/sveltejs/kit/pull/5907 we need to import the param matchers file ending with `.js` so that when the `moduleResolution` is set to something strict such as `NodeNext` (the default for libraries) the type inference isn't lost when it can't resolve the param matcher file due to the lack of a file extension.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
