### PR TITLE
docs: fix endpoint filename, types

### DIFF
--- a/documentation/docs/98-reference/54-types.md
+++ b/documentation/docs/98-reference/54-types.md
@@ -35,7 +35,7 @@ type RouteParams = {
 };
 
 export type RequestHandler = Kit.RequestHandler<RouteParams>;
-export type RequestEvent = Kit.RequestEvent<RouteParams>;
+export type PageLoad = Kit.Load<RouteParams>;
 ```
 
 These files can be imported into your endpoints and pages as siblings, thanks to the [`rootDirs`](https://www.typescriptlang.org/tsconfig#rootDirs) option in your TypeScript configuration:
@@ -84,7 +84,9 @@ export async function load({ params, fetch }) {
 }
 ```
 
-The return types of the load functions are then available through the `$types` module as `PageData` and `LayoutData` respectively, while the union of the return values of all `Actions` is available as `ActionData`. Starting with version 2.16.0, two additional helper types are provided. `PageProps` defines `data: PageData`, as well as `form: ActionData`, when there are actions defined. `LayoutProps` defines `data: LayoutData`, as well as `children: Snippet`:
+The return types of the load functions are then available through the `$types` module as `PageData` and `LayoutData` respectively, while the union of the return values of all `Actions` is available as `ActionData`.
+
+Starting with version 2.16.0, two additional helper types are provided: `PageProps` defines `data: PageData`, as well as `form: ActionData`, when there are actions defined, while `LayoutProps` defines `data: LayoutData`, as well as `children: Snippet`.
 
 ```svelte
 <!--- file: src/routes/+page.svelte --->

--- a/documentation/docs/98-reference/54-types.md
+++ b/documentation/docs/98-reference/54-types.md
@@ -54,7 +54,7 @@ type RouteParams = {
 export type RequestHandler = Kit.RequestHandler<RouteParams>;
 
 // @filename: index.js
-// @errors: 2355
+// @errors: 2355 2322
 // ---cut---
 /** @type {import('./$types').RequestHandler} */
 export async function GET({ params }) {

--- a/documentation/docs/98-reference/54-types.md
+++ b/documentation/docs/98-reference/54-types.md
@@ -34,14 +34,14 @@ type RouteParams = {
 	baz: string;
 };
 
-export type RequestHandler = Kit.RequestHandler<RouteParams, RouteId>;
-export type RequestEvent = Kit.RequestEvent<RouteParams, RouteId>;
+export type RequestHandler = Kit.RequestHandler<RouteParams>;
+export type RequestEvent = Kit.RequestEvent<RouteParams>;
 ```
 
 These files can be imported into your endpoints and pages as siblings, thanks to the [`rootDirs`](https://www.typescriptlang.org/tsconfig#rootDirs) option in your TypeScript configuration:
 
 ```js
-/// file: src/routes/[foo]/[bar]/[baz]/+page.server.js
+/// file: src/routes/[foo]/[bar]/[baz]/+server.js
 // @filename: $types.d.ts
 import type * as Kit from '@sveltejs/kit';
 
@@ -51,12 +51,12 @@ type RouteParams = {
 	baz: string;
 }
 
-export type PageServerLoad = Kit.ServerLoad<RouteParams>;
+export type RequestHandler = Kit.RequestHandler<RouteParams>;
 
 // @filename: index.js
 // @errors: 2355
 // ---cut---
-/** @type {import('./$types').PageServerLoad} */
+/** @type {import('./$types').RequestHandler} */
 export async function GET({ params }) {
 	// ...
 }

--- a/documentation/docs/98-reference/54-types.md
+++ b/documentation/docs/98-reference/54-types.md
@@ -7,7 +7,7 @@ title: Types
 The `RequestHandler` and `Load` types both accept a `Params` argument allowing you to type the `params` object. For example this endpoint expects `foo`, `bar` and `baz` params:
 
 ```js
-/// file: src/routes/[foo]/[bar]/[baz]/+page.server.js
+/// file: src/routes/[foo]/[bar]/[baz]/+server.js
 // @errors: 2355 2322 1360
 /** @type {import('@sveltejs/kit').RequestHandler<{
     foo: string;
@@ -34,8 +34,8 @@ type RouteParams = {
 	baz: string;
 };
 
-export type PageServerLoad = Kit.ServerLoad<RouteParams>;
-export type PageLoad = Kit.Load<RouteParams>;
+export type RequestHandler = Kit.RequestHandler<RouteParams, RouteId>;
+export type RequestEvent = Kit.RequestEvent<RouteParams, RouteId>;
 ```
 
 These files can be imported into your endpoints and pages as siblings, thanks to the [`rootDirs`](https://www.typescriptlang.org/tsconfig#rootDirs) option in your TypeScript configuration:


### PR DESCRIPTION
Current documentation mixes `+server.js` and `+page.server.js` descriptions.

I have unified it to the former. Maybe latter is more desirable?

```ts
// src/routes/[foo]/[bar]/[baz]/+page.server.ts (or js)

// Invalid export 'GET'
export const GET = () => {};
```

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
