### PR TITLE
feat: provide `fetch` to `reroute`

### DIFF
--- a/.changeset/thirty-days-wink.md
+++ b/.changeset/thirty-days-wink.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: provide `fetch` to `reroute`

--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -299,7 +299,24 @@ The `lang` parameter will be correctly derived from the returned pathname.
 
 Using `reroute` will _not_ change the contents of the browser's address bar, or the value of `event.url`.
 
-Since version 2.18, the `reroute` hook can be asynchronous, allowing it to (for example) fetch data from your backend to decide where to reroute to. Use this carefully and make sure it's fast, as it will delay navigation otherwise.
+Since version 2.18, the `reroute` hook can be asynchronous, allowing it to (for example) fetch data from your backend to decide where to reroute to. Use this carefully and make sure it's fast, as it will delay navigation otherwise. In case you fetch data, make sure to use the `fetch` provided to the `reroute` function. It has the [same benefits](load#Making-fetch-requests) as using the special `fetch` of `load` functions, with the caveat that `params` and `id` are unavailable to [`handleFetch`](#Server-hooks-handleFetch) because the route is not known yet.
+
+```js
+/// file: src/hooks.js
+// @errors: 2345
+// @errors: 2304
+
+/** @type {import('@sveltejs/kit').Reroute} */
+export function reroute({ url, fetch }) {
+	// Ask a special endpoint within your app about the destination
+	const api = new URL('/api/reroute', url);
+	api.searchParams.set('pathname', url.pathname);
+
+	const result = await fetch(api).then(r => r.json());
+	return result.pathname;
+}
+```
+
 
 ### transport
 

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -814,7 +814,7 @@ export type ClientInit = () => MaybePromise<void>;
  * The [`reroute`](https://svelte.dev/docs/kit/hooks#Universal-hooks-reroute) hook allows you to modify the URL before it is used to determine which route to render.
  * @since 2.3.0
  */
-export type Reroute = (event: { url: URL }) => MaybePromise<void | string>;
+export type Reroute = (event: { url: URL; fetch: typeof fetch }) => MaybePromise<void | string>;
 
 /**
  * The [`transport`](https://svelte.dev/docs/kit/hooks#Universal-hooks-transport) hook allows you to transport custom types across the server/client boundary.

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -679,12 +679,7 @@ async function load_node({ loader, parent, url, params, route, server_data_node 
 				app.hash
 			),
 			async fetch(resource, init) {
-				/** @type {URL | string} */
-				let requested;
-
 				if (resource instanceof Request) {
-					requested = resource.url;
-
 					// we're not allowed to modify the received `Request` object, so in order
 					// to fixup relative urls we create a new equivalent `init` object instead
 					init = {
@@ -709,25 +704,15 @@ async function load_node({ loader, parent, url, params, route, server_data_node 
 						signal: resource.signal,
 						...init
 					};
-				} else {
-					requested = resource;
 				}
 
-				// we must fixup relative urls so they are resolved from the target page
-				const resolved = new URL(requested, url);
+				const { resolved, promise } = resolve_fetch_url(resource, init, url);
+
 				if (is_tracking) {
 					depends(resolved.href);
 				}
 
-				// match ssr serialized data url, which is important to find cached responses
-				if (resolved.origin === url.origin) {
-					requested = resolved.href.slice(url.origin.length);
-				}
-
-				// prerendered pages may be served from any origin, so `initial_fetch` urls shouldn't be resolved
-				return started
-					? subsequent_fetch(requested, resolved.href, init)
-					: initial_fetch(requested, init);
+				return promise;
 			},
 			setHeaders: () => {}, // noop
 			depends,
@@ -780,6 +765,30 @@ async function load_node({ loader, parent, url, params, route, server_data_node 
 		data: data ?? server_data_node?.data ?? null,
 		slash: node.universal?.trailingSlash ?? server_data_node?.slash
 	};
+}
+
+/**
+ * @param {Request | string | URL} input
+ * @param {RequestInit | undefined} init
+ * @param {URL} url
+ */
+function resolve_fetch_url(input, init, url) {
+	let requested = input instanceof Request ? input.url : input;
+
+	// we must fixup relative urls so they are resolved from the target page
+	const resolved = new URL(requested, url);
+
+	// match ssr serialized data url, which is important to find cached responses
+	if (resolved.origin === url.origin) {
+		requested = resolved.href.slice(url.origin.length);
+	}
+
+	// prerendered pages may be served from any origin, so `initial_fetch` urls shouldn't be resolved
+	const promise = started
+		? subsequent_fetch(requested, resolved.href, init)
+		: initial_fetch(requested, init);
+
+	return { resolved, promise };
 }
 
 /**
@@ -1204,7 +1213,13 @@ async function get_rerouted_url(url) {
 	let rerouted;
 	try {
 		// reroute could alter the given URL, so we pass a copy
-		rerouted = (await app.hooks.reroute({ url: new URL(url) })) ?? url;
+		rerouted =
+			(await app.hooks.reroute({
+				url: new URL(url),
+				fetch: async (input, init) => {
+					return resolve_fetch_url(input, init, url).promise;
+				}
+			})) ?? url;
 
 		if (typeof rerouted === 'string') {
 			const tmp = new URL(url); // do not mutate the incoming URL

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -29,13 +29,13 @@ function validate_options(options) {
 /**
  * @param {Request} request
  * @param {URL} url
- * @param {import('types').TrailingSlash} trailing_slash
  */
-export function get_cookies(request, url, trailing_slash) {
+export function get_cookies(request, url) {
 	const header = request.headers.get('cookie') ?? '';
 	const initial_cookies = parse(header, { decode: (value) => value });
 
-	const normalized_url = normalize_path(url.pathname, trailing_slash);
+	/** @type {string | undefined} */
+	let normalized_url;
 
 	/** @type {Record<string, import('./page/types.js').Cookie>} */
 	const new_cookies = {};
@@ -149,6 +149,9 @@ export function get_cookies(request, url, trailing_slash) {
 			let path = options.path;
 
 			if (!options.domain || options.domain === url.hostname) {
+				if (!normalized_url) {
+					throw new Error('Cannot serialize cookies until after the route is determined');
+				}
 				path = resolve(normalized_url, path);
 			}
 
@@ -190,12 +193,20 @@ export function get_cookies(request, url, trailing_slash) {
 			.join('; ');
 	}
 
+	/** @type {Array<() => void>} */
+	const internal_queue = [];
+
 	/**
 	 * @param {string} name
 	 * @param {string} value
 	 * @param {import('./page/types.js').Cookie['options']} options
 	 */
 	function set_internal(name, value, options) {
+		if (!normalized_url) {
+			internal_queue.push(() => set_internal(name, value, options));
+			return;
+		}
+
 		let path = options.path;
 
 		if (!options.domain || options.domain === url.hostname) {
@@ -220,7 +231,15 @@ export function get_cookies(request, url, trailing_slash) {
 		}
 	}
 
-	return { cookies, new_cookies, get_cookie_header, set_internal };
+	/**
+	 * @param {import('types').TrailingSlash} trailing_slash
+	 */
+	function set_trailing_slash(trailing_slash) {
+		normalized_url = normalize_path(url.pathname, trailing_slash);
+		internal_queue.forEach((fn) => fn());
+	}
+
+	return { cookies, new_cookies, get_cookie_header, set_internal, set_trailing_slash };
 }
 
 /**

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -110,11 +110,82 @@ export async function respond(request, options, manifest, state) {
 		url.searchParams.delete(INVALIDATED_PARAM);
 	}
 
+	/** @type {Record<string, string>} */
+	const headers = {};
+
+	const { cookies, new_cookies, get_cookie_header, set_internal, set_trailing_slash } = get_cookies(
+		request,
+		url
+	);
+
+	/** @type {import('@sveltejs/kit').RequestEvent} */
+	const event = {
+		cookies,
+		// @ts-expect-error `fetch` needs to be created after the `event` itself
+		fetch: null,
+		getClientAddress:
+			state.getClientAddress ||
+			(() => {
+				throw new Error(
+					`${__SVELTEKIT_ADAPTER_NAME__} does not specify getClientAddress. Please raise an issue`
+				);
+			}),
+		locals: {},
+		params: {},
+		platform: state.platform,
+		request,
+		route: { id: null },
+		setHeaders: (new_headers) => {
+			if (__SVELTEKIT_DEV__) {
+				validateHeaders(new_headers);
+			}
+
+			for (const key in new_headers) {
+				const lower = key.toLowerCase();
+				const value = new_headers[key];
+
+				if (lower === 'set-cookie') {
+					throw new Error(
+						'Use `event.cookies.set(name, value, options)` instead of `event.setHeaders` to set cookies'
+					);
+				} else if (lower in headers) {
+					throw new Error(`"${key}" header is already set`);
+				} else {
+					headers[lower] = value;
+
+					if (state.prerendering && lower === 'cache-control') {
+						state.prerendering.cache = /** @type {string} */ (value);
+					}
+				}
+			}
+		},
+		url,
+		isDataRequest: is_data_request,
+		isSubRequest: state.depth > 0
+	};
+
+	event.fetch = create_fetch({
+		event,
+		options,
+		manifest,
+		state,
+		get_cookie_header,
+		set_internal
+	});
+
+	if (state.emulator?.platform) {
+		event.platform = await state.emulator.platform({
+			config: {},
+			prerender: !!state.prerendering?.fallback
+		});
+	}
+
 	let resolved_path;
 
 	try {
 		// reroute could alter the given URL, so we pass a copy
-		resolved_path = (await options.hooks.reroute({ url: new URL(url) })) ?? url.pathname;
+		resolved_path =
+			(await options.hooks.reroute({ url: new URL(url), fetch: event.fetch })) ?? url.pathname;
 	} catch {
 		return text('Internal Server Error', {
 			status: 500
@@ -129,9 +200,6 @@ export async function respond(request, options, manifest, state) {
 
 	/** @type {import('types').SSRRoute | null} */
 	let route = null;
-
-	/** @type {Record<string, string>} */
-	let params = {};
 
 	if (base && !state.prerendering?.fallback) {
 		if (!resolved_path.startsWith(base)) {
@@ -166,67 +234,12 @@ export async function respond(request, options, manifest, state) {
 			const matched = exec(match, candidate.params, matchers);
 			if (matched) {
 				route = candidate;
-				params = decode_params(matched);
+				event.route = { id: route.id };
+				event.params = decode_params(matched);
 				break;
 			}
 		}
 	}
-
-	/** @type {import('types').TrailingSlash | void} */
-	let trailing_slash = undefined;
-
-	/** @type {Record<string, string>} */
-	const headers = {};
-
-	/** @type {Record<string, import('./page/types.js').Cookie>} */
-	let cookies_to_add = {};
-
-	/** @type {import('@sveltejs/kit').RequestEvent} */
-	const event = {
-		// @ts-expect-error `cookies` and `fetch` need to be created after the `event` itself
-		cookies: null,
-		// @ts-expect-error
-		fetch: null,
-		getClientAddress:
-			state.getClientAddress ||
-			(() => {
-				throw new Error(
-					`${__SVELTEKIT_ADAPTER_NAME__} does not specify getClientAddress. Please raise an issue`
-				);
-			}),
-		locals: {},
-		params,
-		platform: state.platform,
-		request,
-		route: { id: route?.id ?? null },
-		setHeaders: (new_headers) => {
-			if (__SVELTEKIT_DEV__) {
-				validateHeaders(new_headers);
-			}
-
-			for (const key in new_headers) {
-				const lower = key.toLowerCase();
-				const value = new_headers[key];
-
-				if (lower === 'set-cookie') {
-					throw new Error(
-						'Use `event.cookies.set(name, value, options)` instead of `event.setHeaders` to set cookies'
-					);
-				} else if (lower in headers) {
-					throw new Error(`"${key}" header is already set`);
-				} else {
-					headers[lower] = value;
-
-					if (state.prerendering && lower === 'cache-control') {
-						state.prerendering.cache = /** @type {string} */ (value);
-					}
-				}
-			}
-		},
-		url,
-		isDataRequest: is_data_request,
-		isSubRequest: state.depth > 0
-	};
 
 	/** @type {import('types').RequiredResolveOptions} */
 	let resolve_opts = {
@@ -234,6 +247,9 @@ export async function respond(request, options, manifest, state) {
 		filterSerializedResponseHeaders: default_filter,
 		preload: default_preload
 	};
+
+	/** @type {import('types').TrailingSlash} */
+	let trailing_slash = 'never';
 
 	try {
 		/** @type {Array<import('types').SSRNode | undefined> | undefined} */
@@ -269,10 +285,10 @@ export async function respond(request, options, manifest, state) {
 					}
 				}
 
-				trailing_slash = get_option(page_nodes, 'trailingSlash');
+				trailing_slash = get_option(page_nodes, 'trailingSlash') ?? 'never';
 			} else if (route.endpoint) {
 				const node = await route.endpoint();
-				trailing_slash = node.trailingSlash;
+				trailing_slash = node.trailingSlash ?? 'never';
 
 				if (DEV) {
 					validate_server_exports(node, /** @type {string} */ (route.endpoint_id));
@@ -280,7 +296,7 @@ export async function respond(request, options, manifest, state) {
 			}
 
 			if (!is_data_request) {
-				const normalized = normalize_path(url.pathname, trailing_slash ?? 'never');
+				const normalized = normalize_path(url.pathname, trailing_slash);
 
 				if (normalized !== url.pathname && !state.prerendering?.fallback) {
 					return new Response(undefined, {
@@ -319,29 +335,9 @@ export async function respond(request, options, manifest, state) {
 					event.platform = await state.emulator.platform({ config, prerender });
 				}
 			}
-		} else if (state.emulator?.platform) {
-			event.platform = await state.emulator.platform({
-				config: {},
-				prerender: !!state.prerendering?.fallback
-			});
 		}
 
-		const { cookies, new_cookies, get_cookie_header, set_internal } = get_cookies(
-			request,
-			url,
-			trailing_slash ?? 'never'
-		);
-
-		cookies_to_add = new_cookies;
-		event.cookies = cookies;
-		event.fetch = create_fetch({
-			event,
-			options,
-			manifest,
-			state,
-			get_cookie_header,
-			set_internal
-		});
+		set_trailing_slash(trailing_slash);
 
 		if (state.prerendering && !state.prerendering.fallback) disable_search(url);
 
@@ -356,7 +352,7 @@ export async function respond(request, options, manifest, state) {
 						response.headers.set(key, /** @type {string} */ (value));
 					}
 
-					add_cookies_to_headers(response.headers, Object.values(cookies_to_add));
+					add_cookies_to_headers(response.headers, Object.values(new_cookies));
 
 					if (state.prerendering && event.route.id !== null) {
 						response.headers.set('x-sveltekit-routeid', encodeURI(event.route.id));
@@ -417,7 +413,7 @@ export async function respond(request, options, manifest, state) {
 				: route?.page && is_action_json_request(event)
 					? action_json_redirect(e)
 					: redirect_response(e.status, e.location);
-			add_cookies_to_headers(response.headers, Object.values(cookies_to_add));
+			add_cookies_to_headers(response.headers, Object.values(new_cookies));
 			return response;
 		}
 		return await handle_fatal_error(event, options, e);
@@ -467,7 +463,7 @@ export async function respond(request, options, manifest, state) {
 						manifest,
 						state,
 						invalidated_data_nodes,
-						trailing_slash ?? 'never'
+						trailing_slash
 					);
 				} else if (route.endpoint && (!route.page || is_endpoint_request(event))) {
 					response = await render_endpoint(event, await route.endpoint(), state);

--- a/packages/kit/test/apps/basics/src/hooks.js
+++ b/packages/kit/test/apps/basics/src/hooks.js
@@ -9,7 +9,7 @@ const mapping = {
 };
 
 /** @type {import("@sveltejs/kit").Reroute} */
-export const reroute = ({ url }) => {
+export const reroute = ({ url, fetch }) => {
 	//Try to rewrite the external url used in /reroute/external to the homepage - This should not work
 	if (browser && url.href.startsWith('https://expired.badssl.com')) {
 		return '/';
@@ -28,11 +28,7 @@ export const reroute = ({ url }) => {
 	}
 
 	if (url.pathname === '/reroute/async/a') {
-		return new Promise((resolve) => {
-			setTimeout(() => {
-				resolve('/reroute/async/b');
-			}, 100);
-		});
+		return fetch('/reroute/api').then((r) => r.text());
 	}
 
 	if (url.pathname in mapping) {

--- a/packages/kit/test/apps/basics/src/routes/reroute/api/+server.ts
+++ b/packages/kit/test/apps/basics/src/routes/reroute/api/+server.ts
@@ -1,0 +1,5 @@
+import { text } from '@sveltejs/kit';
+
+export function GET({ cookies }) {
+	return text(cookies.get('reroute-cookie') ? '/reroute/async/b' : '/reroute/async/a');
+}

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1451,6 +1451,9 @@ test.describe('reroute', () => {
 	});
 
 	test('Apply async reroute during client side navigation', async ({ page }) => {
+		page
+			.context()
+			.addCookies([{ name: 'reroute-cookie', value: 'yes', path: '/', domain: 'localhost' }]);
 		await page.goto('/reroute/async');
 		await page.click("a[href='/reroute/async/a']");
 		expect(await page.textContent('h1')).toContain(

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -796,7 +796,7 @@ declare module '@sveltejs/kit' {
 	 * The [`reroute`](https://svelte.dev/docs/kit/hooks#Universal-hooks-reroute) hook allows you to modify the URL before it is used to determine which route to render.
 	 * @since 2.3.0
 	 */
-	export type Reroute = (event: { url: URL }) => MaybePromise<void | string>;
+	export type Reroute = (event: { url: URL; fetch: typeof fetch }) => MaybePromise<void | string>;
 
 	/**
 	 * The [`transport`](https://svelte.dev/docs/kit/hooks#Universal-hooks-transport) hook allows you to transport custom types across the server/client boundary.


### PR DESCRIPTION
This provides `fetch` as an argument to `reroute`, so that you can get the same benefits as the `fetch` provided to `load` functions from it. This is important (among other things) because else you might not be able to forward cookies on the server which influence where to go to.

The `respond.js` diff looks beefier than it is. Basically the `event` object is moved on top so that it's created before the `reroute`, because the `fetch` method passed to it needs to know about `event`. The biggest change is about cookies, which are now first created without knowing about the trailing slash, so setting new cookies (for which this is important) will wait until after a route is known.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
