### PR TITLE
refactor: use `cookie-es` for cookie utils

### DIFF
--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -42,8 +42,8 @@
 	},
 	"dependencies": {
 		"@iarna/toml": "^2.2.5",
-		"esbuild": "^0.24.0",
-		"set-cookie-parser": "^2.6.0"
+		"cookie-es": "^2.0.0",
+		"esbuild": "^0.24.0"
 	},
 	"devDependencies": {
 		"@netlify/functions": "^3.0.0",
@@ -53,7 +53,6 @@
 		"@sveltejs/kit": "workspace:^",
 		"@sveltejs/vite-plugin-svelte": "^5.0.1",
 		"@types/node": "^18.19.48",
-		"@types/set-cookie-parser": "^2.4.7",
 		"rollup": "^4.14.2",
 		"typescript": "^5.3.3",
 		"vitest": "^3.0.1"

--- a/packages/adapter-netlify/src/headers.js
+++ b/packages/adapter-netlify/src/headers.js
@@ -1,4 +1,4 @@
-import * as set_cookie_parser from 'set-cookie-parser';
+import { splitSetCookieString } from 'cookie-es';
 
 /**
  * Splits headers into two categories: single value and multi value
@@ -18,7 +18,7 @@ export function split_headers(headers) {
 	headers.forEach((value, key) => {
 		if (key === 'set-cookie') {
 			if (!m[key]) m[key] = [];
-			m[key].push(...set_cookie_parser.splitCookiesString(value));
+			m[key].push(...splitSetCookieString(value));
 		} else {
 			h[key] = value;
 		}

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -18,8 +18,7 @@
 	"homepage": "https://svelte.dev",
 	"type": "module",
 	"dependencies": {
-		"@types/cookie": "^0.6.0",
-		"cookie": "^0.6.0",
+		"cookie-es": "^2.0.0",
 		"devalue": "^5.1.0",
 		"esm-env": "^1.2.2",
 		"import-meta-resolve": "^4.1.0",
@@ -27,7 +26,6 @@
 		"magic-string": "^0.30.5",
 		"mrmime": "^2.0.0",
 		"sade": "^1.8.1",
-		"set-cookie-parser": "^2.6.0",
 		"sirv": "^3.0.0"
 	},
 	"devDependencies": {
@@ -35,7 +33,6 @@
 		"@sveltejs/vite-plugin-svelte": "^5.0.1",
 		"@types/connect": "^3.4.38",
 		"@types/node": "^18.19.48",
-		"@types/set-cookie-parser": "^2.4.7",
 		"dts-buddy": "^0.5.5",
 		"rollup": "^4.14.2",
 		"svelte": "^5.2.9",

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -1,6 +1,6 @@
 import { createReadStream } from 'node:fs';
 import { Readable } from 'node:stream';
-import * as set_cookie_parser from 'set-cookie-parser';
+import { splitSetCookieString } from 'cookie-es'
 import { SvelteKitError } from '../../runtime/control.js';
 
 /**
@@ -145,10 +145,10 @@ export async function setResponse(res, response) {
 			res.setHeader(
 				key,
 				key === 'set-cookie'
-					? set_cookie_parser.splitCookiesString(
+					? splitSetCookieString(
 							// This is absurd but necessary, TODO: investigate why
-							/** @type {string}*/ (response.headers.get(key))
-						)
+							/** @type {string}*/(response.headers.get(key))
+					)
 					: value
 			);
 		} catch (error) {
@@ -168,7 +168,7 @@ export async function setResponse(res, response) {
 	if (response.body.locked) {
 		res.end(
 			'Fatal error: Response body is locked. ' +
-				"This can happen when the response was already read (for example through 'response.json()' or 'response.text()')."
+			"This can happen when the response was already read (for example through 'response.json()' or 'response.text()')."
 		);
 		return;
 	}
@@ -186,7 +186,7 @@ export async function setResponse(res, response) {
 
 		// If the reader has already been interrupted with an error earlier,
 		// then it will appear here, it is useless, but it needs to be catch.
-		reader.cancel(error).catch(() => {});
+		reader.cancel(error).catch(() => { });
 		if (error) res.destroy(error);
 	};
 
@@ -196,7 +196,7 @@ export async function setResponse(res, response) {
 	void next();
 	async function next() {
 		try {
-			for (;;) {
+			for (; ;) {
 				const { done, value } = await reader.read();
 
 				if (done) break;

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -215,13 +215,13 @@ export interface Cookies {
 	 * @param name the name of the cookie
 	 * @param opts the options, passed directly to `cookie.parse`. See documentation [here](https://github.com/jshttp/cookie#cookieparsestr-options)
 	 */
-	get: (name: string, opts?: import('cookie').CookieParseOptions) => string | undefined;
+	get: (name: string, opts?: import('cookie-es').CookieParseOptions) => string | undefined;
 
 	/**
 	 * Gets all cookies that were previously set with `cookies.set`, or from the request headers.
 	 * @param opts the options, passed directly to `cookie.parse`. See documentation [here](https://github.com/jshttp/cookie#cookieparsestr-options)
 	 */
-	getAll: (opts?: import('cookie').CookieParseOptions) => Array<{ name: string; value: string }>;
+	getAll: (opts?: import('cookie-es').CookieParseOptions) => Array<{ name: string; value: string }>;
 
 	/**
 	 * Sets a cookie. This will add a `set-cookie` header to the response, but also make the cookie available via `cookies.get` or `cookies.getAll` during the current request.
@@ -236,7 +236,7 @@ export interface Cookies {
 	set: (
 		name: string,
 		value: string,
-		opts: import('cookie').CookieSerializeOptions & { path: string }
+		opts: import('cookie-es').CookieSerializeOptions & { path: string }
 	) => void;
 
 	/**
@@ -246,7 +246,10 @@ export interface Cookies {
 	 * @param name the name of the cookie
 	 * @param opts the options, passed directly to `cookie.serialize`. The `path` must match the path of the cookie you want to delete. See documentation [here](https://github.com/jshttp/cookie#cookieserializename-value-options)
 	 */
-	delete: (name: string, opts: import('cookie').CookieSerializeOptions & { path: string }) => void;
+	delete: (
+		name: string,
+		opts: import('cookie-es').CookieSerializeOptions & { path: string }
+	) => void;
 
 	/**
 	 * Serialize a cookie name-value pair into a `Set-Cookie` header string, but don't apply it to the response.
@@ -262,7 +265,7 @@ export interface Cookies {
 	serialize: (
 		name: string,
 		value: string,
-		opts: import('cookie').CookieSerializeOptions & { path: string }
+		opts: import('cookie-es').CookieSerializeOptions & { path: string }
 	) => string;
 }
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -334,13 +334,6 @@ async function kit({ svelte_config }) {
 					__SVELTEKIT_EMBEDDED__: kit.embedded ? 'true' : 'false',
 					__SVELTEKIT_CLIENT_ROUTING__: kit.router.resolution === 'client' ? 'true' : 'false'
 				};
-
-				// These Kit dependencies are packaged as CommonJS, which means they must always be externalized.
-				// Without this, the tests will still pass but `pnpm dev` will fail in projects that link `@sveltejs/kit`.
-				/** @type {NonNullable<import('vite').UserConfig['ssr']>} */ (new_config.ssr).external = [
-					'cookie',
-					'set-cookie-parser'
-				];
 			}
 
 			warn_overridden_config(config, new_config);
@@ -434,7 +427,7 @@ Tips:
 					if (import_map.has(illegal_module)) {
 						const importer = path.relative(
 							cwd,
-							/** @type {string} */ (import_map.get(illegal_module))
+							/** @type {string} */(import_map.get(illegal_module))
 						);
 						throw new Error(`${error_prefix}\nImported by: ${importer}.${error_suffix}`);
 					}
@@ -1085,7 +1078,7 @@ function warn_overridden_config(config, resolved_config) {
 	if (overridden.length > 0) {
 		console.error(
 			colors.bold().red('The following Vite config options will be overridden by SvelteKit:') +
-				overridden.map((key) => `\n  - ${key}`).join('')
+			overridden.map((key) => `\n  - ${key}`).join('')
 		);
 	}
 }
@@ -1129,9 +1122,9 @@ const create_service_worker_module = (config) => dedent`
 	export const build = [];
 	export const files = [
 		${create_assets(config)
-			.filter((asset) => config.kit.serviceWorker.files(asset.file))
-			.map((asset) => `${s(`${config.kit.paths.base}/${asset.file}`)}`)
-			.join(',\n')}
+		.filter((asset) => config.kit.serviceWorker.files(asset.file))
+		.map((asset) => `${s(`${config.kit.paths.base}/${asset.file}`)}`)
+		.join(',\n')}
 	];
 	export const prerendered = [];
 	export const version = ${s(config.kit.version.name)};

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -1,4 +1,4 @@
-import { parse, serialize } from 'cookie';
+import { parse, serialize } from 'cookie-es';
 import { normalize_path, resolve } from '../../utils/url.js';
 import { add_data_suffix } from '../pathname.js';
 
@@ -40,7 +40,7 @@ export function get_cookies(request, url, trailing_slash) {
 	/** @type {Record<string, import('./page/types.js').Cookie>} */
 	const new_cookies = {};
 
-	/** @type {import('cookie').CookieSerializeOptions} */
+	/** @type {import('cookie-es').CookieSerializeOptions} */
 	const defaults = {
 		httpOnly: true,
 		sameSite: 'lax',
@@ -56,7 +56,7 @@ export function get_cookies(request, url, trailing_slash) {
 
 		/**
 		 * @param {string} name
-		 * @param {import('cookie').CookieParseOptions} [opts]
+		 * @param {import('cookie-es').CookieParseOptions} [opts]
 		 */
 		get(name, opts) {
 			const c = new_cookies[name];
@@ -92,7 +92,7 @@ export function get_cookies(request, url, trailing_slash) {
 		},
 
 		/**
-		 * @param {import('cookie').CookieParseOptions} [opts]
+		 * @param {import('cookie-es').CookieParseOptions} [opts]
 		 */
 		getAll(opts) {
 			const cookies = parse(header, { decode: opts?.decode });

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -1,4 +1,4 @@
-import * as set_cookie_parser from 'set-cookie-parser';
+import { splitSetCookieString, parseSetCookie } from 'cookie-es';
 import { respond } from './respond.js';
 import * as paths from '__sveltekit/paths';
 import { read_implementation } from '__sveltekit/server';
@@ -143,7 +143,7 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 				if (!request.headers.has('accept-language')) {
 					request.headers.set(
 						'accept-language',
-						/** @type {string} */ (event.request.headers.get('accept-language'))
+						/** @type {string} */(event.request.headers.get('accept-language'))
 					);
 				}
 
@@ -154,10 +154,8 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 
 				const set_cookie = response.headers.get('set-cookie');
 				if (set_cookie) {
-					for (const str of set_cookie_parser.splitCookiesString(set_cookie)) {
-						const { name, value, ...options } = set_cookie_parser.parseString(str, {
-							decodeValues: false
-						});
+					for (const str of splitSetCookieString(set_cookie)) {
+						const { name, value, ...options } = parseSetCookie(str, { decode: false });
 
 						const path = options.path ?? (url.pathname.split('/').slice(0, -1).join('/') || '/');
 
@@ -165,7 +163,7 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 						set_internal(name, value, {
 							path,
 							encode: (value) => value,
-							.../** @type {import('cookie').CookieSerializeOptions} */ (options)
+							.../** @type {import('cookie-es').CookieSerializeOptions} */ (options)
 						});
 					}
 				}
@@ -180,7 +178,7 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 	return (input, init) => {
 		// See docs in fetch.js for why we need to do this
 		const response = server_fetch(input, init);
-		response.catch(() => {});
+		response.catch(() => { });
 		return response;
 	};
 }

--- a/packages/kit/src/runtime/server/page/types.d.ts
+++ b/packages/kit/src/runtime/server/page/types.d.ts
@@ -1,4 +1,4 @@
-import { CookieSerializeOptions } from 'cookie';
+import { CookieSerializeOptions } from 'cookie-es';
 import { SSRNode, CspDirectives, ServerDataNode } from 'types';
 
 export interface Fetched {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,12 +113,12 @@ importers:
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
+      cookie-es:
+        specifier: ^2.0.0
+        version: 2.0.0
       esbuild:
         specifier: ^0.24.0
         version: 0.24.2
-      set-cookie-parser:
-        specifier: ^2.6.0
-        version: 2.6.0
     devDependencies:
       '@netlify/functions':
         specifier: ^3.0.0
@@ -339,12 +339,9 @@ importers:
 
   packages/kit:
     dependencies:
-      '@types/cookie':
-        specifier: ^0.6.0
-        version: 0.6.0
-      cookie:
-        specifier: ^0.6.0
-        version: 0.6.0
+      cookie-es:
+        specifier: ^2.0.0
+        version: 2.0.0
       devalue:
         specifier: ^5.1.0
         version: 5.1.0
@@ -366,9 +363,6 @@ importers:
       sade:
         specifier: ^1.8.1
         version: 1.8.1
-      set-cookie-parser:
-        specifier: ^2.6.0
-        version: 2.6.0
       sirv:
         specifier: ^3.0.0
         version: 3.0.0
@@ -385,9 +379,6 @@ importers:
       '@types/node':
         specifier: ^18.19.48
         version: 18.19.50
-      '@types/set-cookie-parser':
-        specifier: ^2.4.7
-        version: 2.4.7
       dts-buddy:
         specifier: ^0.5.5
         version: 0.5.5(typescript@5.6.3)
@@ -1965,9 +1956,6 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
-  '@types/cookie@0.6.0':
-    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
-
   '@types/eslint@8.56.12':
     resolution: {integrity: sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==}
 
@@ -2258,12 +2246,11 @@ packages:
     resolution: {integrity: sha512-pMD+MVR538ipqkG5JXeOEbKWS5um1H4LUUccUQG68qpeqBYbzYy79Gh55jkd2TtPdRfUaLWdv6LPP//5Zt0aPQ==}
     engines: {node: '>=4'}
 
+  cookie-es@2.0.0:
+    resolution: {integrity: sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==}
+
   cookie@0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
-    engines: {node: '>= 0.6'}
-
-  cookie@0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
 
   cross-env@7.0.3:
@@ -3187,9 +3174,6 @@ packages:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  set-cookie-parser@2.6.0:
-    resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
 
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
@@ -4350,8 +4334,6 @@ snapshots:
     dependencies:
       '@types/node': 18.19.50
 
-  '@types/cookie@0.6.0': {}
-
   '@types/eslint@8.56.12':
     dependencies:
       '@types/estree': 1.0.6
@@ -4658,9 +4640,9 @@ snapshots:
 
   console-clear@1.1.1: {}
 
-  cookie@0.5.0: {}
+  cookie-es@2.0.0: {}
 
-  cookie@0.6.0: {}
+  cookie@0.5.0: {}
 
   cross-env@7.0.3:
     dependencies:
@@ -5570,8 +5552,6 @@ snapshots:
   semiver@1.1.0: {}
 
   semver@7.7.1: {}
-
-  set-cookie-parser@2.6.0: {}
 
   sharp@0.33.5:
     dependencies:


### PR DESCRIPTION
I noticed that svelte-kit depends on multiple cookie packages `cookie`, `set-cookie-parser`, `@types/cookie` + workarounds for CJS support.

[unjs/cookie-es](https://github.com/unjs/cookie-es) packs `cookie` and `set-cookie-parser` functionality as an ESM-only and typed package (used and tested across UnJS and Nuxt ecosystem).

Also opened discussion: https://github.com/sveltejs/kit/issues/13511

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
