### PR TITLE
fix: adapter-node uses hardcoded rollup options for Server. Output sourcemap always true.

### DIFF
--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -75,7 +75,7 @@ export default function (opts = {}) {
 			await bundle.write({
 				dir: `${out}/server`,
 				format: 'esm',
-				sourcemap: true,
+				sourcemap: builder.viteConfig.build.sourcemap ?? true,
 				chunkFileNames: 'chunks/[name]-[hash].js'
 			});
 

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -82,6 +82,7 @@ export function create_builder({
 		config,
 		prerendered,
 		routes,
+		viteConfig: vite_config,
 
 		async compress(directory) {
 			if (!existsSync(directory)) {

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -25,6 +25,7 @@ import {
 	ResolvedPathname
 	// @ts-ignore
 } from '$app/types';
+import { ResolvedConfig } from 'vite';
 
 export { PrerenderOption } from '../types/private.js';
 
@@ -110,6 +111,8 @@ export interface Builder {
 	prerendered: Prerendered;
 	/** An array of all routes (including prerendered) */
 	routes: RouteDefinition[];
+	/** Resolved Vite config. */
+	viteConfig: ResolvedConfig;
 
 	// TODO 3.0 remove this method
 	/**

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -5,6 +5,7 @@ declare module '@sveltejs/kit' {
 	import type { SvelteConfig } from '@sveltejs/vite-plugin-svelte';
 	import type { StandardSchemaV1 } from '@standard-schema/spec';
 	import type { RouteId as AppRouteId, LayoutParams as AppLayoutParams, ResolvedPathname } from '$app/types';
+	import type { ResolvedConfig } from 'vite';
 	/**
 	 * [Adapters](https://svelte.dev/docs/kit/adapters) are responsible for taking the production build and turning it into something that can be deployed to a platform of your choosing.
 	 */
@@ -87,6 +88,8 @@ declare module '@sveltejs/kit' {
 		prerendered: Prerendered;
 		/** An array of all routes (including prerendered) */
 		routes: RouteDefinition[];
+		/** Resolved Vite config. */
+		viteConfig: ResolvedConfig;
 
 		// TODO 3.0 remove this method
 		/**


### PR DESCRIPTION
fixes #14125

Gives a control over sourcemap setting for server built with adapter-node.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
