### PR TITLE
fix: prevent infinite loop when calling `pushState`/`replaceState` in effect

### DIFF
--- a/.changeset/chatty-pears-notice.md
+++ b/.changeset/chatty-pears-notice.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+fix: prevent infinite loop when calling `pushState`/`replaceState` in effect

--- a/.changeset/chatty-pears-notice.md
+++ b/.changeset/chatty-pears-notice.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/kit': minor
+'@sveltejs/kit': patch
 ---
 
 fix: prevent infinite loop when calling `pushState`/`replaceState` in effect

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -39,6 +39,7 @@ import { HttpError, Redirect, SvelteKitError } from '../control.js';
 import { INVALIDATED_PARAM, TRAILING_SLASH_PARAM, validate_depends } from '../shared.js';
 import { get_message, get_status } from '../../utils/error.js';
 import { writable } from 'svelte/store';
+import { untrack } from 'svelte';
 import { page, update, navigating } from './state.svelte.js';
 import { add_data_suffix, add_resolution_suffix } from '../pathname.js';
 
@@ -2111,7 +2112,7 @@ export function pushState(url, state) {
 	page.state = state;
 	root.$set({
 		// we need to assign a new page object so that subscribers are correctly notified
-		page: clone_page(page)
+		page: untrack(() => clone_page(page))
 	});
 
 	clear_onward_history(current_history_index, current_navigation_index);
@@ -2154,7 +2155,7 @@ export function replaceState(url, state) {
 
 	page.state = state;
 	root.$set({
-		page: clone_page(page)
+		page: untrack(() => clone_page(page))
 	});
 }
 


### PR DESCRIPTION
<!-- Your PR description here -->

Closes #13794 by untracking `clone_page` calls in `pushState`/`replaceState`

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
