### PR TITLE
chore: upgrade `@sveltejs/adapter-cloudflare` to version 7

### DIFF
--- a/.changeset/curvy-dodos-clean.md
+++ b/.changeset/curvy-dodos-clean.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/adapter-auto": major
+---
+
+feat: upgrade `@sveltejs/adapter-cloudflare` to version 7

--- a/packages/adapter-auto/adapters.js
+++ b/packages/adapter-auto/adapters.js
@@ -13,7 +13,7 @@ export const adapters = [
 		name: 'Cloudflare Pages',
 		test: () => !!process.env.CF_PAGES,
 		module: '@sveltejs/adapter-cloudflare',
-		version: '6'
+		version: '7'
 	},
 	{
 		name: 'Netlify',


### PR DESCRIPTION
made this a major as it's a breaking change for people deploying to cloudflare and matches what we've done in the past: https://github.com/sveltejs/kit/blob/main/packages/adapter-auto/CHANGELOG.md
