### PR TITLE
fix: allow reroute to point to prerendered route 

### DIFF
--- a/.changeset/nine-glasses-build.md
+++ b/.changeset/nine-glasses-build.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow reroute to point to prerendered route

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -2,6 +2,7 @@ import * as set_cookie_parser from 'set-cookie-parser';
 import { respond } from './respond.js';
 import * as paths from '__sveltekit/paths';
 import { read_implementation } from '__sveltekit/server';
+import { has_prerendered_path } from './utils.js';
 
 /**
  * @param {{
@@ -112,10 +113,7 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 					return await fetch(request);
 				}
 
-				if (
-					manifest._.prerendered_routes.has(decoded) ||
-					(decoded.at(-1) === '/' && manifest._.prerendered_routes.has(decoded.slice(0, -1)))
-				) {
+				if (has_prerendered_path(manifest, paths.base + decoded)) {
 					// The path of something prerendered could match a different route
 					// that is still in the manifest, leading to the wrong route being loaded.
 					// We therefore bail early here. The prerendered logic is different for

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -5,7 +5,12 @@ import { render_page } from './page/index.js';
 import { render_response } from './page/render.js';
 import { respond_with_error } from './page/respond_with_error.js';
 import { is_form_content_type } from '../../utils/http.js';
-import { handle_fatal_error, method_not_allowed, redirect_response } from './utils.js';
+import {
+	handle_fatal_error,
+	has_prerendered_path,
+	method_not_allowed,
+	redirect_response
+} from './utils.js';
 import { decode_pathname, decode_params, disable_search, normalize_path } from '../../utils/url.js';
 import { exec } from '../../utils/routing.js';
 import { redirect_json_response, render_data } from './data/index.js';
@@ -21,6 +26,8 @@ import { get_public_env } from './env_module.js';
 import { resolve_route } from './page/server_routing.js';
 import { validateHeaders } from './validate-headers.js';
 import {
+	add_data_suffix,
+	add_resolution_suffix,
 	has_data_suffix,
 	has_resolution_suffix,
 	strip_data_suffix,
@@ -189,6 +196,34 @@ export async function respond(request, options, manifest, state) {
 		resolved_path = decode_pathname(resolved_path);
 	} catch {
 		return text('Malformed URI', { status: 400 });
+	}
+
+	if (
+		resolved_path !== url.pathname &&
+		!state.prerendering?.fallback &&
+		has_prerendered_path(manifest, resolved_path)
+	) {
+		const url = new URL(request.url);
+		url.pathname = is_data_request
+			? add_data_suffix(resolved_path)
+			: is_route_resolution_request
+				? add_resolution_suffix(resolved_path)
+				: resolved_path;
+
+		// `fetch` automatically decodes the body, so we need to delete the related headers to not break the response
+		// Also see https://github.com/sveltejs/kit/issues/12197 for more info (we should fix this more generally at some point)
+		const response = await fetch(url, request);
+		const headers = new Headers(response.headers);
+		if (headers.has('content-encoding')) {
+			headers.delete('content-encoding');
+			headers.delete('content-length');
+		}
+
+		return new Response(response.body, {
+			headers,
+			status: response.status,
+			statusText: response.statusText
+		});
 	}
 
 	/** @type {import('types').SSRRoute | null} */

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -163,3 +163,15 @@ export function stringify_uses(node) {
 
 	return `"uses":{${uses.join(',')}}`;
 }
+
+/**
+ * Returns `true` if the given path was prerendered
+ * @param {import('@sveltejs/kit').SSRManifest} manifest
+ * @param {string} pathname Should include the base and be decoded
+ */
+export function has_prerendered_path(manifest, pathname) {
+	return (
+		manifest._.prerendered_routes.has(pathname) ||
+		(pathname.at(-1) === '/' && manifest._.prerendered_routes.has(pathname.slice(0, -1)))
+	);
+}

--- a/packages/kit/test/apps/basics/src/hooks.js
+++ b/packages/kit/test/apps/basics/src/hooks.js
@@ -31,6 +31,10 @@ export const reroute = ({ url, fetch }) => {
 		return fetch('/reroute/api').then((r) => r.text());
 	}
 
+	if (url.pathname === '/reroute/prerendered/to-destination') {
+		return '/reroute/prerendered/destination';
+	}
+
 	if (url.pathname in mapping) {
 		return mapping[url.pathname];
 	}

--- a/packages/kit/test/apps/basics/src/routes/reroute/prerendered/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/reroute/prerendered/+page.svelte
@@ -1,0 +1,1 @@
+<a href="/reroute/prerendered/to-destination">to prerendered page</a>

--- a/packages/kit/test/apps/basics/src/routes/reroute/prerendered/destination/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/reroute/prerendered/destination/+page.svelte
@@ -1,0 +1,1 @@
+<h1>reroute that points to prerendered page works</h1>

--- a/packages/kit/test/apps/basics/src/routes/reroute/prerendered/destination/+page.ts
+++ b/packages/kit/test/apps/basics/src/routes/reroute/prerendered/destination/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1461,6 +1461,12 @@ test.describe('reroute', () => {
 		);
 	});
 
+	test('Apply reroute to prerendered page during client side navigation', async ({ page }) => {
+		await page.goto('/reroute/prerendered');
+		await page.click("a[href='/reroute/prerendered/to-destination']");
+		expect(await page.textContent('h1')).toContain('reroute that points to prerendered page works');
+	});
+
 	test('Apply reroute after client-only redirects', async ({ page }) => {
 		await page.goto('/reroute/client-only-redirect');
 		expect(await page.textContent('h1')).toContain('Successfully rewritten');

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -683,6 +683,11 @@ test.describe('reroute', () => {
 		);
 	});
 
+	test('Apply reroute to prerendered page when directly accessing a page', async ({ page }) => {
+		await page.goto('/reroute/prerendered/to-destination');
+		expect(await page.textContent('h1')).toContain('reroute that points to prerendered page works');
+	});
+
 	test('Returns a 500 response if reroute throws an error on the server', async ({ page }) => {
 		const response = await page.goto('/reroute/error-handling/server-error');
 		expect(response?.status()).toBe(500);


### PR DESCRIPTION
When rerouting to a path that is a prerendered page, the runtime would previously return a 404, because said path does not point to a route in the manifest. This adds a check for this specifically to do a fetch to the prerendered page in that case.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
