### PR TITLE
fix: robustify form helper types

### DIFF
--- a/.changeset/funny-onions-drive.md
+++ b/.changeset/funny-onions-drive.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: robustify form helper types

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1811,13 +1811,7 @@ export interface Snapshot<T = any> {
 }
 
 // If T is unknown or has an index signature, the types below will recurse indefinitely and create giant unions that TS can't handle
-type WillRecurseIndefinitely<T> = unknown extends T
-	? true
-	: string extends keyof T
-		? true
-		: number extends keyof T
-			? true
-			: false;
+type WillRecurseIndefinitely<T> = unknown extends T ? true : string extends keyof T ? true : false;
 
 // Helper type to convert union to intersection
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void
@@ -1865,8 +1859,6 @@ type FlattenIssues<T, Prefix extends string> = T extends
 							Prefix extends '' ? K & string : `${Prefix}.${K & string}`
 						>;
 					}[keyof T];
-
-type X = FlattenIssues<{ a: string }, ''>;
 
 type FlattenKeys<T, Prefix extends string> = T extends string | number | boolean | null | undefined
 	? { [P in Prefix]: string }

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1822,7 +1822,7 @@ type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
 	? I
 	: never;
 
-type FlattenInput<T, Prefix extends string> =
+type FlattenInput<T, Prefix extends string> = NonNullable<
 	WillRecurseIndefinitely<T> extends true
 		? { [key: string]: string }
 		: T extends Array<infer U>
@@ -1838,9 +1838,10 @@ type FlattenInput<T, Prefix extends string> =
 								Prefix extends '' ? K & string : `${Prefix}.${K & string}`
 							>;
 						}[keyof T]
-					: { [P in Prefix]: string };
+					: { [P in Prefix]: string }
+>;
 
-type FlattenIssues<T, Prefix extends string> =
+type FlattenIssues<T, Prefix extends string> = NonNullable<
 	WillRecurseIndefinitely<T> extends true
 		? { [key: string]: RemoteFormIssue[] }
 		: T extends Array<infer U>
@@ -1857,9 +1858,10 @@ type FlattenIssues<T, Prefix extends string> =
 								Prefix extends '' ? K & string : `${Prefix}.${K & string}`
 							>;
 						}[keyof T]
-					: { [P in Prefix]: RemoteFormIssue[] };
+					: { [P in Prefix]: RemoteFormIssue[] }
+>;
 
-type FlattenKeys<T, Prefix extends string> =
+type FlattenKeys<T, Prefix extends string> = NonNullable<
 	WillRecurseIndefinitely<T> extends true
 		? { [key: string]: string }
 		: T extends Array<infer U>
@@ -1875,7 +1877,8 @@ type FlattenKeys<T, Prefix extends string> =
 								Prefix extends '' ? K & string : `${Prefix}.${K & string}`
 							>;
 						}[keyof T]
-					: { [P in Prefix]: string };
+					: { [P in Prefix]: string }
+>;
 
 export interface RemoteFormInput {
 	[key: string]: FormDataEntryValue | FormDataEntryValue[] | RemoteFormInput | RemoteFormInput[];

--- a/packages/kit/test/types/remote.test.ts
+++ b/packages/kit/test/types/remote.test.ts
@@ -175,6 +175,88 @@ function form_tests() {
 		);
 		y;
 	});
+
+	const f2 = form(
+		null as any as StandardSchemaV1<{ a: string; nested: { prop: string } }>,
+		(data) => {
+			data.a === '';
+			data.nested.prop === '';
+			// @ts-expect-error
+			data.nested.nonexistent;
+			// @ts-expect-error
+			data.nonexistent;
+			// @ts-expect-error
+			data.a === 123;
+			return { success: true };
+		}
+	);
+	f2.issues!.a;
+	f2.issues!['nested.prop'];
+	// @ts-expect-error
+	f2.issues!.nonexistent;
+	f2.input!.a = '';
+	f2.input!['nested.prop'] = '';
+	// @ts-expect-error
+	f2.input!.nonexistent = '';
+	// @ts-expect-error
+	f2.input!.a = 123;
+
+	// all schema properties optional
+	const f3 = form(
+		null as any as StandardSchemaV1<{ a?: string; nested?: { prop?: string } }>,
+		(data) => {
+			data.a === '';
+			data.nested?.prop === '';
+			// @ts-expect-error
+			data.nested.prop === '';
+			// @ts-expect-error
+			data.nested.nonexistent;
+			// @ts-expect-error
+			data.nonexistent;
+			// @ts-expect-error
+			data.a === 123;
+			return { success: true };
+		}
+	);
+	f3.issues!.a;
+	f3.issues!['nested.prop'];
+	// @ts-expect-error
+	f3.issues!.nonexistent;
+	f3.input!.a = '';
+	f3.input!['nested.prop'] = '';
+	// @ts-expect-error
+	f3.input!.nonexistent = '';
+	// @ts-expect-error
+	f3.input!.a = 123;
+
+	// index signature schema
+	const f4 = form(null as any as StandardSchemaV1<Record<string, any>>, (data) => {
+		data.a === '';
+		data.nested?.prop === '';
+		return { success: true };
+	});
+	f4.issues!.a;
+	f4.issues!['nested.prop'];
+	f4.input!.a = '';
+	f4.input!['nested.prop'] = '';
+	// @ts-expect-error
+	f4.input!.a = 123;
+
+	// schema with union types
+	const f5 = form(null as any as StandardSchemaV1<{ foo: 'a' | 'b'; bar: 'c' | 'd' }>, (data) => {
+		data.foo === 'a';
+		data.bar === 'c';
+		// @ts-expect-error
+		data.foo === 'e';
+		return { success: true };
+	});
+	f5.issues!.foo;
+	f5.issues!.bar;
+	// @ts-expect-error
+	f5.issues!.nonexistent;
+	f5.input!.foo = 'a';
+	// @ts-expect-error
+	f5.input!.foo = 123;
 }
 form_tests();
 

