### PR TITLE
docs: update zod coercion example

### DIFF
--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -320,7 +320,7 @@ export const setCount = form(
 		// Valibot:
 		count: v.pipe(v.string(), v.transform((s) => Number(s)), v.number()),
 		// Zod:
-		// count: z.coerce.number()
+		// count: z.coerce.number<string>()
 	}),
 	async ({ count }) => {
 		// ...


### PR DESCRIPTION
closes #14457 


> By default the input type of any z.coerce schema is unknown. In some cases, it may be preferable for the input type to be more specific. You can specify the input type with a generic parameter. (as described [here](https://zod.dev/api?id=coercion))


---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
