### PR TITLE
docs: add missing type information

### DIFF
--- a/documentation/docs/25-build-and-deploy/40-adapter-node.md
+++ b/documentation/docs/25-build-and-deploy/40-adapter-node.md
@@ -13,6 +13,7 @@ Install with `npm i -D @sveltejs/adapter-node`, then add the adapter to your `sv
 /// file: svelte.config.js
 import adapter from '@sveltejs/adapter-node';
 
+/** @type {import('@sveltejs/kit').Config} */
 export default {
 	kit: {
 		adapter: adapter()
@@ -64,13 +65,13 @@ node +++--env-file=.env+++ build
 
 By default, the server will accept connections on `0.0.0.0` using port 3000. These can be customised with the `PORT` and `HOST` environment variables:
 
-```
+```sh
 HOST=127.0.0.1 PORT=4000 node build
 ```
 
 Alternatively, the server can be configured to accept connections on a specified socket path. When this is done using the `SOCKET_PATH` environment variable, the `HOST` and `PORT` environment variables will be disregarded.
 
-```
+```sh
 SOCKET_PATH=/tmp/socket node build
 ```
 
@@ -78,7 +79,7 @@ SOCKET_PATH=/tmp/socket node build
 
 HTTP doesn't give SvelteKit a reliable way to know the URL that is currently being requested. The simplest way to tell SvelteKit where the app is being served is to set the `ORIGIN` environment variable:
 
-```
+```sh
 ORIGIN=https://my.site node build
 
 # or e.g. for local previewing and testing
@@ -87,7 +88,7 @@ ORIGIN=http://localhost:3000 node build
 
 With this, a request for the `/stuff` pathname will correctly resolve to `https://my.site/stuff`. Alternatively, you can specify headers that tell SvelteKit about the request protocol and host, from which it can construct the origin URL:
 
-```
+```sh
 PROTOCOL_HEADER=x-forwarded-proto HOST_HEADER=x-forwarded-host node build
 ```
 
@@ -103,7 +104,7 @@ If `adapter-node` can't correctly determine the URL of your deployment, you may 
 
 The [`RequestEvent`](@sveltejs-kit#RequestEvent) object passed to hooks and endpoints includes an `event.getClientAddress()` function that returns the client's IP address. By default this is the connecting `remoteAddress`. If your server is behind one or more proxies (such as a load balancer), this value will contain the innermost proxy's IP address rather than the client's, so we need to specify an `ADDRESS_HEADER` to read the address from:
 
-```
+```sh
 ADDRESS_HEADER=True-Client-IP node build
 ```
 
@@ -146,6 +147,7 @@ The adapter can be configured with various options:
 /// file: svelte.config.js
 import adapter from '@sveltejs/adapter-node';
 
