### PR TITLE
fix: omit stack when logging 404 errors in dev

### DIFF
--- a/.changeset/dull-pants-glow.md
+++ b/.changeset/dull-pants-glow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: omit stack when logging 404 errors in dev

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -74,7 +74,10 @@ export class Server {
 
 				this.#options.hooks = {
 					handle: module.handle || (({ event, resolve }) => resolve(event)),
-					handleError: module.handleError || (({ error }) => console.error(error)),
+					handleError:
+						module.handleError ||
+						(({ status, error }) =>
+							console.error((status === 404 && /** @type {Error} */ (error)?.message) || error)),
 					handleFetch: module.handleFetch || (({ request, fetch }) => fetch(request)),
 					reroute: module.reroute || (() => {}),
 					transport: module.transport || {}


### PR DESCRIPTION
inspired by #13830, but separate: it makes no sense to log a stack trace with a 404, we can just log `Not found: /blah`. The stack trace will only ever include SvelteKit internals, there's nothing that a developer can do with that information.

We could probably improve logging of server-side errors all round (e.g. a nicely formatted `[500] GET /whatever` with a sanitized stack trace, maybe a code frame if appropriate, maybe opening a model on the client, etc) but I thought it would make sense to start with this no-brainer PR 

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
