### PR TITLE
fix: prevent TypeError in serialize_refreshes when state.refreshes is null

### DIFF
--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -194,7 +194,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 	 * @param {string[]} client_refreshes
 	 */
 	async function serialize_refreshes(client_refreshes) {
-		const refreshes = /** @type {Record<string, Promise<any>>} */ (state.refreshes);
+		const refreshes = /** @type {Record<string, Promise<any>>} */ (state.refreshes || {});
 
 		for (const key of client_refreshes) {
 			if (refreshes[key] !== undefined) continue;


### PR DESCRIPTION
## Problem

When calling `redirect()` in remote functions, SvelteKit crashes with:

```
TypeError: Cannot convert undefined or null to object
    at Object.keys (<anonymous>)
    at serialize_refreshes (packages/kit/src/runtime/server/remote.js:214:14)
```

This happens because:
1. Remote function calls `redirect(302, '/some-path')`
2. SvelteKit catches the `Redirect` exception and tries to create a JSON response
3. During response creation, it calls `serialize_refreshes()` to handle any pending refreshes  
4. `serialize_refreshes` assumes `state.refreshes` is always an object, but it can be `null`/`undefined`
5. `Object.keys(refreshes)` throws when `refreshes` is `null`/`undefined`

## Solution

Add a fallback to an empty object when `state.refreshes` is `null`/`undefined`:

```js
const refreshes = /** @type {Record<string, Promise<any>>} */ (state.refreshes || {});
```

## Testing

- ✅ Remote function redirects now work without crashing
- ✅ Normal remote function calls still work as expected  
- ✅ The fix is minimal and doesn't affect existing functionality

## Reproduction

```js
// This would previously cause a 500 error
export const myRemoteFunction = query(async () => {
  redirect(302, '/auth/logout');
});
```

## Impact

This is a **bug fix** that allows remote functions to use redirects as intended, without breaking existing functionality.