### PR TITLE
fix: upgrade `esm-env` to remove warning when `NODE_ENV` is not set

### DIFF
--- a/.changeset/khaki-melons-add.md
+++ b/.changeset/khaki-melons-add.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: upgrade esm-env to remove warning when NODE_ENV is not set

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -21,7 +21,7 @@
 		"@types/cookie": "^0.6.0",
 		"cookie": "^0.6.0",
 		"devalue": "^5.1.0",
-		"esm-env": "^1.2.1",
+		"esm-env": "^1.2.2",
 		"import-meta-resolve": "^4.1.0",
 		"kleur": "^4.1.5",
 		"magic-string": "^0.30.5",

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -1,5 +1,4 @@
-// @ts-ignore - need to publish types for sub-package imports
-import BROWSER from 'esm-env/browser';
+import { BROWSER } from 'esm-env';
 
 const param_pattern = /^(\[)?(\.\.\.)?(\w+)(?:=(\w+))?(\])?$/;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,8 +349,8 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       esm-env:
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: ^1.2.2
+        version: 1.2.2
       import-meta-resolve:
         specifier: ^4.1.0
         version: 4.1.0
@@ -2443,6 +2443,9 @@ packages:
 
   esm-env@1.2.1:
     resolution: {integrity: sha512-U9JedYYjCnadUlXk7e1Kr+aENQhtUaoaV9+gZm1T8LC/YBAPJx3NSPIAurFOC0U5vrdSevnUJS2/wUVxGwPhng==}
+
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
   espree@10.3.0:
     resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
@@ -4939,6 +4942,8 @@ snapshots:
       - supports-color
 
   esm-env@1.2.1: {}
+
+  esm-env@1.2.2: {}
 
   espree@10.3.0:
     dependencies:


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/13273