### PR TITLE
docs: expand docs for fail method

### DIFF
--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -180,14 +180,14 @@ export function text(body, init) {
 }
 
 /**
- * Create an `ActionFailure` object.
+ * Create an `ActionFailure` object. Call when form submission fails.
  * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
  * @overload
  * @param {number} status
  * @returns {import('./public.js').ActionFailure<undefined>}
  */
 /**
- * Create an `ActionFailure` object.
+ * Create an `ActionFailure` object. Call when form submission fails.
  * @template {Record<string, unknown> | undefined} [T=undefined]
  * @param {number} status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
  * @param {T} data Data associated with the failure (e.g. validation errors)
@@ -197,7 +197,7 @@ export function text(body, init) {
  * @returns {import('./public.js').ActionFailure<T>}
  */
 /**
- * Create an `ActionFailure` object.
+ * Create an `ActionFailure` object. Call when form submission fails.
  * @param {number} status
  * @param {any} [data]
  * @returns {import('./public.js').ActionFailure<any>}

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2001,12 +2001,12 @@ declare module '@sveltejs/kit' {
 	 */
 	export function text(body: string, init?: ResponseInit | undefined): Response;
 	/**
-	 * Create an `ActionFailure` object.
+	 * Create an `ActionFailure` object. Call when form submission fails.
 	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
 	 * */
 	export function fail(status: number): ActionFailure<undefined>;
 	/**
-	 * Create an `ActionFailure` object.
+	 * Create an `ActionFailure` object. Call when form submission fails.
 	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
 	 * @param data Data associated with the failure (e.g. validation errors)
 	 * */


### PR DESCRIPTION
There's nothing on https://svelte.dev/docs/kit/@sveltejs-kit#fail that says it's related to forms. If you were just looking at that page you might have a hard time knowing when to call `error` and when to call `fail`