### PR TITLE
fix: catch error when resolving peer dep

### DIFF
--- a/packages/kit/src/utils/import.js
+++ b/packages/kit/src/utils/import.js
@@ -14,6 +14,7 @@ export async function resolve_peer_dependency(dependency) {
 		return await import(resolved);
 	} catch {
 		try {
+			// both imr.resolve and await import above can throw, which is why we can't just do import(resolved).catch(...) above
 			return await import(dependency);
 		} catch {
 			throw new Error(

--- a/packages/kit/src/utils/import.js
+++ b/packages/kit/src/utils/import.js
@@ -11,10 +11,14 @@ export async function resolve_peer_dependency(dependency) {
 	try {
 		// @ts-expect-error the types are wrong
 		const resolved = imr.resolve(dependency, pathToFileURL(process.cwd() + '/dummy.js'));
-		return await import(resolved).catch(() => import(dependency));
+		return await import(resolved);
 	} catch {
-		throw new Error(
-			`Could not resolve peer dependency "${dependency}" relative to your project — please install it and try again.`
-		);
+		try {
+			return await import(dependency);
+		} catch {
+			throw new Error(
+				`Could not resolve peer dependency "${dependency}" relative to your project — please install it and try again.`
+			);
+		}
 	}
 }


### PR DESCRIPTION
supplements https://github.com/sveltejs/kit/pull/12532 (hopefully before https://github.com/sveltejs/kit/pull/13316 is merged)
fixes https://github.com/sveltejs/kit/issues/13331

While testing the fix from https://github.com/sveltejs/kit/pull/12532 with the reproduction from https://github.com/sveltejs/kit/issues/13331 I found that the `resolve` function throws an uncaught error on line 13
https://github.com/sveltejs/kit/blob/0142dd8e12fc2cc36a137368f0edea90b0e62964/packages/kit/src/utils/import.js#L13

This PR ensures that the resolve error is caught then tries the relative import, similar to the previous behaviour of importing svelte/compiler https://github.com/sveltejs/kit/pull/12532/files#diff-61bc3314d549d23c68f49ea0467f8856c97f8f5f3e150b4b529668f0cbaad7a1 before https://github.com/sveltejs/kit/pull/12532 was merged

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
