### PR TITLE
add pkg.pr.new workflows

### DIFF
--- a/.github/workflows/pkg.pr.new-comment.yml
+++ b/.github/workflows/pkg.pr.new-comment.yml
@@ -1,0 +1,108 @@
+name: Update pkg.pr.new comment
+
+on:
+  workflow_run:
+    workflows: ['Publish Any Commit']
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+
+jobs:
+  build:
+    name: 'Update comment'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: output
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - run: ls -R .
+      - name: 'Post or update comment'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const output = JSON.parse(fs.readFileSync('output.json', 'utf8'));
+
+            const bot_comment_identifier = `<!-- pkg.pr.new comment -->`;
+
+            const body = (number) => `${bot_comment_identifier}
+
+            \`\`\`
+            ${output.packages.map((p) => `pnpm add https://pkg.pr.new/${p.name}@${number}`).join('\n')}
+            \`\`\`
+            `;
+
+            async function find_bot_comment(issue_number) {
+              if (!issue_number) return null;
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue_number,
+              });
+              return comments.data.find((comment) =>
+                comment.body.includes(bot_comment_identifier)
+              );
+            }
+
+            async function create_or_update_comment(issue_number) {
+              if (!issue_number) {
+                console.log('No issue number provided. Cannot post or update comment.');
+                return;
+              }
+
+              const existing_comment = await find_bot_comment(issue_number);
+              if (existing_comment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing_comment.id,
+                  body: body(issue_number),
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  issue_number: issue_number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: body(issue_number),
+                });
+              }
+            }
+
+            async function log_publish_info() {
+              console.log('\n' + '='.repeat(50));
+              console.log('Publish Information');
+              console.log('='.repeat(50));
+              console.log('\nPublished Packages:');
+              console.log(output.packages.map((p) => `${p.name} - pnpm add https://pkg.pr.new/${p.name}@${p.url.replace(/^.+@([^@]+)$/, '$1')}`).join('\n'));
+              console.log('\n' + '='.repeat(50));
+            }
+
+            if (output.event_name === 'pull_request') {
+              if (output.number) {
+                await create_or_update_comment(output.number);
+              }
+            } else if (output.event_name === 'push') {
+              const pull_requests = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                head: `${context.repo.owner}:${output.ref.replace('refs/heads/', '')}`,
+              });
+
+              if (pull_requests.data.length > 0) {
+                await create_or_update_comment(pull_requests.data[0].number);
+              } else {
+                console.log(
+                  'No open pull request found for this push. Logging publish information to console:'
+                );
+                await log_publish_info();
+              }
+            }

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -1,0 +1,47 @@
+name: Publish Any Commit
+on: [push, pull_request]
+
+jobs:
+  build:
+    permissions: {}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: install corepack
+        run: npm i -g corepack@0.31.0
+
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - run: pnpx pkg-pr-new publish --comment=off --json output.json --compact --no-template './packages/*'
+      - name: Add metadata to output
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const output = JSON.parse(fs.readFileSync('output.json', 'utf8'));
+            output.number = context.issue.number;
+            output.event_name = context.eventName;
+            output.ref = context.ref;
+            fs.writeFileSync('output.json', JSON.stringify(output), 'utf8');
+      - name: Upload output
+        uses: actions/upload-artifact@v4
+        with:
+          name: output
+          path: ./output.json
+
+      - run: ls -R .


### PR DESCRIPTION
I suspect this might publish all packages on every push, which probably isn't what we want (it should just publish the packages that have actually changed). Not entirely sure how best to make that happen but we can iterate on it