### PR TITLE
fix: re-add `@sveltejs/kit` to `optimizeDeps.exclude`

### DIFF
--- a/.changeset/young-planes-exist.md
+++ b/.changeset/young-planes-exist.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: re-add `@sveltejs/kit` to `optimizeDeps.exclude`

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -284,6 +284,9 @@ async function kit({ svelte_config }) {
 						`!${kit.files.routes}/**/+*server.*`
 					],
 					exclude: [
+						// Without this SvelteKit will be prebundled on the client, which means we end up with two versions of Redirect etc.
+						// Also see https://github.com/sveltejs/kit/issues/5952#issuecomment-1218844057
+						'@sveltejs/kit',
 						// exclude kit features so that libraries using them work even when they are prebundled
 						// this does not affect app code, just handling of imported libraries that use $app or $env
 						'$app',


### PR DESCRIPTION
This was an accidental removal in #13971, we still need it: Without this SvelteKit will be prebundled on the client, which means we end up with two versions of Redirect etc. Also see https://github.com/sveltejs/kit/issues/5952#issuecomment-1218844057

No test because it's only testeable when SvelteKit is resolved as a npm package, Vite seems to do resolving slightly different within a monorepo

Fixes #13976
