### PR TITLE
fix: rework lazily remote function files discovery

### DIFF
--- a/.changeset/plenty-houses-knock.md
+++ b/.changeset/plenty-houses-knock.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: rework lazily remote function files discovery

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -103,7 +103,7 @@ export function generate_manifest({ build_data, prerendered, relative_path, rout
 					${(node_paths).map(loader).join(',\n')}
 				],
 				remotes: {
-					${remotes.map((remote) => `'${remote.hash}': ${loader(join_relative(relative_path, `chunks/remote-${remote.hash}.js`))}`).join(',\n')}
+					${remotes.map((remote) => `'${remote.hash}': ${loader(join_relative(relative_path, remote.file))}`).join(',\n')}
 				},
 				routes: [
 					${routes.map(route => {

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -170,8 +170,7 @@ async function analyse({
 	// analyse remotes
 	for (const remote of remotes) {
 		const loader = manifest._.remotes[remote.hash];
-		const { default: functions } = await loader();
-
+		const functions = await loader();
 		const exports = new Map();
 
 		for (const name in functions) {

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -495,7 +495,7 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env }) {
 	for (const loader of Object.values(manifest._.remotes)) {
 		const module = await loader();
 
-		for (const fn of Object.values(module.default)) {
+		for (const fn of Object.values(module)) {
 			if (fn?.__?.type === 'prerender') {
 				prerender_functions.push(fn.__);
 				should_prerender = true;

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -269,10 +269,7 @@ export async function dev(vite, vite_config, svelte_config, get_remotes) {
 				prerendered_routes: new Set(),
 				get remotes() {
 					return Object.fromEntries(
-						get_remotes().map((remote) => [
-							remote.hash,
-							() => vite.ssrLoadModule(remote.file).then((module) => ({ default: module }))
-						])
+						get_remotes().map((remote) => [remote.hash, () => vite.ssrLoadModule(remote.file)])
 					);
 				},
 				routes: compact(

--- a/packages/kit/src/runtime/server/remote-manifest.js
+++ b/packages/kit/src/runtime/server/remote-manifest.js
@@ -1,0 +1,2 @@
+// This is a proxy file because you cannot make a virtual module an entry point
+export { map } from '__sveltekit/remote-functions-manifest';

--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -44,7 +44,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 	if (!remotes[hash]) error(404);
 
 	const module = await remotes[hash]();
-	const fn = module.default[name];
+	const fn = module[name];
 
 	if (!fn) error(404);
 
@@ -211,7 +211,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 			const [hash, name, payload] = key.split('/');
 
 			const loader = manifest._.remotes[hash];
-			const fn = (await loader?.())?.default?.[name];
+			const fn = (await loader?.())?.[name];
 
 			if (!fn) error(400, 'Bad Request');
 
@@ -263,7 +263,7 @@ async function handle_remote_form_post_internal(event, state, manifest, id) {
 	const remotes = manifest._.remotes;
 	const module = await remotes[hash]?.();
 
-	let form = /** @type {RemoteForm<any, any>} */ (module?.default[name]);
+	let form = /** @type {RemoteForm<any, any>} */ (module?.[name]);
 
 	if (!form) {
 		event.setHeaders({

--- a/packages/kit/src/types/ambient-private.d.ts
+++ b/packages/kit/src/types/ambient-private.d.ts
@@ -27,3 +27,9 @@ declare module '__sveltekit/server' {
 	export function set_manifest(manifest: SSRManifest): void;
 	export function set_read_implementation(fn: (path: string) => ReadableStream): void;
 }
+
+/** Contains a map of all the remote functions, generated on the fly during build; unused during dev */
+declare module '__sveltekit/remote-functions-manifest' {
+	/** Map of hash -> dynamic import to remote file */
+	export const map: Record<string, () => any>;
+}


### PR DESCRIPTION
Instead of using manualChunks which turns out to cause some weird chunking bugs, we instead use a virtual module which we force to be loaded at the very end after all other modules have been discovered. By that time we have collected all remote function files and can generated a record of hash->import. Vite will then do the proper chunking without further interference by us.

Fixes #14444 and possibly #14430

Putting this into draft because while working on this I discovered that remote functions in node_modules are not loaded at dev time - but this is not new to this PR, it's failing on main, too. Investigating.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
 