### PR TITLE
docs: clarify how to inline assets

### DIFF
--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -505,14 +505,14 @@ export interface KitConfig {
 		 * - If `'inline'`, inlines all JavaScript and CSS of the entire app into the HTML. The result is usable without a server (i.e. you can just open the file in your browser).
 		 *
 		 * When using `'split'`, you can also adjust the bundling behaviour by setting [`output.experimentalMinChunkSize`](https://rollupjs.org/configuration-options/#output-experimentalminchunksize) and [`output.manualChunks`](https://rollupjs.org/configuration-options/#output-manualchunks) inside your Vite config's [`build.rollupOptions`](https://vite.dev/config/build-options.html#build-rollupoptions).
-		 * 
+		 *
 		 * If you want to inline your assets, you'll need to set Vite's [`build.assetsInlineLimit`](https://vite.dev/config/build-options.html#build-assetsinlinelimit) option to an appropriate size then import your assets through Vite.
-		 * 
+		 *
 		 * ```js
 		 * /// file: vite.config.js
 		 * import { sveltekit } from '@sveltejs/kit/vite';
 		 * import { defineConfig } from 'vite';
-		 * 
+		 *
 		 * export default defineConfig({
 		 * 	 plugins: [sveltekit()],
 		 *   build: {
@@ -521,14 +521,14 @@ export interface KitConfig {
 		 *   }
 		 * });
 		 * ```
-		 * 
+		 *
 		 * ```svelte
 		 * /// file: src/routes/+layout.svelte
 		 * <script>
 		 *   // import the asset through Vite
 		 *   import favicon from './favicon.png';
 		 * </script>
-		 * 
+		 *
 		 * <svelte:head>
 		 *   <!-- this asset will be inlined as a base64 URL -->
 		 *   <link rel="icon" href={favicon} />

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -499,11 +499,41 @@ export interface KitConfig {
 		 */
 		preloadStrategy?: 'modulepreload' | 'preload-js' | 'preload-mjs';
 		/**
+		 * The bundle strategy option affects how your app's JavaScript and CSS files are loaded.
 		 * - If `'split'`, splits the app up into multiple .js/.css files so that they are loaded lazily as the user navigates around the app. This is the default, and is recommended for most scenarios.
 		 * - If `'single'`, creates just one .js bundle and one .css file containing code for the entire app.
 		 * - If `'inline'`, inlines all JavaScript and CSS of the entire app into the HTML. The result is usable without a server (i.e. you can just open the file in your browser).
 		 *
-		 * When using `'split'`, you can also adjust the bundling behaviour by setting [`output.experimentalMinChunkSize`](https://rollupjs.org/configuration-options/#output-experimentalminchunksize) and [`output.manualChunks`](https://rollupjs.org/configuration-options/#output-manualchunks)inside your Vite config's [`build.rollupOptions`](https://vite.dev/config/build-options.html#build-rollupoptions).
+		 * When using `'split'`, you can also adjust the bundling behaviour by setting [`output.experimentalMinChunkSize`](https://rollupjs.org/configuration-options/#output-experimentalminchunksize) and [`output.manualChunks`](https://rollupjs.org/configuration-options/#output-manualchunks) inside your Vite config's [`build.rollupOptions`](https://vite.dev/config/build-options.html#build-rollupoptions).
+		 * 
+		 * If you want to inline your assets, you'll need to set Vite's [`build.assetsInlineLimit`](https://vite.dev/config/build-options.html#build-assetsinlinelimit) option to an appropriate size then import your assets through Vite.
+		 * 
+		 * ```js
+		 * /// file: vite.config.js
+		 * import { sveltekit } from '@sveltejs/kit/vite';
+		 * import { defineConfig } from 'vite';
+		 * 
+		 * export default defineConfig({
+		 * 	 plugins: [sveltekit()],
+		 *   build: {
+		 *     // inline all imported assets
+		 *     assetsInlineLimit: Infinity
+		 *   }
+		 * });
+		 * ```
+		 * 
+		 * ```svelte
+		 * /// file: src/routes/+layout.svelte
+		 * <script>
+		 *   // import the asset through Vite
+		 *   import favicon from './favicon.png';
+		 * </script>
+		 * 
+		 * <svelte:head>
+		 *   <!-- this asset will be inlined as a base64 URL -->
+		 *   <link rel="icon" href={favicon} />
+		 * </svelte:head>
+		 * ```
 		 * @default 'split'
 		 * @since 2.13.0
 		 */

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -514,7 +514,7 @@ export interface KitConfig {
 		 * import { defineConfig } from 'vite';
 		 *
 		 * export default defineConfig({
-		 * 	 plugins: [sveltekit()],
+		 *   plugins: [sveltekit()],
 		 *   build: {
 		 *     // inline all imported assets
 		 *     assetsInlineLimit: Infinity

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -487,14 +487,14 @@ declare module '@sveltejs/kit' {
 			 * - If `'inline'`, inlines all JavaScript and CSS of the entire app into the HTML. The result is usable without a server (i.e. you can just open the file in your browser).
 			 *
 			 * When using `'split'`, you can also adjust the bundling behaviour by setting [`output.experimentalMinChunkSize`](https://rollupjs.org/configuration-options/#output-experimentalminchunksize) and [`output.manualChunks`](https://rollupjs.org/configuration-options/#output-manualchunks) inside your Vite config's [`build.rollupOptions`](https://vite.dev/config/build-options.html#build-rollupoptions).
-			 * 
+			 *
 			 * If you want to inline your assets, you'll need to set Vite's [`build.assetsInlineLimit`](https://vite.dev/config/build-options.html#build-assetsinlinelimit) option to an appropriate size then import your assets through Vite.
-			 * 
+			 *
 			 * ```js
 			 * /// file: vite.config.js
 			 * import { sveltekit } from '@sveltejs/kit/vite';
 			 * import { defineConfig } from 'vite';
-			 * 
+			 *
 			 * export default defineConfig({
 			 * 	 plugins: [sveltekit()],
 			 *   build: {
@@ -503,14 +503,14 @@ declare module '@sveltejs/kit' {
 			 *   }
 			 * });
 			 * ```
-			 * 
+			 *
 			 * ```svelte
 			 * /// file: src/routes/+layout.svelte
 			 * <script>
 			 *   // import the asset through Vite
 			 *   import favicon from './favicon.png';
 			 * </script>
-			 * 
+			 *
 			 * <svelte:head>
 			 *   <!-- this asset will be inlined as a base64 URL -->
 			 *   <link rel="icon" href={favicon} />

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -496,7 +496,7 @@ declare module '@sveltejs/kit' {
 			 * import { defineConfig } from 'vite';
 			 *
 			 * export default defineConfig({
-			 * 	 plugins: [sveltekit()],
+			 *   plugins: [sveltekit()],
 			 *   build: {
 			 *     // inline all imported assets
 			 *     assetsInlineLimit: Infinity

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -481,11 +481,41 @@ declare module '@sveltejs/kit' {
 			 */
 			preloadStrategy?: 'modulepreload' | 'preload-js' | 'preload-mjs';
 			/**
+			 * The bundle strategy option affects how your app's JavaScript and CSS files are loaded.
 			 * - If `'split'`, splits the app up into multiple .js/.css files so that they are loaded lazily as the user navigates around the app. This is the default, and is recommended for most scenarios.
 			 * - If `'single'`, creates just one .js bundle and one .css file containing code for the entire app.
 			 * - If `'inline'`, inlines all JavaScript and CSS of the entire app into the HTML. The result is usable without a server (i.e. you can just open the file in your browser).
 			 *
-			 * When using `'split'`, you can also adjust the bundling behaviour by setting [`output.experimentalMinChunkSize`](https://rollupjs.org/configuration-options/#output-experimentalminchunksize) and [`output.manualChunks`](https://rollupjs.org/configuration-options/#output-manualchunks)inside your Vite config's [`build.rollupOptions`](https://vite.dev/config/build-options.html#build-rollupoptions).
+			 * When using `'split'`, you can also adjust the bundling behaviour by setting [`output.experimentalMinChunkSize`](https://rollupjs.org/configuration-options/#output-experimentalminchunksize) and [`output.manualChunks`](https://rollupjs.org/configuration-options/#output-manualchunks) inside your Vite config's [`build.rollupOptions`](https://vite.dev/config/build-options.html#build-rollupoptions).
+			 * 
+			 * If you want to inline your assets, you'll need to set Vite's [`build.assetsInlineLimit`](https://vite.dev/config/build-options.html#build-assetsinlinelimit) option to an appropriate size then import your assets through Vite.
+			 * 
+			 * ```js
+			 * /// file: vite.config.js
+			 * import { sveltekit } from '@sveltejs/kit/vite';
+			 * import { defineConfig } from 'vite';
+			 * 
+			 * export default defineConfig({
+			 * 	 plugins: [sveltekit()],
+			 *   build: {
+			 *     // inline all imported assets
+			 *     assetsInlineLimit: Infinity
+			 *   }
+			 * });
+			 * ```
+			 * 
+			 * ```svelte
+			 * /// file: src/routes/+layout.svelte
+			 * <script>
+			 *   // import the asset through Vite
+			 *   import favicon from './favicon.png';
+			 * </script>
+			 * 
+			 * <svelte:head>
+			 *   <!-- this asset will be inlined as a base64 URL -->
+			 *   <link rel="icon" href={favicon} />
+			 * </svelte:head>
+			 * ```
 			 * @default 'split'
 			 * @since 2.13.0
 			 */


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/13285

This PR clarifies that the `kit.config.output.bundleStrategy` option only affects JS and CSS files while also including an example of how to inline assets through Vite's config.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
