### PR TITLE
fix: don't exclude remote functions when deploying to Netlify edge functions

### DIFF
--- a/.changeset/dirty-rats-switch.md
+++ b/.changeset/dirty-rats-switch.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-netlify': patch
 ---
 
-fix: don't exclude remote functions when deploying to Netlify edge functions
+fix: include remote functions when deploying to Netlify edge functions

--- a/.changeset/dirty-rats-switch.md
+++ b/.changeset/dirty-rats-switch.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+fix: don't exclude remote functions when deploying to Netlify edge functions

--- a/packages/adapter-netlify/index.js
+++ b/packages/adapter-netlify/index.js
@@ -146,7 +146,8 @@ async function generate_edge_functions({ builder }) {
 	// Netlify will handle the optional trailing slash for us
 	const excluded = [
 		// Contains static files
-		`/${builder.getAppPath()}/*`,
+		`/${builder.getAppPath()}/immutable/*`,
+		`/${builder.getAppPath()}/version.json`,
 		...builder.prerendered.paths,
 		...Array.from(assets).flatMap((asset) => {
 			if (asset.endsWith('/index.html')) {


### PR DESCRIPTION
<!-- Your PR description here -->

Fixes https://github.com/sveltejs/kit/issues/14216 by making the `exludedFiles` pattern more restrictive since remote functions are sent at `/_app/remote/*`. This updated pattern is inline with other adapters like Cloudflare, so I don't anticipate issues:

https://github.com/sveltejs/kit/blob/233ea22e4e4676c7041d7e225c836c7dc8096c31/packages/adapter-cloudflare/index.js#L215

I've extended the reproduction repo to use the changes from this PR in: 
https://github.com/nickbreaton/svelte-kit-netlify-adapter-repro/compare/main...fix

The permalink for this deploy is available here, which does allow for the remote function to work:
https://689df1462120180008ab45f6--svelte-kit-netlify-adapter-repro.netlify.app/

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [-] Ideally, include a test that fails without this PR but passes with it.
   - I've not included this since it's a configuration change that would require an E2E with Netlify. Willing to add with some guidance!

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
