### PR TITLE
fix: remove empty nodes from serialized server load data

### DIFF
--- a/.changeset/lazy-boats-stay.md
+++ b/.changeset/lazy-boats-stay.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: remove empty nodes from serialized server load data

--- a/packages/kit/src/runtime/server/page/data_serializer.js
+++ b/packages/kit/src/runtime/server/page/data_serializer.js
@@ -1,4 +1,5 @@
 import * as devalue from 'devalue';
+import { compact } from '../../../utils/array.js';
 import { create_async_iterator } from '../../../utils/streaming.js';
 import {
 	clarify_devalue_error,
@@ -96,7 +97,7 @@ export function server_data_serializer(event, event_state, options) {
 			const close = `</script>\n`;
 
 			return {
-				data: `[${strings.join(',')}]`,
+				data: `[${compact(strings).join(',')}]`,
 				chunks: promise_id > 1 ? iterator.iterate((str) => open + str + close) : null
 			};
 		}

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -198,7 +198,7 @@ export async function render_page(
 					if (node) {
 						data_serializer.add_node(i, server_data);
 					}
-					
+
 					data_serializer_json?.add_node(i, server_data);
 
 					return server_data;

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -195,8 +195,10 @@ export async function render_page(
 						}
 					});
 
-					data_serializer.add_node(i, server_data);
-					data_serializer_json?.add_node(i, server_data);
+					if (node) {
+						data_serializer.add_node(i, server_data);
+						data_serializer_json?.add_node(i, server_data);
+					}
 
 					return server_data;
 				} catch (e) {
@@ -348,7 +350,8 @@ export async function render_page(
 			branch: ssr === false ? [] : compact(branch),
 			action_result,
 			fetched,
-			data_serializer
+			data_serializer:
+				ssr === false ? server_data_serializer(event, event_state, options) : data_serializer
 		});
 	} catch (e) {
 		// if we end up here, it means the data loaded successfully

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -197,8 +197,9 @@ export async function render_page(
 
 					if (node) {
 						data_serializer.add_node(i, server_data);
-						data_serializer_json?.add_node(i, server_data);
 					}
+					
+					data_serializer_json?.add_node(i, server_data);
 
 					return server_data;
 				} catch (e) {

--- a/packages/kit/test/apps/basics/src/routes/load/serialization-empty-node/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization-empty-node/+page.server.js
@@ -1,0 +1,4 @@
+/** @type {import('./$types').PageServerLoad} */
+export function load() {
+	return { answer: 42 };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/serialization-empty-node/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/serialization-empty-node/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	/** @type {import('./$types').PageData} */
+	export let data;
+</script>
+
+<h1>{data.answer}</h1>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -246,7 +246,7 @@ test.describe('Load', () => {
 		);
 	});
 
-	test.only('Server data serialization removes empty nodes', async ({ page }) => {
+	test('Server data serialization removes empty nodes', async ({ page }) => {
 		await page.goto('/load/serialization-empty-node');
 		expect(await page.textContent('h1')).toBe('42');
 	});

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -246,6 +246,11 @@ test.describe('Load', () => {
 		);
 	});
 
+	test.only('Server data serialization removes empty nodes', async ({ page }) => {
+		await page.goto('/load/serialization-empty-node');
+		expect(await page.textContent('h1')).toBe('42');
+	});
+
 	test('POST fetches are serialized', async ({ page, javaScriptEnabled }) => {
 		/** @type {string[]} */
 		const requests = [];


### PR DESCRIPTION
Fixes #14390

Another bug in #14298 🫤
We must only `add_node()` if there is a `node` (`SSRNode`) and then remove empty array items from `strings` (like we do with the `branches` array).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
