### PR TITLE
fix: make route resolution imports root-relative if `path.relative` option is `false`

### DIFF
--- a/.changeset/sharp-games-rule.md
+++ b/.changeset/sharp-games-rule.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: make route resolution imports root-relative if `path.relative` option is `false`
+fix: make route resolution imports root-relative if `paths.relative` option is `false`

--- a/.changeset/sharp-games-rule.md
+++ b/.changeset/sharp-games-rule.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: make route resolution imports root-relative if `path.relative` option is `false`

--- a/packages/kit/src/runtime/server/page/server_routing.js
+++ b/packages/kit/src/runtime/server/page/server_routing.js
@@ -1,4 +1,4 @@
-import { base, assets } from '__sveltekit/paths';
+import { base, assets, relative } from '__sveltekit/paths';
 import { text } from '../../../exports/index.js';
 import { s } from '../../../utils/misc.js';
 import { exec } from '../../../utils/routing.js';
@@ -45,6 +45,10 @@ function create_client_import(import_path, url) {
 	// During PROD, they're root-relative
 	if (assets !== '') {
 		return `import('${assets}/${import_path}')`;
+	}
+
+	if (!relative) {
+		return `import('${base}/${import_path}')`;
 	}
 
 	// Else we make them relative to the server-side route resolution request


### PR DESCRIPTION
It is necessary to adhere to this setting because rewrites that SvelteKit cannot see may otherwise lead to incorrect relative paths.

Example:
- route resolution request to _app/route.js
- rewrite to _app/route/foo.js
- SvelteKit only sees the later, returning a relative `import('../immutable/...`) which is wrong, because the actual relative path would be `import('./immutable/...)`

Tested manually that it works correctly; automated test feels unnecessary

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
