### PR TITLE
fix: serialize server `load` data before passing to universal `load`, to handle mutations

### DIFF
--- a/.changeset/clever-boxes-feel.md
+++ b/.changeset/clever-boxes-feel.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: serialize server `load` data before passing to universal `load`, to handle mutations

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -1,9 +1,10 @@
 import { DEV } from 'esm-env';
+import * as devalue from 'devalue';
 import { disable_search, make_trackable } from '../../../utils/url.js';
 import { validate_depends, validate_load_response } from '../../shared.js';
 import { with_request_store, merge_tracing } from '@sveltejs/kit/internal/server';
 import { record_span } from '../../telemetry/record_span.js';
-import { get_node_type } from '../utils.js';
+import { clarify_devalue_error, get_node_type } from '../utils.js';
 import { base64_encode, text_decoder } from '../../utils.js';
 
 /**
@@ -232,11 +233,38 @@ export async function load_data({
 		},
 		fn: async (current) => {
 			const traced_event = merge_tracing(event, current);
-			return await with_request_store({ event: traced_event, state: event_state }, () =>
-				load.call(null, {
+			return await with_request_store({ event: traced_event, state: event_state }, () => {
+				/** @type {Record<string, any> | null} */
+				let data = null;
+
+				return load.call(null, {
 					url: event.url,
 					params: event.params,
-					data: server_data_node?.data ?? null,
+					get data() {
+						if (data === null && server_data_node?.data != null) {
+							/** @type {Record<string, (value: any) => any>} */
+							const reducers = {};
+
+							/** @type {Record<string, (value: any) => any>} */
+							const revivers = {};
+
+							for (const key in event_state.transport) {
+								reducers[key] = event_state.transport[key].encode;
+								revivers[key] = event_state.transport[key].decode;
+							}
+
+							// run it through devalue so that the developer can't accidentally mutate it
+							try {
+								data = devalue.parse(devalue.stringify(server_data_node.data, reducers), revivers);
+							} catch (e) {
+								// @ts-expect-error
+								e.path = e.path.slice(1);
+								throw new Error(clarify_devalue_error(event, /** @type {any} */ (e)));
+							}
+						}
+
+						return data;
+					},
 					route: event.route,
 					fetch: create_universal_fetch(event, state, fetched, csr, resolve_opts),
 					setHeaders: event.setHeaders,
@@ -244,8 +272,8 @@ export async function load_data({
 					parent,
 					untrack: (fn) => fn(),
 					tracing: traced_event.tracing
-				})
-			);
+				});
+			});
 		}
 	});
 

--- a/packages/kit/test/apps/basics/src/routes/load/serialization/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization/+page.js
@@ -5,5 +5,9 @@ export async function load({ fetch, data, url }) {
 	const res = await fetch(new URL('/load/serialization/fetched-from-shared.json', url.origin));
 	const { b } = await res.json();
 
-	return { a, b, c: a + b };
+	// check that this doesn't mutate the original object
+	// and make the server data unserializable
+	data.sum = () => a + b;
+
+	return { a, b, c: data.sum() };
 }

--- a/packages/kit/test/apps/basics/src/routes/load/serialization/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization/+page.js
@@ -7,7 +7,9 @@ export async function load({ fetch, data, url }) {
 
 	// check that this doesn't mutate the original object
 	// and make the server data unserializable
+	// @ts-expect-error
 	data.sum = () => a + b;
 
+	// @ts-expect-error
 	return { a, b, c: data.sum() };
 }


### PR DESCRIPTION
Fixes #12236. The implementation isn't totally ideal — it causes the server `load` return value to be serialized twice if `data` is used in a universal `load` function, and changing that would be finicky — but given our overall trajectory towards remote functions I think it's an acceptable trade-off given that using `data` is probably relatively rare (and it only affects SSR, not data for subsequent client-side navigations).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
