### PR TITLE
feat: adapter-node bundle sourcemap option

### DIFF
--- a/packages/adapter-node/index.d.ts
+++ b/packages/adapter-node/index.d.ts
@@ -9,6 +9,11 @@ interface AdapterOptions {
 	out?: string;
 	precompress?: boolean;
 	envPrefix?: string;
+	/**
+	 * If set to `false`, sourcemaps for bundled files will not be generated.
+	 * @default true
+	 */
+	bundleSourcemap?: boolean;
 }
 
 export default function plugin(options?: AdapterOptions): Adapter;

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -9,7 +9,7 @@ const files = fileURLToPath(new URL('./files', import.meta.url).href);
 
 /** @type {import('./index.js').default} */
 export default function (opts = {}) {
-	const { out = 'build', precompress = true, envPrefix = '' } = opts;
+	const { out = 'build', precompress = true, envPrefix = '', bundleSourcemap = true } = opts;
 
 	return {
 		name: '@sveltejs/adapter-node',
@@ -75,7 +75,7 @@ export default function (opts = {}) {
 			await bundle.write({
 				dir: `${out}/server`,
 				format: 'esm',
-				sourcemap: true,
+				sourcemap: bundleSourcemap,
 				chunkFileNames: 'chunks/[name]-[hash].js'
 			});
 


### PR DESCRIPTION
solves #14125

Add adapter-node option that disables bundled files sourcemaps genertion.
---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
