### PR TITLE
fix: preload data on tap after code was preloaded on hover

### DIFF
--- a/.changeset/silver-pigs-report.md
+++ b/.changeset/silver-pigs-report.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly preload data on `mousedown`/`touchstart` if code was preloaded on hover

--- a/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/+page.svelte
@@ -8,3 +8,10 @@
 </div>
 
 <a id="tap" href="/data-sveltekit/preload-data/target" data-sveltekit-preload-data="tap">tap</a>
+
+<a
+	id="hover-then-tap"
+	href="/data-sveltekit/preload-data/target"
+	data-sveltekit-preload-code="hover"
+	data-sveltekit-preload-data="tap">hover for code then tap for data</a
+>

--- a/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/target/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/data-sveltekit/preload-data/target/+page.server.js
@@ -1,0 +1,5 @@
+export function load() {
+	return {
+		a: 1
+	};
+}

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -904,6 +904,7 @@ test.describe('data-sveltekit attributes', () => {
 
 		await page.goto('/data-sveltekit/preload-data');
 		await page.locator('#one').hover();
+		await page.locator('#one').dispatchEvent('touchstart');
 		await Promise.all([
 			page.waitForTimeout(100), // wait for preloading to start
 			page.waitForLoadState('networkidle') // wait for preloading to finish
@@ -913,6 +914,7 @@ test.describe('data-sveltekit attributes', () => {
 		requests.length = 0;
 		await page.goto('/data-sveltekit/preload-data');
 		await page.locator('#two').hover();
+		await page.locator('#two').dispatchEvent('touchstart');
 		await Promise.all([
 			page.waitForTimeout(100), // wait for preloading to start
 			page.waitForLoadState('networkidle') // wait for preloading to finish
@@ -922,6 +924,7 @@ test.describe('data-sveltekit attributes', () => {
 		requests.length = 0;
 		await page.goto('/data-sveltekit/preload-data');
 		await page.locator('#three').hover();
+		await page.locator('#three').dispatchEvent('touchstart');
 		await Promise.all([
 			page.waitForTimeout(100), // wait for preloading to start
 			page.waitForLoadState('networkidle') // wait for preloading to finish


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13466 (for real this time)

https://github.com/sveltejs/kit/pull/13486 previously fixed the preload on tap not working by ensuring we do not skip checking the link until a preload has triggered. However, there's also the case where we have both preload link options: preload code on hover and preload data on tap.

This PR ensures that we still preload data on tap even after a successful preload on hover if the preload on hover was only preloading code.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
