### PR TITLE
chore: revert dev error when using `use:enhance` with `+server`

### DIFF
--- a/.changeset/lovely-starfishes-impress.md
+++ b/.changeset/lovely-starfishes-impress.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: revert the changes from #13197 to error during development when using `use:enhance` with `+server`

--- a/.changeset/lovely-starfishes-impress.md
+++ b/.changeset/lovely-starfishes-impress.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-chore: revert the changes from #13197 to error during development when using `use:enhance` with `+server`
+chore: don't error during development when using `use:enhance` with `+server` as some third party libraries make it possible to POST forms to it

--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -353,7 +353,7 @@ The easiest way to progressively enhance a form is to add the `use:enhance` acti
 <form method="POST" +++use:enhance+++>
 ```
 
-> [!NOTE] `use:enhance` can only be used with forms that have `method="POST"`. It will not work with `method="GET"`, which is the default for forms without a specified method. Attempting to use `use:enhance` on forms without `method="POST"` will result in an error.
+> [!NOTE] `use:enhance` can only be used with forms that have `method="POST"` and point to actions defined in a `+page.server.js` file. It will not work with `method="GET"`, which is the default for forms without a specified method. Attempting to use `use:enhance` on forms without `method="POST"` or posting to a `+server.js` endpoint will result in an error.
 
 > [!NOTE] Yes, it's a little confusing that the `enhance` action and `<form action>` are both called 'action'. These docs are action-packed. Sorry.
 

--- a/packages/kit/src/runtime/server/endpoint.js
+++ b/packages/kit/src/runtime/server/endpoint.js
@@ -1,4 +1,3 @@
-import { DEV } from 'esm-env';
 import { ENDPOINT_METHODS, PAGE_METHODS } from '../../constants.js';
 import { negotiate } from '../../utils/http.js';
 import { Redirect } from '../control.js';
@@ -11,10 +10,6 @@ import { method_not_allowed } from './utils.js';
  * @returns {Promise<Response>}
  */
 export async function render_endpoint(event, mod, state) {
-	if (DEV && event.request.headers.get('x-sveltekit-action') === 'true') {
-		throw new Error('use:enhance should only be used with SvelteKit form actions');
-	}
-
 	const method = /** @type {import('types').HttpMethod} */ (event.request.method);
 
 	let handler = mod[method] || mod.fallback;


### PR DESCRIPTION
This PR reverts https://github.com/sveltejs/kit/pull/13197 since it cause an error for users that used [SuperForm's helper](https://superforms.rocks/api#actionresulttype-data-options--status) that made `+server` responses compatible with `use:enhance`.

EDIT: In hindsight, we should probably update the `use:enhance` docs https://svelte.dev/docs/kit/form-actions#Progressive-enhancement to explain that it should only be used with SvelteKit form actions to address the original issue.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits
- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
