### PR TITLE
fix: access `remote_responses` cache lazily in `form` remote functions

### DIFF
--- a/.changeset/cute-boats-hide.md
+++ b/.changeset/cute-boats-hide.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: ensure `form()` remote functions work when the app is configured to a single output

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -25,10 +25,11 @@ export function form(id) {
 		const action_id = id + (key != undefined ? `/${JSON.stringify(key)}` : '');
 		const action = '?/remote=' + encodeURIComponent(action_id);
 
-		const initial_result = {};
-
 		/** @type {any} */
-		let result = $state(initial_result);
+		let result = $state({});
+
+		// svelte-ignore state_referenced_locally
+		const initial_result = result;
 
 		/**
 		 * @param {FormData} data

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -25,10 +25,10 @@ export function form(id) {
 		const action_id = id + (key != undefined ? `/${JSON.stringify(key)}` : '');
 		const action = '?/remote=' + encodeURIComponent(action_id);
 
+		const initial_result = {};
+
 		/** @type {any} */
-		let result = $state(
-			!started ? (remote_responses[create_remote_cache_key(action, '')] ?? undefined) : undefined
-		);
+		let result = $state(initial_result);
 
 		/**
 		 * @param {FormData} data
@@ -250,7 +250,18 @@ export function form(id) {
 				value: button_props
 			},
 			result: {
-				get: () => result
+				get: () => {
+					if (result === initial_result) {
+						// we have to evaluate the default result lazily because it's possible
+						// that `remote_responses` is still uninitialised at this point
+						// when we bundle the app into a single output and this module gets
+						// evaluated before `client.start()` is called
+						return !started
+							? (remote_responses[create_remote_cache_key(action, '')] ?? undefined)
+							: undefined;
+					}
+					return result;
+				}
 			},
 			enhance: {
 				/** @type {RemoteForm<any>['enhance']} */


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/14120

This PR moves the property accessing of the `remote_responses` object to the `result` getter so that it isn't evaluated when the remote function is created. This is similar to the `query` and `prerender` remote function creations.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

No test because it wouldn't work in the `options-2` test app without merging https://github.com/sveltejs/kit/issues/14120 too. Also, the tests from that PR would cover this as well.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
