### PR TITLE
chore: cache reroute results

### DIFF
--- a/.changeset/thin-parents-pull.md
+++ b/.changeset/thin-parents-pull.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: chache reroute results

--- a/.changeset/thin-parents-pull.md
+++ b/.changeset/thin-parents-pull.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-chore: chache reroute results
+chore: cache reroute results

--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -301,7 +301,7 @@ Using `reroute` will _not_ change the contents of the browser's address bar, or 
 
 Since version 2.18, the `reroute` hook can be asynchronous, allowing it to (for example) fetch data from your backend to decide where to reroute to. Use this carefully and make sure it's fast, as it will delay navigation otherwise.
 
-> [!NOTE] `reroute` is considered a pure, idempotent function. That means, it should always return the same output for the same input and not have side effects. Under these assumptions, SvelteKit caches the result of `reroute` on the client so it is only  called once per unique URL.
+> [!NOTE] `reroute` is considered a pure, idempotent function. As such, it must always return the same output for the same input and not have side effects. Under these assumptions, SvelteKit caches the result of `reroute` on the client so it is only called once per unique URL.
 
 ### transport
 

--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -301,6 +301,8 @@ Using `reroute` will _not_ change the contents of the browser's address bar, or 
 
 Since version 2.18, the `reroute` hook can be asynchronous, allowing it to (for example) fetch data from your backend to decide where to reroute to. Use this carefully and make sure it's fast, as it will delay navigation otherwise.
 
+> [!NOTE] `reroute` is considered a pure, idempotent function. That means, it should always return the same output for the same input and not have side effects. Under these assumptions, SvelteKit caches the result of `reroute` on the client so it is only  called once per unique URL.
+
 ### transport
 
 This is a collection of _transporters_, which allow you to pass custom types — returned from `load` and form actions — across the server/client boundary. Each transporter contains an `encode` function, which encodes values on the server (or returns `false` for anything that isn't an instance of the type) and a corresponding `decode` function:

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -189,6 +189,17 @@ const components = [];
 let load_cache = null;
 
 /**
+ * @type {Map<string, Promise<URL>>}
+ * Cache for client-side rerouting, since it could contain async calls which we want to
+ * avoid running multiple times which would slow down navigations (e.g. else preloading
+ * wouldn't help because on navigation it would be called again). Since `reroute` should be
+ * a pure function (i.e. always return the same) value it's safe to cache across navigations.
+ * The server reroute calls don't need to be cached because they are called using `import(...)`
+ * which is cached per the JS spec.
+ */
+let reroute_cache = new Map();
+
+/**
  * Note on before_navigate_callbacks, on_navigate_callbacks and after_navigate_callbacks:
  * do not re-assign as some closures keep references to these Sets
  */
@@ -1201,23 +1212,38 @@ async function load_root_error_page({ status, error, url, route }) {
  * @returns {Promise<URL | undefined>}
  */
 async function get_rerouted_url(url) {
+	const href = url.href;
+
+	if (reroute_cache.has(href)) {
+		return reroute_cache.get(href);
+	}
+
 	let rerouted;
+
 	try {
-		// reroute could alter the given URL, so we pass a copy
-		rerouted = (await app.hooks.reroute({ url: new URL(url) })) ?? url;
+		const promise = (async () => {
+			// reroute could alter the given URL, so we pass a copy
+			let rerouted = (await app.hooks.reroute({ url: new URL(url) })) ?? url;
 
-		if (typeof rerouted === 'string') {
-			const tmp = new URL(url); // do not mutate the incoming URL
+			if (typeof rerouted === 'string') {
+				const tmp = new URL(url); // do not mutate the incoming URL
 
-			if (app.hash) {
-				tmp.hash = rerouted;
-			} else {
-				tmp.pathname = rerouted;
+				if (app.hash) {
+					tmp.hash = rerouted;
+				} else {
+					tmp.pathname = rerouted;
+				}
+
+				rerouted = tmp;
 			}
 
-			rerouted = tmp;
-		}
+			return rerouted;
+		})();
+
+		reroute_cache.set(href, promise);
+		rerouted = await promise;
 	} catch (e) {
+		reroute_cache.delete(href);
 		if (DEV) {
 			// in development, print the error...
 			console.error(e);

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -197,7 +197,7 @@ let load_cache = null;
  * The server reroute calls don't need to be cached because they are called using `import(...)`
  * which is cached per the JS spec.
  */
-let reroute_cache = new Map();
+const reroute_cache = new Map();
 
 /**
  * Note on before_navigate_callbacks, on_navigate_callbacks and after_navigate_callbacks:


### PR DESCRIPTION
Reroute is supposed to be idempotent, i.e. the same income (i.e. URL) should have always the same outcome. With the introduction of async reroute, a crucial advantage of preloading is now lost: Reroute is called on preload, then on the actual click reroute is called again. That means that if it is async and fetches from the backend, two fetches will be made, which means the actual navigation is slowed down by a few miliseconds. Therefore we introduce a cache which solves this problem.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
