### PR TITLE
fix: make `<build>` route exclusion rule only exclude static assets

### DIFF
--- a/.changeset/chilled-timers-give.md
+++ b/.changeset/chilled-timers-give.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+fix: make `<build>` route exclusion rule only exclude static assets

--- a/.changeset/chilled-timers-give.md
+++ b/.changeset/chilled-timers-give.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-cloudflare': patch
 ---
 
-fix: make `<build>` route exclusion rule only exclude static assets
+fix: exclude the dynamic route `/_app/env.js` from the adapter config `routes.exclude` special value `<build>` 

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -127,7 +127,7 @@ function get_routes_json(builder, assets, { include = ['/*'], exclude = ['<all>'
 		.flatMap((rule) => (rule === '<all>' ? ['<build>', '<files>', '<prerendered>'] : rule))
 		.flatMap((rule) => {
 			if (rule === '<build>') {
-				return `/${builder.getAppPath()}/*`;
+				return [`/${builder.getAppPath()}/immutable/*`, `/${builder.getAppPath()}/version.json`];
 			}
 
 			if (rule === '<files>') {


### PR DESCRIPTION
Fixes #13385

The original rule of `/_app/*` broke apps with pre-rendered pages and pages using dynamic environment variables simultaneously, because it excludes `/_app/env.js`, which is loaded in pre-rendered pages. This fixes it by only excluding the assets generated by Vite.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
