### PR TITLE
fix: clear result when form client errors

### DIFF
--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -82,7 +82,6 @@ export function form(id) {
 					if (!response.ok) {
 						// We only end up here in case of a network error or if the server has an internal error
 						// (which shouldn't happen because we handle errors on the server and always send a 200 response)
-						result = undefined;
 						throw new Error('Failed to execute remote function');
 					}
 
@@ -109,6 +108,7 @@ export function form(id) {
 						throw new HttpError(500, form_result.error);
 					}
 				} catch (e) {
+					result = undefined;
 					release_overrides(updates);
 					throw e;
 				} finally {


### PR DESCRIPTION
If a `fetch` fails because of a network error (e.g. no connection),
there will be no `response`. Instead, `fetch` will throw.

When this happens, we should still clear the result so it reflects this
(just like we do when `!response.ok`).

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
