### PR TITLE
docs: fix syntax highlighting for shell commands

### DIFF
--- a/documentation/docs/10-getting-started/30-project-structure.md
+++ b/documentation/docs/10-getting-started/30-project-structure.md
@@ -4,7 +4,7 @@ title: Project structure
 
 A typical SvelteKit project looks like this:
 
-```bash
+```tree
 my-project/
 ├ src/
 │ ├ lib/

--- a/documentation/docs/25-build-and-deploy/40-adapter-node.md
+++ b/documentation/docs/25-build-and-deploy/40-adapter-node.md
@@ -64,13 +64,13 @@ node +++--env-file=.env+++ build
 
 By default, the server will accept connections on `0.0.0.0` using port 3000. These can be customised with the `PORT` and `HOST` environment variables:
 
-```
+```bash
 HOST=127.0.0.1 PORT=4000 node build
 ```
 
 Alternatively, the server can be configured to accept connections on a specified socket path. When this is done using the `SOCKET_PATH` environment variable, the `HOST` and `PORT` environment variables will be disregarded.
 
-```
+```bash
 SOCKET_PATH=/tmp/socket node build
 ```
 
@@ -78,7 +78,7 @@ SOCKET_PATH=/tmp/socket node build
 
 HTTP doesn't give SvelteKit a reliable way to know the URL that is currently being requested. The simplest way to tell SvelteKit where the app is being served is to set the `ORIGIN` environment variable:
 
-```
+```bash
 ORIGIN=https://my.site node build
 
 # or e.g. for local previewing and testing
@@ -87,7 +87,7 @@ ORIGIN=http://localhost:3000 node build
 
 With this, a request for the `/stuff` pathname will correctly resolve to `https://my.site/stuff`. Alternatively, you can specify headers that tell SvelteKit about the request protocol and host, from which it can construct the origin URL:
 
-```
+```bash
 PROTOCOL_HEADER=x-forwarded-proto HOST_HEADER=x-forwarded-host node build
 ```
 
@@ -103,7 +103,7 @@ If `adapter-node` can't correctly determine the URL of your deployment, you may 
 
 The [`RequestEvent`](@sveltejs-kit#RequestEvent) object passed to hooks and endpoints includes an `event.getClientAddress()` function that returns the client's IP address. By default this is the connecting `remoteAddress`. If your server is behind one or more proxies (such as a load balancer), this value will contain the innermost proxy's IP address rather than the client's, so we need to specify an `ADDRESS_HEADER` to read the address from:
 
-```
+```bash
 ADDRESS_HEADER=True-Client-IP node build
 ```
 
@@ -174,7 +174,7 @@ If you need to change the name of the environment variables used to configure th
 envPrefix: 'MY_CUSTOM_';
 ```
 
-```sh
+```bash
 MY_CUSTOM_HOST=127.0.0.1 \
 MY_CUSTOM_PORT=4000 \
 MY_CUSTOM_ORIGIN=https://my.site \

--- a/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
+++ b/documentation/docs/25-build-and-deploy/70-adapter-cloudflare-workers.md
@@ -64,14 +64,14 @@ https://dash.cloudflare.com/<your-account-id>/home
 
 You will need to install [Wrangler](https://developers.cloudflare.com/workers/wrangler/install-and-update/) and log in, if you haven't already:
 
-```sh
+```bash
 npm i -D wrangler
 wrangler login
 ```
 
 Then, you can build your app and deploy it:
 
-```sh
+```bash
 wrangler deploy
 ```
 

--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -131,7 +131,7 @@ Set this string as an environment variable on Vercel by logging in and going to 
 
 To get this key known about for local development, you can use the [Vercel CLI](https://vercel.com/docs/cli/env) by running the `vercel env pull` command locally like so:
 
-```sh
+```bash
 vercel env pull .env.development.local
 ```
 

--- a/documentation/docs/30-advanced/70-packaging.md
+++ b/documentation/docs/30-advanced/70-packaging.md
@@ -249,7 +249,7 @@ You can create so-called declaration maps (`d.ts.map` files) by setting `"declar
 
 To publish the generated package:
 
-```sh
+```bash
 npm publish
 ```
 

--- a/documentation/docs/60-appendix/10-faq.md
+++ b/documentation/docs/60-appendix/10-faq.md
@@ -195,14 +195,14 @@ Currently ESM Support within the latest Yarn (version 3) is considered [experime
 
 The below seems to work although your results may vary. First create a new application:
 
-```sh
+```bash
 yarn create svelte myapp
 cd myapp
 ```
 
 And enable Yarn Berry:
 
-```sh
+```bash
 yarn set version berry
 yarn install
 ```


### PR DESCRIPTION
This PR fixes the syntax highlighting for shell command code blocks in the docs. Using `sh` doesn't actually highlight them since we've configured Shiki to only recognise `bash` in svelte.dev.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
