### PR TITLE
chore: add eslint rule to forbid relative imports to src/exports from src/runtime

### DIFF
--- a/.eslint/no-runtime-to-exports-imports.js
+++ b/.eslint/no-runtime-to-exports-imports.js
@@ -1,0 +1,55 @@
+// @ts-expect-error no types here
+import path from 'node:path';
+
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'disallow relative imports from src/runtime to src/exports',
+			category: 'Possible Errors',
+			recommended: true
+		},
+		schema: [],
+		messages: {
+			noRuntimeToExportsImport:
+				'Relative imports from src/runtime to src/exports are not allowed because they can cause Vite to resolve the same module both via regular Node and internal Vite. Use internal import maps or `@sveltejs/kit/internal` instead.'
+		}
+	},
+
+	create(context) {
+		const filename = context.filename;
+
+		// Only apply this rule to files in packages/kit/src/runtime
+		const in_runtime = filename.includes(path.join('packages', 'kit', 'src', 'runtime'));
+
+		if (!in_runtime) {
+			return {};
+		}
+
+		return {
+			ImportDeclaration(node) {
+				const import_path = node.source.value;
+
+				// Check if this is a relative import
+				if (typeof import_path === 'string' && import_path.startsWith('.')) {
+					// Resolve the import path relative to the current file
+					const current_dir = path.dirname(filename);
+					const resolved_path = path.resolve(current_dir, import_path);
+
+					// Check if the resolved path points to src/exports
+					const exports_path = path.join('packages', 'kit', 'src', 'exports');
+
+					if (resolved_path.includes(exports_path)) {
+						context.report({
+							node: node.source,
+							messageId: 'noRuntimeToExportsImport'
+						});
+					}
+				}
+			}
+		};
+	}
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,5 @@
 import svelte_config from '@sveltejs/eslint-config';
+import noRuntimeToExportsImports from './.eslint/no-runtime-to-exports-imports.js';
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
@@ -9,10 +10,25 @@ export default [
 		}
 	},
 	{
+		files: ['packages/kit/src/runtime/**/*.js'],
+		plugins: {
+			'kit-custom': {
+				rules: {
+					'no-runtime-to-exports-imports': noRuntimeToExportsImports
+				}
+			}
+		},
+		rules: {
+			'kit-custom/no-runtime-to-exports-imports': 'error'
+		}
+	},
+	{
 		ignores: [
 			'**/.svelte-kit',
+			'**/.wrangler',
 			'**/test-results',
 			'**/build',
+			'**/dist',
 			'**/.custom-out-dir',
 			'packages/adapter-*/files',
 			'packages/kit/src/core/config/fixtures/multiple', // dir contains svelte config with multiple extensions tripping eslint

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,10 @@
 {
 	"compilerOptions": {
 		"checkJs": true,
-		"noEmit": true
+		"noEmit": true,
+		"module": "ESNext",
+		"target": "ESNext",
+		"moduleResolution": "bundler"
 	},
-	"include": ["eslint.config.js"]
+	"include": ["eslint.config.js", ".eslint/*.js"]
 }


### PR DESCRIPTION
So that bugs that e.g. #14506 had to fix don't happen again
