### PR TITLE
chore: add .git to the end of package.json repository url

### DIFF
--- a/packages/adapter-auto/package.json
+++ b/packages/adapter-auto/package.json
@@ -13,7 +13,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/sveltejs/kit",
+		"url": "https://github.com/sveltejs/kit.git",
 		"directory": "packages/adapter-auto"
 	},
 	"license": "MIT",

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/sveltejs/kit",
+		"url": "https://github.com/sveltejs/kit.git",
 		"directory": "packages/adapter-cloudflare"
 	},
 	"license": "MIT",

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/sveltejs/kit",
+		"url": "https://github.com/sveltejs/kit.git",
 		"directory": "packages/adapter-netlify"
 	},
 	"license": "MIT",

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/sveltejs/kit",
+		"url": "https://github.com/sveltejs/kit.git",
 		"directory": "packages/adapter-node"
 	},
 	"license": "MIT",

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -13,7 +13,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/sveltejs/kit",
+		"url": "https://github.com/sveltejs/kit.git",
 		"directory": "packages/adapter-static"
 	},
 	"license": "MIT",

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -12,7 +12,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/sveltejs/kit",
+		"url": "https://github.com/sveltejs/kit.git",
 		"directory": "packages/adapter-vercel"
 	},
 	"license": "MIT",

--- a/packages/amp/package.json
+++ b/packages/amp/package.json
@@ -10,7 +10,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/sveltejs/kit",
+		"url": "https://github.com/sveltejs/kit.git",
 		"directory": "packages/amp"
 	},
 	"license": "MIT",

--- a/packages/create-svelte/package.json
+++ b/packages/create-svelte/package.json
@@ -15,7 +15,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/sveltejs/kit",
+		"url": "https://github.com/sveltejs/kit.git",
 		"directory": "packages/create-svelte"
 	},
 	"license": "MIT",

--- a/packages/enhanced-img/package.json
+++ b/packages/enhanced-img/package.json
@@ -4,7 +4,7 @@
 	"description": "Image optimization for your Svelte apps",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/sveltejs/kit",
+		"url": "https://github.com/sveltejs/kit.git",
 		"directory": "packages/enhanced-img"
 	},
 	"keywords": [

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -11,7 +11,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/sveltejs/kit",
+		"url": "https://github.com/sveltejs/kit.git",
 		"directory": "packages/kit"
 	},
 	"license": "MIT",

--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -4,7 +4,7 @@
 	"description": "The fastest way to build Svelte packages",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/sveltejs/kit",
+		"url": "https://github.com/sveltejs/kit.git",
 		"directory": "packages/package"
 	},
 	"keywords": [


### PR DESCRIPTION
Added ".git" to the end of repository URLs in package.json to address https://github.com/sveltejs/kit/issues/13927

> According to publint, the Git URL in our package.json files such as https://publint.dev/@sveltejs/kit@2.22.0 should end with a .git https://publint.dev/rules#invalid_repository_value

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
