### PR TITLE
fix(build): RangeError - Maximum call stack size exceeded

### DIFF
--- a/.changeset/curvy-icons-fall.md
+++ b/.changeset/curvy-icons-fall.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prevent a loop causing the build to fail ([#14444](https://github.com/sveltejs/kit/pull/14444))

--- a/.changeset/curvy-icons-fall.md
+++ b/.changeset/curvy-icons-fall.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: prevent a loop causing the build to fail ([#14444](https://github.com/sveltejs/kit/pull/14444))
+fix: prevent loops in postbuild analysis phase

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -255,8 +255,12 @@ function list_features(route, manifest_data, server_manifest, tracked_features) 
 		manifest_data.routes.find((r) => r.id === route.id)
 	);
 
+	const visited = new Set();
 	/** @param {string} id */
 	function visit(id) {
+		if (visited.has(id)) return;
+		visited.add(id);
+
 		const chunk = server_manifest[id];
 		if (!chunk) return;
 


### PR DESCRIPTION
It is currently possible for a chunk to import chunks that import itself. I'm not exactly sure where this occurs or why as I can't reproduce it in a simple repository, but a simple fix is to prevent importing already visited chunks.

<!-- Your PR description here -->
This addresses #14444 
---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
