### PR TITLE
fix: correctly deserialize on the server

### DIFF
--- a/.changeset/silly-berries-repair.md
+++ b/.changeset/silly-berries-repair.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly run `deserialize` on the server

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -31,7 +31,8 @@ export function deserialize(result) {
 	const parsed = JSON.parse(result);
 
 	if (parsed.data) {
-		parsed.data = devalue.parse(parsed.data, app.decoders);
+		// app is undefined when running this on the server
+		parsed.data = devalue.parse(parsed.data, app?.decoders);
 	}
 
 	return parsed;

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -31,7 +31,7 @@ export function deserialize(result) {
 	const parsed = JSON.parse(result);
 
 	if (parsed.data) {
-		// app is undefined when running this on the server
+		// app is uninitialised on the server
 		parsed.data = devalue.parse(parsed.data, app?.decoders);
 	}
 

--- a/packages/kit/test/apps/basics/src/routes/deserialize/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/deserialize/+page.server.js
@@ -1,0 +1,5 @@
+export const actions = {
+	default: () => {
+		return { a: 1 };
+	}
+};

--- a/packages/kit/test/apps/basics/src/routes/deserialize/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/deserialize/+server.js
@@ -1,0 +1,13 @@
+import { deserialize } from '$app/forms';
+
+export async function GET({ fetch }) {
+	const response = await fetch('/deserialize', {
+		method: 'POST',
+    body: new FormData(),
+		headers: {
+			'x-sveltekit-action': 'true'
+		}
+	});
+	const result = deserialize(await response.text());
+	return Response.json(result);
+}

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -716,3 +716,10 @@ test.describe('getRequestEvent', () => {
 		expect(await response.text()).toBe('hello from hooks.server.js');
 	});
 });
+
+test.describe('$app/forms', () => {
+	test('deserialize works on the server', async ({ request }) => {
+		const response = await request.get('/deserialize');
+		expect(await response.json()).toEqual({ type: 'success', status: 200, data: { a: 1 } });
+	});
+});


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13675

This PR adds an optional chain for when `deserialize` tries to access `app` from `client.js` so that it doesn't complain about it trying to access `app.decoders` when `app` is `undefined` (which it always is on the server).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
