### PR TITLE
Improve server error logging

### DIFF
--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -3,7 +3,7 @@ import { set_private_env, set_public_env, set_safe_public_env } from '../shared-
 import { options, get_hooks } from '__SERVER__/internal.js';
 import { DEV } from 'esm-env';
 import { filter_private_env, filter_public_env } from '../../utils/env.js';
-import { format_server_error } from './utils.js'
+import { format_server_error } from './utils.js';
 import { prerendering } from '__sveltekit/environment';
 import { set_read_implementation, set_manifest } from '__sveltekit/server';
 import { set_app } from './app.js';
@@ -77,10 +77,15 @@ export class Server {
 				this.#options.hooks = {
 					handle: module.handle || (({ event, resolve }) => resolve(event)),
 					handleError:
-						module.handleError || (({ status, error, event }) => {
-                            const error_message = format_server_error(status, /** @type {Error} */ (error), event)
-                            console.error(error_message)
-                        }),
+						module.handleError ||
+						(({ status, error, event }) => {
+							const error_message = format_server_error(
+								status,
+								/** @type {Error} */ (error),
+								event
+							);
+							console.error(error_message);
+						}),
 					handleFetch: module.handleFetch || (({ request, fetch }) => fetch(request)),
 					reroute: module.reroute || (() => {}),
 					transport: module.transport || {}

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -3,6 +3,7 @@ import { set_private_env, set_public_env, set_safe_public_env } from '../shared-
 import { options, get_hooks } from '__SERVER__/internal.js';
 import { DEV } from 'esm-env';
 import { filter_private_env, filter_public_env } from '../../utils/env.js';
+import { format_server_error } from './utils.js'
 import { prerendering } from '__sveltekit/environment';
 import { set_read_implementation, set_manifest } from '__sveltekit/server';
 import { set_app } from './app.js';
@@ -76,9 +77,10 @@ export class Server {
 				this.#options.hooks = {
 					handle: module.handle || (({ event, resolve }) => resolve(event)),
 					handleError:
-						module.handleError ||
-						(({ status, error }) =>
-							console.error((status === 404 && /** @type {Error} */ (error)?.message) || error)),
+						module.handleError || (({ status, error, event }) => {
+                            const error_message = format_server_error(status, /** @type {Error} */ (error), event)
+                            console.error(error_message)
+                        }),
 					handleFetch: module.handleFetch || (({ request, fetch }) => fetch(request)),
 					reroute: module.reroute || (() => {}),
 					transport: module.transport || {}

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -180,3 +180,50 @@ export function has_prerendered_path(manifest, pathname) {
 		(pathname.at(-1) === '/' && manifest._.prerendered_routes.has(pathname.slice(0, -1)))
 	);
 }
+
+/**
+ * Formats the error into a nice message with sanitized stack trace
+ * @param {number} status
+ * @param {Error} error
+ * @param {import('@sveltejs/kit').RequestEvent} event
+ */
+export function format_server_error(status, error, event) {
+    let formatted_text = `\x1b[1;31m[${status}] ${event.request.method} ${event.url.pathname}\x1b[0m\n`
+
+    if (status === 404) {
+        return formatted_text + error.message
+    }
+
+    return formatted_text + clean_up_stack_trace(error)
+}
+
+/**
+ * Provides a refined stack trace by excluding lines following the last occurrence of a line containing +page. +layout. or +server.
+ * @param {Error} error
+ */
+export function clean_up_stack_trace(error) {
+    const stack_trace = error.stack?.split('\n') ?? []
+    const last_line_from_src_code = find_last_index(
+        stack_trace, line => ['+page.', '+layout.', '+server.'].find(snippet => line.includes(snippet)) !== undefined
+    )
+
+    if (last_line_from_src_code === -1) {
+        // default to the whole stack trace
+        return error.stack
+    }
+
+    return stack_trace.slice(0, last_line_from_src_code + 1).join('\n')
+}
+
+/**
+ * @param {any[]} array
+ * @param {(item: any, index: number, array: any[]) => boolean} predicate
+ */
+export function find_last_index(array, predicate) {
+    for (let i = array.length - 1; i >= 0; i--) {
+      if (predicate(array[i], i, array)) {
+        return i;
+      }
+    }
+    return -1;
+  }

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -188,13 +188,13 @@ export function has_prerendered_path(manifest, pathname) {
  * @param {import('@sveltejs/kit').RequestEvent} event
  */
 export function format_server_error(status, error, event) {
-    let formatted_text = `\x1b[1;31m[${status}] ${event.request.method} ${event.url.pathname}\x1b[0m\n`
+	const formatted_text = `\x1b[1;31m[${status}] ${event.request.method} ${event.url.pathname}\x1b[0m\n`;
 
-    if (status === 404) {
-        return formatted_text + error.message
-    }
+	if (status === 404) {
+		return formatted_text + error.message;
+	}
 
-    return formatted_text + clean_up_stack_trace(error)
+	return formatted_text + clean_up_stack_trace(error);
 }
 
 /**
@@ -202,17 +202,19 @@ export function format_server_error(status, error, event) {
  * @param {Error} error
  */
 export function clean_up_stack_trace(error) {
-    const stack_trace = error.stack?.split('\n') ?? []
-    const last_line_from_src_code = find_last_index(
-        stack_trace, line => ['+page.', '+layout.', '+server.'].find(snippet => line.includes(snippet)) !== undefined
-    )
+	const stack_trace = error.stack?.split('\n') ?? [];
+	const last_line_from_src_code = find_last_index(
+		stack_trace,
+		(line) =>
+			['+page.', '+layout.', '+server.'].find((snippet) => line.includes(snippet)) !== undefined
+	);
 
-    if (last_line_from_src_code === -1) {
-        // default to the whole stack trace
-        return error.stack
-    }
+	if (last_line_from_src_code === -1) {
+		// default to the whole stack trace
+		return error.stack;
+	}
 
-    return stack_trace.slice(0, last_line_from_src_code + 1).join('\n')
+	return stack_trace.slice(0, last_line_from_src_code + 1).join('\n');
 }
 
 /**
@@ -220,10 +222,10 @@ export function clean_up_stack_trace(error) {
  * @param {(item: any, index: number, array: any[]) => boolean} predicate
  */
 export function find_last_index(array, predicate) {
-    for (let i = array.length - 1; i >= 0; i--) {
-      if (predicate(array[i], i, array)) {
-        return i;
-      }
-    }
-    return -1;
-  }
+	for (let i = array.length - 1; i >= 0; i--) {
+		if (predicate(array[i], i, array)) {
+			return i;
+		}
+	}
+	return -1;
+}

--- a/packages/kit/src/utils/filesystem.js
+++ b/packages/kit/src/utils/filesystem.js
@@ -105,7 +105,7 @@ export function walk(cwd, dirs = false) {
 		}
 	}
 
