### PR TITLE
feat: support custom worker output path for easier integration of cloudflare worker handlers

### DIFF
--- a/.changeset/small-hounds-greet.md
+++ b/.changeset/small-hounds-greet.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': minor
+---
+
+feat: support custom worker output path for easier integration of cloudflare worker handlers

--- a/packages/adapter-cloudflare/index.d.ts
+++ b/packages/adapter-cloudflare/index.d.ts
@@ -65,6 +65,13 @@ export interface AdapterOptions {
 	 * during development and preview.
 	 */
 	platformProxy?: GetPlatformProxyOptions;
+
+	/**
+	 * Worker script `_worker.js` output directory.
+	 * If not specified, the adapter will use the `main` field in your
+	 * wrangler file, or default to `_worker.js` in the output directory.
+	 */
+	workerScriptPath?: string;
 }
 
 export interface RoutesJSONSpec {

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -44,7 +44,9 @@ export default function (options = {}) {
 					worker_dest = `${dest}/_worker.js`;
 				}
 			} else {
-				if (wrangler_config.main) {
+				if (options.workerScriptPath) {
+					worker_dest = options.workerScriptPath;
+				} else if (wrangler_config.main) {
 					worker_dest = wrangler_config.main;
 				}
 				if (wrangler_config.assets?.directory) {


### PR DESCRIPTION
closes #13692
closes #10117
closes #1712

This PR introduces a new `workerScriptPath` option to `AdapterOptions`, allowing users to specify the output path for the generated worker script. This option takes precedence over the `main` field in the `wrangler` config, enabling more flexible integration with custom Cloudflare Worker handlers.

### The Problem
Currently, `@sveltejs/adapter-cloudflare` outputs the compiled worker to `.svelte-kit/cloudflare/_worker.js`, and this is hardcoded as the entrypoint via the `main` field in `wrangler.jsonc`. This setup makes it difficult to extend the Worker with custom handlers (e.g., `fetch`, `queue`, `scheduled`, etc.) since the generated file isn't easily imported or wrapped.

### After this PR

With this change, you can override the default worker script path and use your own file (e.g., `src/index.ts`) as the `main` entry in the `wrangler` config, allowing for easier extension and composition.

#### Example setup

Update `svelte.config.js`:

```diff
import adapter from '@sveltejs/adapter-cloudflare';

export default {
	kit: {
-		adapter: adapter()
+		adapter: adapter({
+			workerScriptPath: '.svelte-kit/cloudflare/_worker.js'
+		})
	}
};
```

Update `wrangler.jsonc`:

```diff
{
	"name": "<any-name-you-want>",
- 	"main": ".svelte-kit/cloudflare/_worker.js",
+ 	"main": "src/index.ts",
	"compatibility_date": "2025-01-01",
	"assets": {
		"binding": "ASSETS",
		"directory": ".svelte-kit/cloudflare",
	}
}
```

Create `src/index.ts`:

```ts
import sveltekit from '../.svelte-kit/cloudflare/_worker.js'

export default {
    async fetch(req, env, ctx) {
        return sveltekit.fetch(req, env, ctx);
    },
} satisfies ExportedHandler<Env>;
```

You can now extend this file with additional handlers, just like a standard Cloudflare Worker script. For example, you can add `queue`, `scheduled`, or custom logic before or after calling `sveltekit.fetch()`.

### ✅ Result
- The build output (`.svelte-kit/cloudflare/_worker.js`) is now controlled via `workerScriptPath`.
- You can define your own worker entrypoint (e.g., `src/index.ts`).
- This enables easy composition with [Cloudflare Worker handlers](https://developers.cloudflare.com/workers/runtime-apis/handlers/), such as `fetch`, `queue`, `scheduled`, etc.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
