### PR TITLE
fix: Dumber fix for error assertions

### DIFF
--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -85,8 +85,14 @@ export function error(status, body) {
  * @return {e is (HttpError & { status: T extends undefined ? never : T })}
  */
 export function isHttpError(e, status) {
-	if (!(e instanceof HttpError)) return false;
-	return !status || e.status === status;
+	return (
+		typeof e === 'object' &&
+		e !== null &&
+		Object.hasOwn(e, '_tag') &&
+		Object.hasOwn(e, 'status') &&
+		/** @type {{ _tag: string; }} */ (e)._tag === 'SvelteKitHttpError' &&
+		(!status || /** @type {{ status: number }} */ (e).status === status)
+	);
 }
 
 /**
@@ -124,7 +130,12 @@ export function redirect(status, location) {
  * @return {e is Redirect}
  */
 export function isRedirect(e) {
-	return e instanceof Redirect;
+	return (
+		typeof e === 'object' &&
+		e !== null &&
+		Object.hasOwn(e, '_tag') &&
+		/** @type {{ _tag: string }} */ (e)._tag === 'SvelteKitRedirect'
+	);
 }
 
 /**
@@ -213,7 +224,12 @@ export function fail(status, data) {
  * @return {e is import('./public.js').ActionFailure}
  */
 export function isActionFailure(e) {
-	return e instanceof ActionFailure;
+	return (
+		typeof e === 'object' &&
+		e !== null &&
+		Object.hasOwn(e, '_tag') &&
+		/** @type {{ _tag: string }} */ (e)._tag === 'SvelteKitActionFailure'
+	);
 }
 
 /**

--- a/packages/kit/src/runtime/control.js
+++ b/packages/kit/src/runtime/control.js
@@ -1,4 +1,7 @@
 export class HttpError {
+	/** @private */
+	_tag = 'SvelteKitHttpError';
+
 	/**
 	 * @param {number} status
 	 * @param {{message: string} extends App.Error ? (App.Error | string | undefined) : App.Error} body
@@ -20,6 +23,9 @@ export class HttpError {
 }
 
 export class Redirect {
+	/** @private */
+	_tag = 'SvelteKitRedirect';
+
 	/**
 	 * @param {300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308} status
 	 * @param {string} location
@@ -52,6 +58,9 @@ export class SvelteKitError extends Error {
  * @template {Record<string, unknown> | undefined} [T=undefined]
  */
 export class ActionFailure {
+	/** @private */
+	_tag = 'SvelteKitActionFailure';
+
 	/**
 	 * @param {number} status
 	 * @param {T} data


### PR DESCRIPTION
We've had issues in the past because `isHttpError`, `isRedirect`, and `isActionFailure` can start reporting false negatives when something somewhere decides to load two copies of the modules the classes are declared in. This switches to a tagged, structural approach that will survive these boundaries. The downside is that some library could `throw { _tag: 'SvelteKitRedirect' }` and `isRedirect` would report `true`, but... I mean, at that point, "hack the library at your own peril", I guess.

This would let us revert our prior attempt at externalizing dependencies, which has caused additional bugs.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
