### PR TITLE
fix: correctly set sequential focus navigation starting point when using the hash router

### DIFF
--- a/.changeset/grumpy-chefs-retire.md
+++ b/.changeset/grumpy-chefs-retire.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly set the sequential focus navigation point when using hash routing

--- a/.changeset/long-cows-pump.md
+++ b/.changeset/long-cows-pump.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: regression when navigating with hash routing

--- a/packages/kit/test/apps/hash-based-routing/src/routes/focus/+page.svelte
+++ b/packages/kit/test/apps/hash-based-routing/src/routes/focus/+page.svelte
@@ -1,0 +1,1 @@
+<a href="#/focus/a#p">click me!</a>

--- a/packages/kit/test/apps/hash-based-routing/src/routes/focus/a/+page.svelte
+++ b/packages/kit/test/apps/hash-based-routing/src/routes/focus/a/+page.svelte
@@ -1,0 +1,4 @@
+<button>button 1</button>
+<button>button 2</button>
+<p id="p">cannot be focused</p>
+<button id="button3">button 3</button>

--- a/packages/kit/test/apps/hash-based-routing/test/test.js
+++ b/packages/kit/test/apps/hash-based-routing/test/test.js
@@ -115,4 +115,15 @@ test.describe('hash based navigation', () => {
 		await page.goForward();
 		expect(page.locator('p')).toHaveText('b');
 	});
+
+	test('sequential focus navigation point is set correctly', async ({ page, browserName }) => {
+		const tab = browserName === 'webkit' ? 'Alt+Tab' : 'Tab';
+		await page.goto('/#/focus');
+		await page.locator('a[href="#/focus/a#p"]').click();
+		await page.waitForURL('#/focus/a#p');
+		expect(await page.evaluate(() => (document.activeElement || {}).nodeName)).toBe('BODY');
+		await page.keyboard.press(tab);
+		await expect(page.locator('#button3')).toBeFocused();
+		await expect(page.locator('button[id="button3"]')).toBeFocused();
+	});
 });


### PR DESCRIPTION
This PR fixes a regression caused by https://github.com/sveltejs/kit/pull/10856 that didn't take hash routing into account when trying to set the sequential focus navigation starting point. It now correctly determines the hash and uses a cleaner fix than before with `element.focus()` instead of `location.replace` (although used in a bit of a hacky way but not anymore hacky than the previous PR).

~I've tested on Chrome and Firefox on Windows but will need to test this on Safari too. Maybe CI can do that for me.~ `.focus()` does not work on Safari and Firefox Ubuntu 😄 

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
