### PR TITLE
fix: pass options to resolve in resolveId hook

### DIFF
--- a/.changeset/shy-cooks-pay.md
+++ b/.changeset/shy-cooks-pay.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+fix: pass options to resolve in resolveId hook

--- a/.changeset/shy-cooks-pay.md
+++ b/.changeset/shy-cooks-pay.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/kit': minor
+'@sveltejs/kit': patch
 ---
 
 fix: pass options to resolve in resolveId hook

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -550,9 +550,9 @@ async function kit({ svelte_config }) {
 		// are added to the module graph
 		enforce: 'pre',
 
-		async resolveId(id, importer) {
+		async resolveId(id, importer, options) {
 			if (importer && !importer.endsWith('index.html')) {
-				const resolved = await this.resolve(id, importer, { skipSelf: true });
+				const resolved = await this.resolve(id, importer, { ...options, skipSelf: true });
 
 				if (resolved) {
 					const normalized = normalize_id(resolved.id, normalized_lib, normalized_cwd);


### PR DESCRIPTION
I had the same issue mentioned in https://github.com/sveltejs/kit/issues/14217.

According to the warning message and the Rollup plugin development docs:
- https://rollupjs.org/plugin-development/#this-resolve
- https://rollupjs.org/plugin-development/#resolveid

The `resolveId` hook should forward the third `options` parameter to `this.resolve`.  (as stated in the warning):
```
[plugin commonjs--resolver] It appears a plugin has implemented a "resolveId" hook that uses "this.resolve" without forwarding the third "options" parameter of "resolveId". This is problematic as it can lead to wrong module resolutions especially for the node-resolve plugin and in certain cases cause early exit errors for the commonjs plugin.
In rare cases, this warning can appear if the same file is both imported and required from the same mixed ES/CommonJS module, in which case it can be ignored.
```

I updated the `this.resolve` call to include the `options` argument from `resolveId` to ensure correct module resolution and remove the warning.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
