### PR TITLE
fix: extend Svelte Config type

### DIFF
--- a/.changeset/mean-horses-divide.md
+++ b/.changeset/mean-horses-divide.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: extend `vite-plugin-svelte`'s `Config` type instead of duplicating it

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -188,7 +188,11 @@ export interface Builder {
 }
 
 export interface Config extends SvelteConfig {
-	/** SvelteKit options. See https://svelte.dev/docs/kit/configuration */
+	/**
+	 * SvelteKit options.
+	 * 
+	 * @see https://svelte.dev/docs/kit/configuration
+	 */
 	kit?: KitConfig;
 	/** Any additional options required by tooling that integrates with Svelte. */
 	[key: string]: any;

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -190,7 +190,7 @@ export interface Builder {
 export interface Config extends SvelteConfig {
 	/**
 	 * SvelteKit options.
-	 * 
+	 *
 	 * @see https://svelte.dev/docs/kit/configuration
 	 */
 	kit?: KitConfig;

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -187,6 +187,9 @@ export interface Builder {
 	compress: (directory: string) => Promise<void>;
 }
 
+/**
+ * An extension of [`vite-plugin-svelte`'s options](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/config.md#svelte-options).
+ */
 export interface Config extends SvelteConfig {
 	/**
 	 * SvelteKit options.

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -2,7 +2,6 @@ import 'svelte'; // pick up `declare module "*.svelte"`
 import 'vite/client'; // pick up `declare module "*.jpg"`, etc.
 import '../types/ambient.js';
 
-import { CompileOptions } from 'svelte/compiler';
 import {
 	AdapterEntry,
 	CspDirectives,
@@ -18,7 +17,7 @@ import {
 	RouteSegment
 } from '../types/private.js';
 import { BuildData, SSRNodeLoader, SSRRoute, ValidatedConfig } from 'types';
-import type { PluginOptions } from '@sveltejs/vite-plugin-svelte';
+import type { SvelteConfig } from '@sveltejs/vite-plugin-svelte';
 
 export { PrerenderOption } from '../types/private.js';
 
@@ -188,23 +187,9 @@ export interface Builder {
 	compress: (directory: string) => Promise<void>;
 }
 
-export interface Config {
-	/**
-	 * Options passed to [`svelte.compile`](https://svelte.dev/docs/svelte/svelte-compiler#CompileOptions).
-	 * @default {}
-	 */
-	compilerOptions?: CompileOptions;
-	/**
-	 * List of file extensions that should be treated as Svelte files.
-	 * @default [".svelte"]
-	 */
-	extensions?: string[];
-	/** SvelteKit options */
+export interface Config extends SvelteConfig {
+	/** SvelteKit options. See https://svelte.dev/docs/kit/configuration */
 	kit?: KitConfig;
-	/** Preprocessor options, if any. Preprocessing can alternatively also be done through Vite's preprocessor capabilities. */
-	preprocess?: any;
-	/** `vite-plugin-svelte` plugin options. */
-	vitePlugin?: PluginOptions;
 	/** Any additional options required by tooling that integrates with Svelte. */
 	[key: string]: any;
 }

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2,8 +2,7 @@
 /// <reference types="vite/client" />
 
 declare module '@sveltejs/kit' {
-	import type { CompileOptions } from 'svelte/compiler';
-	import type { PluginOptions } from '@sveltejs/vite-plugin-svelte';
+	import type { SvelteConfig } from '@sveltejs/vite-plugin-svelte';
 	/**
 	 * [Adapters](https://svelte.dev/docs/kit/adapters) are responsible for taking the production build and turning it into something that can be deployed to a platform of your choosing.
 	 */
@@ -170,23 +169,9 @@ declare module '@sveltejs/kit' {
 		compress: (directory: string) => Promise<void>;
 	}
 
-	export interface Config {
-		/**
-		 * Options passed to [`svelte.compile`](https://svelte.dev/docs/svelte/svelte-compiler#CompileOptions).
-		 * @default {}
-		 */
-		compilerOptions?: CompileOptions;
-		/**
-		 * List of file extensions that should be treated as Svelte files.
-		 * @default [".svelte"]
-		 */
-		extensions?: string[];
-		/** SvelteKit options */
+	export interface Config extends SvelteConfig {
+		/** SvelteKit options. See https://svelte.dev/docs/kit/configuration */
 		kit?: KitConfig;
-		/** Preprocessor options, if any. Preprocessing can alternatively also be done through Vite's preprocessor capabilities. */
-		preprocess?: any;
-		/** `vite-plugin-svelte` plugin options. */
-		vitePlugin?: PluginOptions;
 		/** Any additional options required by tooling that integrates with Svelte. */
 		[key: string]: any;
 	}

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -170,7 +170,11 @@ declare module '@sveltejs/kit' {
 	}
 
 	export interface Config extends SvelteConfig {
-		/** SvelteKit options. See https://svelte.dev/docs/kit/configuration */
+		/**
+		 * SvelteKit options.
+		 * 
+		 * @see https://svelte.dev/docs/kit/configuration
+		 */
 		kit?: KitConfig;
 		/** Any additional options required by tooling that integrates with Svelte. */
 		[key: string]: any;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -169,6 +169,9 @@ declare module '@sveltejs/kit' {
 		compress: (directory: string) => Promise<void>;
 	}
 
+	/**
+	 * An extension of [`vite-plugin-svelte`'s options](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/config.md#svelte-options).
+	 */
 	export interface Config extends SvelteConfig {
 		/**
 		 * SvelteKit options.

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -172,7 +172,7 @@ declare module '@sveltejs/kit' {
 	export interface Config extends SvelteConfig {
 		/**
 		 * SvelteKit options.
-		 * 
+		 *
 		 * @see https://svelte.dev/docs/kit/configuration
 		 */
 		kit?: KitConfig;


### PR DESCRIPTION
This PR changes our Config type to extend the VPS Config type instead of trying to duplicate it like we are now.

TODO:
- [x] check that the options are consistent with the user's installed VPS rather than the version we've installed in our Kit repo

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
