### PR TITLE
chore: remove references to non-existent types folder

### DIFF
--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -43,8 +43,7 @@
 		"svelte-package": "svelte-package.js"
 	},
 	"files": [
-		"src",
-		"types"
+		"src"
 	],
 	"scripts": {
 		"lint": "prettier --check .",
@@ -54,12 +53,8 @@
 		"test": "uvu test \"^index.js$\""
 	},
 	"exports": {
-		"./package.json": "./package.json",
-		".": {
-			"types": "./types/index.d.ts"
-		}
+		"./package.json": "./package.json"
 	},
-	"types": "types/index.d.ts",
 	"engines": {
 		"node": "^16.14 || >=18"
 	}

--- a/packages/package/test/fixtures/resolve-alias/tsconfig.json
+++ b/packages/package/test/fixtures/resolve-alias/tsconfig.json
@@ -9,5 +9,5 @@
 			"$utils/*": ["./src/lib/utils/*"]
 		}
 	},
-	"include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte"]
+	"include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte", "src/**/*.ts"]
 }

--- a/packages/package/tsconfig.json
+++ b/packages/package/tsconfig.json
@@ -7,12 +7,7 @@
 		"target": "es2022",
 		"module": "node16",
 		"moduleResolution": "node16",
-		"allowSyntheticDefaultImports": true,
-		"paths": {
-			// internal use only
-			"types": ["./types/index"]
-		}
+		"allowSyntheticDefaultImports": true
 	},
-	"include": ["*.js", "src/**/*", "test/index.js", "types/**/*"],
-	"exclude": ["test/fixtures/**/*"]
+	"include": ["*.js", "src/**/*", "test/index.js"]
 }


### PR DESCRIPTION
The types/index.d.ts file was removed in https://github.com/sveltejs/kit/pull/8922/files#diff-0da28c3df913a524b1ad3527d3eff1584499e19a9dd2708748ba4db6f306ac08 but the tsconfig and package.json still references it. Also, one of the fixtures' tsconfig.json was complaining about not having any input files so I added the .ts files to it.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
