### PR TITLE
feat: use devalue for pushState/replaceState

### DIFF
--- a/.changeset/four-pens-cheer.md
+++ b/.changeset/four-pens-cheer.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": minor
+---
+
+feat: use the `transport` hook and `devalue` to serialize state in `pushState`/`replaceState`

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2283,7 +2283,7 @@ export function pushState(url, state) {
 	history.pushState(opts, '', resolve_url(url));
 	has_navigated = true;
 
-	page.state = state;
+	page.state = unstringify(opts[STATES_KEY], app.hooks.transport);
 	root.$set({
 		// we need to assign a new page object so that subscribers are correctly notified
 		page: untrack(() => clone_page(page))
@@ -2317,7 +2317,7 @@ export function replaceState(url, state) {
 
 	history.replaceState(opts, '', resolve_url(url));
 
-	page.state = state;
+	page.state = unstringify(opts[STATES_KEY], app.hooks.transport);
 	root.$set({
 		page: untrack(() => clone_page(page))
 	});

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2619,7 +2619,9 @@ function _start_router() {
 			if (history_index === current_history_index) return;
 
 			const scroll = scroll_positions[history_index];
-			const state = event.state[STATES_KEY] ? unstringify(event.state[STATES_KEY], app.hooks.transport) : {};
+			const state = event.state[STATES_KEY]
+				? unstringify(event.state[STATES_KEY], app.hooks.transport)
+				: {};
 			const url = new URL(event.state[PAGE_URL_KEY] ?? location.href);
 			const navigation_index = event.state[NAVIGATION_INDEX];
 			const is_hash_change = current.url ? strip_hash(location) === strip_hash(current.url) : false;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2619,7 +2619,7 @@ function _start_router() {
 			if (history_index === current_history_index) return;
 
 			const scroll = scroll_positions[history_index];
-			const state = unstringify(event.state[STATES_KEY], app.hooks.transport) ?? {};
+			const state = event.state[STATES_KEY] ? unstringify(event.state[STATES_KEY], app.hooks.transport) : {};
 			const url = new URL(event.state[PAGE_URL_KEY] ?? location.href);
 			const navigation_index = event.state[NAVIGATION_INDEX];
 			const is_hash_change = current.url ? strip_hash(location) === strip_hash(current.url) : false;

--- a/packages/kit/src/runtime/shared.js
+++ b/packages/kit/src/runtime/shared.js
@@ -67,6 +67,17 @@ export function stringify_remote_arg(value, transport) {
 }
 
 /**
+ * Parses `string` with `devalue.parse`, using the provided transport decoders.
+ * @param {string} string
+ * @param {Transport} transport
+ */
+export function parse(string, transport) {
+	const decoders = Object.fromEntries(Object.entries(transport).map(([k, v]) => [k, v.decode]));
+
+	return devalue.parse(string, decoders);
+}
+
+/**
  * Parses the argument (if any) for a remote function
  * @param {string} string
  * @param {Transport} transport
@@ -79,9 +90,7 @@ export function parse_remote_arg(string, transport) {
 		base64_decode(string.replaceAll('-', '+').replaceAll('_', '/'))
 	);
 
-	const decoders = Object.fromEntries(Object.entries(transport).map(([k, v]) => [k, v.decode]));
-
-	return devalue.parse(json_string, decoders);
+	return parse(json_string, transport);
 }
 
 /**

--- a/packages/kit/test/apps/basics/src/app.d.ts
+++ b/packages/kit/test/apps/basics/src/app.d.ts
@@ -1,3 +1,5 @@
+import type { Foo } from '$lib';
+
 declare global {
 	namespace App {
 		interface Locals {
@@ -12,6 +14,7 @@ declare global {
 		interface PageState {
 			active?: boolean;
 			count?: number;
+			foo?: Foo;
 		}
 	}
 }

--- a/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/foo/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/foo/+page.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { pushState } from '$app/navigation';
+	import { page } from '$app/state';
+	import { Foo } from '$lib';
+</script>
+
+<button onclick={() => pushState('', { foo: new Foo('it works?') })}>do the thing</button>
+
+<p>foo: {page.state.foo?.bar() ?? 'nope'}</p>

--- a/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/foo/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/foo/+page.svelte
@@ -4,6 +4,21 @@
 	import { Foo } from '$lib';
 </script>
 
-<button onclick={() => pushState('', { foo: new Foo('it works?') })}>do the thing</button>
+<button
+	onclick={() => {
+		const state = $state({ foo: new Foo('it works?'), count: 0 });
+		pushState('', state);
+	}}>push state</button
+>
 
-<p>foo: {page.state.foo?.bar() ?? 'nope'}</p>
+<!-- Make sure that page.state.count loses its reactivity -->
+<button
+	onclick={() => {
+		page.state.count++;
+	}}
+>
+	bump count
+</button>
+
+<p data-testid="foo">foo: {page.state.foo?.bar() ?? 'nope'}</p>
+<p data-testid="count">count: {page.state.count ?? 'nope'}</p>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1661,7 +1661,7 @@ test.describe('Shallow routing', () => {
 		await expect(page.locator('[data-testid=count]')).toHaveText('count: 0'); // Ensure count is not bumped
 
 		await page.goBack();
-		await expect(page.locator('p')).toHaveText('foo: nope');
+		await expect(page.locator('[data-testid=foo]')).toHaveText('foo: nope');
 		await expect(page.locator('[data-testid=count]')).toHaveText('count: nope');
 	});
 });

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1649,13 +1649,20 @@ test.describe('Shallow routing', () => {
 
 	test('pushState properly serializes objects', async ({ page }) => {
 		await page.goto('/shallow-routing/push-state/foo');
-		await expect(page.locator('p')).toHaveText('foo: nope');
+		await expect(page.locator('[data-testid=foo]')).toHaveText('foo: nope');
+		await expect(page.locator('[data-testid=count]')).toHaveText('count: nope');
 
-		await page.locator('button').click();
-		await expect(page.locator('p')).toHaveText('foo: it works?!');
+		await page.getByText('push state').click();
+		await expect(page.locator('[data-testid=foo]')).toHaveText('foo: it works?!');
+		await expect(page.locator('[data-testid=count]')).toHaveText('count: 0');
+
+		await page.getByText('bump count').click();
+		await expect(page.locator('[data-testid=foo]')).toHaveText('foo: it works?!');
+		await expect(page.locator('[data-testid=count]')).toHaveText('count: 0'); // Ensure count is not bumped
 
 		await page.goBack();
 		await expect(page.locator('p')).toHaveText('foo: nope');
+		await expect(page.locator('[data-testid=count]')).toHaveText('count: nope');
 	});
 });
 

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1646,6 +1646,17 @@ test.describe('Shallow routing', () => {
 		await page.locator('button').click();
 		await expect(page.locator('p')).toHaveText('count: 1');
 	});
+
+	test('pushState properly serializes objects', async ({ page }) => {
+		await page.goto('/shallow-routing/push-state/foo');
+		await expect(page.locator('p')).toHaveText('foo: nope');
+
+		await page.locator('button').click();
+		await expect(page.locator('p')).toHaveText('foo: it works?!');
+
+		await page.goBack();
+		await expect(page.locator('p')).toHaveText('foo: nope');
+	});
 });
 
 test.describe('reroute', () => {


### PR DESCRIPTION
Hi!

Closes #14128: `pushState`/`replaceState` now use devalue+transport to serialize custom objects

I kept it simple, not sure if the idea will be accepted

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
