### PR TITLE
chore: switch to typescript-eslint projectService setting

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,7 +20,7 @@ export default [
 	{
 		languageOptions: {
 			parserOptions: {
-				project: true
+				projectService: true
 			}
 		},
 		rules: {


### PR DESCRIPTION
The `typescript-eslint` docs recommend using `projectService` over `project`: https://typescript-eslint.io/packages/parser/#project

My own testing shows `projectService` to be slightly faster.


**With `project`:**

real	0m36.047s
user	1m10.914s

real	0m29.111s
user	0m56.673s

real	0m29.084s
user	0m53.078s

real	0m31.287s
user	1m3.867s

real	0m28.033s
user	0m53.280s


**With `projectService`:**

real	0m36.333s
user	1m10.211s

real	0m29.553s
user	0m56.994s

real	0m27.674s
user	0m53.531s

real	0m27.125s
user	0m49.013s

real	0m26.967s
user	0m49.587s