### PR TITLE
fix: optional keys in validated forms

### DIFF
--- a/.changeset/chubby-papers-tie.md
+++ b/.changeset/chubby-papers-tie.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: fix type issue with optional keys in validated forms

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1832,12 +1832,15 @@ type FlattenInput<T, Prefix extends string> =
 			: T extends File
 				? { [P in Prefix]: string }
 				: T extends object
-					? {
-							[K in keyof T]: FlattenInput<
-								T[K],
-								Prefix extends '' ? K & string : `${Prefix}.${K & string}`
-							>;
-						}[keyof T]
+					? Exclude<
+							{
+								[K in keyof T]: FlattenInput<
+									T[K],
+									Prefix extends '' ? K & string : `${Prefix}.${K & string}`
+								>;
+							}[keyof T],
+							undefined
+						>
 					: { [P in Prefix]: string };
 
 type FlattenIssues<T, Prefix extends string> =
@@ -1851,12 +1854,15 @@ type FlattenIssues<T, Prefix extends string> =
 			: T extends File
 				? { [P in Prefix]: RemoteFormIssue[] }
 				: T extends object
-					? {
-							[K in keyof T]: FlattenIssues<
-								T[K],
-								Prefix extends '' ? K & string : `${Prefix}.${K & string}`
-							>;
-						}[keyof T]
+					? Exclude<
+							{
+								[K in keyof T]: FlattenIssues<
+									T[K],
+									Prefix extends '' ? K & string : `${Prefix}.${K & string}`
+								>;
+							}[keyof T],
+							undefined
+						>
 					: { [P in Prefix]: RemoteFormIssue[] };
 
 type FlattenKeys<T, Prefix extends string> =
@@ -1869,12 +1875,15 @@ type FlattenKeys<T, Prefix extends string> =
 			: T extends File
 				? { [P in Prefix]: string }
 				: T extends object
