### PR TITLE
refactor: enhanced-img with v-p-s6 preprocessor support

### DIFF
--- a/.changeset/rude-jeans-yell.md
+++ b/.changeset/rude-jeans-yell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/enhanced-img': minor
+---
+
+Use new filters and enhancements from vite-plugin-svelte. Requires vite >= 6.3 and vite-plugin-svelte >= 6.0

--- a/.changeset/rude-jeans-yell.md
+++ b/.changeset/rude-jeans-yell.md
@@ -2,4 +2,4 @@
 '@sveltejs/enhanced-img': minor
 ---
 
-Use new filters and enhancements from vite-plugin-svelte. Requires vite >= 6.3 and vite-plugin-svelte >= 6.0
+breaking: use new filters and enhancements from `vite-plugin-svelte`. Requires `vite >= 6.3` and `vite-plugin-svelte >= 6.0`.

--- a/packages/enhanced-img/package.json
+++ b/packages/enhanced-img/package.json
@@ -53,8 +53,8 @@
 		"vitest": "catalog:"
 	},
 	"peerDependencies": {
-		"@sveltejs/vite-plugin-svelte": "^5.0.0 || ^6.0.0-next.0",
+		"@sveltejs/vite-plugin-svelte": "^6.0.0-next.0",
 		"svelte": "^5.0.0",
-		"vite": ">= 5.0.0"
+		"vite": "^6.3.0 || >=7.0.0"
 	}
 }

--- a/packages/enhanced-img/package.json
+++ b/packages/enhanced-img/package.json
@@ -53,7 +53,7 @@
 		"vitest": "catalog:"
 	},
 	"peerDependencies": {
-		"@sveltejs/vite-plugin-svelte": "^6.0.0-next.0",
+		"@sveltejs/vite-plugin-svelte": "^6.0.0",
 		"svelte": "^5.0.0",
 		"vite": "^6.3.0 || >=7.0.0"
 	}

--- a/packages/enhanced-img/src/vite-plugin.js
+++ b/packages/enhanced-img/src/vite-plugin.js
@@ -34,7 +34,9 @@ export function image_plugin(imagetools_plugin) {
 			vite_config = config;
 			const svelteConfigPlugin = config.plugins.find((p) => p.name === 'vite-plugin-svelte:config');
 			if (!svelteConfigPlugin) {
-				throw new Error('@sveltejs/enhanced-img requires @sveltejs/vite-plugin-svelte 6 or higher to be installed');
+				throw new Error(
+					'@sveltejs/enhanced-img requires @sveltejs/vite-plugin-svelte 6 or higher to be installed'
+				);
 			}
 			// @ts-expect-error plugin.transform is defined below before configResolved is called
 			plugin.transform.filter.id = svelteConfigPlugin.api.idFilter;

--- a/packages/enhanced-img/src/vite-plugin.js
+++ b/packages/enhanced-img/src/vite-plugin.js
@@ -185,7 +185,7 @@ export function image_plugin(imagetools_plugin) {
 
 				return {
 					code: s.toString(),
-					map: s.generateMap({ hires: 'boundary', includeContent: false })
+					map: s.generateMap({ hires: 'boundary' })
 				};
 			}
 		}

--- a/packages/enhanced-img/src/vite-plugin.js
+++ b/packages/enhanced-img/src/vite-plugin.js
@@ -1,8 +1,6 @@
 /** @import { AST } from 'svelte/compiler' */
-
 import { existsSync } from 'node:fs';
 import path from 'node:path';
-import { loadSvelteConfig } from '@sveltejs/vite-plugin-svelte';
 import MagicString from 'magic-string';
 import sharp from 'sharp';
 import { parse } from 'svelte-parse-markup';
