### PR TITLE
feat: export hasUAVisualTransition of popStateEvent

### DIFF
--- a/.changeset/slimy-suits-leave.md
+++ b/.changeset/slimy-suits-leave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: export hasUAVisualTransition of PopStateEvent

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1234,6 +1234,11 @@ export interface Navigation {
 	 * fails or is aborted. In the case of a `willUnload` navigation, the promise will never resolve
 	 */
 	complete: Promise<void>;
+	/**
+	 * Represents value of hasUAVisualTransition of PopStateEvent if navigation type is popstate, 
+	 * otherwise undefined
+	 */
+	hasUAVisualTransition?: boolean;
 }
 
 /**

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1402,15 +1402,20 @@ function get_page_key(url) {
  *   type: import('@sveltejs/kit').Navigation["type"];
  *   intent?: import('./types.js').NavigationIntent;
  *   delta?: number;
+ *   hasUAVisualTransition?: boolean;
  * }} opts
  */
-function _before_navigate({ url, type, intent, delta }) {
+function _before_navigate({ url, type, intent, delta, hasUAVisualTransition }) {
 	let should_block = false;
 
 	const nav = create_navigation(current, intent, url, type);
 
 	if (delta !== undefined) {
 		nav.navigation.delta = delta;
+	}
+
+	if (hasUAVisualTransition !== undefined) {
+		nav.navigation.hasUAVisualTransition = hasUAVisualTransition;
 	}
 
 	const cancellable = {
@@ -1437,6 +1442,7 @@ function _before_navigate({ url, type, intent, delta }) {
  *     state: Record<string, any>;
  *     scroll: { x: number, y: number };
  *     delta: number;
+ *     hasUAVisualTransition?: boolean;
  *   };
  *   keepfocus?: boolean;
  *   noscroll?: boolean;
@@ -1468,7 +1474,13 @@ async function navigate({
 	const nav =
 		type === 'enter'
 			? create_navigation(current, intent, url, type)
-			: _before_navigate({ url, type, delta: popped?.delta, intent });
+			: _before_navigate({
+					url,
+					type,
+					delta: popped?.delta,
+					intent,
+					hasUAVisualTransition: popped?.hasUAVisualTransition
+				});
 
 	if (!nav) {
 		block();
@@ -2523,6 +2535,7 @@ function _start_router() {
 			const is_hash_change = current.url ? strip_hash(location) === strip_hash(current.url) : false;
 			const shallow =
 				navigation_index === current_navigation_index && (has_navigated || is_hash_change);
+			const hasUAVisualTransition = event.hasUAVisualTransition;
 
 			if (shallow) {
 				// We don't need to navigate, we just need to update scroll and/or state.
@@ -2550,7 +2563,8 @@ function _start_router() {
 				popped: {
 					state,
 					scroll,
-					delta
+					delta,
+					hasUAVisualTransition
 				},
 				accept: () => {
 					current_history_index = history_index;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1210,6 +1210,11 @@ declare module '@sveltejs/kit' {
 		 * fails or is aborted. In the case of a `willUnload` navigation, the promise will never resolve
 		 */
 		complete: Promise<void>;
+		/**
+		 * Represents value of hasUAVisualTransition of PopStateEvent if navigation type is popstate, 
+		 * otherwise undefined
+		 */
+		hasUAVisualTransition?: boolean;
 	}
 
 	/**


### PR DESCRIPTION
Export `hasUAVisualTransition` property of `popStateEvent` into onNavigate callback if navigation is `popstate`.

Closes #13169.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
