### PR TITLE
fix: correct type names for new `handleUnseenRoutes` option

### DIFF
--- a/.changeset/shiny-jobs-wear.md
+++ b/.changeset/shiny-jobs-wear.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correct type names for new `handleUnseenRoutes` option

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -12,7 +12,7 @@ import {
 	PrerenderEntryGeneratorMismatchHandlerValue,
 	PrerenderHttpErrorHandlerValue,
 	PrerenderMissingIdHandlerValue,
-	PrerenderMissingRoutesHandlerValue,
+	PrerenderUnseenRoutesHandlerValue,
 	PrerenderOption,
 	RequestOptions,
 	RouteSegment
@@ -755,7 +755,7 @@ export interface KitConfig {
 		 * @default "fail"
 		 * @since 2.16.0
 		 */
-		handleUnseenRoutes?: PrerenderMissingRoutesHandlerValue;
+		handleUnseenRoutes?: PrerenderUnseenRoutesHandlerValue;
 		/**
 		 * The value of `url.origin` during prerendering; useful if it is included in rendered content.
 		 * @default "http://sveltekit-prerender"

--- a/packages/kit/src/types/private.d.ts
+++ b/packages/kit/src/types/private.d.ts
@@ -208,17 +208,17 @@ export interface PrerenderEntryGeneratorMismatchHandler {
 	(details: { generatedFromId: string; entry: string; matchedId: string; message: string }): void;
 }
 
-export interface PrerenderEntryMissingRoutesHandler {
+export interface PrerenderUnseenRoutesHandler {
 	(details: { routes: string[]; message: string }): void;
 }
 
 export type PrerenderHttpErrorHandlerValue = 'fail' | 'warn' | 'ignore' | PrerenderHttpErrorHandler;
 export type PrerenderMissingIdHandlerValue = 'fail' | 'warn' | 'ignore' | PrerenderMissingIdHandler;
-export type PrerenderMissingRoutesHandlerValue =
+export type PrerenderUnseenRoutesHandlerValue =
 	| 'fail'
 	| 'warn'
 	| 'ignore'
-	| PrerenderEntryMissingRoutesHandler;
+	| PrerenderUnseenRoutesHandler;
 export type PrerenderEntryGeneratorMismatchHandlerValue =
 	| 'fail'
 	| 'warn'

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -731,7 +731,7 @@ declare module '@sveltejs/kit' {
 			 * @default "fail"
 			 * @since 2.16.0
 			 */
-			handleUnseenRoutes?: PrerenderMissingRoutesHandlerValue;
+			handleUnseenRoutes?: PrerenderUnseenRoutesHandlerValue;
 			/**
 			 * The value of `url.origin` during prerendering; useful if it is included in rendered content.
 			 * @default "http://sveltekit-prerender"
@@ -2011,17 +2011,17 @@ declare module '@sveltejs/kit' {
 		(details: { generatedFromId: string; entry: string; matchedId: string; message: string }): void;
 	}
 
-	interface PrerenderEntryMissingRoutesHandler {
+	interface PrerenderUnseenRoutesHandler {
 		(details: { routes: string[]; message: string }): void;
 	}
 
 	type PrerenderHttpErrorHandlerValue = 'fail' | 'warn' | 'ignore' | PrerenderHttpErrorHandler;
 	type PrerenderMissingIdHandlerValue = 'fail' | 'warn' | 'ignore' | PrerenderMissingIdHandler;
-	type PrerenderMissingRoutesHandlerValue =
+	type PrerenderUnseenRoutesHandlerValue =
 		| 'fail'
 		| 'warn'
 		| 'ignore'
-		| PrerenderEntryMissingRoutesHandler;
+		| PrerenderUnseenRoutesHandler;
 	type PrerenderEntryGeneratorMismatchHandlerValue =
 		| 'fail'
 		| 'warn'


### PR DESCRIPTION
quick follow-up to #11702 (luckily that wasn't released yet so this isn't breaking)