### PR TITLE
chore: workaround typescript issue

### DIFF
--- a/packages/kit/tsconfig.json
+++ b/packages/kit/tsconfig.json
@@ -5,7 +5,7 @@
 		"noEmit": true,
 		"strict": true,
 		"target": "es2022",
-		"module": "node16",
+		"module": "nodenext",
 		"moduleResolution": "node16",
 		"allowSyntheticDefaultImports": true,
 		"paths": {


### PR DESCRIPTION
I'm getting some errors:
    * packages/kit/test/apps/options/source/pages/inline-assets/+page.server.js#L4C7:7: A parse error occurred: `Unexpected token`.
    * packages/kit/src/runtime/client/client.js#L1675C8:8: A parse error occurred: `Unexpected token`. Check the syntax of the file.

I don't think this is the ideal fix, but is probably the best we can do for now. I filed an issue in the TypeScript repo: https://github.com/microsoft/TypeScript/issues/61441