### PR TITLE
fix: sequential focus navigation starting point regression and hash routing

### DIFF
--- a/.changeset/tall-kids-sit.md
+++ b/.changeset/tall-kids-sit.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly set the sequential focus navigation point when using hash routing

--- a/.changeset/tricky-deers-poke.md
+++ b/.changeset/tricky-deers-poke.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: regression when resetting focus and the URL hash contains selector combinators or separators

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2989,8 +2989,8 @@ function decode_hash(url) {
  * @returns {string}
  */
 function get_id(url) {
-  const [_, first, second] = url.hash.split('#', 3);
-  return decodeURIComponent(second ?? first);
+	const [_, first, second] = url.hash.split('#', 3);
+	return decodeURIComponent(second ?? first);
 }
 
 if (DEV) {

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2989,8 +2989,16 @@ function decode_hash(url) {
  * @returns {string}
  */
 function get_id(url) {
-	const [, first, second] = url.hash.split('#', 3);
-	return decodeURIComponent(second ?? first);
+	let id;
+
+	if (app.hash) {
+		const [, , second] = url.hash.split('#', 3);
+		id = second ?? '';
+	} else {
+		id = url.hash.slice(1);
+	}
+
+	return decodeURIComponent(id);
 }
 
 if (DEV) {

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2989,7 +2989,7 @@ function decode_hash(url) {
  * @returns {string}
  */
 function get_id(url) {
-	const [_, first, second] = url.hash.split('#', 3);
+	const [, first, second] = url.hash.split('#', 3);
 	return decodeURIComponent(second ?? first);
 }
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2990,8 +2990,8 @@ function decode_hash(url) {
  * @returns {string}
  */
 function get_id(url) {
-	const hash = app.hash ? (url.hash.split('#', 3)[2] ?? '') : url.hash.slice(1);
-	return decodeURIComponent(hash);
+  const [_, first, second] = url.hash.split('#', 3);
+  return decodeURIComponent(second ?? first);
 }
 
 if (DEV) {

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2798,7 +2798,6 @@ function deserialize_uses(uses) {
 let resetting_focus = false;
 
 /**
- *
  * @param {URL} url
  */
 function reset_focus(url) {

--- a/packages/kit/test/apps/basics/src/routes/reset-focus/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/reset-focus/+page.js
@@ -1,0 +1,1 @@
+export const ssr = false;

--- a/packages/kit/test/apps/basics/src/routes/reset-focus/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/reset-focus/+page.svelte
@@ -1,0 +1,1 @@
+<button id="an:invalid+selector">I have a weird ID but I should be focused</button>

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -41,6 +41,11 @@ test.describe('a11y', () => {
 		expect(await page.evaluate(() => (document.activeElement || {}).nodeName)).toBe('INPUT');
 	});
 
+	test('sets focus for valid hash but invalid selector', async ({ page }) => {
+		await page.goto('/reset-focus#an:invalid+selector');
+		await expect(page.locator('button')).toBeFocused();
+	});
+
 	test('announces client-side navigation', async ({ page, clicknav, javaScriptEnabled }) => {
 		await page.goto('/accessibility/a');
 

--- a/packages/kit/test/apps/hash-based-routing/src/routes/focus/+page.svelte
+++ b/packages/kit/test/apps/hash-based-routing/src/routes/focus/+page.svelte
@@ -1,0 +1,1 @@
+<a href="#/focus/a#p">click me!</a>

--- a/packages/kit/test/apps/hash-based-routing/src/routes/focus/a/+page.svelte
+++ b/packages/kit/test/apps/hash-based-routing/src/routes/focus/a/+page.svelte
@@ -1,0 +1,4 @@
+<button>button 1</button>
+<button>button 2</button>
+<p id="p">cannot be focused</p>
+<button id="button3">button 3</button>

--- a/packages/kit/test/apps/hash-based-routing/test/test.js
+++ b/packages/kit/test/apps/hash-based-routing/test/test.js
@@ -115,4 +115,15 @@ test.describe('hash based navigation', () => {
 		await page.goForward();
 		expect(page.locator('p')).toHaveText('b');
 	});
+
+	test('sequential focus navigation point is set correctly', async ({ page, browserName }) => {
+		const tab = browserName === 'webkit' ? 'Alt+Tab' : 'Tab';
+		await page.goto('/#/focus');
+		await page.locator('a[href="#/focus/a#p"]').click();
+		await page.waitForURL('#/focus/a#p');
+		expect(await page.evaluate(() => (document.activeElement || {}).nodeName)).toBe('BODY');
+		await page.keyboard.press(tab);
+		await expect(page.locator('#button3')).toBeFocused();
+		await expect(page.locator('button[id="button3"]')).toBeFocused();
+	});
 });


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13883 and sequential focus navigation in hash routing apps.

This PR ensures our sequential focus navigation setting works in hash routing apps by avoiding client-side navigation when using `location.replace()` to set the focus. It also moves the existing logic to obtain the URL hash (based on the routing mode) to its own function and limits the number of times we split the URL string to up to three parts (as Dominik put it, `https://example.com/#<apphash>#<otherhash>`, so if there are more `#` characters in `<otherhash>`, they won't go missing)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