+/** @type {import('@sveltejs/kit').Config} */
 export default {
 	kit: {
 		adapter: adapter({

--- a/documentation/docs/25-build-and-deploy/50-adapter-static.md
+++ b/documentation/docs/25-build-and-deploy/50-adapter-static.md
@@ -15,6 +15,7 @@ Install with `npm i -D @sveltejs/adapter-static`, then add the adapter to your `
 /// file: svelte.config.js
 import adapter from '@sveltejs/adapter-static';
 
+/** @type {import('@sveltejs/kit').Config} */
 export default {
 	kit: {
 		adapter: adapter({

--- a/documentation/docs/25-build-and-deploy/55-single-page-apps.md
+++ b/documentation/docs/25-build-and-deploy/55-single-page-apps.md
@@ -22,6 +22,7 @@ Install with `npm i -D @sveltejs/adapter-static`, then add the adapter to your `
 /// file: svelte.config.js
 import adapter from '@sveltejs/adapter-static';
 
+/** @type {import('@sveltejs/kit').Config} */
 export default {
 	kit: {
 		adapter: adapter({

--- a/documentation/docs/25-build-and-deploy/60-adapter-cloudflare.md
+++ b/documentation/docs/25-build-and-deploy/60-adapter-cloudflare.md
@@ -20,6 +20,7 @@ Install with `npm i -D @sveltejs/adapter-cloudflare`, then add the adapter to yo
 /// file: svelte.config.js
 import adapter from '@sveltejs/adapter-cloudflare';
 
+/** @type {import('@sveltejs/kit').Config} */
 export default {
 	kit: {
 		adapter: adapter({
@@ -126,6 +127,8 @@ The [`env`](https://developers.cloudflare.com/workers/runtime-apis/fetch-event#p
 
 ```js
 // @errors: 7031
+/// file: +server.js
+/** @type {import('./$types').RequestHandler} */
 export async function POST({ request, platform }) {
 	const x = platform.env.YOUR_DURABLE_OBJECT_NAMESPACE.idFromName('x');
 }
@@ -197,6 +200,7 @@ Cloudflare no longer recommends using [Workers Sites](https://developers.cloudfl
 ---import adapter from '@sveltejs/adapter-cloudflare-workers';---
 +++import adapter from '@sveltejs/adapter-cloudflare';+++
 
+/** @type {import('@sveltejs/kit').Config} */
 export default {
 	kit: {
 		adapter: adapter()

--- a/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
+++ b/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
@@ -15,6 +15,7 @@ Install with `npm i -D @sveltejs/adapter-cloudflare-workers`, then add the adapt
 /// file: svelte.config.js
 import adapter from '@sveltejs/adapter-cloudflare-workers';
 
+/** @type {import('@sveltejs/kit').Config} */
 export default {
 	kit: {
 		adapter: adapter({
@@ -81,6 +82,8 @@ The [`env`](https://developers.cloudflare.com/workers/runtime-apis/fetch-event#p
 
 ```js
 // @errors: 7031
+/// file: +server.js
+/** @type {import('./$types').RequestHandler} */
 export async function POST({ request, platform }) {
 	const x = platform.env.YOUR_DURABLE_OBJECT_NAMESPACE.idFromName('x');
 }

--- a/documentation/docs/25-build-and-deploy/80-adapter-netlify.md
+++ b/documentation/docs/25-build-and-deploy/80-adapter-netlify.md
@@ -15,6 +15,7 @@ Install with `npm i -D @sveltejs/adapter-netlify`, then add the adapter to your 
 /// file: svelte.config.js
 import adapter from '@sveltejs/adapter-netlify';
 
+/** @type {import('@sveltejs/kit').Config} */
 export default {
 	kit: {
 		// default options are shown
@@ -55,6 +56,7 @@ SvelteKit supports [Netlify Edge Functions](https://docs.netlify.com/netlify-lab
 /// file: svelte.config.js
 import adapter from '@sveltejs/adapter-netlify';
 
+/** @type {import('@sveltejs/kit').Config} */
 export default {
 	kit: {
 		adapter: adapter({
@@ -94,6 +96,7 @@ With this adapter, SvelteKit endpoints are hosted as [Netlify Functions](https:/
 ```js
 // @errors: 2705 7006
 /// file: +page.server.js
+/** @type {import('./$types').PageServerLoad} */
 export const load = async (event) => {
 	const context = event.platform.context;
 	console.log(context); // shows up in your functions log in the Netlify app

--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -15,6 +15,7 @@ Install with `npm i -D @sveltejs/adapter-vercel`, then add the adapter to your `
 /// file: svelte.config.js
 import adapter from '@sveltejs/adapter-vercel';
 
+/** @type {import('@sveltejs/kit').Config} */
 export default {
 	kit: {
 		adapter: adapter({
@@ -72,6 +73,7 @@ You may set the `images` config to control how Vercel builds your images. See th
 /// file: svelte.config.js
 import adapter from '@sveltejs/adapter-vercel';
 
+/** @type {import('@sveltejs/kit').Config} */
 export default {
 	kit: {
 		adapter: adapter({
@@ -98,6 +100,7 @@ To add ISR to a route, include the `isr` property in your `config` object:
 // @errors: 2664
 import { BYPASS_TOKEN } from '$env/static/private';
 
+/** @type {import('@sveltejs/adapter-vercel').Config} */
 export const config = {
 	isr: {
 		expiration: 60,

--- a/documentation/docs/60-appendix/20-integrations.md
+++ b/documentation/docs/60-appendix/20-integrations.md
@@ -10,6 +10,7 @@ Including [`vitePreprocess`](https://github.com/sveltejs/vite-plugin-svelte/blob
 // svelte.config.js
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
+/** @type {import('@sveltejs/kit').Config} */
 export default {
   preprocess: [vitePreprocess()]
 };


### PR DESCRIPTION
This PR adds missing type information to several code blocks with the benefit being that users get type information on hover and we get validation when building the app. It also inlines the type information for the service worker example so that it's easier to copy and paste for new projects (it provides a js/ts toggle too where there previously was none https://svelte.dev/docs/kit/service-workers#Inside-the-service-worker).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
