### PR TITLE
fix: ensure `__SVELTEKIT_PAYLOAD__.data` access is safe

### DIFF
--- a/.changeset/late-dodos-move.md
+++ b/.changeset/late-dodos-move.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix `__SVELTEKIT_PAYLOAD__.data` access again

--- a/.changeset/late-dodos-move.md
+++ b/.changeset/late-dodos-move.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Fix `__SVELTEKIT_PAYLOAD__.data` access again
+ensure `__SVELTEKIT_PAYLOAD__.data` access is safe

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -291,8 +291,8 @@ export async function start(_app, _target, hydrate) {
 		);
 	}
 
-	if (__SVELTEKIT_PAYLOAD__.data) {
-		remote_responses = __SVELTEKIT_PAYLOAD__?.data;
+	if (__SVELTEKIT_PAYLOAD__?.data) {
+		remote_responses = __SVELTEKIT_PAYLOAD__.data;
 	}
 
 	// detect basic auth credentials in the current URL


### PR DESCRIPTION
In #14195, the access of `__SVELTEKIT_PAYLOAD__.data` had been fixed like this:

```js
export const remote_responses = __SVELTEKIT_PAYLOAD__?.data ?? {};
```

However, #14435 introduced a change (looks like a typo) where the `?` moved to the wrong spot:

```js
if (__SVELTEKIT_PAYLOAD__.data) {
	remote_responses = __SVELTEKIT_PAYLOAD__?.data;
}
```

This brought back the earlier problem in some of my apps. This PR moves the `?` out into the condition.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
