### PR TITLE
chore: Add `@typescript-eslint/no-floating-promises`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,7 +26,8 @@ export default [
 		rules: {
 			'@typescript-eslint/await-thenable': 'error',
 			'@typescript-eslint/no-unused-expressions': 'off',
-			'@typescript-eslint/require-await': 'error'
+			'@typescript-eslint/require-await': 'error',
+			'@typescript-eslint/no-floating-promises': 'error',
 		},
 		ignores: [
 			'packages/adapter-node/rollup.config.js',

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -98,7 +98,7 @@ function serve_prerendered() {
 			if (query) location += search;
 			res.writeHead(308, { location }).end();
 		} else {
-			next();
+			void next();
 		}
 	};
 }
@@ -120,7 +120,7 @@ const ssr = async (req, res) => {
 		return;
 	}
 
-	setResponse(
+	await setResponse(
 		res,
 		await server.respond(request, {
 			platform: { req },

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -330,7 +330,7 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env }) {
 					/** @type {Set<string>} */ (expected_hashlinks.get(key)).add(decoded);
 				}
 
-				enqueue(decoded, decode_uri(pathname), pathname);
+				void enqueue(decoded, decode_uri(pathname), pathname);
 			}
 		}
 	}
@@ -366,7 +366,7 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env }) {
 			if (location) {
 				const resolved = resolve(encoded, location);
 				if (is_root_relative(resolved)) {
-					enqueue(decoded, decode_uri(resolved), resolved);
+					void enqueue(decoded, decode_uri(resolved), resolved);
 				}
 
 				if (!headers['x-sveltekit-normalize']) {
@@ -485,17 +485,17 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env }) {
 
 					if (processed_id.includes('[')) continue;
 					const path = `/${get_route_segments(processed_id).join('/')}`;
-					enqueue(null, config.paths.base + path);
+					void enqueue(null, config.paths.base + path);
 				}
 			}
 		} else {
-			enqueue(null, config.paths.base + entry);
+			void enqueue(null, config.paths.base + entry);
 		}
 	}
 
 	for (const { id, entries } of route_level_entries) {
 		for (const entry of entries) {
-			enqueue(null, config.paths.base + entry, undefined, id);
+			void enqueue(null, config.paths.base + entry, undefined, id);
 		}
 	}
 

