### PR TITLE
chore: add changeset for non-semver-style dependency handling

### DIFF
--- a/.changeset/tiny-masks-watch.md
+++ b/.changeset/tiny-masks-watch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/package': patch
+---
+
+fix: handle non-semver-style dependency versions

--- a/packages/kit/CHANGELOG.md
+++ b/packages/kit/CHANGELOG.md
@@ -40,9 +40,6 @@
 - fix: correctly run `deserialize` on the server ([#13686](https://github.com/sveltejs/kit/pull/13686))
 
 
-- fix: handle non-semver-style dependency versions ([#13850](https://github.com/sveltejs/kit/pull/13850))
-
-
 - fix: correctly inline stylesheets of components dynamically imported in a universal load function if they are below the configured inlineStyleThreshold ([#13723](https://github.com/sveltejs/kit/pull/13723))
 
 ## 2.21.2


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/12521

https://github.com/sveltejs/kit/pull/13850/files#diff-453fcd4d91c0dc6f0ba469918674295a92f8450956c5bc4836fb2e46de274ae2 was merged but the changeset specified Kit instead of svelte-package. We should merge this so a new release of svelte-package will include the fix. I've already edited the GitHub release notes to remove the previous entry from the Kit release.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
