### PR TITLE
fix: match URL-encoded newlines in rest route params

### DIFF
--- a/.changeset/dark-heads-greet.md
+++ b/.changeset/dark-heads-greet.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: match URL-encoded newlines in rest route params

--- a/packages/adapter-vercel/test/utils.spec.js
+++ b/packages/adapter-vercel/test/utils.spec.js
@@ -124,9 +124,9 @@ test('pattern_to_src for route with optional parameter in the middle', () => {
 });
 
 test('pattern_to_src for route with rest parameter', () => {
-	run_pattern_to_src_test('/foo/[...bar]', '^/foo(/.*)?/?');
+	run_pattern_to_src_test('/foo/[...bar]', '^/foo(/[^]*)?/?');
 });
 
 test('pattern_to_src for route with rest parameter in the middle', () => {
-	run_pattern_to_src_test('/foo/[...bar]/baz', '^/foo(/.*)?/baz/?');
+	run_pattern_to_src_test('/foo/[...bar]/baz', '^/foo(/[^]*)?/baz/?');
 });

--- a/packages/kit/src/core/sync/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.spec.js
@@ -268,7 +268,7 @@ test('sorts routes with rest correctly', () => {
 		},
 		{
 			id: '/a/[...rest]',
-			pattern: '/^/a(?:/(.*))?/?$/',
+			pattern: '/^/a(?:/([^]*))?/?$/',
 			page: { layouts: [0], errors: [1], leaf: 2 }
 		},
 		{
@@ -277,7 +277,7 @@ test('sorts routes with rest correctly', () => {
 		},
 		{
 			id: '/b/[...rest]',
-			pattern: '/^/b(?:/(.*))?/?$/',
+			pattern: '/^/b(?:/([^]*))?/?$/',
 			page: { layouts: [0], errors: [1], leaf: 3 }
 		}
 	]);
@@ -301,12 +301,12 @@ test('allows rest parameters inside segments', () => {
 		},
 		{
 			id: '/prefix-[...rest]',
-			pattern: '/^/prefix-(.*?)/?$/',
+			pattern: '/^/prefix-([^]*?)/?$/',
 			page: { layouts: [0], errors: [1], leaf: 2 }
 		},
 		{
 			id: '/[...rest].json',
-			pattern: '/^/(.*?).json/?$/',
+			pattern: '/^/([^]*?).json/?$/',
 			endpoint: {
 				file: 'samples/rest-prefix-suffix/[...rest].json/+server.js'
 			}
@@ -714,7 +714,7 @@ test('handles pages without .svelte file', () => {
 		},
 		{
 			id: '/error/[...path]',
-			pattern: '/^/error(?:/(.*))?/?$/',
+			pattern: '/^/error(?:/([^]*))?/?$/',
 			page: { layouts: [0, undefined], errors: [1, 2], leaf: 6 }
 		},
 		{

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -26,7 +26,7 @@ export function parse_route_id(id) {
 									rest: true,
 									chained: true
 								});
-								return '(?:/(.*))?';
+								return '(?:/([^]*))?';
 							}
 							// special case — /[[optional]]/ could contain zero segments
 							const optional_match = /^\[\[(\w+)(?:=(\w+))?\]\]$/.exec(segment);
@@ -86,7 +86,7 @@ export function parse_route_id(id) {
 											rest: !!is_rest,
 											chained: is_rest ? i === 1 && parts[0] === '' : false
 										});
-										return is_rest ? '(.*?)' : is_optional ? '([^/]*)?' : '([^/]+?)';
+										return is_rest ? '([^]*?)' : is_optional ? '([^/]*)?' : '([^/]+?)';
 									}
 
 									return escape(content);

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -36,11 +36,11 @@ describe('parse_route_id', () => {
 			params: [{ name: 'slug', matcher: undefined, optional: true, rest: false, chained: false }]
 		},
 		'/[...catchall]': {
-			pattern: /^(?:\/(.*))?\/?$/,
+			pattern: /^(?:\/([^]*))?\/?$/,
 			params: [{ name: 'catchall', matcher: undefined, optional: false, rest: true, chained: true }]
 		},
 		'/foo/[...catchall]/bar': {
-			pattern: /^\/foo(?:\/(.*))?\/bar\/?$/,
+			pattern: /^\/foo(?:\/([^]*))?\/bar\/?$/,
 			params: [{ name: 'catchall', matcher: undefined, optional: false, rest: true, chained: true }]
 		},
 		'/matched/[id=uuid]': {

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -244,6 +244,16 @@ describe('exec', () => {
 			route: '/[[slug1=doesntmatch]]/[...slug2=doesntmatch]',
 			path: '/a/b/c',
 			expected: undefined
+		},
+		{
+			route: '/[...catchall]',
+			path: '/\n',
+			expected: { catchall: '\n' }
+		},
+		{
+			route: '/[[...catchall]]',
+			path: '/\n',
+			expected: { catchall: '\n' }
 		}
 	];
 


### PR DESCRIPTION
Rest route params currently cannot match newline characters (or `%0A`, a URL-encoded newline character). This is because in regexes, `.` does not match a newline.

This PR adjusts the regexes created for rest route params to use `[^]` instead. It adjusts existing unit tests and adds a couple more. Note that we use actual newline characters in the unit tests (rather than `%0A`) because by the time the `exec()` function is called in real applications, the URL has already been decoded.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
