### PR TITLE
chore: convert from uvu to vitest

### DIFF
--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -34,7 +34,7 @@
 		"svelte": "^5.35.5",
 		"svelte-preprocess": "^6.0.0",
 		"typescript": "^5.3.3",
-		"uvu": "^0.5.6"
+		"vitest": "catalog:"
 	},
 	"peerDependencies": {
 		"svelte": "^3.44.0 || ^4.0.0 || ^5.0.0-next.1"
@@ -50,7 +50,7 @@
 		"check": "tsc",
 		"check:all": "tsc && pnpm -r --filter=\"./**\" check",
 		"format": "pnpm lint --write",
-		"test": "uvu test \"^index.js$\""
+		"test": "vitest run"
 	},
 	"exports": {
 		"./package.json": "./package.json"

--- a/packages/package/test/errors/no-lib-folder/svelte.config.js
+++ b/packages/package/test/errors/no-lib-folder/svelte.config.js
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/package/test/fixtures/assets/svelte.config.js
+++ b/packages/package/test/fixtures/assets/svelte.config.js
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/package/test/fixtures/javascript/svelte.config.js
+++ b/packages/package/test/fixtures/javascript/svelte.config.js
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/package/test/index.spec.js
+++ b/packages/package/test/index.spec.js
@@ -4,8 +4,7 @@ import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import prettier from 'prettier';
-import { test } from 'uvu';
-import * as assert from 'uvu/assert';
+import { test, expect } from 'vitest';
 
 import { build, watch } from '../src/index.js';
 import { load_config } from '../src/config.js';
@@ -40,13 +39,13 @@ async function test_make_package(path, options) {
 	const expected_files = walk(ewd, true);
 	const actual_files = walk(output, true);
 
-	assert.equal(actual_files, expected_files);
+	expect(actual_files).toEqual(expected_files);
 
 	const extensions = ['.json', '.svelte', '.ts', 'js', '.map'];
 	for (const file of actual_files) {
 		const pathname = join(output, file);
 		if (fs.statSync(pathname).isDirectory()) continue;
-		assert.ok(expected_files.includes(file), `Did not expect ${file} in ${path}`);
+		expect(expected_files.includes(file), `Did not expect ${file} in ${path}`).toBeTruthy();
 
 		const expected = fs.readFileSync(join(ewd, file));
 		const actual = fs.readFileSync(join(output, file));
@@ -55,9 +54,9 @@ async function test_make_package(path, options) {
 		if (extensions.some((ext) => pathname.endsWith(ext))) {
 			const expected_content = await format(file, expected.toString('utf-8'));
 			const actual_content = await format(file, actual.toString('utf-8'));
-			assert.fixture(actual_content, expected_content, err_msg);
+			expect(actual_content, err_msg).toBe(expected_content);
 		} else {
-			assert.ok(expected.equals(actual), err_msg);
+			expect(expected.equals(actual)).toBeTruthy();
 		}
 	}
 }
@@ -95,13 +94,12 @@ for (const dir of fs.readdirSync(join(__dirname, 'errors'))) {
 
 		try {
 			await build({ cwd, input, output, types: true, config });
-			assert.unreachable('Must not pass build');
+			throw new Error('Must not pass build');
 		} catch (/** @type {any} */ error) {
-			assert.instance(error, Error);
+			expect(error).toBeInstanceOf(Error);
 			switch (dir) {
 				case 'no-lib-folder':
-					assert.match(
-						error.message.replace(/\\/g, '/'),
+					expect(error.message.replace(/\\/g, '/')).toMatch(
 						'test/errors/no-lib-folder/src/lib does not exist'
 					);
 					break;
@@ -109,12 +107,11 @@ for (const dir of fs.readdirSync(join(__dirname, 'errors'))) {
 				// 	it detects tsconfig in packages/kit instead and creates package folder
 				// 	in packages/kit/package, not sure how to handle and test this yet
 				// case 'no-tsconfig':
-				// 	assert.match(error.message, 'Failed to locate tsconfig or jsconfig');
+				// 	expect(error.message).toMatch('Failed to locate tsconfig or jsconfig');
 				// 	break;
 
 				default:
-					assert.unreachable('All error test must be handled');
-					break;
+					throw new Error('All error test must be handled');
 			}
 		} finally {
 			rimraf(output);
@@ -191,7 +188,7 @@ if (!process.env.CI) {
 
 		/** @param {string} file */
 		function compare(file) {
-			assert.equal(read(`package/${file}`), read(`expected/${file}`));
+			expect(read(`package/${file}`)).toEqual(read(`expected/${file}`));
 		}
 
 		/** @param {string} file */
@@ -253,7 +250,7 @@ if (!process.env.CI) {
 			remove('src/lib/b.ts');
 			remove('src/lib/post-error.svelte');
 		}
-	});
+	}, 30_000);
 }
 
 /**
@@ -261,11 +258,10 @@ if (!process.env.CI) {
  * @param {string[]} expected
  */
 function has_warnings(actual, expected) {
-	assert.equal(actual.length, expected.length);
-	assert.equal(
-		actual.filter((warning) => expected.some((str) => warning.startsWith(str))).length,
-		expected.length
-	);
+	expect(actual.length).toEqual(expected.length);
+	expect(
+		actual.filter((warning) => expected.some((str) => warning.startsWith(str))).length
+	).toEqual(expected.length);
 }
 
 test('validates package (1)', () => {
@@ -320,7 +316,7 @@ test('validates package (all ok 1)', () => {
 		peerDependencies: { svelte: '^3.55.0' }
 	});
 
-	assert.equal(warnings.length, 0);
+	expect(warnings.length).toEqual(0);
 });
 
 test('validates package (all ok 2)', () => {
@@ -338,7 +334,5 @@ test('validates package (all ok 2)', () => {
 		svelte: './dist/C.svelte'
 	});
 
-	assert.equal(warnings.length, 0);
+	expect(warnings.length).toEqual(0);
 });
-
-test.run();

--- a/packages/package/tsconfig.json
+++ b/packages/package/tsconfig.json
@@ -9,5 +9,5 @@
 		"moduleResolution": "node16",
 		"allowSyntheticDefaultImports": true
 	},
-	"include": ["*.js", "src/**/*", "test/index.js"]
+	"include": ["*.js", "src/**/*", "test/index.spec.js"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1202,9 +1202,9 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
-      uvu:
-        specifier: ^0.5.6
-        version: 0.5.6
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.3(@types/node@18.19.119)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
 
   packages/test-redirect-importer:
     dependencies:
@@ -3766,10 +3766,6 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
-  dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
-
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -3838,10 +3834,6 @@ packages:
 
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
-    engines: {node: '>=0.3.1'}
-
-  diff@5.2.0:
-    resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
@@ -6685,11 +6677,6 @@ packages:
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
-
-  uvu@0.5.6:
-    resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
-    engines: {node: '>=8'}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -9591,8 +9578,6 @@ snapshots:
 
   depd@2.0.0: {}
 
-  dequal@2.0.3: {}
-
   destr@2.0.5: {}
 
   destroy@1.2.0: {}
@@ -9662,8 +9647,6 @@ snapshots:
   devalue@5.1.0: {}
 
   diff@4.0.2: {}
-
-  diff@5.2.0: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -12701,13 +12684,6 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@11.1.0: {}
-
-  uvu@0.5.6:
-    dependencies:
-      dequal: 2.0.3
-      diff: 5.2.0
-      kleur: 4.1.5
-      sade: 1.8.1
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
This is the only place we were still using `uvu`. After this PR we are using `vitest` everywhere