### PR TITLE
fix: better error when `.remote.ts` files are used without the `experimental.remoteFunctions` flag

### DIFF
--- a/.changeset/kind-parents-melt.md
+++ b/.changeset/kind-parents-melt.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: better error when `.remote.ts` files are used without the `experimental.remoteFunctions` flag

--- a/packages/kit/src/exports/vite/utils.js
+++ b/packages/kit/src/exports/vite/utils.js
@@ -210,9 +210,7 @@ export function error_for_missing_config(feature_name, path, value) {
 		dedent`\
 			To enable ${feature_name}, add the following to your \`svelte.config.js\`:
 
-			\`\`\`js
 			${result}
-			\`\`\`
 		`
 	);
 }

--- a/packages/kit/src/exports/vite/utils.js
+++ b/packages/kit/src/exports/vite/utils.js
@@ -206,9 +206,9 @@ export function error_for_missing_config(feature_name, path, value) {
 		return acc.replace(hole, `${indent}${part}: ${rhs}`);
 	}, hole);
 
-	throw new Error(
+	throw stackless(
 		dedent`\
-			To enable \`${feature_name}\`, add the following to your \`svelte.config.js\`:
+			To enable ${feature_name}, add the following to your \`svelte.config.js\`:
 
 			\`\`\`js
 			${result}

--- a/packages/kit/src/exports/vite/utils.spec.js
+++ b/packages/kit/src/exports/vite/utils.spec.js
@@ -42,7 +42,7 @@ test('transform kit.alias to resolve.alias', () => {
 test('error_for_missing_config - simple single level config', () => {
 	expect(() => error_for_missing_config('feature', 'kit.adapter', 'true')).toThrow(
 		dedent`
-			To enable \`feature\`, add the following to your \`svelte.config.js\`:
+			To enable feature, add the following to your \`svelte.config.js\`:
 
 			\`\`\`js
 			kit: {
@@ -62,7 +62,7 @@ test('error_for_missing_config - nested config', () => {
 		)
 	).toThrow(
 		dedent`
-			To enable \`instrumentation.server.js\`, add the following to your \`svelte.config.js\`:
+			To enable instrumentation.server.js, add the following to your \`svelte.config.js\`:
 
 			\`\`\`js
 			kit: {
@@ -80,7 +80,7 @@ test('error_for_missing_config - nested config', () => {
 test('error_for_missing_config - deeply nested config', () => {
 	expect(() => error_for_missing_config('deep feature', 'a.b.c.d.e', '"value"')).toThrow(
 		dedent`
-			To enable \`deep feature\`, add the following to your \`svelte.config.js\`:
+			To enable deep feature, add the following to your \`svelte.config.js\`:
 
 			\`\`\`js
 			a: {
@@ -100,7 +100,7 @@ test('error_for_missing_config - deeply nested config', () => {
 test('error_for_missing_config - two level config', () => {
 	expect(() => error_for_missing_config('some feature', 'kit.someFeature', 'false')).toThrow(
 		dedent`
-			To enable \`some feature\`, add the following to your \`svelte.config.js\`:
+			To enable some feature, add the following to your \`svelte.config.js\`:
 
 			\`\`\`js
 			kit: {
@@ -116,7 +116,7 @@ test('error_for_missing_config - handles special characters in feature name', ()
 		error_for_missing_config('special-feature.js', 'kit.special', '{ enabled: true }')
 	).toThrow(
 		dedent`
-			To enable \`special-feature.js\`, add the following to your \`svelte.config.js\`:
+			To enable special-feature.js, add the following to your \`svelte.config.js\`:
 
 			\`\`\`js
 			kit: {

--- a/packages/kit/src/exports/vite/utils.spec.js
+++ b/packages/kit/src/exports/vite/utils.spec.js
@@ -44,11 +44,9 @@ test('error_for_missing_config - simple single level config', () => {
 		dedent`
 			To enable feature, add the following to your \`svelte.config.js\`:
 
-			\`\`\`js
 			kit: {
 			  adapter: true
 			}
-			\`\`\`
 		`
 	);
 });
@@ -64,7 +62,6 @@ test('error_for_missing_config - nested config', () => {
 		dedent`
 			To enable instrumentation.server.js, add the following to your \`svelte.config.js\`:
 
-			\`\`\`js
 			kit: {
 			  experimental: {
 			    instrumentation: {
@@ -72,7 +69,6 @@ test('error_for_missing_config - nested config', () => {
 			    }
 			  }
 			}
-			\`\`\`
 		`
 	);
 });
@@ -82,7 +78,6 @@ test('error_for_missing_config - deeply nested config', () => {
 		dedent`
 			To enable deep feature, add the following to your \`svelte.config.js\`:
 
-			\`\`\`js
 			a: {
 			  b: {
 			    c: {
@@ -92,7 +87,6 @@ test('error_for_missing_config - deeply nested config', () => {
 			    }
 			  }
 			}
-			\`\`\`
 		`
 	);
 });
@@ -102,11 +96,9 @@ test('error_for_missing_config - two level config', () => {
 		dedent`
 			To enable some feature, add the following to your \`svelte.config.js\`:
 
-			\`\`\`js
 			kit: {
 			  someFeature: false
 			}
-			\`\`\`
 		`
 	);
 });
