### PR TITLE
chore: remove skipLibCheck

### DIFF
--- a/packages/adapter-auto/tsconfig.json
+++ b/packages/adapter-auto/tsconfig.json
@@ -7,8 +7,7 @@
 		"target": "es2022",
 		"module": "node16",
 		"moduleResolution": "node16",
-		"baseUrl": ".",
-		"skipLibCheck": true
+		"baseUrl": "."
 	},
 	"include": ["**/*.js"]
 }

--- a/packages/adapter-node/tsconfig.json
+++ b/packages/adapter-node/tsconfig.json
@@ -11,8 +11,7 @@
 		"baseUrl": ".",
 		"paths": {
 			"@sveltejs/kit": ["../kit/types/index"]
-		},
-		"skipLibCheck": true
+		}
 	},
 	"include": ["index.js", "src/**/*.js", "tests/**/*.js", "internal.d.ts", "utils.js"],
 	"exclude": ["tests/smoke.spec_disabled.js"]

--- a/packages/adapter-static/tsconfig.json
+++ b/packages/adapter-static/tsconfig.json
@@ -11,8 +11,7 @@
 		"baseUrl": ".",
 		"paths": {
 			"@sveltejs/kit": ["../kit/types/index"]
-		},
-		"skipLibCheck": true
+		}
 	},
 	"include": ["index.js", "test/utils.js"]
 }

--- a/packages/adapter-vercel/tsconfig.json
+++ b/packages/adapter-vercel/tsconfig.json
@@ -12,8 +12,7 @@
 		"baseUrl": ".",
 		"paths": {
 			"@sveltejs/kit": ["../kit/types/index"]
-		},
-		"skipLibCheck": true
+		}
 	},
 	"include": ["*.js", "files/**/*.js", "internal.d.ts", "test/**/*.js"]
 }


### PR DESCRIPTION
we added `skipLibCheck` in #13864; as of #14207 they should be unnecessary