### PR TITLE
fix: use `window.fetch` for server load fetch requests

### DIFF
--- a/.changeset/funny-moles-scream.md
+++ b/.changeset/funny-moles-scream.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/kit': major
+'@sveltejs/kit': patch
 ---
 
 fix: use current `window.fetch` for server load fetch requests

--- a/.changeset/funny-moles-scream.md
+++ b/.changeset/funny-moles-scream.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+fix: use current `window.fetch` for server load fetch requests

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2544,7 +2544,6 @@ async function load_data(url, invalid) {
 
 	// use window.fetch directly to allow using a 3rd party-patched fetch implementation
 	const fetcher = DEV ? dev_fetch : window.fetch;
-	// const fetcher = native_fetch;
 	const res = await fetcher(data_url.href, {});
 
 	if (!res.ok) {

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -9,6 +9,7 @@ import {
 	normalize_path
 } from '../../utils/url.js';
 import {
+	dev_fetch,
 	initial_fetch,
 	lock_fetch,
 	native_fetch,
@@ -2548,7 +2549,10 @@ async function load_data(url, invalid) {
 	}
 	data_url.searchParams.append(INVALIDATED_PARAM, invalid.map((i) => (i ? '1' : '0')).join(''));
 
-	const res = await native_fetch(data_url.href);
+	// use window.fetch directly to allow using a 3rd party-patched fetch implementation
+	const fetcher = DEV ? dev_fetch : window.fetch;
+	// const fetcher = native_fetch;
+	const res = await fetcher(data_url.href, {});
 
 	if (!res.ok) {
 		// error message is a JSON-stringified string which devalue can't handle at the top level

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -8,14 +8,7 @@ import {
 	make_trackable,
 	normalize_path
 } from '../../utils/url.js';
-import {
-	dev_fetch,
-	initial_fetch,
-	lock_fetch,
-	native_fetch,
-	subsequent_fetch,
-	unlock_fetch
-} from './fetcher.js';
+import { dev_fetch, initial_fetch, lock_fetch, subsequent_fetch, unlock_fetch } from './fetcher.js';
 import { parse } from './parse.js';
 import * as storage from './session-storage.js';
 import {

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -5,7 +5,7 @@ import { b64_decode } from '../utils.js';
 let loading = 0;
 
 /** @type {typeof fetch} */
-export const native_fetch = BROWSER ? window.fetch : /** @type {any} */ (() => {});
+const native_fetch = BROWSER ? window.fetch : /** @type {any} */ (() => {});
 
 export function lock_fetch() {
 	loading += 1;

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -137,7 +137,7 @@ export function subsequent_fetch(resource, resolved, opts) {
  * @param {RequestInfo | URL} resource
  * @param {RequestInit & Record<string, any> | undefined} opts
  */
-function dev_fetch(resource, opts) {
+export function dev_fetch(resource, opts) {
 	const patched_opts = { ...opts };
 	// This assigns the __sveltekit_fetch__ flag and makes it non-enumerable
 	Object.defineProperty(patched_opts, '__sveltekit_fetch__', {

--- a/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching-server-load-ii/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching-server-load-ii/+page.server.js
@@ -1,4 +1,3 @@
-/** @type {import('./$types').PageLoad} */
 export async function load() {
 	return { msg: 'server load data' };
 }

--- a/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching-server-load-ii/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching-server-load-ii/+page.server.js
@@ -1,0 +1,4 @@
+/** @type {import('./$types').PageLoad} */
+export async function load() {
+	return { msg: 'server load data' };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching-server-load-ii/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching-server-load-ii/+page.svelte
@@ -1,5 +1,4 @@
 <script>
-	/** @type {import('./$types').PageData} */
 	export let data;
 </script>
 

--- a/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching-server-load-ii/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching-server-load-ii/+page.svelte
@@ -1,0 +1,11 @@
+<script>
+	/** @type {import('./$types').PageData} */
+	export let data;
+</script>
+
+<p>
+	This page makes a fetch request to the server to get the data from the server load function when
+	users navigate to it.
+</p>
+
+<h1>{data.msg}</h1>

--- a/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching-server-load/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching-server-load/+page.server.js
@@ -1,4 +1,3 @@
-/** @type {import('./$types').PageLoad} */
 export async function load() {
 	return { msg: 'server load data' };
 }

--- a/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching-server-load/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching-server-load/+page.server.js
@@ -1,0 +1,4 @@
+/** @type {import('./$types').PageLoad} */
+export async function load() {
+	return { msg: 'server load data' };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching-server-load/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching-server-load/+page.svelte
@@ -1,0 +1,19 @@
+<script>
+	import { browser } from '$app/environment';
+
+	if (browser) {
+		console.log('patching window.fetch');
+		const original_fetch = window.fetch;
+		window.fetch = (input, init) => {
+			console.log('Called a patched window.fetch for server load request');
+			return original_fetch(input, init);
+		};
+	}
+</script>
+
+<p>
+	The sole purpose of this page is to apply a `window.fetch` patch before navigating to the next
+	page. Click the link below to navigate to the next page with a server load function.
+</p>
+
+<a href="./patching-server-load-ii">Go To Page with Server Load</a>

--- a/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching-server-load/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/window-fetch/patching-server-load/+page.svelte
@@ -2,7 +2,6 @@
 	import { browser } from '$app/environment';
 
 	if (browser) {
-		console.log('patching window.fetch');
 		const original_fetch = window.fetch;
 		window.fetch = (input, init) => {
 			console.log('Called a patched window.fetch for server load request');

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1,4 +1,4 @@
-import process, { execPath } from 'node:process';
+import process from 'node:process';
 import { expect } from '@playwright/test';
 import { test } from '../../../utils.js';
 

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1,4 +1,4 @@
-import process from 'node:process';
+import process, { execPath } from 'node:process';
 import { expect } from '@playwright/test';
 import { test } from '../../../utils.js';
 
@@ -250,6 +250,23 @@ test.describe('Load', () => {
 		expect(await page.textContent('h1')).toBe('42');
 
 		expect(logs).toContain('Called a patched window.fetch');
+	});
+
+	test('permits 3rd party patching of server load fetch requests', async ({ page }) => {
+		const logs = [];
+		page.on('console', (msg) => {
+			if (msg.type() === 'log') {
+				logs.push(msg.text());
+			}
+		});
+
+		await page.goto('/load/window-fetch/patching-server-load');
+
+		await page.getByText('Go To Page with Server Load').click();
+
+		expect(await page.textContent('h1')).toBe('server load data');
+
+		expect(logs).toEqual(['Called a patched window.fetch for server load request']);
 	});
 
 	test('does not repeat fetch on hydration when using Request object', async ({ page }) => {

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -266,7 +266,7 @@ test.describe('Load', () => {
 
 		expect(await page.textContent('h1')).toBe('server load data');
 
-		expect(logs).toEqual(['Called a patched window.fetch for server load request']);
+		expect(logs).toContain('Called a patched window.fetch for server load request');
 	});
 
 	test('does not repeat fetch on hydration when using Request object', async ({ page }) => {


### PR DESCRIPTION
This PR is a follow up on #10009 which ensured that the `fetch` function from the `load` event would call `window.fetch` so that libraries (like Sentry but there are many others) can patch it. Unfortunately, I missed back then that there's another kind of `fetch` request made by SvelteKit: Whenever a user navigates to a route that contains a server-load function, a request is made to fetch the server-load data. 

This PR ensures that this server-load data request is also patchable by basically using the same mechanism introduced in #10009. I also added a test that would prior to this change fail.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
