### PR TITLE
feat: expose matched route

### DIFF
--- a/packages/adapter-vercel/files/serverless.js
+++ b/packages/adapter-vercel/files/serverless.js
@@ -36,6 +36,12 @@ export default async (req, res) => {
 
 	const request = await getRequest({ base: `https://${req.headers.host}`, request: req });
 
+	const route_id = request.headers.get('x-sveltekit-matched-route');
+
+	if (route_id) {
+		res.setHeader('x-matched-route', route_id);
+	}
+
 	setResponse(
 		res,
 		await server.respond(request, {

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -272,6 +272,7 @@ export async function respond(request, options, manifest, state) {
 				route = candidate;
 				event.route = { id: route.id };
 				event.params = decode_params(matched);
+				headers['x-sveltekit-matched-route'] = route.id;
 				break;
 			}
 		}


### PR DESCRIPTION
This is impromptu hackathon output and shouldn't be merged in its current state — it's here for mostly illustrative purposes.

For apps deployed to Vercel (and many other platforms) a SvelteKit app typically gets bundled into a single serverless function. For observability this is suboptimal since you can't group logs by route, only by path. We can fix this by exposing the matched route from SvelteKit (via a header like `x-sveltekit-matched-route`), and then forwarding that to the deployment platform (theoretically on Vercel via something like `x-matched-route`, though this isn't currently implemented on the Vercel side.

cc @tobiaslins

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
