### PR TITLE
fix: log no svelte config found message

### DIFF
--- a/.changeset/tricky-pants-kick.md
+++ b/.changeset/tricky-pants-kick.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: log when no Svelte config file has been found to avoid confusion

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -67,7 +67,9 @@ export async function load_config({ cwd = process.cwd() } = {}) {
 		.filter((f) => fs.existsSync(f));
 
 	if (config_files.length === 0) {
-		console.log(`No Svelte config file found in ${cwd} - using SvelteKit's default configuration without an adapter.`)
+		console.log(
+			`No Svelte config file found in ${cwd} - using SvelteKit's default configuration without an adapter.`
+		);
 		return process_config({}, { cwd });
 	}
 	const config_file = config_files[0];

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -67,7 +67,7 @@ export async function load_config({ cwd = process.cwd() } = {}) {
 		.filter((f) => fs.existsSync(f));
 
 	if (config_files.length === 0) {
-		console.log(`No Svelte config file found in ${cwd} - using builtin default configuration without an adapter.`)
+		console.log(`No Svelte config file found in ${cwd} - using SvelteKit's default configuration without an adapter.`)
 		return process_config({}, { cwd });
 	}
 	const config_file = config_files[0];

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -67,6 +67,7 @@ export async function load_config({ cwd = process.cwd() } = {}) {
 		.filter((f) => fs.existsSync(f));
 
 	if (config_files.length === 0) {
+		console.log(`No Svelte config file found in ${cwd} - using builtin default configuration without an adapter.`)
 		return process_config({}, { cwd });
 	}
 	const config_file = config_files[0];


### PR DESCRIPTION
Running with the default configuration can be confusing when the user expects a Svelte config file to be used that is in a different location or was deleted/moved by accident.

The most obvious setting needed is an adapter.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
