### PR TITLE
feat: use edge-light condition when building for Vercel Edge Runtime

### DIFF
--- a/.changeset/silly-ears-visit.md
+++ b/.changeset/silly-ears-visit.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+fix: include the `edge-light` bundling condition when building edge functions

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -137,7 +137,9 @@ const plugin = function (defaults = {}) {
 					const result = await esbuild.build({
 						entryPoints: [`${tmp}/edge.js`],
 						outfile: `${dirs.functions}/${name}.func/index.js`,
-						target: 'es2020', // TODO verify what the edge runtime supports
+						// minimum Node.js version supported is v14.6.0 that is mapped to ES2019
+						// see https://edge-runtime.vercel.app/features/polyfills
+						target: 'es2020',
 						bundle: true,
 						platform: 'browser',
 						conditions: [

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -141,8 +141,11 @@ const plugin = function (defaults = {}) {
 						bundle: true,
 						platform: 'browser',
 						conditions: [
+							// Vercel's Edge runtime key https://runtime-keys.proposal.wintercg.org/#edge-light
 							'edge-light',
-							'module' // Matching behavior of esbuild without custom conditions
+							// re-include these since they are included by default when no conditions are specified
+							// https://esbuild.github.io/api/#conditions
+							'module'
 						],
 						format: 'esm',
 						external: [

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -138,7 +138,8 @@ const plugin = function (defaults = {}) {
 						entryPoints: [`${tmp}/edge.js`],
 						outfile: `${dirs.functions}/${name}.func/index.js`,
 						// minimum Node.js version supported is v14.6.0 that is mapped to ES2019
-						// see https://edge-runtime.vercel.app/features/polyfills
+						// https://edge-runtime.vercel.app/features/polyfills
+						// TODO verify the latest ES version the edge runtime supports
 						target: 'es2020',
 						bundle: true,
 						platform: 'browser',

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -140,6 +140,10 @@ const plugin = function (defaults = {}) {
 						target: 'es2020', // TODO verify what the edge runtime supports
 						bundle: true,
 						platform: 'browser',
+						conditions: [
+							"edge-light",
+							"module" // Matching behavior of esbuild without custom conditions
+						],
 						format: 'esm',
 						external: [
 							...compatible_node_modules,

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -141,8 +141,8 @@ const plugin = function (defaults = {}) {
 						bundle: true,
 						platform: 'browser',
 						conditions: [
-							"edge-light",
-							"module" // Matching behavior of esbuild without custom conditions
+							'edge-light',
+							'module' // Matching behavior of esbuild without custom conditions
 						],
 						format: 'esm',
 						external: [


### PR DESCRIPTION
<!-- Your PR description here -->
This adds the `edge-light` condition to the `esbuild.build()` command used to bundle code for Vercel's Edge Runtime. I noticed that the condition wasn't respected when marking some dependencies as `ssr.external` even though the packages supported Edge Runtime via the `edge-light` condition.

This change brings the compilation more in line with Next.js, as it leverages the `edge-light` condition.

Adding the `conditions` configuration also requires manually adding `module` because it is [only defaulted if nothing is configured](https://esbuild.github.io/api/#how-conditions-work).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
       - I didn't see any tests for the adapters.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
