### PR TITLE
chore: allow remote functions in all of the src directory

### DIFF
--- a/.changeset/many-coins-lie.md
+++ b/.changeset/many-coins-lie.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: allow remote functions in all of the src directory

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -481,18 +481,14 @@ function create_remotes(config, cwd) {
 	const remotes = [];
 
 	// TODO could files live in other directories, including node_modules?
-	for (const dir of [config.kit.files.lib, config.kit.files.routes]) {
-		if (!fs.existsSync(dir)) continue;
+	for (const file of walk(config.kit.files.src)) {
+		if (extensions.some((ext) => file.endsWith(ext))) {
+			const posixified = posixify(path.relative(cwd, `${config.kit.files.src}/${file}`));
 
-		for (const file of walk(dir)) {
-			if (extensions.some((ext) => file.endsWith(ext))) {
-				const posixified = posixify(path.relative(cwd, `${dir}/${file}`));
-
-				remotes.push({
-					hash: hash(posixified),
-					file: posixified
-				});
-			}
+			remotes.push({
+				hash: hash(posixified),
+				file: posixified
+			});
 		}
 	}
 


### PR DESCRIPTION
uses the newly-added src option to our advantage. Helps with most of #14077, tbd on the node_modules stuff
