### PR TITLE
feat: typed route ids

### DIFF
--- a/.changeset/wicked-bananas-yawn.md
+++ b/.changeset/wicked-bananas-yawn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: `RouteId` type, and type safety for things like `resolveRoute`, `page.route.id` and `page.params`

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -98,7 +98,10 @@ export function get_tsconfig(kit) {
 	const config = {
 		compilerOptions: {
 			// generated options
-			paths: get_tsconfig_paths(kit),
+			paths: {
+				...get_tsconfig_paths(kit),
+				'$app/types': ['./types/index.d.ts']
+			},
 			rootDirs: [config_relative('.'), './types'],
 
 			// essential options

--- a/packages/kit/src/core/sync/write_tsconfig.spec.js
+++ b/packages/kit/src/core/sync/write_tsconfig.spec.js
@@ -20,6 +20,7 @@ test('Creates tsconfig path aliases from kit.alias', () => {
 	// $lib isn't part of the outcome because there's a "path exists"
 	// check in the implementation
 	expect(compilerOptions.paths).toEqual({
+		'$app/types': ['./types/index.d.ts'],
 		simpleKey: ['../simple/value'],
 		'simpleKey/*': ['../simple/value/*'],
 		key: ['../value'],

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -60,6 +60,10 @@ export function write_all_types(config, manifest_data) {
 		routes.push(type);
 	}
 
+	try {
+		fs.mkdirSync(types_dir, { recursive: true });
+	} catch {}
+
 	fs.writeFileSync(
 		`${types_dir}/index.d.ts`,
 		[

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -65,7 +65,7 @@ export function write_all_types(config, manifest_data) {
 		[
 			`type Routes = {\n\t${routes.join(';\n\t')}\n};`,
 			`export type RouteId = ${manifest_data.routes.map((r) => s(r.id)).join(' | ')};`,
-			'export type RouteParams<T extends RouteId> = Routes[T];'
+			'export type RouteParams<T extends RouteId> = Routes[T] | Record<string, never>;'
 		].join('\n\n')
 	);
 

--- a/packages/kit/src/core/sync/write_types/index.spec.js
+++ b/packages/kit/src/core/sync/write_types/index.spec.js
@@ -30,7 +30,7 @@ function run_test(dir) {
 	write_all_types(initial, manifest);
 }
 
-test('Creates correct $types', { timeout: 6000 }, () => {
+test('Creates correct $types', { timeout: 30000 }, () => {
 	// To save us from creating a real SvelteKit project for each of the tests,
 	// we first run the type generation directly for each test case, and then
 	// call `tsc` to check that the generated types are valid.
@@ -47,9 +47,11 @@ test('Creates correct $types', { timeout: 6000 }, () => {
 			run_test(dir);
 
 			try {
-				tsconfig.compilerOptions.paths = {
-					'$app/types': [`${cwd}/${dir}/.svelte-kit/types/index.d.ts`]
-				};
+				tsconfig.compilerOptions.paths['$app/types'] = [
+					`${cwd}/${dir}/.svelte-kit/types/index.d.ts`
+				];
+
+				tsconfig.include = [`./${dir}/**/*.js`];
 
 				fs.writeFileSync(tsconfig_file, JSON.stringify(tsconfig));
 

--- a/packages/kit/src/core/sync/write_types/index.spec.js
+++ b/packages/kit/src/core/sync/write_types/index.spec.js
@@ -1,4 +1,5 @@
 import { execSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { assert, expect, test } from 'vitest';
@@ -33,20 +34,33 @@ test('Creates correct $types', { timeout: 6000 }, () => {
 	// To save us from creating a real SvelteKit project for each of the tests,
 	// we first run the type generation directly for each test case, and then
 	// call `tsc` to check that the generated types are valid.
-	run_test('actions');
-	run_test('simple-page-shared-only');
-	run_test('simple-page-server-only');
-	run_test('simple-page-server-and-shared');
-	run_test('layout');
-	run_test('layout-advanced');
-	run_test('slugs');
-	run_test('slugs-layout-not-all-pages-have-load');
-	run_test('param-type-inference');
+	const directories = fs
+		.readdirSync(cwd)
+		.filter((dir) => fs.statSync(`${cwd}/${dir}`).isDirectory());
+
+	const tsconfig_file = `${cwd}/tsconfig.json`;
+	const tsconfig_json = fs.readFileSync(tsconfig_file, 'utf-8');
+	const tsconfig = JSON.parse(tsconfig_json);
+
 	try {
-		execSync('pnpm testtypes', { cwd });
-	} catch (e) {
-		console.error(/** @type {any} */ (e).stdout.toString());
-		throw new Error('Type tests failed');
+		for (const dir of directories) {
+			run_test(dir);
+
+			try {
+				tsconfig.compilerOptions.paths = {
+					'$app/types': [`${cwd}/${dir}/.svelte-kit/types/index.d.ts`]
+				};
+
+				fs.writeFileSync(tsconfig_file, JSON.stringify(tsconfig));
+
+				execSync('pnpm testtypes', { cwd });
+			} catch (e) {
+				console.error(/** @type {any} */ (e).stdout.toString());
+				throw new Error('Type tests failed');
+			}
+		}
+	} finally {
+		fs.writeFileSync(tsconfig_file, tsconfig_json);
 	}
 });
 

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -19,6 +19,7 @@ import {
 } from '../types/private.js';
 import { BuildData, SSRNodeLoader, SSRRoute, ValidatedConfig } from 'types';
 import type { PluginOptions } from '@sveltejs/vite-plugin-svelte';
+import { RouteId as AppRouteId, RouteParams as AppRouteParams } from '$app/types';
 
 export { PrerenderOption } from '../types/private.js';
 
@@ -858,11 +859,11 @@ export interface Transporter<
  * rather than using `Load` directly.
  */
 export type Load<
-	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
+	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
 	InputData extends Record<string, unknown> | null = Record<string, any> | null,
 	ParentData extends Record<string, unknown> = Record<string, any>,
 	OutputData extends Record<string, unknown> | void = Record<string, any> | void,
-	RouteId extends string | null = string | null
+	RouteId extends AppRouteId | null = AppRouteId | null
 > = (event: LoadEvent<Params, InputData, ParentData, RouteId>) => MaybePromise<OutputData>;
 
 /**
@@ -870,10 +871,10 @@ export type Load<
  * rather than using `LoadEvent` directly.
  */
 export interface LoadEvent<
-	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
+	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
 	Data extends Record<string, unknown> | null = Record<string, any> | null,
 	ParentData extends Record<string, unknown> = Record<string, any>,
-	RouteId extends string | null = string | null
+	RouteId extends AppRouteId | null = AppRouteId | null
 > extends NavigationEvent<Params, RouteId> {
 	/**
 	 * `fetch` is equivalent to the [native `fetch` web API](https://developer.mozilla.org/en-US/docs/Web/API/fetch), with a few additional features:
@@ -978,8 +979,8 @@ export interface LoadEvent<
 }
 
 export interface NavigationEvent<
-	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
-	RouteId extends string | null = string | null
+	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+	RouteId extends AppRouteId | null = AppRouteId | null
 > {
 	/**
 	 * The parameters of the current page - e.g. for a route like `/blog/[slug]`, a `{ slug: string }` object
@@ -1118,8 +1119,8 @@ export interface AfterNavigate extends Omit<Navigation, 'type'> {
  * The shape of the [`page`](https://svelte.dev/docs/kit/$app-state#page) reactive object and the [`$page`](https://svelte.dev/docs/kit/$app-stores) store.
  */
 export interface Page<
-	Params extends Record<string, string> = Record<string, string>,
-	RouteId extends string | null = string | null
+	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+	RouteId extends AppRouteId | null = AppRouteId | null
 > {
 	/**
 	 * The URL of the current page.
@@ -1166,8 +1167,8 @@ export interface Page<
 export type ParamMatcher = (param: string) => boolean;
 
 export interface RequestEvent<
-	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
-	RouteId extends string | null = string | null
+	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+	RouteId extends AppRouteId | null = AppRouteId | null
 > {
 	/**
 	 * Get or set cookies related to the current request
@@ -1258,8 +1259,8 @@ export interface RequestEvent<
  * It receives `Params` as the first generic argument, which you can skip by using [generated types](https://svelte.dev/docs/kit/types#Generated-types) instead.
  */
 export type RequestHandler<
-	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
-	RouteId extends string | null = string | null
+	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+	RouteId extends AppRouteId | null = AppRouteId | null
 > = (event: RequestEvent<Params, RouteId>) => MaybePromise<Response>;
 
 export interface ResolveOptions {
@@ -1337,16 +1338,16 @@ export interface SSRManifest {
  * rather than using `ServerLoad` directly.
  */
 export type ServerLoad<
-	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
+	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
 	ParentData extends Record<string, any> = Record<string, any>,
 	OutputData extends Record<string, any> | void = Record<string, any> | void,
-	RouteId extends string | null = string | null
+	RouteId extends AppRouteId | null = AppRouteId | null
 > = (event: ServerLoadEvent<Params, ParentData, RouteId>) => MaybePromise<OutputData>;
 
 export interface ServerLoadEvent<
-	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
+	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
 	ParentData extends Record<string, any> = Record<string, any>,
-	RouteId extends string | null = string | null
+	RouteId extends AppRouteId | null = AppRouteId | null
 > extends RequestEvent<Params, RouteId> {
 	/**
 	 * `await parent()` returns data from parent `+layout.server.js` `load` functions.
@@ -1413,9 +1414,9 @@ export interface ServerLoadEvent<
  * See [form actions](https://svelte.dev/docs/kit/form-actions) for more information.
  */
 export type Action<
-	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
+	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
 	OutputData extends Record<string, any> | void = Record<string, any> | void,
-	RouteId extends string | null = string | null
+	RouteId extends AppRouteId | null = AppRouteId | null
 > = (event: RequestEvent<Params, RouteId>) => MaybePromise<OutputData>;
 
 /**
@@ -1423,9 +1424,9 @@ export type Action<
  * See [form actions](https://svelte.dev/docs/kit/form-actions) for more information.
  */
 export type Actions<
-	Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
+	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
 	OutputData extends Record<string, any> | void = Record<string, any> | void,
-	RouteId extends string | null = string | null
+	RouteId extends AppRouteId | null = AppRouteId | null
 > = Record<string, Action<Params, OutputData, RouteId>>;
 
 /**

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -19,7 +19,11 @@ import {
 } from '../types/private.js';
 import { BuildData, SSRNodeLoader, SSRRoute, ValidatedConfig } from 'types';
 import type { PluginOptions } from '@sveltejs/vite-plugin-svelte';
-import { RouteId as AppRouteId, RouteParams as AppRouteParams } from '$app/types';
+import {
+	RouteId as AppRouteId,
+	RouteParams as AppRouteParams,
+	LayoutParams as AppLayoutParams
+} from '$app/types';
 
 export { PrerenderOption } from '../types/private.js';
 
@@ -859,7 +863,7 @@ export interface Transporter<
  * rather than using `Load` directly.
  */
 export type Load<
-	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+	Params extends AppLayoutParams<AppRouteId> = AppLayoutParams<AppRouteId>,
 	InputData extends Record<string, unknown> | null = Record<string, any> | null,
 	ParentData extends Record<string, unknown> = Record<string, any>,
 	OutputData extends Record<string, unknown> | void = Record<string, any> | void,
@@ -871,7 +875,7 @@ export type Load<
  * rather than using `LoadEvent` directly.
  */
 export interface LoadEvent<
-	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+	Params extends AppLayoutParams<AppRouteId> = AppLayoutParams<AppRouteId>,
 	Data extends Record<string, unknown> | null = Record<string, any> | null,
 	ParentData extends Record<string, unknown> = Record<string, any>,
 	RouteId extends AppRouteId | null = AppRouteId | null
@@ -979,7 +983,7 @@ export interface LoadEvent<
 }
 
 export interface NavigationEvent<
-	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+	Params extends AppLayoutParams<AppRouteId> = AppLayoutParams<AppRouteId>,
 	RouteId extends AppRouteId | null = AppRouteId | null
 > {
 	/**
@@ -1167,7 +1171,7 @@ export interface Page<
 export type ParamMatcher = (param: string) => boolean;
 
 export interface RequestEvent<
-	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+	Params extends AppLayoutParams<AppRouteId> = AppLayoutParams<AppRouteId>,
 	RouteId extends AppRouteId | null = AppRouteId | null
 > {
 	/**
@@ -1259,7 +1263,7 @@ export interface RequestEvent<
  * It receives `Params` as the first generic argument, which you can skip by using [generated types](https://svelte.dev/docs/kit/types#Generated-types) instead.
  */
 export type RequestHandler<
-	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+	Params extends AppLayoutParams<AppRouteId> = AppLayoutParams<AppRouteId>,
 	RouteId extends AppRouteId | null = AppRouteId | null
 > = (event: RequestEvent<Params, RouteId>) => MaybePromise<Response>;
 
@@ -1338,14 +1342,14 @@ export interface SSRManifest {
  * rather than using `ServerLoad` directly.
  */
 export type ServerLoad<
-	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+	Params extends AppLayoutParams<AppRouteId> = AppLayoutParams<AppRouteId>,
 	ParentData extends Record<string, any> = Record<string, any>,
 	OutputData extends Record<string, any> | void = Record<string, any> | void,
 	RouteId extends AppRouteId | null = AppRouteId | null
 > = (event: ServerLoadEvent<Params, ParentData, RouteId>) => MaybePromise<OutputData>;
 
 export interface ServerLoadEvent<
-	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+	Params extends AppLayoutParams<AppRouteId> = AppLayoutParams<AppRouteId>,
 	ParentData extends Record<string, any> = Record<string, any>,
 	RouteId extends AppRouteId | null = AppRouteId | null
 > extends RequestEvent<Params, RouteId> {
@@ -1414,7 +1418,7 @@ export interface ServerLoadEvent<
  * See [form actions](https://svelte.dev/docs/kit/form-actions) for more information.
  */
 export type Action<
-	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+	Params extends AppLayoutParams<AppRouteId> = AppLayoutParams<AppRouteId>,
 	OutputData extends Record<string, any> | void = Record<string, any> | void,
 	RouteId extends AppRouteId | null = AppRouteId | null
 > = (event: RequestEvent<Params, RouteId>) => MaybePromise<OutputData>;
@@ -1424,7 +1428,7 @@ export type Action<
  * See [form actions](https://svelte.dev/docs/kit/form-actions) for more information.
  */
 export type Actions<
-	Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+	Params extends AppLayoutParams<AppRouteId> = AppLayoutParams<AppRouteId>,
 	OutputData extends Record<string, any> | void = Record<string, any> | void,
 	RouteId extends AppRouteId | null = AppRouteId | null
 > = Record<string, Action<Params, OutputData, RouteId>>;

--- a/packages/kit/src/runtime/app/paths/types.d.ts
+++ b/packages/kit/src/runtime/app/paths/types.d.ts
@@ -1,3 +1,5 @@
+import { RouteId, RouteParams } from '$app/types';
+
 /**
  * A string that matches [`config.kit.paths.base`](https://svelte.dev/docs/kit/configuration#paths).
  *
@@ -11,6 +13,9 @@ export let base: '' | `/${string}`;
  * > [!NOTE] If a value for `config.kit.paths.assets` is specified, it will be replaced with `'/_svelte_kit_assets'` during `vite dev` or `vite preview`, since the assets don't yet live at their eventual URL.
  */
 export let assets: '' | `https://${string}` | `http://${string}` | '/_svelte_kit_assets';
+
+type ResolveRouteArgs<T extends RouteId> =
+	RouteParams<T> extends undefined ? [route: T] : [route: T, params: RouteParams<T>];
 
 /**
  * Populate a route ID with params to resolve a pathname.
@@ -27,4 +32,4 @@ export let assets: '' | `https://${string}` | `http://${string}` | '/_svelte_kit
  * ); // `/blog/hello-world/something/else`
  * ```
  */
-export function resolveRoute(id: string, params: Record<string, string | undefined>): string;
+export function resolveRoute<T extends RouteId>(...args: ResolveRouteArgs<T>): string;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -4,6 +4,7 @@
 declare module '@sveltejs/kit' {
 	import type { CompileOptions } from 'svelte/compiler';
 	import type { PluginOptions } from '@sveltejs/vite-plugin-svelte';
+	import type { RouteId as AppRouteId, RouteParams as AppRouteParams } from '$app/types';
 	/**
 	 * [Adapters](https://svelte.dev/docs/kit/adapters) are responsible for taking the production build and turning it into something that can be deployed to a platform of your choosing.
 	 */
@@ -840,11 +841,11 @@ declare module '@sveltejs/kit' {
 	 * rather than using `Load` directly.
 	 */
 	export type Load<
-		Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
+		Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
 		InputData extends Record<string, unknown> | null = Record<string, any> | null,
 		ParentData extends Record<string, unknown> = Record<string, any>,
 		OutputData extends Record<string, unknown> | void = Record<string, any> | void,
-		RouteId extends string | null = string | null
+		RouteId extends AppRouteId | null = AppRouteId | null
 	> = (event: LoadEvent<Params, InputData, ParentData, RouteId>) => MaybePromise<OutputData>;
 
 	/**
@@ -852,10 +853,10 @@ declare module '@sveltejs/kit' {
 	 * rather than using `LoadEvent` directly.
 	 */
 	export interface LoadEvent<
-		Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
+		Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
 		Data extends Record<string, unknown> | null = Record<string, any> | null,
 		ParentData extends Record<string, unknown> = Record<string, any>,
-		RouteId extends string | null = string | null
+		RouteId extends AppRouteId | null = AppRouteId | null
 	> extends NavigationEvent<Params, RouteId> {
 		/**
 		 * `fetch` is equivalent to the [native `fetch` web API](https://developer.mozilla.org/en-US/docs/Web/API/fetch), with a few additional features:
@@ -960,8 +961,8 @@ declare module '@sveltejs/kit' {
 	}
 
 	export interface NavigationEvent<
-		Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
-		RouteId extends string | null = string | null
+		Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+		RouteId extends AppRouteId | null = AppRouteId | null
 	> {
 		/**
 		 * The parameters of the current page - e.g. for a route like `/blog/[slug]`, a `{ slug: string }` object
@@ -1100,8 +1101,8 @@ declare module '@sveltejs/kit' {
 	 * The shape of the [`page`](https://svelte.dev/docs/kit/$app-state#page) reactive object and the [`$page`](https://svelte.dev/docs/kit/$app-stores) store.
 	 */
 	export interface Page<
-		Params extends Record<string, string> = Record<string, string>,
-		RouteId extends string | null = string | null
+		Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+		RouteId extends AppRouteId | null = AppRouteId | null
 	> {
 		/**
 		 * The URL of the current page.
@@ -1148,8 +1149,8 @@ declare module '@sveltejs/kit' {
 	export type ParamMatcher = (param: string) => boolean;
 
 	export interface RequestEvent<
-		Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
-		RouteId extends string | null = string | null
+		Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+		RouteId extends AppRouteId | null = AppRouteId | null
 	> {
 		/**
 		 * Get or set cookies related to the current request
@@ -1240,8 +1241,8 @@ declare module '@sveltejs/kit' {
 	 * It receives `Params` as the first generic argument, which you can skip by using [generated types](https://svelte.dev/docs/kit/types#Generated-types) instead.
 	 */
 	export type RequestHandler<
-		Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
-		RouteId extends string | null = string | null
+		Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+		RouteId extends AppRouteId | null = AppRouteId | null
 	> = (event: RequestEvent<Params, RouteId>) => MaybePromise<Response>;
 
 	export interface ResolveOptions {
@@ -1319,16 +1320,16 @@ declare module '@sveltejs/kit' {
 	 * rather than using `ServerLoad` directly.
 	 */
 	export type ServerLoad<
-		Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
+		Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
 		ParentData extends Record<string, any> = Record<string, any>,
 		OutputData extends Record<string, any> | void = Record<string, any> | void,
-		RouteId extends string | null = string | null
+		RouteId extends AppRouteId | null = AppRouteId | null
 	> = (event: ServerLoadEvent<Params, ParentData, RouteId>) => MaybePromise<OutputData>;
 
 	export interface ServerLoadEvent<
-		Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
+		Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
 		ParentData extends Record<string, any> = Record<string, any>,
-		RouteId extends string | null = string | null
+		RouteId extends AppRouteId | null = AppRouteId | null
 	> extends RequestEvent<Params, RouteId> {
 		/**
 		 * `await parent()` returns data from parent `+layout.server.js` `load` functions.
@@ -1395,9 +1396,9 @@ declare module '@sveltejs/kit' {
 	 * See [form actions](https://svelte.dev/docs/kit/form-actions) for more information.
 	 */
 	export type Action<
-		Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
+		Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
 		OutputData extends Record<string, any> | void = Record<string, any> | void,
-		RouteId extends string | null = string | null
+		RouteId extends AppRouteId | null = AppRouteId | null
 	> = (event: RequestEvent<Params, RouteId>) => MaybePromise<OutputData>;
 
 	/**
@@ -1405,9 +1406,9 @@ declare module '@sveltejs/kit' {
 	 * See [form actions](https://svelte.dev/docs/kit/form-actions) for more information.
 	 */
 	export type Actions<
-		Params extends Partial<Record<string, string>> = Partial<Record<string, string>>,
+		Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
 		OutputData extends Record<string, any> | void = Record<string, any> | void,
-		RouteId extends string | null = string | null
+		RouteId extends AppRouteId | null = AppRouteId | null
 	> = Record<string, Action<Params, OutputData, RouteId>>;
 
 	/**
@@ -2426,7 +2427,7 @@ declare module '$app/server' {
 	 * In environments without [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage), this must be called synchronously (i.e. not after an `await`).
 	 * @since 2.20.0
 	 */
-	export function getRequestEvent(): RequestEvent<Partial<Record<string, string>>, string | null>;
+	export function getRequestEvent(): RequestEvent<AppRouteParams<AppRouteId>, any>;
 
 	export {};
 }

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -4,7 +4,7 @@
 declare module '@sveltejs/kit' {
 	import type { CompileOptions } from 'svelte/compiler';
 	import type { PluginOptions } from '@sveltejs/vite-plugin-svelte';
-	import type { RouteId as AppRouteId, RouteParams as AppRouteParams } from '$app/types';
+	import type { RouteId as AppRouteId, RouteParams as AppRouteParams, LayoutParams as AppLayoutParams } from '$app/types';
 	/**
 	 * [Adapters](https://svelte.dev/docs/kit/adapters) are responsible for taking the production build and turning it into something that can be deployed to a platform of your choosing.
 	 */
@@ -841,7 +841,7 @@ declare module '@sveltejs/kit' {
 	 * rather than using `Load` directly.
 	 */
 	export type Load<
-		Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+		Params extends AppLayoutParams<AppRouteId> = AppLayoutParams<AppRouteId>,
 		InputData extends Record<string, unknown> | null = Record<string, any> | null,
 		ParentData extends Record<string, unknown> = Record<string, any>,
 		OutputData extends Record<string, unknown> | void = Record<string, any> | void,
@@ -853,7 +853,7 @@ declare module '@sveltejs/kit' {
 	 * rather than using `LoadEvent` directly.
 	 */
 	export interface LoadEvent<
-		Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+		Params extends AppLayoutParams<AppRouteId> = AppLayoutParams<AppRouteId>,
 		Data extends Record<string, unknown> | null = Record<string, any> | null,
 		ParentData extends Record<string, unknown> = Record<string, any>,
 		RouteId extends AppRouteId | null = AppRouteId | null
@@ -961,7 +961,7 @@ declare module '@sveltejs/kit' {
 	}
 
 	export interface NavigationEvent<
-		Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+		Params extends AppLayoutParams<AppRouteId> = AppLayoutParams<AppRouteId>,
 		RouteId extends AppRouteId | null = AppRouteId | null
 	> {
 		/**
@@ -1149,7 +1149,7 @@ declare module '@sveltejs/kit' {
 	export type ParamMatcher = (param: string) => boolean;
 
 	export interface RequestEvent<
-		Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+		Params extends AppLayoutParams<AppRouteId> = AppLayoutParams<AppRouteId>,
 		RouteId extends AppRouteId | null = AppRouteId | null
 	> {
 		/**
@@ -1320,14 +1320,14 @@ declare module '@sveltejs/kit' {
 	 * rather than using `ServerLoad` directly.
 	 */
 	export type ServerLoad<
-		Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+		Params extends AppLayoutParams<AppRouteId> = AppLayoutParams<AppRouteId>,
 		ParentData extends Record<string, any> = Record<string, any>,
 		OutputData extends Record<string, any> | void = Record<string, any> | void,
 		RouteId extends AppRouteId | null = AppRouteId | null
 	> = (event: ServerLoadEvent<Params, ParentData, RouteId>) => MaybePromise<OutputData>;
 
 	export interface ServerLoadEvent<
-		Params extends AppRouteParams<AppRouteId> = AppRouteParams<AppRouteId>,
+		Params extends AppLayoutParams<AppRouteId> = AppLayoutParams<AppRouteId>,
 		ParentData extends Record<string, any> = Record<string, any>,
 		RouteId extends AppRouteId | null = AppRouteId | null
 	> extends RequestEvent<Params, RouteId> {
@@ -2427,7 +2427,7 @@ declare module '$app/server' {
 	 * In environments without [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage), this must be called synchronously (i.e. not after an `await`).
 	 * @since 2.20.0
 	 */
-	export function getRequestEvent(): RequestEvent<AppRouteParams<AppRouteId>, any>;
+	export function getRequestEvent(): RequestEvent<AppLayoutParams<AppRouteId>, any>;
 
 	export {};
 }

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2367,6 +2367,7 @@ declare module '$app/navigation' {
 }
 
 declare module '$app/paths' {
+	import type { RouteId, RouteParams } from '$app/types';
 	/**
 	 * A string that matches [`config.kit.paths.base`](https://svelte.dev/docs/kit/configuration#paths).
 	 *
@@ -2380,6 +2381,9 @@ declare module '$app/paths' {
 	 * > [!NOTE] If a value for `config.kit.paths.assets` is specified, it will be replaced with `'/_svelte_kit_assets'` during `vite dev` or `vite preview`, since the assets don't yet live at their eventual URL.
 	 */
 	export let assets: '' | `https://${string}` | `http://${string}` | '/_svelte_kit_assets';
+
+	type ResolveRouteArgs<T extends RouteId> =
+		RouteParams<T> extends undefined ? [route: T] : [route: T, params: RouteParams<T>];
 
 	/**
 	 * Populate a route ID with params to resolve a pathname.
@@ -2396,7 +2400,7 @@ declare module '$app/paths' {
 	 * ); // `/blog/hello-world/something/else`
 	 * ```
 	 */
-	export function resolveRoute(id: string, params: Record<string, string | undefined>): string;
+	export function resolveRoute<T extends RouteId>(...args: ResolveRouteArgs<T>): string;
 
 	export {};
 }


### PR DESCRIPTION
This is long overdue, but @jycouet goaded me into working on it with the 1.0 release of [`vite-plugin-kit-routes`](https://www.kitql.dev/docs/tools/06_vite-plugin-kit-routes) 🎉 

Everyone should have type safety when dealing with routes!

This PR adds a new generated `$app/types` module which exports three types:

- `RouteId` is a union of all the routes in your app (`'/' | '/about' | '/blog' | '/blog/[slug]'` etc)
- `RouteParams<T extends RouteId>` is a utility that gives you the type of the params for a given route
- `LayoutParams<T extends RouteId>` is the same, but also gives you the type of any children of `T` (for example, if you're in the `/blog` layout, the route could be either `/blog` or `/blog/[slug]`, so `slug` is an optional param

Most of the time you won't use these types directly, but via things like `page.route.id` and `resolveRoute`:

![Screenshot 2025-06-07 at 3 49 11 PM](https://github.com/user-attachments/assets/d8797da9-f0f5-49fc-885f-3b0fc861f04f)

![Screenshot 2025-06-07 at 3 50 53 PM](https://github.com/user-attachments/assets/21bfb0f9-a945-4ee3-a46a-acf91e96c194)

![Screenshot 2025-06-07 at 3 49 32 PM](https://github.com/user-attachments/assets/1c9ddacd-4f9c-4308-9e5c-6cb99f72327b)

![Screenshot 2025-06-07 at 3 49 51 PM](https://github.com/user-attachments/assets/276b3ea9-b785-4039-83c7-5202d0752c45)

I couldn't figure out a sensible way to add a test for this. Maybe someone else can, if not then I'm not too worried about it.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
