### PR TITLE
fix: treeshake internal `storage.get` helper

### DIFF
--- a/.changeset/heavy-ants-reply.md
+++ b/.changeset/heavy-ants-reply.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: treeshake internal `storage.get` helper

--- a/packages/kit/src/runtime/client/session-storage.js
+++ b/packages/kit/src/runtime/client/session-storage.js
@@ -3,6 +3,7 @@
  * @param {string} key
  * @param {(value: string) => any} parse
  */
+/*@__NO_SIDE_EFFECTS__*/
 export function get(key, parse = JSON.parse) {
 	try {
 		return parse(sessionStorage[key]);


### PR DESCRIPTION
tiny thing I just noticed — this function is ending up in server bundles, quite unnecessarily. (Ideally server code wouldn't import `client.js` at all, but either way it's helpful to mark functions as treeshakeable where possible.) Doubtless there are more like this

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
