### PR TITLE
fix: lazily load CSS for CSR dynamically imported components

### DIFF
--- a/.changeset/flat-cows-cough.md
+++ b/.changeset/flat-cows-cough.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: lazily load CSS for dynamically imported components

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -137,13 +137,23 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 				universal = find_deps(server_manifest, node.universal, true);
 			}
 
+			if (entry.stylesheet_map.size > 0) {
+				console.dir({
+					entry: entry.stylesheet_map,
+					component: component?.stylesheet_map,
+					universal: universal?.stylesheet_map,
+				}, { colors: true, depth: null, maxArrayLength: null });
+			}
+
+			/** @type {Set<string>} */
 			const css_used_by_server = new Set();
+			/** @type {Set<string>} */
 			const assets_used_by_server = new Set();
 
-			const relative_entry_path = normalizePath(relative(process.cwd(), entry_path));
 			entry.stylesheet_map.forEach((value, key) => {
-				if (key === relative_entry_path) {
-					// map the client node index to the server component source
+				// pages and layouts are named as node indexes in the client manifest
+				// so we need to use the original filename when checking against the server manifest
+				if (key === entry_path) {
 					key = node.component ?? key;
 				}
 

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -122,7 +122,7 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 			const entry = find_deps(
 				client_manifest,
 				`${normalizePath(kit.outDir)}/generated/client-optimized/nodes/${i}.js`,
-				true
+				false
 			);
 
 			imported.push(...entry.imports);

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { mkdirp } from '../../../utils/filesystem.js';
-import { find_deps, resolve_symlinks } from './utils.js';
+import { filter_fonts, find_deps, resolve_symlinks } from './utils.js';
 import { s } from '../../../utils/misc.js';
 import { normalizePath } from 'vite';
 import { basename } from 'node:path';
@@ -83,13 +83,13 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 		const exports = [`export const index = ${i};`];
 
 		/** @type {string[]} */
-		const imported = [];
+		let imported = [];
 
 		/** @type {string[]} */
-		const stylesheets = [];
+		let stylesheets = [];
 
 		/** @type {string[]} */
-		const fonts = [];
+		let fonts = [];
 
 		if (node.component && client_manifest) {
 			exports.push(
@@ -122,12 +122,37 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 			const entry = find_deps(
 				client_manifest,
 				`${normalizePath(kit.outDir)}/generated/client-optimized/nodes/${i}.js`,
-				false
+				true
 			);
 
-			imported.push(...entry.imports);
-			stylesheets.push(...entry.stylesheets);
-			fonts.push(...entry.fonts);
+			// eagerly load stylesheets and fonts imported by the SSR-ed page to avoid FOUC.
+			// If it is not used during SSR, it can be lazily loaded in the browser.
+	
+			/** @type {import('types').AssetDependencies | undefined} */
+			let component;
+			if (node.component) {
+				component = find_deps(server_manifest, node.component, true);
+			}
+
+			/** @type {import('types').AssetDependencies | undefined} */
+			let universal;
+			if (node.universal) {
+				universal = find_deps(server_manifest, node.universal, true);
+			}
+
+			const css_used_by_server = new Set();
+			const assets_used_by_server = new Set();
+
+			entry.stylesheet_map.forEach((value, key) => {
+				if (component?.stylesheet_map.has(key) || universal?.stylesheet_map.has(key)) {
+					value.css.forEach(file => css_used_by_server.add(file));
+					value.assets.forEach(file => assets_used_by_server.add(file));
+				}
+			});
+
+			imported = entry.imports;
+			stylesheets = Array.from(css_used_by_server);
+			fonts = filter_fonts(Array.from(assets_used_by_server));
 		}
 
 		exports.push(

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -140,7 +140,7 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 			const css_used_by_server = new Set();
 			const assets_used_by_server = new Set();
 
-			const relative_entry_path = relative(process.cwd(), entry_path);
+			const relative_entry_path = normalizePath(relative(process.cwd(), entry_path));
 			entry.stylesheet_map.forEach((value, key) => {
 				if (key === relative_entry_path) {
 					// map the client node index to the server component source

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -3,7 +3,7 @@ import { mkdirp } from '../../../utils/filesystem.js';
 import { filter_fonts, find_deps, resolve_symlinks } from './utils.js';
 import { s } from '../../../utils/misc.js';
 import { normalizePath } from 'vite';
-import { basename, relative } from 'node:path';
+import { basename } from 'node:path';
 
 /**
  * @param {string} out

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -137,14 +137,6 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 				universal = find_deps(server_manifest, node.universal, true);
 			}
 
-			if (entry.stylesheet_map.size > 0) {
-				console.dir({
-					entry: entry.stylesheet_map,
-					component: component?.stylesheet_map,
-					universal: universal?.stylesheet_map,
-				}, { colors: true, depth: null, maxArrayLength: null });
-			}
-
 			/** @type {Set<string>} */
 			const css_used_by_server = new Set();
 			/** @type {Set<string>} */

--- a/packages/kit/src/exports/vite/build/utils.js
+++ b/packages/kit/src/exports/vite/build/utils.js
@@ -52,7 +52,7 @@ export function find_deps(manifest, entry, add_dynamic_css) {
 
 		if (!add_dynamic_css) return;
 
-		if (dynamic_import_depth <= 1) {
+		if ((chunk.css || chunk.assets) && dynamic_import_depth <= 1) {
 			stylesheet_map.set(current, {
 				css: chunk.css ?? [], assets: chunk.assets ?? []
 			});

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -59,6 +59,7 @@ export interface AssetDependencies {
 	imports: string[];
 	stylesheets: string[];
 	fonts: string[];
+	stylesheet_map: Map<string, { css: string[]; assets: string[] }>;
 }
 
 export interface BuildData {

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -59,7 +59,7 @@ export interface AssetDependencies {
 	imports: string[];
 	stylesheets: string[];
 	fonts: string[];
-	stylesheet_map: Map<string, { css: string[]; assets: string[] }>;
+	stylesheet_map: Map<string, { css: Set<string>; assets: Set<string> }>;
 }
 
 export interface BuildData {

--- a/packages/kit/test/apps/basics/src/routes/css/dynamic/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/css/dynamic/+page.svelte
@@ -1,0 +1,11 @@
+<script>
+	let Dynamic;
+</script>
+
+<button
+	on:click={async () => {
+		Dynamic = (await import('./Dynamic.svelte')).default;
+	}}>load component</button
+>
+
+<svelte:component this={Dynamic}></svelte:component>

--- a/packages/kit/test/apps/basics/src/routes/css/dynamic/Dynamic.svelte
+++ b/packages/kit/test/apps/basics/src/routes/css/dynamic/Dynamic.svelte
@@ -1,0 +1,7 @@
+<p>I'm dynamically imported</p>
+
+<style>
+	p {
+		color: blue;
+	}
+</style>

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -532,6 +532,24 @@ test.describe('CSS', () => {
 
 		expect(await get_computed_style('#svelte-announcer', 'position')).toBe('absolute');
 	});
+
+	test('dynamically imported components lazily load CSS', async ({ page, get_computed_style }) => {
+		const requests = [];
+		page.on('request', (request) => {
+			const url = request.url();
+			if (url.includes('Dynamic') && url.endsWith('.css')) {
+				requests.push(url);
+			}
+		});
+
+		await page.goto('/css/dynamic');
+		expect(requests.length).toBe(0);
+
+		await page.locator('button').click();
+		await expect(page.locator('p')).toHaveText('I\'m dynamically imported');
+		expect(await get_computed_style('p', 'color')).toBe('rgb(0, 0, 255)');
+		expect(requests.length).toBe(1);
+	});
 });
 
 test.describe.serial('Errors', () => {

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -546,7 +546,7 @@ test.describe('CSS', () => {
 		expect(requests.length).toBe(0);
 
 		await page.locator('button').click();
-		await expect(page.locator('p')).toHaveText('I\'m dynamically imported');
+		await expect(page.locator('p')).toHaveText("I'm dynamically imported");
 		expect(await get_computed_style('p', 'color')).toBe('rgb(0, 0, 255)');
 		expect(requests.length).toBe(1);
 	});


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13546

This PR changes server nodes from always loading dynamically imported component's styles and fonts to only loading them if they are used during SSR (to avoid FOUC). This fixes lazy loading of components on the client, only retrieving the styles when needed.

We can tell which deps are used during SSR by analysing the deps of the node with both the server manifest and the client manifest, then comparing the results. If a style or font is missing from the server deps, it's probably only used on the client. Therefore, it should be safe to load lazily.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
