### PR TITLE
fix: handling of PROTOCOL_HEADER and HOST_HEADER env vars

### DIFF
--- a/.changeset/floppy-memes-warn.md
+++ b/.changeset/floppy-memes-warn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+fix: handling of PROTOCOL_HEADER and HOST_HEADER env vars

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -182,8 +182,8 @@ function sequence(handlers) {
  * @returns
  */
 function get_origin(headers) {
-	const protocol = (protocol_header && headers[protocol_header]) ?? 'https';
-	const host = (host_header && headers[host_header]) ?? headers['host'];
+	const protocol = (protocol_header && headers[protocol_header]) || 'https';
+	const host = (host_header && headers[host_header]) || headers['host'];
 	const port = port_header && headers[port_header];
 
 	return port ? `${protocol}://${host}:${port}` : `${protocol}://${host}`;


### PR DESCRIPTION
Fixes #14218, hopefully. This simply reverts the change from `??`s to `||`s. The values here being empty strings might indicate the environment variable not being set (in which case we definitely want to fall back to the default values) or it might indicate the env var being set and the header being set but to an empty value (in which case, it would be more helpful to also fall back to the default values). Using `??` over `||` is generally a worthwhile endeavor for more strict correctness, but not in this case.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
