### PR TITLE
fix: correctly detect internal links when hash router is used

### DIFF
--- a/.changeset/green-flowers-heal.md
+++ b/.changeset/green-flowers-heal.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prevent infinite reload when using the hash router and previewing `/index.html`

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -623,7 +623,7 @@ export interface KitConfig {
 		 * What type of client-side router to use.
 		 * - `'pathname'` is the default and means the current URL pathname determines the route
 		 * - `'hash'` means the route is determined by `location.hash`. In this case, SSR and prerendering are disabled. This is only recommended if `pathname` is not an option, for example because you don't control the webserver where your app is deployed.
-		 *   It comes with some caveats: you can't use server-side rendering (or indeed any server logic), and you have to make sure that the links in your app all start with #, or they won't work. Beyond that, everything works exactly like a normal SvelteKit app.
+		 *   It comes with some caveats: you can't use server-side rendering (or indeed any server logic), and you have to make sure that the links in your app all start with #/, or they won't work. Beyond that, everything works exactly like a normal SvelteKit app.
 		 *
 		 * @default "pathname"
 		 * @since 2.14.0

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -623,7 +623,7 @@ export interface KitConfig {
 		 * What type of client-side router to use.
 		 * - `'pathname'` is the default and means the current URL pathname determines the route
 		 * - `'hash'` means the route is determined by `location.hash`. In this case, SSR and prerendering are disabled. This is only recommended if `pathname` is not an option, for example because you don't control the webserver where your app is deployed.
-		 *   It comes with some caveats: you can't use server-side rendering (or indeed any server logic), and you have to make sure that the links in your app all start with /#/, or they won't work. Beyond that, everything works exactly like a normal SvelteKit app.
+		 *   It comes with some caveats: you can't use server-side rendering (or indeed any server logic), and you have to make sure that the links in your app all start with #, or they won't work. Beyond that, everything works exactly like a normal SvelteKit app.
 		 *
 		 * @default "pathname"
 		 * @since 2.14.0

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -311,7 +311,7 @@ export function is_external_url(url, base, hash_routing) {
 	}
 
 	if (hash_routing) {
-		if (url.pathname === base + '/') {
+		if (url.pathname === base + '/' || url.pathname === base + '/index.html') {
 			return false;
 		}
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -605,7 +605,7 @@ declare module '@sveltejs/kit' {
 			 * What type of client-side router to use.
 			 * - `'pathname'` is the default and means the current URL pathname determines the route
 			 * - `'hash'` means the route is determined by `location.hash`. In this case, SSR and prerendering are disabled. This is only recommended if `pathname` is not an option, for example because you don't control the webserver where your app is deployed.
-			 *   It comes with some caveats: you can't use server-side rendering (or indeed any server logic), and you have to make sure that the links in your app all start with #, or they won't work. Beyond that, everything works exactly like a normal SvelteKit app.
+			 *   It comes with some caveats: you can't use server-side rendering (or indeed any server logic), and you have to make sure that the links in your app all start with #/, or they won't work. Beyond that, everything works exactly like a normal SvelteKit app.
 			 *
 			 * @default "pathname"
 			 * @since 2.14.0

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -605,7 +605,7 @@ declare module '@sveltejs/kit' {
 			 * What type of client-side router to use.
 			 * - `'pathname'` is the default and means the current URL pathname determines the route
 			 * - `'hash'` means the route is determined by `location.hash`. In this case, SSR and prerendering are disabled. This is only recommended if `pathname` is not an option, for example because you don't control the webserver where your app is deployed.
-			 *   It comes with some caveats: you can't use server-side rendering (or indeed any server logic), and you have to make sure that the links in your app all start with /#/, or they won't work. Beyond that, everything works exactly like a normal SvelteKit app.
+			 *   It comes with some caveats: you can't use server-side rendering (or indeed any server logic), and you have to make sure that the links in your app all start with #, or they won't work. Beyond that, everything works exactly like a normal SvelteKit app.
 			 *
 			 * @default "pathname"
 			 * @since 2.14.0


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13287

This PR fixes the client-side external link evaluation so that when using the hash router, accessing `/index.html` is considered an internal link. This prevents the page from reloading infinitely because the router incorrectly considered `/index.html` an external link.

There's also a slight doc change. Instead of suggesting all links start with `/#/`, suggesting links start with `#` allows the router to preserve the `/index.html` pathname. For example, links to `/about` should be `#/about` instead of `/#/about` so that it navigates to `/index.html#/about`.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
