### PR TITLE
remote functions: fix prerender types etc

### DIFF
--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1560,7 +1560,7 @@ export interface Snapshot<T = any> {
  * </ul>
  * ```
  */
-export type RemoteFormAction<Success, Failure> = ((data: FormData) => Promise<void>) & {
+export type RemoteForm<Success, Failure> = ((data: FormData) => Promise<void>) & {
 	method: 'POST';
 	/** The URL to send the form to. */
 	action: string;
@@ -1599,7 +1599,7 @@ export type RemoteFormAction<Success, Failure> = ((data: FormData) => Promise<vo
 	 *	{/each}
 	 * ```
 	 */
-	for: (key: string | number | boolean) => Omit<RemoteFormAction<Success, Failure>, 'for'>;
+	for: (key: string | number | boolean) => Omit<RemoteForm<Success, Failure>, 'for'>;
 	/** The result of the form submission */
 	get result(): Success | Failure | undefined;
 	/** When there's an error during form submission, it appears on this property */

--- a/packages/kit/src/runtime/app/server/remote.js
+++ b/packages/kit/src/runtime/app/server/remote.js
@@ -1,4 +1,4 @@
-/** @import { RemoteFormAction, RemoteQuery, RemoteCommand, RequestEvent, ActionFailure as IActionFailure } from '@sveltejs/kit' */
+/** @import { RemoteForm, RemoteQuery, RemoteCommand, RequestEvent, ActionFailure as IActionFailure } from '@sveltejs/kit' */
 /** @import { RemotePrerenderInputsGenerator, RemoteInfo, ServerHooks, MaybePromise } from 'types' */
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 
@@ -516,7 +516,7 @@ export function command(validate_or_fn, maybe_fn) {
  * @template T
  * @template [U=never]
  * @param {(formData: FormData) => T | IActionFailure<U>} fn
- * @returns {RemoteFormAction<T, U>}
+ * @returns {RemoteForm<T, U>}
  */
 /*@__NO_SIDE_EFFECTS__*/
 export function form(fn) {
@@ -611,7 +611,7 @@ export function form(fn) {
 
 		if (key == undefined) {
 			Object.defineProperty(wrapper, 'for', {
-				/** @type {RemoteFormAction<any, any>['for']} */
+				/** @type {RemoteForm<any, any>['for']} */
 				value: (key) => {
 					const info = get_remote_info(getRequestEvent());
 					let entry = info.form_instances.get(key);

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -369,7 +369,7 @@ async function _invalidate(include_load_functions = true, reset_page_state = tru
 	// Rerun queries
 	if (force_invalidation) {
 		query_map.forEach(({ resource }) => {
-			resource.refresh();
+			resource.refresh?.();
 		});
 	}
 
@@ -464,7 +464,7 @@ async function _goto(url, options, redirect_count, nav_token) {
 				query_map.forEach(({ resource }, key) => {
 					// Only refresh those that already existed on the old page
 					if (query_keys?.includes(key)) {
-						resource.refresh();
+						resource.refresh?.();
 					}
 				});
 			});

--- a/packages/kit/src/runtime/client/remote.svelte.js
+++ b/packages/kit/src/runtime/client/remote.svelte.js
@@ -1,4 +1,4 @@
-/** @import { RemoteFormAction, RemoteQuery, RemoteCommand } from '@sveltejs/kit' */
+/** @import { RemoteForm, RemoteQuery, RemoteCommand } from '@sveltejs/kit' */
 /** @import { RemoteFunctionResponse } from 'types' */
 
 import { app_dir } from '__sveltekit/paths';
@@ -494,7 +494,7 @@ export function command(id) {
 /**
  * Client-version of the `form` function from `$app/server`.
  * @param {string} id
- * @returns {RemoteFormAction<any, any>}
+ * @returns {RemoteForm<any, any>}
  */
 export function form(id) {
 	/**
@@ -650,7 +650,7 @@ export function form(id) {
 			return form_data;
 		}
 
-		/** @param {Parameters<RemoteFormAction<any, any>['enhance']>[0]} callback */
+		/** @param {Parameters<RemoteForm<any, any>['enhance']>[0]} callback */
 		const form_onsubmit = (callback) => {
 			/** @param {SubmitEvent} event */
 			return (event) => {
@@ -688,7 +688,7 @@ export function form(id) {
 		submit.action = action;
 		submit.onsubmit = form_onsubmit(({ submit }) => default_submit(submit));
 
-		/** @param {Parameters<RemoteFormAction<any, any>['formAction']['enhance']>[0]} callback */
+		/** @param {Parameters<RemoteForm<any, any>['formAction']['enhance']>[0]} callback */
 		const form_action_onclick = (callback) => {
 			/** @param {Event} event */
 			return (event) => {
@@ -710,7 +710,7 @@ export function form(id) {
 			};
 		};
 
-		/** @type {RemoteFormAction<any, any>['formAction']} */
+		/** @type {RemoteForm<any, any>['formAction']} */
 		// @ts-expect-error we gotta set enhance as a non-enumerable property
 		const form_action = {
 			type: 'submit',
@@ -719,7 +719,7 @@ export function form(id) {
 		};
 
 		Object.defineProperty(form_action, 'enhance', {
-			/** @type {RemoteFormAction<any, any>['formAction']['enhance']} */
+			/** @type {RemoteForm<any, any>['formAction']['enhance']} */
 			value: (callback) => {
 				return {
 					type: 'submit',
@@ -748,7 +748,7 @@ export function form(id) {
 				enumerable: false
 			},
 			enhance: {
-				/** @type {RemoteFormAction<any, any>['enhance']} */
+				/** @type {RemoteForm<any, any>['enhance']} */
 				value: (callback) => {
 					return {
 						method: 'POST',
@@ -762,7 +762,7 @@ export function form(id) {
 
 		if (key == undefined) {
 			Object.defineProperty(submit, 'for', {
-				/** @type {RemoteFormAction<any, any>['for']} */
+				/** @type {RemoteForm<any, any>['for']} */
 				value: (key) => {
 					let entry = instance_cache.get(key);
 

--- a/packages/kit/src/runtime/client/remote.svelte.js
+++ b/packages/kit/src/runtime/client/remote.svelte.js
@@ -303,22 +303,6 @@ class Query {
 	}
 
 	/**
-	 * @param {(old: T) => T} fn
-	 * @returns {() => void}
-	 */
-	override(fn) {
-		this.#overrides.push(fn);
-
-		return () => {
-			const i = this.#overrides.indexOf(fn);
-
-			if (i !== -1) {
-				this.#overrides.splice(i, 1);
-			}
-		};
-	}
-
-	/**
 	 * @returns {Promise<void>}
 	 */
 	refresh() {
@@ -340,9 +324,17 @@ class Query {
 	 * @param {(old: T) => T} fn
 	 */
 	withOverride(fn) {
+		this.#overrides.push(fn);
+
 		return {
 			_key: this._key,
-			release: this.override(fn)
+			release: () => {
+				const i = this.#overrides.indexOf(fn);
+
+				if (i !== -1) {
+					this.#overrides.splice(i, 1);
+				}
+			}
 		};
 	}
 }

--- a/packages/kit/test/apps/basics/src/routes/remote/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/remote/+page.svelte
@@ -27,15 +27,6 @@
 <button onclick={() => count.refresh()} id="refresh-btn">Refresh</button>
 
 <button
-	onclick={() => {
-		release = count.override((count) => count + 10);
-	}}
-	id="override-btn">Override</button
->
-
-<button onclick={() => release?.()} id="release-btn">Release</button>
-
-<button
 	onclick={async () => {
 		command_result = await set_count({ c: 2 });
 	}}

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1723,33 +1723,6 @@ test.describe('remote functions', () => {
 		expect(request_count).toBe(1); // no query refreshes, since that happens as part of the command response
 	});
 
-	test('override works and persists across updates or refreshes', async ({ page }) => {
-		await page.goto('/remote');
-		await expect(page.locator('#count-result')).toHaveText('0 / 0 (false)');
-
-		// override the value
-		await page.click('#override-btn');
-		await expect(page.locator('#count-result')).toHaveText('10 / 10 (false)');
-
-		let request_count = 0;
-		page.on('request', (r) => (request_count += r.url().includes('/_app/remote') ? 1 : 0));
-
-		await page.click('#refresh-btn');
-		await expect(page.locator('#count-result')).toHaveText('10 / 10 (false)');
-
-		await page.click('#multiply-btn');
-		await expect(page.locator('#count-result')).toHaveText('12 / 12 (false)');
-
-		await page.click('#multiply-refresh-btn');
-		await expect(page.locator('#count-result')).toHaveText('13 / 13 (false)');
-
-		await page.click('#multiply-server-refresh-btn');
-		await expect(page.locator('#count-result')).toHaveText('14 / 14 (false)');
-
-		await page.click('#release-btn');
-		await expect(page.locator('#count-result')).toHaveText('4 / 4 (false)');
-	});
-
 	test('form.enhance works', async ({ page }) => {
 		await page.goto('/remote/form');
 		await page.fill('#input-task-enhance', 'abort');

--- a/packages/kit/test/types/remote.test.ts
+++ b/packages/kit/test/types/remote.test.ts
@@ -1,16 +1,18 @@
 import { query, prerender, command, form } from '$app/server';
 import { StandardSchemaV1 } from '@standard-schema/spec';
-import { RemoteQuery } from '@sveltejs/kit';
+import { RemotePrerenderFunction, RemoteQueryFunction } from '@sveltejs/kit';
 
 const schema: StandardSchemaV1<string> = null as any;
 
 function query_tests() {
-	const no_args: RemoteQuery<void, string> = query(() => 'Hello world');
+	const no_args: RemoteQueryFunction<void, string> = query(() => 'Hello world');
 	no_args();
 	// @ts-expect-error
 	no_args('');
 
-	const one_arg: RemoteQuery<number, string> = query('unchecked', (a: number) => a.toString());
+	const one_arg: RemoteQueryFunction<number, string> = query('unchecked', (a: number) =>
+		a.toString()
+	);
 	one_arg(1);
 	// @ts-expect-error
 	one_arg('1');
@@ -52,11 +54,13 @@ function query_tests() {
 query_tests();
 
 function prerender_tests() {
-	const no_args: RemoteQuery<void, string> = prerender(() => 'Hello world');
+	const no_args: RemotePrerenderFunction<void, string> = prerender(() => 'Hello world');
 	no_args();
 	// @ts-expect-error
 	no_args('');
-	const one_arg: RemoteQuery<number, string> = prerender('unchecked', (a: number) => a.toString());
+	const one_arg: RemotePrerenderFunction<number, string> = prerender('unchecked', (a: number) =>
+		a.toString()
+	);
 	one_arg(1);
 	// @ts-expect-error
 	one_arg('1');

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -221,10 +221,7 @@ declare module '@sveltejs/kit' {
 		 * @param name the name of the cookie
 		 * @param opts the options, passed directly to `cookie.serialize`. The `path` must match the path of the cookie you want to delete. See documentation [here](https://github.com/jshttp/cookie#cookieserializename-value-options)
 		 */
-		delete: (
-			name: string,
-			opts: import('cookie').CookieSerializeOptions & { path: string }
-		) => void;
+		delete: (name: string, opts: import('cookie').CookieSerializeOptions & { path: string }) => void;
 
 		/**
 		 * Serialize a cookie name-value pair into a `Set-Cookie` header string, but don't apply it to the response.
@@ -1270,10 +1267,7 @@ declare module '@sveltejs/kit' {
 		 * but they will always be split at sensible boundaries such as `%sveltekit.head%` or layout/page components.
 		 * @param input the html chunk and the info if this is the last chunk
 		 */
-		transformPageChunk?: (input: {
-			html: string;
-			done: boolean;
-		}) => MaybePromise<string | undefined>;
+		transformPageChunk?: (input: { html: string; done: boolean }) => MaybePromise<string | undefined>;
 		/**
 		 * Determines which headers should be included in serialized responses when a `load` function loads a resource with `fetch`.
 		 * By default, none will be included.
@@ -1561,10 +1555,7 @@ declare module '@sveltejs/kit' {
 				data: FormData;
 				submit: () => Promise<void> & {
 					updates: (
-						...queries: Array<
-							| ReturnType<RemoteQuery<any, any>>
-							| ReturnType<ReturnType<RemoteQuery<any, any>>['withOverride']>
-						>
+						...queries: Array<RemoteQuery<any> | ReturnType<RemoteQuery<any>['withOverride']>>
 					) => Promise<void>;
 				};
 			}) => void
@@ -1604,10 +1595,7 @@ declare module '@sveltejs/kit' {
 					data: FormData;
 					submit: () => Promise<void> & {
 						updates: (
-							...queries: Array<
-								| ReturnType<RemoteQuery<any, any>>
-								| ReturnType<ReturnType<RemoteQuery<any, any>>['withOverride']>
-							>
+							...queries: Array<RemoteQuery<any> | ReturnType<RemoteQuery<any>['withOverride']>>
 						) => Promise<void>;
 					};
 				}) => void
@@ -1666,25 +1654,34 @@ declare module '@sveltejs/kit' {
 	 */
 	export type RemoteCommand<Input, Output> = (arg: Input) => Promise<Awaited<Output>> & {
 		updates: (
-			...queries: Array<
-				| ReturnType<RemoteQuery<any, any>>
-				| ReturnType<ReturnType<RemoteQuery<any, any>>['withOverride']>
-			>
+			...queries: Array<RemoteQuery<any> | ReturnType<RemoteQuery<any>['withOverride']>>
 		) => Promise<Awaited<Output>>;
 	};
 
-	/**
-	 * The return value of a remote `query` or `prerender` function.
-	 * Call it with the input arguments to retrieve the value.
-	 * On the server, this will directly call the underlying function.
-	 * On the client, this will `fetch` data from the server.
-	 * When the query is called in a reactive context on the client, it will update its dependencies with a new value whenever `refresh()` or `override()` are called.
-	 */
-	export type RemoteQuery<Input, Output> = (arg: Input) => Promise<Awaited<Output>> & {
+	export type RemoteResource<T> = Promise<Awaited<T>> & {
 		/** The error in case the query fails. Most often this is a [`HttpError`](https://svelte.dev/docs/kit/@sveltejs-kit#HttpError) but it isn't guaranteed to be. */
 		get error(): any;
 		/** `true` before the first result is available and during refreshes */
 		get loading(): boolean;
+	} & (
+			| {
+					/** The current value of the query. Undefined as long as there's no value yet */
+					get current(): undefined;
+					status: 'loading';
+			  }
+			| {
+					/** The current value of the query. Undefined as long as there's no value yet */
+					get current(): Awaited<T>;
+					status: 'success' | 'reloading';
+			  }
+			| {
+					/** The current value of the query. Undefined as long as there's no value yet */
+					get current(): Awaited<T> | undefined;
+					status: 'error';
+			  }
+		);
+
+	export type RemoteQuery<T> = RemoteResource<T> & {
 		/**
 		 * On the client, this function will re-fetch the query from the server.
 		 *
@@ -1692,44 +1689,6 @@ declare module '@sveltejs/kit' {
 		 * transport the updated data to the client along with the response, if the action was successful.
 		 */
 		refresh: () => Promise<void>;
-		/**
-		 * Temporarily override the value of a query. Useful for optimistic UI updates outside of a `command` or `form` remote function (for those, use `withOverride`).
-		 * `override` expects a function that takes the current value and returns the new value. It returns a function that will release the override.
-		 * Overrides are applied on new values, too, until they are released.
-		 *
-		 * ```svelte
-		 * <script>
-		 *   import { getList, commit } from './todos.remote.js';
-		 *   const list = getList();
-		 *   let release = [];
-		 * </script>
-		 *
-		 * <h2>Select items to remove</h2>
-		 *
-		 * <ul>
-		 *   {#each list as item}
-		 *     <li>{item.text}</li>
-		 *     <button onclick={() => {
-		 *       release.push(list.override((current) => current.filter((i) => i.id !== item.id)));
-		 *     }}>Remove</button>
-		 *   {/each}
-		 * </ul>
-		 *
-		 * <button onclick={() => {
-		 *   release.forEach((r) => r());
-		 *   release = [];
-		 * }}>Revert</button>
-		 *
-		 * <button onclick={async () => {
-		 *   await commit();
-		 *   release.forEach((r) => r());
-		 *   release = [];
-		 * }}>Confirm</button>
-		 * ```
-		 *
-		 * Can only be called on the client.
-		 */
-		override: (update: (current: Awaited<Output>) => Awaited<Output>) => () => void;
 		/**
 		 * Temporarily override the value of a query. Useful for optimistic UI updates.
 		 * `withOverride` expects a function that takes the current value and returns the new value.
@@ -1750,27 +1709,28 @@ declare module '@sveltejs/kit' {
 		 * </form>
 		 * ```
 		 */
-		withOverride: (update: (current: Awaited<Output>) => Awaited<Output>) => {
+		withOverride: (update: (current: Awaited<T>) => Awaited<T>) => {
 			_key: string;
 			release: () => void;
 		};
-	} & (
-			| {
-					/** The current value of the query. Undefined as long as there's no value yet */
-					get current(): undefined;
-					status: 'loading';
-			  }
-			| {
-					/** The current value of the query. Undefined as long as there's no value yet */
-					get current(): Awaited<Output>;
-					status: 'success' | 'reloading';
-			  }
-			| {
-					/** The current value of the query. Undefined as long as there's no value yet */
-					get current(): Awaited<Output> | undefined;
-					status: 'error';
-			  }
-		);
+	};
+
+	/**
+	 * The return value of a remote `prerender` function.
+	 * Call it with the input arguments to retrieve the value.
+	 * On the server, this will directly call the underlying function.
+	 * On the client, this will `fetch` data from the server.
+	 */
+	export type RemotePrerenderFunction<Input, Output> = (arg: Input) => RemoteResource<Output>;
+
+	/**
+	 * The return value of a remote `query` function.
+	 * Call it with the input arguments to retrieve the value.
+	 * On the server, this will directly call the underlying function.
+	 * On the client, this will `fetch` data from the server.
+	 * When the query is called in a reactive context on the client, it will update its dependencies with a new value whenever `refresh()` or `override()` are called.
+	 */
+	export type RemoteQueryFunction<Input, Output> = (arg: Input) => RemoteQuery<Output>;
 	interface AdapterEntry {
 		/**
 		 * A string that uniquely identifies an HTTP service (e.g. serverless function) and is used for deduplication.
@@ -1793,9 +1753,7 @@ declare module '@sveltejs/kit' {
 		 * A function that is invoked once the entry has been created. This is where you
 		 * should write the function to the filesystem and generate redirect manifests.
 		 */
-		complete(entry: {
-			generateManifest(opts: { relativePath: string }): string;
-		}): MaybePromise<void>;
+		complete(entry: { generateManifest(opts: { relativePath: string }): string }): MaybePromise<void>;
 	}
 
 	// Based on https://github.com/josh-hemphill/csp-typed-directives/blob/latest/src/csp.types.ts
@@ -2248,24 +2206,16 @@ declare module '@sveltejs/kit' {
 	 * @throws {HttpError} This error instructs SvelteKit to initiate HTTP error handling.
 	 * @throws {Error} If the provided status is invalid (not between 400 and 599).
 	 */
-	export function error(
-		status: number,
-		body?: {
-			message: string;
-		} extends App.Error
-			? App.Error | string | undefined
-			: never
-	): never;
+	export function error(status: number, body?: {
+		message: string;
+	} extends App.Error ? App.Error | string | undefined : never): never;
 	/**
 	 * Checks whether this is an error thrown by {@link error}.
 	 * @param status The status to filter for.
 	 * */
-	export function isHttpError<T extends number>(
-		e: unknown,
-		status?: T | undefined
-	): e is HttpError_1 & {
+	export function isHttpError<T extends number>(e: unknown, status?: T | undefined): e is (HttpError_1 & {
 		status: T extends undefined ? never : T;
-	};
+	});
 	/**
 	 * Redirect a request. When called during request handling, SvelteKit will return a redirect response.
 	 * Make sure you're not catching the thrown redirect, which would prevent SvelteKit from handling it.
@@ -2282,10 +2232,7 @@ declare module '@sveltejs/kit' {
 	 * @throws {Redirect} This error instructs SvelteKit to redirect to the specified location.
 	 * @throws {Error} If the provided status is invalid.
 	 * */
-	export function redirect(
-		status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308 | ({} & number),
-		location: string | URL
-	): never;
+	export function redirect(status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308 | ({} & number), location: string | URL): never;
 	/**
 	 * Checks whether this is a redirect thrown by {@link redirect}.
 	 * @param e The object to check.
@@ -2337,31 +2284,20 @@ declare module '@sveltejs/kit' {
 		wasNormalized: boolean;
 		denormalize: (url?: string | URL) => URL;
 	};
-	export type LessThan<
-		TNumber extends number,
-		TArray extends any[] = []
-	> = TNumber extends TArray['length']
-		? TArray[number]
-		: LessThan<TNumber, [...TArray, TArray['length']]>;
-	export type NumericRange<TStart extends number, TEnd extends number> = Exclude<
-		TEnd | LessThan<TEnd>,
-		LessThan<TStart>
-	>;
+	export type LessThan<TNumber extends number, TArray extends any[] = []> = TNumber extends TArray["length"] ? TArray[number] : LessThan<TNumber, [...TArray, TArray["length"]]>;
+	export type NumericRange<TStart extends number, TEnd extends number> = Exclude<TEnd | LessThan<TEnd>, LessThan<TStart>>;
 	export const VERSION: string;
 	class HttpError_1 {
-		constructor(
-			status: number,
-			body: {
-				message: string;
-			} extends App.Error
-				? App.Error | string | undefined
-				: App.Error
-		);
+		
+		constructor(status: number, body: {
+			message: string;
+		} extends App.Error ? (App.Error | string | undefined) : App.Error);
 		status: number;
 		body: App.Error;
 		toString(): string;
 	}
 	class Redirect_1 {
+		
 		constructor(status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308, location: string);
 		status: 301 | 302 | 303 | 307 | 308 | 300 | 304 | 305 | 306;
 		location: string;
@@ -2441,28 +2377,19 @@ declare module '@sveltejs/kit/hooks' {
 	 *
 	 * @param handlers The chain of `handle` functions
 	 * */
-	export function sequence(
-		...handlers: import('@sveltejs/kit').Handle[]
-	): import('@sveltejs/kit').Handle;
+	export function sequence(...handlers: import("@sveltejs/kit").Handle[]): import("@sveltejs/kit").Handle;
 
 	export {};
 }
 
 declare module '@sveltejs/kit/node' {
-	export function getRequest({
-		request,
-		base,
-		bodySizeLimit
-	}: {
-		request: import('http').IncomingMessage;
+	export function getRequest({ request, base, bodySizeLimit }: {
+		request: import("http").IncomingMessage;
 		base: string;
 		bodySizeLimit?: number;
 	}): Promise<Request>;
 
-	export function setResponse(
-		res: import('http').ServerResponse,
-		response: Response
-	): Promise<void>;
+	export function setResponse(res: import("http").ServerResponse, response: Response): Promise<void>;
 	/**
 	 * Converts a file on disk to a readable stream
 	 * @since 2.4.0
@@ -2487,7 +2414,7 @@ declare module '@sveltejs/kit/vite' {
 	/**
 	 * Returns the SvelteKit Vite plugins.
 	 * */
-	export function sveltekit(): Promise<import('vite').Plugin[]>;
+	export function sveltekit(): Promise<import("vite").Plugin[]>;
 
 	export {};
 }
@@ -2535,10 +2462,7 @@ declare module '$app/forms' {
 	 * }
 	 * ```
 	 * */
-	export function deserialize<
-		Success extends Record<string, unknown> | undefined,
-		Failure extends Record<string, unknown> | undefined
-	>(result: string): import('@sveltejs/kit').ActionResult<Success, Failure>;
+	export function deserialize<Success extends Record<string, unknown> | undefined, Failure extends Record<string, unknown> | undefined>(result: string): import("@sveltejs/kit").ActionResult<Success, Failure>;
 	/**
 	 * This action enhances a `<form>` element that otherwise would work without JavaScript.
 	 *
@@ -2562,23 +2486,14 @@ declare module '$app/forms' {
 	 * @param form_element The form element
 	 * @param submit Submit callback
 	 */
-	export function enhance<
-		Success extends Record<string, unknown> | undefined,
-		Failure extends Record<string, unknown> | undefined
-	>(
-		form_element: HTMLFormElement,
-		submit?: import('@sveltejs/kit').SubmitFunction<Success, Failure>
-	): {
+	export function enhance<Success extends Record<string, unknown> | undefined, Failure extends Record<string, unknown> | undefined>(form_element: HTMLFormElement, submit?: import("@sveltejs/kit").SubmitFunction<Success, Failure>): {
 		destroy(): void;
 	};
 	/**
 	 * This action updates the `form` property of the current page with the given data and updates `page.status`.
 	 * In case of an error, it redirects to the nearest error page.
 	 * */
-	export function applyAction<
-		Success extends Record<string, unknown> | undefined,
-		Failure extends Record<string, unknown> | undefined
-	>(result: import('@sveltejs/kit').ActionResult<Success, Failure>): Promise<void>;
+	export function applyAction<Success extends Record<string, unknown> | undefined, Failure extends Record<string, unknown> | undefined>(result: import("@sveltejs/kit").ActionResult<Success, Failure>): Promise<void>;
 
 	export {};
 }
@@ -2589,9 +2504,7 @@ declare module '$app/navigation' {
 	 *
 	 * `afterNavigate` must be called during a component initialization. It remains active as long as the component is mounted.
 	 * */
-	export function afterNavigate(
-		callback: (navigation: import('@sveltejs/kit').AfterNavigate) => void
-	): void;
+	export function afterNavigate(callback: (navigation: import("@sveltejs/kit").AfterNavigate) => void): void;
 	/**
 	 * A navigation interceptor that triggers before we navigate to a URL, whether by clicking a link, calling `goto(...)`, or using the browser back/forward controls.
 	 *
@@ -2603,9 +2516,7 @@ declare module '$app/navigation' {
 	 *
 	 * `beforeNavigate` must be called during a component initialization. It remains active as long as the component is mounted.
 	 * */
-	export function beforeNavigate(
-		callback: (navigation: import('@sveltejs/kit').BeforeNavigate) => void
-	): void;
+	export function beforeNavigate(callback: (navigation: import("@sveltejs/kit").BeforeNavigate) => void): void;
 	/**
 	 * A lifecycle function that runs the supplied `callback` immediately before we navigate to a new URL except during full-page navigations.
 	 *
@@ -2615,9 +2526,7 @@ declare module '$app/navigation' {
 	 *
 	 * `onNavigate` must be called during a component initialization. It remains active as long as the component is mounted.
 	 * */
-	export function onNavigate(
-		callback: (navigation: import('@sveltejs/kit').OnNavigate) => MaybePromise<(() => void) | void>
-	): void;
+	export function onNavigate(callback: (navigation: import("@sveltejs/kit").OnNavigate) => MaybePromise<(() => void) | void>): void;
 	/**
 	 * If called when the page is being updated following a navigation (in `onMount` or `afterNavigate` or an action, for example), this disables SvelteKit's built-in scroll handling.
 	 * This is generally discouraged, since it breaks user expectations.
@@ -2632,19 +2541,14 @@ declare module '$app/navigation' {
 	 * @param url Where to navigate to. Note that if you've set [`config.kit.paths.base`](https://svelte.dev/docs/kit/configuration#paths) and the URL is root-relative, you need to prepend the base path if you want to navigate within the app.
 	 * @param {Object} opts Options related to the navigation
 	 * */
-	export function goto(
-		url: string | URL,
-		opts?:
-			| {
-					replaceState?: boolean | undefined;
-					noScroll?: boolean | undefined;
-					keepFocus?: boolean | undefined;
-					invalidateAll?: boolean | undefined;
-					invalidate?: (string | URL | ((url: URL) => boolean))[] | undefined;
-					state?: App.PageState | undefined;
-			  }
-			| undefined
-	): Promise<void>;
+	export function goto(url: string | URL, opts?: {
+		replaceState?: boolean | undefined;
+		noScroll?: boolean | undefined;
+		keepFocus?: boolean | undefined;
+		invalidateAll?: boolean | undefined;
+		invalidate?: (string | URL | ((url: URL) => boolean))[] | undefined;
+		state?: App.PageState | undefined;
+	} | undefined): Promise<void>;
 	/**
 	 * Causes any `load` functions belonging to the currently active page to re-run if they depend on the `url` in question, via `fetch` or `depends`. Returns a `Promise` that resolves when the page is subsequently updated.
 	 *
@@ -2671,13 +2575,9 @@ declare module '$app/navigation' {
 	 * Causes all currently active remote functions to refresh, and all `load` functions belonging to the currently active page to re-run (unless disabled via the option argument).
 	 * Returns a `Promise` that resolves when the page is subsequently updated.
 	 * */
-	export function refreshAll({
-		includeLoadFunctions
-	}?:
-		| {
-				includeLoadFunctions?: boolean;
-		  }
-		| undefined): Promise<void>;
+	export function refreshAll({ includeLoadFunctions }?: {
+		includeLoadFunctions?: boolean;
+	} | undefined): Promise<void>;
 	/**
 	 * Programmatically preloads the given page, which means
 	 *  1. ensuring that the code for the page is loaded, and
@@ -2689,17 +2589,14 @@ declare module '$app/navigation' {
 	 *
 	 * @param href Page to preload
 	 * */
-	export function preloadData(href: string): Promise<
-		| {
-				type: 'loaded';
-				status: number;
-				data: Record<string, any>;
-		  }
-		| {
-				type: 'redirect';
-				location: string;
-		  }
-	>;
+	export function preloadData(href: string): Promise<{
+		type: "loaded";
+		status: number;
+		data: Record<string, any>;
+	} | {
+		type: "redirect";
+		location: string;
+	}>;
 	/**
 	 * Programmatically imports the code for routes that haven't yet been fetched.
 	 * Typically, you might call this to speed up subsequent navigation.
@@ -2762,13 +2659,7 @@ declare module '$app/paths' {
 }
 
 declare module '$app/server' {
-	import type {
-		RequestEvent,
-		RemoteQuery,
-		RemoteCommand,
-		ActionFailure as IActionFailure,
-		RemoteForm
-	} from '@sveltejs/kit';
+	import type { RequestEvent, RemoteQueryFunction, RemotePrerenderFunction, RemoteCommand, ActionFailure as IActionFailure, RemoteForm } from '@sveltejs/kit';
 	import type { StandardSchemaV1 } from '@standard-schema/spec';
 	/**
 	 * Read the contents of an imported asset from the filesystem
@@ -2809,7 +2700,7 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function query<Output>(fn: () => Output): RemoteQuery<void, Output>;
+	export function query<Output>(fn: () => Output): RemoteQueryFunction<void, Output>;
 	/**
 	 * Creates a remote function that can be invoked like a regular function within components.
 	 * The given function is invoked directly on the backend and via a fetch call on the client.
@@ -2829,10 +2720,7 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function query<Input, Output>(
-		validate: 'unchecked',
-		fn: (arg: Input) => Output
-	): RemoteQuery<Input, Output>;
+	export function query<Input, Output>(validate: "unchecked", fn: (arg: Input) => Output): RemoteQueryFunction<Input, Output>;
 	/**
 	 * Creates a remote function that can be invoked like a regular function within components.
 	 * The given function is invoked directly on the backend and via a fetch call on the client.
@@ -2852,10 +2740,7 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function query<Schema extends StandardSchemaV1, Output>(
-		schema: Schema,
-		fn: (arg: StandardSchemaV1.InferOutput<Schema>) => Output
-	): RemoteQuery<StandardSchemaV1.InferOutput<Schema>, Output>;
+	export function query<Schema extends StandardSchemaV1, Output>(schema: Schema, fn: (arg: StandardSchemaV1.InferOutput<Schema>) => Output): RemoteQueryFunction<StandardSchemaV1.InferOutput<Schema>, Output>;
 	/**
 	 * Creates a prerendered remote function. The given function is invoked at build time and the result is stored to disk.
 	 * ```ts
@@ -2877,15 +2762,10 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function prerender<Output>(
-		fn: () => Output,
-		options?:
-			| {
-					inputs?: RemotePrerenderInputsGenerator<void>;
-					dynamic?: boolean;
-			  }
-			| undefined
-	): RemoteQuery<void, Output>;
+	export function prerender<Output>(fn: () => Output, options?: {
+		inputs?: RemotePrerenderInputsGenerator<void>;
+		dynamic?: boolean;
+	} | undefined): RemotePrerenderFunction<void, Output>;
 	/**
 	 * Creates a prerendered remote function. The given function is invoked at build time and the result is stored to disk.
 	 * ```ts
@@ -2906,16 +2786,10 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function prerender<Input, Output>(
-		validate: 'unchecked',
-		fn: (arg: Input) => Output,
-		options?:
-			| {
-					inputs?: RemotePrerenderInputsGenerator<Input>;
-					dynamic?: boolean;
-			  }
-			| undefined
-	): RemoteQuery<Input, Output>;
+	export function prerender<Input, Output>(validate: "unchecked", fn: (arg: Input) => Output, options?: {
+		inputs?: RemotePrerenderInputsGenerator<Input>;
+		dynamic?: boolean;
+	} | undefined): RemotePrerenderFunction<Input, Output>;
 	/**
 	 * Creates a prerendered remote function. The given function is invoked at build time and the result is stored to disk.
 	 * ```ts
@@ -2937,16 +2811,10 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function prerender<Schema extends StandardSchemaV1, Output>(
-		schema: Schema,
-		fn: (arg: StandardSchemaV1.InferOutput<Schema>) => Output,
-		options?:
-			| {
-					inputs?: RemotePrerenderInputsGenerator<StandardSchemaV1.InferOutput<Schema>>;
-					dynamic?: boolean;
-			  }
-			| undefined
-	): RemoteQuery<StandardSchemaV1.InferOutput<Schema>, Output>;
+	export function prerender<Schema extends StandardSchemaV1, Output>(schema: Schema, fn: (arg: StandardSchemaV1.InferOutput<Schema>) => Output, options?: {
+		inputs?: RemotePrerenderInputsGenerator<StandardSchemaV1.InferOutput<Schema>>;
+		dynamic?: boolean;
+	} | undefined): RemotePrerenderFunction<StandardSchemaV1.InferOutput<Schema>, Output>;
 	/**
 	 * Creates a remote command. The given function is invoked directly on the server and via a fetch call on the client.
 	 *
@@ -3008,10 +2876,7 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function command<Input, Output>(
-		validate: 'unchecked',
-		fn: (arg: Input) => Output
-	): RemoteCommand<Input, Output>;
+	export function command<Input, Output>(validate: "unchecked", fn: (arg: Input) => Output): RemoteCommand<Input, Output>;
 	/**
 	 * Creates a remote command. The given function is invoked directly on the server and via a fetch call on the client.
 	 *
@@ -3042,10 +2907,7 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function command<Schema extends StandardSchemaV1, Output>(
-		validate: Schema,
-		fn: (arg: StandardSchemaV1.InferOutput<Schema>) => Output
-	): RemoteCommand<StandardSchemaV1.InferOutput<Schema>, Output>;
+	export function command<Schema extends StandardSchemaV1, Output>(validate: Schema, fn: (arg: StandardSchemaV1.InferOutput<Schema>) => Output): RemoteCommand<StandardSchemaV1.InferOutput<Schema>, Output>;
 	/**
 	 * Creates a form action. The passed function will be called when the form is submitted.
 	 * Returns an object that can be spread onto a form element to connect it to the function.
@@ -3071,9 +2933,7 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function form<T, U = never>(
-		fn: (formData: FormData) => T | IActionFailure<U>
-	): RemoteForm<T, U>;
+	export function form<T, U = never>(fn: (formData: FormData) => T | IActionFailure<U>): RemoteForm<T, U>;
 	type RemotePrerenderInputsGenerator<Input = any> = () => MaybePromise<Input[]>;
 	type MaybePromise<T> = T | Promise<T>;
 
@@ -3117,21 +2977,19 @@ declare module '$app/state' {
 	 * On the server, values can only be read during rendering (in other words _not_ in e.g. `load` functions). In the browser, the values can be read at any time.
 	 *
 	 * */
-	export const page: import('@sveltejs/kit').Page;
+	export const page: import("@sveltejs/kit").Page;
 	/**
 	 * A read-only object representing an in-progress navigation, with `from`, `to`, `type` and (if `type === 'popstate'`) `delta` properties.
 	 * Values are `null` when no navigation is occurring, or during server rendering.
 	 * */
-	export const navigating:
-		| import('@sveltejs/kit').Navigation
-		| {
-				from: null;
-				to: null;
-				type: null;
-				willUnload: null;
-				delta: null;
-				complete: null;
-		  };
+	export const navigating: import("@sveltejs/kit").Navigation | {
+		from: null;
+		to: null;
+		type: null;
+		willUnload: null;
+		delta: null;
+		complete: null;
+	};
 	/**
 	 * A read-only reactive value that's initially `false`. If [`version.pollInterval`](https://svelte.dev/docs/kit/configuration#version) is a non-zero value, SvelteKit will poll for new versions of the app and update `current` to `true` when it detects one. `updated.check()` will force an immediate check, regardless of polling.
 	 * */
@@ -3145,10 +3003,11 @@ declare module '$app/state' {
 
 declare module '$app/stores' {
 	export function getStores(): {
+		
 		page: typeof page;
-
+		
 		navigating: typeof navigating;
-
+		
 		updated: typeof updated;
 	};
 	/**
@@ -3158,7 +3017,7 @@ declare module '$app/stores' {
 	 *
 	 * @deprecated Use `page` from `$app/state` instead (requires Svelte 5, [see docs for more info](https://svelte.dev/docs/kit/migrating-to-sveltekit-2#SvelteKit-2.12:-$app-stores-deprecated))
 	 * */
-	export const page: import('svelte/store').Readable<import('@sveltejs/kit').Page>;
+	export const page: import("svelte/store").Readable<import("@sveltejs/kit").Page>;
 	/**
 	 * A readable store.
 	 * When navigating starts, its value is a `Navigation` object with `from`, `to`, `type` and (if `type === 'popstate'`) `delta` properties.
@@ -3168,9 +3027,7 @@ declare module '$app/stores' {
 	 *
 	 * @deprecated Use `navigating` from `$app/state` instead (requires Svelte 5, [see docs for more info](https://svelte.dev/docs/kit/migrating-to-sveltekit-2#SvelteKit-2.12:-$app-stores-deprecated))
 	 * */
-	export const navigating: import('svelte/store').Readable<
-		import('@sveltejs/kit').Navigation | null
-	>;
+	export const navigating: import("svelte/store").Readable<import("@sveltejs/kit").Navigation | null>;
 	/**
 	 * A readable store whose initial value is `false`. If [`version.pollInterval`](https://svelte.dev/docs/kit/configuration#version) is a non-zero value, SvelteKit will poll for new versions of the app and update the store value to `true` when it detects one. `updated.check()` will force an immediate check, regardless of polling.
 	 *
@@ -3178,12 +3035,12 @@ declare module '$app/stores' {
 	 *
 	 * @deprecated Use `updated` from `$app/state` instead (requires Svelte 5, [see docs for more info](https://svelte.dev/docs/kit/migrating-to-sveltekit-2#SvelteKit-2.12:-$app-stores-deprecated))
 	 * */
-	export const updated: import('svelte/store').Readable<boolean> & {
+	export const updated: import("svelte/store").Readable<boolean> & {
 		check(): Promise<boolean>;
 	};
 
 	export {};
-} /**
+}/**
  * It's possible to tell SvelteKit how to type objects inside your app by declaring the `App` namespace. By default, a new project will have a file called `src/app.d.ts` containing the following:
  *
  * ```ts

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -221,7 +221,10 @@ declare module '@sveltejs/kit' {
 		 * @param name the name of the cookie
 		 * @param opts the options, passed directly to `cookie.serialize`. The `path` must match the path of the cookie you want to delete. See documentation [here](https://github.com/jshttp/cookie#cookieserializename-value-options)
 		 */
-		delete: (name: string, opts: import('cookie').CookieSerializeOptions & { path: string }) => void;
+		delete: (
+			name: string,
+			opts: import('cookie').CookieSerializeOptions & { path: string }
+		) => void;
 
 		/**
 		 * Serialize a cookie name-value pair into a `Set-Cookie` header string, but don't apply it to the response.
@@ -1267,7 +1270,10 @@ declare module '@sveltejs/kit' {
 		 * but they will always be split at sensible boundaries such as `%sveltekit.head%` or layout/page components.
 		 * @param input the html chunk and the info if this is the last chunk
 		 */
-		transformPageChunk?: (input: { html: string; done: boolean }) => MaybePromise<string | undefined>;
+		transformPageChunk?: (input: {
+			html: string;
+			done: boolean;
+		}) => MaybePromise<string | undefined>;
 		/**
 		 * Determines which headers should be included in serialized responses when a `load` function loads a resource with `fetch`.
 		 * By default, none will be included.
@@ -1542,7 +1548,7 @@ declare module '@sveltejs/kit' {
 	 * </ul>
 	 * ```
 	 */
-	export type RemoteFormAction<Success, Failure> = ((data: FormData) => Promise<void>) & {
+	export type RemoteForm<Success, Failure> = ((data: FormData) => Promise<void>) & {
 		method: 'POST';
 		/** The URL to send the form to. */
 		action: string;
@@ -1581,7 +1587,7 @@ declare module '@sveltejs/kit' {
 		 *	{/each}
 		 * ```
 		 */
-		for: (key: string | number | boolean) => Omit<RemoteFormAction<Success, Failure>, 'for'>;
+		for: (key: string | number | boolean) => Omit<RemoteForm<Success, Failure>, 'for'>;
 		/** The result of the form submission */
 		get result(): Success | Failure | undefined;
 		/** When there's an error during form submission, it appears on this property */
@@ -1787,7 +1793,9 @@ declare module '@sveltejs/kit' {
 		 * A function that is invoked once the entry has been created. This is where you
 		 * should write the function to the filesystem and generate redirect manifests.
 		 */
-		complete(entry: { generateManifest(opts: { relativePath: string }): string }): MaybePromise<void>;
+		complete(entry: {
+			generateManifest(opts: { relativePath: string }): string;
+		}): MaybePromise<void>;
 	}
 
 	// Based on https://github.com/josh-hemphill/csp-typed-directives/blob/latest/src/csp.types.ts
@@ -2240,16 +2248,24 @@ declare module '@sveltejs/kit' {
 	 * @throws {HttpError} This error instructs SvelteKit to initiate HTTP error handling.
 	 * @throws {Error} If the provided status is invalid (not between 400 and 599).
 	 */
-	export function error(status: number, body?: {
-		message: string;
-	} extends App.Error ? App.Error | string | undefined : never): never;
+	export function error(
+		status: number,
+		body?: {
+			message: string;
+		} extends App.Error
+			? App.Error | string | undefined
+			: never
+	): never;
 	/**
 	 * Checks whether this is an error thrown by {@link error}.
 	 * @param status The status to filter for.
 	 * */
-	export function isHttpError<T extends number>(e: unknown, status?: T | undefined): e is (HttpError_1 & {
+	export function isHttpError<T extends number>(
+		e: unknown,
+		status?: T | undefined
+	): e is HttpError_1 & {
 		status: T extends undefined ? never : T;
-	});
+	};
 	/**
 	 * Redirect a request. When called during request handling, SvelteKit will return a redirect response.
 	 * Make sure you're not catching the thrown redirect, which would prevent SvelteKit from handling it.
@@ -2266,7 +2282,10 @@ declare module '@sveltejs/kit' {
 	 * @throws {Redirect} This error instructs SvelteKit to redirect to the specified location.
 	 * @throws {Error} If the provided status is invalid.
 	 * */
-	export function redirect(status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308 | ({} & number), location: string | URL): never;
+	export function redirect(
+		status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308 | ({} & number),
+		location: string | URL
+	): never;
 	/**
 	 * Checks whether this is a redirect thrown by {@link redirect}.
 	 * @param e The object to check.
@@ -2318,20 +2337,31 @@ declare module '@sveltejs/kit' {
 		wasNormalized: boolean;
 		denormalize: (url?: string | URL) => URL;
 	};
-	export type LessThan<TNumber extends number, TArray extends any[] = []> = TNumber extends TArray["length"] ? TArray[number] : LessThan<TNumber, [...TArray, TArray["length"]]>;
-	export type NumericRange<TStart extends number, TEnd extends number> = Exclude<TEnd | LessThan<TEnd>, LessThan<TStart>>;
+	export type LessThan<
+		TNumber extends number,
+		TArray extends any[] = []
+	> = TNumber extends TArray['length']
+		? TArray[number]
+		: LessThan<TNumber, [...TArray, TArray['length']]>;
+	export type NumericRange<TStart extends number, TEnd extends number> = Exclude<
+		TEnd | LessThan<TEnd>,
+		LessThan<TStart>
+	>;
 	export const VERSION: string;
 	class HttpError_1 {
-		
-		constructor(status: number, body: {
-			message: string;
-		} extends App.Error ? (App.Error | string | undefined) : App.Error);
+		constructor(
+			status: number,
+			body: {
+				message: string;
+			} extends App.Error
+				? App.Error | string | undefined
+				: App.Error
+		);
 		status: number;
 		body: App.Error;
 		toString(): string;
 	}
 	class Redirect_1 {
-		
 		constructor(status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308, location: string);
 		status: 301 | 302 | 303 | 307 | 308 | 300 | 304 | 305 | 306;
 		location: string;
@@ -2411,19 +2441,28 @@ declare module '@sveltejs/kit/hooks' {
 	 *
 	 * @param handlers The chain of `handle` functions
 	 * */
-	export function sequence(...handlers: import("@sveltejs/kit").Handle[]): import("@sveltejs/kit").Handle;
+	export function sequence(
+		...handlers: import('@sveltejs/kit').Handle[]
+	): import('@sveltejs/kit').Handle;
 
 	export {};
 }
 
 declare module '@sveltejs/kit/node' {
-	export function getRequest({ request, base, bodySizeLimit }: {
-		request: import("http").IncomingMessage;
+	export function getRequest({
+		request,
+		base,
+		bodySizeLimit
+	}: {
+		request: import('http').IncomingMessage;
 		base: string;
 		bodySizeLimit?: number;
 	}): Promise<Request>;
 
-	export function setResponse(res: import("http").ServerResponse, response: Response): Promise<void>;
+	export function setResponse(
+		res: import('http').ServerResponse,
+		response: Response
+	): Promise<void>;
 	/**
 	 * Converts a file on disk to a readable stream
 	 * @since 2.4.0
@@ -2448,7 +2487,7 @@ declare module '@sveltejs/kit/vite' {
 	/**
 	 * Returns the SvelteKit Vite plugins.
 	 * */
-	export function sveltekit(): Promise<import("vite").Plugin[]>;
+	export function sveltekit(): Promise<import('vite').Plugin[]>;
 
 	export {};
 }
@@ -2496,7 +2535,10 @@ declare module '$app/forms' {
 	 * }
 	 * ```
 	 * */
-	export function deserialize<Success extends Record<string, unknown> | undefined, Failure extends Record<string, unknown> | undefined>(result: string): import("@sveltejs/kit").ActionResult<Success, Failure>;
+	export function deserialize<
+		Success extends Record<string, unknown> | undefined,
+		Failure extends Record<string, unknown> | undefined
+	>(result: string): import('@sveltejs/kit').ActionResult<Success, Failure>;
 	/**
 	 * This action enhances a `<form>` element that otherwise would work without JavaScript.
 	 *
@@ -2520,14 +2562,23 @@ declare module '$app/forms' {
 	 * @param form_element The form element
 	 * @param submit Submit callback
 	 */
-	export function enhance<Success extends Record<string, unknown> | undefined, Failure extends Record<string, unknown> | undefined>(form_element: HTMLFormElement, submit?: import("@sveltejs/kit").SubmitFunction<Success, Failure>): {
+	export function enhance<
+		Success extends Record<string, unknown> | undefined,
+		Failure extends Record<string, unknown> | undefined
+	>(
+		form_element: HTMLFormElement,
+		submit?: import('@sveltejs/kit').SubmitFunction<Success, Failure>
+	): {
 		destroy(): void;
 	};
 	/**
 	 * This action updates the `form` property of the current page with the given data and updates `page.status`.
 	 * In case of an error, it redirects to the nearest error page.
 	 * */
-	export function applyAction<Success extends Record<string, unknown> | undefined, Failure extends Record<string, unknown> | undefined>(result: import("@sveltejs/kit").ActionResult<Success, Failure>): Promise<void>;
+	export function applyAction<
+		Success extends Record<string, unknown> | undefined,
+		Failure extends Record<string, unknown> | undefined
+	>(result: import('@sveltejs/kit').ActionResult<Success, Failure>): Promise<void>;
 
 	export {};
 }
@@ -2538,7 +2589,9 @@ declare module '$app/navigation' {
 	 *
 	 * `afterNavigate` must be called during a component initialization. It remains active as long as the component is mounted.
 	 * */
-	export function afterNavigate(callback: (navigation: import("@sveltejs/kit").AfterNavigate) => void): void;
+	export function afterNavigate(
+		callback: (navigation: import('@sveltejs/kit').AfterNavigate) => void
+	): void;
 	/**
 	 * A navigation interceptor that triggers before we navigate to a URL, whether by clicking a link, calling `goto(...)`, or using the browser back/forward controls.
 	 *
@@ -2550,7 +2603,9 @@ declare module '$app/navigation' {
 	 *
 	 * `beforeNavigate` must be called during a component initialization. It remains active as long as the component is mounted.
 	 * */
-	export function beforeNavigate(callback: (navigation: import("@sveltejs/kit").BeforeNavigate) => void): void;
+	export function beforeNavigate(
+		callback: (navigation: import('@sveltejs/kit').BeforeNavigate) => void
+	): void;
 	/**
 	 * A lifecycle function that runs the supplied `callback` immediately before we navigate to a new URL except during full-page navigations.
 	 *
@@ -2560,7 +2615,9 @@ declare module '$app/navigation' {
 	 *
 	 * `onNavigate` must be called during a component initialization. It remains active as long as the component is mounted.
 	 * */
-	export function onNavigate(callback: (navigation: import("@sveltejs/kit").OnNavigate) => MaybePromise<(() => void) | void>): void;
+	export function onNavigate(
+		callback: (navigation: import('@sveltejs/kit').OnNavigate) => MaybePromise<(() => void) | void>
+	): void;
 	/**
 	 * If called when the page is being updated following a navigation (in `onMount` or `afterNavigate` or an action, for example), this disables SvelteKit's built-in scroll handling.
 	 * This is generally discouraged, since it breaks user expectations.
@@ -2575,14 +2632,19 @@ declare module '$app/navigation' {
 	 * @param url Where to navigate to. Note that if you've set [`config.kit.paths.base`](https://svelte.dev/docs/kit/configuration#paths) and the URL is root-relative, you need to prepend the base path if you want to navigate within the app.
 	 * @param {Object} opts Options related to the navigation
 	 * */
-	export function goto(url: string | URL, opts?: {
-		replaceState?: boolean | undefined;
-		noScroll?: boolean | undefined;
-		keepFocus?: boolean | undefined;
-		invalidateAll?: boolean | undefined;
-		invalidate?: (string | URL | ((url: URL) => boolean))[] | undefined;
-		state?: App.PageState | undefined;
-	} | undefined): Promise<void>;
+	export function goto(
+		url: string | URL,
+		opts?:
+			| {
+					replaceState?: boolean | undefined;
+					noScroll?: boolean | undefined;
+					keepFocus?: boolean | undefined;
+					invalidateAll?: boolean | undefined;
+					invalidate?: (string | URL | ((url: URL) => boolean))[] | undefined;
+					state?: App.PageState | undefined;
+			  }
+			| undefined
+	): Promise<void>;
 	/**
 	 * Causes any `load` functions belonging to the currently active page to re-run if they depend on the `url` in question, via `fetch` or `depends`. Returns a `Promise` that resolves when the page is subsequently updated.
 	 *
@@ -2609,9 +2671,13 @@ declare module '$app/navigation' {
 	 * Causes all currently active remote functions to refresh, and all `load` functions belonging to the currently active page to re-run (unless disabled via the option argument).
 	 * Returns a `Promise` that resolves when the page is subsequently updated.
 	 * */
-	export function refreshAll({ includeLoadFunctions }?: {
-		includeLoadFunctions?: boolean;
-	} | undefined): Promise<void>;
+	export function refreshAll({
+		includeLoadFunctions
+	}?:
+		| {
+				includeLoadFunctions?: boolean;
+		  }
+		| undefined): Promise<void>;
 	/**
 	 * Programmatically preloads the given page, which means
 	 *  1. ensuring that the code for the page is loaded, and
@@ -2623,14 +2689,17 @@ declare module '$app/navigation' {
 	 *
 	 * @param href Page to preload
 	 * */
-	export function preloadData(href: string): Promise<{
-		type: "loaded";
-		status: number;
-		data: Record<string, any>;
-	} | {
-		type: "redirect";
-		location: string;
-	}>;
+	export function preloadData(href: string): Promise<
+		| {
+				type: 'loaded';
+				status: number;
+				data: Record<string, any>;
+		  }
+		| {
+				type: 'redirect';
+				location: string;
+		  }
+	>;
 	/**
 	 * Programmatically imports the code for routes that haven't yet been fetched.
 	 * Typically, you might call this to speed up subsequent navigation.
@@ -2693,7 +2762,13 @@ declare module '$app/paths' {
 }
 
 declare module '$app/server' {
-	import type { RequestEvent, RemoteQuery, RemoteCommand, ActionFailure as IActionFailure, RemoteFormAction } from '@sveltejs/kit';
+	import type {
+		RequestEvent,
+		RemoteQuery,
+		RemoteCommand,
+		ActionFailure as IActionFailure,
+		RemoteForm
+	} from '@sveltejs/kit';
 	import type { StandardSchemaV1 } from '@standard-schema/spec';
 	/**
 	 * Read the contents of an imported asset from the filesystem
@@ -2754,7 +2829,10 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function query<Input, Output>(validate: "unchecked", fn: (arg: Input) => Output): RemoteQuery<Input, Output>;
+	export function query<Input, Output>(
+		validate: 'unchecked',
+		fn: (arg: Input) => Output
+	): RemoteQuery<Input, Output>;
 	/**
 	 * Creates a remote function that can be invoked like a regular function within components.
 	 * The given function is invoked directly on the backend and via a fetch call on the client.
@@ -2774,7 +2852,10 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function query<Schema extends StandardSchemaV1, Output>(schema: Schema, fn: (arg: StandardSchemaV1.InferOutput<Schema>) => Output): RemoteQuery<StandardSchemaV1.InferOutput<Schema>, Output>;
+	export function query<Schema extends StandardSchemaV1, Output>(
+		schema: Schema,
+		fn: (arg: StandardSchemaV1.InferOutput<Schema>) => Output
+	): RemoteQuery<StandardSchemaV1.InferOutput<Schema>, Output>;
 	/**
 	 * Creates a prerendered remote function. The given function is invoked at build time and the result is stored to disk.
 	 * ```ts
@@ -2796,10 +2877,15 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function prerender<Output>(fn: () => Output, options?: {
-		inputs?: RemotePrerenderInputsGenerator<void>;
-		dynamic?: boolean;
-	} | undefined): RemoteQuery<void, Output>;
+	export function prerender<Output>(
+		fn: () => Output,
+		options?:
+			| {
+					inputs?: RemotePrerenderInputsGenerator<void>;
+					dynamic?: boolean;
+			  }
+			| undefined
+	): RemoteQuery<void, Output>;
 	/**
 	 * Creates a prerendered remote function. The given function is invoked at build time and the result is stored to disk.
 	 * ```ts
@@ -2820,10 +2906,16 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function prerender<Input, Output>(validate: "unchecked", fn: (arg: Input) => Output, options?: {
-		inputs?: RemotePrerenderInputsGenerator<Input>;
-		dynamic?: boolean;
-	} | undefined): RemoteQuery<Input, Output>;
+	export function prerender<Input, Output>(
+		validate: 'unchecked',
+		fn: (arg: Input) => Output,
+		options?:
+			| {
+					inputs?: RemotePrerenderInputsGenerator<Input>;
+					dynamic?: boolean;
+			  }
+			| undefined
+	): RemoteQuery<Input, Output>;
 	/**
 	 * Creates a prerendered remote function. The given function is invoked at build time and the result is stored to disk.
 	 * ```ts
@@ -2845,10 +2937,16 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function prerender<Schema extends StandardSchemaV1, Output>(schema: Schema, fn: (arg: StandardSchemaV1.InferOutput<Schema>) => Output, options?: {
-		inputs?: RemotePrerenderInputsGenerator<StandardSchemaV1.InferOutput<Schema>>;
-		dynamic?: boolean;
-	} | undefined): RemoteQuery<StandardSchemaV1.InferOutput<Schema>, Output>;
+	export function prerender<Schema extends StandardSchemaV1, Output>(
+		schema: Schema,
+		fn: (arg: StandardSchemaV1.InferOutput<Schema>) => Output,
+		options?:
+			| {
+					inputs?: RemotePrerenderInputsGenerator<StandardSchemaV1.InferOutput<Schema>>;
+					dynamic?: boolean;
+			  }
+			| undefined
+	): RemoteQuery<StandardSchemaV1.InferOutput<Schema>, Output>;
 	/**
 	 * Creates a remote command. The given function is invoked directly on the server and via a fetch call on the client.
 	 *
@@ -2910,7 +3008,10 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function command<Input, Output>(validate: "unchecked", fn: (arg: Input) => Output): RemoteCommand<Input, Output>;
+	export function command<Input, Output>(
+		validate: 'unchecked',
+		fn: (arg: Input) => Output
+	): RemoteCommand<Input, Output>;
 	/**
 	 * Creates a remote command. The given function is invoked directly on the server and via a fetch call on the client.
 	 *
@@ -2941,7 +3042,10 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function command<Schema extends StandardSchemaV1, Output>(validate: Schema, fn: (arg: StandardSchemaV1.InferOutput<Schema>) => Output): RemoteCommand<StandardSchemaV1.InferOutput<Schema>, Output>;
+	export function command<Schema extends StandardSchemaV1, Output>(
+		validate: Schema,
+		fn: (arg: StandardSchemaV1.InferOutput<Schema>) => Output
+	): RemoteCommand<StandardSchemaV1.InferOutput<Schema>, Output>;
 	/**
 	 * Creates a form action. The passed function will be called when the form is submitted.
 	 * Returns an object that can be spread onto a form element to connect it to the function.
@@ -2967,7 +3071,9 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function form<T, U = never>(fn: (formData: FormData) => T | IActionFailure<U>): RemoteFormAction<T, U>;
+	export function form<T, U = never>(
+		fn: (formData: FormData) => T | IActionFailure<U>
+	): RemoteForm<T, U>;
 	type RemotePrerenderInputsGenerator<Input = any> = () => MaybePromise<Input[]>;
 	type MaybePromise<T> = T | Promise<T>;
 
@@ -3011,19 +3117,21 @@ declare module '$app/state' {
 	 * On the server, values can only be read during rendering (in other words _not_ in e.g. `load` functions). In the browser, the values can be read at any time.
 	 *
 	 * */
-	export const page: import("@sveltejs/kit").Page;
+	export const page: import('@sveltejs/kit').Page;
 	/**
 	 * A read-only object representing an in-progress navigation, with `from`, `to`, `type` and (if `type === 'popstate'`) `delta` properties.
 	 * Values are `null` when no navigation is occurring, or during server rendering.
 	 * */
-	export const navigating: import("@sveltejs/kit").Navigation | {
-		from: null;
-		to: null;
-		type: null;
-		willUnload: null;
-		delta: null;
-		complete: null;
-	};
+	export const navigating:
+		| import('@sveltejs/kit').Navigation
+		| {
+				from: null;
+				to: null;
+				type: null;
+				willUnload: null;
+				delta: null;
+				complete: null;
+		  };
 	/**
 	 * A read-only reactive value that's initially `false`. If [`version.pollInterval`](https://svelte.dev/docs/kit/configuration#version) is a non-zero value, SvelteKit will poll for new versions of the app and update `current` to `true` when it detects one. `updated.check()` will force an immediate check, regardless of polling.
 	 * */
@@ -3037,11 +3145,10 @@ declare module '$app/state' {
 
 declare module '$app/stores' {
 	export function getStores(): {
-		
 		page: typeof page;
-		
+
 		navigating: typeof navigating;
-		
+
 		updated: typeof updated;
 	};
 	/**
@@ -3051,7 +3158,7 @@ declare module '$app/stores' {
 	 *
 	 * @deprecated Use `page` from `$app/state` instead (requires Svelte 5, [see docs for more info](https://svelte.dev/docs/kit/migrating-to-sveltekit-2#SvelteKit-2.12:-$app-stores-deprecated))
 	 * */
-	export const page: import("svelte/store").Readable<import("@sveltejs/kit").Page>;
+	export const page: import('svelte/store').Readable<import('@sveltejs/kit').Page>;
 	/**
 	 * A readable store.
 	 * When navigating starts, its value is a `Navigation` object with `from`, `to`, `type` and (if `type === 'popstate'`) `delta` properties.
@@ -3061,7 +3168,9 @@ declare module '$app/stores' {
 	 *
 	 * @deprecated Use `navigating` from `$app/state` instead (requires Svelte 5, [see docs for more info](https://svelte.dev/docs/kit/migrating-to-sveltekit-2#SvelteKit-2.12:-$app-stores-deprecated))
 	 * */
-	export const navigating: import("svelte/store").Readable<import("@sveltejs/kit").Navigation | null>;
+	export const navigating: import('svelte/store').Readable<
+		import('@sveltejs/kit').Navigation | null
+	>;
 	/**
 	 * A readable store whose initial value is `false`. If [`version.pollInterval`](https://svelte.dev/docs/kit/configuration#version) is a non-zero value, SvelteKit will poll for new versions of the app and update the store value to `true` when it detects one. `updated.check()` will force an immediate check, regardless of polling.
 	 *
@@ -3069,12 +3178,12 @@ declare module '$app/stores' {
 	 *
 	 * @deprecated Use `updated` from `$app/state` instead (requires Svelte 5, [see docs for more info](https://svelte.dev/docs/kit/migrating-to-sveltekit-2#SvelteKit-2.12:-$app-stores-deprecated))
 	 * */
-	export const updated: import("svelte/store").Readable<boolean> & {
+	export const updated: import('svelte/store').Readable<boolean> & {
 		check(): Promise<boolean>;
 	};
 
 	export {};
-}/**
+} /**
  * It's possible to tell SvelteKit how to type objects inside your app by declaring the `App` namespace. By default, a new project will have a file called `src/app.d.ts` containing the following:
  *
  * ```ts


### PR DESCRIPTION
This addresses some of the notes in #13986:

- `RemoteFormAction` is now `RemoteForm` (I also think we should make this non-callable, but didn't make that change here in case there's a reason that it needs to be)
- the return value of `query` is now a `RemoteQueryFunction`; for `prerender`, `RemotePrerenderFunction`. These return a `RemoteQuery` and `RemoteResource` respectively. A `RemoteQuery` extends `RemoteResource` with `refresh` and `withOverride` methods, which should _not_ belong on the return value of a prerender function. (It looks like `set` should be on `RemoteQuery` too? I didn't add that though)
- removed the `override` method from queries. There's no real sense in exposing this; the only time you want to override a query value is in the context of an optimistic update
- separated the implementation of `query` and `prerender` on the client. I get why these shared a class, but it turns out to be much simpler to keep them separate — for example `Prerender` just doesn't need most of the machinery that exists on `Query`. We get a tiny bit of duplication this way, but less branching, and fewer unnecessary signals being created and subscribed to for values that we know will never change