### PR TITLE
fix: use configured base path when calling remote functions from the client

### DIFF
--- a/.changeset/dry-owls-open.md
+++ b/.changeset/dry-owls-open.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: use the configured base path when calling remote functions from the client

--- a/packages/kit/src/runtime/client/remote-functions/command.js
+++ b/packages/kit/src/runtime/client/remote-functions/command.js
@@ -1,7 +1,7 @@
 /** @import { RemoteCommand, RemoteQueryOverride } from '@sveltejs/kit' */
 /** @import { RemoteFunctionResponse } from 'types' */
 /** @import { Query } from './query.svelte.js' */
-import { app_dir } from '__sveltekit/paths';
+import { app_dir, base } from '__sveltekit/paths';
 import * as devalue from 'devalue';
 import { HttpError } from '@sveltejs/kit/internal';
 import { app } from '../client.js';
@@ -25,7 +25,7 @@ export function command(id) {
 			// Wait a tick to give room for the `updates` method to be called
 			await Promise.resolve();
 
-			const response = await fetch(`/${app_dir}/remote/${id}`, {
+			const response = await fetch(`${base}/${app_dir}/remote/${id}`, {
 				method: 'POST',
 				body: JSON.stringify({
 					payload: stringify_remote_arg(arg, app.hooks.transport),

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -1,7 +1,7 @@
 /** @import { RemoteForm, RemoteQueryOverride } from '@sveltejs/kit' */
 /** @import { RemoteFunctionResponse } from 'types' */
 /** @import { Query } from './query.svelte.js' */
-import { app_dir } from '__sveltekit/paths';
+import { app_dir, base } from '__sveltekit/paths';
 import * as devalue from 'devalue';
 import { DEV } from 'esm-env';
 import { HttpError } from '@sveltejs/kit/internal';
@@ -64,7 +64,7 @@ export function form(id) {
 						data.set('sveltekit:remote_refreshes', JSON.stringify(updates.map((u) => u._key)));
 					}
 
-					const response = await fetch(`/${app_dir}/remote/${action_id}`, {
+					const response = await fetch(`${base}/${app_dir}/remote/${action_id}`, {
 						method: 'POST',
 						body: data
 					});

--- a/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
@@ -1,5 +1,5 @@
 /** @import { RemoteFunctionResponse } from 'types' */
-import { app_dir } from '__sveltekit/paths';
+import { app_dir, base } from '__sveltekit/paths';
 import { version } from '__sveltekit/environment';
 import * as devalue from 'devalue';
 import { DEV } from 'esm-env';
@@ -124,7 +124,7 @@ export function prerender(id) {
 				}
 			}
 
-			const url = `/${app_dir}/remote/${id}${payload ? `/${payload}` : ''}`;
+			const url = `${base}/${app_dir}/remote/${id}${payload ? `/${payload}` : ''}`;
 
 			// Check the Cache API first
 			if (prerender_cache) {

--- a/packages/kit/src/runtime/client/remote-functions/query.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query.svelte.js
@@ -1,5 +1,5 @@
 /** @import { RemoteQueryFunction } from '@sveltejs/kit' */
-import { app_dir } from '__sveltekit/paths';
+import { app_dir, base } from '__sveltekit/paths';
 import { remote_responses, started } from '../client.js';
 import { tick } from 'svelte';
 import { create_remote_function, remote_request } from './shared.svelte.js';
@@ -18,7 +18,7 @@ export function query(id) {
 				}
 			}
 
-			const url = `/${app_dir}/remote/${id}${payload ? `?payload=${payload}` : ''}`;
+			const url = `${base}/${app_dir}/remote/${id}${payload ? `?payload=${payload}` : ''}`;
 
 			return await remote_request(url);
 		});

--- a/packages/kit/test/apps/options/source/pages/remote/+page.svelte
+++ b/packages/kit/test/apps/options/source/pages/remote/+page.svelte
@@ -1,0 +1,28 @@
+<script>
+	import { prerendered, get_count, set_count, set_count_form } from './count.remote.js';
+
+	let count = $state(null);
+	let prerendered_result = $state(null);
+</script>
+
+<p id="count">{count}</p>
+
+<button onclick={async () => (count = await get_count())}>get count</button>
+
+<button onclick={async () => (count = await set_count(0))} id="reset-btn">reset</button>
+
+<form
+	{...set_count_form.enhance(async ({ submit }) => {
+		await submit().updates(get_count());
+		count = await get_count();
+	})}
+>
+	<input type="number" name="count" />
+	<button>submit</button>
+</form>
+
+<button id="fetch-prerendered" onclick={async () => (prerendered_result = await prerendered())}>
+	get prerendered
+</button>
+
+<p>{prerendered_result}</p>

--- a/packages/kit/test/apps/options/source/pages/remote/+page.svelte
+++ b/packages/kit/test/apps/options/source/pages/remote/+page.svelte
@@ -25,4 +25,4 @@
 	get prerendered
 </button>
 
-<p>{prerendered_result}</p>
+<p id="prerendered">{prerendered_result}</p>

--- a/packages/kit/test/apps/options/source/pages/remote/count.remote.js
+++ b/packages/kit/test/apps/options/source/pages/remote/count.remote.js
@@ -1,0 +1,27 @@
+import { building, dev } from '$app/environment';
+import { command, form, prerender, query } from '$app/server';
+
+let count = 0;
+
+export const get_count = query(() => count);
+
+export const set_count = command(
+	'unchecked',
+	/** @param {number} c */
+	async (c) => {
+		return (count = c);
+	}
+);
+
+export const prerendered = prerender(() => {
+	if (!building && !dev) {
+		throw new Error('this prerender should not be called at runtime in production');
+	}
+
+	return 'yes';
+});
+
+export const set_count_form = form(async (form_data) => {
+	const c = /** @type {string} */ (form_data.get('count'));
+	return (count = parseInt(c));
+});

--- a/packages/kit/test/apps/options/svelte.config.js
+++ b/packages/kit/test/apps/options/svelte.config.js
@@ -40,6 +40,9 @@ const config = {
 		},
 		router: {
 			resolution: /** @type {'client' | 'server'} */ (process.env.ROUTER_RESOLUTION) || 'client'
+		},
+		experimental: {
+			remoteFunctions: true
 		}
 	}
 };

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -124,7 +124,7 @@ test.describe('base path', () => {
 
 		await page.goto('/path-base/remote');
 		await expect(page.locator('#count')).toHaveText('');
-		await page.locator('button', { hasText: 'set count' }).click();
+		await page.locator('button', { hasText: 'reset' }).click();
 		await expect(page.locator('#count')).toHaveText('0');
 	});
 

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -100,6 +100,43 @@ test.describe('base path', () => {
 		expect(page.url()).toBe(`${baseURL}/path-base/resolve-route/resolved/`);
 		expect(await page.textContent('h2')).toBe('resolved');
 	});
+
+	test('query remote function from client uses base path', async ({ page, javaScriptEnabled }) => {
+		test.skip(!javaScriptEnabled);
+
+		await page.goto('/path-base/remote');
+		await expect(page.locator('#count')).toHaveText('');
+		await page.locator('button', { hasText: 'get count' }).click();
+		await expect(page.locator('#count')).toHaveText('0');
+	});
+
+	test('prerender remote function from client uses base path', async ({ page, javaScriptEnabled }) => {
+		test.skip(!javaScriptEnabled);
+
+		await page.goto('/path-base/remote');
+		await expect(page.locator('#prerendered')).toHaveText('');
+		await page.locator('button', { hasText: 'get prerendered' }).click();
+		await expect(page.locator('#prerendered')).toHaveText('yes');
+	});
+
+	test('command remote function from client uses base path', async ({ page, javaScriptEnabled }) => {
+		test.skip(!javaScriptEnabled);
+
+		await page.goto('/path-base/remote');
+		await expect(page.locator('#count')).toHaveText('');
+		await page.locator('button', { hasText: 'set count' }).click();
+		await expect(page.locator('#count')).toHaveText('0');
+	});
+
+	test('form remote function from client uses base path', async ({ page, javaScriptEnabled }) => {
+		test.skip(!javaScriptEnabled);
+
+		await page.goto('/path-base/remote');
+		await expect(page.locator('#count')).toHaveText('');
+		await page.locator('input').fill('1');
+		await page.locator('button', { hasText: 'submit' }).click();
+		await expect(page.locator('#count')).toHaveText('1');
+	});
 });
 
 test.describe('assets path', () => {


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/14089

This PR ensures the user's configured base path is taken into account when calling remote functions from the client.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
