### PR TITLE
fix: use `__SVELTEKIT_PAYLOAD__` to reference boot payload

### DIFF
--- a/.changeset/cute-boats-hide.md
+++ b/.changeset/cute-boats-hide.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: ensure `form()` remote functions work when the app is configured to a single output

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -331,7 +331,10 @@ async function kit({ svelte_config }) {
 					__SVELTEKIT_DEV__: 'false',
 					__SVELTEKIT_EMBEDDED__: s(kit.embedded),
 					__SVELTEKIT_EXPERIMENTAL__REMOTE_FUNCTIONS__: s(kit.experimental.remoteFunctions),
-					__SVELTEKIT_CLIENT_ROUTING__: kit.router.resolution === 'client' ? 'true' : 'false'
+					__SVELTEKIT_CLIENT_ROUTING__: kit.router.resolution === 'client' ? 'true' : 'false',
+					__SVELTEKIT_PAYLOAD__: new_config.build.ssr
+						? '{}'
+						: `globalThis.__sveltekit_${version_hash}`
 				};
 
 				if (!secondary_build_started) {
@@ -343,8 +346,12 @@ async function kit({ svelte_config }) {
 					__SVELTEKIT_DEV__: 'true',
 					__SVELTEKIT_EMBEDDED__: s(kit.embedded),
 					__SVELTEKIT_EXPERIMENTAL__REMOTE_FUNCTIONS__: s(kit.experimental.remoteFunctions),
-					__SVELTEKIT_CLIENT_ROUTING__: kit.router.resolution === 'client' ? 'true' : 'false'
+					__SVELTEKIT_CLIENT_ROUTING__: kit.router.resolution === 'client' ? 'true' : 'false',
+					__SVELTEKIT_PAYLOAD__: 'globalThis.__sveltekit_dev'
 				};
+
+				// @ts-ignore this prevents a reference error if `client.js` is imported on the server
+				globalThis.__sveltekit_dev = {};
 
 				// These Kit dependencies are packaged as CommonJS, which means they must always be externalized.
 				// Without this, the tests will still pass but `pnpm dev` will fail in projects that link `@sveltejs/kit`.

--- a/packages/kit/src/runtime/app/server/remote/form.js
+++ b/packages/kit/src/runtime/app/server/remote/form.js
@@ -67,7 +67,7 @@ export function form(fn) {
 				// We don't need to care about args or deduplicating calls, because uneval results are only relevant in full page reloads
 				// where only one form submission is active at the same time
 				if (!event.isRemoteRequest) {
-					state.form_result = [key, result];
+					(state.remote_data ??= {})[__.id] = result;
 				}
 
 				return result;
@@ -89,8 +89,8 @@ export function form(fn) {
 		Object.defineProperty(instance, 'result', {
 			get() {
 				try {
-					const { form_result } = get_event_state(getRequestEvent());
-					return form_result && form_result[0] === key ? form_result[1] : undefined;
+					const { remote_data } = get_event_state(getRequestEvent());
+					return remote_data?.[__.id];
 				} catch {
 					return undefined;
 				}

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -178,7 +178,7 @@ let target;
 export let app;
 
 /** @type {Record<string, any>} */
-export let remote_responses = __SVELTEKIT_PAYLOAD__.data ?? {};
+export const remote_responses = __SVELTEKIT_PAYLOAD__.data ?? {};
 
 /** @type {Array<((url: URL) => boolean)>} */
 const invalidated = [];

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -178,7 +178,7 @@ let target;
 export let app;
 
 /** @type {Record<string, any>} */
-export let remote_responses;
+export let remote_responses = __SVELTEKIT_PAYLOAD__.data ?? {};
 
 /** @type {Array<((url: URL) => boolean)>} */
 const invalidated = [];
@@ -288,7 +288,6 @@ export async function start(_app, _target, hydrate) {
 	}
 
 	app = _app;
-	remote_responses = hydrate?.remote ?? {};
 
 	await _app.hooks.init?.();
 

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -25,10 +25,11 @@ export function form(id) {
 		const action_id = id + (key != undefined ? `/${JSON.stringify(key)}` : '');
 		const action = '?/remote=' + encodeURIComponent(action_id);
 
-		const initial_result = {};
-
 		/** @type {any} */
-		let result = $state(initial_result);
+		let result = $state({});
+
+		// svelte-ignore state_referenced_locally
+		const initial_result = result;
 
 		/**
 		 * @param {FormData} data

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -25,10 +25,10 @@ export function form(id) {
 		const action_id = id + (key != undefined ? `/${JSON.stringify(key)}` : '');
 		const action = '?/remote=' + encodeURIComponent(action_id);
 
+		const initial_result = {};
+
 		/** @type {any} */
-		let result = $state(
-			!started ? (remote_responses[create_remote_cache_key(action, '')] ?? undefined) : undefined
-		);
+		let result = $state(initial_result);
 
 		/**
 		 * @param {FormData} data
@@ -250,7 +250,18 @@ export function form(id) {
 				value: button_props
 			},
 			result: {
-				get: () => result
+				get: () => {
+					if (result === initial_result) {
+						// we have to evaluate the default result lazily because it's possible
+						// that `remote_responses` is still uninitialised at this point
+						// when we bundle the app into a single output and this module gets
+						// evaluated before `client.start()` is called
+						return !started
+							? (remote_responses[create_remote_cache_key(action, '')] ?? undefined)
+							: undefined;
+					}
+					return result;
+				}
 			},
 			enhance: {
 				/** @type {RemoteForm<any>['enhance']} */

--- a/packages/kit/src/runtime/server/event-state.js
+++ b/packages/kit/src/runtime/server/event-state.js
@@ -1,5 +1,5 @@
 /** @import { RequestEvent } from '@sveltejs/kit' */
-/** @import { PrerenderOptions, ServerHooks, SSROptions, SSRState } from 'types' */
+/** @import { MaybePromise, PrerenderOptions, ServerHooks, SSROptions, SSRState } from 'types' */
 
 export const EVENT_STATE = Symbol('remote');
 
@@ -11,8 +11,7 @@ export const EVENT_STATE = Symbol('remote');
  *  transport: ServerHooks['transport'];
  *  handleValidationError: ServerHooks['handleValidationError'];
  *  form_instances?: Map<any, any>;
- *  form_result?: [key: any, value: any];
- * 	remote_data?: Record<string, Promise<any>>;
+ * 	remote_data?: Record<string, MaybePromise<any>>;
  *  refreshes?: Record<string, any>;
  * }} RequestEventState
  */

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -378,6 +378,29 @@ export async function render_response({
 						}`);
 		}
 
+		const { remote_data } = get_event_state(event);
+
+		if (remote_data) {
+			/** @type {Record<string, any>} */
+			const remote = {};
+
+			for (const key in remote_data) {
+				remote[key] = await remote_data[key];
+			}
+
+			// TODO this is repeated in a few places — dedupe it
+			const replacer = (/** @type {any} */ thing) => {
+				for (const key in options.hooks.transport) {
+					const encoded = options.hooks.transport[key].encode(thing);
+					if (encoded) {
+						return `app.decode('${key}', ${devalue.uneval(encoded, replacer)})`;
+					}
+				}
+			};
+
+			properties.push(`data: ${devalue.uneval(remote, replacer)}`);
+		}
+
 		// create this before declaring `data`, which may contain references to `${global}`
 		blocks.push(`${global} = {
 						${properties.join(',\n\t\t\t\t\t\t')}
@@ -402,35 +425,11 @@ export async function render_response({
 				serialized.error = devalue.uneval(error);
 			}
 
-			const { remote_data } = get_event_state(event);
-
-			if (remote_data) {
-				/** @type {Record<string, any>} */
-				const remote = {};
-
-				for (const key in remote_data) {
-					remote[key] = await remote_data[key];
-				}
-
-				// TODO this is repeated in a few places — dedupe it
-				const replacer = (/** @type {any} */ thing) => {
-					for (const key in options.hooks.transport) {
-						const encoded = options.hooks.transport[key].encode(thing);
-						if (encoded) {
-							return `app.decode('${key}', ${devalue.uneval(encoded, replacer)})`;
-						}
-					}
-				};
-
-				serialized.remote = devalue.uneval(remote, replacer);
-			}
-
 			const hydrate = [
 				`node_ids: [${branch.map(({ node }) => node.index).join(', ')}]`,
 				`data: ${data}`,
 				`form: ${serialized.form}`,
-				`error: ${serialized.error}`,
-				`remote: ${serialized.remote}`
+				`error: ${serialized.error}`
 			];
 
 			if (status !== 200) {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -411,7 +411,7 @@ export async function render_response({
 		blocks.push('const element = document.currentScript.parentElement;');
 
 		if (page_config.ssr) {
-			const serialized = { form: 'null', error: 'null', remote: 'null' };
+			const serialized = { form: 'null', error: 'null' };
 
 			if (form_value) {
 				serialized.form = uneval_action_response(

--- a/packages/kit/src/types/global-private.d.ts
+++ b/packages/kit/src/types/global-private.d.ts
@@ -14,7 +14,9 @@ declare global {
 		assets: string;
 		/** Public environment variables */
 		env?: Record<string, string>;
+		/** Serialized data from remote functions */
 		data?: Record<string, any>;
+		/** Streamed promises */
 		defer?: (id: number) => Promise<any>;
 		resolve?: (data: { id: number; data: any; error: any }) => void;
 	};

--- a/packages/kit/src/types/global-private.d.ts
+++ b/packages/kit/src/types/global-private.d.ts
@@ -10,14 +10,17 @@ declare global {
 	const __SVELTEKIT_CLIENT_ROUTING__: boolean;
 	/** The `__sveltekit_abc123` object in the init `<script>` */
 	const __SVELTEKIT_PAYLOAD__: {
+		/** The basepath, usually relative to the current page */
 		base: string;
-		assets: string;
+		/** Path to externally-hosted assets */
+		assets?: string;
 		/** Public environment variables */
 		env?: Record<string, string>;
 		/** Serialized data from remote functions */
 		data?: Record<string, any>;
-		/** Streamed promises */
+		/** Create a placeholder promise */
 		defer?: (id: number) => Promise<any>;
+		/** Resolve a placeholder promise */
 		resolve?: (data: { id: number; data: any; error: any }) => void;
 	};
 	/**

--- a/packages/kit/src/types/global-private.d.ts
+++ b/packages/kit/src/types/global-private.d.ts
@@ -8,6 +8,16 @@ declare global {
 	const __SVELTEKIT_EXPERIMENTAL__REMOTE_FUNCTIONS__: boolean;
 	/** True if `config.kit.router.resolution === 'client'` */
 	const __SVELTEKIT_CLIENT_ROUTING__: boolean;
+	/** The `__sveltekit_abc123` object in the init `<script>` */
+	const __SVELTEKIT_PAYLOAD__: {
+		base: string;
+		assets: string;
+		/** Public environment variables */
+		env?: Record<string, string>;
+		data?: Record<string, any>;
+		defer?: (id: number) => Promise<any>;
+		resolve?: (data: { id: number; data: any; error: any }) => void;
+	};
 	/**
 	 * This makes the use of specific features visible at both dev and build time, in such a
 	 * way that we can error when they are not supported by the target platform.


### PR DESCRIPTION
This is an alternative to #14121, which eliminates the (already remote) possibility of race conditions. It does so by making the entire boot payload (the `__sveltekit_abc123 = {...}` object that exists in the hydration `<script>`) accessible via a `__SVELTEKIT_PAYLOAD__` [define](https://vite.dev/config/shared-options.html#define).

No test because the failure conditions are quite hard to engineer. But this general approach feels more robust than what we have now, and could enable further simplifications (by reducing the need for virtual modules, etc)

Fixes #14120

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
