### PR TITLE
fix: false positive `csrf` error in remote functions

### DIFF
--- a/.changeset/twenty-parrots-invent.md
+++ b/.changeset/twenty-parrots-invent.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix remote functions `csrf` missing config check
+fix: `csrf` option ignored by `command` and `form` remote functions

--- a/.changeset/twenty-parrots-invent.md
+++ b/.changeset/twenty-parrots-invent.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix remote functions `csrf` missing config check

--- a/.changeset/twenty-parrots-invent.md
+++ b/.changeset/twenty-parrots-invent.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: `csrf` option ignored by `command` and `form` remote functions
+fix: false positive `csrf` error in remote functions

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -77,7 +77,7 @@ export async function internal_respond(request, options, manifest, state) {
 	const request_origin = request.headers.get('origin');
 
 	if (remote_id) {
-		if (request.method !== 'GET' && request_origin !== url.origin) {
+		if (options.csrf_check_origin && request.method !== 'GET' && request_origin !== url.origin) {
 			const message = 'Cross-site remote requests are forbidden';
 			return json({ message }, { status: 403 });
 		}


### PR DESCRIPTION
Hey there 👋,

I think a bug was introduced in `0.36.0` with #14021. The `command` and `form` remote functions ignore the `csrf` configuration.

My app was successfully working on `0.35.0`, and with `0.36.0` I get this error:

```
{ message: "Cross-site remote requests are forbidden" }
```

If I downgrade my remote calls start working again.

After looking a few in recent PRs: previously, the error was behind a `csrf_check_origin`, and it isn't anymore, allowing for false-positive CSRF errors.

I think this fixes the issue. Thanks for the amazing work on kit 😉!

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
