### PR TITLE
fix: load CSS when using server-side route resolution

### DIFF
--- a/.changeset/stupid-clocks-turn.md
+++ b/.changeset/stupid-clocks-turn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: load CSS when using server-side route resolution

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -143,7 +143,7 @@ async function generate_edge_functions({ builder }) {
 	writeFileSync(`${tmp}/manifest.js`, `export const manifest = ${manifest};\n`);
 
 	/** @type {{ assets: Set<string> }} */
-  // we have to prepend the file:// protocol because Windows doesn't support absolute path imports
+	// we have to prepend the file:// protocol because Windows doesn't support absolute path imports
 	const { assets } = (await import(`file://${tmp}/manifest.js`)).manifest;
 
 	const path = '/*';

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -145,6 +145,7 @@ export async function dev(vite, vite_config, svelte_config) {
 										return `${svelte_config.kit.paths.base}${to_fs(svelte_config.kit.outDir)}/generated/client/nodes/${i}.js`;
 									}
 								}),
+					// `css` is not necessary in dev, as the JS file from `nodes` will reference the CSS file
 					routes:
 						svelte_config.kit.router.resolution === 'client'
 							? undefined

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -19,7 +19,8 @@ import {
 	origin,
 	scroll_state,
 	notifiable_store,
-	create_updated_store
+	create_updated_store,
+	load_css
 } from './utils.js';
 import { base } from '__sveltekit/paths';
 import * as devalue from 'devalue';
@@ -40,6 +41,8 @@ import { get_message, get_status } from '../../utils/error.js';
 import { writable } from 'svelte/store';
 import { page, update, navigating } from './state.svelte.js';
 import { add_data_suffix, add_resolution_suffix } from '../pathname.js';
+
+export { load_css };
 
 const ICON_REL_ATTRIBUTES = new Set(['icon', 'shortcut icon', 'apple-touch-icon']);
 

--- a/packages/kit/src/runtime/client/entry.js
+++ b/packages/kit/src/runtime/client/entry.js
@@ -1,3 +1,3 @@
 // we expose this as a separate entry point (rather than treating client.js as the entry point)
