### PR TITLE
chore: fix types for universal and server fields

### DIFF
--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -214,7 +214,7 @@ function check_named_default_separate(actions) {
 
 /**
  * @param {import('@sveltejs/kit').RequestEvent} event
- * @param {NonNullable<import('types').SSRNode['server']['actions']>} actions
+ * @param {NonNullable<import('types').ServerNode['actions']>} actions
  * @throws {Redirect | HttpError | SvelteKitError | Error}
  */
 async function call_action(event, actions) {

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -364,6 +364,27 @@ export interface SSRComponent {
 
 export type SSRComponentLoader = () => Promise<SSRComponent>;
 
+export interface UniversalNode {
+	load?: Load;
+	prerender?: PrerenderOption;
+	ssr?: boolean;
+	csr?: boolean;
+	trailingSlash?: TrailingSlash;
+	config?: any;
+	entries?: PrerenderEntryGenerator;
+}
+
+export interface ServerNode {
+	load?: ServerLoad;
+	prerender?: PrerenderOption;
+	ssr?: boolean;
+	csr?: boolean;
+	trailingSlash?: TrailingSlash;
+	actions?: Actions;
+	config?: any;
+	entries?: PrerenderEntryGenerator;
+}
+
 export interface SSRNode {
 	component: SSRComponentLoader;
 	/** index into the `nodes` array in the generated `client/app.js`. */
@@ -377,29 +398,10 @@ export interface SSRNode {
 	/** inlined styles. */
 	inline_styles?(): MaybePromise<Record<string, string>>;
 
-	universal: {
-		load?: Load;
-		prerender?: PrerenderOption;
-		ssr?: boolean;
-		csr?: boolean;
-		trailingSlash?: TrailingSlash;
-		config?: any;
-		entries?: PrerenderEntryGenerator;
-	};
-
-	server: {
-		load?: ServerLoad;
-		prerender?: PrerenderOption;
-		ssr?: boolean;
-		csr?: boolean;
-		trailingSlash?: TrailingSlash;
-		actions?: Actions;
-		config?: any;
-		entries?: PrerenderEntryGenerator;
-	};
-
 	universal_id?: string;
 	server_id?: string;
+	universal?: UniversalNode;
+	server?: ServerNode;
 }
 
 export type SSRNodeLoader = () => Promise<SSRNode>;

--- a/packages/kit/src/utils/options.js
+++ b/packages/kit/src/utils/options.js
@@ -1,6 +1,6 @@
 /**
  * @template {'prerender' | 'ssr' | 'csr' | 'trailingSlash' | 'entries'} Option
- * @template {(import('types').SSRNode['universal'] | import('types').SSRNode['server'])[Option]} Value
+ * @template {(import('types').UniversalNode | import('types').ServerNode)[Option]} Value
  *
  * @param {Array<import('types').SSRNode | undefined>} nodes
  * @param {Option} option

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1842,6 +1842,27 @@ declare module '@sveltejs/kit' {
 
 	type SSRComponentLoader = () => Promise<SSRComponent>;
 
+	interface UniversalNode {
+		load?: Load;
+		prerender?: PrerenderOption;
+		ssr?: boolean;
+		csr?: boolean;
+		trailingSlash?: TrailingSlash;
+		config?: any;
+		entries?: PrerenderEntryGenerator;
+	}
+
+	interface ServerNode {
+		load?: ServerLoad;
+		prerender?: PrerenderOption;
+		ssr?: boolean;
+		csr?: boolean;
+		trailingSlash?: TrailingSlash;
+		actions?: Actions;
+		config?: any;
+		entries?: PrerenderEntryGenerator;
+	}
+
 	interface SSRNode {
 		component: SSRComponentLoader;
 		/** index into the `nodes` array in the generated `client/app.js`. */
@@ -1855,29 +1876,10 @@ declare module '@sveltejs/kit' {
 		/** inlined styles. */
 		inline_styles?(): MaybePromise<Record<string, string>>;
 
-		universal: {
-			load?: Load;
-			prerender?: PrerenderOption;
-			ssr?: boolean;
-			csr?: boolean;
-			trailingSlash?: TrailingSlash;
-			config?: any;
-			entries?: PrerenderEntryGenerator;
-		};
-
-		server: {
-			load?: ServerLoad;
-			prerender?: PrerenderOption;
-			ssr?: boolean;
-			csr?: boolean;
-			trailingSlash?: TrailingSlash;
-			actions?: Actions;
-			config?: any;
-			entries?: PrerenderEntryGenerator;
-		};
-
 		universal_id?: string;
 		server_id?: string;
+		universal?: UniversalNode;
+		server?: ServerNode;
 	}
 
 	type SSRNodeLoader = () => Promise<SSRNode>;


### PR DESCRIPTION
In https://github.com/sveltejs/kit/pull/13535 I corrected the IDs to be optional, but I missed that the nodes themselves also weren't marked as optional. In `dev.js` and `build_server.js` they aren't necessarily filled out and everywhere they are accessed they are first checked