### PR TITLE
fix: consistently use bare import for internals

### DIFF
--- a/.changeset/five-rooms-draw.md
+++ b/.changeset/five-rooms-draw.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: consistently use bare import for internals

--- a/packages/kit/src/runtime/app/paths/server.js
+++ b/packages/kit/src/runtime/app/paths/server.js
@@ -1,6 +1,6 @@
 import { base, assets, relative } from './internal/server.js';
 import { resolve_route } from '../../../utils/routing.js';
-import { get_request_store } from '../../../exports/internal/server.js'; // TODO not sure why we can't use `@sveltejs/kit/internal/server` here
+import { get_request_store } from '@sveltejs/kit/internal/server';
 
 /** @type {import('./client.js').asset} */
 export function asset(file) {


### PR DESCRIPTION
In #14447 I broke a cardinal rule — code in `src/runtime` should only ever import code from `src/exports` via the public bare imports made available via `pkg.exports`. Otherwise, there's a danger that a given module will be loaded through both Vite _and_ Node, causing breakage.

I ignored that rule because I was trying to deal with some tricky resolution bug, and #14505 was my reward. Luckily I think the tricky resolution bug is solved by not having a nested `pkg.exports` map, and instead abusing `pkg.imports` to achieve the intended outcome.

This is one of those things that's extremely hard to test for from within the workspace, because of how Vite works. But I _think_ this solution is good. Closes #14505.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
