### PR TITLE
fix: correct edge function path for route resolution endpoint

### DIFF
--- a/.changeset/healthy-bees-repeat.md
+++ b/.changeset/healthy-bees-repeat.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+fix: correct edge function path for route resolution endpoint

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -396,7 +396,7 @@ const plugin = function (defaults = {}) {
 				// By omitting all routes we're ensuring it's small (the routes will still be available
 				// to the route resolution, becaue it does not rely on the server routing manifest)
 				await generate_edge_function(
-					`${builder.config.kit.appDir}/routes`,
+					`${builder.config.kit.appDir}/route`,
 					{
 						external: 'external' in defaults ? defaults.external : undefined,
 						runtime: 'edge'
@@ -405,8 +405,8 @@ const plugin = function (defaults = {}) {
 				);
 
 				static_config.routes.push({
-					src: `${builder.config.kit.paths.base}/${builder.config.kit.appDir}/routes(\\.js|/.*)`,
-					dest: `${builder.config.kit.paths.base}/${builder.config.kit.appDir}/routes`
+					src: `${builder.config.kit.paths.base}/${builder.config.kit.appDir}/route(\\.js|/.*)`,
+					dest: `${builder.config.kit.paths.base}/${builder.config.kit.appDir}/route`
 				});
 			}
 

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -394,7 +394,7 @@ const plugin = function (defaults = {}) {
 			if (builder.config.kit.router?.resolution === 'server') {
 				// Create a separate edge function just for server-side route resolution.
 				// By omitting all routes we're ensuring it's small (the routes will still be available
-				// to the route resolution, becaue it does not rely on the server routing manifest)
+				// to the route resolution, because it does not rely on the server routing manifest)
 				await generate_edge_function(
 					`${builder.config.kit.appDir}/route`,
 					{


### PR DESCRIPTION
Went missing during a refactoring in #13383
