### PR TITLE
feat: allow to control behavior on hydration error

### DIFF
--- a/.changeset/orange-apes-change.md
+++ b/.changeset/orange-apes-change.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: allow to control behavior on hydration error

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -262,7 +262,8 @@ const options = object(
 
 			router: object({
 				type: list(['pathname', 'hash']),
-				resolution: list(['client', 'server'])
+				resolution: list(['client', 'server']),
+				hydrationErrorHandling: list(['error', 'keep html'])
 			}),
 
 			serviceWorker: object({

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -681,6 +681,16 @@ export interface KitConfig {
 		 * @since 2.17.0
 		 */
 		resolution?: 'client' | 'server';
+		/**
+		 * Sometimes the server renders the HTML successfully, but during hydration on the client something goes wrong. One example is a flaky network where
+		 * the request for one of the JavaScript files that is needed for a page to work fails. This option allows you to configure what should happen in such a case:
+		 * - `'error'` (default) - the client will fall back to the root error page. The user will immediately see something's off and depending on the error page can act accordingly. Use this if your app is too sensitive to not-immediately-visible broken states.
+		 * - `'keep html'` - the client will show the HTML that was rendered on the server and not attempt to hydrate the page. The user will see the successful server-rendered page, but no interactivity will be available and navigations are full page reloads. Use this if your app can largely function without JavaScript.
+		 *
+		 * @default "error"
+		 * @since 2.18.0
+		 */
+		hydrationErrorHandling?: 'error' | 'keep html';
 	};
 	serviceWorker?: {
 		/**

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -321,7 +321,9 @@ async function kit({ svelte_config }) {
 					__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: s(kit.version.pollInterval),
 					__SVELTEKIT_DEV__: 'false',
 					__SVELTEKIT_EMBEDDED__: kit.embedded ? 'true' : 'false',
-					__SVELTEKIT_CLIENT_ROUTING__: kit.router.resolution === 'client' ? 'true' : 'false'
+					__SVELTEKIT_CLIENT_ROUTING__: kit.router.resolution === 'client' ? 'true' : 'false',
+					__SVELTEKIT_NO_ROOT_ERROR_ON_HYDRATION__:
+						kit.router.hydrationErrorHandling === 'keep html'
 				};
 
 				if (!secondary_build_started) {
@@ -332,7 +334,9 @@ async function kit({ svelte_config }) {
 					__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: '0',
 					__SVELTEKIT_DEV__: 'true',
 					__SVELTEKIT_EMBEDDED__: kit.embedded ? 'true' : 'false',
-					__SVELTEKIT_CLIENT_ROUTING__: kit.router.resolution === 'client' ? 'true' : 'false'
+					__SVELTEKIT_CLIENT_ROUTING__: kit.router.resolution === 'client' ? 'true' : 'false',
+					__SVELTEKIT_NO_ROOT_ERROR_ON_HYDRATION__:
+						kit.router.hydrationErrorHandling === 'keep html'
 				};
 
 				// These Kit dependencies are packaged as CommonJS, which means they must always be externalized.

--- a/packages/kit/src/types/global-private.d.ts
+++ b/packages/kit/src/types/global-private.d.ts
@@ -6,6 +6,8 @@ declare global {
 	const __SVELTEKIT_EMBEDDED__: boolean;
 	/** True if `config.kit.router.resolution === 'client'` */
 	const __SVELTEKIT_CLIENT_ROUTING__: boolean;
+	/** True if `config.kit.router.hydrationErrorHandling === 'keep html'` */
+	const __SVELTEKIT_NO_ROOT_ERROR_ON_HYDRATION__: boolean;
 	/**
 	 * This makes the use of specific features visible at both dev and build time, in such a
 	 * way that we can error when they are not supported by the target platform.

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -663,6 +663,16 @@ declare module '@sveltejs/kit' {
 			 * @since 2.17.0
 			 */
 			resolution?: 'client' | 'server';
+			/**
+			 * Sometimes the server renders the HTML successfully, but during hydration on the client something goes wrong. One example is a flaky network where
+			 * the request for one of the JavaScript files that is needed for a page to work fails. This option allows you to configure what should happen in such a case:
+			 * - `'error'` (default) - the client will fall back to the root error page. The user will immediately see something's off and depending on the error page can act accordingly. Use this if your app is too sensitive to not-immediately-visible broken states.
+			 * - `'keep html'` - the client will show the HTML that was rendered on the server and not attempt to hydrate the page. The user will see the successful server-rendered page, but no interactivity will be available and navigations are full page reloads. Use this if your app can largely function without JavaScript.
+			 *
+			 * @default "error"
+			 * @since 2.18.0
+			 */
+			hydrationErrorHandling?: 'error' | 'keep html';
 		};
 		serviceWorker?: {
 			/**


### PR DESCRIPTION
closes #13519

This adds a new option to the SvelteKit router that allows you to control how to react when a page doesn't successfully hydrate. You can choose to keep it as is today (show root error page; the default) or keep the HTML around (the new option).

Name is subject to bikeshedding and I'm pretty sure there are better names. Also haven't talked to other maintainers yet if this is a generally good direction (but I think it's a pragmatic solution to the real world of flaky internet connections).

For now it only handles the part when loading the JS/data prior to the "hydrate the components", might be worthwhile to investigate that other part in the future as well.

Also needs tests.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
