### PR TITLE
feat: add CSRF allowedOrigins bypass list 

### DIFF
--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -68,7 +68,8 @@ const get_defaults = (prefix = '') => ({
 			reportOnly: directive_defaults
 		},
 		csrf: {
-			checkOrigin: true
+			checkOrigin: true,
+			allowedOrigins: []
 		},
 		embedded: false,
 		env: {

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -109,7 +109,8 @@ const options = object(
 			}),
 
 			csrf: object({
-				checkOrigin: boolean(true)
+				checkOrigin: boolean(true),
+				allowedOrigins: string_array([])
 			}),
 
 			embedded: boolean(false),

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -38,6 +38,7 @@ export const options = {
 	app_template_contains_nonce: ${template.includes('%sveltekit.nonce%')},
 	csp: ${s(config.kit.csp)},
 	csrf_check_origin: ${s(config.kit.csrf.checkOrigin)},
+	csrf_allowed_origins: ${s(config.kit.csrf.allowedOrigins)},
 	embedded: ${config.kit.embedded},
 	env_public_prefix: '${config.kit.env.publicPrefix}',
 	env_private_prefix: '${config.kit.env.privatePrefix}',

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -373,6 +373,17 @@ export interface KitConfig {
 		 * @default true
 		 */
 		checkOrigin?: boolean;
+		/**
+		 * An array of origins that are allowed to make cross-origin form submissions to your app, even when `checkOrigin` is `true`.
+		 *
+		 * Each origin should be a complete origin including protocol (e.g., `https://payment-gateway.com`).
+		 * This is useful for allowing trusted third-party services like payment gateways or authentication providers to submit forms to your app.
+		 *
+		 * **Warning**: Only add origins you completely trust, as this bypasses CSRF protection for those origins.
+		 * @default []
+		 * @example ['https://checkout.stripe.com', 'https://accounts.google.com']
+		 */
+		allowedOrigins?: string[];
 	};
 	/**
 	 * Whether or not the app is embedded inside a larger app. If `true`, SvelteKit will add its event listeners related to navigation etc on the parent of `%sveltekit.body%` instead of `window`, and will pass `params` from the server rather than inferring them from `location.pathname`.

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -65,13 +65,15 @@ export async function respond(request, options, manifest, state) {
 	const url = new URL(request.url);
 
 	if (options.csrf_check_origin) {
+		const request_origin = request.headers.get('origin');
 		const forbidden =
 			is_form_content_type(request) &&
 			(request.method === 'POST' ||
 				request.method === 'PUT' ||
 				request.method === 'PATCH' ||
 				request.method === 'DELETE') &&
-			request.headers.get('origin') !== url.origin;
+			request_origin !== url.origin &&
+			(!request_origin || !options.csrf_allowed_origins.includes(request_origin));
 
 		if (forbidden) {
 			const csrf_error = new HttpError(

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -417,6 +417,7 @@ export interface SSROptions {
 	app_template_contains_nonce: boolean;
 	csp: ValidatedConfig['kit']['csp'];
 	csrf_check_origin: boolean;
+	csrf_allowed_origins: string[];
 	embedded: boolean;
 	env_public_prefix: string;
 	env_private_prefix: string;

--- a/packages/kit/test/apps/basics/src/routes/csrf/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/csrf/+server.js
@@ -1,4 +1,24 @@
 /** @type {import('./$types').RequestHandler} */
+export function GET() {
+	return new Response('ok', { status: 200 });
+}
+
+/** @type {import('./$types').RequestHandler} */
 export function POST() {
-	return new Response(undefined, { status: 201 });
+	return new Response('ok', { status: 200 });
+}
+
+/** @type {import('./$types').RequestHandler} */
+export function PUT() {
+	return new Response('ok', { status: 200 });
+}
+
+/** @type {import('./$types').RequestHandler} */
+export function PATCH() {
+	return new Response('ok', { status: 200 });
+}
+
+/** @type {import('./$types').RequestHandler} */
+export function DELETE() {
+	return new Response('ok', { status: 200 });
 }

--- a/packages/kit/test/apps/basics/svelte.config.js
+++ b/packages/kit/test/apps/basics/svelte.config.js
@@ -18,6 +18,11 @@ const config = {
 			}
 		},
 
+		csrf: {
+			checkOrigin: true,
+			allowedOrigins: ['https://trusted.example.com', 'https://payment-gateway.test']
+		},
+
 		prerender: {
 			entries: [
 				'*',

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -194,13 +194,12 @@ test.describe('CSRF', () => {
 		}
 	});
 
-	test('Handles null origin correctly', async ({ baseURL }) => {
+	test('Handles undefined origin correctly', async ({ baseURL }) => {
 		// Some requests may have null origin (e.g., from certain mobile apps)
 		const res = await fetch(`${baseURL}/csrf`, {
 			method: 'POST',
 			headers: {
 				'content-type': 'application/x-www-form-urlencoded',
-				origin: 'null'
 			}
 		});
 		expect(res.status).toBe(403);

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -199,7 +199,7 @@ test.describe('CSRF', () => {
 		const res = await fetch(`${baseURL}/csrf`, {
 			method: 'POST',
 			headers: {
-				'content-type': 'application/x-www-form-urlencoded',
+				'content-type': 'application/x-www-form-urlencoded'
 			}
 		});
 		expect(res.status).toBe(403);


### PR DESCRIPTION
Adds `csrf.allowedOrigins` config to whitelist trusted domains that can submit forms to your app.

###  Problem

Certain payment providers (and possibly auth services) redirect users back with form submissions that get blocked by CSRF protection. Previously you had to disable CSRF entirely or handle these outside SvelteKit. This is a fairly common  [Example thread](https://discord.com/channels/457912077277855764/1396106350110441493)

###  Solution

```
  export default {
    kit: {
      csrf: {
        checkOrigin: true,
        allowedOrigins: ['https://checkout.stripe.com', 'https://accounts.google.com']
      }
    }
  }
```

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