@@ -118,11 +110,9 @@ test('error_for_missing_config - handles special characters in feature name', ()
 		dedent`
 			To enable special-feature.js, add the following to your \`svelte.config.js\`:
 
-			\`\`\`js
 			kit: {
 			  special: { enabled: true }
 			}
-			\`\`\`
 		`
 	);
 });

--- a/packages/kit/src/runtime/app/server/remote/command.js
+++ b/packages/kit/src/runtime/app/server/remote/command.js
@@ -2,7 +2,7 @@
 /** @import { RemoteInfo, MaybePromise } from 'types' */
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 import { get_request_store } from '@sveltejs/kit/internal';
-import { check_experimental, create_validator, run_remote_function } from './shared.js';
+import { create_validator, run_remote_function } from './shared.js';
 
 /**
  * Creates a remote command. When called from the browser, the function will be invoked on the server via a `fetch` call.
@@ -51,8 +51,6 @@ import { check_experimental, create_validator, run_remote_function } from './sha
  */
 /*@__NO_SIDE_EFFECTS__*/
 export function command(validate_or_fn, maybe_fn) {
-	check_experimental('command');
-
 	/** @type {(arg?: Input) => Output} */
 	const fn = maybe_fn ?? validate_or_fn;
 

--- a/packages/kit/src/runtime/app/server/remote/form.js
+++ b/packages/kit/src/runtime/app/server/remote/form.js
@@ -1,7 +1,7 @@
 /** @import { RemoteForm } from '@sveltejs/kit' */
 /** @import { RemoteInfo, MaybePromise } from 'types' */
 import { get_request_store } from '@sveltejs/kit/internal';
-import { check_experimental, run_remote_function } from './shared.js';
+import { run_remote_function } from './shared.js';
 
 /**
  * Creates a form object that can be spread onto a `<form>` element.
@@ -16,8 +16,6 @@ import { check_experimental, run_remote_function } from './shared.js';
 /*@__NO_SIDE_EFFECTS__*/
 // @ts-ignore we don't want to prefix `fn` with an underscore, as that will be user-visible
 export function form(fn) {
-	check_experimental('form');
-
 	/**
 	 * @param {string | number | boolean} [key]
 	 */

--- a/packages/kit/src/runtime/app/server/remote/prerender.js
+++ b/packages/kit/src/runtime/app/server/remote/prerender.js
@@ -7,7 +7,6 @@ import { get_request_store } from '@sveltejs/kit/internal';
 import { create_remote_cache_key, stringify, stringify_remote_arg } from '../../../shared.js';
 import { app_dir, base } from '__sveltekit/paths';
 import {
-	check_experimental,
 	create_validator,
 	get_response,
 	parse_remote_response,
@@ -65,8 +64,6 @@ import {
  */
 /*@__NO_SIDE_EFFECTS__*/
 export function prerender(validate_or_fn, fn_or_options, maybe_options) {
-	check_experimental('prerender');
-
 	const maybe_fn = typeof fn_or_options === 'function' ? fn_or_options : undefined;
 
 	/** @type {typeof maybe_options} */

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -4,12 +4,7 @@
 import { get_request_store } from '@sveltejs/kit/internal';
 import { create_remote_cache_key, stringify_remote_arg } from '../../../shared.js';
 import { prerendering } from '__sveltekit/environment';
-import {
-	check_experimental,
-	create_validator,
-	get_response,
-	run_remote_function
-} from './shared.js';
+import { create_validator, get_response, run_remote_function } from './shared.js';
 
 /**
  * Creates a remote query. When called from the browser, the function will be invoked on the server via a `fetch` call.
@@ -58,8 +53,6 @@ import {
  */
 /*@__NO_SIDE_EFFECTS__*/
 export function query(validate_or_fn, maybe_fn) {
-	check_experimental('query');
-
 	/** @type {(arg?: Input) => Output} */
 	const fn = maybe_fn ?? validate_or_fn;
 

--- a/packages/kit/src/runtime/app/server/remote/shared.js
+++ b/packages/kit/src/runtime/app/server/remote/shared.js
@@ -74,15 +74,6 @@ export function get_response(id, arg, state, get_result) {
 	return ((state.remote_data ??= {})[cache_key] ??= get_result());
 }
 
-/** @param {string} feature */
-export function check_experimental(feature) {
-	if (!__SVELTEKIT_EXPERIMENTAL__REMOTE_FUNCTIONS__) {
-		throw new Error(
-			`Cannot use \`${feature}\` from \`$app/server\` without the experimental flag set to true. Please set kit.experimental.remoteFunctions to \`true\` in your config.`
-		);
-	}
-}
-
 /**
  * @param {any} data
  * @param {ServerHooks['transport']} transport


### PR DESCRIPTION
closes #14111

## before

<img width="1006" height="425" alt="image" src="https://github.com/user-attachments/assets/a35a2683-38be-45ed-b2e5-48c85949bbd9" />

## after

<img width="1007" height="357" alt="image" src="https://github.com/user-attachments/assets/1981fbf7-020e-454f-9f7d-6bb1833599f5" />

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
