### PR TITLE
docs: add `@since` annotation for the `normalizeUrl` helper

### DIFF
--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -229,6 +229,7 @@ export function isActionFailure(e) {
  * ```
  * @param {URL | string} url
  * @returns {{ url: URL, wasNormalized: boolean, denormalize: (url?: string | URL) => URL }}
+ * @since 2.18.0
  */
 export function normalizeUrl(url) {
 	url = new URL(url, 'http://internal');

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2016,7 +2016,8 @@ declare module '@sveltejs/kit' {
 	 * console.log(url.pathname); // /blog/post
 	 * console.log(denormalize('/blog/post/a')); // /blog/post/a/__data.json
 	 * ```
-	 * */
+	 * @since 2.18.0
+	 */
 	export function normalizeUrl(url: URL | string): {
 		url: URL;
 		wasNormalized: boolean;


### PR DESCRIPTION
This PR notes the SvelteKit version the `normalizeUrl` helper was added in. Not sure if this is that useful but I noticed it was missing.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
