### PR TITLE
fix: include components dynamically imported in the universal load function when inlining CSS

### DIFF
--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -11,65 +11,82 @@ import { basename } from 'node:path';
  * @param {import('types').ManifestData} manifest_data
  * @param {import('vite').Manifest} server_manifest
  * @param {import('vite').Manifest | null} client_manifest
- * @param {import('vite').Rollup.OutputAsset[] | null} css
+ * @param {import('vite').Rollup.OutputBundle | null} server_bundle
+ * @param {import('vite').Rollup.RollupOutput['output'] | null} client_bundle
  * @param {import('types').RecursiveRequired<import('types').ValidatedConfig['kit']['output']>} output_config
  */
-export function build_server_nodes(out, kit, manifest_data, server_manifest, client_manifest, css, output_config) {
+export function build_server_nodes(out, kit, manifest_data, server_manifest, client_manifest, server_bundle, client_bundle, output_config) {
 	mkdirp(`${out}/server/nodes`);
 	mkdirp(`${out}/server/stylesheets`);
 
 	/** @type {Map<string, string>} */
-	const stylesheet_lookup = new Map();
+	const stylesheets_to_inline = new Map();
 
-	if (css) {
-		/** @type {Set<string>} */
-		const client_stylesheets = new Set();
-		for (const key in client_manifest) {
-			client_manifest[key].css?.forEach((filename) => {
-				client_stylesheets.add(filename);
-			});
-		}
-
-		/** @type {Map<number, string[]>} */
-		const server_stylesheets = new Map();
-		manifest_data.nodes.forEach((node, i) => {
-			if (!node.component || !server_manifest[node.component]) return;
-
-			const { stylesheets } = find_deps(server_manifest, node.component, false);
-
-			if (stylesheets.length) {
-				server_stylesheets.set(i, stylesheets);
-			}
-		});
-
-		for (const asset of css) {
-			// ignore dynamically imported stylesheets since we don't need to inline those
-			if (!client_stylesheets.has(asset.fileName) || asset.source.length >= kit.inlineStyleThreshold) {
+	if (server_bundle && client_bundle) {
+		/** @type {Map<string, string[]>} */
+		const client_stylesheets = new Map();
+		for (const chunk of client_bundle) {
+			if (chunk.type !== 'chunk' || !chunk.viteMetadata?.importedCss.size) {
 				continue;
 			}
-
-			// We know that the names for entry points are numbers.
-			const [index] = basename(asset.fileName).split('.');
-			// There can also be other CSS files from shared components
-			// for example, which we need to ignore here.
-			if (isNaN(+index)) continue;
-
-			const file = `${out}/server/stylesheets/${index}.js`;
-
-			// we need to inline the server stylesheet instead of the client one
-			// so that asset paths are correct on document load
-			const filenames = server_stylesheets.get(+index);
-
-			if (!filenames) {
-				throw new Error('This should never happen, but if it does, it means we failed to find the server stylesheet for a node.');
+			const css = Array.from(chunk.viteMetadata.importedCss);
+			for (const id of chunk.moduleIds) {
+				client_stylesheets.set(id, css );
 			}
+		}
 
-			const sources = filenames.map((filename) => {
-				return fs.readFileSync(`${out}/server/${filename}`, 'utf-8');
-			});
-			fs.writeFileSync(file, `// ${filenames.join(', ')}\nexport default ${s(sources.join('\n'))};`);
+		/** @type {Map<string, string[]>} */
+		const server_stylesheets = new Map();
+		for (const key in server_bundle) {
+			const chunk = server_bundle[key];
+			if (chunk.type !== 'chunk' || !chunk.viteMetadata?.importedCss.size) {
+				continue;
+			}
+			const css = Array.from(chunk.viteMetadata.importedCss);
+			for (const id of chunk.moduleIds) {
+				server_stylesheets.set(id, css );
+			}
+		}
 
-			stylesheet_lookup.set(asset.fileName, index);
+		// map server stylesheet name to the client stylesheet name
+		for (const [id, client_css] of client_stylesheets) {
+			const server_css = server_stylesheets.get(id);
+			if (!server_css) {
+				continue;
+			}
+			client_css.forEach((file, i) => {
+				stylesheets_to_inline.set(file, server_css[i]);
+			}) 
+		}
+
+		// filter out stylesheets that should not be inlined
+		for (const chunk of client_bundle) {
+			if (
+				chunk.type === 'asset' &&
+				chunk.fileName.endsWith('.css') &&
+				chunk.source.length < kit.inlineStyleThreshold
+			) {
+				continue;
+			}
+			stylesheets_to_inline.delete(chunk.fileName);
+		}
+
+		/** @type {Map<string, string>} */
+		const server_stylesheet_sources = new Map();
+		for (const key in server_bundle) {
+			const chunk = server_bundle[key];
+			if (chunk.type === 'asset' && chunk.fileName.endsWith('.css')) {
+				server_stylesheet_sources.set(chunk.fileName, chunk.source.toString());
+			}
+		}
+
+		// map server stylesheet source to the client stylesheet name
+		for (const [client_file, server_file] of stylesheets_to_inline) {
+			const source = server_stylesheet_sources.get(server_file);
+			if (!source) {
+				throw new Error(`Server stylesheet source not found for client stylesheet ${client_file}`);
+			}
+			stylesheets_to_inline.set(client_file, source);
 		}
 	}
 
@@ -122,8 +139,9 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 			const entry_path = `${normalizePath(kit.outDir)}/generated/client-optimized/nodes/${i}.js`;
 			const entry = find_deps(client_manifest, entry_path, true);
 
-			// eagerly load stylesheets and fonts imported by the SSR-ed page to avoid FOUC.
-			// If it is not used during SSR, it can be lazily loaded in the browser.
+			// eagerly load client stylesheets and fonts imported by the SSR-ed page to avoid FOUC.
+			// However, if it is not used during SSR (not present in the server manifest),
+			// then it can be lazily loaded in the browser.
 	
 			/** @type {import('types').AssetDependencies | undefined} */
 			let component;
@@ -138,26 +156,26 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 			}
 
 			/** @type {Set<string>} */
-			const css_used_by_server = new Set();
+			const eager_css = new Set();
 			/** @type {Set<string>} */
-			const assets_used_by_server = new Set();
+			const eager_assets = new Set();
 
-			entry.stylesheet_map.forEach((value, key) => {
-				// pages and layouts are named as node indexes in the client manifest
-				// so we need to use the original filename when checking against the server manifest
-				if (key === entry_path) {
-					key = node.component ?? key;
+			entry.stylesheet_map.forEach((value, filepath) => {
+				// pages and layouts are renamed to node indexes when optimised for the client
+				// so we use the original filename instead to check against the server manifest
+				if (filepath === entry_path) {
+					filepath = node.component ?? filepath;
 				}
 
-				if (component?.stylesheet_map.has(key) || universal?.stylesheet_map.has(key)) {
-					value.css.forEach(file => css_used_by_server.add(file));
-					value.assets.forEach(file => assets_used_by_server.add(file));
+				if (component?.stylesheet_map.has(filepath) || universal?.stylesheet_map.has(filepath)) {
+					value.css.forEach(file => eager_css.add(file));
+					value.assets.forEach(file => eager_assets.add(file));
 				}
 			});
 
 			imported = entry.imports;
-			stylesheets = Array.from(css_used_by_server);
-			fonts = filter_fonts(Array.from(assets_used_by_server));
+			stylesheets = Array.from(eager_css);
+			fonts = filter_fonts(Array.from(eager_assets));
 		}
 
 		exports.push(
@@ -167,19 +185,26 @@ export function build_server_nodes(out, kit, manifest_data, server_manifest, cli
 		);
 
 		/** @type {string[]} */
-		const styles = [];
+		const inline_styles = [];
 
 		stylesheets.forEach((file) => {
-			if (stylesheet_lookup.has(file)) {
-				const index = stylesheet_lookup.get(file);
-				const name = `stylesheet_${index}`;
-				imports.push(`import ${name} from '../stylesheets/${index}.js';`);
-				styles.push(`\t${s(file)}: ${name}`);
+			if (stylesheets_to_inline.has(file)) {
+				const [filename] = basename(file).split('.');
+				const dest = `${out}/server/stylesheets/${filename}.js`;
+				const source = stylesheets_to_inline.get(file);
+				if (!source) {
+					throw new Error(`Server stylesheet source not found for client stylesheet ${file}`);
+				}
+				fs.writeFileSync(dest, `// ${filename}\nexport default ${s(source)};`);
+
+				const name = `stylesheet_${filename}`;
+				imports.push(`import ${name} from '../stylesheets/${filename}.js';`);
+				inline_styles.push(`\t${s(file)}: ${name}`);
 			}
 		});
 
-		if (styles.length > 0) {
-			exports.push(`export const inline_styles = () => ({\n${styles.join(',\n')}\n});`);
+		if (inline_styles.length > 0) {
+			exports.push(`export const inline_styles = () => ({\n${inline_styles.join(',\n')}\n});`);
 		}
 
 		fs.writeFileSync(

--- a/packages/kit/test/apps/options/source/pages/inline-assets/dynamic-import/+page.js
+++ b/packages/kit/test/apps/options/source/pages/inline-assets/dynamic-import/+page.js
@@ -1,0 +1,5 @@
+export async function load() {
+	return {
+		Thing: (await import('./Thing.svelte')).default
+	};
+}

--- a/packages/kit/test/apps/options/source/pages/inline-assets/dynamic-import/+page.svelte
+++ b/packages/kit/test/apps/options/source/pages/inline-assets/dynamic-import/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	export let data;
+</script>
+
+<svelte:component this={data.Thing} />

--- a/packages/kit/test/apps/options/source/pages/inline-assets/dynamic-import/Thing.svelte
+++ b/packages/kit/test/apps/options/source/pages/inline-assets/dynamic-import/Thing.svelte
@@ -1,0 +1,8 @@
+<p>I'm dynamically imported</p>
+
+<style>
+	p {
+		color: blue;
+		font-size: 20px;
+	}
+</style>


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13670

This PR changes how we map client stylesheets to their server equivalent by using the Rollup bundle data from the client and server builds instead of the Vite manifests. There are several benefits to this such as better mapping for non-node css (think shared components) and components with the same filename. This is only possible with the Rollup bundle data because it has the original module IDs where the CSS originated from, which allows us to identify the origin more precisely.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
