### PR TITLE
fix: recover scroll position on reload of SPAs

### DIFF
--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -312,12 +312,16 @@ export async function start(_app, _target, hydrate) {
 	// if we reload the page, or Cmd-Shift-T back to it,
 	// recover scroll position
 	const scroll = scroll_positions[current_history_index];
-	if (scroll) {
-		history.scrollRestoration = 'manual';
-		scrollTo(scroll.x, scroll.y);
+	function restore_scroll() {
+		if (scroll) {
+			history.scrollRestoration = 'manual';
+			scrollTo(scroll.x, scroll.y);
+		}
 	}
 
 	if (hydrate) {
+		restore_scroll();
+
 		await _hydrate(target, hydrate);
 	} else {
 		await navigate({
@@ -325,6 +329,8 @@ export async function start(_app, _target, hydrate) {
 			url: resolve_url(app.hash ? decode_hash(new URL(location.href)) : location.href),
 			replace_state: true
 		});
+
+		restore_scroll();
 	}
 
 	_start_router();


### PR DESCRIPTION
If SSR is disabled, the scroll position won't be restored when the page is reloaded. This happens because `scrollTo` is called before the page is rendered, meaning the target scroll position does not yet exist. Conversely, when SSR is enabled, `scrollTo` works as expected since the page is already rendered, and the scroll position exists.

I wasn't sure if the order of scrolling and hydrating mattered, so I did not move the `scrollTo` behind the `if (hydrate)` block.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
