### PR TITLE
Tries to allow the rendering of relative paths

### DIFF
--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -473,7 +473,7 @@ Tips:
 				// for internal use only. it's published as $app/paths externally
 				// we use this alias so that we won't collide with user aliases
 				case sveltekit_paths: {
-					const { assets, base } = svelte_config.kit.paths;
+					const { assets, base, relative } = svelte_config.kit.paths;
 
 					// use the values defined in `global`, but fall back to hard-coded values
 					// for the sake of things like Vitest which may import this module
@@ -488,10 +488,10 @@ Tips:
 
 					return dedent`
 						export let base = ${s(base)};
-						export let assets = ${assets ? s(assets) : 'base'};
+						export let assets = ${relative ? '.' : ''} + ${assets ? s(assets) : 'base'};
 						export const app_dir = ${s(kit.appDir)};
 
-						export const relative = ${svelte_config.kit.paths.relative};
+						export const relative = ${relative};
 
 						const initial = { base, assets };
 


### PR DESCRIPTION
<!-- Your PR description here -->

Allows building SPA sites with a relative asset path.

E.g., whether server from:
- `https://some.server/foo`
- `https://some.server/foo/bar`
- `https://some.server/foo/bar/baz`

...the SPA should be able to find the `_app/` subdirectory as a sibling to the fallback page. E.g., given a fallback page of `index.html`:

```
someDirectory/
  index.html
  _app/
    immutable/
      assets/...
      chunks/...
      entry/...
      nodes/...
    env.js
    version.json
```

When `kit.paths.relative` is set, this change renders references to the `_app/` directory with a leading `.` so the browser interprets them as relative paths.

Related issues:
https://github.com/sveltejs/kit/issues/595
https://github.com/sveltejs/kit/issues/9569

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
