### PR TITLE
fix: warning for chrome devtools requests now suggests sv instead of vite plugin

### DIFF
--- a/.changeset/tame-teachers-listen.md
+++ b/.changeset/tame-teachers-listen.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: warning for chrome devtools requests now suggests sv instead of vite plugin

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -577,11 +577,11 @@ export async function respond(request, options, manifest, state) {
 			if (state.depth === 0) {
 				// In local development, Chrome requests this file for its 'automatic workspace folders' feature,
 				// causing console spam. If users want to serve this file they can install
-				// https://github.com/ChromeDevTools/vite-plugin-devtools-json
+				// https://svelte.dev/docs/cli/devtools-json
 				if (DEV && event.url.pathname === '/.well-known/appspecific/com.chrome.devtools.json') {
 					if (!warned_on_devtools_json_request) {
 						console.warn(
-							`\nGoogle Chrome is requesting ${event.url.pathname} to automatically configure devtools project settings. To serve this file, add this plugin to your Vite config:\n\nhttps://github.com/ChromeDevTools/vite-plugin-devtools-json\n`
+							`\nGoogle Chrome is requesting ${event.url.pathname} to automatically configure devtools project settings. To serve this file, configure the devtools-json add-on via:\n\nnpx sv add devtools-json\n`
 						);
 
 						warned_on_devtools_json_request = true;


### PR DESCRIPTION
Suggest setting up the devtools config using the newly release `sv add devtools-json` command. Follow-up for https://github.com/sveltejs/kit/pull/13830
Relates https://github.com/sveltejs/cli/pull/581

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
