### PR TITLE
fix: skip calling `respond` for server-side `fetch` on prerendered pages

### DIFF
--- a/.changeset/nine-llamas-fetch.md
+++ b/.changeset/nine-llamas-fetch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: skip hooks for server fetch to prerendered routes

--- a/.changeset/slow-penguins-play.md
+++ b/.changeset/slow-penguins-play.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: default server fetch to use prerendered paths

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -138,7 +138,7 @@ export function create_builder({
 						generateManifest: ({ relativePath }) =>
 							generate_manifest({
 								build_data,
-								prerendered: null,
+								prerendered: [],
 								relative_path: relativePath,
 								routes: Array.from(filtered)
 							})
@@ -186,7 +186,7 @@ export function create_builder({
 		generateManifest({ relativePath, routes: subset }) {
 			return generate_manifest({
 				build_data,
-				prerendered,
+				prerendered: prerendered.paths,
 				relative_path: relativePath,
 				routes: subset
 					? subset.map((route) => /** @type {import('types').RouteData} */ (lookup.get(route)))

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -138,6 +138,7 @@ export function create_builder({
 						generateManifest: ({ relativePath }) =>
 							generate_manifest({
 								build_data,
+								prerendered: null,
 								relative_path: relativePath,
 								routes: Array.from(filtered)
 							})
@@ -185,6 +186,7 @@ export function create_builder({
 		generateManifest({ relativePath, routes: subset }) {
 			return generate_manifest({
 				build_data,
+				prerendered,
 				relative_path: relativePath,
 				routes: subset
 					? subset.map((route) => /** @type {import('types').RouteData} */ (lookup.get(route)))

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -14,7 +14,7 @@ import { find_server_assets } from './find_server_assets.js';
  * build process, to power routing, etc.
  * @param {{
  *   build_data: import('types').BuildData;
- *   prerendered: import('types').Prerendered | null;
+ *   prerendered: string[];
  *   relative_path: string;
  *   routes: import('types').RouteData[];
  * }} opts
@@ -114,7 +114,7 @@ export function generate_manifest({ build_data, prerendered, relative_path, rout
 						`;
 					}).filter(Boolean).join(',\n')}
 				],
-				prerendered_routes: new Set(${s(prerendered === null ? [] : prerendered.paths)}),
+				prerendered_routes: new Set(${s(prerendered)}),
 				matchers: async () => {
 					${Array.from(
 						matchers,

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -14,11 +14,12 @@ import { find_server_assets } from './find_server_assets.js';
  * build process, to power routing, etc.
  * @param {{
  *   build_data: import('types').BuildData;
+ *   prerendered: import('types').Prerendered | null;
  *   relative_path: string;
  *   routes: import('types').RouteData[];
  * }} opts
  */
-export function generate_manifest({ build_data, relative_path, routes }) {
+export function generate_manifest({ build_data, prerendered, relative_path, routes }) {
 	/**
 	 * @type {Map<any, number>} The new index of each node in the filtered nodes array
 	 */
@@ -113,6 +114,7 @@ export function generate_manifest({ build_data, relative_path, routes }) {
 						`;
 					}).filter(Boolean).join(',\n')}
 				],
+				prerendered_routes: new Set(${s(prerendered === null ? [] : prerendered.paths)}),
 				matchers: async () => {
 					${Array.from(
 						matchers,

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1297,6 +1297,7 @@ export interface SSRManifest {
 		client: NonNullable<BuildData['client']>;
 		nodes: SSRNodeLoader[];
 		routes: SSRRoute[];
+		prerendered_routes: Set<string>;
 		matchers: () => Promise<Record<string, ParamMatcher>>;
 		/** A `[file]: size` map of all assets imported by server code */
 		server_assets: Record<string, number>;

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -222,6 +222,7 @@ export async function dev(vite, vite_config, svelte_config) {
 						return result;
 					};
 				}),
+				prerendered_routes: new Set(),
 				routes: compact(
 					manifest_data.routes.map((route) => {
 						if (!route.page && !route.endpoint) return null;

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -795,6 +795,7 @@ Tips:
 					manifest_path,
 					`export const manifest = ${generate_manifest({
 						build_data,
+						prerendered: null,
 						relative_path: '.',
 						routes: manifest_data.routes
 					})};\n`
@@ -917,6 +918,7 @@ Tips:
 					manifest_path,
 					`export const manifest = ${generate_manifest({
 						build_data,
+						prerendered: null,
 						relative_path: '.',
 						routes: manifest_data.routes
 					})};\n`
@@ -948,6 +950,7 @@ Tips:
 					`${out}/server/manifest.js`,
 					`export const manifest = ${generate_manifest({
 						build_data,
+						prerendered,
 						relative_path: '.',
 						routes: manifest_data.routes.filter((route) => prerender_map.get(route.id) !== true)
 					})};\n`

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -795,7 +795,7 @@ Tips:
 					manifest_path,
 					`export const manifest = ${generate_manifest({
 						build_data,
-						prerendered: null,
+						prerendered: [],
 						relative_path: '.',
 						routes: manifest_data.routes
 					})};\n`
@@ -918,7 +918,7 @@ Tips:
 					manifest_path,
 					`export const manifest = ${generate_manifest({
 						build_data,
-						prerendered: null,
+						prerendered: [],
 						relative_path: '.',
 						routes: manifest_data.routes
 					})};\n`
@@ -950,7 +950,7 @@ Tips:
 					`${out}/server/manifest.js`,
 					`export const manifest = ${generate_manifest({
 						build_data,
-						prerendered,
+						prerendered: prerendered.paths,
 						relative_path: '.',
 						routes: manifest_data.routes.filter((route) => prerender_map.get(route.id) !== true)
 					})};\n`

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -116,10 +116,11 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 					manifest._.prerendered_routes.has(decoded) ||
 					(decoded.at(-1) === '/' && manifest._.prerendered_routes.has(decoded.slice(0, -1)))
 				) {
-					// the prerendered logic is different for each adapter,
-					// (except maybe for prerendered redirects)
-					// so we need to make an actual HTTP request
-					// We do it here to avoid calling server-side hooks for prerendered routes
+					// The path of something prerendered could match a different route
+					// that is still in the manifest, leading to the wrong route being loaded.
+					// We therefore bail early here. The prerendered logic is different for
+					// each adapter, (except maybe for prerendered redirects)
+					// so we need to make an actual HTTP request.
 					return await fetch(request);
 				}
 

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -112,7 +112,10 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 					return await fetch(request);
 				}
 
-				if (manifest._.prerendered_routes.has(decoded)) {
+				if (
+					manifest._.prerendered_routes.has(decoded) ||
+					(decoded.at(-1) === '/' && manifest._.prerendered_routes.has(decoded.slice(0, -1)))
+				) {
 					// the prerendered logic is different for each adapter,
 					// (except maybe for prerendered redirects)
 					// so we need to make an actual HTTP request

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -112,6 +112,14 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 					return await fetch(request);
 				}
 
+				if (manifest._.prerendered_routes.has(decoded)) {
+					// the prerendered logic is different for each adapter,
+					// (except maybe for prerendered redirects)
+					// so we need to make an actual HTTP request
+					// We do it here to avoid calling server-side hooks for prerendered routes
+					return await fetch(request);
+				}
+
 				if (credentials !== 'omit') {
 					const cookie = get_cookie_header(url, request.headers.get('cookie'));
 					if (cookie) {

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -141,7 +141,7 @@ export async function respond(request, options, manifest, state) {
 		return text('Not found', { status: 404, headers });
 	}
 
-	if (!state.prerendering?.fallback && !manifest._.prerendered_routes.has(decoded)) {
+	if (!state.prerendering?.fallback) {
 		// TODO this could theoretically break — should probably be inside a try-catch
 		const matchers = await manifest._.matchers();
 

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -141,7 +141,7 @@ export async function respond(request, options, manifest, state) {
 		return text('Not found', { status: 404, headers });
 	}
 
-	if (!state.prerendering?.fallback) {
+	if (!state.prerendering?.fallback && !manifest._.prerendered_routes.has(decoded)) {
 		// TODO this could theoretically break — should probably be inside a try-catch
 		const matchers = await manifest._.matchers();
 

--- a/packages/kit/test/apps/basics/src/hooks.server.js
+++ b/packages/kit/test/apps/basics/src/hooks.server.js
@@ -1,3 +1,4 @@
+import { building, dev } from '$app/environment';
 import { error, isHttpError, redirect } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
 import fs from 'node:fs';
@@ -134,6 +135,15 @@ export const handle = sequence(
 			redirect(303, '/actions/enhance');
 		}
 
+		return resolve(event);
+	},
+	async ({ event, resolve }) => {
+		if (!dev && !building && event.url.pathname === '/prerendering/prerendered-endpoint/api') {
+			error(
+				500,
+				`Server hooks should not be called for prerendered endpoints: isSubRequest=${event.isSubRequest}`
+			);
+		}
 		return resolve(event);
 	},
 	async ({ event, resolve }) => {

--- a/packages/kit/test/apps/basics/src/routes/prerendering/prerendered-endpoint/api-with-param/[option]/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/prerendering/prerendered-endpoint/api-with-param/[option]/+server.js
@@ -1,0 +1,23 @@
+import { building, dev } from '$app/environment';
+import { error, json } from '@sveltejs/kit';
+
+export const prerender = 'auto';
+
+export function entries() {
+	return [
+		{
+			option: 'prerendered'
+		}
+	];
+}
+
+export async function GET({ params: { option } }) {
+	if ((await entries()).find((entry) => entry.option === option)) {
+		if (dev || building) {
+			return json({ message: 'Im prerendered and called from a non-prerendered +page.server.js' });
+		} else {
+			error(500, 'I should not be called at runtime because I am prerendered');
+		}
+	}
+	return json({ message: 'Im not prerendered' });
+}

--- a/packages/kit/test/apps/basics/src/routes/prerendering/prerendered-endpoint/proxy/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/prerendering/prerendered-endpoint/proxy/+server.js
@@ -1,3 +1,7 @@
-export async function GET({ fetch }) {
+export async function GET({ fetch, url }) {
+	if (url.searchParams.get('api-with-param-option') === 'prerendered') {
+		return await fetch('/prerendering/prerendered-endpoint/api-with-param/prerendered');
+	}
+
 	return await fetch('/prerendering/prerendered-endpoint/api');
 }

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -121,6 +121,27 @@ test.describe('Endpoints', () => {
 		});
 	});
 
+	test('Partially Prerendered +server.js called from a non-prerendered +server.js works', async ({
+		baseURL
+	}) => {
+		for (const [description, url] of [
+			['direct', `${baseURL}/prerendering/prerendered-endpoint/api-with-param/prerendered`],
+			[
+				'proxied',
+				`${baseURL}/prerendering/prerendered-endpoint/proxy?api-with-param-option=prerendered`
+			]
+		]) {
+			await test.step(description, async () => {
+				const res = await fetch(url);
+
+				expect(res.status).toBe(200);
+				expect(await res.json()).toStrictEqual({
+					message: 'Im prerendered and called from a non-prerendered +page.server.js'
+				});
+			});
+		}
+	});
+
 	test('invalid request method returns allow header', async ({ request }) => {
 		const response = await request.post('/endpoint-output/body');
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1279,6 +1279,7 @@ declare module '@sveltejs/kit' {
 			client: NonNullable<BuildData['client']>;
 			nodes: SSRNodeLoader[];
 			routes: SSRRoute[];
+			prerendered_routes: Set<string>;
 			matchers: () => Promise<Record<string, ParamMatcher>>;
 			/** A `[file]: size` map of all assets imported by server code */
 			server_assets: Record<string, number>;


### PR DESCRIPTION
Server-side `fetch()` (e.g. when `isSubRequest: true`) currently has a few bugs when called on a `prerendered` route.

1. When a non-prerendered route also matches the same URL as the prerendered route, the non-prerendered routes are taking precedence (e.g. if `export const prerender = 'auto'`)
2. Prerendered routes still have `hooks.server.js` run on them, but only when `isSubRequest: true`

I've fixed both of these issues by adding a `prerendered_routes: Set<string>` to the manifest. Then, we instantly call a real HTTP `fetch()` if the path matches, just like when calling server-side `fetch()` on assets (when the adapter doesn't support reading assets from the file-system).

During dev/build, there are no `prerendered_routes`, so it's left empty in the manifest (although that does mean the `manifest-full.js` also excludes it!)

Fixes #12778
Fixes #12739

### Potential issues

- According to the docs for `prerendered.paths` (which I'm using to set `prerendered_routes`), it only has the routes without a trailing slash. Would this be an issue? If so, the code might get a lot more complicated! https://github.com/sveltejs/kit/blob/873a09eac86817d1cbb53bf3f9c8842d7346d20d/packages/kit/src/types/private.d.ts#L189-L190 
- In the future, we might want to make a new entry like `prerendered_redirects`, so that we can follow the redirect chain without having to make a real HTTP request, but I think that should be fine if this is under the private `_` field in the `manifest.js` file.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
  - Fixes #12739. I'm not super sure if this implementation is the best way to fix it, though!
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
  - `pnpm test` fails on `main` locally for me, so let's see if the CI passes on it!

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
  - I've made two separate changesets for both the bugs I've fixed! Let me know if you want me to combine them (or if I should add more info to them, since I've just copied my commit message title, which are 50 chars long)

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