--- a/packages/kit/src/core/postbuild/queue.js
+++ b/packages/kit/src/core/postbuild/queue.js
@@ -13,6 +13,7 @@ export function queue(concurrency) {
 
 	let current = 0;
 
+	// TODO: Whenever Node >21 is minimum supported version, we can use `Promise.withResolvers` to avoid this ceremony
 	/** @type {(value?: any) => void} */
 	let fulfil;
 
@@ -39,7 +40,7 @@ export function queue(concurrency) {
 				current += 1;
 				const promise = Promise.resolve(task.fn());
 
-				promise
+				void promise
 					.then(task.fulfil, (err) => {
 						task.reject(err);
 						reject(err);

--- a/packages/kit/src/core/postbuild/queue.spec.js
+++ b/packages/kit/src/core/postbuild/queue.spec.js
@@ -76,7 +76,7 @@ test('starts tasks in sequence', async () => {
 
 test('q.add fails if queue is already finished', async () => {
 	const q = queue(1);
-	await q.add(() => {});
+	void q.add(() => {});
 
 	await q.done();
 	expect(() => q.add(() => {})).throws(/Cannot add tasks to a queue that has ended/);

--- a/packages/kit/src/core/postbuild/queue.spec.js
+++ b/packages/kit/src/core/postbuild/queue.spec.js
@@ -76,7 +76,7 @@ test('starts tasks in sequence', async () => {
 
 test('q.add fails if queue is already finished', async () => {
 	const q = queue(1);
-	q.add(() => {});
+	await q.add(() => {});
 
 	await q.done();
 	expect(() => q.add(() => {})).throws(/Cannot add tasks to a queue that has ended/);

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -26,7 +26,7 @@ function get_raw_body(req, body_size_limit) {
 
 	if (req.destroyed) {
 		const readable = new ReadableStream();
-		readable.cancel();
+		void readable.cancel();
 		return readable;
 	}
 
@@ -176,7 +176,7 @@ export async function setResponse(res, response) {
 	const reader = response.body.getReader();
 
 	if (res.destroyed) {
-		reader.cancel();
+		void reader.cancel();
 		return;
 	}
 
@@ -193,7 +193,7 @@ export async function setResponse(res, response) {
 	res.on('close', cancel);
 	res.on('error', cancel);
 
-	next();
+	void next();
 	async function next() {
 		try {
 			for (;;) {

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -375,11 +375,11 @@ export async function dev(vite, vite_config, svelte_config) {
 	// changing the svelte config requires restarting the dev server
 	// the config is only read on start and passed on to vite-plugin-svelte
 	// which needs up-to-date values to operate correctly
-	vite.watcher.on('change', (file) => {
+	vite.watcher.on('change', async (file) => {
 		if (path.basename(file) === 'svelte.config.js') {
 			console.log(`svelte config changed, restarting vite dev-server. changed file: ${file}`);
 			restarting = true;
-			vite.restart();
+			await vite.restart();
 		}
 	});
 
@@ -408,14 +408,14 @@ export async function dev(vite, vite_config, svelte_config) {
 			SvelteKitError: control_module_vite.SvelteKitError
 		});
 	}
-	align_exports();
+	await align_exports();
 	const ws_send = vite.ws.send;
 	/** @param {any} args */
 	vite.ws.send = function (...args) {
 		// We need to reapply the patch after Vite did dependency optimizations
 		// because that clears the module resolutions
 		if (args[0]?.type === 'full-reload' && args[0].path === '*') {
-			align_exports();
+			void align_exports();
 		}
 		return ws_send.apply(vite.ws, args);
 	};
@@ -568,10 +568,10 @@ export async function dev(vite, vite_config, svelte_config) {
 				if (rendered.status === 404) {
 					// @ts-expect-error
 					serve_static_middleware.handle(req, res, () => {
-						setResponse(res, rendered);
+						void setResponse(res, rendered);
 					});
 				} else {
-					setResponse(res, rendered);
+					void setResponse(res, rendered);
 				}
 			} catch (e) {
 				const error = coalesce_to_error(e);

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -192,7 +192,7 @@ export async function preview(vite, vite_config, svelte_config) {
 				request: req
 			});
 
-			setResponse(
+			await setResponse(
 				res,
 				await server.respond(request, {
 					getClientAddress: () => {

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -109,7 +109,7 @@ export function enhance(form_element, submit = () => {}) {
 			result.type === 'redirect' ||
 			result.type === 'error'
 		) {
-			applyAction(result);
+			await applyAction(result);
 		}
 	};
 
@@ -205,7 +205,7 @@ export function enhance(form_element, submit = () => {}) {
 			result = { type: 'error', error };
 		}
 
-		callback({
+		await callback({
 			action,
 			formData: form_data,
 			formElement: form_element,

--- a/packages/kit/src/runtime/client/bundle.js
+++ b/packages/kit/src/runtime/client/bundle.js
@@ -11,5 +11,5 @@ import * as app from '__sveltekit/manifest';
  * @param {import('./types.js').HydrateOptions} options
  */
 export function start(element, options) {
-	kit.start(app, element, options);
+	void kit.start(app, element, options);
 }

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -273,8 +273,8 @@ export async function start(_app, _target, hydrate) {
 	// connectivity errors after initialisation don't nuke the app
 	default_layout_loader = _app.nodes[0];
 	default_error_loader = _app.nodes[1];
-	default_layout_loader();
-	default_error_loader();
+	void default_layout_loader();
+	void default_error_loader();
 
 	current_history_index = history.state?.[HISTORY_INDEX];
 	current_navigation_index = history.state?.[NAVIGATION_INDEX];
@@ -306,7 +306,7 @@ export async function start(_app, _target, hydrate) {
 	if (hydrate) {
 		await _hydrate(target, hydrate);
 	} else {
-		goto(app.hash ? decode_hash(new URL(location.href)) : location.href, {
+		await goto(app.hash ? decode_hash(new URL(location.href)) : location.href, {
 			replaceState: true
 		});
 	}
@@ -1448,7 +1448,7 @@ async function navigate({
 				route: { id: null }
 			});
 		} else {
-			_goto(new URL(navigation_result.location, url).href, {}, redirect_count + 1, nav_token);
+			await _goto(new URL(navigation_result.location, url).href, {}, redirect_count + 1, nav_token);
 			return false;
 		}
 	} else if (/** @type {number} */ (navigation_result.props.page.status) >= 400) {
@@ -1644,14 +1644,14 @@ function setup_preload() {
 
 		clearTimeout(mousemove_timeout);
 		mousemove_timeout = setTimeout(() => {
-			preload(target, 2);
+			void preload(target, 2);
 		}, 20);
 	});
 
 	/** @param {Event} event */
 	function tap(event) {
 		if (event.defaultPrevented) return;
-		preload(/** @type {Element} */ (event.composedPath()[0]), 1);
+		void preload(/** @type {Element} */ (event.composedPath()[0]), 1);
 	}
 
 	container.addEventListener('mousedown', tap);
@@ -1661,7 +1661,7 @@ function setup_preload() {
 		(entries) => {
 			for (const entry of entries) {
 				if (entry.isIntersecting) {
-					_preload_code(new URL(/** @type {HTMLAnchorElement} */ (entry.target).href));
+					void _preload_code(new URL(/** @type {HTMLAnchorElement} */ (entry.target).href));
 					observer.unobserve(entry.target);
 				}
 			}
@@ -1692,7 +1692,7 @@ function setup_preload() {
 				const intent = await get_navigation_intent(url, false);
 				if (intent) {
 					if (DEV) {
-						_preload_data(intent).then((result) => {
+						void _preload_data(intent).then((result) => {
 							if (result.type === 'loaded' && result.state.error) {
 								console.warn(
 									`Preloading data for ${intent.url.pathname} failed with the following error: ${result.state.error.message}\n` +
@@ -1703,11 +1703,11 @@ function setup_preload() {
 							}
 						});
 					} else {
-						_preload_data(intent);
+						void _preload_data(intent);
 					}
 				}
 			} else if (priority <= options.preload_code) {
-				_preload_code(/** @type {URL} */ (url));
+				void _preload_code(/** @type {URL} */ (url));
 			}
 		}
 	}
@@ -1727,7 +1727,7 @@ function setup_preload() {
 			}
 
 			if (options.preload_code === PRELOAD_PRIORITIES.eager) {
-				_preload_code(/** @type {URL} */ (url));
+				void _preload_code(/** @type {URL} */ (url));
 			}
 		}
 	}
@@ -2127,10 +2127,10 @@ export async function applyAction(result) {
 			root.$set(navigation_result.props);
 			update(navigation_result.props.page);
 
-			tick().then(reset_focus);
+			void tick().then(reset_focus);
 		}
 	} else if (result.type === 'redirect') {
-		_goto(result.location, { invalidateAll: true }, 0);
+		await _goto(result.location, { invalidateAll: true }, 0);
 	} else {
 		page.form = result.data;
 		page.status = result.status;
@@ -2311,7 +2311,7 @@ function _start_router() {
 			setTimeout(fulfil, 100); // fallback for edge case where rAF doesn't fire because e.g. tab was backgrounded
 		});
 
-		navigate({
+		await navigate({
 			type: 'link',
 			url,
 			keepfocus: options.keepfocus,
@@ -2362,7 +2362,7 @@ function _start_router() {
 		// @ts-expect-error `URLSearchParams(fd)` is kosher, but typescript doesn't know that
 		url.search = new URLSearchParams(data).toString();
 
-		navigate({
+		void navigate({
 			type: 'form',
 			url,
 			keepfocus: options.keepfocus,
@@ -2455,7 +2455,7 @@ function _start_router() {
 			// (surprisingly!) mutates `current.url`, allowing us to
 			// detect it and trigger a navigation
 			if (current.url.hash === location.hash) {
-				navigate({ type: 'goto', url: decode_hash(current.url) });
+				void navigate({ type: 'goto', url: decode_hash(current.url) });
 			}
 		}
 	});

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -25,7 +25,7 @@ if (DEV && BROWSER) {
 		can_inspect_stack_trace = stack.includes('check_stack_trace');
 	};
 
-	check_stack_trace();
+	void check_stack_trace();
 
 	/**
 	 * @param {RequestInfo | URL} input

--- a/packages/kit/src/utils/streaming.spec.js
+++ b/packages/kit/src/utils/streaming.spec.js
@@ -4,9 +4,9 @@ import { create_async_iterator } from './streaming.js';
 test('works with fast consecutive promise resolutions', async () => {
 	const iterator = create_async_iterator();
 
-	Promise.resolve(1).then((n) => iterator.push(n));
-	Promise.resolve(2).then((n) => iterator.push(n));
-	Promise.resolve().then(() => iterator.done());
+	void Promise.resolve(1).then((n) => iterator.push(n));
+	void Promise.resolve(2).then((n) => iterator.push(n));
+	void Promise.resolve().then(() => iterator.done());
 
 	const actual = [];
 	for await (const value of iterator.iterator) {

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -8,7 +8,7 @@ import { test as base, devices } from '@playwright/test';
 export const test = base.extend({
 	app: ({ page }, use) => {
 		// these are assumed to have been put in the global scope by the layout
-		use({
+		void use({
 			/**
 			 * @param {string} url
 			 * @param {{ replaceState?: boolean }} opts

--- a/packages/package/test/index.js
+++ b/packages/package/test/index.js
@@ -236,7 +236,7 @@ if (!process.env.CI) {
 			await settled();
 			compare('post-error.svelte');
 		} finally {
-			watcher.close();
+			await watcher.close();
 
 			remove('src/lib/Test.svelte');
 			remove('src/lib/a.js');


### PR DESCRIPTION
Adding this actually caught a couple of (actual) dangling promises in our codebase. There are a few instances where I'm not _positive_ whether the promise should or shouldn't be awaited -- but this rule also improves that use case. Being forced to `void x` your promises that you _want_ to ignore provides explicit signal for people later, so they don't have to wonder whether you meant to let it dangle or not.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
