### PR TITLE
fix: ensure environment setup is in its own chunk

### DIFF
--- a/.changeset/busy-pumas-tap.md
+++ b/.changeset/busy-pumas-tap.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: ensure environment setup is in its own chunk

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -682,8 +682,12 @@ async function kit({ svelte_config }) {
 			config.build.rollupOptions.output = {
 				...config.build.rollupOptions.output,
 				manualChunks(id, meta) {
+					// Prevent core runtime and env from ending up in a remote chunk, which could break because of initialization order
 					if (id === `${runtime_directory}/app/server/index.js`) {
 						return 'app-server';
+					}
+					if (id === `${runtime_directory}/shared-server.js`) {
+						return 'app-shared-server';
 					}
 
 					// Check if this is a *.remote.ts file

--- a/packages/kit/test/apps/basics/src/routes/remote/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/remote/+page.js
@@ -1,6 +1,8 @@
+import { q } from './accessing-env.remote';
 import { echo } from './query-command.remote';
 
 export async function load() {
+	q();
 	return {
 		echo_result: await echo('Hello world')
 	};

--- a/packages/kit/test/apps/basics/src/routes/remote/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/remote/+page.js
@@ -1,8 +1,6 @@
-import { q } from './accessing-env.remote';
 import { echo } from './query-command.remote';
 
 export async function load() {
-	q();
 	return {
 		echo_result: await echo('Hello world')
 	};

--- a/packages/kit/test/apps/basics/src/routes/remote/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/remote/+page.svelte
@@ -9,11 +9,14 @@
 		set_count_server_set,
 		resolve_deferreds
 	} from './query-command.remote.js';
+	import { q } from './accessing-env.remote';
 
 	let { data } = $props();
 
 	let command_result = $state(null);
-	let release;
+
+	// we just want it not to be treeshaken away
+	q;
 
 	const count = browser ? get_count() : null; // so that we get a remote request in the browser
 </script>

--- a/packages/kit/test/apps/basics/src/routes/remote/accessing-env.remote.js
+++ b/packages/kit/test/apps/basics/src/routes/remote/accessing-env.remote.js
@@ -1,8 +1,14 @@
+import { query } from '$app/server';
 import { env } from '$env/dynamic/private';
 import { env as public_env } from '$env/dynamic/public';
 
 if (!env.PRIVATE_DYNAMIC || !public_env.PUBLIC_DYNAMIC) {
 	// This checks that dynamic env vars are available when prerendering remote functions
 	// https://github.com/sveltejs/kit/pull/14219
+	// and are not in the same chunk as this one
+	// https://github.com/sveltejs/kit/issues/14439
 	throw new Error('Dynamic environment variables are not set up correctly');
 }
+
+// placeholder query that needs to be imported/used elsewhere so that bundling/chunking would include env setup if not setup correctly
+export const q = query(() => {});


### PR DESCRIPTION
This way you cannot run into initialization order issues where e.g. some remote function uses environment variables before they're set

Fixes #14439

<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
