### PR TITLE
fix: correctly preload links on `mousedown`/`touchstart`

### DIFF
--- a/.changeset/mighty-kiwis-laugh.md
+++ b/.changeset/mighty-kiwis-laugh.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly preload links on `mousedown`/`touchstart`

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1677,8 +1677,6 @@ function setup_preload() {
 		const a = find_anchor(element, container);
 		if (!a || a === current_a) return;
 
-		current_a = a;
-
 		const { url, external, download } = get_link_info(a, base, app.hash);
 		if (external || download) return;
 
@@ -1689,6 +1687,7 @@ function setup_preload() {
 
 		if (!options.reload && !same_url) {
 			if (priority <= options.preload_data) {
+				current_a = a;
 				const intent = await get_navigation_intent(url, false);
 				if (intent) {
 					if (DEV) {
@@ -1707,6 +1706,7 @@ function setup_preload() {
 					}
 				}
 			} else if (priority <= options.preload_code) {
+				current_a = a;
 				void _preload_code(/** @type {URL} */ (url));
 			}
 		}

--- a/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-code/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-code/+page.svelte
@@ -1,3 +1,5 @@
+<a id="eager" href="/data-sveltekit/preload-code/target/eager" data-sveltekit-preload-code="eager">eager</a>
+
 <div style="height: 200vh"></div>
 
 <a

--- a/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-code/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-code/+page.svelte
@@ -1,4 +1,6 @@
-<a id="eager" href="/data-sveltekit/preload-code/target/eager" data-sveltekit-preload-code="eager">eager</a>
+<a id="eager" href="/data-sveltekit/preload-code/target/eager" data-sveltekit-preload-code="eager"
+	>eager</a
+>
 
 <div style="height: 200vh"></div>
 

--- a/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/+page.svelte
@@ -6,3 +6,5 @@
 		>three</a
 	>
 </div>
+
+<a id="tap" href="/data-sveltekit/preload-data/target" data-sveltekit-preload-data="tap">tap</a>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -842,6 +842,8 @@ test.describe('data-sveltekit attributes', () => {
 
 		// eager
 		await page.goto('/data-sveltekit/preload-code');
+		await page.locator('#eager').hover();
+		await page.locator('#eager').dispatchEvent('touchstart');
 		// expect 4 nodes on initial load: root layout, root error, current page, and eager preload
 		expect(responses.length).toEqual(4);
 
@@ -849,6 +851,7 @@ test.describe('data-sveltekit attributes', () => {
 		responses.length = 0;
 		page.locator('#viewport').scrollIntoViewIfNeeded();
 		await page.locator('#viewport').hover();
+		await page.locator('#viewport').dispatchEvent('touchstart');
 		await Promise.all([
 			page.waitForTimeout(100), // wait for preloading to start
 			page.waitForLoadState('networkidle') // wait for preloading to finish
@@ -858,6 +861,7 @@ test.describe('data-sveltekit attributes', () => {
 		// hover
 		responses.length = 0;
 		await page.locator('#hover').hover();
+		await page.locator('#hover').dispatchEvent('touchstart');
 		await Promise.all([
 			page.waitForTimeout(100), // wait for preloading to start
 			page.waitForLoadState('networkidle') // wait for preloading to finish
@@ -867,6 +871,7 @@ test.describe('data-sveltekit attributes', () => {
 		// tap
 		responses.length = 0;
 		await page.locator('#tap').hover();
+		await page.locator('#tap').dispatchEvent('touchstart');
 		await Promise.all([
 			page.waitForTimeout(100), // wait for preloading to start
 			page.waitForLoadState('networkidle') // wait for preloading to finish
@@ -922,6 +927,7 @@ test.describe('data-sveltekit attributes', () => {
 		requests.length = 0;
 		await page.goto('/data-sveltekit/preload-data');
 		await page.locator('#tap').hover();
+		await page.locator('#tap').dispatchEvent('touchstart');
 		await Promise.all([
 			page.waitForTimeout(100), // wait for preloading to start
 			page.waitForLoadState('networkidle') // wait for preloading to finish


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13466

This PR changes the link preload behaviour so that it only ignores a link which has already triggered a preload. Previously, it would start ignoring a link the moment it was hovered on. This caused a link that only preloads on `mousedown` to always be ignored since a user's mouse would hover on the link first, causing it to be ignored on the subsequent `mousedown` event. This PR also fixes the data-sveltekit-preload tests that did not manage to catch this regression by changing the tests to use playwright mouse hover simulation instead of programmatically dispatching the `mouseover` event which didn't complete before firing the other events.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
