### PR TITLE
chore: always use `manualChunks` for bundling single and inline apps

### DIFF
--- a/.changeset/tough-beers-drum.md
+++ b/.changeset/tough-beers-drum.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: use `manualChunks` to bundle single and inline apps with Rolldown

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -695,6 +695,7 @@ Tips:
 								assetFileNames: `${prefix}/assets/[name].[hash][extname]`,
 								hoistTransitiveImports: false,
 								sourcemapIgnoreList,
+								manualChunks: split ? undefined : () => 'bundle',
 								inlineDynamicImports: false
 							},
 							preserveEntrySignatures: 'strict',
@@ -734,19 +735,6 @@ Tips:
 					// 	enableNativePlugin: true
 					// }
 				};
-
-				if (!split && new_config.build?.rollupOptions?.output) {
-					const output_options = /** @type {import('vite').Rollup.OutputOptions} */ (
-						new_config.build.rollupOptions.output
-					);
-					// @ts-expect-error `vite.rolldownVersion` only exists in `rolldown-vite`
-					if (vite.rolldownVersion) {
-						output_options.inlineDynamicImports = true;
-					} else {
-						/** @type {import('rollup').OutputOptions} */ (output_options).manualChunks = () =>
-							'bundle';
-					}
-				}
 			} else {
 				new_config = {
 					appType: 'custom',


### PR DESCRIPTION
Previously, `rolldown-vite` didn't support `manualChunks`, so we had to use a workaround. Now that it's implemented in https://github.com/rolldown/rolldown/issues/4311 we can simplify our config options a bit.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
	- we already have a test for checking that single apps have a single bundled JS file

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