--- a/packages/kit/test/types/remote.test.ts
+++ b/packages/kit/test/types/remote.test.ts
@@ -190,6 +190,10 @@ function form_tests() {
 			return { success: true };
 		}
 	);
+	f2.field('a');
+	f2.field('nested.prop');
+	// @ts-expect-error
+	f2.field('nonexistent');
 	f2.issues!.a;
 	f2.issues!['nested.prop'];
 	// @ts-expect-error
@@ -218,6 +222,10 @@ function form_tests() {
 			return { success: true };
 		}
 	);
+	f3.field('a');
+	f3.field('nested.prop');
+	// @ts-expect-error
+	f3.field('nonexistent');
 	f3.issues!.a;
 	f3.issues!['nested.prop'];
 	// @ts-expect-error
@@ -235,6 +243,8 @@ function form_tests() {
 		data.nested?.prop === '';
 		return { success: true };
 	});
+	f4.field('a');
+	f4.field('nested.prop');
 	f4.issues!.a;
 	f4.issues!['nested.prop'];
 	f4.input!.a = '';
@@ -250,6 +260,9 @@ function form_tests() {
 		data.foo === 'e';
 		return { success: true };
 	});
+	f5.field('foo');
+	// @ts-expect-error
+	f5.field('nonexistent');
 	f5.issues!.foo;
 	f5.issues!.bar;
 	// @ts-expect-error
@@ -257,6 +270,37 @@ function form_tests() {
 	f5.input!.foo = 'a';
 	// @ts-expect-error
 	f5.input!.foo = 123;
+
+	// schema with arrays
+	const f6 = form(
+		null as any as StandardSchemaV1<{ array: Array<{ array: string[]; prop: string }> }>,
+		(data) => {
+			data.array[0].prop === 'a';
+			data.array[0].array[0] === 'a';
+			// @ts-expect-error
+			data.array[0].array[0] === 1;
+			return { success: true };
+		}
+	);
+	f6.field('array[0].prop');
+	f6.field('array[0].array[]');
+	// @ts-expect-error
+	f6.field('array[0].array');
+	f6.issues!.array;
+	f6.issues!['array[0].prop'];
+	f6.issues!['array[0].array'];
+	// @ts-expect-error
+	f6.issues!['array[0].array[]'];
+	// @ts-expect-error
+	f6.issues!.nonexistent;
+	f6.input!['array[0].prop'] = '';
+	f6.input!['array[0].array'] = [''];
+	// @ts-expect-error
+	f6.input!['array[0].array'] = '';
+	// @ts-expect-error
+	f6.input!['array[0].array[]'] = [''];
+	// @ts-expect-error
+	f6.input!['array[0].prop'] = 123;
 }
 form_tests();
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1787,13 +1787,7 @@ declare module '@sveltejs/kit' {
 	}
 
 	// If T is unknown or has an index signature, the types below will recurse indefinitely and create giant unions that TS can't handle
-	type WillRecurseIndefinitely<T> = unknown extends T
-		? true
-		: string extends keyof T
-			? true
-			: number extends keyof T
-				? true
-				: false;
+	type WillRecurseIndefinitely<T> = unknown extends T ? true : string extends keyof T ? true : false;
 
 	// Helper type to convert union to intersection
 	type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void
@@ -1841,8 +1835,6 @@ declare module '@sveltejs/kit' {
 								Prefix extends '' ? K & string : `${Prefix}.${K & string}`
 							>;
 						}[keyof T];
-
-	type X = FlattenIssues<{ a: string }, ''>;
 
 	type FlattenKeys<T, Prefix extends string> = T extends string | number | boolean | null | undefined
 		? { [P in Prefix]: string }

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1786,20 +1786,23 @@ declare module '@sveltejs/kit' {
 		restore: (snapshot: T) => void;
 	}
 
