### PR TITLE
fix: deserialise streamed custom types

### DIFF
--- a/.changeset/brown-seals-rhyme.md
+++ b/.changeset/brown-seals-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly decode custom types streamed from a server load function

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -33,7 +33,7 @@ export function deserialize(result) {
 
 	if (parsed.data) {
 		// the decoders should never be initialised at the top-level because `app`
-		// will not initialised yet if `kit.output.bundleStrategy` is 'single' or 'inline'
+		// will not be initialised yet if `kit.output.bundleStrategy` is 'single' or 'inline'
 		parsed.data = devalue.parse(parsed.data, BROWSER ? client_app.decoders : server_app.decoders);
 	}
 

--- a/packages/kit/src/runtime/client/bundle.js
+++ b/packages/kit/src/runtime/client/bundle.js
@@ -13,3 +13,5 @@ import * as app from '__sveltekit/manifest';
 export function start(element, options) {
 	void kit.start(app, element, options);
 }
+
+export { app };

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -675,11 +675,11 @@ function get_data(event, event_state, options, nodes, csp, global, client, prefi
 						if (!client.inline && str.includes("app.decode('")) {
 							if (client.app) {
 								push(
-									`<script${nonce}>import(${prefixed(client.app)}).then((app)=>{${code}})</script>\n`
+									`<script${nonce}>import(${s(prefixed(client.app))}).then((app)=>{${code}})</script>\n`
 								);
 							} else {
 								push(
-									`<script${nonce}>import(${prefixed(client.start)}).then(({app})=>{${code}})</script>\n`
+									`<script${nonce}>import(${s(prefixed(client.start))}).then(({app})=>{${code}})</script>\n`
 								);
 							}
 						} else {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -680,7 +680,7 @@ function get_data(event, event_state, options, nodes, csp, global) {
 								new Error(`Failed to serialize promise while rendering ${event.route.id}`)
 							);
 							data = undefined;
-							str = devalue.uneval([null, error], replacer);
+							str = devalue.uneval([, error], replacer);
 						}
 
 						const nonce = csp.script_needs_nonce ? ` nonce="${csp.nonce}"` : '';

--- a/packages/kit/test/apps/basics/src/routes/serialization-stream/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/serialization-stream/+page.server.js
@@ -2,6 +2,6 @@ import { Foo } from '$lib';
 
 export const load = () => {
 	return {
-		foo: Promise.resolve(new Foo("It works"))
+		foo: Promise.resolve(new Foo('It works'))
 	};
 };

--- a/packages/kit/test/apps/basics/src/routes/serialization-stream/+page.server.ts
+++ b/packages/kit/test/apps/basics/src/routes/serialization-stream/+page.server.ts
@@ -1,0 +1,7 @@
+import { Foo } from '$lib';
+
+export const load = () => {
+	return {
+		foo: Promise.resolve(new Foo("It works"))
+	};
+};

--- a/packages/kit/test/apps/basics/src/routes/serialization-stream/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/serialization-stream/+page.svelte
@@ -1,0 +1,11 @@
+<script>
+	export let data;
+</script>
+
+<h1>
+	{#await data.foo}
+		Loading...
+	{:then result}
+		{result.bar()}
+	{/await}
+</h1>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1560,6 +1560,13 @@ test.describe('Serialization', () => {
 		await page.click('button');
 		await expect(page.locator('h1')).toHaveText('It works!');
 	});
+
+	test('works with streaming', async ({ page, javaScriptEnabled }) => {
+		test.skip(!javaScriptEnabled, 'skip when JavaScript is disabled');
+
+		await page.goto('/serialization-stream');
+		await expect(page.locator('h1', { hasText: 'It works!'})).toBeVisible();
+	});
 });
 
 test.describe('getRequestEvent', () => {

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1565,7 +1565,7 @@ test.describe('Serialization', () => {
 		test.skip(!javaScriptEnabled, 'skip when JavaScript is disabled');
 
 		await page.goto('/serialization-stream');
-		await expect(page.locator('h1', { hasText: 'It works!'})).toBeVisible();
+		await expect(page.locator('h1', { hasText: 'It works!' })).toBeVisible();
 	});
 });
 

--- a/packages/kit/test/apps/options-2/src/hooks.js
+++ b/packages/kit/test/apps/options-2/src/hooks.js
@@ -1,0 +1,9 @@
+import { Foo } from "$lib";
+
+/** @type {import("@sveltejs/kit").Transport} */
+export const transport = {
+	Foo: {
+		encode: (value) => value instanceof Foo && [value.message],
+		decode: ([message]) => new Foo(message)
+	}
+};

--- a/packages/kit/test/apps/options-2/src/hooks.js
+++ b/packages/kit/test/apps/options-2/src/hooks.js
@@ -1,4 +1,4 @@
-import { Foo } from "$lib";
+import { Foo } from '$lib';
 
 /** @type {import("@sveltejs/kit").Transport} */
 export const transport = {

--- a/packages/kit/test/apps/options-2/src/lib/index.js
+++ b/packages/kit/test/apps/options-2/src/lib/index.js
@@ -1,0 +1,9 @@
+export class Foo {
+	constructor(message) {
+		this.message = message;
+	}
+
+	bar() {
+		return this.message + '!';
+	}
+}

--- a/packages/kit/test/apps/options-2/src/routes/serialization-stream/+page.server.js
+++ b/packages/kit/test/apps/options-2/src/routes/serialization-stream/+page.server.js
@@ -1,0 +1,7 @@
+import { Foo } from '$lib';
+
+export const load = () => {
+	return {
+		foo: Promise.resolve(new Foo('It works'))
+	};
+};

--- a/packages/kit/test/apps/options-2/src/routes/serialization-stream/+page.svelte
+++ b/packages/kit/test/apps/options-2/src/routes/serialization-stream/+page.svelte
@@ -1,0 +1,11 @@
+<script>
+	export let data;
+</script>
+
+<h1>
+	{#await data.foo}
+		Loading...
+	{:then result}
+		{result.bar()}
+	{/await}
+</h1>

--- a/packages/kit/test/apps/options-2/test/test.js
+++ b/packages/kit/test/apps/options-2/test/test.js
@@ -190,4 +190,9 @@ test.describe("bundleStrategy: 'single'", () => {
 		await page.goto('/basepath/deserialize');
 		await expect(page.locator('p')).toHaveText('Hello world!');
 	});
+
+	test('serialization works with streaming', async ({ page }) => {
+		await page.goto('/basepath/serialization-stream');
+		await expect(page.locator('h1', { hasText: 'It works!' })).toBeVisible();
+	});
 });

--- a/packages/kit/test/apps/options-3/package.json
+++ b/packages/kit/test/apps/options-3/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "test-options-3",
+	"private": true,
+	"version": "0.0.1",
+	"scripts": {
+		"dev": "vite dev",
+		"build": "vite build",
+		"preview": "vite preview",
+		"prepare": "svelte-kit sync",
+		"check": "svelte-kit sync && tsc && svelte-check",
+		"test": "playwright test"
+	},
+	"devDependencies": {
+		"@sveltejs/adapter-node": "workspace:^",
+		"@sveltejs/kit": "workspace:^",
+		"@sveltejs/vite-plugin-svelte": "catalog:",
+		"svelte": "^5.35.5",
+		"svelte-check": "^4.1.1",
+		"typescript": "^5.5.4",
+		"vite": "catalog:"
+	},
+	"type": "module"
+}

