### PR TITLE
fix: ignore non-entry-point CSS files during inlining

### DIFF
--- a/.changeset/shaggy-ravens-unite.md
+++ b/.changeset/shaggy-ravens-unite.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: ignore non-entry-point CSS files during inlining

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -47,7 +47,12 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 		css.filter(asset => client_stylesheets.has(asset.fileName))
 			.forEach((asset) => {
 				if (asset.source.length < kit.inlineStyleThreshold) {
+					// We know that the names for entry points are numbers.
 					const [index] = basename(asset.fileName).split('.');
+					// There can also be other CSS files from shared components
+					// for example, which we need to ignore here.
+					if (isNaN(+index)) return;
+
 					const server_stylesheet = server_stylesheets.get(+index);
 					const file = `${out}/server/stylesheets/${index}.js`;
 

--- a/packages/kit/test/apps/options/source/components/SharedCSS.svelte
+++ b/packages/kit/test/apps/options/source/components/SharedCSS.svelte
@@ -1,0 +1,9 @@
+<p>
+	This component is imported in multiple pages and therefore its CSS lands in a separate CSS chunk
+</p>
+
+<style>
+	p {
+		color: blue;
+	}
+</style>

--- a/packages/kit/test/apps/options/source/pages/inline-assets/+page.svelte
+++ b/packages/kit/test/apps/options/source/pages/inline-assets/+page.svelte
@@ -1,8 +1,13 @@
 <script>
+	import SharedCSS from '$lib/SharedCSS.svelte';
 	import '@fontsource/libre-barcode-128-text';
 </script>
 
-<p>Hello world!</p>
+<p>
+	Test that the fontsource is referenced correctly, while the shared CSS in SharedCSS doesn't cause
+	problems
+</p>
+<SharedCSS />
 
 <style>
 	p {

--- a/packages/kit/test/apps/options/source/pages/resolve-route/+page.svelte
+++ b/packages/kit/test/apps/options/source/pages/resolve-route/+page.svelte
@@ -1,5 +1,7 @@
 <script>
 	import { resolveRoute } from '$app/paths';
+	import SharedCss from '$lib/SharedCSS.svelte';
 </script>
 
+<SharedCss />
 <a data-id="target" href={resolveRoute('/resolve-route/[foo]', { foo: 'resolved' })}>click me</a>


### PR DESCRIPTION
We didn't take into account that the list of CSS files could also contain references to non-entry-point files that are below the threshold.

fixes https://github.com/sveltejs/kit/pull/13068#discussion_r1933373266

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
