### PR TITLE
fix: reset form inputs by default when using remote form functions

### DIFF
--- a/.changeset/twelve-turkeys-reply.md
+++ b/.changeset/twelve-turkeys-reply.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: reset form inputs by default when using remote form functions

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -210,7 +210,7 @@ export function form(id) {
 			};
 		};
 
-		instance.onsubmit = form_onsubmit(({ submit }) => submit());
+		instance.onsubmit = form_onsubmit(({ submit, form }) => submit().then(() => form.reset()));
 
 		/** @param {Parameters<RemoteForm<any>['buttonProps']['enhance']>[0]} callback */
 		const form_action_onclick = (callback) => {
@@ -247,7 +247,7 @@ export function form(id) {
 			type: 'submit',
 			formmethod: 'POST',
 			formaction: action,
-			onclick: form_action_onclick(({ submit }) => submit())
+			onclick: form_action_onclick(({ submit, form }) => submit().then(() => form.reset()))
 		};
 
 		Object.defineProperty(button_props, 'enhance', {

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1605,6 +1605,7 @@ test.describe('remote functions', () => {
 		await page.fill('#input-task', 'hi');
 		await page.click('#submit-btn-one');
 		await expect(page.locator('#form-result-1')).toHaveText('hi');
+		await expect(page.locator('#input-task')).toHaveValue('');
 	});
 
 	test('form error works', async ({ page }) => {


### PR DESCRIPTION
Fixes a weird inconsistency: Full page reloads clear the form fields, but when using JS to enhance it (which happens by default) it's no longer resetting. This fixes that. If you enhance you still can decide which way you want to go.

<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
