### PR TITLE
chore: Halve the number of routes necessary to serve prerendered files on Vercel

### DIFF
--- a/.changeset/fresh-bikes-call.md
+++ b/.changeset/fresh-bikes-call.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-vercel': patch
+---
+
+fix: Halve the number of routes necessary to serve prerendered files on Vercel"

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -554,10 +554,11 @@ function static_vercel_config(builder, config, dir) {
 				overrides_path = path.slice(1, -1);
 			}
 
-			prerendered_redirects.push(
-				{ src: path, dest: counterpart_route },
-				{ src: counterpart_route, status: 308, headers: { Location: path } }
-			);
+			prerendered_redirects.push({
+				src: counterpart_route,
+				status: 308,
+				headers: { Location: path }
+			});
 		}
 
 		overrides[page.file] = { path: overrides_path };


### PR DESCRIPTION
Previously, for a route like `/blog/[slug]` where `/blog/first-post` is prerendered with `trailingSlash: 'always'`, we output the following routing:

```json
{
	"version": 3,
	"routes": [
                 {
                         "src": "/blog/first-post/",
                         "dest": "/blog/first-post"
                 },
		{
			"src": "/blog/first-post",
			"status": 308,
			"headers": {
				"Location": "/about/"
			}
		},
		...
	],
	"overrides": {
		"blog/first-post/index.html": {
			"path": "blog/first-post"
		}
	}
}
```

The original code from #7725 assumes that the first routing entry is necessary to get `/blog/first-post/` to match the `path` from the `overrides`, but it's not -- both `blog/first-post` and `blog/first-post/` match this path, so all we really have to do is make sure we deploy a redirect route that sends the user to the correct variant. The new version of this routing code looks like this:

```json
{
	"version": 3,
	"routes": [
		{
			"src": "/blog/first-post",
			"status": 308,
			"headers": {
				"Location": "/about/"
			}
		},
		...
	],
	"overrides": {
		"blog/first-post/index.html": {
			"path": "blog/first-post"
		}
	}
}
```

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
