### PR TITLE
docs: corrections

### DIFF
--- a/.changeset/light-facts-hope.md
+++ b/.changeset/light-facts-hope.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly spell server-side in error messages

--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -188,7 +188,7 @@ Conceptually, they're the same thing, but there are some important differences t
 
 Server `load` functions _always_ run on the server.
 
-By default, universal `load` functions run on the server during SSR when the user first visits your page. They will then run again during hydration, reusing any responses from [fetch requests](#Making-fetch-requests). All subsequent invocations of universal `load` functions happen in the browser. You can customize the behavior through [page options](page-options). If you disable [server side rendering](page-options#ssr), you'll get an SPA and universal `load` functions _always_ run on the client.
+By default, universal `load` functions run on the server during SSR when the user first visits your page. They will then run again during hydration, reusing any responses from [fetch requests](#Making-fetch-requests). All subsequent invocations of universal `load` functions happen in the browser. You can customize the behavior through [page options](page-options). If you disable [server-side rendering](page-options#ssr), you'll get an SPA and universal `load` functions _always_ run on the client.
 
 If a route contains both universal and server `load` functions, the server `load` runs first.
 

--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -6,7 +6,7 @@ title: Remote functions
 	<p>Available since 2.27</p>
 </blockquote>
 
-Remote functions are a tool for type-safe communication between client and server. They can be _called_ anywhere in your app, but always _run_ on the server, and as such can safely access [server-only modules](server-only-modules) containing things like environment variables and database clients.
+Remote functions are a tool for type-safe communication between client and server. They can be _called_ anywhere in your app, but always _run_ on the server, and thus can safely access [server-only modules](server-only-modules) containing things like environment variables and database clients.
 
 Combined with Svelte's experimental support for [`await`](/docs/svelte/await-expressions), it allows you to load and manipulate data directly inside your components.
 
@@ -160,7 +160,7 @@ Any query can be updated via its `refresh` method:
 </button>
 ```
 
-> [!NOTE] Queries are cached while they're on the page, meaning `getPosts() === getPosts()`. As such, you don't need a reference like `const posts = getPosts()` in order to refresh the query.
+> [!NOTE] Queries are cached while they're on the page, meaning `getPosts() === getPosts()`. This means you don't need a reference like `const posts = getPosts()` in order to refresh the query.
 
 ## form
 
@@ -656,7 +656,7 @@ export const getPost = prerender(
 );
 ```
 
-> [!NOTE] Svelte does not yet support asynchronous server-side rendering, and as such it's likely that you're only calling remote functions from the browser, rather than during prerendering. Because of this you will need to use `inputs`, for now. We're actively working on this roadblock.
+> [!NOTE] Svelte does not yet support asynchronous server-side rendering, so it's likely that you're only calling remote functions from the browser, rather than during prerendering. Because of this, you will need to use `inputs`, for now. We're actively working on this roadblock.
 
 By default, prerender functions are excluded from your server bundle, which means that you cannot call them with any arguments that were _not_ prerendered. You can set `dynamic: true` to change this behaviour:
 

--- a/documentation/docs/60-appendix/30-migrating-to-sveltekit-2.md
+++ b/documentation/docs/60-appendix/30-migrating-to-sveltekit-2.md
@@ -90,7 +90,7 @@ This inconsistency is fixed in version 2. Paths are either always relative or al
 
 ## Server fetches are not trackable anymore
 
-Previously it was possible to track URLs from `fetch`es on the server in order to rerun load functions. This poses a possible security risk (private URLs leaking), and as such it was behind the `dangerZone.trackServerFetches` setting, which is now removed.
+Previously it was possible to track URLs from `fetch`es on the server in order to rerun load functions. This poses a possible security risk (private URLs leaking), and for this reason it was behind the `dangerZone.trackServerFetches` setting, which is now removed.
 
 ## `preloadCode` arguments must be prefixed with `base`
 
@@ -104,7 +104,7 @@ Additionally, `preloadCode` now takes a single argument rather than _n_ argument
 
 SvelteKit 1 included a function called `resolvePath` which allows you to resolve a route ID (like `/blog/[slug]`) and a set of parameters (like `{ slug: 'hello' }`) to a pathname. Unfortunately the return value didn't include the `base` path, limiting its usefulness in cases where `base` was set.
 
-As such, SvelteKit 2 replaces `resolvePath` with a (slightly better named) function called `resolveRoute`, which is imported from `$app/paths` and which takes `base` into account.
+For this reason, SvelteKit 2 replaces `resolvePath` with a (slightly better named) function called `resolveRoute`, which is imported from `$app/paths` and which takes `base` into account.
 
 ```js
 ---import { resolvePath } from '@sveltejs/kit';
@@ -127,7 +127,7 @@ SvelteKit 2 cleans this up by calling `handleError` hooks with two new propertie
 
 The `$env/dynamic/public` and `$env/dynamic/private` modules provide access to _run time_ environment variables, as opposed to the _build time_ environment variables exposed by `$env/static/public` and `$env/static/private`.
 
-During prerendering in SvelteKit 1, they are one and the same. As such, prerendered pages that make use of 'dynamic' environment variables are really 'baking in' build time values, which is incorrect. Worse, `$env/dynamic/public` is populated in the browser with these stale values if the user happens to land on a prerendered page before navigating to dynamically-rendered pages.
+During prerendering in SvelteKit 1, they are one and the same. Thus, prerendered pages that make use of 'dynamic' environment variables are really 'baking in' build time values, which is incorrect. Worse, `$env/dynamic/public` is populated in the browser with these stale values if the user happens to land on a prerendered page before navigating to dynamically-rendered pages.
 
 Because of this, dynamic environment variables can no longer be read during prerendering in SvelteKit 2 — you should use the `static` modules instead. If the user lands on a prerendered page, SvelteKit will request up-to-date values for `$env/dynamic/public` from the server (by default from a module called `/_app/env.js`) instead of reading them from the server-rendered HTML.
 

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -59,7 +59,7 @@ export function generate_manifest({ build_data, prerendered, relative_path, rout
 		assets.push(build_data.service_worker);
 	}
 
-	// In case of server side route resolution, we need to include all matchers. Prerendered routes are not part
+	// In case of server-side route resolution, we need to include all matchers. Prerendered routes are not part
 	// of the server manifest, and they could reference matchers that then would not be included.
 	const matchers = new Set(
 		build_data.client?.nodes ? Object.keys(build_data.manifest_data.matchers) : undefined

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -178,11 +178,11 @@ export async function render_response({
 			globalThis.fetch = (info, init) => {
 				if (typeof info === 'string' && !SCHEME.test(info)) {
 					throw new Error(
-						`Cannot call \`fetch\` eagerly during server side rendering with relative URL (${info}) — put your \`fetch\` calls inside \`onMount\` or a \`load\` function instead`
+						`Cannot call \`fetch\` eagerly during server-side rendering with relative URL (${info}) — put your \`fetch\` calls inside \`onMount\` or a \`load\` function instead`
 					);
 				} else if (!warned) {
 					console.warn(
-						'Avoid calling `fetch` eagerly during server side rendering — put your `fetch` calls inside `onMount` or a `load` function instead'
+						'Avoid calling `fetch` eagerly during server-side rendering — put your `fetch` calls inside `onMount` or a `load` function instead'
 					);
 					warned = true;
 				}

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -90,7 +90,7 @@ export interface BuildData {
 		 */
 		css?: Array<string[] | undefined>;
 		/**
-		 * Contains the client route manifest in a form suitable for the server which is used for server side route resolution.
+		 * Contains the client route manifest in a form suitable for the server which is used for server-side route resolution.
 		 * Notably, it contains all routes, regardless of whether they are prerendered or not (those are missing in the optimized server route manifest).
 		 * Only set in case of `router.resolution === 'server'`.
 		 */

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1893,7 +1893,7 @@ declare module '@sveltejs/kit' {
 			 */
 			css?: Array<string[] | undefined>;
 			/**
-			 * Contains the client route manifest in a form suitable for the server which is used for server side route resolution.
+			 * Contains the client route manifest in a form suitable for the server which is used for server-side route resolution.
 			 * Notably, it contains all routes, regardless of whether they are prerendered or not (those are missing in the optimized server route manifest).
 			 * Only set in case of `router.resolution === 'server'`.
 			 */


### PR DESCRIPTION
This PR corrects two grammatical issues:

- A few instances of a missing hyphen in "server-side rendering"
- A common mistake in which "as such" is used as a synonym for "therefore", "thus", "so", "this means that", "for this reason", etc.

To illustrate the second issue, this sentence uses "as such" correctly:

> `reroute` is considered a pure, idempotent function. **As such**, it must always return the same output for the same input and not have side effects.

The rule of thumb is that "such" should be able to be replaced with a noun phrase from the previous sentence:

> `reroute` is considered a pure, idempotent function. **As [_a pure, idempotent function_]**, it must always return the same output for the same input and not have side effects.

This sentence uses "as such" incorrectly:

> For instance, if `condition` is `true` in the code snippet below, the code inside the `if` block will run and `color` will be evaluated. **As such**, changes to either `condition` or `color` will cause the effect to re-run.

In this case, I've replaced "As such" with "This means that", since "such" does not refer to an aforementioned noun phrase that could logically be the subject of the sentence. "as such" is not a synonym for "this means that":

> For instance, if `condition` is `true` in the code snippet below, the code inside the `if` block will run and `color` will be evaluated. **This means that** changes to either `condition` or `color` will cause the effect to re-run.