### PR TITLE
docs: expand on async Svelte in Remote Functions

### DIFF
--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -73,21 +73,9 @@ The query returned from `getPosts` works as a [`Promise`](https://developer.mozi
 
 <h1>Recent posts</h1>
 
-<svelte:boundary>
-	<ul>
-		{#each await getPosts() as { title, slug }}
-			<li><a href="/blog/{slug}">{title}</a></li>
-		{/each}
-	</ul>
-
-	{#snippet pending()}
-		<p>loading...</p>
-	{/snippet}
-
-	{#snippet failed()}
-		<p>oops!</p>
-	{/snippet}
-</svelte:boundary>
+{#each await getPosts() as { title, slug }}
+	<li><a href="/blog/{slug}">{title}</a></li>
+{/each}
 ```
 
 Until the promise resolves, the nearest [`<svelte:boundary>`](../svelte/svelte-boundary) will be invoked, and its `pending` snippet will be rendered. If it errors, the `failed` snippet will be rendered instead.

--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -73,9 +73,11 @@ The query returned from `getPosts` works as a [`Promise`](https://developer.mozi
 
 <h1>Recent posts</h1>
 
-{#each await getPosts() as { title, slug }}
-	<li><a href="/blog/{slug}">{title}</a></li>
-{/each}
+<ul>
+	{#each await getPosts() as { title, slug }}
+		<li><a href="/blog/{slug}">{title}</a></li>
+	{/each}
+</ul>
 ```
 
 Until the promise resolves — and if it errors — the nearest [`<svelte:boundary>`](../svelte/svelte-boundary) will be invoked.

--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -10,7 +10,7 @@ Remote functions are a tool for type-safe communication between client and serve
 
 Combined with Svelte's experimental support for [`await`](/docs/svelte/await-expressions), it allows you to load and manipulate data directly inside your components.
 
-This feature is currently experimental, meaning it is likely to contain bugs and is subject to change without notice. You must opt in by adding the `kit.experimental.remoteFunctions` option in your `svelte.config.js` and optionally, the `compilerOptions.experimental.async` option to use `await`.
+This feature is currently experimental, meaning it is likely to contain bugs and is subject to change without notice. You must opt in by adding the `kit.experimental.remoteFunctions` option in your `svelte.config.js` and optionally, the `compilerOptions.experimental.async` option to use `await`:
 
 ```js
 /// file: svelte.config.js

--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -78,7 +78,7 @@ The query returned from `getPosts` works as a [`Promise`](https://developer.mozi
 {/each}
 ```
 
-Until the promise resolves, the nearest [`<svelte:boundary>`](../svelte/svelte-boundary) will be invoked, and its `pending` snippet will be rendered. If it errors, the `failed` snippet will be rendered instead.
+Until the promise resolves — and if it errors — the nearest [`<svelte:boundary>`](../svelte/svelte-boundary) will be invoked.
 
 While using `await` is recommended, as an alternative the query also has `loading`, `error` and `current` properties:
 

--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -10,7 +10,7 @@ Remote functions are a tool for type-safe communication between client and serve
 
 Combined with Svelte's experimental support for [`await`](/docs/svelte/await-expressions), it allows you to load and manipulate data directly inside your components.
 
-This feature is currently experimental, meaning it is likely to contain bugs and is subject to change without notice. You must opt in by adding the `kit.experimental.remoteFunctions` option in your `svelte.config.js` and optionally, the `compilerOptions.experimental.async` option to use `await`:
+This feature is currently experimental, meaning it is likely to contain bugs and is subject to change without notice. You must opt in by adding the `kit.experimental.remoteFunctions` option in your `svelte.config.js` and optionally, the `compilerOptions.experimental.async` option to use `await` in components:
 
 ```js
 /// file: svelte.config.js

--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -10,7 +10,7 @@ Remote functions are a tool for type-safe communication between client and serve
 
 Combined with Svelte's experimental support for [`await`](/docs/svelte/await-expressions), it allows you to load and manipulate data directly inside your components.
 
-This feature is currently experimental, meaning it is likely to contain bugs and is subject to change without notice. You must opt in by adding the `kit.experimental.remoteFunctions` option in your `svelte.config.js`:
+This feature is currently experimental, meaning it is likely to contain bugs and is subject to change without notice. You must opt in by adding the `kit.experimental.remoteFunctions` option in your `svelte.config.js` and optionally, the `compilerOptions.experimental.async` option to use `await`.
 
 ```js
 /// file: svelte.config.js
@@ -18,6 +18,11 @@ export default {
 	kit: {
 		experimental: {
 			+++remoteFunctions: true+++
+		}
+	},
+	compilerOptions: {
+		experimental: {
+			+++async: true+++
 		}
 	}
 };
@@ -68,14 +73,24 @@ The query returned from `getPosts` works as a [`Promise`](https://developer.mozi
 
 <h1>Recent posts</h1>
 
-<ul>
-	{#each await getPosts() as { title, slug }}
-		<li><a href="/blog/{slug}">{title}</a></li>
-	{/each}
-</ul>
+<svelte:boundary>
+	<ul>
+		{#each await getPosts() as { title, slug }}
+			<li><a href="/blog/{slug}">{title}</a></li>
+		{/each}
+	</ul>
+
+	{#snippet pending()}
+		<p>loading...</p>
+	{/snippet}
+
+	{#snippet failed()}
+		<p>oops!</p>
+	{/snippet}
+</svelte:boundary>
 ```
 
-Until the promise resolves — and if it errors — the nearest [`<svelte:boundary>`](../svelte/svelte-boundary) will be invoked.
+Until the promise resolves, the nearest [`<svelte:boundary>`](../svelte/svelte-boundary) will be invoked, and its `pending` snippet will be rendered. If it errors, the `failed` snippet will be rendered instead.
 
 While using `await` is recommended, as an alternative the query also has `loading`, `error` and `current` properties:
 
@@ -86,6 +101,8 @@ While using `await` is recommended, as an alternative the query also has `loadin
 
 	const query = getPosts();
 </script>
+
+<h1>Recent posts</h1>
 
 {#if query.error}
 	<p>oops!</p>


### PR DESCRIPTION
This PR mentions the async config option ~and the pending and failed snippet~. These are essential to add/enable especially when the doc examples all use `await`.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
