### PR TITLE
fix: posixify internal app server path

### DIFF
--- a/.changeset/loose-tips-go.md
+++ b/.changeset/loose-tips-go.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: posixify internal app server path

--- a/packages/kit/src/exports/vite/module_ids.js
+++ b/packages/kit/src/exports/vite/module_ids.js
@@ -1,4 +1,5 @@
 import { fileURLToPath } from 'node:url';
+import { posixify } from '../../utils/filesystem.js';
 
 export const env_static_private = '\0virtual:env/static/private';
 export const env_static_public = '\0virtual:env/static/public';
@@ -11,6 +12,6 @@ export const sveltekit_environment = '\0virtual:__sveltekit/environment';
 export const sveltekit_paths = '\0virtual:__sveltekit/paths';
 export const sveltekit_server = '\0virtual:__sveltekit/server';
 
-export const app_server = fileURLToPath(
-	new URL('../../runtime/app/server/index.js', import.meta.url)
+export const app_server = posixify(
+	fileURLToPath(new URL('../../runtime/app/server/index.js', import.meta.url))
 );


### PR DESCRIPTION
Noticed this while working on remote functions - this could yield false negatives on windows for resolving internal server path and for the server module guard (there's no security issue here, this would've just failed right away both at runtime and build time since the imported server code, which is only SvelteKit runtime code and not user code, is invalid in the browser)
