### PR TITLE
fix: set `$env` and `$app/environment` variables before analysing server nodes

### DIFF
--- a/.changeset/smooth-rockets-complain.md
+++ b/.changeset/smooth-rockets-complain.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: ensure `$env` and `$app/environment` are correctly set while analysing server nodes

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -21,9 +21,9 @@ export default forked(import.meta.url, analyse);
  *   manifest_data: import('types').ManifestData;
  *   server_manifest: import('vite').Manifest;
  *   tracked_features: Record<string, string[]>;
- *   env: Record<string, string>
- *   out: string
- *   output_config: import('types').RecursiveRequired<import('types').ValidatedConfig['kit']['output']>
+ *   env: Record<string, string>;
+ *   out: string;
+ *   output_config: import('types').RecursiveRequired<import('types').ValidatedConfig['kit']['output']>;
  * }} opts
  */
 async function analyse({
@@ -63,8 +63,19 @@ async function analyse({
 	internal.set_manifest(manifest);
 	internal.set_read_implementation((file) => createReadableStream(`${server_root}/server/${file}`));
 
+	const static_exports = new Map();
+
 	// first, build server nodes without the client manifest so we can analyse it
-	await build_server_nodes(out, config, manifest_data, server_manifest, null, null, output_config);
+	await build_server_nodes(
+		out,
+		config,
+		manifest_data,
+		server_manifest,
+		null,
+		null,
+		output_config,
+		static_exports
+	);
 
 	/** @type {import('types').ServerMetadata} */
 	const metadata = {
@@ -151,7 +162,7 @@ async function analyse({
 		});
 	}
 
-	return metadata;
+	return { metadata, static_exports };
 }
 
 /**

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -10,6 +10,7 @@ import { has_server_load, resolve_route } from '../../utils/routing.js';
 import { check_feature } from '../../utils/features.js';
 import { createReadableStream } from '@sveltejs/kit/node';
 import { PageNodes } from '../../utils/page_nodes.js';
+import { build_server_nodes } from '../../exports/vite/build/build_server.js';
 
 export default forked(import.meta.url, analyse);
 
@@ -21,6 +22,8 @@ export default forked(import.meta.url, analyse);
  *   server_manifest: import('vite').Manifest;
  *   tracked_features: Record<string, string[]>;
  *   env: Record<string, string>
+ *   out: string
+ *   output_config: import('types').RecursiveRequired<import('types').ValidatedConfig['kit']['output']>
  * }} opts
  */
 async function analyse({
@@ -29,7 +32,9 @@ async function analyse({
 	manifest_data,
 	server_manifest,
 	tracked_features,
-	env
+	env,
+	out,
+	output_config
 }) {
 	/** @type {import('@sveltejs/kit').SSRManifest} */
 	const manifest = (await import(pathToFileURL(manifest_path).href)).manifest;
@@ -57,6 +62,9 @@ async function analyse({
 	internal.set_safe_public_env(public_env);
 	internal.set_manifest(manifest);
 	internal.set_read_implementation((file) => createReadableStream(`${server_root}/server/${file}`));
+
+	// first, build server nodes without the client manifest so we can analyse it
+	await build_server_nodes(out, config, manifest_data, server_manifest, null, null, output_config);
 
 	/** @type {import('types').ServerMetadata} */
 	const metadata = {

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -109,7 +109,12 @@ export async function build_server_nodes(out, kit, manifest_data, server_manifes
 		}
 
 		if (node.universal) {
-			const page_options = await get_page_options(node);
+			let page_options;
+
+			if (!client_manifest) {
+				page_options = await get_page_options(node);
+			}
+
 			if (!!page_options && page_options.ssr === false) {
 				exports.push(`export const universal = ${s(page_options, null, 2)};`)
 			} else {

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -4,7 +4,7 @@ import { filter_fonts, find_deps, resolve_symlinks } from './utils.js';
 import { s } from '../../../utils/misc.js';
 import { normalizePath } from 'vite';
 import { basename, join } from 'node:path';
-import { create_static_analyser } from '../static_analysis/index.js';
+import { create_node_analyser } from '../static_analysis/index.js';
 
 /**
  * @param {string} out
@@ -74,7 +74,7 @@ export async function build_server_nodes(out, kit, manifest_data, server_manifes
 		}
 	}
 
-	const { get_page_options } = create_static_analyser(async (server_node) => {
+	const { get_page_options } = create_node_analyser(async (server_node) => {
 		// Windows needs the file:// protocol for absolute path dynamic imports
 		return import(`file://${join(out, 'server', resolve_symlinks(server_manifest, server_node).chunk.file)}`);
 	});

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -128,9 +128,11 @@ export async function dev(vite, vite_config, svelte_config) {
 			return;
 		}
 
-		const node_analyser = create_node_analyser(async (server_node) => {
-			const { module } = await resolve(server_node);
-			return module;
+		const node_analyser = create_node_analyser({
+			resolve: async (server_node) => {
+				const { module } = await resolve(server_node);
+				return module;
+			}
 		});
 		invalidate_page_options = node_analyser.invalidate_page_options;
 

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -19,7 +19,7 @@ import { not_found } from '../utils.js';
 import { SCHEME } from '../../../utils/url.js';
 import { check_feature } from '../../../utils/features.js';
 import { escape_html } from '../../../utils/escape.js';
-import { create_static_analyser } from '../static_analysis/index.js';
+import { create_node_analyser } from '../static_analysis/index.js';
 
 const cwd = process.cwd();
 // vite-specifc queries that we should skip handling for css urls
@@ -128,11 +128,11 @@ export async function dev(vite, vite_config, svelte_config) {
 			return;
 		}
 
-		const static_analyser = create_static_analyser(async (server_node) => {
+		const node_analyser = create_node_analyser(async (server_node) => {
 			const { module } = await resolve(server_node);
 			return module;
 		});
-		invalidate_page_options = static_analyser.invalidate_page_options;
+		invalidate_page_options = node_analyser.invalidate_page_options;
 
 		manifest = {
 			appDir: svelte_config.kit.appDir,
@@ -212,7 +212,7 @@ export async function dev(vite, vite_config, svelte_config) {
 						}
 
 						if (node.universal) {
-							const page_options = await static_analyser.get_page_options(node);
+							const page_options = await node_analyser.get_page_options(node);
 							if (page_options?.ssr === false) {
 								result.universal = page_options;
 							} else {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -818,18 +818,7 @@ Tips:
 					})};\n`
 				);
 
-				// first, build server nodes without the client manifest so we can analyse it
 				log.info('Analysing routes');
-
-				await build_server_nodes(
-					out,
-					kit,
-					manifest_data,
-					server_manifest,
-					null,
-					null,
-					svelte_config.output
-				);
 
 				const metadata = await analyse({
 					hash: kit.router.type === 'hash',
@@ -837,7 +826,9 @@ Tips:
 					manifest_data,
 					server_manifest,
 					tracked_features,
-					env: { ...env.private, ...env.public }
+					env: { ...env.private, ...env.public },
+					out,
+					output_config: svelte_config.output
 				});
 
 				log.info('Building app');

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -820,7 +820,7 @@ Tips:
 
 				log.info('Analysing routes');
 
-				const metadata = await analyse({
+				const { metadata, static_exports } = await analyse({
 					hash: kit.router.type === 'hash',
 					manifest_path,
 					manifest_data,
@@ -981,7 +981,8 @@ Tips:
 					server_manifest,
 					client_manifest,
 					css,
-					svelte_config.kit.output
+					svelte_config.kit.output,
+					static_exports
 				);
 
 				// ...and prerender

--- a/packages/kit/src/exports/vite/static_analysis/index.js
+++ b/packages/kit/src/exports/vite/static_analysis/index.js
@@ -181,12 +181,12 @@ export function get_name(node) {
 }
 
 /**
- * @param {(server_node: string) => Promise<Record<string, any>>} resolve function to evaluate the `+page.server`/`+layout.server` files so that we can get any the page options
+ * @param {{
+ *   resolve: (file: string) => Promise<Record<string, any>>;
+ *   static_exports?: Map<string, Record<string, any> | null>;
+ * }} opts
  */
-export function create_node_analyser(resolve) {
-	/** @type {Map<string, Record<string, any> | null>} */
-	const static_exports = new Map();
-
+export function create_node_analyser({ resolve, static_exports = new Map() }) {
 	/**
 	 * Computes the final page options for a node (if possible). Otherwise, returns `null`.
 	 * @param {import('types').PageNode} node

--- a/packages/kit/src/exports/vite/static_analysis/index.js
+++ b/packages/kit/src/exports/vite/static_analysis/index.js
@@ -181,9 +181,9 @@ export function get_name(node) {
 }
 
 /**
- * @param {(server_node: string) => Promise<Record<string, any>>} resolve
+ * @param {(server_node: string) => Promise<Record<string, any>>} resolve function to evaluate the `+page.server`/`+layout.server` files so that we can get any the page options
  */
-export function create_static_analyser(resolve) {
+export function create_node_analyser(resolve) {
 	/** @type {Map<string, Record<string, any> | null>} */
 	const static_exports = new Map();
 

--- a/packages/kit/test/apps/basics/src/routes/node-analysis/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/node-analysis/+page.js
@@ -1,0 +1,1 @@
+// we need this file to exist so that the node is analysed

--- a/packages/kit/test/apps/basics/src/routes/node-analysis/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/node-analysis/+page.js
@@ -1,1 +1,1 @@
-// we need this file to exist so that the node is analysed
+// this universal file causes the server node to be evaluated during static analysis

--- a/packages/kit/test/apps/basics/src/routes/node-analysis/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/node-analysis/+page.server.js
@@ -1,0 +1,9 @@
+// this module is evaluated when building the server nodes to determine its page options
+// Therefore, we need to ensure $env, etc. still works during this process so that it doesn't throw errors
+// when it's evaluated as `undefined`
+
+import { env } from '$env/dynamic/public';
+
+if (!env.PUBLIC_DYNAMIC) {
+  throw Error('this should not happen');
+}

--- a/packages/kit/test/apps/basics/src/routes/node-analysis/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/node-analysis/+page.server.js
@@ -5,5 +5,5 @@
 import { env } from '$env/dynamic/public';
 
 if (!env.PUBLIC_DYNAMIC) {
-  throw Error('this should not happen');
+	throw Error('this should not happen');
 }


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13785

This PR ensures the `$env` and `$app/environment`, etc. are set before we evaluate the `+page.server`/`+layout.server` files so that they have the correct values when we are analysing the page options of each node. It now also uses the static analysis cache when we build the server nodes again. This lets us avoid evaluating the server files again where those internal variables aren't set.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
