### PR TITLE
docs: change "Cloudflare Pages" title to just "Cloudflare"

### DIFF
--- a/documentation/docs/25-build-and-deploy/60-adapter-cloudflare.md
+++ b/documentation/docs/25-build-and-deploy/60-adapter-cloudflare.md
@@ -1,5 +1,5 @@
 ---
-title: Cloudflare Pages
+title: Cloudflare
 ---
 
 To deploy to [Cloudflare Workers](https://workers.cloudflare.com/) or [Cloudflare Pages](https://pages.cloudflare.com/), use [`adapter-cloudflare`](https://github.com/sveltejs/kit/tree/main/packages/adapter-cloudflare).

--- a/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
+++ b/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
@@ -1,5 +1,5 @@
 ---
-title: Cloudflare Workers
+title: Cloudflare Workers Sites
 ---
 
 > [!NOTE] `adapter-cloudflare-workers` has been deprecated in favour of [`adapter-cloudflare`](adapter-cloudflare). We recommend using `adapter-cloudflare` to deploy to Cloudflare Workers with [Static Assets](https://developers.cloudflare.com/workers/static-assets/) since Cloudflare Workers Sites will be deprecated in favour of it.

--- a/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
+++ b/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
@@ -1,5 +1,5 @@
 ---
-title: Cloudflare Workers Sites
+title: Cloudflare Workers
 ---
 
 > [!NOTE] `adapter-cloudflare-workers` has been deprecated in favour of [`adapter-cloudflare`](adapter-cloudflare). We recommend using `adapter-cloudflare` to deploy to Cloudflare Workers with [Static Assets](https://developers.cloudflare.com/workers/static-assets/) since Cloudflare Workers Sites will be deprecated in favour of it.


### PR DESCRIPTION
This PR includes a small change to the display titles of the adapter-cloudflare and adapter-cloudflare-workers doc pages to better distinguish them in the nav bar and page itself.

Cloudflare Pages -> Cloudflare
Cloudflare Workers -> Cloudflare Workers Sites

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
