### PR TITLE
chore: replace `@ts-expect-error` with `@ts-ignore` so it doesn't error when `rolldown-vite` is installed

### DIFF
--- a/.changeset/stupid-oranges-know.md
+++ b/.changeset/stupid-oranges-know.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+feat: enable native plugins for `rolldown-vite`

--- a/.changeset/stupid-oranges-know.md
+++ b/.changeset/stupid-oranges-know.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': patch
----
-
-feat: enable native plugins for `rolldown-vite`

--- a/packages/kit/src/exports/vite/build/build_service_worker.js
+++ b/packages/kit/src/exports/vite/build/build_service_worker.js
@@ -103,7 +103,7 @@ export async function build_service_worker(
 				},
 				output: {
 					// .mjs so that esbuild doesn't incorrectly inject `export` https://github.com/vitejs/vite/issues/15379
-					// @ts-expect-error `vite.rolldownVersion` only exists in `rolldown-vite`
+					// @ts-ignore `vite.rolldownVersion` only exists in `rolldown-vite`
 					entryFileNames: `service-worker.${vite.rolldownVersion ? 'js' : 'mjs'}`,
 					assetFileNames: `${kit.appDir}/immutable/assets/[name].[hash][extname]`,
 					inlineDynamicImports: true
@@ -130,7 +130,7 @@ export async function build_service_worker(
 	});
 
 	// rename .mjs to .js to avoid incorrect MIME types with ancient webservers
-	// @ts-expect-error `vite.rolldownVersion` only exists in `rolldown-vite`
+	// @ts-ignore `vite.rolldownVersion` only exists in `rolldown-vite`
 	if (!vite.rolldownVersion) {
 		fs.renameSync(`${out}/client/service-worker.mjs`, `${out}/client/service-worker.js`);
 	}

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -701,7 +701,7 @@ Tips:
 							preserveEntrySignatures: 'strict',
 							onwarn(warning, handler) {
 								if (
-									// @ts-expect-error `vite.rolldownVersion` only exists in `rolldown-vite`
+									// @ts-ignore `vite.rolldownVersion` only exists in `rolldown-vite`
 									(vite.rolldownVersion
 										? warning.code === 'IMPORT_IS_UNDEFINED'
 										: warning.code === 'MISSING_EXPORT') &&
@@ -745,10 +745,10 @@ Tips:
 				};
 			}
 
-			// @ts-expect-error `vite.rolldownVersion` only exists in `rolldown-vite`
+			// @ts-ignore `vite.rolldownVersion` only exists in `rolldown-vite`
 			if (vite.rolldownVersion) {
 				new_config.experimental = {
-					// @ts-expect-error `enableNativePlugin` only exists in `rolldown-vite`
+					// @ts-ignore `enableNativePlugin` only exists in `rolldown-vite`
 					enableNativePlugin: true
 				};
 			}

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -745,14 +745,6 @@ Tips:
 				};
 			}
 
-			// @ts-ignore `vite.rolldownVersion` only exists in `rolldown-vite`
-			if (vite.rolldownVersion) {
-				new_config.experimental = {
-					// @ts-ignore `enableNativePlugin` only exists in `rolldown-vite`
-					enableNativePlugin: true
-				};
-			}
-
 			warn_overridden_config(config, new_config);
 
 			return new_config;

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -729,11 +729,6 @@ Tips:
 							}
 						}
 					}
-					// TODO: enabling `experimental.enableNativePlugin` causes styles to not be applied
-					// see https://github.com/vitejs/rolldown-vite/issues/213
-					// experimental: {
-					// 	enableNativePlugin: true
-					// }
 				};
 			} else {
 				new_config = {
@@ -747,11 +742,14 @@ Tips:
 						}
 					},
 					publicDir: kit.files.assets
-					// TODO: enabling `experimental.enableNativePlugin` causes styles to not be applied
-					// see https://github.com/vitejs/rolldown-vite/issues/213
-					// experimental: {
-					// 	enableNativePlugin: true
-					// }
+				};
+			}
+
+			// @ts-expect-error `vite.rolldownVersion` only exists in `rolldown-vite`
+			if (vite.rolldownVersion) {
+				new_config.experimental = {
+					// @ts-expect-error `enableNativePlugin` only exists in `rolldown-vite`
+					enableNativePlugin: true
 				};
 			}
 


### PR DESCRIPTION
`@ts-expect-error` only works when we have rollup vite installed. It wouldn't work with rolldown vite installed since there wouldn't be any error. https://github.com/sveltejs/kit/pull/13964#discussion_r2192549148

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