-	return (walk_dir(''), all_files);
+	return walk_dir(''), all_files;
 }
 
 /** @param {string} str */

--- a/packages/kit/test/apps/basics/src/routes/css/dynamic/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/css/dynamic/+page.svelte
@@ -2,10 +2,10 @@
 	let Dynamic;
 </script>
 
-<button on:click={async () => {
+<button
+	on:click={async () => {
 		Dynamic = (await import('./Dynamic.svelte')).default;
-	}}
-	>load component</button
+	}}>load component</button
 >
 
 <svelte:component this={Dynamic}></svelte:component>

--- a/playgrounds/basic/src/routes/+page.svelte
+++ b/playgrounds/basic/src/routes/+page.svelte
@@ -12,4 +12,5 @@
 
 <ul>
 	<li><a href="images">images</a></li>
+	<li><a href="force-error">force error</a></li>
 </ul>

--- a/playgrounds/basic/src/routes/force-error/+page.server.ts
+++ b/playgrounds/basic/src/routes/force-error/+page.server.ts
@@ -1,0 +1,5 @@
+export const actions = {
+    default: async () => {
+        throw new Error('test')
+    }
+}

--- a/playgrounds/basic/src/routes/force-error/+page.server.ts
+++ b/playgrounds/basic/src/routes/force-error/+page.server.ts
@@ -1,5 +1,5 @@
 export const actions = {
-    default: async () => {
-        throw new Error('test')
-    }
-}
+	default: async () => {
+		throw new Error('test');
+	}
+};

--- a/playgrounds/basic/src/routes/force-error/+page.svelte
+++ b/playgrounds/basic/src/routes/force-error/+page.svelte
@@ -1,6 +1,4 @@
-<br>
+<br />
 <form method="post">
-    <button type="submit">
-        Trigger server error
-    </button>
+	<button type="submit"> Trigger server error </button>
 </form>

--- a/playgrounds/basic/src/routes/force-error/+page.svelte
+++ b/playgrounds/basic/src/routes/force-error/+page.svelte
@@ -1,0 +1,6 @@
+<br>
+<form method="post">
+    <button type="submit">
+        Trigger server error
+    </button>
+</form>


### PR DESCRIPTION
<!-- Your PR description here -->

Partly resolves #13862.

This PR sanitizes stack trace for server errors by finding the last occurrence of "+page.", "+server.", or "+layout." in the stack trace, and removing everything that comes after that line.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests

As for the tests, I couldn't find a way to write Playwrite tests for the server logs. I dug up some [similar tests](https://github.com/hamboomger/kit/blob/96ce0f9735c4d1a1d467c1f9641e91b5858eea93/packages/kit/test/apps/basics/test/server.test.js#L329-L339), but they only test the error object itself, not the server log messages.

It seems like you can't easily listen on the server logs in Playwright, so if we really need it, I'd have to intercept the `console.log(...)` statements with something like this:

```typescript
  const originalError = console.error;
  console.error = (...args) => {
    globalThis.__collected_errors = globalThis.__collected_errors || [];
    globalThis.__collected_errors.push(args);
    originalError(...args);
  };
```

- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
