### PR TITLE
fix: avoid using top-level await

### DIFF
--- a/.changeset/nervous-islands-shave.md
+++ b/.changeset/nervous-islands-shave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: avoid using top-level await

--- a/packages/kit/src/runtime/app/server/event.js
+++ b/packages/kit/src/runtime/app/server/event.js
@@ -6,14 +6,13 @@ let request_event = null;
 /** @type {import('node:async_hooks').AsyncLocalStorage<RequestEvent | null>} */
 let als;
 
-try {
-	const hooks = await import('node:async_hooks');
-	als = new hooks.AsyncLocalStorage();
-} catch {
-	// can't use AsyncLocalStorage, but can still call getRequestEvent synchronously.
-	// this isn't behind `supports` because it's basically just StackBlitz (i.e.
-	// in-browser usage) that doesn't support it AFAICT
-}
+import('node:async_hooks')
+	.then((hooks) => (als = new hooks.AsyncLocalStorage()))
+	.catch(() => {
+		// can't use AsyncLocalStorage, but can still call getRequestEvent synchronously.
+		// this isn't behind `supports` because it's basically just StackBlitz (i.e.
+		// in-browser usage) that doesn't support it AFAICT
+	});
 
 /**
  * Returns the current `RequestEvent`. Can be used inside `handle`, `load` and actions (and functions called by them).


### PR DESCRIPTION
This avoid using a top-level await in the code introduced for `getRequestEvent()`, which was causing issues like #13598. Avoiding TLA sounds like a better solution than potentially changing transpilation targets everywhere.

Even though in dev this module will be lazily loaded when the first network request comes in, I _think_ we might be safe, because during synchronous calls to `getRequestEvent()`, we don't actually need `AsyncLocalStorage` yet.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
