### PR TITLE
Fix FAQ link from jumping to database section

### DIFF
--- a/documentation/docs/60-appendix/20-integrations.md
+++ b/documentation/docs/60-appendix/20-integrations.md
@@ -49,4 +49,4 @@ Since SvelteKit projects are built with Vite, you can use Vite plugins to enhanc
 
 ## Integration FAQs
 
-The SvelteKit FAQ has a [how to do X with SvelteKit](./faq#How-do-I-set-up-a-database), which may be helpful if you still have questions.
+The SvelteKit FAQ has a [how to do X with SvelteKit](./faq), which may be helpful if you still have questions.


### PR DESCRIPTION
On the [SvelteKit Integrations page](https://svelte.dev/docs/kit/integrations#Integration-FAQs), the [link to the FAQ page](https://svelte.dev/docs/kit/faq#How-do-I-set-up-a-database) jumps to the "How do I set up a database?" header. This doesn't seem intentional, as the entire FAQ page is useful, not just the database section.

This PR fixes the link by making it go to the top of the page.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
