### PR TITLE
docs: fix wrong package name @opentelemetry/exporter-trace-oltp-proto

### DIFF
--- a/documentation/docs/30-advanced/68-observability.md
+++ b/documentation/docs/30-advanced/68-observability.md
@@ -69,7 +69,7 @@ To view your first trace, you'll need to set up a local collector. We'll use [Ja
 - Turn on the experimental flags mentioned earlier in your `svelte.config.js` file
 - Use your package manager to install the dependencies you'll need:
   ```sh
-  npm i @opentelemetry/sdk-node @opentelemetry/auto-instrumentations-node @opentelemetry/exporter-trace-oltp-proto import-in-the-middle
+  npm i @opentelemetry/sdk-node @opentelemetry/auto-instrumentations-node @opentelemetry/exporter-trace-otlp-proto import-in-the-middle
   ```
 - Create `src/instrumentation.server.js` with the following:
 


### PR DESCRIPTION
Fix package name in doc.

Wrong: @opentelemetry/exporter-trace-oltp-proto
Correct: @opentelemetry/exporter-trace-otlp-proto 

repository: https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-proto 

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
