### PR TITLE
Improved Vercel build output for Observability improvements

### DIFF
--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -373,7 +373,8 @@ const plugin = function (defaults = {}) {
 				} else if (!singular) {
 					static_config.routes.push({ src: src + '(?:/__data.json)?$', dest: `/${name}` });
 				} else {
-					// Create a symlink for each route to the main function
+					// Create a symlink for each route to the main function for better observability
+					// (without this, every request appears to go through `/fn` or `fn-{n}`)
 
 					// Use 'index' for the root route's filesystem representation
 					// Use an empty string ('') for the root route's destination name part in Vercel config

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -370,8 +370,6 @@ const plugin = function (defaults = {}) {
 						src: src + '/__data.json$',
 						dest: `/${isr_name}/__data.json${q}`
 					});
-				} else if (!singular) {
-					static_config.routes.push({ src: src + '(?:/__data.json)?$', dest: `/${name}` });
 				} else {
 					// Create a symlink for each route to the main function for better observability
 					// (without this, every request appears to go through `/fn` or `fn-{n}`)

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -394,14 +394,8 @@ const plugin = function (defaults = {}) {
 					builder.mkdirp(base_dir);
 
 					// Calculate relative paths FROM the directory containing the symlink TO the target
-					const relative_for_main = path.relative(
-						path.dirname(main_symlink_path),
-						target,
-					);
-					const relative_for_data = path.relative(
-						path.dirname(data_symlink_path),
-						target,
-					); // This is path.relative(base_dir, target)
+					const relative_for_main = path.relative(path.dirname(main_symlink_path), target);
+					const relative_for_data = path.relative(path.dirname(data_symlink_path), target); // This is path.relative(base_dir, target)
 
 					// Create symlinks
 					fs.symlinkSync(relative_for_main, main_symlink_path); // Creates functions/index.func -> fn.func
@@ -410,7 +404,7 @@ const plugin = function (defaults = {}) {
 					// Add route to the config
 					static_config.routes.push({
 						src: src + '(?:/__data.json)?$', // Matches the incoming request path
-						dest: `/${route_dest_name}`, // Maps to the function: '/' for root, '/about' for about, etc.
+						dest: `/${route_dest_name}` // Maps to the function: '/' for root, '/about' for about, etc.
 						// Vercel uses this dest to find the corresponding .func dir/symlink
 					});
 				}

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -377,9 +377,9 @@ const plugin = function (defaults = {}) {
 
 					// Use 'index' for the root route's filesystem representation
 					// Use an empty string ('') for the root route's destination name part in Vercel config
-					const isRoot = route.id === '/';
-					const route_fs_name = isRoot ? 'index' : route.id.slice(1);
-					const route_dest_name = isRoot ? '' : route.id.slice(1);
+					const is_root = route.id === '/';
+					const route_fs_name = is_root ? 'index' : route.id.slice(1);
+					const route_dest_name = is_root ? '' : route.id.slice(1);
 
 					// Define paths using path.join for safety
 					const base_dir = path.join(dirs.functions, route_fs_name); // e.g., .vercel/output/functions/index


### PR DESCRIPTION
Extending the build output to mimic the use of multiple functions being deployed. This improved the observability feature on Vercel for sveltekit projects

<img width="1017" alt="image" src="https://github.com/user-attachments/assets/8acd62c2-5137-4196-8a1d-7f44be02a4e3" />



### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
