### PR TITLE
fix: correctly map shared entry-point CSS files during inlining

### DIFF
--- a/.changeset/ten-planes-relax.md
+++ b/.changeset/ten-planes-relax.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly find shared entry-point CSS files during inlining

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -35,14 +35,7 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 		manifest_data.nodes.forEach((node, i) => {
 			if (!node.component || !server_manifest[node.component]) return;
 
-			let stylesheets = new Set(server_manifest[node.component].css);
-
-			// if the page/layout is imported by another file, the css is associated with a separate chunk instead
-			server_manifest[node.component].imports?.forEach((filename) => {
-				server_manifest[filename].css?.forEach(stylesheet => {
-					stylesheets.add(stylesheet);
-				})
-			});
+			const { stylesheets } = find_deps(server_manifest, node.component, false);
 
 			if (stylesheets.size) {
 				server_stylesheets.set(i, Array.from(stylesheets));

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -35,14 +35,20 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 		manifest_data.nodes.forEach((node, i) => {
 			if (!node.component || !server_manifest[node.component]) return;
 
-			let stylesheets = new Set(server_manifest[node.component].css);
+			let stylesheets = new Set();
 
-			// if the page/layout is imported by another file, the css is associated with a separate chunk instead
-			server_manifest[node.component].imports?.forEach((filename) => {
+			/**
+			 * @param {string} filename 
+			 */
+			const get_stylesheets = (filename) => {
 				server_manifest[filename].css?.forEach(stylesheet => {
 					stylesheets.add(stylesheet);
-				})
-			});
+				});
+				// if the page/layout is imported by another file, the css is associated with a separate chunk instead
+				server_manifest[filename].imports?.forEach(get_stylesheets);
+			};
+
+			get_stylesheets(node.component);
 
 			if (stylesheets.size) {
 				server_stylesheets.set(i, Array.from(stylesheets));

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -37,8 +37,8 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 
 			const { stylesheets } = find_deps(server_manifest, node.component, false);
 
-			if (stylesheets.size) {
-				server_stylesheets.set(i, Array.from(stylesheets));
+			if (stylesheets.length) {
+				server_stylesheets.set(i, stylesheets);
 			}
 		});
 

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -35,20 +35,14 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 		manifest_data.nodes.forEach((node, i) => {
 			if (!node.component || !server_manifest[node.component]) return;
 
-			let stylesheets = new Set();
+			let stylesheets = new Set(server_manifest[node.component].css);
 
-			/**
-			 * @param {string} filename 
-			 */
-			const get_stylesheets = (filename) => {
+			// if the page/layout is imported by another file, the css is associated with a separate chunk instead
+			server_manifest[node.component].imports?.forEach((filename) => {
 				server_manifest[filename].css?.forEach(stylesheet => {
 					stylesheets.add(stylesheet);
-				});
-				// if the page/layout is imported by another file, the css is associated with a separate chunk instead
-				server_manifest[filename].imports?.forEach(get_stylesheets);
-			};
-
-			get_stylesheets(node.component);
+				})
+			});
 
 			if (stylesheets.size) {
 				server_stylesheets.set(i, Array.from(stylesheets));

--- a/packages/kit/test/apps/options/source/pages/inline-assets/+page.server.js
+++ b/packages/kit/test/apps/options/source/pages/inline-assets/+page.server.js
@@ -1,0 +1,4 @@
+// test that the server-client stylesheet map is constructed correctly when
+// a page is imported. Importing a page causes Vite to associate the css with
+// a separate chunk instead of the page component itself
+import.meta.glob('./import-meta/+page.svelte', { eager: true });

--- a/packages/kit/test/apps/options/source/pages/inline-assets/import-meta/+page.svelte
+++ b/packages/kit/test/apps/options/source/pages/inline-assets/import-meta/+page.svelte
@@ -1,0 +1,7 @@
+<div>this page is being imported so its css is associated with a separate chunk</div>
+
+<style>
+	div {
+		color: pink;
+	}
+</style>


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13423

This PR fixes the case where we fail to find a server stylesheet when Vite associates a page's CSS with a different chunk instead of the component itself. This can happen when the page is imported by another file. So, we need to crawl the imports property in the manifest for CSS too.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
