### PR TITLE
@sveltejs/package: Assume no svelte 3 if can't read version with semver (pnpm calalog)

### DIFF
--- a/packages/package/src/typescript.js
+++ b/packages/package/src/typescript.js
@@ -28,10 +28,14 @@ export async function emit_dts(input, output, final_output, cwd, alias, files, t
 	const require = createRequire(import.meta.url);
 	const pkg = load_pkg_json(cwd);
 	const svelte_dep = pkg.peerDependencies?.svelte || pkg.dependencies?.svelte || '3.0';
-	let no_svelte_3 = true
+	let no_svelte_3 = true;
 	try {
-	  no_svelte_3 = !semver.intersects(svelte_dep, '^3.0.0');
-	} catch(e) { }
+		no_svelte_3 = !semver.intersects(svelte_dep, '^3.0.0');
+	} catch (e) {
+		if (e instanceof Error) {
+			console.info(`Can't check svelte version ${svelte_dep}`, e.message);
+		}
+	}
 	await emitDts({
 		libRoot: input,
 		svelteShimsPath: no_svelte_3

--- a/packages/package/src/typescript.js
+++ b/packages/package/src/typescript.js
@@ -33,7 +33,7 @@ export async function emit_dts(input, output, final_output, cwd, alias, files, t
 		no_svelte_3 = !semver.intersects(svelte_dep, '^3.0.0');
 	} catch (e) {
 		if (!(e instanceof Error)) throw e;
-		console.info(`Can't check svelte version ${svelte_dep}`, e.message);
+		console.warn(`Can't check svelte version ${svelte_dep}`, e.message);
 	}
 	await emitDts({
 		libRoot: input,

--- a/packages/package/src/typescript.js
+++ b/packages/package/src/typescript.js
@@ -32,7 +32,7 @@ export async function emit_dts(input, output, final_output, cwd, alias, files, t
 	try {
 		no_svelte_3 = !semver.intersects(svelte_dep, '^3.0.0');
 	} catch (e) {
-    if (!(e instanceof Error)) throw error;
+		if (!(e instanceof Error)) throw e;
 		console.info(`Can't check svelte version ${svelte_dep}`, e.message);
 	}
 	await emitDts({

--- a/packages/package/src/typescript.js
+++ b/packages/package/src/typescript.js
@@ -32,9 +32,8 @@ export async function emit_dts(input, output, final_output, cwd, alias, files, t
 	try {
 		no_svelte_3 = !semver.intersects(svelte_dep, '^3.0.0');
 	} catch (e) {
-		if (e instanceof Error) {
-			console.info(`Can't check svelte version ${svelte_dep}`, e.message);
-		}
+    if (!(e instanceof Error)) throw error;
+		console.info(`Can't check svelte version ${svelte_dep}`, e.message);
 	}
 	await emitDts({
 		libRoot: input,

--- a/packages/package/src/typescript.js
+++ b/packages/package/src/typescript.js
@@ -28,7 +28,10 @@ export async function emit_dts(input, output, final_output, cwd, alias, files, t
 	const require = createRequire(import.meta.url);
 	const pkg = load_pkg_json(cwd);
 	const svelte_dep = pkg.peerDependencies?.svelte || pkg.dependencies?.svelte || '3.0';
-	const no_svelte_3 = !semver.intersects(svelte_dep, '^3.0.0');
+	let no_svelte_3 = true
+	try {
+	  no_svelte_3 = !semver.intersects(svelte_dep, '^3.0.0');
+	} catch(e) { }
 	await emitDts({
 		libRoot: input,
 		svelteShimsPath: no_svelte_3


### PR DESCRIPTION
I'm using `pnpm` and the `catalog` feature.
It's nice in monorepos to manage deps & version in one place. (+ you can name & group deps)

In `package.json`:
```json
{
  "peerDependencies": {
    "svelte": "catalog:svelte-dep"
  }  
}
```
An in `pnpm-workspace.yaml`
```yaml
catalogs:
  # adding comment is GREAT!
  svelte-dep:
    'svelte': '^5.0.0'
  
  # this is the stuff bla bla bla
  sveltekit:
    '@sveltejs/kit': '2.17.3'
    '@sveltejs/package': '2.3.7'
    '@sveltejs/vite-plugin-svelte': '5.0.1'
    '@sveltejs/adapter-auto': '4.0.0'
    '@sveltejs/adapter-node': '5.2.12'
```

BUT, it's not `semver` standard. :( (Maybe one day?)

That's why I would suggest this fix ?
Feel free to le me know what do you think

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
