### PR TITLE
fix: force `$app/*` modules to be bundled

### DIFF
--- a/.changeset/flat-eggs-start.md
+++ b/.changeset/flat-eggs-start.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: force `$app/*` modules to be bundled

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -301,7 +301,7 @@ async function kit({ svelte_config }) {
 						// This forces `$app/*` modules to be bundled, since they depend on
 						// virtual modules like `__sveltekit/paths` (this isn't a valid bare
 						// import, but it works with vite-node's externalization logic, which
-						// uses basic concatenation
+						// uses basic concatenation)
 						'@sveltejs/kit/src/runtime'
 					]
 				}

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -299,9 +299,10 @@ async function kit({ svelte_config }) {
 						// because they for example use esbuild.build with `platform: 'browser'`
 						'esm-env',
 						// This forces `$app/*` modules to be bundled, since they depend on
-						// virtual modules like `__sveltekit/paths`
-						// TODO use RegExp.escape once we drop Node <22
-						new RegExp(runtime_directory.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&'))
+						// virtual modules like `__sveltekit/paths` (this isn't a valid bare
+						// import, but it works with vite-node's externalization logic, which
+						// uses basic concatenation
+						'@sveltejs/kit/src/runtime'
 					]
 				}
 			};

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -297,7 +297,11 @@ async function kit({ svelte_config }) {
 						// that bundle later on from resolving the export conditions incorrectly
 						// and for example include browser-only code in the server output
 						// because they for example use esbuild.build with `platform: 'browser'`
-						'esm-env'
+						'esm-env',
+						// This forces `$app/*` modules to be bundled, since they depend on
+						// virtual modules like `__sveltekit/paths`
+						// TODO use RegExp.escape once we drop Node <22
+						new RegExp(runtime_directory.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&'))
 					]
 				}
 			};


### PR DESCRIPTION
I _think_ this fixes #13975, but tbh it's hard to tell because a linked copy of `kit` doesn't exhibit the bug. Hopefully we can test it out with a pkg.pr.new install once it's available

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
