### PR TITLE
docs: correct .refresh() example

### DIFF
--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -270,7 +270,7 @@ export const createPost = form(async (data) => {
 
 	// Refresh `getPosts()` on the server, and send
 	// the data back with the result of `createPost`
-	+++getPosts().refresh();+++
+	+++await getPosts().refresh();+++
 
 	// Redirect to the newly created page
 	redirect(303, `/blog/${slug}`);


### PR DESCRIPTION
Seems like `.refresh()` returns a Promise and if you are not awaiting it the single-flight mutation does not work. Adding the await makes it work in my testing so might just be a typo in docs.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
