### PR TITLE
Squelch rollup warnings

### DIFF
--- a/.changeset/thirty-foxes-study.md
+++ b/.changeset/thirty-foxes-study.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prevent Rollup warnings for undefined hooks

--- a/packages/kit/src/core/sync/write_client_manifest.js
+++ b/packages/kit/src/core/sync/write_client_manifest.js
@@ -161,13 +161,19 @@ export function write_client_manifest(kit, manifest_data, output, metadata) {
 
 			export const dictionary = ${dictionary};
 
+			// This indirection prevents Rollup from issuing a warning when hooks aren't defined
+			const HANDLE_ERROR = 'handleError';
+			const INIT = 'init';
+			const REROUTE = 'reroute';
+			const TRANSPORT = 'transport';
+
 			export const hooks = {
 				handleError: ${
-					client_hooks_file ? 'client_hooks.handleError || ' : ''
+					client_hooks_file ? 'client_hooks[HANDLE_ERROR] || ' : ''
 				}(({ error }) => { console.error(error) }),
-				${client_hooks_file ? 'init: client_hooks.init,' : ''}
-				reroute: ${universal_hooks_file ? 'universal_hooks.reroute || ' : ''}(() => {}),
-				transport: ${universal_hooks_file ? 'universal_hooks.transport || ' : ''}{}
+				${client_hooks_file ? 'init: client_hooks[INIT],' : ''}
+				reroute: ${universal_hooks_file ? 'universal_hooks[REROUTE] || ' : ''}(() => {}),
+				transport: ${universal_hooks_file ? 'universal_hooks[TRANSPORT] || ' : ''}{}
 			};
 
 			export const decoders = Object.fromEntries(Object.entries(hooks.transport).map(([k, v]) => [k, v.decode]));

--- a/packages/kit/src/core/sync/write_client_manifest.js
+++ b/packages/kit/src/core/sync/write_client_manifest.js
@@ -161,19 +161,13 @@ export function write_client_manifest(kit, manifest_data, output, metadata) {
 
 			export const dictionary = ${dictionary};
 
-			// This indirection prevents Rollup from issuing a warning when hooks aren't defined
-			const HANDLE_ERROR = 'handleError';
-			const INIT = 'init';
-			const REROUTE = 'reroute';
-			const TRANSPORT = 'transport';
-
 			export const hooks = {
 				handleError: ${
-					client_hooks_file ? 'client_hooks[HANDLE_ERROR] || ' : ''
+					client_hooks_file ? 'client_hooks.handleError || ' : ''
 				}(({ error }) => { console.error(error) }),
-				${client_hooks_file ? 'init: client_hooks[INIT],' : ''}
-				reroute: ${universal_hooks_file ? 'universal_hooks[REROUTE] || ' : ''}(() => {}),
-				transport: ${universal_hooks_file ? 'universal_hooks[TRANSPORT] || ' : ''}{}
+				${client_hooks_file ? 'init: client_hooks.init,' : ''}
+				reroute: ${universal_hooks_file ? 'universal_hooks.reroute || ' : ''}(() => {}),
+				transport: ${universal_hooks_file ? 'universal_hooks.transport || ' : ''}{}
 			};
 
 			export const decoders = Object.fromEntries(Object.entries(hooks.transport).map(([k, v]) => [k, v.decode]));

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -678,7 +678,19 @@ Tips:
 								manualChunks: split ? undefined : () => 'bundle',
 								inlineDynamicImports: false
 							},
-							preserveEntrySignatures: 'strict'
+							preserveEntrySignatures: 'strict',
+							onwarn(warning, handler) {
+								if (
+									warning.code === 'MISSING_EXPORT' &&
+									warning.id === `${kit.outDir}/generated/client-optimized/app.js`
+								) {
+									// ignore e.g. undefined `handleError` hook when
+									// referencing `client_hooks.handleError`
+									return;
+								}
+
+								handler(warning);
+							}
 						},
 						ssrEmitAssets: true,
 						target: ssr ? 'node18.13' : undefined


### PR DESCRIPTION
Rollup is quite aggressive about warning on missing imports — if you have something this...

```js
import * as foo from './foo.js';

if (foo.bar) {
  foo.bar();
}
```

...it will yell at you if `foo.js` doesn't export `bar`. This is a useful warning, unless the import is in code the user doesn't control, such as the generated `app.js` referencing `client_hooks.handleError` (which is known to be harmless).

This PR squelches those warnings.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
