### PR TITLE
write server to _worker.js directory

### DIFF
--- a/.changeset/shy-knives-matter.md
+++ b/.changeset/shy-knives-matter.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+fix: write server files to the cloudflare build directory


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13300

This PR changes the written `_worker.js` file to a directory, allowing us to include the server files in the `.svelte-kit/cloudflare` build output without making them public. It was not possible to include the server files before because all the files in the build output are made public, but there is an [undocumented feature](https://github.com/cloudflare/workers-sdk/blob/b487415473b7a12830323003d5ae867441d41df5/packages/wrangler/src/api/pages/deploy.ts#L312-L319) in Wrangler that allows us to store all server files in a `_worker.js/` directory to be bundled. The result is that all build artefacts are once again stored in a single directory instead of linking server files relatively to the Vite output folder.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
