### PR TITLE
fix: change server-side route resolution endpoint

### DIFF
--- a/.changeset/modern-fishes-chew.md
+++ b/.changeset/modern-fishes-chew.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/adapter-vercel': patch
+'@sveltejs/kit': patch
+---
+
+fix: change server-side route resolution endpoint

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -405,7 +405,7 @@ const plugin = function (defaults = {}) {
 				);
 
 				static_config.routes.push({
-					src: `${builder.config.kit.paths.base}/${builder.config.kit.appDir}/route(\\.js|/.*)`,
+					src: `${builder.config.kit.paths.base}(.*)/__route\\.js$`,
 					dest: `${builder.config.kit.paths.base}/${builder.config.kit.appDir}/route`
 				});
 			}

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -39,7 +39,7 @@ import { INVALIDATED_PARAM, TRAILING_SLASH_PARAM, validate_depends } from '../sh
 import { get_message, get_status } from '../../utils/error.js';
 import { writable } from 'svelte/store';
 import { page, update, navigating } from './state.svelte.js';
-import { add_data_suffix, add_resolution_prefix } from '../pathname.js';
+import { add_data_suffix, add_resolution_suffix } from '../pathname.js';
 
 const ICON_REL_ATTRIBUTES = new Set(['icon', 'shortcut icon', 'apple-touch-icon']);
 
@@ -1265,7 +1265,7 @@ async function get_navigation_intent(url, invalidating) {
 		/** @type {{ route?: import('types').CSRRouteServer, params: Record<string, string>}} */
 		const { route, params } = await import(
 			/* @vite-ignore */
-			add_resolution_prefix(url.pathname)
+			add_resolution_suffix(url.pathname)
 		);
 
 		if (!route) return;

--- a/packages/kit/src/runtime/pathname.js
+++ b/packages/kit/src/runtime/pathname.js
@@ -1,5 +1,3 @@
-import { base, app_dir } from '__sveltekit/paths';
-
 const DATA_SUFFIX = '/__data.json';
 const HTML_DATA_SUFFIX = '.html__data.json';
 
@@ -23,14 +21,14 @@ export function strip_data_suffix(pathname) {
 	return pathname.slice(0, -DATA_SUFFIX.length);
 }
 
-const ROUTE_PREFIX = `${base}/${app_dir}/route`;
+const ROUTE_SUFFIX = `/__route.js`;
 
 /**
  * @param {string} pathname
  * @returns {boolean}
  */
-export function has_resolution_prefix(pathname) {
-	return pathname === `${ROUTE_PREFIX}.js` || pathname.startsWith(`${ROUTE_PREFIX}/`);
+export function has_resolution_suffix(pathname) {
+	return pathname.endsWith(ROUTE_SUFFIX);
 }
 
 /**
@@ -38,17 +36,14 @@ export function has_resolution_prefix(pathname) {
  * @param {string} pathname
  * @returns {string}
  */
-export function add_resolution_prefix(pathname) {
-	let normalized = pathname.slice(base.length);
-	if (normalized.endsWith('/')) normalized = normalized.slice(0, -1);
-
-	return `${ROUTE_PREFIX}${normalized}.js`;
+export function add_resolution_suffix(pathname) {
+	return pathname.replace(/\/$/, '') + ROUTE_SUFFIX;
 }
 
 /**
  * @param {string} pathname
  * @returns {string}
  */
-export function strip_resolution_prefix(pathname) {
-	return base + (pathname.slice(ROUTE_PREFIX.length, -3) || '/');
+export function strip_resolution_suffix(pathname) {
+	return pathname.slice(0, -ROUTE_SUFFIX.length);
 }

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -14,7 +14,7 @@ import { create_async_iterator } from '../../../utils/streaming.js';
 import { SVELTE_KIT_ASSETS } from '../../../constants.js';
 import { SCHEME } from '../../../utils/url.js';
 import { create_server_routing_response, generate_route_object } from './server_routing.js';
-import { add_resolution_prefix } from '../../pathname.js';
+import { add_resolution_suffix } from '../../pathname.js';
 
 // TODO rename this function/module
 
@@ -323,7 +323,7 @@ export async function render_response({
 
 		// prerender a `/_app/route/path/to/page.js` module
 		if (manifest._.client.routes && state.prerendering && !state.prerendering.fallback) {
-			const pathname = add_resolution_prefix(event.url.pathname);
+			const pathname = add_resolution_suffix(event.url.pathname);
 
 			state.prerendering.dependencies.set(
 				pathname,

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -30,9 +30,9 @@ import { resolve_route } from './page/server_routing.js';
 import { validateHeaders } from './validate-headers.js';
 import {
 	has_data_suffix,
-	has_resolution_prefix,
+	has_resolution_suffix,
 	strip_data_suffix,
-	strip_resolution_prefix
+	strip_resolution_suffix
 } from '../pathname.js';
 
 /* global __SVELTEKIT_ADAPTER_NAME__ */
@@ -94,11 +94,11 @@ export async function respond(request, options, manifest, state) {
 	 * If the request is for a route resolution, first modify the URL, then continue as normal
 	 * for path resolution, then return the route object as a JS file.
 	 */
-	const is_route_resolution_request = has_resolution_prefix(url.pathname);
+	const is_route_resolution_request = has_resolution_suffix(url.pathname);
 	const is_data_request = has_data_suffix(url.pathname);
 
 	if (is_route_resolution_request) {
-		url.pathname = strip_resolution_prefix(url.pathname);
+		url.pathname = strip_resolution_suffix(url.pathname);
 	} else if (is_data_request) {
 		url.pathname =
 			strip_data_suffix(url.pathname) +


### PR DESCRIPTION
Instead of doing route resolution requests through `_app/route/...`, do it through `<pathname>/__route.js`:
- more consistent with what we do for `/__data.json` requests already
- avoids problems with cookies: If you set a cookie on `/foo`, we would need to add it to `_app/route/foo` aswell, if we didn't change this
