### PR TITLE
fix: revert writing server files to the cloudflare build directory

### DIFF
--- a/.changeset/silent-tables-raise.md
+++ b/.changeset/silent-tables-raise.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+fix: revert writing server files to the cloudflare build directory


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13621

This PR reverts the changes made in https://github.com/sveltejs/kit/pull/13610 which causes the server-side dependencies to not be resolved correctly by Wrangler when it bundles the server files. In the first place, writing the server files to the build output wasn't useful since the dependencies aren't there too.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
