### PR TITLE
fix: ensure rendering starts off synchronously

### DIFF
--- a/.changeset/flat-ducks-attack.md
+++ b/.changeset/flat-ducks-attack.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: ensure rendering starts off synchronously

--- a/packages/kit/src/exports/internal/event.js
+++ b/packages/kit/src/exports/internal/event.js
@@ -45,7 +45,17 @@ export function getRequestEvent() {
 export function get_request_store() {
 	const result = try_get_request_store();
 	if (!result) {
-		throw new Error('Could not get the request store. This is an internal error.');
+		let message = 'Could not get the request store.';
+
+		if (als) {
+			message += ' This is an internal error.';
+		} else {
+			message +=
+				' In environments without `AsyncLocalStorage`, the request store (used by e.g. remote functions) must be accessed synchronously, not after an `await`.' +
+				' If it was accessed synchronously then this is an internal error.';
+		}
+
+		throw new Error(message);
 	}
 	return result;
 }


### PR DESCRIPTION
We have to invoke .then eagerly here in order to kick off rendering: it's only starting on access, and `await maybe_promise` would eagerly access the .then property but call its function only after a tick, which is too late for the paths.reset() below and for any eager getRequestEvent() calls during rendering without AsyncLocalStorage available.

Fixes https://github.com/sveltejs/kit/issues/14520

<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
