### PR TITLE
fix: allow `HandleServerError` hook to access the ` getRequestEvent`

### DIFF
--- a/.changeset/ninety-planets-remember.md
+++ b/.changeset/ninety-planets-remember.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+allow `HandleServerError` hook to access `getRequestEvent`

--- a/packages/kit/src/runtime/app/server/event.js
+++ b/packages/kit/src/runtime/app/server/event.js
@@ -15,7 +15,7 @@ import('node:async_hooks')
 	});
 
 /**
- * Returns the current `RequestEvent`. Can be used inside `handle`, `handleError`, `load` and actions (and functions called by them).
+ * Returns the current `RequestEvent`. Can be used inside server hooks, server `load` functions, actions, and endpoints (and functions called by them).
  *
  * In environments without [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage), this must be called synchronously (i.e. not after an `await`).
  * @since 2.20.0

--- a/packages/kit/src/runtime/app/server/event.js
+++ b/packages/kit/src/runtime/app/server/event.js
@@ -25,7 +25,7 @@ export function getRequestEvent() {
 
 	if (!event) {
 		let message =
-			'Can only read the current request event inside functions invoked during `handle`, such as server `load` functions, actions, and server endpoints, and `handleError`.';
+			'Can only read the current request event inside functions invoked during `handle`, such as server `load` functions, actions, endpoints, and other server hooks.';
 
 		if (!als) {
 			message +=

--- a/packages/kit/src/runtime/app/server/event.js
+++ b/packages/kit/src/runtime/app/server/event.js
@@ -15,7 +15,7 @@ import('node:async_hooks')
 	});
 
 /**
- * Returns the current `RequestEvent`. Can be used inside `handle`, `load` and actions (and functions called by them).
+ * Returns the current `RequestEvent`. Can be used inside `handle`, `handleError`, `load` and actions (and functions called by them).
  *
  * In environments without [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage), this must be called synchronously (i.e. not after an `await`).
  * @since 2.20.0
@@ -25,7 +25,7 @@ export function getRequestEvent() {
 
 	if (!event) {
 		let message =
-			'Can only read the current request event inside functions invoked during `handle`, such as server `load` functions, actions, and server endpoints.';
+			'Can only read the current request event inside functions invoked during `handle`, such as server `load` functions, actions, and server endpoints, and `handleError`.';
 
 		if (!als) {
 			message +=

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -6,6 +6,7 @@ import { HttpError } from '../control.js';
 import { fix_stack_trace } from '../shared-server.js';
 import { ENDPOINT_METHODS } from '../../constants.js';
 import { escape_html } from '../../utils/escape.js';
+import { with_event } from '../app/server/event.js';
 
 /** @param {any} body */
 export function is_pojo(body) {
@@ -107,7 +108,7 @@ export async function handle_error_and_jsonify(event, options, error) {
 	const status = get_status(error);
 	const message = get_message(error);
 
-	return (await options.hooks.handleError({ error, event, status, message })) ?? { message };
+	return (await with_event(event, () => options.hooks.handleError({ error, event, status, message }))) ?? { message };
 }
 
 /**

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -108,7 +108,11 @@ export async function handle_error_and_jsonify(event, options, error) {
 	const status = get_status(error);
 	const message = get_message(error);
 
-	return (await with_event(event, () => options.hooks.handleError({ error, event, status, message }))) ?? { message };
+	return (
+		(await with_event(event, () =>
+			options.hooks.handleError({ error, event, status, message })
+		)) ?? { message }
+	);
 }
 
 /**

--- a/packages/kit/test/apps/basics/src/hooks.server.js
+++ b/packages/kit/test/apps/basics/src/hooks.server.js
@@ -38,6 +38,11 @@ export const handleError = ({ event, error: e, status, message }) => {
 	errors[event.url.pathname] = error_to_pojo(error);
 	fs.writeFileSync('test/errors.json', JSON.stringify(errors));
 
+	if (event.url.pathname.startsWith('/get-request-event/')) {
+		const ev = getRequestEvent();
+		message = ev.locals.message;
+	}
+
 	return event.url.pathname.endsWith('404-fallback')
 		? undefined
 		: { message: `${error.message} (${status} ${message})` };

--- a/packages/kit/test/apps/basics/src/routes/get-request-event/with-error/+error.svelte
+++ b/packages/kit/test/apps/basics/src/routes/get-request-event/with-error/+error.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { page } from '$app/state';
+</script>
+
+<h1>{page.error.message}</h1>

--- a/packages/kit/test/apps/basics/src/routes/get-request-event/with-error/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/get-request-event/with-error/+page.server.js
@@ -1,0 +1,3 @@
+export const load = async () => {
+	throw new Error('Crashing now');
+};

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1544,5 +1544,8 @@ test.describe('getRequestEvent', () => {
 		await page.click('button');
 
 		expect(await page.textContent('h1')).toBe('from form: hello');
+
+		await page.goto('/get-request-event/with-error');
+		expect(await page.textContent('h1')).toBe('Crashing now (500 hello from hooks.server.js)');
 	});
 });

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2417,7 +2417,7 @@ declare module '$app/server' {
 	 */
 	export function read(asset: string): Response;
 	/**
-	 * Returns the current `RequestEvent`. Can be used inside `handle`, `load` and actions (and functions called by them).
+	 * Returns the current `RequestEvent`. Can be used inside `handle`, `handleError`, `load` and actions (and functions called by them).
 	 *
 	 * In environments without [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage), this must be called synchronously (i.e. not after an `await`).
 	 * @since 2.20.0

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2417,7 +2417,7 @@ declare module '$app/server' {
 	 */
 	export function read(asset: string): Response;
 	/**
-	 * Returns the current `RequestEvent`. Can be used inside `handle`, `handleError`, `load` and actions (and functions called by them).
+	 * Returns the current `RequestEvent`. Can be used inside server hooks, server `load` functions, actions, and endpoints (and functions called by them).
 	 *
 	 * In environments without [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage), this must be called synchronously (i.e. not after an `await`).
 	 * @since 2.20.0


### PR DESCRIPTION
Resolves #13654: Allow `HandleServerError` hook to access `getRequestEvent`.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
