### PR TITLE
chore: fix node ID types

### DIFF
--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -177,16 +177,17 @@ export async function dev(vite, vite_config, svelte_config) {
 					return async () => {
 						/** @type {import('types').SSRNode} */
 						const result = {};
-
-						/** @type {import('vite').ModuleNode[]} */
-						const module_nodes = [];
-
 						result.index = index;
+						result.universal_id = node.universal;
+						result.server_id = node.server;
 
-						// these are unused in dev, it's easier to include them
+						// these are unused in dev, but it's easier to include them
 						result.imports = [];
 						result.stylesheets = [];
 						result.fonts = [];
+
+						/** @type {import('vite').ModuleNode[]} */
+						const module_nodes = [];
 
 						if (node.component) {
 							result.component = async () => {
@@ -202,17 +203,13 @@ export async function dev(vite, vite_config, svelte_config) {
 
 						if (node.universal) {
 							const { module, module_node } = await resolve(node.universal);
-
 							module_nodes.push(module_node);
-
 							result.universal = module;
-							result.universal_id = node.universal;
 						}
 
 						if (node.server) {
 							const { module } = await resolve(node.server);
 							result.server = module;
-							result.server_id = node.server;
 						}
 
 						// in dev we inline all styles to avoid FOUC. this gets populated lazily so that

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -78,7 +78,7 @@ export async function load_server_data({ event, state, node, parent }) {
 				const { href } = new URL(dep, event.url);
 
 				if (DEV) {
-					validate_depends(node.server_id, dep);
+					validate_depends(node.server_id || 'missing route ID', dep);
 
 					if (done && !uses.dependencies.has(href)) {
 						console.warn(

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -79,13 +79,13 @@ export interface BuildData {
 		 * An entry is undefined if the layout/page has no component or universal file (i.e. only has a `.server.js` file).
 		 * Only set in case of `router.resolution === 'server'`.
 		 */
-		nodes?: (string | undefined)[];
+		nodes?: Array<string | undefined>;
 		/**
 		 * CSS files referenced in the entry points of the layouts/pages.
 		 * An entry is undefined if the layout/page has no component or universal file (i.e. only has a `.server.js` file) or if has no CSS.
 		 * Only set in case of `router.resolution === 'server'`.
 		 */
-		css?: (string[] | undefined)[];
+		css?: Array<string[] | undefined>;
 		/**
 		 * Contains the client route manifest in a form suitable for the server which is used for server side route resolution.
 		 * Notably, it contains all routes, regardless of whether they are prerendered or not (those are missing in the optimized server route manifest).
@@ -396,8 +396,8 @@ export interface SSRNode {
 		entries?: PrerenderEntryGenerator;
 	};
 
-	universal_id: string;
-	server_id: string;
+	universal_id?: string;
+	server_id?: string;
 }
 
 export type SSRNodeLoader = () => Promise<SSRNode>;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1726,13 +1726,13 @@ declare module '@sveltejs/kit' {
 			 * An entry is undefined if the layout/page has no component or universal file (i.e. only has a `.server.js` file).
 			 * Only set in case of `router.resolution === 'server'`.
 			 */
-			nodes?: (string | undefined)[];
+			nodes?: Array<string | undefined>;
 			/**
 			 * CSS files referenced in the entry points of the layouts/pages.
 			 * An entry is undefined if the layout/page has no component or universal file (i.e. only has a `.server.js` file) or if has no CSS.
 			 * Only set in case of `router.resolution === 'server'`.
 			 */
-			css?: (string[] | undefined)[];
+			css?: Array<string[] | undefined>;
 			/**
 			 * Contains the client route manifest in a form suitable for the server which is used for server side route resolution.
 			 * Notably, it contains all routes, regardless of whether they are prerendered or not (those are missing in the optimized server route manifest).
@@ -1873,8 +1873,8 @@ declare module '@sveltejs/kit' {
 			entries?: PrerenderEntryGenerator;
 		};
 
-		universal_id: string;
-		server_id: string;
+		universal_id?: string;
+		server_id?: string;
 	}
 
 	type SSRNodeLoader = () => Promise<SSRNode>;


### PR DESCRIPTION
`universal_id` and `server_id` aren't required and those files may not be present

eslint in VSCode was telling me it has to be `Array<>` rather than `[]`. Not sure why the command line doesn't apply the same rule