### PR TITLE
chore: use catalog for more "svelte" dependencies

### DIFF
--- a/packages/adapter-cloudflare/test/apps/pages/package.json
+++ b/packages/adapter-cloudflare/test/apps/pages/package.json
@@ -13,7 +13,7 @@
 		"@sveltejs/kit": "workspace:^",
 		"@sveltejs/vite-plugin-svelte": "catalog:",
 		"server-side-dep": "file:server-side-dep",
-		"svelte": "^5.38.5",
+		"svelte": "catalog:",
 		"vite": "catalog:",
 		"wrangler": "^4.14.3"
 	},

--- a/packages/adapter-cloudflare/test/apps/workers/package.json
+++ b/packages/adapter-cloudflare/test/apps/workers/package.json
@@ -15,7 +15,7 @@
 		"@sveltejs/kit": "workspace:^",
 		"@sveltejs/vite-plugin-svelte": "catalog:",
 		"server-side-dep": "file:server-side-dep",
-		"svelte": "^5.38.5",
+		"svelte": "catalog:",
 		"vite": "catalog:",
 		"wrangler": "^4.14.3"
 	},

--- a/packages/adapter-netlify/test/apps/basic/package.json
+++ b/packages/adapter-netlify/test/apps/basic/package.json
@@ -13,7 +13,7 @@
 		"@sveltejs/kit": "workspace:^",
 		"@sveltejs/vite-plugin-svelte": "catalog:",
 		"netlify-cli": "^23.5.1",
-		"svelte": "^5.23.1",
+		"svelte": "catalog:",
 		"vite": "catalog:"
 	},
 	"type": "module"

--- a/packages/adapter-netlify/test/apps/edge/package.json
+++ b/packages/adapter-netlify/test/apps/edge/package.json
@@ -13,7 +13,7 @@
 		"@sveltejs/kit": "workspace:^",
 		"@sveltejs/vite-plugin-svelte": "catalog:",
 		"netlify-cli": "^23.5.1",
-		"svelte": "^5.23.1",
+		"svelte": "catalog:",
 		"vite": "catalog:"
 	},
 	"type": "module"

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -44,7 +44,7 @@
 		"@sveltejs/vite-plugin-svelte": "catalog:",
 		"@types/node": "catalog:",
 		"sirv": "^3.0.0",
-		"svelte": "^5.38.5",
+		"svelte": "catalog:",
 		"typescript": "^5.3.3",
 		"vite": "catalog:"
 	},

--- a/packages/adapter-static/test/apps/prerendered/package.json
+++ b/packages/adapter-static/test/apps/prerendered/package.json
@@ -12,7 +12,7 @@
 		"@sveltejs/kit": "workspace:^",
 		"@sveltejs/vite-plugin-svelte": "catalog:",
 		"sirv-cli": "^3.0.0",
-		"svelte": "^5.38.5",
+		"svelte": "catalog:",
 		"vite": "catalog:"
 	},
 	"type": "module"

--- a/packages/adapter-static/test/apps/spa/package.json
+++ b/packages/adapter-static/test/apps/spa/package.json
@@ -13,7 +13,7 @@
 		"@sveltejs/kit": "workspace:^",
 		"@sveltejs/vite-plugin-svelte": "catalog:",
 		"sirv-cli": "^3.0.0",
-		"svelte": "^5.38.5",
+		"svelte": "catalog:",
 		"vite": "catalog:"
 	},
 	"type": "module"

--- a/packages/enhanced-img/package.json
+++ b/packages/enhanced-img/package.json
@@ -47,7 +47,7 @@
 		"@types/estree": "^1.0.5",
 		"@types/node": "catalog:",
 		"rollup": "^4.27.4",
-		"svelte": "^5.38.5",
+		"svelte": "catalog:",
 		"typescript": "^5.6.3",
 		"vite": "catalog:",
 		"vitest": "catalog:"

--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -31,7 +31,7 @@
 		"@types/node": "catalog:",
 		"@types/semver": "^7.5.6",
 		"prettier": "^3.1.1",
-		"svelte": "^5.38.5",
+		"svelte": "catalog:",
 		"svelte-preprocess": "^6.0.0",
 		"typescript": "^5.3.3",
 		"vitest": "catalog:"

--- a/playgrounds/basic/package.json
+++ b/playgrounds/basic/package.json
@@ -29,7 +29,7 @@
 		"prettier": "^3.3.2",
 		"prettier-plugin-svelte": "^3.2.6",
 		"publint": "^0.3.0",
-		"svelte": "^5.38.5",
+		"svelte": "catalog:",
 		"svelte-check": "^4.1.1",
 		"typescript": "^5.5.0",
 		"valibot": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,7 +115,7 @@ importers:
         specifier: file:server-side-dep
         version: file:packages/adapter-cloudflare/test/apps/pages/server-side-dep
       svelte:
-        specifier: ^5.38.5
+        specifier: 'catalog:'
         version: 5.38.10
       vite:
         specifier: 'catalog:'
@@ -136,7 +136,7 @@ importers:
         specifier: file:server-side-dep
         version: file:packages/adapter-cloudflare/test/apps/workers/server-side-dep
       svelte:
-        specifier: ^5.38.5
+        specifier: 'catalog:'
         version: 5.38.10
       vite:
         specifier: 'catalog:'
@@ -206,7 +206,7 @@ importers:
         specifier: ^23.5.1
         version: 23.5.1(@types/node@18.19.119)(picomatch@4.0.3)(rollup@4.50.1)
       svelte:
-        specifier: ^5.23.1
+        specifier: 'catalog:'
         version: 5.38.10
       vite:
         specifier: 'catalog:'
@@ -224,7 +224,7 @@ importers:
         specifier: ^23.5.1
         version: 23.5.1(@types/node@18.19.119)(picomatch@4.0.3)(rollup@4.50.1)
       svelte:
-        specifier: ^5.23.1
+        specifier: 'catalog:'
         version: 5.38.10
       vite:
         specifier: 'catalog:'
@@ -288,7 +288,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.2
       svelte:
-        specifier: ^5.38.5
+        specifier: 'catalog:'
         version: 5.38.10
       typescript:
         specifier: ^5.3.3
@@ -309,7 +309,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       svelte:
-        specifier: ^5.38.5
+        specifier: 'catalog:'
         version: 5.38.10
       vite:
         specifier: 'catalog:'
@@ -330,7 +330,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       svelte:
-        specifier: ^5.38.5
+        specifier: 'catalog:'
         version: 5.38.10
       vite:
         specifier: 'catalog:'
@@ -401,7 +401,7 @@ importers:
         specifier: ^4.27.4
         version: 4.50.1
       svelte:
-        specifier: ^5.38.5
+        specifier: 'catalog:'
         version: 5.38.10
       typescript:
         specifier: ^5.6.3
@@ -1231,7 +1231,7 @@ importers:
         specifier: ^3.1.1
         version: 3.6.0
       svelte:
-        specifier: ^5.38.5
+        specifier: 'catalog:'
         version: 5.38.10
       svelte-preprocess:
         specifier: ^6.0.0
@@ -1294,7 +1294,7 @@ importers:
         specifier: ^0.3.0
         version: 0.3.0
       svelte:
-        specifier: ^5.38.5
+        specifier: 'catalog:'
         version: 5.38.10
       svelte-check:
         specifier: ^4.1.1


### PR DESCRIPTION
to reduce the size of the #14447 diff

It's probably worth doing this for all deps, as suggested by @hugos68 in https://github.com/sveltejs/kit/pull/14445#issuecomment-3310009361, but for now I'm just making minimal changes