### PR TITLE
feat: Native tracing

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -33,6 +33,7 @@
 		"vitefu": "^1.0.6"
 	},
 	"devDependencies": {
+		"@opentelemetry/api": "1.0.0",
 		"@playwright/test": "catalog:",
 		"@sveltejs/vite-plugin-svelte": "^5.0.1",
 		"@types/connect": "^3.4.38",
@@ -47,9 +48,15 @@
 		"vitest": "catalog:"
 	},
 	"peerDependencies": {
+		"@opentelemetry/api": "1.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0",
 		"svelte": "^4.0.0 || ^5.0.0-next.0",
 		"vite": "^5.0.3 || ^6.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@opentelemetry/api": {
+			"optional": true
+		}
 	},
 	"bin": {
 		"svelte-kit": "svelte-kit.js"

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -33,7 +33,7 @@
 		"vitefu": "^1.0.6"
 	},
 	"devDependencies": {
-		"@opentelemetry/api": "1.0.0",
+		"@opentelemetry/api": "^1.0.0",
 		"@playwright/test": "catalog:",
 		"@sveltejs/vite-plugin-svelte": "^5.0.1",
 		"@types/connect": "^3.4.38",
@@ -48,7 +48,7 @@
 		"vitest": "catalog:"
 	},
 	"peerDependencies": {
-		"@opentelemetry/api": "1.0.0",
+		"@opentelemetry/api": "^1.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0",
 		"svelte": "^4.0.0 || ^5.0.0-next.0",
 		"vite": "^5.0.3 || ^6.0.0"

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -3,6 +3,8 @@ import { disable_search, make_trackable } from '../../../utils/url.js';
 import { validate_depends } from '../../shared.js';
 import { b64_encode } from '../../utils.js';
 import { with_event } from '../../app/server/event.js';
+import { record_span } from '../telemetry/record-span.js';
+import { get_tracer } from '../telemetry/get-tracer.js';
 
 /**
  * Calls the user's server `load` function.
@@ -68,94 +70,109 @@ export async function load_server_data({ event, state, node, parent }) {
 
 	let done = false;
 
-	const result = await with_event(event, () =>
-		load.call(null, {
-			...event,
-			fetch: (info, init) => {
-				const url = new URL(info instanceof Request ? info.url : info, event.url);
+	const tracer = get_tracer({ is_enabled: true }); // TODO: Make this configurable
 
-				if (DEV && done && !uses.dependencies.has(url.href)) {
-					console.warn(
-						`${node.server_id}: Calling \`event.fetch(...)\` in a promise handler after \`load(...)\` has returned will not cause the function to re-run when the dependency is invalidated`
-					);
-				}
+	const result = await record_span({
+		name: 'sveltekit.load.server',
+		tracer,
+		attributes: {
+			'sveltekit.load.node_id': node.server_id || 'unknown',
+			'sveltekit.load.type': 'server',
+			'sveltekit.route.id': event.route.id || 'unknown'
+		},
+		fn: async () => {
+			const result = await with_event(event, () =>
+				load.call(null, {
+					...event,
+					fetch: (info, init) => {
+						const url = new URL(info instanceof Request ? info.url : info, event.url);
 
-				// Note: server fetches are not added to uses.depends due to security concerns
-				return event.fetch(info, init);
-			},
-			/** @param {string[]} deps */
-			depends: (...deps) => {
-				for (const dep of deps) {
-					const { href } = new URL(dep, event.url);
-
-					if (DEV) {
-						validate_depends(node.server_id || 'missing route ID', dep);
-
-						if (done && !uses.dependencies.has(href)) {
+						if (DEV && done && !uses.dependencies.has(url.href)) {
 							console.warn(
-								`${node.server_id}: Calling \`depends(...)\` in a promise handler after \`load(...)\` has returned will not cause the function to re-run when the dependency is invalidated`
+								`${node.server_id}: Calling \`event.fetch(...)\` in a promise handler after \`load(...)\` has returned will not cause the function to re-run when the dependency is invalidated`
 							);
 						}
-					}
 
-					uses.dependencies.add(href);
-				}
-			},
-			params: new Proxy(event.params, {
-				get: (target, key) => {
-					if (DEV && done && typeof key === 'string' && !uses.params.has(key)) {
-						console.warn(
-							`${node.server_id}: Accessing \`params.${String(
-								key
-							)}\` in a promise handler after \`load(...)\` has returned will not cause the function to re-run when the param changes`
-						);
-					}
+						// Note: server fetches are not added to uses.depends due to security concerns
+						return event.fetch(info, init);
+					},
+					/** @param {string[]} deps */
+					depends: (...deps) => {
+						for (const dep of deps) {
+							const { href } = new URL(dep, event.url);
 
-					if (is_tracking) {
-						uses.params.add(key);
-					}
-					return target[/** @type {string} */ (key)];
-				}
-			}),
-			parent: async () => {
-				if (DEV && done && !uses.parent) {
-					console.warn(
-						`${node.server_id}: Calling \`parent(...)\` in a promise handler after \`load(...)\` has returned will not cause the function to re-run when parent data changes`
-					);
-				}
+							if (DEV) {
+								validate_depends(node.server_id || 'missing route ID', dep);
 
-				if (is_tracking) {
-					uses.parent = true;
-				}
-				return parent();
-			},
-			route: new Proxy(event.route, {
-				get: (target, key) => {
-					if (DEV && done && typeof key === 'string' && !uses.route) {
-						console.warn(
-							`${node.server_id}: Accessing \`route.${String(
-								key
-							)}\` in a promise handler after \`load(...)\` has returned will not cause the function to re-run when the route changes`
-						);
-					}
+								if (done && !uses.dependencies.has(href)) {
+									console.warn(
+										`${node.server_id}: Calling \`depends(...)\` in a promise handler after \`load(...)\` has returned will not cause the function to re-run when the dependency is invalidated`
+									);
+								}
+							}
 
-					if (is_tracking) {
-						uses.route = true;
+							uses.dependencies.add(href);
+						}
+					},
+					params: new Proxy(event.params, {
+						get: (target, key) => {
+							if (DEV && done && typeof key === 'string' && !uses.params.has(key)) {
+								console.warn(
+									`${node.server_id}: Accessing \`params.${String(
+										key
+									)}\` in a promise handler after \`load(...)\` has returned will not cause the function to re-run when the param changes`
+								);
+							}
+
+							if (is_tracking) {
+								uses.params.add(key);
+							}
+							return target[/** @type {string} */ (key)];
+						}
+					}),
+					parent: async () => {
+						if (DEV && done && !uses.parent) {
+							console.warn(
+								`${node.server_id}: Calling \`parent(...)\` in a promise handler after \`load(...)\` has returned will not cause the function to re-run when parent data changes`
+							);
+						}
+
+						if (is_tracking) {
+							uses.parent = true;
+						}
+						return parent();
+					},
+					route: new Proxy(event.route, {
+						get: (target, key) => {
+							if (DEV && done && typeof key === 'string' && !uses.route) {
+								console.warn(
+									`${node.server_id}: Accessing \`route.${String(
+										key
+									)}\` in a promise handler after \`load(...)\` has returned will not cause the function to re-run when the route changes`
+								);
+							}
+
+							if (is_tracking) {
+								uses.route = true;
+							}
+							return target[/** @type {'id'} */ (key)];
+						}
+					}),
+					url,
+					untrack(fn) {
+						is_tracking = false;
+						try {
+							return fn();
+						} finally {
+							is_tracking = true;
+						}
 					}
-					return target[/** @type {'id'} */ (key)];
-				}
-			}),
-			url,
-			untrack(fn) {
-				is_tracking = false;
-				try {
-					return fn();
-				} finally {
-					is_tracking = true;
-				}
-			}
-		})
-	);
+				})
+			);
+
+			return result;
+		}
+	});
 
 	if (__SVELTEKIT_DEV__) {
 		validate_load_response(result, node.server_id);
@@ -201,16 +218,34 @@ export async function load_data({
 		return server_data_node?.data ?? null;
 	}
 
-	const result = await node.universal.load.call(null, {
-		url: event.url,
-		params: event.params,
-		data: server_data_node?.data ?? null,
-		route: event.route,
-		fetch: create_universal_fetch(event, state, fetched, csr, resolve_opts),
-		setHeaders: event.setHeaders,
-		depends: () => {},
-		parent,
-		untrack: (fn) => fn()
+	const { load } = node.universal;
+
+	const tracer = get_tracer({ is_enabled: true }); // TODO: Make this configurable
+
+	const result = await record_span({
+		name: 'sveltekit.load.universal',
+		tracer,
+		attributes: {
+			'sveltekit.load.node_id': node.universal_id || 'unknown',
+			'sveltekit.load.type': 'universal',
+			'sveltekit.load.environment': 'client',
+			'sveltekit.route.id': event.route.id || 'unknown'
+		},
+		fn: async () => {
+			const result = await load.call(null, {
+				url: event.url,
+				params: event.params,
+				data: server_data_node?.data ?? null,
+				route: event.route,
+				fetch: create_universal_fetch(event, state, fetched, csr, resolve_opts),
+				setHeaders: event.setHeaders,
+				depends: () => {},
+				parent,
+				untrack: (fn) => fn()
+			});
+
+			return result;
+		}
 	});
 
 	if (__SVELTEKIT_DEV__) {

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -34,6 +34,8 @@ import {
 	strip_resolution_suffix
 } from '../pathname.js';
 import { with_event } from '../app/server/event.js';
+import { record_span } from './telemetry/record-span.js';
+import { get_tracer } from './telemetry/get-tracer.js';
 
 /* global __SVELTEKIT_ADAPTER_NAME__ */
 /* global __SVELTEKIT_DEV__ */
@@ -362,32 +364,67 @@ export async function respond(request, options, manifest, state) {
 			disable_search(url);
 		}
 
-		const response = await with_event(event, () =>
-			options.hooks.handle({
-				event,
-				resolve: (event, opts) =>
-					// counter-intuitively, we need to clear the event, so that it's not
-					// e.g. accessible when loading modules needed to handle the request
-					with_event(null, () =>
-						resolve(event, page_nodes, opts).then((response) => {
-							// add headers/cookies here, rather than inside `resolve`, so that we
-							// can do it once for all responses instead of once per `return`
-							for (const key in headers) {
-								const value = headers[key];
-								response.headers.set(key, /** @type {string} */ (value));
-							}
+		const tracer = get_tracer({ is_enabled: true }); // TODO: Make this configurable via options
 
-							add_cookies_to_headers(response.headers, Object.values(new_cookies));
+		const response = await record_span({
+			name: 'sveltekit.handle',
+			tracer,
+			attributes: {
+				'sveltekit.route.id': event.route.id || 'unknown',
+				'http.method': event.request.method,
+				'http.url': event.url.href,
+				'sveltekit.is_data_request': is_data_request,
+				'sveltekit.is_sub_request': event.isSubRequest
+			},
+			fn: async () => {
+				return await with_event(event, () =>
+					options.hooks.handle({
+						event,
+						resolve: (event, opts) => {
+							return record_span({
+								name: 'sveltekit.resolve',
+								tracer,
+								attributes: {
+									'sveltekit.route.id': event.route.id || 'unknown',
+									'sveltekit.resolve.transform_page_chunk': !!opts?.transformPageChunk,
+									'sveltekit.resolve.filter_serialized_response_headers':
+										!!opts?.filterSerializedResponseHeaders,
+									'sveltekit.resolve.preload': !!opts?.preload
+								},
+								fn: async (resolveSpan) => {
+									// counter-intuitively, we need to clear the event, so that it's not
+									// e.g. accessible when loading modules needed to handle the request
+									return with_event(null, () =>
+										resolve(event, page_nodes, opts).then((response) => {
+											// add headers/cookies here, rather than inside `resolve`, so that we
+											// can do it once for all responses instead of once per `return`
+											for (const key in headers) {
+												const value = headers[key];
+												response.headers.set(key, /** @type {string} */ (value));
+											}
 
-							if (state.prerendering && event.route.id !== null) {
-								response.headers.set('x-sveltekit-routeid', encodeURI(event.route.id));
-							}
+											add_cookies_to_headers(response.headers, Object.values(new_cookies));
 
-							return response;
-						})
-					)
-			})
-		);
+											if (state.prerendering && event.route.id !== null) {
+												response.headers.set('x-sveltekit-routeid', encodeURI(event.route.id));
+											}
+
+											resolveSpan.setAttributes({
+												'http.response.status_code': response.status,
+												'http.response.body.size':
+													response.headers.get('content-length') || 'unknown'
+											});
+
+											return response;
+										})
+									);
+								}
+							});
+						}
+					})
+				);
+			}
+		});
 
 		// respond with 304 if etag matches
 		if (response.status === 200 && response.headers.has('etag')) {

--- a/packages/kit/src/runtime/server/telemetry/get-tracer.js
+++ b/packages/kit/src/runtime/server/telemetry/get-tracer.js
@@ -1,0 +1,21 @@
+/** @import { Tracer } from '@opentelemetry/api' */
+import { trace } from '@opentelemetry/api';
+import { noop_tracer } from './noop-tracer.js';
+
+/**
+ * @param {Object} [options={}] - Configuration options
+ * @param {boolean} [options.is_enabled=false] - Whether tracing is enabled
+ * @param {Tracer} [options.tracer] - Custom tracer instance
+ * @returns {Tracer} The tracer instance
+ */
+export function get_tracer({ is_enabled = false, tracer } = {}) {
+	if (!is_enabled) {
+		return noop_tracer;
+	}
+
+	if (tracer) {
+		return tracer;
+	}
+
+	return trace.getTracer('sveltekit');
+}

--- a/packages/kit/src/runtime/server/telemetry/noop-tracer.js
+++ b/packages/kit/src/runtime/server/telemetry/noop-tracer.js
@@ -1,0 +1,75 @@
+/** @import { Tracer, Span, SpanContext } from '@opentelemetry/api' */
+
+/**
+ * Tracer implementation that does nothing (null object).
+ * @type {Tracer}
+ */
+export const noop_tracer = {
+	/**
+	 * @returns {Span}
+	 */
+	startSpan() {
+		return noop_span;
+	},
+
+	/**
+	 * @param {unknown} _name
+	 * @param {unknown} arg_1
+	 * @param {unknown} [arg_2]
+	 * @param {Function} [arg_3]
+	 * @returns {unknown}
+	 */
+	startActiveSpan(_name, arg_1, arg_2, arg_3) {
+		if (typeof arg_1 === 'function') {
+			return arg_1(noop_span);
+		}
+		if (typeof arg_2 === 'function') {
+			return arg_2(noop_span);
+		}
+		if (typeof arg_3 === 'function') {
+			return arg_3(noop_span);
+		}
+	}
+};
+
+/**
+ * @type {Span}
+ */
+const noop_span = {
+	spanContext() {
+		return noop_span_context;
+	},
+	setAttribute() {
+		return this;
+	},
+	setAttributes() {
+		return this;
+	},
+	addEvent() {
+		return this;
+	},
+	setStatus() {
+		return this;
+	},
+	updateName() {
+		return this;
+	},
+	end() {
+		return this;
+	},
+	isRecording() {
+		return false;
+	},
+	recordException() {
+		return this;
+	}
+};
+
+/**
+ * @type {SpanContext}
+ */
+const noop_span_context = {
+	traceId: '',
+	spanId: '',
+	traceFlags: 0
+};

--- a/packages/kit/src/runtime/server/telemetry/record-span.js
+++ b/packages/kit/src/runtime/server/telemetry/record-span.js
@@ -1,0 +1,65 @@
+/** @import { SpanAttributes, SpanAttributeValue, Span, Tracer } from '@opentelemetry/api' */
+import { SpanStatusCode } from '@opentelemetry/api';
+import { HttpError, Redirect } from '../../control.js';
+
+/**
+ * @template T
+ * @param {Object} options
+ * @param {string} options.name
+ * @param {Tracer} options.tracer
+ * @param {SpanAttributes} options.attributes
+ * @param {function(Span): Promise<T>} options.fn
+ * @returns {Promise<T>}
+ */
+export function record_span({ name, tracer, attributes, fn }) {
+	return tracer.startActiveSpan(name, { attributes }, async (span) => {
+		try {
+			const result = await fn(span);
+			span.end();
+			return result;
+		} catch (error) {
+			if (error instanceof HttpError) {
+				span.setAttributes({
+					[`${name}.result.type`]: 'known_error',
+					[`${name}.result.status`]: error.status,
+					[`${name}.result.message`]: error.body.message
+				});
+				span.recordException({
+					name: 'HttpError',
+					message: error.body.message
+				});
+				span.setStatus({
+					code: SpanStatusCode.ERROR,
+					message: error.body.message
+				});
+			} else if (error instanceof Redirect) {
+				span.setAttributes({
+					[`${name}.result.type`]: 'redirect',
+					[`${name}.result.status`]: error.status,
+					[`${name}.result.location`]: error.location
+				});
+			} else if (error instanceof Error) {
+				span.setAttributes({
+					[`${name}.result.type`]: 'unknown_error'
+				});
+				span.recordException({
+					name: error.name,
+					message: error.message,
+					stack: error.stack
+				});
+				span.setStatus({
+					code: SpanStatusCode.ERROR,
+					message: error.message
+				});
+			} else {
+				span.setAttributes({
+					[`${name}.result.type`]: 'unknown_error'
+				});
+				span.setStatus({ code: SpanStatusCode.ERROR });
+			}
+			span.end();
+
+			throw error;
+		}
+	});
+}

--- a/packages/kit/src/runtime/server/telemetry/record-span.js
+++ b/packages/kit/src/runtime/server/telemetry/record-span.js
@@ -1,4 +1,4 @@
-/** @import { SpanAttributes, SpanAttributeValue, Span, Tracer } from '@opentelemetry/api' */
+/** @import { SpanAttributes, Span, Tracer } from '@opentelemetry/api' */
 import { SpanStatusCode } from '@opentelemetry/api';
 import { HttpError, Redirect } from '../../control.js';
 

--- a/packages/kit/src/runtime/server/telemetry/settings.d.ts
+++ b/packages/kit/src/runtime/server/telemetry/settings.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Telemetry configuration.
+ */
+// This is meant to be both flexible for custom app requirements (metadata)
+// and extensible for standardization (example: functionId, more to come).
+export type TelemetrySettings = {
+  /**
+   * Enable or disable telemetry. Disabled by default while experimental.
+   */
+  enabled?: boolean;
+};

--- a/packages/kit/src/runtime/server/telemetry/settings.d.ts
+++ b/packages/kit/src/runtime/server/telemetry/settings.d.ts
@@ -4,8 +4,8 @@
 // This is meant to be both flexible for custom app requirements (metadata)
 // and extensible for standardization (example: functionId, more to come).
 export type TelemetrySettings = {
-  /**
-   * Enable or disable telemetry. Disabled by default while experimental.
-   */
-  enabled?: boolean;
+	/**
+	 * Enable or disable telemetry. Disabled by default while experimental.
+	 */
+	enabled?: boolean;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,7 +311,7 @@ importers:
     dependencies:
       '@sveltejs/kit':
         specifier: ^1.0.0 || ^2.0.0
-        version: link:../kit
+        version: 2.21.5(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.23.1)(vite@6.2.7(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.23.1)(vite@6.2.7(@types/node@18.19.50)(lightningcss@1.24.1))
     devDependencies:
       typescript:
         specifier: ^5.3.3
@@ -405,7 +405,7 @@ importers:
         version: 1.0.6(vite@6.2.7(@types/node@18.19.50)(lightningcss@1.24.1))
     devDependencies:
       '@opentelemetry/api':
-        specifier: 1.0.0
+        specifier: ^1.0.0
         version: 1.0.0
       '@playwright/test':
         specifier: 'catalog:'
@@ -2202,6 +2202,15 @@ packages:
       eslint-plugin-svelte: '>= 2.36'
       typescript: '>= 5'
       typescript-eslint: '>= 7.5'
+
+  '@sveltejs/kit@2.21.5':
+    resolution: {integrity: sha512-P5m7yZtvD1Kx/Z6JcjgJtdMqef/tCGMDrd9B9S2q8j+FMnkeKTMxW1nidnjVzk4HEDRGf4IlBI94/niy6t3hLA==}
+    engines: {node: '>=18.13'}
+    hasBin: true
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      vite: ^5.0.3 || ^6.0.0
 
   '@sveltejs/vite-plugin-svelte-inspector@4.0.1':
     resolution: {integrity: sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==}
@@ -5497,6 +5506,25 @@ snapshots:
       globals: 15.15.0
       typescript: 5.8.3
       typescript-eslint: 8.26.0(eslint@9.6.0)(typescript@5.8.3)
+
+  '@sveltejs/kit@2.21.5(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.23.1)(vite@6.2.7(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.23.1)(vite@6.2.7(@types/node@18.19.50)(lightningcss@1.24.1))':
+    dependencies:
+      '@sveltejs/acorn-typescript': 1.0.5(acorn@8.14.1)
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.23.1)(vite@6.2.7(@types/node@18.19.50)(lightningcss@1.24.1))
+      '@types/cookie': 0.6.0
+      acorn: 8.14.1
+      cookie: 0.6.0
+      devalue: 5.1.0
+      esm-env: 1.2.2
+      kleur: 4.1.5
+      magic-string: 0.30.17
+      mrmime: 2.0.0
+      sade: 1.8.1
+      set-cookie-parser: 2.6.0
+      sirv: 3.0.0
+      svelte: 5.23.1
+      vite: 6.2.7(@types/node@18.19.50)(lightningcss@1.24.1)
+      vitefu: 1.0.6(vite@6.2.7(@types/node@18.19.50)(lightningcss@1.24.1))
 
   '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.23.1)(vite@6.2.7(@types/node@18.19.50)(lightningcss@1.24.1)))(svelte@5.23.1)(vite@6.2.7(@types/node@18.19.50)(lightningcss@1.24.1))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,6 +404,9 @@ importers:
         specifier: ^1.0.6
         version: 1.0.6(vite@6.2.7(@types/node@18.19.50)(lightningcss@1.24.1))
     devDependencies:
+      '@opentelemetry/api':
+        specifier: 1.0.0
+        version: 1.0.0
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.51.1
@@ -2021,6 +2024,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@opentelemetry/api@1.0.0':
+    resolution: {integrity: sha512-TcdhrGy+ehLIFs79/TcWiHiPujishrhSgQ7wxvWvk8WY2YT8Np/pYXmRP94voG3N8GJ/5nIVyzacfViwhN50AQ==}
+    engines: {node: '>=8.0.0'}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -5358,6 +5365,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@opentelemetry/api@1.0.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true


### PR DESCRIPTION
WIP. 

This PR adds native tracing via `@opentelemetry/api` to SvelteKit.

It traces:
- `load` invocations
- `action` invocations
- `handle` and `resolve` invocations

`@opentelemetry/api@^1.0.0` becomes an optional peer dependency. Users who want to opt into tracing can install the package along with their instrumentation packages and it will "just work"!

TODO:
- [ ] Configuration / extensibility -- what should we expose?
    - Just a global `enable` option?
    - An `addAttributes` option on the `event` to enable user-tagged attributes on the `load` spans?
        - IMO no, users can create child spans of their own inside of `load` which will be attached as children
    - Route-level `tracing: boolean` exports? 
- [ ] Testing
- [x] Find a way to tag clientside `load` functions with their node IDs?

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
