### PR TITLE
fix: correctly handle relative anchors when hash router is enabled

### DIFF
--- a/.changeset/forty-houses-collect.md
+++ b/.changeset/forty-houses-collect.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly handle relative anchors when using the hash router

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -130,6 +130,12 @@ export function get_link_info(a, base, uses_hash_router) {
 
 	try {
 		url = new URL(a instanceof SVGAElement ? a.href.baseVal : a.href, document.baseURI);
+
+		// if the hash doesn't start with `#/` then it's probably linking to an id on the current page
+		if (uses_hash_router && url.hash.match(/^#[^/]/)) {
+			const route = location.hash.split('#')[1] || '/';
+			url.hash = `#${route}${url.hash}`;
+		}
 	} catch {}
 
 	const target = a instanceof SVGAElement ? a.target.baseVal : a.target;

--- a/packages/kit/test/apps/hash-based-routing/src/routes/anchor/+page.svelte
+++ b/packages/kit/test/apps/hash-based-routing/src/routes/anchor/+page.svelte
@@ -1,0 +1,3 @@
+<a href="#test">go to #test</a>
+
+<p id="test">#test</p>

--- a/packages/kit/test/apps/hash-based-routing/test/test.js
+++ b/packages/kit/test/apps/hash-based-routing/test/test.js
@@ -89,4 +89,13 @@ test.describe('hash based navigation', () => {
 		url = new URL(page.url());
 		expect(url.hash).toBe('#/reroute-b');
 	});
+
+	test('relative anchor works', async ({ page }) => {
+		await page.goto('/#/anchor');
+
+		await page.locator('a[href="#test"]').click();
+		await expect(page.locator('#test')).toHaveText('#test');
+		const url = new URL(page.url());
+		expect(url.hash).toBe('#/anchor#test');
+	});
 });


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13320

This PR enables relative hash links to be used with the hash router so that links such as `#example` get recognised as a link to the current page. We do this by assuming links that have a hash value starting with `#/` links to a route while anything else is probably linking to an element with an id on the current page.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
