### PR TITLE
fix: use fallback if `untrack` doesn't exist in svelte package

### DIFF
--- a/.changeset/nasty-forks-drum.md
+++ b/.changeset/nasty-forks-drum.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: use fallback if `untrack` doesn't exist in svelte package

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1,5 +1,7 @@
 import { BROWSER, DEV } from 'esm-env';
-import { onMount, tick, untrack } from 'svelte';
+import { onMount, tick } from 'svelte';
+// Svelte 4 and under don't have `untrack`, so we have to fallback if `untrack` is not exported
+const untrack = (await import('svelte')).untrack ?? ((value) => value());
 import {
 	decode_params,
 	decode_pathname,

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1,7 +1,8 @@
 import { BROWSER, DEV } from 'esm-env';
-import { onMount, tick } from 'svelte';
+import * as svelte from 'svelte';
+const { onMount, tick } = svelte;
 // Svelte 4 and under don't have `untrack`, so we have to fallback if `untrack` is not exported
-const untrack = (await import('svelte')).untrack ?? ((value) => value());
+const untrack = svelte.untrack ?? ((value) => value());
 import {
 	decode_params,
 	decode_pathname,


### PR DESCRIPTION
Fixes regression from #13914 where `untrack` is imported, without checking if it exists in the `svelte` package. 

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
