### PR TITLE
fix: avoid setting sequential focus navigation starting point when using hash router

### DIFF
--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2800,7 +2800,8 @@ function reset_focus() {
 		autofocus.focus();
 	} else {
 		// Reset page selection and focus
-		if (location.hash && document.querySelector(location.hash)) {
+		// TODO: find a fix that works with hash routing too
+		if (!app.hash && location.hash && document.querySelector(location.hash)) {
 			const { x, y } = scroll_state();
 
 			setTimeout(() => {


### PR DESCRIPTION
This PR fixes a regression caused by https://github.com/sveltejs/kit/pull/10856 which broke hash router navigation.

We can't apply the same fix for hash routing because `location.replace` doesn't work since the browser interprets the entire hash as the element it should focus but we're using it as a pathname replacement. `element.focus()` doesn't work on Safari and Ubuntu Firefox so that's moot too.