### PR TITLE
Statically analyse exports v2

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -18,7 +18,9 @@
 	"homepage": "https://svelte.dev",
 	"type": "module",
 	"dependencies": {
+		"@sveltejs/acorn-typescript": "^1.0.5",
 		"@types/cookie": "^0.6.0",
+		"acorn": "^8.14.1",
 		"cookie": "^0.6.0",
 		"devalue": "^5.1.0",
 		"esm-env": "^1.2.2",

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -101,6 +101,7 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 		}
 
 		if (node.universal) {
+			// TODO: avoid loading the module if ssr is false
 			imports.push(
 				`import * as universal from '../${
 					resolve_symlinks(server_manifest, node.universal).chunk.file

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -101,13 +101,17 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 		}
 
 		if (node.universal) {
-			// TODO: avoid loading the module if ssr is false
-			imports.push(
-				`import * as universal from '../${
-					resolve_symlinks(server_manifest, node.universal).chunk.file
-				}';`
-			);
-			exports.push('export { universal };');
+			if (node.universal_static_exports?.ssr === false) {
+				const universal_exports = Object.entries(node.universal_static_exports).map(([name, value]) => `${name}: ${s(value)}`);
+				exports.push(`export const universal = { ${universal_exports} };`);
+			} else {
+				imports.push(
+					`import * as universal from '../${
+						resolve_symlinks(server_manifest, node.universal).chunk.file
+					}';`
+				);
+				exports.push('export { universal };');
+			}
 			exports.push(`export const universal_id = ${s(node.universal)};`);
 		}
 

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -202,6 +202,7 @@ export async function dev(vite, vite_config, svelte_config) {
 						}
 
 						if (node.universal) {
+							// TODO: avoid loading the module if ssr is false
 							const { module, module_node } = await resolve(node.universal);
 							module_nodes.push(module_node);
 							result.universal = module;

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -288,7 +288,7 @@ export async function respond(request, options, manifest, state) {
 	let trailing_slash = 'never';
 
 	try {
-		/** @type {PageNodes|undefined} */
+		/** @type {PageNodes | undefined} */
 		const page_nodes = route?.page
 			? new PageNodes(await load_page_nodes(route.page, manifest))
 			: undefined;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -409,6 +409,12 @@ export interface SSRNode {
 	universal?: UniversalNode;
 	/** +page.server.js, +layout.server.js, or +server.js */
 	server?: ServerNode;
+	statically_analysed_option?: {
+		ssr?: boolean;
+		csr?: boolean;
+		prerender?: boolean;
+		trailingSlash?: TrailingSlash;
+	};
 }
 
 export type SSRNodeLoader = () => Promise<SSRNode>;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -199,6 +199,8 @@ export interface PageNode {
 	component?: string; // TODO supply default component if it's missing (bit of an edge case)
 	/** The `+page/layout.js/.ts`. */
 	universal?: string;
+	/** The `+page/layout.js/.ts` exports we could analyze statically, and their values */
+	universal_static_exports?: Omit<UniversalNode, 'load' | 'entries'> & Record<string, any>;
 	/** The `+page/layout.server.js/ts`. */
 	server?: string;
 	parent_id?: string;

--- a/packages/kit/src/utils/page_nodes.js
+++ b/packages/kit/src/utils/page_nodes.js
@@ -27,6 +27,7 @@ export class PageNodes {
 		for (const layout of this.layouts()) {
 			if (layout) {
 				validate_layout_server_exports(layout.server, /** @type {string} */ (layout.server_id));
+				// TODO: validate exports without loading the module?
 				validate_layout_exports(layout.universal, /** @type {string} */ (layout.universal_id));
 			}
 		}
@@ -34,6 +35,7 @@ export class PageNodes {
 		const page = this.page();
 		if (page) {
 			validate_page_server_exports(page.server, /** @type {string} */ (page.server_id));
+			// TODO: validate exports without loading the module?
 			validate_page_exports(page.universal, /** @type {string} */ (page.universal_id));
 		}
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,9 +336,15 @@ importers:
 
   packages/kit:
     dependencies:
+      '@sveltejs/acorn-typescript':
+        specifier: ^1.0.5
+        version: 1.0.5(acorn@8.14.1)
       '@types/cookie':
         specifier: ^0.6.0
         version: 0.6.0
+      acorn:
+        specifier: ^8.14.1
+        version: 8.14.1
       cookie:
         specifier: ^0.6.0
         version: 0.6.0


### PR DESCRIPTION
WIP alternative to #13669, with a few differences
- static analysis happens as part of the transform hook. That means we don't need acorn/acorn-ts. It's a tiny bit more hacky that way though since we mutate the manifest after its creation. If we wanna be pure we do the analysis as part of generating the manifest, and then we would need acorn/acorn-ts. I also didn't find a good way yet to influence the dev manifest (probably more hacky mutation needed there)
- static analysis is all-or-nothing: if one of the exports cannot be statically analysed, the whole thing returns `null` and as such the whole thing falls back to dynamic loading. With this we can avoid the proxy and avoid making all export values be promises, which in turn means less code paths are touched

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
