### PR TITLE
chore: add missing `await`

### DIFF
--- a/packages/kit/src/runtime/server/page/load_data.spec.js
+++ b/packages/kit/src/runtime/server/page/load_data.spec.js
@@ -47,10 +47,10 @@ test('succeeds when acao header present on cors', async () => {
 	assert.equal(text, 'foo');
 });
 
-test('errors when no acao header present on cors', () => {
+test('errors when no acao header present on cors', async () => {
 	const fetch = create_fetch({});
 
-	expect(async () => {
+	await expect(async () => {
 		const response = await fetch('https://domain-b.com');
 		await response.text();
 	}).rejects.toThrowError(


### PR DESCRIPTION
I saw a notice buried in the logs that this line will start failing in Vitest 3. I can't actually do the Vitest 3 upgrade yet due to other issues, so thought I'd send this separately so that we don't forget about it