### PR TITLE
fix(adapter-cloudflare): resolve paths from wrangler config

### DIFF
--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -1,9 +1,10 @@
 import { VERSION } from '@sveltejs/kit';
 import { copyFileSync, existsSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import { fileURLToPath } from 'node:url';
-import { is_building_for_cloudflare_pages, validate_worker_settings } from './utils.js';
 import { getPlatformProxy, unstable_readConfig } from 'wrangler';
+import { is_building_for_cloudflare_pages, validate_worker_settings } from './utils.js';
 
 const name = '@sveltejs/adapter-cloudflare';
 const [kit_major, kit_minor] = VERSION.split('.');
@@ -32,6 +33,13 @@ export default function (options = {}) {
 			}
 
 			const wrangler_config = validate_wrangler_config(options.config);
+
+			// Resolve all paths relative to the wrangler config file, if any
+			const parent_dir = wrangler_config.configPath
+				? path.dirname(path.resolve(wrangler_config.configPath))
+				: process.cwd();
+			const resolve = (/** @type {string} */ p) => path.resolve(parent_dir, p);
+
 			const building_for_cloudflare_pages = is_building_for_cloudflare_pages(wrangler_config);
 
 			let dest = builder.getBuildDirectory('cloudflare');
@@ -40,15 +48,15 @@ export default function (options = {}) {
 
 			if (building_for_cloudflare_pages) {
 				if (wrangler_config.pages_build_output_dir) {
-					dest = wrangler_config.pages_build_output_dir;
+					dest = resolve(wrangler_config.pages_build_output_dir);
 					worker_dest = `${dest}/_worker.js`;
 				}
 			} else {
 				if (wrangler_config.main) {
-					worker_dest = wrangler_config.main;
+					worker_dest = resolve(wrangler_config.main);
 				}
 				if (wrangler_config.assets?.directory) {
-					dest = wrangler_config.assets.directory;
+					dest = resolve(wrangler_config.assets.directory);
 				}
 				if (wrangler_config.assets?.binding) {
 					assets_binding = wrangler_config.assets.binding;

--- a/packages/adapter-cloudflare/test/apps/workers/config/wrangler.jsonc
+++ b/packages/adapter-cloudflare/test/apps/workers/config/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+	"main": "../dist/index.js",
+	"assets": {
+		"directory": "../dist/public",
+		"binding": "ASSETS"
+	}
+}

--- a/packages/adapter-cloudflare/test/apps/workers/svelte.config.js
+++ b/packages/adapter-cloudflare/test/apps/workers/svelte.config.js
@@ -3,7 +3,9 @@ import adapter from '../../../index.js';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter()
+		adapter: adapter({
+			config: 'config/wrangler.jsonc'
+		})
 	}
 };
 

--- a/packages/adapter-cloudflare/test/apps/workers/wrangler.jsonc
+++ b/packages/adapter-cloudflare/test/apps/workers/wrangler.jsonc
@@ -1,7 +1,0 @@
-{
-	"main": "./dist/index.js",
-	"assets": {
-		"directory": "./dist/public",
-		"binding": "ASSETS"
-	}
-}


### PR DESCRIPTION
Hi!

This PR fixes a bug in the current version of the Cloudflare adapter: it always assumes that the wrangler.json config file is in the same directory as the .svelte-kit directory.

With this fix, the wrangler.json can be placed anywhere (parent and children directories work)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
