### PR TITLE
chore: get rid of class-replacement hack

### DIFF
--- a/.changeset/olive-mugs-search.md
+++ b/.changeset/olive-mugs-search.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: replace internal class-replacement hack with package imports map

--- a/.changeset/olive-mugs-search.md
+++ b/.changeset/olive-mugs-search.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-chore: replace internal class-replacement hack with package imports map
+chore: remove internal class-replacement hack that isn't needed anymore

--- a/packages/kit/src/runtime/control.js
+++ b/packages/kit/src/runtime/control.js
@@ -61,27 +61,3 @@ export class ActionFailure {
 		this.data = data;
 	}
 }
-
-/**
- * This is a grotesque hack that, in dev, allows us to replace the implementations
- * of these classes that you'd get by importing them from `@sveltejs/kit` with the
- * ones that are imported via Vite and loaded internally, so that instanceof
- * checks work even though SvelteKit imports this module via Vite and consumers
- * import it via Node
- * @param {{
- *   ActionFailure: typeof ActionFailure;
- *   HttpError: typeof HttpError;
- *   Redirect: typeof Redirect;
- *   SvelteKitError: typeof SvelteKitError;
- * }} implementations
- */
-export function replace_implementations(implementations) {
-	// @ts-expect-error
-	ActionFailure = implementations.ActionFailure; // eslint-disable-line no-class-assign
-	// @ts-expect-error
-	HttpError = implementations.HttpError; // eslint-disable-line no-class-assign
-	// @ts-expect-error
-	Redirect = implementations.Redirect; // eslint-disable-line no-class-assign
-	// @ts-expect-error
-	SvelteKitError = implementations.SvelteKitError; // eslint-disable-line no-class-assign
-}


### PR DESCRIPTION
We previously used a grotesque hack that would ensure the `HttpError` etc classes would be the same between what Vite imports via its transformation toolchain and what you get from a regular node import.

Turns out we don't need that anymore - since #9242 SvelteKit is guaranteed to always be loaded through the Vite toolchain.

This investigation was triggered by https://github.com/vitest-dev/vitest/pull/7783 - removing this might alleviate the pressure on Vitest, though we still do some `vite.ssrLoadModule` suspicously close to the `configureServer` hook, so we'll see.

> At first thought we can leverage the imports map of the `package.json` instead. Through that, Vite would (hopefully?) not load these into its own toolchain, instead defer to the regular node loader to get the module. But then I realized it changed nothing, which lead me to discover this even simpler solution
