### PR TITLE
remove deprecated tag from `kit.files.src`

### DIFF
--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -425,7 +425,6 @@ export interface KitConfig {
 	files?: {
 		/**
 		 * the location of your source code
-		 * @deprecated
 		 * @default "src"
 		 * @since 2.28
 		 */


### PR DESCRIPTION
<!-- Your PR description here -->

In this [PR](https://github.com/sveltejs/kit/pull/14152) the kit.files.src option was added to the config, however it was also marked as `@deprecated`. I'm guessing this was a mistake since my understanding of the PR was that this was the new way of defining the src folder. 

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
