### PR TITLE
fix: avoid caching static analysis results during dev

### DIFF
--- a/.changeset/big-eels-watch.md
+++ b/.changeset/big-eels-watch.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: avoid static analysis stale cache results
+fix: correctly invalidate static analysis cache when modifying a universal `+page`/`+layout` file

--- a/.changeset/big-eels-watch.md
+++ b/.changeset/big-eels-watch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: avoid static analysis stale cache results

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -102,8 +102,15 @@ export async function dev(vite, vite_config, svelte_config) {
 		return { module, module_node, url };
 	}
 
-	/** @type {(file: string) => void} */
-	let invalidate_page_options;
+	/**
+	 *
+	 * @param {string} server_node
+	 * @returns {Promise<Record<string, any>>}
+	 */
+	const resolve_server_node = async (server_node) => {
+		const { module } = await resolve(server_node);
+		return module;
+	};
 
 	function update_manifest() {
 		try {
@@ -127,12 +134,6 @@ export async function dev(vite, vite_config, svelte_config) {
 
 			return;
 		}
-
-		const static_analyser = create_static_analyser(async (server_node) => {
-			const { module } = await resolve(server_node);
-			return module;
-		});
-		invalidate_page_options = static_analyser.invalidate_page_options;
 
 		manifest = {
 			appDir: svelte_config.kit.appDir,
@@ -210,6 +211,8 @@ export async function dev(vite, vite_config, svelte_config) {
 								return module.default;
 							};
 						}
+
+						const static_analyser = create_static_analyser(resolve_server_node);
 
 						if (node.universal) {
 							const page_options = await static_analyser.get_page_options(node);
@@ -360,7 +363,6 @@ export async function dev(vite, vite_config, svelte_config) {
 		if (timeout || restarting) return;
 
 		sync.update(svelte_config, manifest_data, file);
-		invalidate_page_options(path.relative(cwd, file));
 	});
 
 	const { appTemplate, errorTemplate, serviceWorker, hooks } = svelte_config.kit.files;

--- a/packages/kit/src/exports/vite/static_analysis/index.js
+++ b/packages/kit/src/exports/vite/static_analysis/index.js
@@ -247,5 +247,13 @@ export function create_static_analyser(resolve) {
 		return page_options;
 	};
 
-	return { get_page_options };
+	/**
+	 * @param {string} file
+	 * @returns {void}
+	 */
+	const invalidate_page_options = (file) => {
+		static_exports.delete(file);
+	};
+
+	return { get_page_options, invalidate_page_options };
 }

--- a/packages/kit/src/exports/vite/static_analysis/index.js
+++ b/packages/kit/src/exports/vite/static_analysis/index.js
@@ -247,13 +247,5 @@ export function create_static_analyser(resolve) {
 		return page_options;
 	};
 
-	/**
-	 * @param {string} file
-	 * @returns {void}
-	 */
-	const invalidate_page_options = (file) => {
-		static_exports.delete(file);
-	};
-
-	return { get_page_options, invalidate_page_options };
+	return { get_page_options };
 }


### PR DESCRIPTION
Forgot to add the static analysis cache invalidation to the Vite file change listener.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
