### PR TITLE
feat: automatically resolve `query.refresh()` promises on the server

### DIFF
--- a/.changeset/cute-toys-doubt.md
+++ b/.changeset/cute-toys-doubt.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+feat: automatically resolve `query.refresh()` promises on the server

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -587,7 +587,15 @@ export interface RequestState {
 	};
 	form_instances?: Map<any, any>;
 	remote_data?: Record<string, MaybePromise<any>>;
-	refreshes?: Record<string, any>;
+	refreshes?: Record<string, {
+		value: undefined;
+		resolved: false;
+		promise: Promise<void>;
+	} | {
+		value: any;
+		resolved: true;
+		promise: null;
+	}>;
 }
 
 export interface RequestStore {


### PR DESCRIPTION
This should close #14331

<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
