### PR TITLE
chore: align error message when `read(...)` fails in an edge function

### DIFF
--- a/.changeset/famous-lands-bathe.md
+++ b/.changeset/famous-lands-bathe.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+fix: improve the error message when `read(...)` fails

--- a/.changeset/quick-seals-accept.md
+++ b/.changeset/quick-seals-accept.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-netlify': patch
+---
+
+fix: improve the error message when `read(...)` fails from an edge function

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -21,12 +21,13 @@ const initialized = server.init({
 	// @ts-expect-error env contains environment variables and bindings
 	env,
 	read: async (file) => {
-		const response = await /** @type {{ ASSETS: { fetch: typeof fetch } }} */ (env).ASSETS.fetch(
-			`${origin}/${file}`
-		);
+		const url = `${origin}/${file}`;
+		const response = await /** @type {{ ASSETS: { fetch: typeof fetch } }} */ (env).ASSETS.fetch(url);
+
 		if (!response.ok) {
-			throw new Error(`Failed to fetch ${file}: ${response.status} ${response.statusText}`);
+			throw new Error(`read(...) failed: could not fetch ${url} (${response.status} ${response.statusText})`);
 		}
+
 		return response.body;
 	}
 });

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -22,10 +22,14 @@ const initialized = server.init({
 	env,
 	read: async (file) => {
 		const url = `${origin}/${file}`;
-		const response = await /** @type {{ ASSETS: { fetch: typeof fetch } }} */ (env).ASSETS.fetch(url);
+		const response = await /** @type {{ ASSETS: { fetch: typeof fetch } }} */ (env).ASSETS.fetch(
+			url
+		);
 
 		if (!response.ok) {
-			throw new Error(`read(...) failed: could not fetch ${url} (${response.status} ${response.statusText})`);
+			throw new Error(
+				`read(...) failed: could not fetch ${url} (${response.status} ${response.statusText})`
+			);
 		}
 
 		return response.body;

--- a/packages/adapter-netlify/src/edge.js
+++ b/packages/adapter-netlify/src/edge.js
@@ -18,7 +18,9 @@ const initialized = server.init({
 		const response = await fetch(url);
 
 		if (!response.ok) {
-			throw new Error(`read(...) failed: could not fetch ${url} (${response.status} ${response.statusText})`);
+			throw new Error(
+				`read(...) failed: could not fetch ${url} (${response.status} ${response.statusText})`
+			);
 		}
 
 		return response.body;

--- a/packages/adapter-netlify/src/edge.js
+++ b/packages/adapter-netlify/src/edge.js
@@ -14,10 +14,13 @@ const initialized = server.init({
 	// @ts-ignore
 	env: Deno.env.toObject(),
 	read: async (file) => {
-		const response = await fetch(`${origin}/${file}`);
+		const url = `${origin}/${file}`;
+		const response = await fetch(url);
+
 		if (!response.ok) {
-			throw new Error(`Failed to fetch ${file}: ${response.status} ${response.statusText}`);
+			throw new Error(`read(...) failed: could not fetch ${url} (${response.status} ${response.statusText})`);
 		}
+
 		return response.body;
 	}
 });


### PR DESCRIPTION
follow up to https://github.com/sveltejs/kit/pull/14147/files#diff-da750858952944694371448b721a910039c987d1bd7d3e465a6aebb5cd760d9bR42

This PR changes the `read(...)` error message for Netlify's edge functions and Cloudflare to be similar to the one from the Vercel adapter.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
