### PR TITLE
fix: correctly resolve paths provided through Wrangler config on Windows

### DIFF
--- a/.changeset/bright-houses-kick.md
+++ b/.changeset/bright-houses-kick.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+fix: correctly write the worker to the `pages_build_output_dir` path if set in the Wrangler configuration path

--- a/.changeset/gentle-parrots-clap.md
+++ b/.changeset/gentle-parrots-clap.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-cloudflare': patch
 ---
 
-fix: correctly resolve Wrangler config paths on Windows
+fix: correctly resolve paths provided by the Wrangler config on Windows

--- a/.changeset/gentle-parrots-clap.md
+++ b/.changeset/gentle-parrots-clap.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+fix: correctly resolve Wrangler config paths on Windows

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -37,6 +37,7 @@ export default function (options = {}) {
 			if (building_for_cloudflare_pages) {
 				if (wrangler_config.pages_build_output_dir) {
 					dest = wrangler_config.pages_build_output_dir;
+					worker_dest = `${dest}/_worker.js`;
 				}
 			} else {
 				if (wrangler_config.main) {

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -92,8 +92,11 @@ export default function (options = {}) {
 			);
 			builder.copy(`${files}/worker.js`, worker_dest, {
 				replace: {
-					SERVER: `${path.posix.relative(worker_dest_dir, builder.getServerDirectory())}/index.js`,
-					MANIFEST: `${path.posix.relative(worker_dest_dir, tmp)}/manifest.js`,
+					// the paths returned by the Wrangler config might be Windows paths,
+					// so we need to convert them to POSIX paths or else the backslashes
+					// will be interpreted as escape characters and create an incorrect import path
+					SERVER: `${posixify(path.relative(worker_dest_dir, builder.getServerDirectory()))}/index.js`,
+					MANIFEST: `${posixify(path.relative(worker_dest_dir, tmp))}/manifest.js`,
 					ASSETS: assets_binding
 				}
 			});
@@ -308,4 +311,9 @@ function is_building_for_cloudflare_pages(wrangler_config) {
 		!wrangler_config.main ||
 		!wrangler_config.assets
 	);
+}
+
+/** @param {string} str */
+function posixify(str) {
+	return str.replace(/\\/g, '/');
 }


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13667

This PR uses the non-posix `relative()` method so that it correctly resolves when used with Windows paths that may be provided through the Wrangler configuration. It also converts the path to a POSIX path before embedding them into the worker script since backslashes get interpreted as escape characters and are lost in the process.

Also includes a minor fix where if the user had `pages_build_output_dir` set in their wrangler configuration, the adapter wasn't writing the worker to that directory (Cloudflare Pages expects the worker and assets to be in the same directory).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
