### PR TITLE
fix: avoid file import that is incompatible with Windows

### DIFF
--- a/.changeset/eight-walls-melt.md
+++ b/.changeset/eight-walls-melt.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+fix: avoid file import that is incompatible with Windows

--- a/.changeset/eight-walls-melt.md
+++ b/.changeset/eight-walls-melt.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-netlify': patch
 ---
 
-fix: avoid file import that is incompatible with Windows
+fix: correctly import manifest on Windows machines

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -143,7 +143,7 @@ async function generate_edge_functions({ builder }) {
 	writeFileSync(`${tmp}/manifest.js`, `export const manifest = ${manifest};\n`);
 
 	/** @type {{ assets: Set<string> }} */
-	const { assets } = (await import(`${tmp}/manifest.js`)).manifest;
+	const { assets } = JSON.parse(manifest);
 
 	const path = '/*';
 	// We only need to specify paths without the trailing slash because

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -143,7 +143,8 @@ async function generate_edge_functions({ builder }) {
 	writeFileSync(`${tmp}/manifest.js`, `export const manifest = ${manifest};\n`);
 
 	/** @type {{ assets: Set<string> }} */
-	const { assets } = JSON.parse(manifest);
+  // we have to prepend the file:// protocol because Windows doesn't support absolute path imports
+	const { assets } = (await import(`file://${tmp}/manifest.js`)).manifest;
 
 	const path = '/*';
 	// We only need to specify paths without the trailing slash because


### PR DESCRIPTION
The file import from an absolute path without a `file:///` isn't compatible with Windows, and it's also unnecessary since the content is generated a few lines above.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
