### PR TITLE
chore: tweak tsconfig includes

### DIFF
--- a/packages/kit/test/build-errors/tsconfig.json
+++ b/packages/kit/test/build-errors/tsconfig.json
@@ -9,5 +9,5 @@
 		"moduleResolution": "node",
 		"allowSyntheticDefaultImports": true
 	},
-	"include": ["./*", "./mocks/**/*", "./prerendering/*"]
+	"include": ["./*"]
 }

--- a/packages/kit/test/tsconfig.json
+++ b/packages/kit/test/tsconfig.json
@@ -8,5 +8,6 @@
 		"module": "esnext",
 		"moduleResolution": "node",
 		"allowSyntheticDefaultImports": true
-	}
+	},
+	"include": ["./*"]
 }

--- a/packages/kit/tsconfig.json
+++ b/packages/kit/tsconfig.json
@@ -17,6 +17,6 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true
 	},
-	"include": ["*.js", "scripts/**/*", "src/**/*", "src/types/**/*"],
+	"include": ["*.js", "scripts/**/*", "src/**/*"],
 	"exclude": ["./**/write_types/test/**"]
 }


### PR DESCRIPTION
this should hopefully make the editor experience more stable, as the chance of the world being loaded in is minimized. Previously (I think) the import of the general utils file from any of the project's test files meant that as soon as you open _one_ test project, _all_ the test projects at once were loaded into memory, including stuff from `.svelte-kit`, because the general test config didn't have an include config. Also removes an unnecessary duplicate from the kit root tsconfig
