### PR TITLE
fix: only call `afterNavigate` once on start when SSR is disabled

### DIFF
--- a/.changeset/angry-ravens-eat.md
+++ b/.changeset/angry-ravens-eat.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: only call `afterNavigate` once on app start when SSR is disabled

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1025,7 +1025,7 @@ export interface NavigationTarget {
 }
 
 /**
- * - `enter`: The app has hydrated
+ * - `enter`: The app has hydrated/started
  * - `form`: The user submitted a `<form>` with a GET method
  * - `leave`: The user is leaving the app by closing the tab or using the back/forward buttons to go to a different document
  * - `link`: Navigation was triggered by a link click
@@ -1101,7 +1101,7 @@ export interface OnNavigate extends Navigation {
 export interface AfterNavigate extends Omit<Navigation, 'type'> {
 	/**
 	 * The type of navigation:
-	 * - `enter`: The app has hydrated
+	 * - `enter`: The app has hydrated/started
 	 * - `form`: The user submitted a `<form>`
 	 * - `link`: Navigation was triggered by a link click
 	 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect

--- a/packages/kit/test/apps/basics/src/routes/no-ssr/after-navigate/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/no-ssr/after-navigate/+page.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { afterNavigate } from '$app/navigation';
+
+	let count = 0;
+  let type = '';
+
+	afterNavigate((event) => {
+		count += 1;
+    type = event.type;
+	});
+</script>
+
+<p>{type.toString()} {count}</p>

--- a/packages/kit/test/apps/basics/src/routes/no-ssr/after-navigate/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/no-ssr/after-navigate/+page.svelte
@@ -2,11 +2,11 @@
 	import { afterNavigate } from '$app/navigation';
 
 	let count = 0;
-  let type = '';
+	let type = '';
 
 	afterNavigate((event) => {
 		count += 1;
-    type = event.type;
+		type = event.type;
 	});
 </script>
 

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -335,8 +335,8 @@ test.describe('Load', () => {
 	}
 });
 
-test.describe('Page options', () => {
-	test('applies generated component styles with ssr=false (hides announcer)', async ({
+test.describe('SPA mode / no SSR', () => {
+	test('applies generated component styles (hides announcer)', async ({
 		page,
 		clicknav,
 		get_computed_style
@@ -346,9 +346,7 @@ test.describe('Page options', () => {
 
 		expect(await get_computed_style('#svelte-announcer', 'position')).toBe('absolute');
 	});
-});
 
-test.describe('SPA mode / no SSR', () => {
 	test('Can use browser-only global on client-only page through ssr config in handle', async ({
 		page,
 		read_errors
@@ -358,7 +356,7 @@ test.describe('SPA mode / no SSR', () => {
 		expect(read_errors('/no-ssr/browser-only-global')).toBe(undefined);
 	});
 
-	test('Can use browser-only global on client-only page through ssr config in +layout.js', async ({
+	test('can use browser-only global on client-only page through ssr config in +layout.js', async ({
 		page,
 		read_errors
 	}) => {
@@ -367,7 +365,7 @@ test.describe('SPA mode / no SSR', () => {
 		expect(read_errors('/no-ssr/ssr-page-config')).toBe(undefined);
 	});
 
-	test('Can use browser-only global on client-only page through ssr config in +page.js', async ({
+	test('can use browser-only global on client-only page through ssr config in +page.js', async ({
 		page,
 		read_errors
 	}) => {
@@ -376,13 +374,18 @@ test.describe('SPA mode / no SSR', () => {
 		expect(read_errors('/no-ssr/ssr-page-config/layout/inherit')).toBe(undefined);
 	});
 
-	test('Cannot use browser-only global on page because of ssr config in +page.js', async ({
+	test('cannot use browser-only global on page because of ssr config in +page.js', async ({
 		page
 	}) => {
 		await page.goto('/no-ssr/ssr-page-config/layout/overwrite');
 		await expect(page.locator('p')).toHaveText(
 			'This is your custom error page saying: "document is not defined (500 Internal Error)"'
 		);
+	});
+
+	test('afterNavigate is only called once during start', async ({ page }) => {
+		await page.goto('/no-ssr/after-navigate');
+		await expect(page.locator('p')).toHaveText('enter 1');
 	});
 });
 

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -257,7 +257,10 @@ test.describe('Navigation lifecycle functions', () => {
 		);
 	});
 
-	test('afterNavigate properly removed', async ({ page, clicknav }) => {
+	test('onNavigate returned function is only called once', async ({
+		page,
+		clicknav
+	}) => {
 		await page.goto('/navigation-lifecycle/after-navigate-properly-removed/b');
 		await clicknav('[href="/navigation-lifecycle/after-navigate-properly-removed/a"]');
 		await clicknav('[href="/navigation-lifecycle/after-navigate-properly-removed/b"]');

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -257,10 +257,7 @@ test.describe('Navigation lifecycle functions', () => {
 		);
 	});
 
-	test('onNavigate returned function is only called once', async ({
-		page,
-		clicknav
-	}) => {
+	test('onNavigate returned function is only called once', async ({ page, clicknav }) => {
 		await page.goto('/navigation-lifecycle/after-navigate-properly-removed/b');
 		await clicknav('[href="/navigation-lifecycle/after-navigate-properly-removed/a"]');
 		await clicknav('[href="/navigation-lifecycle/after-navigate-properly-removed/b"]');

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1007,7 +1007,7 @@ declare module '@sveltejs/kit' {
 	}
 
 	/**
-	 * - `enter`: The app has hydrated
+	 * - `enter`: The app has hydrated/started
 	 * - `form`: The user submitted a `<form>` with a GET method
 	 * - `leave`: The user is leaving the app by closing the tab or using the back/forward buttons to go to a different document
 	 * - `link`: Navigation was triggered by a link click
@@ -1083,7 +1083,7 @@ declare module '@sveltejs/kit' {
 	export interface AfterNavigate extends Omit<Navigation, 'type'> {
 		/**
 		 * The type of navigation:
-		 * - `enter`: The app has hydrated
+		 * - `enter`: The app has hydrated/started
 		 * - `form`: The user submitted a `<form>`
 		 * - `link`: Navigation was triggered by a link click
 		 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13573

This PR changes the unexpected behaviour of `afterNavigate` being called twice when SSR is disabled to only once (same as when SSR is enabled). It was being called twice: once with type 'enter' and again with type 'goto' because we initialised the app and used `goto` under the hood to render the page client-side. Now, it should only be called once with type 'enter'. This also adjusts the docs to state that a navigation with type 'enter' is when the app starts and not just when it's hydrated.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