-// so that everything other than `start` can be treeshaken
-export { start } from './client.js';
+// so that everything other than `start`/`load_css` can be treeshaken
+export { start, load_css } from './client.js';

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -345,10 +345,10 @@ const seen = {};
 export function load_css(deps) {
 	if (__SVELTEKIT_CLIENT_ROUTING__) return;
 
-	const cspNonceMeta = /** @type {HTMLMetaElement} */ (
+	const csp_nonce_meta = /** @type {HTMLMetaElement} */ (
 		document.querySelector('meta[property=csp-nonce]')
 	);
-	const cspNonce = cspNonceMeta?.nonce || cspNonceMeta?.getAttribute('nonce');
+	const csp_nonce = csp_nonce_meta?.nonce || csp_nonce_meta?.getAttribute('nonce');
 
 	for (const dep of deps) {
 		if (dep in seen) continue;
@@ -362,8 +362,8 @@ export function load_css(deps) {
 		link.rel = 'stylesheet';
 		link.crossOrigin = '';
 		link.href = dep;
-		if (cspNonce) {
-			link.setAttribute('nonce', cspNonce);
+		if (csp_nonce) {
+			link.setAttribute('nonce', csp_nonce);
 		}
 		document.head.appendChild(link);
 	}

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -331,3 +331,40 @@ export function is_external_url(url, base, hash_routing) {
 
 	return false;
 }
+
+/** @type {Record<string, boolean>} */
+const seen = {};
+
+/**
+ * Used for server-side resolution, to replicate Vite's CSS loading behaviour in production.
+ *
+ * Closely modelled after https://github.com/vitejs/vite/blob/3dd12f4724130fdf8ba44c6d3252ebdff407fd47/packages/vite/src/node/plugins/importAnalysisBuild.ts#L214
+ * (which ideally we could just use directly, but it's not exported)
+ * @param {string[]} deps
+ */
+export function load_css(deps) {
+	if (__SVELTEKIT_CLIENT_ROUTING__) return;
+
+	const cspNonceMeta = /** @type {HTMLMetaElement} */ (
+		document.querySelector('meta[property=csp-nonce]')
+	);
+	const cspNonce = cspNonceMeta?.nonce || cspNonceMeta?.getAttribute('nonce');
+
+	for (const dep of deps) {
+		if (dep in seen) continue;
+		seen[dep] = true;
+
+		if (document.querySelector(`link[href="${dep}"][rel="stylesheet"]`)) {
+			continue;
+		}
+
+		const link = document.createElement('link');
+		link.rel = 'stylesheet';
+		link.crossOrigin = '';
+		link.href = dep;
+		if (cspNonce) {
+			link.setAttribute('nonce', cspNonce);
+		}
+		document.head.appendChild(link);
+	}
+}

--- a/packages/kit/src/runtime/server/page/server_routing.js
+++ b/packages/kit/src/runtime/server/page/server_routing.js
@@ -133,11 +133,7 @@ function create_css_import(route, url, manifest) {
 		if (typeof node !== 'number') continue;
 		const node_css = manifest._.client.css?.[node];
 		for (const css_path of node_css ?? []) {
-			if (assets !== '') {
-				css += `'${assets}/${css_path}',`;
-			} else {
-				css += `'${base}/${css_path}',`;
-			}
+			css += `'${assets || base}/${css_path}',`;
 		}
 	}
 

--- a/packages/kit/src/runtime/server/page/server_routing.js
+++ b/packages/kit/src/runtime/server/page/server_routing.js
@@ -105,10 +105,43 @@ export function create_server_routing_response(route, params, url, manifest) {
 
 	if (route) {
 		const csr_route = generate_route_object(route, url, manifest);
-		const body = `export const route = ${csr_route}; export const params = ${JSON.stringify(params)};`;
+		const body = `${create_css_import(route, url, manifest)}\nexport const route = ${csr_route}; export const params = ${JSON.stringify(params)};`;
 
 		return { response: text(body, { headers }), body };
 	} else {
 		return { response: text('', { headers }), body: '' };
 	}
+}
+
+/**
+ * This function generates the client-side import for the CSS files that are
+ * associated with the current route. Vite takes care of that when using
+ * client-side route resolution, but for server-side resolution it does
+ * not know about the CSS files automatically.
+ *
+ * @param {import('types').SSRClientRoute} route
+ * @param {URL} url
+ * @param {import('@sveltejs/kit').SSRManifest} manifest
+ * @returns {string}
+ */
+function create_css_import(route, url, manifest) {
+	const { errors, layouts, leaf } = route;
+
+	let css = '';
+
+	for (const node of [...errors, ...layouts.map((l) => l?.[1]), leaf[1]]) {
+		if (typeof node !== 'number') continue;
+		const node_css = manifest._.client.css?.[node];
+		for (const css_path of node_css ?? []) {
+			if (assets !== '') {
+				css += `'${assets}/${css_path}',`;
+			} else {
+				css += `'${base}/${css_path}',`;
+			}
+		}
+	}
+
+	if (!css) return '';
+
+	return `${create_client_import(/** @type {string} */ (manifest._.client.start), url)}.then(x => x.load_css([${css}]));`;
 }

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -81,6 +81,12 @@ export interface BuildData {
 		 */
 		nodes?: (string | undefined)[];
 		/**
+		 * CSS files referenced in the entry points of the layouts/pages.
+		 * An entry is undefined if the layout/page has no component or universal file (i.e. only has a `.server.js` file) or if has no CSS.
+		 * Only set in case of `router.resolution === 'server'`.
+		 */
+		css?: (string[] | undefined)[];
+		/**
 		 * Contains the client route manifest in a form suitable for the server which is used for server side route resolution.
 		 * Notably, it contains all routes, regardless of whether they are prerendered or not (those are missing in the optimized server route manifest).
 		 * Only set in case of `router.resolution === 'server'`.

--- a/packages/kit/test/apps/basics/test/cross-platform/test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/test.js
@@ -7,9 +7,10 @@ import { test } from '../../../../utils.js';
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('CSS', () => {
-	test('applies styles correctly', async ({ page, get_computed_style }) => {
-		await page.goto('/css');
-
+	/**
+	 * @param {(selector: string, prop: string) => Promise<string>} get_computed_style
+	 */
+	function check_styles(get_computed_style) {
 		test.step('applies imported styles', async () => {
 			expect(await get_computed_style('.styled', 'color')).toBe('rgb(255, 0, 0)');
 		});
@@ -29,6 +30,26 @@ test.describe('CSS', () => {
 		test.step('does not apply raw and url', async () => {
 			expect(await get_computed_style('.not', 'color')).toBe('rgb(0, 0, 0)');
 		});
+	}
+
+	test('applies styles correctly', async ({ page, get_computed_style }) => {
+		await page.goto('/css');
+
+		check_styles(get_computed_style);
+	});
+
+	test('applies styles correctly after client-side navigation', async ({
+		page,
+		app,
+		get_computed_style,
+		javaScriptEnabled
+	}) => {
+		if (!javaScriptEnabled) return;
+
+		await page.goto('/');
+		await app.goto('/css');
+
+		check_styles(get_computed_style);
 	});
 
 	test('loads styles on routes with encoded characters', async ({ page, get_computed_style }) => {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1728,6 +1728,12 @@ declare module '@sveltejs/kit' {
 			 */
 			nodes?: (string | undefined)[];
 			/**
+			 * CSS files referenced in the entry points of the layouts/pages.
+			 * An entry is undefined if the layout/page has no component or universal file (i.e. only has a `.server.js` file) or if has no CSS.
+			 * Only set in case of `router.resolution === 'server'`.
+			 */
+			css?: (string[] | undefined)[];
+			/**
 			 * Contains the client route manifest in a form suitable for the server which is used for server side route resolution.
 			 * Notably, it contains all routes, regardless of whether they are prerendered or not (those are missing in the optimized server route manifest).
 			 * Only set in case of `router.resolution === 'server'`.


### PR DESCRIPTION
When implementing server-side route resolution we didn't think of the CSS associated with the entry points of the pages. Since Vite isn't involved in that chain, it can't automatically wire up the imports correctly, so we gotta add code to load them ourselves.

Fixes #13491


### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
