### PR TITLE
docs: added most common status codes to redirect() doc

### DIFF
--- a/.changeset/quick-crabs-camp.md
+++ b/.changeset/quick-crabs-camp.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+chore: added most common status codes to `redirect()` JS documentation

--- a/.changeset/quick-crabs-camp.md
+++ b/.changeset/quick-crabs-camp.md
@@ -2,4 +2,4 @@
 "@sveltejs/kit": patch
 ---
 
-chore: added most common status codes to `redirect()` JS documentation
+chore: add most common status codes to `redirect()` JS documentation

--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -86,7 +86,7 @@ export function isHttpError(e, status) {
  * Make sure you're not catching the thrown redirect, which would prevent SvelteKit from handling it.
  *
  * Most common status codes:
- *  * `303 See Other`: redirect as a `GET` request
+ *  * `303 See Other`: redirect as a `GET` request (often used after a form POST request)
  *  * `307 Temporary Redirect`: redirect will keep the request method
  *  * `308 Permanent Redirect`: redirect will keep the request method, SEO will be transferred to the new page
  *

--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -86,7 +86,7 @@ export function isHttpError(e, status) {
  * Make sure you're not catching the thrown redirect, which would prevent SvelteKit from handling it.
  *
  * Most common status codes:
- *  * `303 See Other`: redirect as a `GET` request (often used after a form POST request)
+ *  * `303 See Other`: redirect as a GET request (often used after a form POST request)
  *  * `307 Temporary Redirect`: redirect will keep the request method
  *  * `308 Permanent Redirect`: redirect will keep the request method, SEO will be transferred to the new page
  *

--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -84,6 +84,14 @@ export function isHttpError(e, status) {
 /**
  * Redirect a request. When called during request handling, SvelteKit will return a redirect response.
  * Make sure you're not catching the thrown redirect, which would prevent SvelteKit from handling it.
+ *
+ * Most common status codes:
+ *  * `303 See Other`: redirect as a `GET` request
+ *  * `307 Temporary Redirect`: redirect will keep the request method
+ *  * `308 Permanent Redirect`: redirect will keep the request method, SEO will be transferred to the new page
+ *
+ * [See all redirect status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages)
+ *
  * @param {300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308 | ({} & number)} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages). Must be in the range 300-308.
  * @param {string | URL} location The location to redirect to.
  * @throws {Redirect} This error instructs SvelteKit to redirect to the specified location.

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1903,7 +1903,7 @@ declare module '@sveltejs/kit' {
 	 * Make sure you're not catching the thrown redirect, which would prevent SvelteKit from handling it.
 	 *
 	 * Most common status codes:
-	 *  * `303 See Other`: redirect as a `GET` request
+	 *  * `303 See Other`: redirect as a `GET` request (often used after a form POST request)
 	 *  * `307 Temporary Redirect`: redirect will keep the request method
 	 *  * `308 Permanent Redirect`: redirect will keep the request method, SEO will be transferred to the new page
 	 *

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1903,7 +1903,7 @@ declare module '@sveltejs/kit' {
 	 * Make sure you're not catching the thrown redirect, which would prevent SvelteKit from handling it.
 	 *
 	 * Most common status codes:
-	 *  * `303 See Other`: redirect as a `GET` request (often used after a form POST request)
+	 *  * `303 See Other`: redirect as a GET request (often used after a form POST request)
 	 *  * `307 Temporary Redirect`: redirect will keep the request method
 	 *  * `308 Permanent Redirect`: redirect will keep the request method, SEO will be transferred to the new page
 	 *

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1901,6 +1901,14 @@ declare module '@sveltejs/kit' {
 	/**
 	 * Redirect a request. When called during request handling, SvelteKit will return a redirect response.
 	 * Make sure you're not catching the thrown redirect, which would prevent SvelteKit from handling it.
+	 *
+	 * Most common status codes:
+	 *  * `303 See Other`: redirect as a `GET` request
+	 *  * `307 Temporary Redirect`: redirect will keep the request method
+	 *  * `308 Permanent Redirect`: redirect will keep the request method, SEO will be transferred to the new page
+	 *
+	 * [See all redirect status codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages)
+	 *
 	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#redirection_messages). Must be in the range 300-308.
 	 * @param location The location to redirect to.
 	 * @throws {Redirect} This error instructs SvelteKit to redirect to the specified location.


### PR DESCRIPTION
<!-- Your PR description here -->

Hey! Small QOL improvement, I often google HTTP status codes to know which one I should use. I picked the three values that should cover 99% of use cases; `302 Found` is not in there because its behavior is [disambiguated by 303 and 307](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
