### PR TITLE
fix: validate that the `version.name` config option is deterministic

### DIFF
--- a/.changeset/free-bars-clap.md
+++ b/.changeset/free-bars-clap.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: validate that the `version.name` config option is deterministic

--- a/packages/kit/src/core/config/fixtures/non-deterministic-version/svelte.config.js
+++ b/packages/kit/src/core/config/fixtures/non-deterministic-version/svelte.config.js
@@ -1,0 +1,7 @@
+export default {
+	kit: {
+		version: {
+			name: Date.now().toString()
+		}
+	}
+};

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -123,8 +123,8 @@ const get_defaults = (prefix = '') => ({
 	}
 });
 
-test('fills in defaults', () => {
-	const validated = validate_config({});
+test('fills in defaults', async () => {
+	const validated = await validate_config(async () => ({}));
 
 	assert.equal(validated.kit.serviceWorker.files(''), true);
 
@@ -137,47 +137,47 @@ test('fills in defaults', () => {
 });
 
 test('errors on invalid values', () => {
-	assert.throws(() => {
-		validate_config({
+	expect(
+		// @ts-expect-error - given value expected to throw
+		validate_config(async () => ({
 			kit: {
-				// @ts-expect-error - given value expected to throw
 				appDir: 42
 			}
-		});
-	}, /^config\.kit\.appDir should be a string, if specified$/);
+		}))
+	).rejects.toThrow(/^config\.kit\.appDir should be a string, if specified$/);
 });
 
 test('errors on invalid nested values', () => {
-	assert.throws(() => {
-		validate_config({
+	expect(
+		// @ts-expect-error - given value expected to throw
+		validate_config(async () => ({
 			kit: {
 				files: {
-					// @ts-expect-error - given value expected to throw
-					potato: 'blah'
+					potato: 42
 				}
 			}
-		});
-	}, /^Unexpected option config\.kit\.files\.potato$/);
+		}))
+	).rejects.toThrow(/^Unexpected option config\.kit\.files\.potato$/);
 });
 
-test('does not error on invalid top-level values', () => {
-	assert.doesNotThrow(() => {
-		validate_config({
+test('does not error on invalid top-level values', async () => {
+	expect(
+		validate_config(async () => ({
 			onwarn: () => {}
-		});
-	});
+		}))
+	).resolves.not.toThrow();
 });
 
 test('errors on extension without leading .', () => {
-	assert.throws(() => {
-		validate_config({
+	expect(
+		validate_config(async () => ({
 			extensions: ['blah']
-		});
-	}, /Each member of config\.extensions must start with '\.' — saw 'blah'/);
+		}))
+	).rejects.toThrow(/Each member of config\.extensions must start with '\.' — saw 'blah'/);
 });
 
-test('fills in partial blanks', () => {
-	const validated = validate_config({
+test('fills in partial blanks', async () => {
+	const validated = await validate_config(async () => ({
 		kit: {
 			files: {
 				assets: 'public'
@@ -186,7 +186,7 @@ test('fills in partial blanks', () => {
 				name: '0'
 			}
 		}
-	});
+	}));
 
 	assert.equal(validated.kit.serviceWorker.files(''), true);
 
@@ -200,106 +200,122 @@ test('fills in partial blanks', () => {
 });
 
 test('fails if kit.appDir is blank', () => {
-	assert.throws(() => {
-		validate_config({
+	expect(
+		validate_config(async () => ({
 			kit: {
 				appDir: ''
 			}
-		});
-	}, /^config\.kit\.appDir cannot be empty$/);
+		}))
+	).rejects.toThrow(/^config\.kit\.appDir cannot be empty$/);
 });
 
 test('fails if kit.appDir is only slash', () => {
-	assert.throws(() => {
-		validate_config({
+	expect(
+		validate_config(async () => ({
 			kit: {
 				appDir: '/'
 			}
-		});
-	}, /^config\.kit\.appDir cannot start or end with '\/'. See https:\/\/svelte\.dev\/docs\/kit\/configuration$/);
+		}))
+	).rejects.toThrow(
+		/^config\.kit\.appDir cannot start or end with '\/'. See https:\/\/svelte\.dev\/docs\/kit\/configuration$/
+	);
 });
 
 test('fails if kit.appDir starts with slash', () => {
-	assert.throws(() => {
-		validate_config({
+	expect(
+		validate_config(async () => ({
 			kit: {
 				appDir: '/_app'
 			}
-		});
-	}, /^config\.kit\.appDir cannot start or end with '\/'. See https:\/\/svelte\.dev\/docs\/kit\/configuration$/);
+		}))
+	).rejects.toThrow(
+		/^config\.kit\.appDir cannot start or end with '\/'. See https:\/\/svelte\.dev\/docs\/kit\/configuration$/
+	);
 });
 
 test('fails if kit.appDir ends with slash', () => {
-	assert.throws(() => {
-		validate_config({
+	expect(
+		validate_config(async () => ({
 			kit: {
 				appDir: '_app/'
 			}
-		});
-	}, /^config\.kit\.appDir cannot start or end with '\/'. See https:\/\/svelte\.dev\/docs\/kit\/configuration$/);
+		}))
+	).rejects.toThrow(
+		/^config\.kit\.appDir cannot start or end with '\/'. See https:\/\/svelte\.dev\/docs\/kit\/configuration$/
+	);
 });
 
 test('fails if paths.base is not root-relative', () => {
-	assert.throws(() => {
-		validate_config({
+	expect(
+		// @ts-expect-error
+		validate_config(async () => ({
 			kit: {
 				paths: {
-					// @ts-expect-error
 					base: 'https://example.com/somewhere/else'
 				}
 			}
-		});
-	}, /^config\.kit\.paths\.base option must either be the empty string or a root-relative path that starts but doesn't end with '\/'. See https:\/\/svelte\.dev\/docs\/kit\/configuration#paths$/);
+		}))
+	).rejects.toThrow(
+		/^config\.kit\.paths\.base option must either be the empty string or a root-relative path that starts but doesn't end with '\/'. See https:\/\/svelte\.dev\/docs\/kit\/configuration#paths$/
+	);
 });
 
 test("fails if paths.base ends with '/'", () => {
-	assert.throws(() => {
-		validate_config({
+	expect(
+		validate_config(async () => ({
 			kit: {
 				paths: {
 					base: '/github-pages/'
 				}
 			}
-		});
-	}, /^config\.kit\.paths\.base option must either be the empty string or a root-relative path that starts but doesn't end with '\/'. See https:\/\/svelte\.dev\/docs\/kit\/configuration#paths$/);
+		}))
+	).rejects.toThrow(
+		/^config\.kit\.paths\.base option must either be the empty string or a root-relative path that starts but doesn't end with '\/'. See https:\/\/svelte\.dev\/docs\/kit\/configuration#paths$/
+	);
 });
 
 test('fails if paths.assets is relative', () => {
-	assert.throws(() => {
-		validate_config({
+	expect(
+		// @ts-expect-error
+		validate_config(async () => ({
 			kit: {
 				paths: {
-					// @ts-expect-error
 					assets: 'foo'
 				}
 			}
-		});
-	}, /^config\.kit\.paths\.assets option must be an absolute path, if specified. See https:\/\/svelte\.dev\/docs\/kit\/configuration#paths$/);
+		}))
+	).rejects.toThrow(
+		/^config\.kit\.paths\.assets option must be an absolute path, if specified. See https:\/\/svelte\.dev\/docs\/kit\/configuration#paths$/
+	);
 });
 
 test('fails if paths.assets has trailing slash', () => {
-	assert.throws(() => {
-		validate_config({
+	expect(
+		validate_config(async () => ({
 			kit: {
 				paths: {
 					assets: 'https://cdn.example.com/stuff/'
 				}
 			}
-		});
-	}, /^config\.kit\.paths\.assets option must not end with '\/'. See https:\/\/svelte\.dev\/docs\/kit\/configuration#paths$/);
+		}))
+	).rejects.toThrow(
+		/^config\.kit\.paths\.assets option must not end with '\/'. See https:\/\/svelte\.dev\/docs\/kit\/configuration#paths$/
+	);
 });
 
 test('fails if prerender.entries are invalid', () => {
-	assert.throws(() => {
-		validate_config({
+	expect(
+		// @ts-expect-error - given value expected to throw
+		validate_config(async () => ({
 			kit: {
 				prerender: {
-					// @ts-expect-error - given value expected to throw
 					entries: ['foo']
 				}
 			}
-		});
-	}, /^Each member of config\.kit.prerender.entries must be either '\*' or an absolute path beginning with '\/' — saw 'foo'$/);
+		}))
+	).rejects.toThrow(
+		/^Each member of config\.kit.prerender.entries must be either '\*' or an absolute path beginning with '\/' — saw 'foo'$/
+	);
 });
 
 /**
@@ -308,13 +324,15 @@ test('fails if prerender.entries are invalid', () => {
  * @param {import('@sveltejs/kit').KitConfig['paths']} output
  */
 function validate_paths(name, input, output) {
-	test(name, () => {
+	test(name, async () => {
 		expect(
-			validate_config({
-				kit: {
-					paths: input
-				}
-			}).kit.paths
+			(
+				await validate_config(async () => ({
+					kit: {
+						paths: input
+					}
+				}))
+			).kit.paths
 		).toEqual(output);
 	});
 }
@@ -405,5 +423,21 @@ test('errors on loading config with incorrect default export', async () => {
 	assert.equal(
 		message,
 		'The Svelte config file must have a configuration object as its default export. See https://svelte.dev/docs/kit/configuration'
+	);
+});
+
+test('errors on non-deterministic version name', async () => {
+	let message = null;
+
+	try {
+		const cwd = join(__dirname, 'fixtures', 'non-deterministic-version');
+		await load_config({ cwd });
+	} catch (/** @type {any} */ e) {
+		message = e.message;
+	}
+
+	assert.equal(
+		message,
+		'The `version.name` option must be deterministic (e.g. a commit ref rather than` Math.random()` or `Date.now().toString()`). See https://svelte.dev/docs/kit/configuration#version'
 	);
 });

--- a/packages/kit/src/core/sync/write_tsconfig.spec.js
+++ b/packages/kit/src/core/sync/write_tsconfig.spec.js
@@ -2,8 +2,8 @@ import { assert, expect, test } from 'vitest';
 import { validate_config } from '../config/index.js';
 import { get_tsconfig } from './write_tsconfig.js';
 
-test('Creates tsconfig path aliases from kit.alias', () => {
-	const { kit } = validate_config({
+test('Creates tsconfig path aliases from kit.alias', async () => {
+	const { kit } = await validate_config(async () => ({
 		kit: {
 			alias: {
 				simpleKey: 'simple/value',
@@ -13,7 +13,7 @@ test('Creates tsconfig path aliases from kit.alias', () => {
 				$routes: '.svelte-kit/types/src/routes'
 			}
 		}
-	});
+	}));
 
 	const { compilerOptions } = get_tsconfig(kit);
 
@@ -31,8 +31,8 @@ test('Creates tsconfig path aliases from kit.alias', () => {
 	});
 });
 
-test('Allows generated tsconfig to be mutated', () => {
-	const { kit } = validate_config({
+test('Allows generated tsconfig to be mutated', async () => {
+	const { kit } = await validate_config(async () => ({
 		kit: {
 			typescript: {
 				config: (config) => {
@@ -40,7 +40,7 @@ test('Allows generated tsconfig to be mutated', () => {
 				}
 			}
 		}
-	});
+	}));
 
 	const config = get_tsconfig(kit);
 
@@ -48,8 +48,8 @@ test('Allows generated tsconfig to be mutated', () => {
 	assert.equal(config.extends, 'some/other/tsconfig.json');
 });
 
-test('Allows generated tsconfig to be replaced', () => {
-	const { kit } = validate_config({
+test('Allows generated tsconfig to be replaced', async () => {
+	const { kit } = await validate_config(async () => ({
 		kit: {
 			typescript: {
 				config: (config) => ({
@@ -58,7 +58,7 @@ test('Allows generated tsconfig to be replaced', () => {
 				})
 			}
 		}
-	});
+	}));
 
 	const config = get_tsconfig(kit);
 
@@ -66,14 +66,14 @@ test('Allows generated tsconfig to be replaced', () => {
 	assert.equal(config.extends, 'some/other/tsconfig.json');
 });
 
-test('Creates tsconfig include from kit.files', () => {
-	const { kit } = validate_config({
+test('Creates tsconfig include from kit.files', async () => {
+	const { kit } = await validate_config(async () => ({
 		kit: {
 			files: {
 				lib: 'app'
 			}
 		}
-	});
+	}));
 
 	const { include } = get_tsconfig(kit);
 

--- a/packages/kit/src/exports/vite/utils.spec.js
+++ b/packages/kit/src/exports/vite/utils.spec.js
@@ -4,8 +4,8 @@ import { validate_config } from '../../core/config/index.js';
 import { posixify } from '../../utils/filesystem.js';
 import { get_config_aliases } from './utils.js';
 
-test('transform kit.alias to resolve.alias', () => {
-	const config = validate_config({
+test('transform kit.alias to resolve.alias', async () => {
+	const config = await validate_config(async () => ({
 		kit: {
 			alias: {
 				simpleKey: 'simple/value',
@@ -15,7 +15,7 @@ test('transform kit.alias to resolve.alias', () => {
 				'$regexChar/*': 'windows\\path\\*'
 			}
 		}
-	});
+	}));
 
 	const aliases = get_config_aliases(config.kit);
 


### PR DESCRIPTION
Related to https://github.com/gageracer/sudokusu/pull/6#issuecomment-3173666829

The issue of a non-deterministic version name became more noticeable since we started using the app hash in the client script in addition to the server. This PR validates that it's deterministic by loading the Svelte config twice and checking if the value is the same.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