--- a/packages/kit/test/apps/options-3/playwright.config.js
+++ b/packages/kit/test/apps/options-3/playwright.config.js
@@ -1,0 +1,1 @@
+export { config as default } from '../../utils.js';

--- a/packages/kit/test/apps/options-3/src/app.html
+++ b/packages/kit/test/apps/options-3/src/app.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%sveltekit.head%
+	</head>
+	<body>
+		<div style="display: contents">%sveltekit.body%</div>
+	</body>
+</html>

--- a/packages/kit/test/apps/options-3/src/hooks.js
+++ b/packages/kit/test/apps/options-3/src/hooks.js
@@ -1,0 +1,9 @@
+import { Foo } from "$lib";
+
+/** @type {import("@sveltejs/kit").Transport} */
+export const transport = {
+	Foo: {
+		encode: (value) => value instanceof Foo && [value.message],
+		decode: ([message]) => new Foo(message)
+	}
+};

--- a/packages/kit/test/apps/options-3/src/hooks.js
+++ b/packages/kit/test/apps/options-3/src/hooks.js
@@ -1,4 +1,4 @@
-import { Foo } from "$lib";
+import { Foo } from '$lib';
 
 /** @type {import("@sveltejs/kit").Transport} */
 export const transport = {

--- a/packages/kit/test/apps/options-3/src/lib/index.js
+++ b/packages/kit/test/apps/options-3/src/lib/index.js
@@ -1,0 +1,9 @@
+export class Foo {
+	constructor(message) {
+		this.message = message;
+	}
+
+	bar() {
+		return this.message + '!';
+	}
+}

--- a/packages/kit/test/apps/options-3/src/routes/+layout.svelte
+++ b/packages/kit/test/apps/options-3/src/routes/+layout.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { setup } from '../../../../setup.js';
+
+	setup();
+</script>
+
+<slot />

--- a/packages/kit/test/apps/options-3/src/routes/serialization-stream/+page.server.js
+++ b/packages/kit/test/apps/options-3/src/routes/serialization-stream/+page.server.js
@@ -1,0 +1,7 @@
+import { Foo } from '$lib';
+
+export const load = () => {
+	return {
+		foo: Promise.resolve(new Foo('It works'))
+	};
+};

--- a/packages/kit/test/apps/options-3/src/routes/serialization-stream/+page.svelte
+++ b/packages/kit/test/apps/options-3/src/routes/serialization-stream/+page.svelte
@@ -1,0 +1,11 @@
+<script>
+	export let data;
+</script>
+
+<h1>
+	{#await data.foo}
+		Loading...
+	{:then result}
+		{result.bar()}
+	{/await}
+</h1>

--- a/packages/kit/test/apps/options-3/svelte.config.js
+++ b/packages/kit/test/apps/options-3/svelte.config.js
@@ -1,0 +1,10 @@
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	kit: {
+		output: {
+			bundleStrategy: 'inline'
+		}
+	}
+};
+
+export default config;

--- a/packages/kit/test/apps/options-3/test/test.js
+++ b/packages/kit/test/apps/options-3/test/test.js
@@ -1,6 +1,4 @@
-import path from 'node:path';
 import process from 'node:process';
-import { fileURLToPath } from 'node:url';
 import { expect } from '@playwright/test';
 import { test } from '../../../utils.js';
 

--- a/packages/kit/test/apps/options-3/test/test.js
+++ b/packages/kit/test/apps/options-3/test/test.js
@@ -1,0 +1,18 @@
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { expect } from '@playwright/test';
+import { test } from '../../../utils.js';
+
+/** @typedef {import('@playwright/test').Response} Response */
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe("bundleStrategy: 'inline'", () => {
+	test.skip(({ javaScriptEnabled }) => !javaScriptEnabled || !!process.env.DEV);
+
+	test('serialization works with streaming', async ({ page }) => {
+		await page.goto('/serialization-stream');
+		await expect(page.locator('h1', { hasText: 'It works!' })).toBeVisible();
+	});
+});

--- a/packages/kit/test/apps/options-3/tsconfig.json
+++ b/packages/kit/test/apps/options-3/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"noEmit": true
+	},
+	"extends": "./.svelte-kit/tsconfig.json"
+}