@@ -27,37 +25,27 @@ export function image_plugin(imagetools_plugin) {
 	/** @type {import('vite').ResolvedConfig} */
 	let vite_config;
 
-	/** @type {Partial<import('@sveltejs/vite-plugin-svelte').SvelteConfig | undefined>} */
-	let svelte_config;
-
 	const name = 'vite-plugin-enhanced-img-markup';
 
-	return {
+	/** @type {import('vite').Plugin<void>} */
+	const plugin = {
 		name,
-		enforce: 'pre',
-		async configResolved(config) {
+		configResolved(config) {
 			vite_config = config;
-			for (const plugin of config.plugins || []) {
-				if (plugin.name === name) {
-					break;
-				}
-				if (plugin.name === 'vite-plugin-svelte') {
-					throw new Error(
-						'@sveltejs/enhanced-img must come before the Svelte or SvelteKit plugins'
-					);
-				}
+			const svelteConfigPlugin = config.plugins.find((p) => p.name === 'vite-plugin-svelte:config');
+			if (!svelteConfigPlugin) {
+				throw new Error('@sveltejs/enhanced-img requires @sveltejs/vite-plugin-svelte 6 or higher');
 			}
-			svelte_config = await loadSvelteConfig();
-			if (!svelte_config) throw new Error('Could not load Svelte config file');
+			plugin.transform.filter.id = svelteConfigPlugin.api.idFilter;
 		},
-		async transform(content, filename) {
-			const plugin_context = this;
-			const extensions = svelte_config?.extensions || ['.svelte'];
-			if (extensions.some((ext) => filename.endsWith(ext))) {
-				if (!content.includes('<enhanced:img')) {
-					return;
-				}
+		transform: {
+			order: 'pre', // puts it before vite-plugin-svelte:compile
+			filter: {
+				code: /<enhanced:img/ // code filter must match in addition to the id filter set in configResolved hook above
+			},
 
+			async handler(content, filename) {
+				const plugin_context = this;
 				const s = new MagicString(content);
 				const ast = parse(content, { filename, modern: true });
 
@@ -196,11 +184,12 @@ export function image_plugin(imagetools_plugin) {
 
 				return {
 					code: s.toString(),
-					map: s.generateMap()
+					map: s.generateMap({ hires: 'boundary', includeContent: false })
 				};
 			}
 		}
 	};
+	return plugin;
 }
 
 /**

--- a/packages/enhanced-img/src/vite-plugin.js
+++ b/packages/enhanced-img/src/vite-plugin.js
@@ -34,7 +34,7 @@ export function image_plugin(imagetools_plugin) {
 			vite_config = config;
 			const svelteConfigPlugin = config.plugins.find((p) => p.name === 'vite-plugin-svelte:config');
 			if (!svelteConfigPlugin) {
-				throw new Error('@sveltejs/enhanced-img requires @sveltejs/vite-plugin-svelte 6 or higher');
+				throw new Error('@sveltejs/enhanced-img requires @sveltejs/vite-plugin-svelte 6 or higher to be installed');
 			}
 			// @ts-expect-error plugin.transform is defined below before configResolved is called
 			plugin.transform.filter.id = svelteConfigPlugin.api.idFilter;

--- a/packages/enhanced-img/src/vite-plugin.js
+++ b/packages/enhanced-img/src/vite-plugin.js
@@ -36,6 +36,7 @@ export function image_plugin(imagetools_plugin) {
 			if (!svelteConfigPlugin) {
 				throw new Error('@sveltejs/enhanced-img requires @sveltejs/vite-plugin-svelte 6 or higher');
 			}
+			// @ts-expect-error plugin.transform is defined below before configResolved is called
 			plugin.transform.filter.id = svelteConfigPlugin.api.idFilter;
 		},
 		transform: {

--- a/packages/enhanced-img/test/markup-plugin.spec.js
+++ b/packages/enhanced-img/test/markup-plugin.spec.js
@@ -27,7 +27,8 @@ it('Image preprocess snapshot test', async () => {
 		})
 	);
 	const transform =
-		/** @type {(this: import('vite').Rollup.TransformPluginContext, code: string, id: string, options?: {ssr?: boolean;}) => Promise<import('rollup').TransformResult>} */ (
+		/** @type {(this: import('vite').Rollup.TransformPluginContext, code: string, id: string, options?: {ssr?: boolean;}) => Promise<import('vite').Rollup.TransformResult>} */ (
+		// @ts-expect-error fails until vite is updated
 			vite_plugin.transform.handler
 		);
 	const transformed = await transform.call(

--- a/packages/enhanced-img/test/markup-plugin.spec.js
+++ b/packages/enhanced-img/test/markup-plugin.spec.js
@@ -28,7 +28,7 @@ it('Image preprocess snapshot test', async () => {
 	);
 	const transform =
 		/** @type {(this: import('vite').Rollup.TransformPluginContext, code: string, id: string, options?: {ssr?: boolean;}) => Promise<import('rollup').TransformResult>} */ (
-			vite_plugin.transform
+			vite_plugin.transform.handler
 		);
 	const transformed = await transform.call(
 		plugin_context,

--- a/packages/enhanced-img/test/markup-plugin.spec.js
+++ b/packages/enhanced-img/test/markup-plugin.spec.js
@@ -28,7 +28,7 @@ it('Image preprocess snapshot test', async () => {
 	);
 	const transform =
 		/** @type {(this: import('vite').Rollup.TransformPluginContext, code: string, id: string, options?: {ssr?: boolean;}) => Promise<import('vite').Rollup.TransformResult>} */ (
-		// @ts-expect-error fails until vite is updated
+			// @ts-expect-error fails until vite is updated
 			vite_plugin.transform.handler
 		);
 	const transformed = await transform.call(


### PR DESCRIPTION
This PR updates enhanced-img to the changes in vite-plugin-svelte that allow transforming svelte files

see https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/advanced-usage.md#transform-svelte-files-with-vite-plugins

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
