### PR TITLE
adapter-node - support writable sockets

### DIFF
--- a/.changeset/blue-glasses-hug.md
+++ b/.changeset/blue-glasses-hug.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-node": minor
+---
+
+feat: ability to create writable sockets

--- a/documentation/docs/25-build-and-deploy/40-adapter-node.md
+++ b/documentation/docs/25-build-and-deploy/40-adapter-node.md
@@ -60,7 +60,7 @@ If you use Node.js v20.6+, you can use the [`--env-file`](https://nodejs.org/en/
 node +++--env-file=.env+++ build
 ```
 
-### `PORT`, `HOST` and `SOCKET_PATH`
+### `PORT`, `HOST`, `SOCKET_PATH` and `SOCKET_PATH_IS_WRITABLE`
 
 By default, the server will accept connections on `0.0.0.0` using port 3000. These can be customised with the `PORT` and `HOST` environment variables:
 
@@ -73,6 +73,13 @@ Alternatively, the server can be configured to accept connections on a specified
 ```
 SOCKET_PATH=/tmp/socket node build
 ```
+
+By default, node will create a socket based on the `umask` (commonly `0022`, resulting in `0755`). When `SOCKET_PATH_IS_WRITABLE` is set to `1`, the socket will be created with `0777`.
+
+```
+SOCKET_PATH_IS_WRITABLE=1 SOCKET_PATH=/tmp/socket node build
+```
+
 
 ### `ORIGIN`, `PROTOCOL_HEADER`, `HOST_HEADER`, and `PORT_HEADER`
 

--- a/packages/adapter-node/src/env.js
+++ b/packages/adapter-node/src/env.js
@@ -3,6 +3,7 @@ import process from 'node:process';
 
 const expected = new Set([
 	'SOCKET_PATH',
+	'SOCKET_PATH_IS_WRITABLE',
 	'HOST',
 	'PORT',
 	'ORIGIN',

--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -4,6 +4,7 @@ import { env } from 'ENV';
 import polka from 'polka';
 
 export const path = env('SOCKET_PATH', false);
+const writableAll = parseInt(env('SOCKET_PATH_IS_WRITABLE', 0)) === 1;
 export const host = env('HOST', '0.0.0.0');
 export const port = env('PORT', !path && '3000');
 
@@ -38,7 +39,7 @@ if (socket_activation) {
 		console.log(`Listening on file descriptor ${SD_LISTEN_FDS_START}`);
 	});
 } else {
-	server.listen({ path, host, port }, () => {
+	server.listen({ path, host, port, writableAll }, () => {
 		console.log(`Listening on ${path || `http://${host}:${port}`}`);
 	});
 }


### PR DESCRIPTION
Current the socket is created based on the umask (commonly `0022`), resulting in read only sockets.

This change adds the env variable `SOCKET_PATH_IS_WRITABLE`, which configures `writableAll`, supporting writable sockets.

<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
