### PR TITLE
chore: remove `__SVELTEKIT_DEV__` global

### DIFF
--- a/.changeset/true-moles-tap.md
+++ b/.changeset/true-moles-tap.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+chore: consolidate dev checks to `esm-env` and remove the `__SVELTEKIT_DEV__` global

--- a/.changeset/true-moles-tap.md
+++ b/.changeset/true-moles-tap.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-chore: consolidate dev checks to `esm-env` and remove the `__SVELTEKIT_DEV__` global
+chore: consolidate dev checks to use `esm-env` instead of a `__SVELTEKIT_DEV__` global

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -80,7 +80,9 @@
 		"test:cross-platform:build": "pnpm test:unit && pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:cross-platform:build",
 		"test:server-side-route-resolution:dev": "pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:server-side-route-resolution:dev",
 		"test:server-side-route-resolution:build": "pnpm test:unit && pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:server-side-route-resolution:build",
-		"test:unit": "vitest --config kit.vitest.config.js run",
+		"test:unit:dev": "vitest --config kit.vitest.config.js run",
+		"test:unit:prod": "NODE_ENV=production vitest --config kit.vitest.config.js run csp.spec.js cookie.spec.js",
+		"test:unit": "pnpm test:unit:dev && pnpm test:unit:prod",
 		"prepublishOnly": "pnpm generate:types",
 		"generate:version": "node scripts/generate-version.js",
 		"generate:types": "node scripts/generate-dts.js"

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -335,7 +335,6 @@ async function kit({ svelte_config }) {
 					__SVELTEKIT_ADAPTER_NAME__: s(kit.adapter?.name),
 					__SVELTEKIT_APP_VERSION_FILE__: s(`${kit.appDir}/version.json`),
 					__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: s(kit.version.pollInterval),
-					__SVELTEKIT_DEV__: 'false',
 					__SVELTEKIT_EMBEDDED__: s(kit.embedded),
 					__SVELTEKIT_EXPERIMENTAL__REMOTE_FUNCTIONS__: s(kit.experimental.remoteFunctions),
 					__SVELTEKIT_CLIENT_ROUTING__: s(kit.router.resolution === 'client'),
@@ -351,7 +350,6 @@ async function kit({ svelte_config }) {
 			} else {
 				new_config.define = {
 					__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: '0',
-					__SVELTEKIT_DEV__: 'true',
 					__SVELTEKIT_EMBEDDED__: s(kit.embedded),
 					__SVELTEKIT_EXPERIMENTAL__REMOTE_FUNCTIONS__: s(kit.experimental.remoteFunctions),
 					__SVELTEKIT_CLIENT_ROUTING__: s(kit.router.resolution === 'client'),

--- a/packages/kit/src/runtime/app/state/server.js
+++ b/packages/kit/src/runtime/app/state/server.js
@@ -1,3 +1,4 @@
+import { DEV } from 'esm-env';
 import { getContext } from 'svelte';
 
 function context() {
@@ -16,31 +17,30 @@ function context_dev(name) {
 	}
 }
 
-// TODO we're using DEV in some places and __SVELTEKIT_DEV__ in others - why? Can we consolidate?
 export const page = {
 	get data() {
-		return (__SVELTEKIT_DEV__ ? context_dev('page.data') : context()).page.data;
+		return (DEV ? context_dev('page.data') : context()).page.data;
 	},
 	get error() {
-		return (__SVELTEKIT_DEV__ ? context_dev('page.error') : context()).page.error;
+		return (DEV ? context_dev('page.error') : context()).page.error;
 	},
 	get form() {
-		return (__SVELTEKIT_DEV__ ? context_dev('page.form') : context()).page.form;
+		return (DEV ? context_dev('page.form') : context()).page.form;
 	},
 	get params() {
-		return (__SVELTEKIT_DEV__ ? context_dev('page.params') : context()).page.params;
+		return (DEV ? context_dev('page.params') : context()).page.params;
 	},
 	get route() {
-		return (__SVELTEKIT_DEV__ ? context_dev('page.route') : context()).page.route;
+		return (DEV ? context_dev('page.route') : context()).page.route;
 	},
 	get state() {
-		return (__SVELTEKIT_DEV__ ? context_dev('page.state') : context()).page.state;
+		return (DEV ? context_dev('page.state') : context()).page.state;
 	},
 	get status() {
-		return (__SVELTEKIT_DEV__ ? context_dev('page.status') : context()).page.status;
+		return (DEV ? context_dev('page.status') : context()).page.status;
 	},
 	get url() {
-		return (__SVELTEKIT_DEV__ ? context_dev('page.url') : context()).page.url;
+		return (DEV ? context_dev('page.url') : context()).page.url;
 	}
 };
 

--- a/packages/kit/src/runtime/app/stores.js
+++ b/packages/kit/src/runtime/app/stores.js
@@ -1,5 +1,5 @@
 import { getContext } from 'svelte';
-import { BROWSER } from 'esm-env';
+import { BROWSER, DEV } from 'esm-env';
 import { stores as browser_stores } from '../client/client.js';
 
 /**
@@ -35,7 +35,7 @@ export const getStores = () => {
  */
 export const page = {
 	subscribe(fn) {
-		const store = __SVELTEKIT_DEV__ ? get_store('page') : getStores().page;
+		const store = DEV ? get_store('page') : getStores().page;
 		return store.subscribe(fn);
 	}
 };
@@ -52,7 +52,7 @@ export const page = {
  */
 export const navigating = {
 	subscribe(fn) {
-		const store = __SVELTEKIT_DEV__ ? get_store('navigating') : getStores().navigating;
+		const store = DEV ? get_store('navigating') : getStores().navigating;
 		return store.subscribe(fn);
 	}
 };
@@ -67,7 +67,7 @@ export const navigating = {
  */
 export const updated = {
 	subscribe(fn) {
-		const store = __SVELTEKIT_DEV__ ? get_store('updated') : getStores().updated;
+		const store = DEV ? get_store('updated') : getStores().updated;
 
 		if (BROWSER) {
 			updated.check = store.check;

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -1,8 +1,8 @@
 import { parse, serialize } from 'cookie';
+import { DEV } from 'esm-env';
 import { normalize_path, resolve } from '../../utils/url.js';
 import { add_data_suffix } from '../pathname.js';
 import { text_encoder } from '../utils.js';
-import { DEV } from 'esm-env';
 
 // eslint-disable-next-line no-control-regex -- control characters are invalid in cookie names
 const INVALID_COOKIE_CHARACTER_REGEX = /[\x00-\x1F\x7F()<>@,;:"/[\]?={} \t]/;

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -2,6 +2,7 @@ import { parse, serialize } from 'cookie';
 import { normalize_path, resolve } from '../../utils/url.js';
 import { add_data_suffix } from '../pathname.js';
 import { text_encoder } from '../utils.js';
+import { DEV } from 'esm-env';
 
 // eslint-disable-next-line no-control-regex -- control characters are invalid in cookie names
 const INVALID_COOKIE_CHARACTER_REGEX = /[\x00-\x1F\x7F()<>@,;:"/[\]?={} \t]/;
@@ -96,7 +97,7 @@ export function get_cookies(request, url) {
 			// in development, if the cookie was set during this session with `cookies.set`,
 			// but at a different path, warn the user. (ignore cookies from request headers,
 			// since we don't know which path they were set at)
-			if (__SVELTEKIT_DEV__ && !cookie) {
+			if (DEV && !cookie) {
 				const paths = Array.from(cookie_paths[name] ?? []).filter((path) => {
 					// we only care about paths that are _more_ specific than the current path
 					return path_matches(path, url.pathname) && path !== url.pathname;
@@ -252,7 +253,7 @@ export function get_cookies(request, url) {
 		const cookie = { name, value, options: { ...options, path } };
 		new_cookies.set(cookie_key, cookie);
 
-		if (__SVELTEKIT_DEV__) {
+		if (DEV) {
 			const serialized = serialize(name, value, cookie.options);
 			if (text_encoder.encode(serialized).byteLength > MAX_COOKIE_SIZE) {
 				throw new Error(`Cookie "${name}" is too large, and will be discarded by the browser`);

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import { assert, expect, test, describe } from 'vitest';
 import { domain_matches, path_matches, get_cookies } from './cookie.js';
 import { installPolyfills } from '@sveltejs/kit/node/polyfills';

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -37,7 +37,6 @@ const cookies_setup = ({ href, headers } = {}) => {
 	return result;
 };
 
-
 describe.skipIf(process.env.NODE_ENV === 'production')('cookies in dev', () => {
 	test('warns if cookie exceeds 4,129 bytes', () => {
 		try {

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -1,4 +1,4 @@
-import { assert, expect, test } from 'vitest';
+import { assert, expect, test, describe } from 'vitest';
 import { domain_matches, path_matches, get_cookies } from './cookie.js';
 import { installPolyfills } from '@sveltejs/kit/node/polyfills';
 
@@ -23,24 +23,6 @@ const paths = {
 	]
 };
 
-domains.positive.forEach(([hostname, constraint]) => {
-	test(`${hostname} / ${constraint}`, () => {
-		assert.ok(domain_matches(hostname, constraint));
-	});
-});
-
-paths.positive.forEach(([path, constraint]) => {
-	test(`${path} / ${constraint}`, () => {
-		assert.ok(path_matches(path, constraint));
-	});
-});
-
-paths.negative.forEach(([path, constraint]) => {
-	test(`! ${path} / ${constraint}`, () => {
-		assert.isFalse(path_matches(path, constraint));
-	});
-});
-
 /** @param {{ href?: string, headers?: Record<string, string> }} href */
 const cookies_setup = ({ href, headers } = {}) => {
 	const url = new URL(href || 'https://example.com');
@@ -55,223 +37,246 @@ const cookies_setup = ({ href, headers } = {}) => {
 	return result;
 };
 
-test('a cookie should not be present after it is deleted', () => {
-	const { cookies } = cookies_setup();
-	cookies.set('a', 'b', { path: '/' });
-	expect(cookies.get('a')).toEqual('b');
-	cookies.delete('a', { path: '/' });
-	assert.isUndefined(cookies.get('a'));
-});
 
-test('default values when set is called', () => {
-	const { cookies, new_cookies } = cookies_setup();
-	cookies.set('a', 'b', { path: '/' });
-	const opts = new_cookies.get('/?a')?.options;
-	assert.equal(opts?.secure, true);
-	assert.equal(opts?.httpOnly, true);
-	assert.equal(opts?.path, '/');
-	assert.equal(opts?.sameSite, 'lax');
-});
+describe.skipIf(process.env.NODE_ENV === 'production')('cookies in dev', () => {
+	test('warns if cookie exceeds 4,129 bytes', () => {
+		try {
+			const { cookies } = cookies_setup();
+			cookies.set('a', 'a'.repeat(4097), { path: '/' });
+		} catch (e) {
+			const error = /** @type {Error} */ (e);
 
-test('default values when set is called on sub path', () => {
-	const { cookies, new_cookies } = cookies_setup({ href: 'https://example.com/foo/bar' });
-	cookies.set('a', 'b', { path: '' });
-	const opts = new_cookies.get('/foo/bar?a')?.options;
-	assert.equal(opts?.secure, true);
-	assert.equal(opts?.httpOnly, true);
-	assert.equal(opts?.path, '/foo/bar');
-	assert.equal(opts?.sameSite, 'lax');
-});
-
-test('default values when on localhost', () => {
-	const { cookies, new_cookies } = cookies_setup({ href: 'http://localhost:1234' });
-	cookies.set('a', 'b', { path: '/' });
-	const opts = new_cookies.get('/?a')?.options;
-	assert.equal(opts?.secure, false);
-});
-
-test('overridden defaults when set is called', () => {
-	const { cookies, new_cookies } = cookies_setup();
-	cookies.set('a', 'b', { secure: false, httpOnly: false, sameSite: 'strict', path: '/a/b/c' });
-	const opts = new_cookies.get('/a/b/c?a')?.options;
-	assert.equal(opts?.secure, false);
-	assert.equal(opts?.httpOnly, false);
-	assert.equal(opts?.path, '/a/b/c');
-	assert.equal(opts?.sameSite, 'strict');
-});
-
-test('default values when delete is called', () => {
-	const { cookies, new_cookies } = cookies_setup();
-	cookies.delete('a', { path: '/' });
-	const opts = new_cookies.get('/?a')?.options;
-	assert.equal(opts?.secure, true);
-	assert.equal(opts?.httpOnly, true);
-	assert.equal(opts?.path, '/');
-	assert.equal(opts?.sameSite, 'lax');
-	assert.equal(opts?.maxAge, 0);
-});
-
-test('overridden defaults when delete is called', () => {
-	const { cookies, new_cookies } = cookies_setup();
-	cookies.delete('a', { secure: false, httpOnly: false, sameSite: 'strict', path: '/a/b/c' });
-	const opts = new_cookies.get('/a/b/c?a')?.options;
-	assert.equal(opts?.secure, false);
-	assert.equal(opts?.httpOnly, false);
-	assert.equal(opts?.path, '/a/b/c');
-	assert.equal(opts?.sameSite, 'strict');
-	assert.equal(opts?.maxAge, 0);
-});
-
-test('cannot override maxAge on delete', () => {
-	const { cookies, new_cookies } = cookies_setup();
-	cookies.delete('a', { path: '/', maxAge: 1234 });
-	const opts = new_cookies.get('/?a')?.options;
-	assert.equal(opts?.maxAge, 0);
-});
-
-test('last cookie set with the same name wins', () => {
-	const { cookies, new_cookies } = cookies_setup();
-	cookies.set('a', 'foo', { path: '/' });
-	cookies.set('a', 'bar', { path: '/' });
-	const entry = new_cookies.get('/?a');
-	assert.equal(entry?.value, 'bar');
-});
-
-test('cookie names are case sensitive', () => {
-	const { cookies, new_cookies } = cookies_setup();
-	// not that one should do this, but we follow the spec...
-	cookies.set('a', 'foo', { path: '/' });
-	cookies.set('A', 'bar', { path: '/' });
-	const entrya = new_cookies.get('/?a');
-	const entryA = new_cookies.get('/?A');
-	assert.equal(entrya?.value, 'foo');
-	assert.equal(entryA?.value, 'bar');
-});
-
-test('serialized cookie header should be url-encoded', () => {
-	const href = 'https://example.com';
-	const { cookies, get_cookie_header } = cookies_setup({
-		href,
-		headers: {
-			cookie: 'a=f%C3%BC; b=foo+bar' // a=fü
+			assert.equal(error.message, 'Cookie "a" is too large, and will be discarded by the browser');
 		}
 	});
-	cookies.set('c', 'fö', { path: '/' }); // should use default encoding
-	cookies.set('d', 'fö', { path: '/', encode: () => 'öf' }); // should respect `encode`
-	const header = get_cookie_header(new URL(href), 'e=f%C3%A4; f=foo+bar');
-	assert.equal(header, 'a=f%C3%BC; b=foo+bar; c=f%C3%B6; d=öf; e=f%C3%A4; f=foo+bar');
 });
 
-test('warns if cookie exceeds 4,129 bytes', () => {
-	try {
-		const { cookies } = cookies_setup();
-		cookies.set('a', 'a'.repeat(4097), { path: '/' });
-	} catch (e) {
-		const error = /** @type {Error} */ (e);
-
-		assert.equal(error.message, 'Cookie "a" is too large, and will be discarded by the browser');
-	}
-});
-
-test('get all cookies from header and set calls', () => {
-	const { cookies } = cookies_setup();
-	expect(cookies.getAll()).toEqual([{ name: 'a', value: 'b' }]);
-
-	cookies.set('a', 'foo', { path: '/' });
-	cookies.set('a', 'bar', { path: '/' });
-	cookies.set('b', 'baz', { path: '/' });
-
-	expect(cookies.getAll()).toEqual([
-		{ name: 'a', value: 'bar' },
-		{ name: 'b', value: 'baz' }
-	]);
-});
-
-test("set_internal isn't affected by defaults", () => {
-	const { cookies, new_cookies, set_internal } = cookies_setup({
-		href: 'https://example.com/a/b/c'
+describe.skipIf(process.env.NODE_ENV !== 'production')('cookies in prod', () => {
+	domains.positive.forEach(([hostname, constraint]) => {
+		test(`${hostname} / ${constraint}`, () => {
+			assert.ok(domain_matches(hostname, constraint));
+		});
 	});
 
-	const options = {
-		secure: false,
-		httpOnly: false,
-		sameSite: /** @type {const} */ ('none'),
-		path: '/a/b/c'
-	};
+	paths.positive.forEach(([path, constraint]) => {
+		test(`${path} / ${constraint}`, () => {
+			assert.ok(path_matches(path, constraint));
+		});
+	});
 
-	set_internal('test', 'foo', options);
+	paths.negative.forEach(([path, constraint]) => {
+		test(`! ${path} / ${constraint}`, () => {
+			assert.isFalse(path_matches(path, constraint));
+		});
+	});
 
-	expect(cookies.get('test')).toEqual('foo');
-	expect(new_cookies.get('/a/b/c?test')?.options).toEqual(options);
-});
+	test('a cookie should not be present after it is deleted', () => {
+		const { cookies } = cookies_setup();
+		cookies.set('a', 'b', { path: '/' });
+		expect(cookies.get('a')).toEqual('b');
+		cookies.delete('a', { path: '/' });
+		assert.isUndefined(cookies.get('a'));
+	});
 
-test('reproduce issue #13947: multiple cookies with same name but different paths', () => {
-	// Test on root path to see if most specific cookie wins
-	const { cookies: root_cookies } = cookies_setup({ href: 'https://example.com/' });
-	root_cookies.set('key', 'value_root', { path: '/' });
-	root_cookies.set('key', 'value_foo', { path: '/foo' });
+	test('default values when set is called', () => {
+		const { cookies, new_cookies } = cookies_setup();
+		cookies.set('a', 'b', { path: '/' });
+		const opts = new_cookies.get('/?a')?.options;
+		assert.equal(opts?.secure, true);
+		assert.equal(opts?.httpOnly, true);
+		assert.equal(opts?.path, '/');
+		assert.equal(opts?.sameSite, 'lax');
+	});
 
-	// When on root path, should get the root cookie
-	expect(root_cookies.get('key')).toEqual('value_root');
+	test('default values when set is called on sub path', () => {
+		const { cookies, new_cookies } = cookies_setup({ href: 'https://example.com/foo/bar' });
+		cookies.set('a', 'b', { path: '' });
+		const opts = new_cookies.get('/foo/bar?a')?.options;
+		assert.equal(opts?.secure, true);
+		assert.equal(opts?.httpOnly, true);
+		assert.equal(opts?.path, '/foo/bar');
+		assert.equal(opts?.sameSite, 'lax');
+	});
 
-	// Test on /foo path to see if more specific cookie wins
-	const { cookies: foo_cookies } = cookies_setup({ href: 'https://example.com/foo' });
-	foo_cookies.set('key', 'value_root', { path: '/' });
-	foo_cookies.set('key', 'value_foo', { path: '/foo' });
+	test('default values when on localhost', () => {
+		const { cookies, new_cookies } = cookies_setup({ href: 'http://localhost:1234' });
+		cookies.set('a', 'b', { path: '/' });
+		const opts = new_cookies.get('/?a')?.options;
+		assert.equal(opts?.secure, false);
+	});
 
-	// When on /foo path, should get the more specific /foo cookie
-	expect(foo_cookies.get('key')).toEqual('value_foo');
-});
+	test('overridden defaults when set is called', () => {
+		const { cookies, new_cookies } = cookies_setup();
+		cookies.set('a', 'b', { secure: false, httpOnly: false, sameSite: 'strict', path: '/a/b/c' });
+		const opts = new_cookies.get('/a/b/c?a')?.options;
+		assert.equal(opts?.secure, false);
+		assert.equal(opts?.httpOnly, false);
+		assert.equal(opts?.path, '/a/b/c');
+		assert.equal(opts?.sameSite, 'strict');
+	});
 
-test('cookies with same name but different domains work correctly', () => {
-	// Test setting cookies with different domains (unique key storage should work)
-	const { cookies, new_cookies } = cookies_setup({ href: 'https://example.com/' });
+	test('default values when delete is called', () => {
+		const { cookies, new_cookies } = cookies_setup();
+		cookies.delete('a', { path: '/' });
+		const opts = new_cookies.get('/?a')?.options;
+		assert.equal(opts?.secure, true);
+		assert.equal(opts?.httpOnly, true);
+		assert.equal(opts?.path, '/');
+		assert.equal(opts?.sameSite, 'lax');
+		assert.equal(opts?.maxAge, 0);
+	});
 
-	cookies.set('key', 'value1', { path: '/', domain: 'example.com' });
-	cookies.set('key', 'value2', { path: '/', domain: 'sub.example.com' });
+	test('overridden defaults when delete is called', () => {
+		const { cookies, new_cookies } = cookies_setup();
+		cookies.delete('a', { secure: false, httpOnly: false, sameSite: 'strict', path: '/a/b/c' });
+		const opts = new_cookies.get('/a/b/c?a')?.options;
+		assert.equal(opts?.secure, false);
+		assert.equal(opts?.httpOnly, false);
+		assert.equal(opts?.path, '/a/b/c');
+		assert.equal(opts?.sameSite, 'strict');
+		assert.equal(opts?.maxAge, 0);
+	});
 
-	// Both cookies should be stored with unique keys
-	expect(new_cookies.get('example.com/?key')).toBeDefined();
-	expect(new_cookies.get('sub.example.com/?key')).toBeDefined();
-	expect(new_cookies.get('example.com/?key')?.value).toEqual('value1');
-	expect(new_cookies.get('sub.example.com/?key')?.value).toEqual('value2');
-});
+	test('cannot override maxAge on delete', () => {
+		const { cookies, new_cookies } = cookies_setup();
+		cookies.delete('a', { path: '/', maxAge: 1234 });
+		const opts = new_cookies.get('/?a')?.options;
+		assert.equal(opts?.maxAge, 0);
+	});
 
-test('cookie path specificity: more specific paths win', () => {
-	const { cookies } = cookies_setup({ href: 'https://example.com/x/y/z' });
+	test('last cookie set with the same name wins', () => {
+		const { cookies, new_cookies } = cookies_setup();
+		cookies.set('a', 'foo', { path: '/' });
+		cookies.set('a', 'bar', { path: '/' });
+		const entry = new_cookies.get('/?a');
+		assert.equal(entry?.value, 'bar');
+	});
 
-	// Set cookies with increasing path specificity
-	cookies.set('n', '1', { path: '/' });
-	cookies.set('n', '2', { path: '/x' });
-	cookies.set('n', '3', { path: '/x/y' });
-	cookies.set('n', '4', { path: '/x/y/z' });
+	test('cookie names are case sensitive', () => {
+		const { cookies, new_cookies } = cookies_setup();
+		// not that one should do this, but we follow the spec...
+		cookies.set('a', 'foo', { path: '/' });
+		cookies.set('A', 'bar', { path: '/' });
+		const entrya = new_cookies.get('/?a');
+		const entryA = new_cookies.get('/?A');
+		assert.equal(entrya?.value, 'foo');
+		assert.equal(entryA?.value, 'bar');
+	});
 
-	// Most specific path should win
-	expect(cookies.get('n')).toEqual('4');
-});
+	test('serialized cookie header should be url-encoded', () => {
+		const href = 'https://example.com';
+		const { cookies, get_cookie_header } = cookies_setup({
+			href,
+			headers: {
+				cookie: 'a=f%C3%BC; b=foo+bar' // a=fü
+			}
+		});
+		cookies.set('c', 'fö', { path: '/' }); // should use default encoding
+		cookies.set('d', 'fö', { path: '/', encode: () => 'öf' }); // should respect `encode`
+		const header = get_cookie_header(new URL(href), 'e=f%C3%A4; f=foo+bar');
+		assert.equal(header, 'a=f%C3%BC; b=foo+bar; c=f%C3%B6; d=öf; e=f%C3%A4; f=foo+bar');
+	});
 
-test('backward compatibility: get without domain/path options still works', () => {
-	const { cookies } = cookies_setup();
+	test('get all cookies from header and set calls', () => {
+		const { cookies } = cookies_setup();
+		expect(cookies.getAll()).toEqual([{ name: 'a', value: 'b' }]);
 
-	// Set a cookie the old way
-	cookies.set('old-style', 'value', { path: '/' });
+		cookies.set('a', 'foo', { path: '/' });
+		cookies.set('a', 'bar', { path: '/' });
+		cookies.set('b', 'baz', { path: '/' });
 
-	// Should be retrievable without specifying path
-	expect(cookies.get('old-style')).toEqual('value');
-});
+		expect(cookies.getAll()).toEqual([
+			{ name: 'a', value: 'bar' },
+			{ name: 'b', value: 'baz' }
+		]);
+	});
 
-test('getAll should return most specific cookie when multiple cookies have same name', () => {
-	// This test demonstrates the bug: getAll doesn't respect path specificity like get() does
-	const { cookies } = cookies_setup({ href: 'https://example.com/foo/bar' });
+	test("set_internal isn't affected by defaults", () => {
+		const { cookies, new_cookies, set_internal } = cookies_setup({
+			href: 'https://example.com/a/b/c'
+		});
 
-	// Set cookies with the same name but different path specificity
-	// Setting most specific first, then less specific ones to expose the bug
-	cookies.set('duplicate', 'foobar_value', { path: '/foo/bar' }); // Most specific
-	cookies.set('duplicate', 'root_value', { path: '/' }); // Least specific
-	cookies.set('duplicate', 'foo_value', { path: '/foo' }); // Middle specificity
+		const options = {
+			secure: false,
+			httpOnly: false,
+			sameSite: /** @type {const} */ ('none'),
+			path: '/a/b/c'
+		};
 
-	const all = cookies.getAll();
-	const duplicate = all.find((c) => c.name === 'duplicate');
+		set_internal('test', 'foo', options);
 
-	expect(duplicate?.value).toEqual('foobar_value');
+		expect(cookies.get('test')).toEqual('foo');
+		expect(new_cookies.get('/a/b/c?test')?.options).toEqual(options);
+	});
+
+	test('reproduce issue #13947: multiple cookies with same name but different paths', () => {
+		// Test on root path to see if most specific cookie wins
+		const { cookies: root_cookies } = cookies_setup({ href: 'https://example.com/' });
+		root_cookies.set('key', 'value_root', { path: '/' });
+		root_cookies.set('key', 'value_foo', { path: '/foo' });
+
+		// When on root path, should get the root cookie
+		expect(root_cookies.get('key')).toEqual('value_root');
+
+		// Test on /foo path to see if more specific cookie wins
+		const { cookies: foo_cookies } = cookies_setup({ href: 'https://example.com/foo' });
+		foo_cookies.set('key', 'value_root', { path: '/' });
+		foo_cookies.set('key', 'value_foo', { path: '/foo' });
+
+		// When on /foo path, should get the more specific /foo cookie
+		expect(foo_cookies.get('key')).toEqual('value_foo');
+	});
+
+	test('cookies with same name but different domains work correctly', () => {
+		// Test setting cookies with different domains (unique key storage should work)
+		const { cookies, new_cookies } = cookies_setup({ href: 'https://example.com/' });
+
+		cookies.set('key', 'value1', { path: '/', domain: 'example.com' });
+		cookies.set('key', 'value2', { path: '/', domain: 'sub.example.com' });
+
+		// Both cookies should be stored with unique keys
+		expect(new_cookies.get('example.com/?key')).toBeDefined();
+		expect(new_cookies.get('sub.example.com/?key')).toBeDefined();
+		expect(new_cookies.get('example.com/?key')?.value).toEqual('value1');
+		expect(new_cookies.get('sub.example.com/?key')?.value).toEqual('value2');
+	});
+
+	test('cookie path specificity: more specific paths win', () => {
+		const { cookies } = cookies_setup({ href: 'https://example.com/x/y/z' });
+
+		// Set cookies with increasing path specificity
+		cookies.set('n', '1', { path: '/' });
+		cookies.set('n', '2', { path: '/x' });
+		cookies.set('n', '3', { path: '/x/y' });
+		cookies.set('n', '4', { path: '/x/y/z' });
+
+		// Most specific path should win
+		expect(cookies.get('n')).toEqual('4');
+	});
+
+	test('backward compatibility: get without domain/path options still works', () => {
+		const { cookies } = cookies_setup();
+
+		// Set a cookie the old way
+		cookies.set('old-style', 'value', { path: '/' });
+
+		// Should be retrievable without specifying path
+		expect(cookies.get('old-style')).toEqual('value');
+	});
+
+	test('getAll should return most specific cookie when multiple cookies have same name', () => {
+		// This test demonstrates the bug: getAll doesn't respect path specificity like get() does
+		const { cookies } = cookies_setup({ href: 'https://example.com/foo/bar' });
+
+		// Set cookies with the same name but different path specificity
+		// Setting most specific first, then less specific ones to expose the bug
+		cookies.set('duplicate', 'foobar_value', { path: '/foo/bar' }); // Most specific
+		cookies.set('duplicate', 'root_value', { path: '/' }); // Least specific
+		cookies.set('duplicate', 'foo_value', { path: '/foo' }); // Middle specificity
+
+		const all = cookies.getAll();
+		const duplicate = all.find((c) => c.name === 'duplicate');
+
+		expect(duplicate?.value).toEqual('foobar_value');
+	});
 });

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -4,9 +4,6 @@ import { installPolyfills } from '@sveltejs/kit/node/polyfills';
 
 installPolyfills();
 
-// @ts-expect-error
-globalThis.__SVELTEKIT_DEV__ = false;
-
 const domains = {
 	positive: [
 		['localhost'],
@@ -166,9 +163,6 @@ test('serialized cookie header should be url-encoded', () => {
 });
 
 test('warns if cookie exceeds 4,129 bytes', () => {
-	// @ts-expect-error
-	globalThis.__SVELTEKIT_DEV__ = true;
-
 	try {
 		const { cookies } = cookies_setup();
 		cookies.set('a', 'a'.repeat(4097), { path: '/' });
@@ -176,9 +170,6 @@ test('warns if cookie exceeds 4,129 bytes', () => {
 		const error = /** @type {Error} */ (e);
 
 		assert.equal(error.message, 'Cookie "a" is too large, and will be discarded by the browser');
-	} finally {
-		// @ts-expect-error
-		globalThis.__SVELTEKIT_DEV__ = false;
 	}
 });
 

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -57,7 +57,7 @@ export async function handle_action_json_request(event, event_state, options, se
 	try {
 		const data = await call_action(event, event_state, actions);
 
-		if (__SVELTEKIT_DEV__) {
+		if (DEV) {
 			validate_action_return(data);
 		}
 
@@ -176,7 +176,7 @@ export async function handle_action_request(event, event_state, server) {
 	try {
 		const data = await call_action(event, event_state, actions);
 
-		if (__SVELTEKIT_DEV__) {
+		if (DEV) {
 			validate_action_return(data);
 		}
 

--- a/packages/kit/src/runtime/server/page/csp.js
+++ b/packages/kit/src/runtime/server/page/csp.js
@@ -1,3 +1,4 @@
+import { DEV } from 'esm-env';
 import { escape_html } from '../../../utils/escape.js';
 import { sha256 } from './crypto.js';
 
@@ -77,7 +78,7 @@ class BaseProvider {
 	 */
 	constructor(use_hashes, directives, nonce) {
 		this.#use_hashes = use_hashes;
-		this.#directives = __SVELTEKIT_DEV__ ? { ...directives } : directives; // clone in dev so we can safely mutate
+		this.#directives = DEV ? { ...directives } : directives; // clone in dev so we can safely mutate
 
 		const d = this.#directives;
 
@@ -93,7 +94,7 @@ class BaseProvider {
 		const style_src_attr = d['style-src-attr'];
 		const style_src_elem = d['style-src-elem'];
 
-		if (__SVELTEKIT_DEV__) {
+		if (DEV) {
 			// remove strict-dynamic in dev...
 			// TODO reinstate this if we can figure out how to make strict-dynamic work
 			// if (d['default-src']) {
@@ -148,7 +149,7 @@ class BaseProvider {
 
 		this.#script_needs_csp = this.#script_src_needs_csp || this.#script_src_elem_needs_csp;
 		this.#style_needs_csp =
-			!__SVELTEKIT_DEV__ &&
+			!DEV &&
 			(this.#style_src_needs_csp ||
 				this.#style_src_attr_needs_csp ||
 				this.#style_src_elem_needs_csp);

--- a/packages/kit/src/runtime/server/page/csp.spec.js
+++ b/packages/kit/src/runtime/server/page/csp.spec.js
@@ -1,5 +1,5 @@
 import { webcrypto } from 'node:crypto';
-import { assert, beforeAll, test } from 'vitest';
+import { assert, test } from 'vitest';
 import { Csp } from './csp.js';
 
 // TODO: remove after bumping peer dependency to require Node 20
@@ -7,11 +7,6 @@ if (!globalThis.crypto) {
 	// @ts-expect-error
 	globalThis.crypto = webcrypto;
 }
-
-beforeAll(() => {
-	// @ts-expect-error
-	globalThis.__SVELTEKIT_DEV__ = false;
-});
 
 test('generates blank CSP header', () => {
 	const csp = new Csp(
@@ -287,9 +282,6 @@ test('adds hash to script-src-elem, style-src-attr and style-src-elem if necessa
 });
 
 test('adds unsafe-inline styles in dev', () => {
-	// @ts-expect-error
-	globalThis.__SVELTEKIT_DEV__ = true;
-
 	const csp = new Csp(
 		{
 			mode: 'hash',
@@ -325,9 +317,6 @@ test('adds unsafe-inline styles in dev', () => {
 
 test.skip('removes strict-dynamic in dev', () => {
 	['default-src', 'script-src'].forEach((name) => {
-		// @ts-expect-error
-		globalThis.__SVELTEKIT_DEV__ = true;
-
 		const csp = new Csp(
 			{
 				mode: 'hash',

--- a/packages/kit/src/runtime/server/page/csp.spec.js
+++ b/packages/kit/src/runtime/server/page/csp.spec.js
@@ -1,5 +1,5 @@
 import { webcrypto } from 'node:crypto';
-import { assert, test } from 'vitest';
+import { assert, test, describe } from 'vitest';
 import { Csp } from './csp.js';
 
 // TODO: remove after bumping peer dependency to require Node 20
@@ -8,323 +8,114 @@ if (!globalThis.crypto) {
 	globalThis.crypto = webcrypto;
 }
 
-test('generates blank CSP header', () => {
-	const csp = new Csp(
-		{
-			mode: 'hash',
-			directives: {},
-			reportOnly: {}
-		},
-		{
-			prerender: false
-		}
-	);
-
-	assert.equal(csp.csp_provider.get_header(), '');
-	assert.equal(csp.report_only_provider.get_header(), '');
-});
-
-test('generates CSP header with directive', () => {
-	const csp = new Csp(
-		{
-			mode: 'hash',
-			directives: {
-				'default-src': ['self']
-			},
-			reportOnly: {
-				'default-src': ['self'],
-				'report-uri': ['/']
-			}
-		},
-		{
-			prerender: false
-		}
-	);
-
-	assert.equal(csp.csp_provider.get_header(), "default-src 'self'");
-	assert.equal(csp.report_only_provider.get_header(), "default-src 'self'; report-uri /");
-});
-
-test('generates CSP header with nonce', () => {
-	const csp = new Csp(
-		{
-			mode: 'nonce',
-			directives: {
-				'default-src': ['self']
-			},
-			reportOnly: {
-				'default-src': ['self'],
-				'report-uri': ['/']
-			}
-		},
-		{
-			prerender: false
-		}
-	);
-
-	csp.add_script('');
-
-	assert.ok(
-		csp.csp_provider.get_header().startsWith("default-src 'self'; script-src 'self' 'nonce-")
-	);
-	assert.ok(
-		csp.report_only_provider
-			.get_header()
-			.startsWith("default-src 'self'; report-uri /; script-src 'self' 'nonce-")
-	);
-});
-
-test('skips nonce with unsafe-inline', () => {
-	const csp = new Csp(
-		{
-			mode: 'nonce',
-			directives: {
-				'default-src': ['unsafe-inline'],
-				'script-src': ['unsafe-inline'],
-				'script-src-elem': ['unsafe-inline'],
-				'style-src': ['unsafe-inline'],
-				'style-src-attr': ['unsafe-inline'],
-				'style-src-elem': ['unsafe-inline']
-			},
-			reportOnly: {
-				'default-src': ['unsafe-inline'],
-				'script-src': ['unsafe-inline'],
-				'script-src-elem': ['unsafe-inline'],
-				'style-src': ['unsafe-inline'],
-				'style-src-attr': ['unsafe-inline'],
-				'style-src-elem': ['unsafe-inline'],
-				'report-uri': ['/']
-			}
-		},
-		{
-			prerender: false
-		}
-	);
-
-	csp.add_script('');
-	csp.add_style('');
-
-	assert.equal(
-		csp.csp_provider.get_header(),
-		"default-src 'unsafe-inline'; script-src 'unsafe-inline'; script-src-elem 'unsafe-inline'; style-src 'unsafe-inline'; style-src-attr 'unsafe-inline'; style-src-elem 'unsafe-inline'"
-	);
-	assert.equal(
-		csp.report_only_provider.get_header(),
-		"default-src 'unsafe-inline'; script-src 'unsafe-inline'; script-src-elem 'unsafe-inline'; style-src 'unsafe-inline'; style-src-attr 'unsafe-inline'; style-src-elem 'unsafe-inline'; report-uri /"
-	);
-});
-
-test('skips nonce in style-src when using unsafe-inline', () => {
-	const csp = new Csp(
-		{
-			mode: 'nonce',
-			directives: {
-				'style-src': ['self', 'unsafe-inline']
-			},
-			reportOnly: {
-				'style-src': ['self', 'unsafe-inline'],
-				'report-uri': ['/']
-			}
-		},
-		{
-			prerender: false
-		}
-	);
-
-	csp.add_style('');
-
-	assert.equal(csp.csp_provider.get_header(), "style-src 'self' 'unsafe-inline'");
-	assert.equal(
-		csp.report_only_provider.get_header(),
-		"style-src 'self' 'unsafe-inline'; report-uri /"
-	);
-});
-
-test('skips hash with unsafe-inline', () => {
-	const csp = new Csp(
-		{
-			mode: 'hash',
-			directives: {
-				'default-src': ['unsafe-inline']
-			},
-			reportOnly: {
-				'default-src': ['unsafe-inline'],
-				'report-uri': ['/']
-			}
-		},
-		{
-			prerender: false
-		}
-	);
-
-	csp.add_script('');
-
-	assert.equal(csp.csp_provider.get_header(), "default-src 'unsafe-inline'");
-	assert.equal(csp.report_only_provider.get_header(), "default-src 'unsafe-inline'; report-uri /");
-});
-
-test('does not add empty comment hash to style-src-elem if already defined', () => {
-	const csp = new Csp(
-		{
-			mode: 'hash',
-			directives: {
-				'style-src-elem': ['self', 'sha256-9OlNO0DNEeaVzHL4RZwCLsBHA8WBQ8toBp/4F5XV2nc=']
-			},
-			reportOnly: {
-				'report-uri': ['/']
-			}
-		},
-		{
-			prerender: false
-		}
-	);
-
-	csp.add_style('/* empty */');
-
-	assert.equal(
-		csp.csp_provider.get_header(),
-		"style-src-elem 'self' 'sha256-9OlNO0DNEeaVzHL4RZwCLsBHA8WBQ8toBp/4F5XV2nc='"
-	);
-});
-
-test('skips frame-ancestors, report-uri, sandbox from meta tags', () => {
-	const csp = new Csp(
-		{
-			mode: 'hash',
-			directives: {
-				'default-src': ['self'],
-				'frame-ancestors': ['self'],
-				'report-uri': ['/csp-violation-report-endpoint/'],
-				sandbox: ['allow-modals']
-			},
-			reportOnly: {}
-		},
-		{
-			prerender: false
-		}
-	);
-
-	assert.equal(
-		csp.csp_provider.get_header(),
-		"default-src 'self'; frame-ancestors 'self'; report-uri /csp-violation-report-endpoint/; sandbox allow-modals"
-	);
-
-	assert.equal(
-		csp.csp_provider.get_meta(),
-		'<meta http-equiv="content-security-policy" content="default-src \'self\'">'
-	);
-});
-
-test('adds nonce style-src-attr and style-src-elem and nonce + sha to script-src-elem if necessary', () => {
-	const csp = new Csp(
-		{
-			mode: 'auto',
-			directives: {
-				'script-src-elem': ['self'],
-				'style-src-attr': ['self'],
-				'style-src-elem': ['self']
-			},
-			reportOnly: {}
-		},
-		{
-			prerender: false
-		}
-	);
-
-	csp.add_script('');
-	csp.add_style('');
-
-	const csp_header = csp.csp_provider.get_header();
-	assert.ok(csp_header.includes("script-src-elem 'self' 'nonce-"));
-	assert.ok(csp_header.includes("style-src-attr 'self' 'nonce-"));
-	assert.ok(
-		csp_header.includes(
-			"style-src-elem 'self' 'sha256-9OlNO0DNEeaVzHL4RZwCLsBHA8WBQ8toBp/4F5XV2nc=' 'nonce-"
-		)
-	);
-});
-
-test('adds hash to script-src-elem, style-src-attr and style-src-elem if necessary during prerendering', () => {
-	const csp = new Csp(
-		{
-			mode: 'auto',
-			directives: {
-				'script-src-elem': ['self'],
-				'style-src-attr': ['self'],
-				'style-src-elem': ['self']
-			},
-			reportOnly: {}
-		},
-		{
-			prerender: true
-		}
-	);
-
-	csp.add_script('');
-	csp.add_style('');
-
-	const csp_header = csp.csp_provider.get_header();
-	assert.ok(
-		csp_header.includes(
-			"script-src-elem 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
-		)
-	);
-	assert.ok(
-		csp_header.includes(
-			"style-src-attr 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
-		)
-	);
-	assert.ok(
-		csp_header.includes(
-			"style-src-elem 'self' 'sha256-9OlNO0DNEeaVzHL4RZwCLsBHA8WBQ8toBp/4F5XV2nc=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
-		)
-	);
-});
-
-test('adds unsafe-inline styles in dev', () => {
-	const csp = new Csp(
-		{
-			mode: 'hash',
-			directives: {
-				'default-src': ['self'],
-				'style-src-attr': ['self', 'sha256-9OlNO0DNEeaVzHL4RZwCLsBHA8WBQ8toBp/4F5XV2nc='],
-				'style-src-elem': ['self', 'sha256-9OlNO0DNEeaVzHL4RZwCLsBHA8WBQ8toBp/4F5XV2nc=']
-			},
-			reportOnly: {
-				'default-src': ['self'],
-				'style-src-attr': ['self'],
-				'style-src-elem': ['self'],
-				'report-uri': ['/']
-			}
-		},
-		{
-			prerender: false
-		}
-	);
-
-	csp.add_style('');
-
-	assert.equal(
-		csp.csp_provider.get_header(),
-		"default-src 'self'; style-src-attr 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
-	);
-
-	assert.equal(
-		csp.report_only_provider.get_header(),
-		"default-src 'self'; style-src-attr 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; report-uri /; style-src 'self' 'unsafe-inline'"
-	);
-});
-
-test.skip('removes strict-dynamic in dev', () => {
-	['default-src', 'script-src'].forEach((name) => {
+describe.skipIf(process.env.NODE_ENV === 'production')('CSPs in dev', () => {
+	test('adds unsafe-inline styles', () => {
 		const csp = new Csp(
 			{
 				mode: 'hash',
 				directives: {
-					[name]: ['strict-dynamic']
+					'default-src': ['self'],
+					'style-src-attr': ['self', 'sha256-9OlNO0DNEeaVzHL4RZwCLsBHA8WBQ8toBp/4F5XV2nc='],
+					'style-src-elem': ['self', 'sha256-9OlNO0DNEeaVzHL4RZwCLsBHA8WBQ8toBp/4F5XV2nc=']
 				},
 				reportOnly: {
-					[name]: ['strict-dynamic'],
+					'default-src': ['self'],
+					'style-src-attr': ['self'],
+					'style-src-elem': ['self'],
+					'report-uri': ['/']
+				}
+			},
+			{
+				prerender: false
+			}
+		);
+
+		csp.add_style('');
+
+		assert.equal(
+			csp.csp_provider.get_header(),
+			"default-src 'self'; style-src-attr 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
+		);
+
+		assert.equal(
+			csp.report_only_provider.get_header(),
+			"default-src 'self'; style-src-attr 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; report-uri /; style-src 'self' 'unsafe-inline'"
+		);
+	});
+
+	test.skip('removes strict-dynamic', () => {
+		['default-src', 'script-src'].forEach((name) => {
+			const csp = new Csp(
+				{
+					mode: 'hash',
+					directives: {
+						[name]: ['strict-dynamic']
+					},
+					reportOnly: {
+						[name]: ['strict-dynamic'],
+						'report-uri': ['/']
+					}
+				},
+				{
+					prerender: false
+				}
+			);
+
+			csp.add_script('');
+
+			assert.equal(csp.csp_provider.get_header(), '');
+			assert.equal(csp.report_only_provider.get_header(), '');
+		});
+	});
+});
+
+describe.skipIf(process.env.NODE_ENV !== 'production')('CSPs in prod', () => {
+	test('generates blank CSP header', () => {
+		const csp = new Csp(
+			{
+				mode: 'hash',
+				directives: {},
+				reportOnly: {}
+			},
+			{
+				prerender: false
+			}
+		);
+
+		assert.equal(csp.csp_provider.get_header(), '');
+		assert.equal(csp.report_only_provider.get_header(), '');
+	});
+
+	test('generates CSP header with directive', () => {
+		const csp = new Csp(
+			{
+				mode: 'hash',
+				directives: {
+					'default-src': ['self']
+				},
+				reportOnly: {
+					'default-src': ['self'],
+					'report-uri': ['/']
+				}
+			},
+			{
+				prerender: false
+			}
+		);
+
+		assert.equal(csp.csp_provider.get_header(), "default-src 'self'");
+		assert.equal(csp.report_only_provider.get_header(), "default-src 'self'; report-uri /");
+	});
+
+	test('generates CSP header with nonce', () => {
+		const csp = new Csp(
+			{
+				mode: 'nonce',
+				directives: {
+					'default-src': ['self']
+				},
+				reportOnly: {
+					'default-src': ['self'],
 					'report-uri': ['/']
 				}
 			},
@@ -335,69 +126,285 @@ test.skip('removes strict-dynamic in dev', () => {
 
 		csp.add_script('');
 
-		assert.equal(csp.csp_provider.get_header(), '');
-		assert.equal(csp.report_only_provider.get_header(), '');
+		assert.ok(
+			csp.csp_provider.get_header().startsWith("default-src 'self'; script-src 'self' 'nonce-")
+		);
+		assert.ok(
+			csp.report_only_provider
+				.get_header()
+				.startsWith("default-src 'self'; report-uri /; script-src 'self' 'nonce-")
+		);
 	});
-});
 
-test('uses hashes when prerendering', () => {
-	const csp = new Csp(
-		{
-			mode: 'auto',
-			directives: {
-				'script-src': ['self']
-			},
-			reportOnly: {
-				'script-src': ['self'],
-				'report-uri': ['/']
-			}
-		},
-		{
-			prerender: true
-		}
-	);
-
-	csp.add_script('');
-
-	assert.equal(
-		csp.csp_provider.get_header(),
-		"script-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
-	);
-
-	assert.equal(
-		csp.report_only_provider.get_header(),
-		"script-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; report-uri /"
-	);
-});
-
-test('always creates a nonce when template needs it', () => {
-	const csp = new Csp(
-		{
-			mode: 'hash',
-			directives: {},
-			reportOnly: {}
-		},
-		{
-			prerender: false
-		}
-	);
-
-	assert.ok(csp.nonce);
-});
-
-test('throws when reportOnly contains directives but no report-uri or report-to', () => {
-	assert.throws(() => {
-		new Csp(
+	test('skips nonce with unsafe-inline', () => {
+		const csp = new Csp(
 			{
-				mode: 'hash',
-				directives: {},
+				mode: 'nonce',
+				directives: {
+					'default-src': ['unsafe-inline'],
+					'script-src': ['unsafe-inline'],
+					'script-src-elem': ['unsafe-inline'],
+					'style-src': ['unsafe-inline'],
+					'style-src-attr': ['unsafe-inline'],
+					'style-src-elem': ['unsafe-inline']
+				},
 				reportOnly: {
-					'script-src': ['self']
+					'default-src': ['unsafe-inline'],
+					'script-src': ['unsafe-inline'],
+					'script-src-elem': ['unsafe-inline'],
+					'style-src': ['unsafe-inline'],
+					'style-src-attr': ['unsafe-inline'],
+					'style-src-elem': ['unsafe-inline'],
+					'report-uri': ['/']
 				}
 			},
 			{
 				prerender: false
 			}
 		);
-	}, '`content-security-policy-report-only` must be specified with either the `report-to` or `report-uri` directives, or both');
+
+		csp.add_script('');
+		csp.add_style('');
+
+		assert.equal(
+			csp.csp_provider.get_header(),
+			"default-src 'unsafe-inline'; script-src 'unsafe-inline'; script-src-elem 'unsafe-inline'; style-src 'unsafe-inline'; style-src-attr 'unsafe-inline'; style-src-elem 'unsafe-inline'"
+		);
+		assert.equal(
+			csp.report_only_provider.get_header(),
+			"default-src 'unsafe-inline'; script-src 'unsafe-inline'; script-src-elem 'unsafe-inline'; style-src 'unsafe-inline'; style-src-attr 'unsafe-inline'; style-src-elem 'unsafe-inline'; report-uri /"
+		);
+	});
+
+	test('skips nonce in style-src when using unsafe-inline', () => {
+		const csp = new Csp(
+			{
+				mode: 'nonce',
+				directives: {
+					'style-src': ['self', 'unsafe-inline']
+				},
+				reportOnly: {
+					'style-src': ['self', 'unsafe-inline'],
+					'report-uri': ['/']
+				}
+			},
+			{
+				prerender: false
+			}
+		);
+
+		csp.add_style('');
+
+		assert.equal(csp.csp_provider.get_header(), "style-src 'self' 'unsafe-inline'");
+		assert.equal(
+			csp.report_only_provider.get_header(),
+			"style-src 'self' 'unsafe-inline'; report-uri /"
+		);
+	});
+
+	test('skips hash with unsafe-inline', () => {
+		const csp = new Csp(
+			{
+				mode: 'hash',
+				directives: {
+					'default-src': ['unsafe-inline']
+				},
+				reportOnly: {
+					'default-src': ['unsafe-inline'],
+					'report-uri': ['/']
+				}
+			},
+			{
+				prerender: false
+			}
+		);
+
+		csp.add_script('');
+
+		assert.equal(csp.csp_provider.get_header(), "default-src 'unsafe-inline'");
+		assert.equal(
+			csp.report_only_provider.get_header(),
+			"default-src 'unsafe-inline'; report-uri /"
+		);
+	});
+
+	test('does not add empty comment hash to style-src-elem if already defined', () => {
+		const csp = new Csp(
+			{
+				mode: 'hash',
+				directives: {
+					'style-src-elem': ['self', 'sha256-9OlNO0DNEeaVzHL4RZwCLsBHA8WBQ8toBp/4F5XV2nc=']
+				},
+				reportOnly: {
+					'report-uri': ['/']
+				}
+			},
+			{
+				prerender: false
+			}
+		);
+
+		csp.add_style('/* empty */');
+
+		assert.equal(
+			csp.csp_provider.get_header(),
+			"style-src-elem 'self' 'sha256-9OlNO0DNEeaVzHL4RZwCLsBHA8WBQ8toBp/4F5XV2nc='"
+		);
+	});
+
+	test('skips frame-ancestors, report-uri, sandbox from meta tags', () => {
+		const csp = new Csp(
+			{
+				mode: 'hash',
+				directives: {
+					'default-src': ['self'],
+					'frame-ancestors': ['self'],
+					'report-uri': ['/csp-violation-report-endpoint/'],
+					sandbox: ['allow-modals']
+				},
+				reportOnly: {}
+			},
+			{
+				prerender: false
+			}
+		);
+
+		assert.equal(
+			csp.csp_provider.get_header(),
+			"default-src 'self'; frame-ancestors 'self'; report-uri /csp-violation-report-endpoint/; sandbox allow-modals"
+		);
+
+		assert.equal(
+			csp.csp_provider.get_meta(),
+			'<meta http-equiv="content-security-policy" content="default-src \'self\'">'
+		);
+	});
+
+	test('adds nonce style-src-attr and style-src-elem and nonce + sha to script-src-elem if necessary', () => {
+		const csp = new Csp(
+			{
+				mode: 'auto',
+				directives: {
+					'script-src-elem': ['self'],
+					'style-src-attr': ['self'],
+					'style-src-elem': ['self']
+				},
+				reportOnly: {}
+			},
+			{
+				prerender: false
+			}
+		);
+
+		csp.add_script('');
+		csp.add_style('');
+
+		const csp_header = csp.csp_provider.get_header();
+		assert.ok(csp_header.includes("script-src-elem 'self' 'nonce-"));
+		assert.ok(csp_header.includes("style-src-attr 'self' 'nonce-"));
+		assert.ok(
+			csp_header.includes(
+				"style-src-elem 'self' 'sha256-9OlNO0DNEeaVzHL4RZwCLsBHA8WBQ8toBp/4F5XV2nc=' 'nonce-"
+			)
+		);
+	});
+
+	test('adds hash to script-src-elem, style-src-attr and style-src-elem if necessary during prerendering', () => {
+		const csp = new Csp(
+			{
+				mode: 'auto',
+				directives: {
+					'script-src-elem': ['self'],
+					'style-src-attr': ['self'],
+					'style-src-elem': ['self']
+				},
+				reportOnly: {}
+			},
+			{
+				prerender: true
+			}
+		);
+
+		csp.add_script('');
+		csp.add_style('');
+
+		const csp_header = csp.csp_provider.get_header();
+		assert.ok(
+			csp_header.includes(
+				"script-src-elem 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
+			)
+		);
+		assert.ok(
+			csp_header.includes(
+				"style-src-attr 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
+			)
+		);
+		assert.ok(
+			csp_header.includes(
+				"style-src-elem 'self' 'sha256-9OlNO0DNEeaVzHL4RZwCLsBHA8WBQ8toBp/4F5XV2nc=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
+			)
+		);
+	});
+
+	test('uses hashes when prerendering', () => {
+		const csp = new Csp(
+			{
+				mode: 'auto',
+				directives: {
+					'script-src': ['self']
+				},
+				reportOnly: {
+					'script-src': ['self'],
+					'report-uri': ['/']
+				}
+			},
+			{
+				prerender: true
+			}
+		);
+
+		csp.add_script('');
+
+		assert.equal(
+			csp.csp_provider.get_header(),
+			"script-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
+		);
+
+		assert.equal(
+			csp.report_only_provider.get_header(),
+			"script-src 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; report-uri /"
+		);
+	});
+
+	test('always creates a nonce when template needs it', () => {
+		const csp = new Csp(
+			{
+				mode: 'hash',
+				directives: {},
+				reportOnly: {}
+			},
+			{
+				prerender: false
+			}
+		);
+
+		assert.ok(csp.nonce);
+	});
+
+	test('throws when reportOnly contains directives but no report-uri or report-to', () => {
+		assert.throws(() => {
+			new Csp(
+				{
+					mode: 'hash',
+					directives: {},
+					reportOnly: {
+						'script-src': ['self']
+					}
+				},
+				{
+					prerender: false
+				}
+			);
+		}, '`content-security-policy-report-only` must be specified with either the `report-to` or `report-uri` directives, or both');
+	});
 });

--- a/packages/kit/src/runtime/server/page/csp.spec.js
+++ b/packages/kit/src/runtime/server/page/csp.spec.js
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import { webcrypto } from 'node:crypto';
 import { assert, test, describe } from 'vitest';
 import { Csp } from './csp.js';

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -176,7 +176,7 @@ export async function load_server_data({ event, event_state, state, node, parent
 		}
 	});
 
-	if (__SVELTEKIT_DEV__) {
+	if (DEV) {
 		validate_load_response(result, `in ${node.server_id}`);
 	}
 
@@ -278,7 +278,7 @@ export async function load_data({
 		}
 	});
 
-	if (__SVELTEKIT_DEV__) {
+	if (DEV) {
 		validate_load_response(result, `in ${node.universal_id}`);
 	}
 

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -182,7 +182,7 @@ export async function render_response({
 			])
 		};
 
-		if (__SVELTEKIT_DEV__) {
+		if (DEV) {
 			const fetch = globalThis.fetch;
 			let warned = false;
 			globalThis.fetch = (info, init) => {
@@ -255,7 +255,7 @@ export async function render_response({
 		: Array.from(inline_styles.values()).join('\n');
 
 	if (style) {
-		const attributes = __SVELTEKIT_DEV__ ? [' data-sveltekit'] : [];
+		const attributes = DEV ? [' data-sveltekit'] : [];
 		if (csp.style_needs_nonce) attributes.push(` nonce="${csp.nonce}"`);
 
 		csp.add_style(style);
@@ -295,7 +295,7 @@ export async function render_response({
 		}
 	}
 
-	const global = __SVELTEKIT_DEV__ ? '__sveltekit_dev' : `__sveltekit_${options.version_hash}`;
+	const global = DEV ? '__sveltekit_dev' : `__sveltekit_${options.version_hash}`;
 
 	const { data, chunks } = get_data(
 		event,
@@ -516,10 +516,10 @@ export async function render_response({
 		}
 
 		if (options.service_worker) {
-			let opts = __SVELTEKIT_DEV__ ? ", { type: 'module' }" : '';
+			let opts = DEV ? ", { type: 'module' }" : '';
 			if (options.service_worker_options != null) {
 				const service_worker_options = { ...options.service_worker_options };
-				if (__SVELTEKIT_DEV__) {
+				if (DEV) {
 					service_worker_options.type = 'module';
 				}
 				opts = `, ${s(service_worker_options)}`;

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -40,7 +40,6 @@ import { record_span } from '../telemetry/record_span.js';
 import { otel } from '../telemetry/otel.js';
 
 /* global __SVELTEKIT_ADAPTER_NAME__ */
-/* global __SVELTEKIT_DEV__ */
 
 /** @type {import('types').RequiredResolveOptions['transformPageChunk']} */
 const default_transform = ({ html }) => html;
@@ -167,7 +166,7 @@ export async function internal_respond(request, options, manifest, state) {
 		request,
 		route: { id: null },
 		setHeaders: (new_headers) => {
-			if (__SVELTEKIT_DEV__) {
+			if (DEV) {
 				validateHeaders(new_headers);
 			}
 

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -104,7 +104,7 @@ export async function handle_error_and_jsonify(event, state, options, error) {
 		return { message: 'Unknown Error', ...error.body };
 	}
 
-	if (__SVELTEKIT_DEV__ && typeof error == 'object') {
+	if (DEV && typeof error == 'object') {
 		fix_stack_trace(error);
 	}
 

--- a/packages/kit/src/types/global-private.d.ts
+++ b/packages/kit/src/types/global-private.d.ts
@@ -2,7 +2,6 @@ declare global {
 	const __SVELTEKIT_ADAPTER_NAME__: string;
 	const __SVELTEKIT_APP_VERSION_FILE__: string;
 	const __SVELTEKIT_APP_VERSION_POLL_INTERVAL__: number;
-	const __SVELTEKIT_DEV__: boolean;
 	const __SVELTEKIT_EMBEDDED__: boolean;
 	/** True if `config.kit.experimental.instrumentation.server` is `true` */
 	const __SVELTEKIT_SERVER_TRACING_ENABLED__: boolean;

--- a/packages/kit/test/prerendering/basics/test/tests.spec.js
+++ b/packages/kit/test/prerendering/basics/test/tests.spec.js
@@ -240,7 +240,7 @@ test('prerenders a page in a (group)', () => {
 
 test('injects relative service worker', () => {
 	const content = read('index.html');
-	expect(content).toMatch("navigator.serviceWorker.register('./service-worker.js')");
+	expect(content).toMatch("navigator.serviceWorker.register('./service-worker.js'");
 });
 
 test('define service worker variables', () => {


### PR DESCRIPTION
This PR addresses one of the TODO comments by consolidating our dev environment checks to use `esm-env` instead of relying on the (probably legacy) `__SVELTEKIT_DEV__` global variable. It also adjusts some unit tests to run in production mode from the Vitest CLI where previously we just manipulated the global variable (but as far as I'm aware that's not possible to do inline in a test in Vitest to get `esm-env` to behave similarly)

Not sure if this is breaking or not but if it is let me know so we can adjust the changeset or delay the merging of this PR.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
