### PR TITLE
fix: svelte-package resolve alias

### DIFF
--- a/.changeset/many-gorillas-shout.md
+++ b/.changeset/many-gorillas-shout.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/package': minor
+---
+
+fix resolving alias

--- a/.changeset/many-gorillas-shout.md
+++ b/.changeset/many-gorillas-shout.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/package': minor
+'@sveltejs/package': patch
 ---
 
-fix resolving alias
+fix: resolve aliases more robustly

--- a/packages/package/src/utils.js
+++ b/packages/package/src/utils.js
@@ -17,10 +17,9 @@ const is_svelte_5_plus = Number(VERSION.split('.')[0]) >= 5;
 export function resolve_aliases(input, file, content, aliases) {
 	/**
 	 * @param {string} match
-	 * @param {string} _
 	 * @param {string} import_path
 	 */
-	const replace_import_path = (match, _, import_path) => {
+	const replace_import_path = (match, import_path) => {
 		for (const [alias, value] of Object.entries(aliases)) {
 			if (!import_path.startsWith(alias)) continue;
 
@@ -33,8 +32,26 @@ export function resolve_aliases(input, file, content, aliases) {
 		return match;
 	};
 
-	content = content.replace(/from\s+('|")([^"';,]+?)\1/g, replace_import_path);
-	content = content.replace(/import\s*\(\s*('|")([^"';,]+?)\1\s*\)/g, replace_import_path);
+	// import/export ... from ...
+	content = content.replace(
+		/\b(import|export)\s+([\w*\s{},]*)\s+from\s+(['"])([^'";]+)\3/g,
+		(_, keyword, specifier, quote, import_path) =>
+			replace_import_path(
+				`${keyword} ${specifier} from ${quote}${import_path}${quote}`,
+				import_path
+			)
+	);
+
+	// import(...)
+	content = content.replace(/\bimport\s*\(\s*(['"])([^'";]+)\1\s*\)/g, (_, quote, import_path) =>
+		replace_import_path(`import(${quote}${import_path}${quote})`, import_path)
+	);
+
+	// import '...'
+	content = content.replace(/\bimport\s+(['"])([^'";]+)\1/g, (_, quote, import_path) =>
+		replace_import_path(`import ${quote}${import_path}${quote}`, import_path)
+	);
+
 	return content;
 }
 

--- a/packages/package/test/fixtures/resolve-alias/expected/not.d.ts
+++ b/packages/package/test/fixtures/resolve-alias/expected/not.d.ts
@@ -1,0 +1,1 @@
+export declare const notImportFromLib: () => string;

--- a/packages/package/test/fixtures/resolve-alias/expected/not.js
+++ b/packages/package/test/fixtures/resolve-alias/expected/not.js
@@ -1,1 +1,1 @@
-export const notImportFromLib = () => `from '$lib/Test.svelte''`;
+export const notImportFromLib = () => " from '$lib/Test.svelte'";

--- a/packages/package/test/fixtures/resolve-alias/expected/not.js
+++ b/packages/package/test/fixtures/resolve-alias/expected/not.js
@@ -1,0 +1,1 @@
+export const notImportFromLib = () => `from '$lib/Test.svelte''`;

--- a/packages/package/test/fixtures/resolve-alias/expected/sub/bar.d.ts
+++ b/packages/package/test/fixtures/resolve-alias/expected/sub/bar.d.ts
@@ -1,2 +1,3 @@
-export declare const bar1: import('./foo').Foo;
-export declare const bar2: import('../baz').Baz;
+export declare const dynamic: () => Promise<typeof import("../Test.svelte")>;
+export declare const bar1: import("./foo").Foo;
+export declare const bar2: import("../baz").Baz;

--- a/packages/package/test/fixtures/resolve-alias/expected/sub/bar.d.ts
+++ b/packages/package/test/fixtures/resolve-alias/expected/sub/bar.d.ts
@@ -1,3 +1,3 @@
-export declare const dynamic: () => Promise<typeof import("../Test.svelte")>;
-export declare const bar1: import("./foo").Foo;
-export declare const bar2: import("../baz").Baz;
+export declare const dynamic: () => Promise<typeof import('../Test.svelte')>;
+export declare const bar1: import('./foo').Foo;
+export declare const bar2: import('../baz').Baz;

--- a/packages/package/test/fixtures/resolve-alias/expected/sub/bar.js
+++ b/packages/package/test/fixtures/resolve-alias/expected/sub/bar.js
@@ -1,5 +1,5 @@
 import { baz } from '../baz';
 import { foo } from './foo';
-export const dynamic = () => import("../Test.svelte");
+export const dynamic = () => import('../Test.svelte');
 export const bar1 = foo;
 export const bar2 = baz;

--- a/packages/package/test/fixtures/resolve-alias/expected/sub/bar.js
+++ b/packages/package/test/fixtures/resolve-alias/expected/sub/bar.js
@@ -1,4 +1,5 @@
 import { baz } from '../baz';
 import { foo } from './foo';
+export const dynamic = () => import("../Test.svelte");
 export const bar1 = foo;
 export const bar2 = baz;

--- a/packages/package/test/fixtures/resolve-alias/src/lib/not.ts
+++ b/packages/package/test/fixtures/resolve-alias/src/lib/not.ts
@@ -1,1 +1,1 @@
-export const notImportFromLib = () => `from '$lib/Test.svelte''`;
+export const notImportFromLib = () => " from '$lib/Test.svelte'";

--- a/packages/package/test/fixtures/resolve-alias/src/lib/not.ts
+++ b/packages/package/test/fixtures/resolve-alias/src/lib/not.ts
@@ -1,0 +1,1 @@
+export const notImportFromLib = () => `from '$lib/Test.svelte''`;

--- a/packages/package/test/fixtures/resolve-alias/src/lib/sub/bar.ts
+++ b/packages/package/test/fixtures/resolve-alias/src/lib/sub/bar.ts
@@ -1,5 +1,6 @@
 import { baz } from '$lib/baz';
 import { foo } from '$lib/sub/foo';
 
+export const dynamic = () => import('$lib/Test.svelte');
 export const bar1 = foo;
 export const bar2 = baz;


### PR DESCRIPTION
This PR refines the **alias** resolution process to correctly handle import and export statements. Previously, alias replacement was applied too broadly, affecting non-import strings. Now, the RegExps specifically target `import/export` statements.

Prevents accidental replacements of non-import strings that resemble imports (e.g., `const text = "from 'alias'"`).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