-					? {
-							[K in keyof T]: FlattenKeys<
-								T[K],
-								Prefix extends '' ? K & string : `${Prefix}.${K & string}`
-							>;
-						}[keyof T]
+					? Exclude<
+							{
+								[K in keyof T]: FlattenKeys<
+									T[K],
+									Prefix extends '' ? K & string : `${Prefix}.${K & string}`
+								>;
+							}[keyof T],
+							undefined
+						>
 					: { [P in Prefix]: string };
 
 export interface RemoteFormInput {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1808,12 +1808,15 @@ declare module '@sveltejs/kit' {
 				: T extends File
 					? { [P in Prefix]: string }
 					: T extends object
-						? {
-								[K in keyof T]: FlattenInput<
-									T[K],
-									Prefix extends '' ? K & string : `${Prefix}.${K & string}`
-								>;
-							}[keyof T]
+						? Exclude<
+								{
+									[K in keyof T]: FlattenInput<
+										T[K],
+										Prefix extends '' ? K & string : `${Prefix}.${K & string}`
+									>;
+								}[keyof T],
+								undefined
+							>
 						: { [P in Prefix]: string };
 
 	type FlattenIssues<T, Prefix extends string> =
@@ -1827,12 +1830,15 @@ declare module '@sveltejs/kit' {
 				: T extends File
 					? { [P in Prefix]: RemoteFormIssue[] }
 					: T extends object
-						? {
-								[K in keyof T]: FlattenIssues<
-									T[K],
-									Prefix extends '' ? K & string : `${Prefix}.${K & string}`
-								>;
-							}[keyof T]
+						? Exclude<
+								{
+									[K in keyof T]: FlattenIssues<
+										T[K],
+										Prefix extends '' ? K & string : `${Prefix}.${K & string}`
+									>;
+								}[keyof T],
+								undefined
+							>
 						: { [P in Prefix]: RemoteFormIssue[] };
 
 	type FlattenKeys<T, Prefix extends string> =
@@ -1845,12 +1851,15 @@ declare module '@sveltejs/kit' {
 				: T extends File
 					? { [P in Prefix]: string }
 					: T extends object
-						? {
-								[K in keyof T]: FlattenKeys<
-									T[K],
-									Prefix extends '' ? K & string : `${Prefix}.${K & string}`
-								>;
-							}[keyof T]
+						? Exclude<
+								{
+									[K in keyof T]: FlattenKeys<
+										T[K],
+										Prefix extends '' ? K & string : `${Prefix}.${K & string}`
+									>;
+								}[keyof T],
+								undefined
+							>
 						: { [P in Prefix]: string };
 
 	export interface RemoteFormInput {
@@ -2517,7 +2526,7 @@ declare module '@sveltejs/kit' {
 	 * Checks whether this is an error thrown by {@link error}.
 	 * @param status The status to filter for.
 	 * */
-	export function isHttpError<T extends number>(e: unknown, status?: T): e is (HttpError_1 & {
+	export function isHttpError<T extends number>(e: unknown, status?: T | undefined): e is (HttpError_1 & {
 		status: T extends undefined ? never : T;
 	});
 	/**
@@ -2547,13 +2556,13 @@ declare module '@sveltejs/kit' {
 	 * @param data The value that will be serialized as JSON.
 	 * @param init Options such as `status` and `headers` that will be added to the response. `Content-Type: application/json` and `Content-Length` headers will be added automatically.
 	 */
-	export function json(data: any, init?: ResponseInit): Response;
+	export function json(data: any, init?: ResponseInit | undefined): Response;
 	/**
 	 * Create a `Response` object from the supplied body.
 	 * @param body The value that will be used as-is.
 	 * @param init Options such as `status` and `headers` that will be added to the response. A `Content-Length` header will be added automatically.
 	 */
-	export function text(body: string, init?: ResponseInit): Response;
+	export function text(body: string, init?: ResponseInit | undefined): Response;
 	/**
 	 * Create an `ActionFailure` object. Call when form submission fails.
 	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
@@ -2853,7 +2862,7 @@ declare module '$app/navigation' {
 		invalidateAll?: boolean | undefined;
 		invalidate?: (string | URL | ((url: URL) => boolean))[] | undefined;
 		state?: App.PageState | undefined;
-	}): Promise<void>;
+	} | undefined): Promise<void>;
 	/**
 	 * Causes any `load` functions belonging to the currently active page to re-run if they depend on the `url` in question, via `fetch` or `depends`. Returns a `Promise` that resolves when the page is subsequently updated.
 	 *
@@ -2882,7 +2891,7 @@ declare module '$app/navigation' {
 	 * */
 	export function refreshAll({ includeLoadFunctions }?: {
 		includeLoadFunctions?: boolean;
-	}): Promise<void>;
+	} | undefined): Promise<void>;
 	/**
 	 * Programmatically preloads the given page, which means
 	 *  1. ensuring that the code for the page is loaded, and

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2526,7 +2526,7 @@ declare module '@sveltejs/kit' {
 	 * Checks whether this is an error thrown by {@link error}.
 	 * @param status The status to filter for.
 	 * */
-	export function isHttpError<T extends number>(e: unknown, status?: T | undefined): e is (HttpError_1 & {
+	export function isHttpError<T extends number>(e: unknown, status?: T): e is (HttpError_1 & {
 		status: T extends undefined ? never : T;
 	});
 	/**
@@ -2556,13 +2556,13 @@ declare module '@sveltejs/kit' {
 	 * @param data The value that will be serialized as JSON.
 	 * @param init Options such as `status` and `headers` that will be added to the response. `Content-Type: application/json` and `Content-Length` headers will be added automatically.
 	 */
-	export function json(data: any, init?: ResponseInit | undefined): Response;
+	export function json(data: any, init?: ResponseInit): Response;
 	/**
 	 * Create a `Response` object from the supplied body.
 	 * @param body The value that will be used as-is.
 	 * @param init Options such as `status` and `headers` that will be added to the response. A `Content-Length` header will be added automatically.
 	 */
-	export function text(body: string, init?: ResponseInit | undefined): Response;
+	export function text(body: string, init?: ResponseInit): Response;
 	/**
 	 * Create an `ActionFailure` object. Call when form submission fails.
 	 * @param status The [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses). Must be in the range 400-599.
@@ -2862,7 +2862,7 @@ declare module '$app/navigation' {
 		invalidateAll?: boolean | undefined;
 		invalidate?: (string | URL | ((url: URL) => boolean))[] | undefined;
 		state?: App.PageState | undefined;
-	} | undefined): Promise<void>;
+	}): Promise<void>;
 	/**
 	 * Causes any `load` functions belonging to the currently active page to re-run if they depend on the `url` in question, via `fetch` or `depends`. Returns a `Promise` that resolves when the page is subsequently updated.
 	 *
@@ -2891,7 +2891,7 @@ declare module '$app/navigation' {
 	 * */
 	export function refreshAll({ includeLoadFunctions }?: {
 		includeLoadFunctions?: boolean;
-	} | undefined): Promise<void>;
+	}): Promise<void>;
 	/**
 	 * Programmatically preloads the given page, which means
 	 *  1. ensuring that the code for the page is loaded, and


### PR DESCRIPTION
- `UnionToIntersection<{ foo: string } | undefined>` -> `never`
- `FlattenInput<{ foo: string, bar?: string }, ''>` -> `{ foo: string; } | { bar: string; } | undefined`

this PR fixes that issue, but there's still an issue here:

- `WillRecurseIndefinitely<{foo?: string}>` -> `true`
This doesn't actually recurse indefinitely -- `RemoteFormInput extends { foo?: string }` gives a false positive. I don't know if the other change fixes the indefinite recursion that this was meant to catch.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
