### PR TITLE
chore: fix type and add docs

### DIFF
--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -116,11 +116,6 @@ export async function render_response({
 	}
 
 	if (page_config.ssr) {
-		if (__SVELTEKIT_DEV__ && !branch.at(-1)?.node.component) {
-			// Can only be the leaf, layouts have a fallback component generated
-			throw new Error(`Missing +page.svelte component for route ${event.route.id}`);
-		}
-
 		/** @type {Record<string, any>} */
 		const props = {
 			stores: {
@@ -128,7 +123,15 @@ export async function render_response({
 				navigating: writable(null),
 				updated
 			},
-			constructors: await Promise.all(branch.map(({ node }) => node.component())),
+			constructors: await Promise.all(
+				branch.map(({ node }) => {
+					if (!node.component) {
+						// Can only be the leaf, layouts have a fallback component generated
+						throw new Error(`Missing +page.svelte component for route ${event.route.id}`);
+					}
+					return node.component();
+				})
+			),
 			form: form_value
 		};
 

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -386,7 +386,6 @@ export interface ServerNode {
 }
 
 export interface SSRNode {
-	component: SSRComponentLoader;
 	/** index into the `nodes` array in the generated `client/app.js`. */
 	index: number;
 	/** external JS files that are loaded on the client. `imports[0]` is the entry point (e.g. `client/nodes/0.js`) */
@@ -395,12 +394,17 @@ export interface SSRNode {
 	stylesheets: string[];
 	/** external font files that are loaded on the client */
 	fonts: string[];
-	/** inlined styles. */
-	inline_styles?(): MaybePromise<Record<string, string>>;
 
 	universal_id?: string;
 	server_id?: string;
+
+	/** inlined styles. */
+	inline_styles?(): MaybePromise<Record<string, string>>;
+	/** Svelte component */
+	component?: SSRComponentLoader;
+	/** +page.js or +layout.js */
 	universal?: UniversalNode;
+	/** +page.server.js, +layout.server.js, or +server.js */
 	server?: ServerNode;
 }
 
@@ -484,6 +488,10 @@ export interface SSRState {
 	 */
 	prerender_default?: PrerenderOption;
 	read?: (file: string) => Buffer;
+	/**
+	 * Used to setup `__SVELTEKIT_TRACK__` which checks if a used feature is supported.
+	 * E.g. if `read` from `$app/server` is used, it checks whether the route's config is compatible.
+	 */
 	before_handle?: (event: RequestEvent, config: any, prerender: PrerenderOption) => void;
 	emulator?: Emulator;
 }

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1864,7 +1864,6 @@ declare module '@sveltejs/kit' {
 	}
 
 	interface SSRNode {
-		component: SSRComponentLoader;
 		/** index into the `nodes` array in the generated `client/app.js`. */
 		index: number;
 		/** external JS files that are loaded on the client. `imports[0]` is the entry point (e.g. `client/nodes/0.js`) */
@@ -1873,12 +1872,17 @@ declare module '@sveltejs/kit' {
 		stylesheets: string[];
 		/** external font files that are loaded on the client */
 		fonts: string[];
-		/** inlined styles. */
-		inline_styles?(): MaybePromise<Record<string, string>>;
 
 		universal_id?: string;
 		server_id?: string;
+
+		/** inlined styles. */
+		inline_styles?(): MaybePromise<Record<string, string>>;
+		/** Svelte component */
+		component?: SSRComponentLoader;
+		/** +page.js or +layout.js */
 		universal?: UniversalNode;
+		/** +page.server.js, +layout.server.js, or +server.js */
 		server?: ServerNode;
 	}
 


### PR DESCRIPTION
`component` can be `undefined`. E.g. it will not be present for an endpoint `+server.js`