--- a/packages/kit/test/apps/options-3/vite.config.js
+++ b/packages/kit/test/apps/options-3/vite.config.js
@@ -1,0 +1,18 @@
+import * as path from 'node:path';
+import { sveltekit } from '@sveltejs/kit/vite';
+
+/** @type {import('vite').UserConfig} */
+const config = {
+	build: {
+		minify: false
+	},
+	clearScreen: false,
+	plugins: [sveltekit()],
+	server: {
+		fs: {
+			allow: [path.resolve('../../../src')]
+		}
+	}
+};
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -714,6 +714,30 @@ importers:
         specifier: 'catalog:'
         version: 6.3.5(@types/node@18.19.119)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
 
+  packages/kit/test/apps/options-3:
+    devDependencies:
+      '@sveltejs/adapter-node':
+        specifier: workspace:^
+        version: link:../../../../adapter-node
+      '@sveltejs/kit':
+        specifier: workspace:^
+        version: link:../../..
+      '@sveltejs/vite-plugin-svelte':
+        specifier: 'catalog:'
+        version: 6.0.0-next.3(svelte@5.35.5)(vite@6.3.5(@types/node@18.19.119)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
+      svelte:
+        specifier: ^5.35.5
+        version: 5.35.5
+      svelte-check:
+        specifier: ^4.1.1
+        version: 4.1.1(picomatch@4.0.3)(svelte@5.35.5)(typescript@5.8.3)
+      typescript:
+        specifier: ^5.5.4
+        version: 5.8.3
+      vite:
+        specifier: 'catalog:'
+        version: 6.3.5(@types/node@18.19.119)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
+
   packages/kit/test/apps/prerendered-app-error-pages:
     devDependencies:
       '@sveltejs/kit':


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/13428

This PR ensures the `app` variable is available when the server pushes chunks to the client to decode custom data types as they stream in. This fixes streaming for split and single apps by wrapping the code that references `app` after an import statement, and providing the correct global variable for inline apps.

An additional test suite for inline apps has also been added since none existed before. However, feel free to remove it if it's too much just to test inline apps.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
