### PR TITLE
feat: typed `params` prop for page/layout components

### DIFF
--- a/.changeset/long-bars-rush.md
+++ b/.changeset/long-bars-rush.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: typed `params` prop for page/layout components

--- a/packages/kit/src/core/sync/write_root.js
+++ b/packages/kit/src/core/sync/write_root.js
@@ -36,25 +36,25 @@ export function write_root(manifest_data, output) {
 					isSvelte5Plus()
 						? dedent`{@const Pyramid_${l} = constructors[${l}]}
 						<!-- svelte-ignore binding_property_non_reactive -->
-						<Pyramid_${l} bind:this={components[${l}]} data={data_${l}} {form}>
+						<Pyramid_${l} bind:this={components[${l}]} data={data_${l}} {form} params={page.params}>
 							${pyramid}
 						</Pyramid_${l}>`
-						: dedent`<svelte:component this={constructors[${l}]} bind:this={components[${l}]} data={data_${l}}>
+						: dedent`<svelte:component this={constructors[${l}]} bind:this={components[${l}]} data={data_${l}} params={page.params}>
 					${pyramid}
 				</svelte:component>`
 				}
-				
+
 			{:else}
 				${
 					isSvelte5Plus()
 						? dedent`
 					{@const Pyramid_${l} = constructors[${l}]}
 					<!-- svelte-ignore binding_property_non_reactive -->
-					<Pyramid_${l} bind:this={components[${l}]} data={data_${l}} {form} />
+					<Pyramid_${l} bind:this={components[${l}]} data={data_${l}} {form} params={page.params} />
 					`
-						: dedent`<svelte:component this={constructors[${l}]} bind:this={components[${l}]} data={data_${l}} {form} />`
+						: dedent`<svelte:component this={constructors[${l}]} bind:this={components[${l}]} data={data_${l}} {form} params={page.params} />`
 				}
-				
+
 			{/if}
 		`;
 	}

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -272,9 +272,11 @@ function update_types(config, routes, route, to_delete = new Set()) {
 		}
 
 		if (route.leaf.server) {
-			exports.push('export type PageProps = { data: PageData; form: ActionData }');
+			exports.push(
+				'export type PageProps = { params: RouteParams; data: PageData; form: ActionData }'
+			);
 		} else {
-			exports.push('export type PageProps = { data: PageData }');
+			exports.push('export type PageProps = { params: RouteParams; data: PageData }');
 		}
 	}
 
@@ -341,7 +343,7 @@ function update_types(config, routes, route, to_delete = new Set()) {
 		if (proxies.universal?.modified) to_delete.delete(proxies.universal.file_name);
 
 		exports.push(
-			'export type LayoutProps = { data: LayoutData; children: import("svelte").Snippet }'
+			'export type LayoutProps = { params: LayoutParams; data: LayoutData; children: import("svelte").Snippet }'
 		);
 	}
 

--- a/packages/kit/test/apps/basics/src/routes/params-prop/+layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/params-prop/+layout.svelte
@@ -1,0 +1,8 @@
+<script>
+	let { children } = $props();
+</script>
+
+<a href="/params-prop/123">123</a>
+<a href="/params-prop/456">456</a>
+
+{@render children()}

--- a/packages/kit/test/apps/basics/src/routes/params-prop/[x]/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/params-prop/[x]/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { params } = $props();
+</script>
+
+<p>x: {params.x}</p>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1556,3 +1556,15 @@ test.describe('getRequestEvent', () => {
 		expect(await page.textContent('h1')).toBe('Crashing now (500 hello from hooks.server.js)');
 	});
 });
+
+test.describe('params prop', () => {
+	test('params prop is passed to the page', async ({ page, clicknav }) => {
+		await page.goto('/params-prop');
+
+		await clicknav('[href="/params-prop/123"]');
+		await expect(page.locator('p')).toHaveText('x: 123');
+
+		await clicknav('[href="/params-prop/456"]');
+		await expect(page.locator('p')).toHaveText('x: 456');
+	});
+});


### PR DESCRIPTION
Closes #13904, though it looks like we need a corresponding update in language-tools @dummdidumm — if only `params` is used, it's typed as `any`...

<img width="414" height="100" alt="image" src="https://github.com/user-attachments/assets/89701522-3d36-427f-9381-bec721c6ceae" />

...whereas if `data` is also used then we get a squiggly:

<img width="782" height="317" alt="image" src="https://github.com/user-attachments/assets/f0c960ae-7d61-4fb9-b184-b2596e57d7b7" />

We can of course use the type explicitly:

<img width="632" height="174" alt="image" src="https://github.com/user-attachments/assets/d6f87905-f16d-4ea4-b6b7-066e67bdc37e" />

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
