### PR TITLE
fix: prevent Vitest from hanging

### DIFF
--- a/.changeset/rare-berries-retire.md
+++ b/.changeset/rare-berries-retire.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/adapter-cloudflare-workers': patch
+'@sveltejs/adapter-cloudflare': patch
+---
+
+fix: prevent vitest from hanging

--- a/packages/adapter-cloudflare-workers/index.js
+++ b/packages/adapter-cloudflare-workers/index.js
@@ -152,7 +152,7 @@ export default function ({ config = 'wrangler.toml', platformProxy = {} } = {}) 
 		emulate() {
 			// we want to invoke `getPlatformProxy` only once, but await it only when it is accessed.
 			// If we would await it here, it would hang indefinitely because the platform proxy only resolves once a request happens
-			const getting_platform = (async () => {
+			const get_emulated = (async () => {
 				const proxy = await getPlatformProxy(platformProxy);
 				const platform = /** @type {App.Platform} */ ({
 					env: proxy.env,
@@ -160,11 +160,11 @@ export default function ({ config = 'wrangler.toml', platformProxy = {} } = {}) 
 					caches: proxy.caches,
 					cf: proxy.cf
 				});
-
+		
 				/** @type {Record<string, any>} */
 				const env = {};
 				const prerender_platform = /** @type {App.Platform} */ (/** @type {unknown} */ ({ env }));
-
+		
 				for (const key in proxy.env) {
 					Object.defineProperty(env, key, {
 						get: () => {
@@ -173,12 +173,15 @@ export default function ({ config = 'wrangler.toml', platformProxy = {} } = {}) 
 					});
 				}
 				return { platform, prerender_platform };
-			})();
+			});
+
+			/** @type {{ platform: App.Platform, prerender_platform: App.Platform }} */
+			let emulated;
 
 			return {
 				platform: async ({ prerender }) => {
-					const { platform, prerender_platform } = await getting_platform;
-					return prerender ? prerender_platform : platform;
+					emulated ??= await get_emulated();
+					return prerender ? emulated.prerender_platform : emulated.platform;
 				}
 			};
 		}

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -70,7 +70,7 @@ export default function (options = {}) {
 		emulate() {
 			// we want to invoke `getPlatformProxy` only once, but await it only when it is accessed.
 			// If we would await it here, it would hang indefinitely because the platform proxy only resolves once a request happens
-			const getting_platform = (async () => {
+			const get_emulated = (async () => {
 				const proxy = await getPlatformProxy(options.platformProxy);
 				const platform = /** @type {App.Platform} */ ({
 					env: proxy.env,
@@ -78,11 +78,11 @@ export default function (options = {}) {
 					caches: proxy.caches,
 					cf: proxy.cf
 				});
-
+		
 				/** @type {Record<string, any>} */
 				const env = {};
 				const prerender_platform = /** @type {App.Platform} */ (/** @type {unknown} */ ({ env }));
-
+		
 				for (const key in proxy.env) {
 					Object.defineProperty(env, key, {
 						get: () => {
@@ -91,12 +91,15 @@ export default function (options = {}) {
 					});
 				}
 				return { platform, prerender_platform };
-			})();
+			});
+
+			/** @type {{ platform: App.Platform, prerender_platform: App.Platform }} */
+			let emulated;
 
 			return {
 				platform: async ({ prerender }) => {
-					const { platform, prerender_platform } = await getting_platform;
-					return prerender ? prerender_platform : platform;
+					emulated ??= await get_emulated();
+					return prerender ? emulated.prerender_platform : emulated.platform;
 				}
 			};
 		}


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13368

I thought https://github.com/sveltejs/kit/pull/12830 fixed this but on testing again it doesn't. This PR builds upon it be delaying the call of `getPlatformProxy` even further, calling it only once when `platform` is accessed.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
