### PR TITLE
chore: get rid of AbortController when calling queries on server

### DIFF
--- a/packages/kit/src/runtime/app/server/remote/shared.js
+++ b/packages/kit/src/runtime/app/server/remote/shared.js
@@ -66,16 +66,14 @@ export function create_validator(validate_or_fn, maybe_fn) {
  * @param {any} arg
  * @param {RequestState} state
  * @param {() => Promise<T>} get_result
- * @param {AbortSignal | undefined=} signal
  * @returns {Promise<T>}
  */
-export async function get_response(id, arg, state, get_result, signal) {
-	if (signal) {
-		await new Promise((r) => setTimeout(r, 0));
-		if (signal.aborted) throw new DOMException('The operation was aborted.', 'AbortError');
-	}
-	const cache_key = create_remote_cache_key(id, stringify_remote_arg(arg, state.transport));
+export async function get_response(id, arg, state, get_result) {
+	// wait a beat, in case `myQuery().set(...)` is immediately called
+	// eslint-disable-next-line @typescript-eslint/await-thenable
+	await 0;
 
+	const cache_key = create_remote_cache_key(id, stringify_remote_arg(arg, state.transport));
 	return ((state.remote_data ??= {})[cache_key] ??= get_result());
 }
 


### PR DESCRIPTION
see https://github.com/sveltejs/kit/pull/14304#discussion_r2307962421 — creating a `AbortController` every time we call a query function on the server is unnecessary overhead. We can just refer to the event cache

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
