### PR TITLE
fix: only decode URL hash instead of entire URL

### DIFF
--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2809,6 +2809,7 @@ function clone_page(page) {
  */
 function decode_hash(url) {
 	const new_url = new URL(url);
+	// Safari, for some reason, does change # to %23, when entered through the address bar
 	new_url.hash = decodeURIComponent(url.hash);
 	return new_url;
 }

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -306,7 +306,9 @@ export async function start(_app, _target, hydrate) {
 	if (hydrate) {
 		await _hydrate(target, hydrate);
 	} else {
-		goto(app.hash ? decodeURIComponent(location.href) : location.href, { replaceState: true });
+		goto(app.hash ? decode_hash(new URL(location.href)) : location.href, {
+			replaceState: true
+		});
 	}
 
 	_start_router();
@@ -2407,7 +2409,7 @@ function _start_router() {
 			// (surprisingly!) mutates `current.url`, allowing us to
 			// detect it and trigger a navigation
 			if (current.url.hash === location.hash) {
-				navigate({ type: 'goto', url: new URL(decodeURIComponent(current.url.href)) });
+				navigate({ type: 'goto', url: decode_hash(current.url) });
 			}
 		}
 	});
@@ -2799,6 +2801,16 @@ function clone_page(page) {
 		status: page.status,
 		url: page.url
 	};
+}
+
+/**
+ * @param {URL} url
+ * @returns {URL}
+ */
+function decode_hash(url) {
+	const new_url = new URL(url);
+	new_url.hash = decodeURIComponent(url.hash);
+	return new_url;
 }
 
 if (DEV) {

--- a/packages/kit/test/apps/hash-based-routing/test/test.js
+++ b/packages/kit/test/apps/hash-based-routing/test/test.js
@@ -56,10 +56,10 @@ test.describe('hash based navigation', () => {
 	});
 
 	test('navigation works with URL encoded characters', async ({ page }) => {
-		await page.goto('/#/%23test');
+		await page.goto('/?query=%23abc#/%23test');
 		await expect(page.locator('p')).toHaveText('home');
 		// hashchange event
-		await page.goto('/#/a%23test');
+		await page.goto('/?query=%23abc#/a%23test');
 		await expect(page.locator('p')).toHaveText('a');
 	});
 


### PR DESCRIPTION
quick fix for https://github.com/sveltejs/kit/pull/13321 (hopefully before https://github.com/sveltejs/kit/pull/13316 is released)

This PR ensures only the hash of the URL is decoded so that any encoded hash character in the query parameters remains encoded.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
