### PR TITLE
Make headers accessible in the reroute hook

### DIFF
--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -114,8 +114,11 @@ export async function respond(request, options, manifest, state) {
 	let resolved_path;
 
 	try {
-		// reroute could alter the given URL, so we pass a copy
-		resolved_path = options.hooks.reroute({ url: new URL(url) }) ?? url.pathname;
+		// reroute could alter the given data, so we pass copies
+		resolved_path = options.hooks.reroute({
+			url: new URL(url),
+			headers: new Headers(request.headers),
+		}) ?? url.pathname;
 	} catch {
 		return text('Internal Server Error', {
 			status: 500


### PR DESCRIPTION
The `reroute` hook is really powerful stuff! This PR exposes the request headers to the reroute function, making it possible to determine where to reroute also based on headers and cookies, in addition to the url.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
