### PR TITLE
fix: correctly check index file exists when resolving an entry

### DIFF
--- a/.changeset/cyan-dancers-tap.md
+++ b/.changeset/cyan-dancers-tap.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly resolve index file entrypoints such as `src/service-worker/index.js`

--- a/packages/kit/src/utils/filesystem.js
+++ b/packages/kit/src/utils/filesystem.js
@@ -169,11 +169,12 @@ export function from_fs(str) {
 export function resolve_entry(entry) {
 	if (fs.existsSync(entry)) {
 		const stats = fs.statSync(entry);
-		const index = path.join(entry, 'index');
-
 		if (stats.isFile()) {
 			return entry;
-		} else if (fs.existsSync(index)) {
+		}
+
+		const index = path.join(entry, 'index');
+		if (fs.existsSync(index + '.js') || fs.existsSync(index + '.ts')) {
 			return resolve_entry(index);
 		}
 	}

--- a/packages/kit/src/utils/filesystem.spec.js
+++ b/packages/kit/src/utils/filesystem.spec.js
@@ -100,27 +100,35 @@ test('replaces strings', () => {
 	);
 });
 
-test('ignores hooks.server folder when resolving hooks', () => {
-	write(join('hooks.server', 'index.js'), '');
+test('resolves index files', () => {
+	write(join('service-worker', 'index.js'), '');
 
-	expect(resolve_entry(source_dir + '/hooks')).null;
-});
-
-test('ignores hooks folder that has no index file when resolving hooks', () => {
-	write(join('hooks', 'not-index.js'), '');
-	write('hooks.js', '');
-
-	expect(resolve_entry(source_dir + '/hooks')).toBe(join(source_dir, 'hooks.js'));
-});
-
-test('ignores hooks folder when resolving universal hooks', () => {
-	write(join('hooks', 'hooks.server.js'), '');
-
-	expect(resolve_entry(source_dir + '/hooks')).null;
+	expect(resolve_entry(source_dir + '/service-worker')).toBe(
+		join(source_dir, 'service-worker', 'index.js')
+	);
 });
 
 test('resolves entries that have an extension', () => {
 	write('hooks.js', '');
 
 	expect(resolve_entry(join(source_dir, 'hooks.js'))).toBe(join(source_dir, 'hooks.js'));
+});
+
+test('resolves universal hooks file when hooks folder exists', () => {
+	write(join('hooks', 'not-index.js'), '');
+	write('hooks.js', '');
+
+	expect(resolve_entry(source_dir + '/hooks')).toBe(join(source_dir, 'hooks.js'));
+});
+
+test('ignores hooks.server folder when resolving universal hooks file', () => {
+	write(join('hooks.server', 'index.js'), '');
+
+	expect(resolve_entry(source_dir + '/hooks')).null;
+});
+
+test('ignores hooks folder when resolving universal hooks file', () => {
+	write(join('hooks', 'hooks.server.js'), '');
+
+	expect(resolve_entry(source_dir + '/hooks')).null;
 });


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13350

https://github.com/sveltejs/kit/pull/13188 caused a regression where `index.js` and `index.ts` files would not be resolved as entries because of the additional `isFile()` check that was added to prioritise matching files over folders.
https://github.com/sveltejs/kit/blob/2ca09ce6ff1b5dbd5bb2ac0099b6b1d2a45ea3f0/packages/kit/src/utils/filesystem.js#L187

This PR fixes it by including the .js and .ts extensions when checking if an index file exists. Previously, it only checked without the extensions, hence the condition never passed.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
