### PR TITLE
fix: handle missing package.json gracefully

### DIFF
--- a/.changeset/red-pugs-smell.md
+++ b/.changeset/red-pugs-smell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/package': patch
+---
+
+Using the load_pkg_json method instead of readFile which throws when there is no package.json

--- a/.changeset/red-pugs-smell.md
+++ b/.changeset/red-pugs-smell.md
@@ -2,4 +2,4 @@
 '@sveltejs/package': patch
 ---
 
-Using the load_pkg_json method instead of readFile which throws when there is no package.json
+fix: handle missing package.json gracefully

--- a/packages/package/src/config.js
+++ b/packages/package/src/config.js
@@ -29,7 +29,7 @@ export async function load_config({ cwd = process.cwd() } = {}) {
 
 /**
  * @param {string} cwd
- * @returns Record<string, any>
+ * @returns {Record<string, any>}
  */
 export function load_pkg_json(cwd = process.cwd()) {
 	const pkg_json_file = path.join(cwd, 'package.json');

--- a/packages/package/src/validate.js
+++ b/packages/package/src/validate.js
@@ -18,7 +18,7 @@ export function create_validator(options) {
 		},
 		validate() {
 			/** @type {Record<string, any>} */
-			const pkg = load_pkg_json();
+			const pkg = load_pkg_json(options.cwd);
 			const warnings = validate(pkg);
 			if (Object.keys(pkg).length === 0) {
 				warnings.push(

--- a/packages/package/src/validate.js
+++ b/packages/package/src/validate.js
@@ -22,7 +22,7 @@ export function create_validator(options) {
 			const warnings = validate(pkg);
 			if (Object.keys(pkg).length === 0) {
 				warnings.push(
-					'No package.json found in the current directory. Please create one or run this command in a package directory.'
+					'No package.json found in the current directory. Please create one or run this command in a directory containing one.'
 				);
 			}
 

--- a/packages/package/src/validate.js
+++ b/packages/package/src/validate.js
@@ -1,6 +1,5 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import colors from 'kleur';
+import { load_pkg_json } from './config.js';
 
 /**
  * @param {import("./types.js").Options} options
@@ -19,8 +18,14 @@ export function create_validator(options) {
 		},
 		validate() {
 			/** @type {Record<string, any>} */
-			const pkg = JSON.parse(readFileSync(join(options.cwd, 'package.json'), 'utf-8'));
+			const pkg = load_pkg_json();
 			const warnings = validate(pkg);
+			if (Object.keys(pkg).length === 0) {
+				warnings.push(
+					'No package.json found in the current directory. Please create one or run this command in a package directory.'
+				);
+			}
+
 			// Just warnings, not errors, because
 			// - would be annoying in watch mode (would have to restart the server)
 			// - maybe there's a custom post-build script that fixes some of these


### PR DESCRIPTION
This PR updates the package logic to avoid throwing an error when package.json is missing in the current directory.
Uses the `load_pkg_json` function instead of `readFileSync`.

I found this issue when packaging for a monorepo

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
