### PR TITLE
chore: move `esbuild` to a devDependency

### DIFF
--- a/.changeset/eleven-ears-hide.md
+++ b/.changeset/eleven-ears-hide.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+chore: move `esbuild` to devDependencies

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -41,13 +41,12 @@
 	},
 	"dependencies": {
 		"@cloudflare/workers-types": "^4.20250312.0",
-		"esbuild": "^0.24.0",
 		"worktop": "0.8.0-next.18"
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",
 		"@types/node": "^18.19.48",
-		"@types/ws": "^8.5.10",
+		"esbuild": "^0.24.0",
 		"typescript": "^5.3.3"
 	},
 	"peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,9 +60,6 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20250312.0
         version: 4.20250312.0
-      esbuild:
-        specifier: ^0.24.0
-        version: 0.24.2
       worktop:
         specifier: 0.8.0-next.18
         version: 0.8.0-next.18
@@ -76,9 +73,9 @@ importers:
       '@types/node':
         specifier: ^18.19.48
         version: 18.19.50
-      '@types/ws':
-        specifier: ^8.5.10
-        version: 8.5.10
+      esbuild:
+        specifier: ^0.24.0
+        version: 0.24.2
       typescript:
         specifier: ^5.3.3
         version: 5.6.3
@@ -1887,9 +1884,6 @@ packages:
 
   '@types/set-cookie-parser@2.4.7':
     resolution: {integrity: sha512-+ge/loa0oTozxip6zmhRIk8Z/boU51wl9Q6QdLZcokIGMzY5lFXYy/x7Htj2HTC6/KZP1hUbZ1ekx8DYXICvWg==}
-
-  '@types/ws@8.5.10':
-    resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
 
   '@typescript-eslint/eslint-plugin@8.26.0':
     resolution: {integrity: sha512-cLr1J6pe56zjKYajK6SSSre6nl1Gj6xDp1TY0trpgPzjVbgDwd09v2Ws37LABxzkicmUjhEeg/fAUjPJJB1v5Q==}
@@ -4196,10 +4190,6 @@ snapshots:
   '@types/semver@7.5.8': {}
 
   '@types/set-cookie-parser@2.4.7':
-    dependencies:
-      '@types/node': 18.19.50
-
-  '@types/ws@8.5.10':
     dependencies:
       '@types/node': 18.19.50
 


### PR DESCRIPTION
splitting up some of the changes in https://github.com/sveltejs/kit/pull/13427 into separate PRs

This PR moves `esbuild` to a dev dep since we no longer use it during build to bundle the server into a single worker file, we only use it to bundle `worktop` into the worker before we publish the package. This also removes the `@types/ws` from the dev deps since it's not in use and may have been [added accidentally?](https://github.com/sveltejs/kit/pull/4468/files#diff-1ac6ebb9247195e0dfa0f18975077643b0e0743c80cd8588b0084f5252cecec0R35)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
