### PR TITLE
fix: keep serialized remote data alive until navigation

### DIFF
--- a/.changeset/large-chicken-obey.md
+++ b/.changeset/large-chicken-obey.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: keep serialized remote data alive until navigation

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -243,7 +243,7 @@ let current = {
 
 /** this being true means we SSR'd */
 let hydrated = false;
-export let started = false;
+let started = false;
 let autoscroll = true;
 let updating = false;
 let is_navigating = false;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2101,6 +2101,8 @@ export function refreshAll({ includeLoadFunctions = true } = {}) {
 		throw new Error('Cannot call refreshAll() on the server');
 	}
 
+	remote_responses = {};
+
 	force_invalidation = true;
 	return _invalidate(includeLoadFunctions, false);
 }

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -189,7 +189,10 @@ let target;
 /** @type {import('./types.js').SvelteKitApp} */
 export let app;
 
-/** @type {Record<string, any>} */
+/**
+ * Data that was serialized during SSR. This is cleared when the user first navigates
+ * @type {Record<string, any>}
+ */
 export let remote_responses = {};
 
 /** @type {Array<((url: URL) => boolean)>} */
@@ -1488,6 +1491,8 @@ async function navigate({
 	block = noop,
 	event
 }) {
+	remote_responses = {};
+
 	const prev_token = token;
 	token = nav_token;
 

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -35,9 +35,7 @@ export function form(id) {
 		let issues = $state.raw({});
 
 		/** @type {any} */
-		let result = $state.raw(
-			Object.hasOwn(remote_responses, action_id) ? remote_responses[action_id] : undefined
-		);
+		let result = $state.raw(remote_responses[action_id]);
 
 		/** @type {number} */
 		let pending_count = $state(0);

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -6,14 +6,7 @@ import { app_dir, base } from '$app/paths/internal/client';
 import * as devalue from 'devalue';
 import { DEV } from 'esm-env';
 import { HttpError } from '@sveltejs/kit/internal';
-import {
-	app,
-	remote_responses,
-	started,
-	_goto,
-	set_nearest_error_page,
-	invalidateAll
-} from '../client.js';
+import { app, remote_responses, _goto, set_nearest_error_page, invalidateAll } from '../client.js';
 import { tick } from 'svelte';
 import { refresh_queries, release_overrides } from './shared.svelte.js';
 import { createAttachmentKey } from 'svelte/attachments';
@@ -42,7 +35,9 @@ export function form(id) {
 		let issues = $state.raw({});
 
 		/** @type {any} */
-		let result = $state.raw(started ? undefined : remote_responses[action_id]);
+		let result = $state.raw(
+			Object.hasOwn(remote_responses, action_id) ? remote_responses[action_id] : undefined
+		);
 
 		/** @type {number} */
 		let pending_count = $state(0);

--- a/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
@@ -3,7 +3,7 @@ import { app_dir, base } from '$app/paths/internal/client';
 import { version } from '__sveltekit/environment';
 import * as devalue from 'devalue';
 import { DEV } from 'esm-env';
-import { app, remote_responses, started } from '../client.js';
+import { app, remote_responses } from '../client.js';
 import { create_remote_function, remote_request } from './shared.svelte.js';
 
 // Initialize Cache API for prerender functions
@@ -117,11 +117,8 @@ class Prerender {
 export function prerender(id) {
 	return create_remote_function(id, (cache_key, payload) => {
 		return new Prerender(async () => {
-			if (!started) {
-				const result = remote_responses[cache_key];
-				if (result) {
-					return result;
-				}
+			if (Object.hasOwn(remote_responses, cache_key)) {
+				return remote_responses[cache_key];
 			}
 
 			const url = `${base}/${app_dir}/remote/${id}${payload ? `/${payload}` : ''}`;

--- a/packages/kit/src/runtime/client/remote-functions/query.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query.svelte.js
@@ -14,11 +14,8 @@ import { HttpError, Redirect } from '@sveltejs/kit/internal';
 export function query(id) {
 	return create_remote_function(id, (cache_key, payload) => {
 		return new Query(cache_key, async () => {
-			if (!started) {
-				const result = remote_responses[cache_key];
-				if (result) {
-					return result;
-				}
+			if (Object.hasOwn(remote_responses, cache_key)) {
+				return remote_responses[cache_key];
 			}
 
 			const url = `${base}/${app_dir}/remote/${id}${payload ? `?payload=${payload}` : ''}`;
@@ -38,11 +35,8 @@ export function query_batch(id) {
 
 	return create_remote_function(id, (cache_key, payload) => {
 		return new Query(cache_key, () => {
-			if (!started) {
-				const result = remote_responses[cache_key];
-				if (result) {
-					return result;
-				}
+			if (Object.hasOwn(remote_responses, cache_key)) {
+				return remote_responses[cache_key];
 			}
 
 			// Collect all the calls to the same query in the same macrotask,

--- a/packages/kit/src/runtime/client/remote-functions/query.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query.svelte.js
@@ -271,6 +271,7 @@ export class Query {
 	 * @returns {Promise<void>}
 	 */
 	refresh() {
+		delete remote_responses[this._key];
 		return (this.#promise = this.#run());
 	}
 

--- a/packages/kit/src/runtime/client/remote-functions/query.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query.svelte.js
@@ -1,7 +1,7 @@
 /** @import { RemoteQueryFunction } from '@sveltejs/kit' */
 /** @import { RemoteFunctionResponse } from 'types' */
 import { app_dir, base } from '$app/paths/internal/client';
-import { app, goto, remote_responses, started } from '../client.js';
+import { app, goto, remote_responses } from '../client.js';
 import { tick } from 'svelte';
 import { create_remote_function, remote_request } from './shared.svelte.js';
 import * as devalue from 'devalue';


### PR DESCRIPTION
This PR allows both of these remote function calls...

```svelte
{#if await condition()}
  <h1>{await message()}</h1>
{/if}
```

...to use the data that was serialized when those queries were encountered during SSR. At present, only `condition()` is used, because `started` becomes `true` synchronously after the `hydrate(...)` call, before the contents of the if block are rendered.

The heuristic here (use the serialized data until navigation occurs) is 98% good enough, though in the long term it would be preferable to knit this stuff into the actual hydration process. That's a ways off though.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
