### PR TITLE
feat: add `vite-plugin-svelte` 6 to the peer dependency range

### DIFF
--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -43,7 +43,8 @@
 		"svelte-package": "svelte-package.js"
 	},
 	"files": [
-		"src"
+		"src",
+		"types"
 	],
 	"scripts": {
 		"lint": "prettier --check .",
@@ -53,8 +54,12 @@
 		"test": "uvu test \"^index.js$\""
 	},
 	"exports": {
-		"./package.json": "./package.json"
+		"./package.json": "./package.json",
+		".": {
+			"types": "./types/index.d.ts"
+		}
 	},
+	"types": "types/index.d.ts",
 	"engines": {
 		"node": "^16.14 || >=18"
 	}

--- a/packages/package/tsconfig.json
+++ b/packages/package/tsconfig.json
@@ -7,7 +7,12 @@
 		"target": "es2022",
 		"module": "node16",
 		"moduleResolution": "node16",
-		"allowSyntheticDefaultImports": true
+		"allowSyntheticDefaultImports": true,
+		"paths": {
+			// internal use only
+			"types": ["./types/index"]
+		}
 	},
-	"include": ["*.js", "src/**/*", "test/index.js"]
+	"include": ["*.js", "src/**/*", "test/index.js", "types/**/*"],
+	"exclude": ["test/fixtures/**/*"]
 }


### PR DESCRIPTION
I forgot to add VPS 6 to the `@sveltejs/enhanced-img` package's peer dep range. Probably important for users trying out VP6 and rolldown-vite together with the enhanced-img package.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
