### PR TITLE
fix: redirect trailing slash normalization relatively instead of against root

### DIFF
--- a/.changeset/honest-pandas-itch.md
+++ b/.changeset/honest-pandas-itch.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/adapter-node': patch
+'@sveltejs/kit': patch
+---
+
+fix: redirect trailing slash normalization relatively instead of against root

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -5,7 +5,12 @@ import process from 'node:process';
 import sirv from 'sirv';
 import { fileURLToPath } from 'node:url';
 import { parse as polka_url_parser } from '@polka/url';
-import { getRequest, setResponse, createReadableStream } from '@sveltejs/kit/node';
+import {
+	getRequest,
+	setResponse,
+	createReadableStream,
+	relative_pathname
+} from '@sveltejs/kit/node';
 import { Server } from 'SERVER';
 import { manifest, prerendered, base } from 'MANIFEST';
 import { env } from 'ENV';
@@ -81,8 +86,11 @@ function serve_prerendered() {
 		}
 
 		// remove or add trailing slash as appropriate
-		let location = pathname.at(-1) === '/' ? pathname.slice(0, -1) : pathname + '/';
-		if (prerendered.has(location)) {
+		const inverted_trailing_slash =
+			pathname.at(-1) === '/' ? pathname.slice(0, -1) : pathname + '/';
+		if (prerendered.has(inverted_trailing_slash)) {
+			// ensure preservation of (possibly invisible) path prefixes
+			let location = relative_pathname(pathname, inverted_trailing_slash);
 			if (query) location += search;
 			res.writeHead(308, { location }).end();
 		} else {

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -22,6 +22,7 @@
 		"cookie": "^0.6.0",
 		"devalue": "^5.1.0",
 		"esm-env": "^1.2.2",
+		"get-relative-path": "^1.0.2",
 		"import-meta-resolve": "^4.1.0",
 		"kleur": "^4.1.5",
 		"magic-string": "^0.30.5",

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -222,3 +222,5 @@ export async function setResponse(res, response) {
 export function createReadableStream(file) {
 	return /** @type {ReadableStream} */ (Readable.toWeb(createReadStream(file)));
 }
+
+export { relative_pathname } from '../../utils/url.js';

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -11,7 +11,13 @@ import {
 	method_not_allowed,
 	redirect_response
 } from './utils.js';
-import { decode_pathname, decode_params, disable_search, normalize_path } from '../../utils/url.js';
+import {
+	decode_pathname,
+	decode_params,
+	disable_search,
+	normalize_path,
+	relative_pathname
+} from '../../utils/url.js';
 import { exec } from '../../utils/routing.js';
 import { redirect_json_response, render_data } from './data/index.js';
 import { add_cookies_to_headers, get_cookies } from './cookie.js';
@@ -321,9 +327,8 @@ export async function respond(request, options, manifest, state) {
 						headers: {
 							'x-sveltekit-normalize': '1',
 							location:
-								// ensure paths starting with '//' are not treated as protocol-relative
-								(normalized.startsWith('//') ? url.origin + normalized : normalized) +
-								(url.search === '?' ? '' : url.search)
+								// ensure preservation of (possibly invisible) path prefixes
+								relative_pathname(url.pathname, normalized) + (url.search === '?' ? '' : url.search)
 						}
 					});
 				}

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -1,4 +1,5 @@
 import { BROWSER, DEV } from 'esm-env';
+import getRelativePath from 'get-relative-path';
 
 /**
  * Matches a URI scheme. See https://www.rfc-editor.org/rfc/rfc3986#section-3.1
@@ -75,6 +76,18 @@ export function decode_uri(uri) {
 		}
 		throw e;
 	}
+}
+
+/**
+ * Calculates the relative path between two URL pathnames.
+ * Note that `relative` from `node:path` works with file system paths which are subtly diffent.
+ * For example: it ignores trailing slashes, which are significant in URLs.
+ * @param {string} from
+ * @param {string} to
+ */
+export function relative_pathname(from, to) {
+	// TODO inline
+	return getRelativePath(from, to);
 }
 
 /**

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2145,6 +2145,12 @@ declare module '@sveltejs/kit/node' {
 	 * @since 2.4.0
 	 */
 	export function createReadableStream(file: string): ReadableStream;
+	/**
+	 * Calculates the relative path between two URL pathnames.
+	 * Note that `relative` from `node:path` works with file system paths which are subtly diffent.
+	 * For example: it ignores trailing slashes, which are significant in URLs.
+	 * */
+	export function relative_pathname(from: string, to: string): string;
 
 	export {};
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,6 +368,9 @@ importers:
       esm-env:
         specifier: ^1.2.2
         version: 1.2.2
+      get-relative-path:
+        specifier: ^1.0.2
+        version: 1.0.2
       import-meta-resolve:
         specifier: ^4.1.0
         version: 4.1.0
@@ -2509,6 +2512,9 @@ packages:
   get-port@5.1.1:
     resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
     engines: {node: '>=8'}
+
+  get-relative-path@1.0.2:
+    resolution: {integrity: sha512-dGkopYfmB4sXMTcZslq5SojEYakpdCSj/SVSHLhv7D6RBHzvDtd/3Q8lTEOAhVKxPPeAHu/YYkENbbz3PaH+8w==}
 
   get-source@2.0.12:
     resolution: {integrity: sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==}
@@ -4887,6 +4893,8 @@ snapshots:
   function-bind@1.1.2: {}
 
   get-port@5.1.1: {}
+
+  get-relative-path@1.0.2: {}
 
   get-source@2.0.12:
     dependencies:


### PR DESCRIPTION
Fixes #13718.
As mentioned there: `Location` is allowed to be relative, so I just... did that.
For the scenario listed in the issue that means `/sveltekit/sverdle/` is redirected with `Location: ../sverdle`, which correctly resolves to `/sveltekit/sverdle`.

### Remaining things to consider
- [ ] 1. Still need to inline the [`get-relative-path`](https://www.npmjs.com/package/get-relative-path) code that does the heavy lifting, but I'd like to confirm this is the correct solution first.
- [ ] 2. What should tests for this look like? Should I create a whole `adapter-node`+dynamic base project or keep it simple and just check if the path is relative?
- [ ] 3. `adapter-node` currently imports the internal `relative_pathname` utility through `@sveltejs/kit/node`, which feels a bit weird, is there a better place for this?
- [ ] 4. I'm not 100% confident this doesn't regress [#2515](https://github.com/sveltejs/kit/issues/2515), unfortunately there's no minimal reproduction and [#4414](https://github.com/sveltejs/kit/pull/4414) didn't add a test. I tried various combinations of slashes and protocol-ish paths, but even taking out [#4414](https://github.com/sveltejs/kit/pull/4414)'s fix I always got 404 rather than redirected. Is this perhaps taken care of elsewhere now? Perhaps @wbster or @benmccann can clarify.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
