### PR TITLE
fix: only simulate CORS errors with HTTP URLs

### DIFF
--- a/.changeset/forty-crabs-hang.md
+++ b/.changeset/forty-crabs-hang.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: avoid simulated CORS errors with non-HTTP URLs

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -242,7 +242,7 @@ export function create_universal_fetch(event, state, fetched, csr, resolve_opts)
 				dependency = { response, body: null };
 				state.prerendering.dependencies.set(url.pathname, dependency);
 			}
-		} else {
+		} else if (url.protocol === 'https:' || url.protocol === 'http:') {
 			// simulate CORS errors and "no access to body in no-cors mode" server-side for consistency with client-side behaviour
 			const mode = input instanceof Request ? input.mode : (init?.mode ?? 'cors');
 			if (mode === 'no-cors') {

--- a/packages/kit/src/runtime/server/page/load_data.spec.js
+++ b/packages/kit/src/runtime/server/page/load_data.spec.js
@@ -58,6 +58,13 @@ test('errors when no acao header present on cors', async () => {
 	);
 });
 
+test('succeeds when fetching from local scheme', async () => {
+	const fetch = create_fetch({});
+	const response = await fetch('data:text/plain;foo');
+	const text = await response.text();
+	assert.equal(text, 'foo');
+});
+
 test('errors when trying to access non-serialized request headers on the server', async () => {
 	const fetch = create_fetch({});
 	const response = await fetch('https://domain-a.com');


### PR DESCRIPTION
closes #13362. I wasn't sure whether to specifically bypass the check for `data:` (since browsers apparently treat data URLs as same-origin) or to only enable the check for `http:`/`https:`. I went with the latter because I don't really know what CORS means for non-HTTP protocols.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.