### PR TITLE
fix: case-insensitive matching of tags

### DIFF
--- a/.changeset/smart-gifts-swim.md
+++ b/.changeset/smart-gifts-swim.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/amp': patch
+---
+
+fix: case-insensitive matching of tags

--- a/packages/amp/index.js
+++ b/packages/amp/index.js
@@ -8,9 +8,9 @@ const boilerplate = `
 /** @param {string} html */
 export function transform(html) {
 	return html
-		.replace(/<style([^]+?)<\/style>/, (match, $1) => `<style amp-custom${$1}</style>`)
-		.replace(/<script[^]+?<\/script>/g, '')
-		.replace(/<link[^>]+>/g, (match) => {
+		.replace(/<style([^]+?)<\/style>/i, (match, $1) => `<style amp-custom${$1}</style>`)
+		.replace(/<script[^]+?<\/script>/gi, '')
+		.replace(/<link[^>]+>/gi, (match) => {
 			if (/rel=('|")?stylesheet\1/.test(match)) {
 				if (/ disabled /.test(match)) return '';
 				throw new Error(


### PR DESCRIPTION
GitHub is giving us some code scanning alerts. I'm not sure these matter that much, but thought I'd take a stab at fixing one: https://github.com/sveltejs/kit/security/code-scanning/8