### PR TITLE
fix(perf): correctly apply id filter in enhanced:img

### DIFF
--- a/.changeset/many-items-greet.md
+++ b/.changeset/many-items-greet.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/enhanced-img': patch
+---
+
+fix(perf): correctly apply id filter from vite-plugin-svelte

--- a/packages/enhanced-img/src/vite-plugin.js
+++ b/packages/enhanced-img/src/vite-plugin.js
@@ -39,7 +39,7 @@ export function image_plugin(imagetools_plugin) {
 				);
 			}
 			// @ts-expect-error plugin.transform is defined below before configResolved is called
-			plugin.transform.filter.id = svelteConfigPlugin.api.idFilter;
+			plugin.transform.filter.id = svelteConfigPlugin.api.idFilter.id;
 		},
 		transform: {
 			order: 'pre', // puts it before vite-plugin-svelte:compile


### PR DESCRIPTION
Without this change, no id filter is active in enhanced-img, leading to all files being checked with the code regex.
If a file that isn't a svelte file contains `<enhanced:img` this can cause build errors too (discovered during dependency update in svelte.dev repo)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
