### PR TITLE
refactor: migrate to `exsolve` for module resolution

### DIFF
--- a/packages/adapter-auto/index.js
+++ b/packages/adapter-auto/index.js
@@ -1,6 +1,5 @@
 import { execSync } from 'node:child_process';
-import { pathToFileURL } from 'node:url';
-import { resolve } from 'import-meta-resolve';
+import { resolveModuleURL } from 'exsolve';
 import { adapters } from './adapters.js';
 import { dirname, join } from 'node:path';
 import { existsSync } from 'node:fs';
@@ -40,10 +39,7 @@ function detect_package_manager() {
 
 /** @param {string} name */
 function import_from_cwd(name) {
-	const cwd = pathToFileURL(process.cwd()).href;
-	const url = resolve(name, cwd + '/x.js');
-
-	return import(url);
+	return import(resolveModuleURL(name));
 }
 
 /** @typedef {import('@sveltejs/kit').Adapter} Adapter */

--- a/packages/adapter-auto/package.json
+++ b/packages/adapter-auto/package.json
@@ -47,7 +47,7 @@
 		"vitest": "^3.0.1"
 	},
 	"dependencies": {
-		"import-meta-resolve": "^4.1.0"
+		"exsolve": "^1.0.1"
 	},
 	"peerDependencies": {
 		"@sveltejs/kit": "^2.0.0"

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -22,7 +22,7 @@
 		"cookie": "^0.6.0",
 		"devalue": "^5.1.0",
 		"esm-env": "^1.2.2",
-		"import-meta-resolve": "^4.1.0",
+		"exsolve": "^1.0.1",
 		"kleur": "^4.1.5",
 		"magic-string": "^0.30.5",
 		"mrmime": "^2.0.0",

--- a/packages/kit/src/utils/import.js
+++ b/packages/kit/src/utils/import.js
@@ -1,6 +1,4 @@
-import * as imr from 'import-meta-resolve';
-import process from 'node:process';
-import { pathToFileURL } from 'node:url';
+import { resolveModuleURL } from 'exsolve'
 
 /**
  * Resolve a dependency relative to the current working directory,
@@ -9,8 +7,7 @@ import { pathToFileURL } from 'node:url';
  */
 export async function resolve_peer_dependency(dependency) {
 	try {
-		// @ts-expect-error the types are wrong
-		const resolved = imr.resolve(dependency, pathToFileURL(process.cwd() + '/dummy.js'));
+		const resolved = resolveModuleURL(dependency);
 		return await import(resolved);
 	} catch {
 		try {

--- a/packages/kit/src/utils/import.js
+++ b/packages/kit/src/utils/import.js
@@ -1,4 +1,4 @@
-import { resolveModuleURL } from 'exsolve'
+import { resolveModuleURL } from 'exsolve';
 
 /**
  * Resolve a dependency relative to the current working directory,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,9 @@ importers:
 
   packages/adapter-auto:
     dependencies:
-      import-meta-resolve:
-        specifier: ^4.1.0
-        version: 4.1.0
+      exsolve:
+        specifier: ^1.0.1
+        version: 1.0.1
     devDependencies:
       '@sveltejs/kit':
         specifier: workspace:^
@@ -351,9 +351,9 @@ importers:
       esm-env:
         specifier: ^1.2.2
         version: 1.2.2
-      import-meta-resolve:
-        specifier: ^4.1.0
-        version: 4.1.0
+      exsolve:
+        specifier: ^1.0.1
+        version: 1.0.1
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
@@ -2497,6 +2497,9 @@ packages:
     resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
     engines: {node: '>=12.0.0'}
 
+  exsolve@1.0.1:
+    resolution: {integrity: sha512-Smf0iQtkQVJLaph8r/qS8C8SWfQkaq9Q/dFcD44MLbJj6DNhlWefVuaS21SjfqOsBbjVlKtbCj6L9ekXK6EZUg==}
+
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
@@ -2652,9 +2655,6 @@ packages:
   import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
-
-  import-meta-resolve@4.1.0:
-    resolution: {integrity: sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -4945,6 +4945,8 @@ snapshots:
 
   expect-type@1.1.0: {}
 
+  exsolve@1.0.1: {}
+
   extendable-error@0.1.7: {}
 
   external-editor@3.1.0:
@@ -5103,8 +5105,6 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
-
-  import-meta-resolve@4.1.0: {}
 
   imurmurhash@0.1.4: {}
 


### PR DESCRIPTION
This PR migrates `import-meta-resolve` to [unjs/exsolve](https://github.com/unjs/exsolve) which is actively maintained and has features such as global cache to improve performance.

Note: exsolve utils default to resolving from CWD which I noticed was the case for both usages here.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
