### PR TITLE
fix: resolve_route prevent dropping a trailing slash of id

### DIFF
--- a/.changeset/every-kings-wink.md
+++ b/.changeset/every-kings-wink.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: resolve_route prevent dropping a trailing slash of id

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -240,6 +240,8 @@ const basic_param_pattern = /\[(\[)?(\.\.\.)?(\w+?)(?:=(\w+))?\]\]?/g;
  */
 export function resolve_route(id, params) {
 	const segments = get_route_segments(id);
+	const has_id_trailing_slash = id != '/' && id.endsWith('/');
+
 	return (
 		'/' +
 		segments
@@ -262,7 +264,8 @@ export function resolve_route(id, params) {
 				})
 			)
 			.filter(Boolean)
-			.join('/')
+			.join('/') +
+		(has_id_trailing_slash ? '/' : '')
 	);
 }
 

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -279,9 +279,19 @@ describe('resolve_route', () => {
 			expected: '/blog/one/two'
 		},
 		{
+			route: '/blog/[one]/[two]/',
+			params: { one: 'one', two: 'two' },
+			expected: '/blog/one/two/'
+		},
+		{
 			route: '/blog/[one=matcher]/[...two]',
 			params: { one: 'one', two: 'two/three' },
 			expected: '/blog/one/two/three'
+		},
+		{
+			route: '/blog/[one=matcher]/[...two]/',
+			params: { one: 'one', two: 'two/three' },
+			expected: '/blog/one/two/three/'
 		},
 		{
 			route: '/blog/[one=matcher]/[[two]]',
@@ -289,9 +299,19 @@ describe('resolve_route', () => {
 			expected: '/blog/one'
 		},
 		{
+			route: '/blog/[one=matcher]/[[two]]/',
+			params: { one: 'one' },
+			expected: '/blog/one/'
+		},
+		{
 			route: '/blog/[one]/[two]-and-[three]',
 			params: { one: 'one', two: '2', three: '3' },
 			expected: '/blog/one/2-and-3'
+		},
+		{
+			route: '/blog/[one]/[two]-and-[three]/',
+			params: { one: 'one', two: '2', three: '3' },
+			expected: '/blog/one/2-and-3/'
 		},
 		{
 			route: '/blog/[...one]',
@@ -299,9 +319,19 @@ describe('resolve_route', () => {
 			expected: '/blog'
 		},
 		{
+			route: '/blog/[...one]/',
+			params: { one: '' },
+			expected: '/blog/'
+		},
+		{
 			route: '/blog/[one]/[...two]-not-three',
 			params: { one: 'one', two: 'two/2' },
 			expected: '/blog/one/two/2-not-three'
+		},
+		{
+			route: '/blog/[one]/[...two]-not-three/',
+			params: { one: 'one', two: 'two/2' },
+			expected: '/blog/one/two/2-not-three/'
 		}
 	];
 


### PR DESCRIPTION
Issue #14047 

Previous PR was #14065, but it was actually just support a trailing slash for type Pathname, not solving the issue.
Apologize about that I misunderstood the issue.

Problem was `resolve() from @app/paths` drops trailing slash (technically `resolve_route()` in `resolve()` does).
For example `resolve('/hoge/huga/')` returns string of `/hoge/huga`

Change to keep the trailing slash if `id` has the trailing slash. 

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