-	// If T is unknown or RemoteFormInput, the types below will recurse indefinitely and create giant unions that TS can't handle
+	// If T is unknown or has an index signature, the types below will recurse indefinitely and create giant unions that TS can't handle
 	type WillRecurseIndefinitely<T> = unknown extends T
 		? true
-		: RemoteFormInput extends T
+		: string extends keyof T
 			? true
-			: false;
+			: number extends keyof T
+				? true
+				: false;
 
 	// Helper type to convert union to intersection
 	type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void
 		? I
 		: never;
 
-	type FlattenInput<T, Prefix extends string> =
-		WillRecurseIndefinitely<T> extends true
+	type FlattenInput<T, Prefix extends string> = T extends string | number | boolean | null | undefined
+		? { [P in Prefix]: string }
+		: WillRecurseIndefinitely<T> extends true
 			? { [key: string]: string }
 			: T extends Array<infer U>
 				? U extends string | File
@@ -1807,17 +1810,22 @@ declare module '@sveltejs/kit' {
 					: FlattenInput<U, `${Prefix}[${number}]`>
 				: T extends File
 					? { [P in Prefix]: string }
-					: T extends object
-						? {
-								[K in keyof T]: FlattenInput<
-									T[K],
-									Prefix extends '' ? K & string : `${Prefix}.${K & string}`
-								>;
-							}[keyof T]
-						: { [P in Prefix]: string };
+					: {
+							// Required<T> is crucial here to avoid an undefined type to sneak into the union, which would turn the intersection into never
+							[K in keyof Required<T>]: FlattenInput<
+								T[K],
+								Prefix extends '' ? K & string : `${Prefix}.${K & string}`
+							>;
+						}[keyof T];
 
-	type FlattenIssues<T, Prefix extends string> =
-		WillRecurseIndefinitely<T> extends true
+	type FlattenIssues<T, Prefix extends string> = T extends
+		| string
+		| number
+		| boolean
+		| null
+		| undefined
+		? { [P in Prefix]: RemoteFormIssue[] }
+		: WillRecurseIndefinitely<T> extends true
 			? { [key: string]: RemoteFormIssue[] }
 			: T extends Array<infer U>
 				? { [P in Prefix | `${Prefix}[${number}]`]: RemoteFormIssue[] } & FlattenIssues<
@@ -1826,17 +1834,19 @@ declare module '@sveltejs/kit' {
 					>
 				: T extends File
 					? { [P in Prefix]: RemoteFormIssue[] }
-					: T extends object
-						? {
-								[K in keyof T]: FlattenIssues<
-									T[K],
-									Prefix extends '' ? K & string : `${Prefix}.${K & string}`
-								>;
-							}[keyof T]
-						: { [P in Prefix]: RemoteFormIssue[] };
+					: {
+							// Required<T> is crucial here to avoid an undefined type to sneak into the union, which would turn the intersection into never
+							[K in keyof Required<T>]: FlattenIssues<
+								T[K],
+								Prefix extends '' ? K & string : `${Prefix}.${K & string}`
+							>;
+						}[keyof T];
 
-	type FlattenKeys<T, Prefix extends string> =
-		WillRecurseIndefinitely<T> extends true
+	type X = FlattenIssues<{ a: string }, ''>;
+
+	type FlattenKeys<T, Prefix extends string> = T extends string | number | boolean | null | undefined
+		? { [P in Prefix]: string }
+		: WillRecurseIndefinitely<T> extends true
 			? { [key: string]: string }
 			: T extends Array<infer U>
 				? U extends string | File
@@ -1844,14 +1854,13 @@ declare module '@sveltejs/kit' {
 					: FlattenKeys<U, `${Prefix}[${number}]`>
 				: T extends File
 					? { [P in Prefix]: string }
-					: T extends object
-						? {
-								[K in keyof T]: FlattenKeys<
-									T[K],
-									Prefix extends '' ? K & string : `${Prefix}.${K & string}`
-								>;
-							}[keyof T]
-						: { [P in Prefix]: string };
+					: {
+							// Required<T> is crucial here to avoid an undefined type to sneak into the union, which would turn the intersection into never
+							[K in keyof Required<T>]: FlattenKeys<
+								T[K],
+								Prefix extends '' ? K & string : `${Prefix}.${K & string}`
+							>;
+						}[keyof T];
 
 	export interface RemoteFormInput {
 		[key: string]: FormDataEntryValue | FormDataEntryValue[] | RemoteFormInput | RemoteFormInput[];


### PR DESCRIPTION
Optional properties make the resulting type `X | undefined` which when turned into an intersection results in the never type. We therefore mark all properties as required while transforming the objects into their desired shape.

There's another adjacent bug: If you have an object only consisting of optional properties, e.g. `{a?: string}`, then `RemoteFormInput` extends it and the type is degraded to e.g. `{ [key: string]: RemoteFormIssues[] }`. A fix to the "will recurse indefinetly" helper type solves this: we now check if the object keys match an index signature, and only bail in that case.

Also added a few tests

Fixes #14461

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
