### PR TITLE
respect replace_state on external navigation where applicable

### DIFF
--- a/.changeset/dirty-rats-divide.md
+++ b/.changeset/dirty-rats-divide.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+respect `replaceState` on external navigation

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -143,9 +143,15 @@ function clear_onward_history(current_history_index, current_navigation_index) {
  * Returns a `Promise` that never resolves (to prevent any
  * subsequent work, e.g. history manipulation, from happening)
  * @param {URL} url
+ * @param {Object} [opts] Options related to the navigation
+ * @param {boolean} [opts.replace_state] If `true`, will replace the current `history` entry rather than creating a new one with `pushState`
  */
-function native_navigation(url) {
-	location.href = url.href;
+function native_navigation(url, opts = {}) {
+	if (opts.replace_state) {
+		location.replace(url.href);
+	} else {
+		location.href = url.href;
+	}
 	return new Promise(() => {});
 }
 
@@ -1375,7 +1381,7 @@ async function navigate({
 					404
 				);
 			} else {
-				return await native_navigation(url);
+				return await native_navigation(url, { replace_state });
 			}
 		} else {
 			navigation_result = await server_fallback(
@@ -1423,7 +1429,7 @@ async function navigate({
 		if (updated) {
 			// Before reloading, try to update the service worker if it exists
 			await update_service_worker();
-			await native_navigation(url);
+			await native_navigation(url, { replace_state });
 		}
 	}
 


### PR DESCRIPTION
When navigating via goto with `replaceState: true` with full page reload (e.g. navigating outside of the app) the page is not being replaced, but pushed to history instead
This PR aims to fix that

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
