### PR TITLE
fix: Webcontainer AsyncLocalStorage workaround throttle

### DIFF
--- a/.changeset/deep-insects-do.md
+++ b/.changeset/deep-insects-do.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: Webcontainer AsyncLocalStorage workaround

--- a/packages/kit/src/exports/internal/event.js
+++ b/packages/kit/src/exports/internal/event.js
@@ -2,6 +2,8 @@
 /** @import { RequestStore } from 'types' */
 /** @import { AsyncLocalStorage } from 'node:async_hooks' */
 
+import { IN_WEBCONTAINER } from '../../runtime/server/constants.js';
+
 /** @type {RequestStore | null} */
 let sync_store = null;
 
@@ -64,6 +66,10 @@ export function with_request_store(store, fn) {
 		sync_store = store;
 		return als ? als.run(store, fn) : fn();
 	} finally {
-		sync_store = null;
+		// Since AsyncLocalStorage is not working in webcontainers, we don't reset `sync_store`
+		// and handle only one request at a time in `src/runtime/server/index.js`.
+		if (!IN_WEBCONTAINER) {
+			sync_store = null;
+		}
 	}
 }

--- a/packages/kit/src/runtime/server/constants.js
+++ b/packages/kit/src/runtime/server/constants.js
@@ -1,1 +1,5 @@
+import { DEV } from 'esm-env';
+import process from 'node:process';
+
 export const NULL_BODY_STATUS = [101, 103, 204, 205, 304];
+export const IN_WEBCONTAINER = DEV && !!process.versions.webcontainer;

--- a/packages/kit/src/runtime/server/constants.js
+++ b/packages/kit/src/runtime/server/constants.js
@@ -2,12 +2,4 @@ import { DEV } from 'esm-env';
 import process from 'node:process';
 
 export const NULL_BODY_STATUS = [101, 103, 204, 205, 304];
-
-export const IN_WEBCONTAINER =
-	DEV &&
-	!!process.versions.webcontainer &&
-	// @ts-expect-error
-	(await import('@blitz/internal/env')).then(
-		(/** @type {any} */ mod) => !!mod,
-		() => false
-	);
+export const IN_WEBCONTAINER = DEV && !!process.versions.webcontainer;

--- a/packages/kit/src/runtime/server/constants.js
+++ b/packages/kit/src/runtime/server/constants.js
@@ -2,4 +2,12 @@ import { DEV } from 'esm-env';
 import process from 'node:process';
 
 export const NULL_BODY_STATUS = [101, 103, 204, 205, 304];
-export const IN_WEBCONTAINER = DEV && !!process.versions.webcontainer;
+
+export const IN_WEBCONTAINER =
+	DEV &&
+	!!process.versions.webcontainer &&
+	// @ts-expect-error
+	(await import('@blitz/internal/env')).then(
+		(/** @type {any} */ mod) => !!mod,
+		() => false
+	);

--- a/packages/kit/src/runtime/server/constants.js
+++ b/packages/kit/src/runtime/server/constants.js
@@ -2,4 +2,4 @@ import { DEV } from 'esm-env';
 import process from 'node:process';
 
 export const NULL_BODY_STATUS = [101, 103, 204, 205, 304];
-export const IN_WEBCONTAINER = DEV && !!process.versions.webcontainer;
+export const IN_WEBCONTAINER = !!process.versions.webcontainer;

--- a/packages/kit/src/runtime/server/constants.js
+++ b/packages/kit/src/runtime/server/constants.js
@@ -1,5 +1,4 @@
-import { DEV } from 'esm-env';
-import process from 'node:process';
-
 export const NULL_BODY_STATUS = [101, 103, 204, 205, 304];
-export const IN_WEBCONTAINER = !!process.versions.webcontainer;
+
+// eslint-disable-next-line n/prefer-global/process
+export const IN_WEBCONTAINER = !!globalThis.process?.versions?.webcontainer;

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -13,6 +13,9 @@ import { set_app } from './app.js';
 /** @type {Promise<any>} */
 let init_promise;
 
+/** @type {Promise<void> | null} */
+let current = null;
+
 export class Server {
 	/** @type {import('types').SSROptions} */
 	#options;
@@ -30,9 +33,6 @@ export class Server {
 		// in `src/exports/internal/event.js` and handle only one request at a time.
 		if (IN_WEBCONTAINER) {
 			const respond = this.respond.bind(this);
-
-			/** @type {Promise<void> | null} */
-			let current = null;
 
 			/** @type {typeof respond} */
 			this.respond = async (...args) => {

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -1,3 +1,5 @@
+/** @import { PromiseWithResolvers } from '../../utils/promise.js' */
+import { with_resolvers } from '../../utils/promise.js';
 import { IN_WEBCONTAINER } from './constants.js';
 import { respond } from './respond.js';
 import { set_private_env, set_public_env } from '../shared-server.js';
@@ -34,17 +36,12 @@ export class Server {
 
 			/** @type {typeof respond} */
 			this.respond = async (...args) => {
-				/** @type {(value?: any) => void} */
-				let resolve;
-
-				const promise = new Promise(r => (resolve = r));
+				const { promise, resolve } = /** @type {PromiseWithResolvers<void>} */ (with_resolvers());
 
 				const previous = current;
 				current = promise;
 
 				await previous;
-
-				// @ts-expect-error `resolve` is assigned!
 				return respond(...args).finally(resolve);
 			};
 		}

--- a/packages/kit/src/utils/promise.js
+++ b/packages/kit/src/utils/promise.js
@@ -1,0 +1,29 @@
+/** @see https://github.com/microsoft/TypeScript/blob/904e7dd97dc8da1352c8e05d70829dff17c73214/src/lib/es2024.promise.d.ts */
+
+/**
+ * @template T
+ * @typedef {{
+ *   promise: Promise<T>;
+ *   resolve: (value: T | PromiseLike<T>) => void;
+ *   reject: (reason?: any) => void;
+ * }} PromiseWithResolvers<T>
+ */
+
+/**
+ * TODO: Whenever Node >21 is minimum supported version, we can use `Promise.withResolvers` to avoid this ceremony
+ *
+ * @template T
+ * @returns {PromiseWithResolvers<T>}
+ */
+export function with_resolvers() {
+	let resolve;
+	let reject;
+
+	const promise = new Promise((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+
+	// @ts-expect-error `resolve` and `reject` are assigned!
+	return { promise, resolve, reject };
+}


### PR DESCRIPTION
Follow up to #14521

I'm not quite sure why, but it seems like the throttle only works if `current` is defined in the top-level.
I guess every request creates a new `Server` instance in dev mode?
I should've tested this before.

[without this PR](https://stackblitz.com/edit/sveltejs-kit-template-default-asxqrmbt?file=src%2Froutes%2F%2Bpage.svelte)
with this PR (follows in a minute)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
