### PR TITLE
remote functions: simplify status

### DIFF
--- a/packages/kit/src/runtime/client/remote.svelte.js
+++ b/packages/kit/src/runtime/client/remote.svelte.js
@@ -54,7 +54,6 @@ class Prerender {
 	/** @type {T | undefined} */
 	#current = $state.raw();
 
-	#errored = $state(false);
 	#error = $state.raw(undefined);
 
 	/**
@@ -69,7 +68,6 @@ class Prerender {
 			},
 			(error) => {
 				this.#loading = false;
-				this.#errored = true;
 				this.#error = error;
 				throw error;
 			}
@@ -123,7 +121,7 @@ class Prerender {
 	 */
 	get status() {
 		if (this.#loading) return 'loading';
-		if (this.#errored) return 'error';
+		if (this.#error) return 'error';
 		return 'idle';
 	}
 }
@@ -160,7 +158,6 @@ class Query {
 		return this.#overrides.reduce((v, r) => r(v), /** @type {T} */ (this.#raw));
 	});
 
-	#errored = $state(false);
 	#error = $state.raw(undefined);
 
 	/** @type {Promise<T>['then']} */
@@ -225,7 +222,6 @@ class Query {
 				this.#inited = true;
 				this.#loading = false;
 				this.#raw = value;
-				this.#errored = false;
 				this.#error = undefined;
 
 				resolve();
@@ -235,7 +231,6 @@ class Query {
 				if (idx === -1) return;
 
 				this.#latest.splice(0, idx).forEach((r) => r());
-				this.#errored = true;
 				this.#error = e;
 				this.#loading = false;
 				reject(e);
@@ -289,7 +284,7 @@ class Query {
 	 */
 	get status() {
 		if (this.#loading) return this.#inited ? 'reloading' : 'loading';
-		if (this.#errored) return 'error';
+		if (this.#error) return 'error';
 		return 'idle';
 	}
 


### PR DESCRIPTION
simplifies `get status` and renames `'success'` -> `'idle'` since 'success' suggests finality (which might be okay for `prerender` but not for `query` or resources in general)