### PR TITLE
fix: correct hash routing behavior

### DIFF
--- a/.changeset/moody-monkeys-check.md
+++ b/.changeset/moody-monkeys-check.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correct browsing behavior of hash router

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2432,6 +2432,12 @@ function _start_router() {
 			if (!hash_navigating) {
 				const url = new URL(location.href);
 				update_url(url);
+
+				// if the user edits the hash via the browser URL bar, trigger a full-page
+				// reload to align with pathname router behavior
+				if (app.hash) {
+					location.reload();
+				}
 			}
 		}
 	});
@@ -2450,13 +2456,6 @@ function _start_router() {
 				'',
 				location.href
 			);
-		} else if (app.hash) {
-			// If the user edits the hash via the browser URL bar, it
-			// (surprisingly!) mutates `current.url`, allowing us to
-			// detect it and trigger a navigation
-			if (current.url.hash === location.hash) {
-				void navigate({ type: 'goto', url: decode_hash(current.url) });
-			}
 		}
 	});
 

--- a/packages/kit/test/apps/hash-based-routing/src/routes/+layout.svelte
+++ b/packages/kit/test/apps/hash-based-routing/src/routes/+layout.svelte
@@ -9,11 +9,14 @@
 
 <a href="/">/</a>
 <a href="/#/a">/#/a</a>
+<a href="/#/b">/#/b</a>
 <a href="/#/a#b">/#/a#b</a>
 <a href="/#/b/123">/#/b/123</a>
 <a href="/#/b/456">/#/b/456</a>
 <a href="/#/reroute-a">/#/reroute-a</a>
 <a href="/#/reroute-b">/#/reroute-b</a>
+<a href="/#/params/route-1">/#/route-1</a>
+<a href="/#/params/route-2">/#/route-2</a>
 <button data-goto onclick={() => goto('/#/b')}>goto /#/b</button>
 <button data-push onclick={() => pushState('/#/b', {})}>pushState /#/b</button>
 <button data-replace onclick={() => replaceState('/#/a#b', {})}>replaceState /#/a#b</button>

--- a/packages/kit/test/apps/hash-based-routing/src/routes/+layout.svelte
+++ b/packages/kit/test/apps/hash-based-routing/src/routes/+layout.svelte
@@ -15,8 +15,6 @@
 <a href="/#/b/456">/#/b/456</a>
 <a href="/#/reroute-a">/#/reroute-a</a>
 <a href="/#/reroute-b">/#/reroute-b</a>
-<a href="/#/params/route-1">/#/route-1</a>
-<a href="/#/params/route-2">/#/route-2</a>
 <button data-goto onclick={() => goto('/#/b')}>goto /#/b</button>
 <button data-push onclick={() => pushState('/#/b', {})}>pushState /#/b</button>
 <button data-replace onclick={() => replaceState('/#/a#b', {})}>replaceState /#/a#b</button>

--- a/packages/kit/test/apps/hash-based-routing/src/routes/params/[slug]/+page.svelte
+++ b/packages/kit/test/apps/hash-based-routing/src/routes/params/[slug]/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { page } from '$app/state';
+</script>
+
+<p>{page.params.slug}</p>

--- a/packages/kit/test/apps/hash-based-routing/src/routes/params/[slug]/+page.svelte
+++ b/packages/kit/test/apps/hash-based-routing/src/routes/params/[slug]/+page.svelte
@@ -1,5 +1,0 @@
-<script>
-	import { page } from '$app/state';
-</script>
-
-<p>{page.params.slug}</p>

--- a/packages/kit/test/apps/hash-based-routing/test/test.js
+++ b/packages/kit/test/apps/hash-based-routing/test/test.js
@@ -112,14 +112,4 @@ test.describe('hash based navigation', () => {
 		await page.goForward();
 		expect(page.locator('p')).toHaveText('b');
 	});
-
-	test('load functions are rerun', async ({ page }) => {
-		await page.goto('/');
-
-		await page.locator('a[href="/#/params/route-1"]').click();
-		expect(page.locator('p')).toHaveText('route-1');
-
-		await page.goto('/#/params/route-2');
-		expect(page.locator('p')).toHaveText('route-2');
-	});
 });

--- a/packages/kit/test/apps/hash-based-routing/test/test.js
+++ b/packages/kit/test/apps/hash-based-routing/test/test.js
@@ -104,7 +104,10 @@ test.describe('hash based navigation', () => {
 		await page.goto('/');
 
 		await page.locator('a[href="/#/a"]').click();
+		await page.waitForURL('/#/a');
+
 		await page.locator('a[href="/#/b"]').click();
+		await page.waitForURL('/#/b');
 
 		await page.goBack();
 		expect(page.locator('p')).toHaveText('a');

--- a/packages/kit/test/apps/hash-based-routing/test/test.js
+++ b/packages/kit/test/apps/hash-based-routing/test/test.js
@@ -99,4 +99,27 @@ test.describe('hash based navigation', () => {
 		const url = new URL(page.url());
 		expect(url.hash).toBe('#/anchor#test');
 	});
+
+	test('navigation history works', async ({ page }) => {
+		await page.goto('/');
+
+		await page.locator('a[href="/#/a"]').click();
+		await page.locator('a[href="/#/b"]').click();
+
+		await page.goBack();
+		expect(page.locator('p')).toHaveText('a');
+
+		await page.goForward();
+		expect(page.locator('p')).toHaveText('b');
+	});
+
+	test('load functions are rerun', async ({ page }) => {
+		await page.goto('/');
+
+		await page.locator('a[href="/#/params/route-1"]').click();
+		expect(page.locator('p')).toHaveText('route-1');
+
+		await page.goto('/#/params/route-2');
+		expect(page.locator('p')).toHaveText('route-2');
+	});
 });


### PR DESCRIPTION
closes #13460 and #13322

This is an interesting issue -- as is, Kit doesn't correctly handle some aspects of hash routing. Spurious navigations are triggered when using the back button in the browser, but only for certain kinds of routes and in certain environments (see #13460 for details). This seems to be a consequence of differences in when `current.url` is modified, which makes the existing check for user edits to the URL error-prone. Instead (and to also fix #13322), the `popstate` event is used and triggers a simple page reload.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
