### PR TITLE
docs: update service-worker example to cache on-demand

### DIFF
--- a/documentation/docs/30-advanced/40-service-workers.md
+++ b/documentation/docs/30-advanced/40-service-workers.md
@@ -48,6 +48,17 @@ const ASSETS = new Set([
 	...files  // everything in `static`
 ]);
 
+self.addEventListener('install', (event) => {
+	event.waitUntil(
+		(async () => {
+			const cache = await caches.open(CACHE);
+			// Cache assets on service worker installation.
+			// e.g. For offline PWA, cache all ASSETS here.
+			await cache.addAll([]);
+		})()
+	);
+});
+
 self.addEventListener('activate', (event) => {
 	event.waitUntil(
 		(async () => {

--- a/documentation/docs/30-advanced/40-service-workers.md
+++ b/documentation/docs/30-advanced/40-service-workers.md
@@ -43,10 +43,10 @@ const self = /** @type {ServiceWorkerGlobalScope} */ (/** @type {unknown} */ (gl
 // Create a unique cache name for this deployment
 const CACHE = `cache-${version}`;
 
-const ASSETS = [
+const ASSETS = new Set([
 	...build, // the app itself
 	...files  // everything in `static`
-];
+]);
 
 self.addEventListener('activate', (event) => {
 	event.waitUntil(
@@ -64,7 +64,7 @@ self.addEventListener('fetch', (event) => {
 	if (event.request.method !== 'GET') return;
 
 	const url = new URL(event.request.url);
-	if (!ASSETS.includes(url.pathname)) return;
+	if (!ASSETS.has(url.pathname)) return;
 
 	event.respondWith(
 		(async () => {


### PR DESCRIPTION
Current service worker example caches all static files[^1] on the service worker installation.

[^1]: Immutable assets hashed by Vite, Assets placed in the `/static/` directory.

This is great for full offline PWA, but could load unused or unnecessary assets eagerly.

By making the default example to cache files on-demand (on 1st request), it can be more universal.

e.g. Cloudflare Pages hosting can have performance gain as documented in the https://github.com/sveltejs/kit/issues/14196 issue body.

---

### Notes

Fetch seems to throw on network errors[^2], instead of returning non-Response.

[^2]: https://web.dev/articles/offline-fallback-page#the_service_worker_code

The following comment and the try-catch block has been removed for now.

> if we're offline, fetch can return a value that is not a Response instead of throwing - and we can't pass this non-Response to `respondWith`

For non-cached assets, there's no fallback available if the client is offline.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
