### PR TITLE
fix: decode URL before navigating when hash router is enabled

### DIFF
--- a/.changeset/wild-coins-live.md
+++ b/.changeset/wild-coins-live.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly navigate when hash router is enabled and the browser encodes extra hashes

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -306,7 +306,7 @@ export async function start(_app, _target, hydrate) {
 	if (hydrate) {
 		await _hydrate(target, hydrate);
 	} else {
-		goto(location.href, { replaceState: true });
+		goto(app.hash ? decodeURIComponent(location.href) : location.href, { replaceState: true });
 	}
 
 	_start_router();
@@ -2395,7 +2395,7 @@ function _start_router() {
 			// (surprisingly!) mutates `current.url`, allowing us to
 			// detect it and trigger a navigation
 			if (current.url.hash === location.hash) {
-				navigate({ type: 'goto', url: current.url });
+				navigate({ type: 'goto', url: new URL(decodeURIComponent(current.url.href)) });
 			}
 		}
 	});

--- a/packages/kit/test/apps/hash-based-routing/test/test.js
+++ b/packages/kit/test/apps/hash-based-routing/test/test.js
@@ -55,6 +55,14 @@ test.describe('hash based navigation', () => {
 		await expect(page.locator('p')).toHaveText('a');
 	});
 
+	test('navigation works with URL encoded characters', async ({ page }) => {
+		await page.goto('/#/%23test');
+		await expect(page.locator('p')).toHaveText('home');
+		// hashchange event
+		await page.goto('/#/a%23test');
+		await expect(page.locator('p')).toHaveText('a');
+	});
+
 	test('route id and params are correct', async ({ page }) => {
 		await page.goto('/#/b/123');
 		await expect(page.locator('p[data-data]')).toHaveText('{"slug":"123"} /b/[slug] /#/b/123');


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13318

This PR decodes the URL when the hash router is enabled and the user enters the URL through the browser address bar (during app initialisation and the `hashchange` event). We need to do this because Safari seems to encode any extra hashes in the URL (only when accessed through the file protocol?). So, entering `/#/#about` in the address bar becomes `/#/%23about` which the client router incorrectly thinks is a route instead of just an ID.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
