### PR TITLE
fix: fall back to non-relative resolution when calling `resolve(...)` outside an event context

### DIFF
--- a/.changeset/common-llamas-argue.md
+++ b/.changeset/common-llamas-argue.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: fall back to non-relative resolution when calling `resolve(...)` outside an event context

--- a/packages/kit/src/runtime/app/paths/server.js
+++ b/packages/kit/src/runtime/app/paths/server.js
@@ -1,6 +1,6 @@
 import { base, assets, relative } from './internal/server.js';
 import { resolve_route } from '../../../utils/routing.js';
-import { get_request_store } from '@sveltejs/kit/internal/server';
+import { get_request_store, try_get_request_store } from '@sveltejs/kit/internal/server';
 
 /** @type {import('./client.js').asset} */
 export function asset(file) {
@@ -13,19 +13,17 @@ export function resolve(id, params) {
 	const resolved = resolve_route(id, /** @type {Record<string, string>} */ (params));
 
 	if (relative) {
-		const { event, state } = get_request_store();
+		const store = try_get_request_store();
 
-		if (state.prerendering?.fallback) {
-			return resolved;
+		if (store && !store.state.prerendering?.fallback) {
+			const segments = store.event.url.pathname.slice(base.length).split('/').slice(2);
+			const prefix = segments.map(() => '..').join('/') || '.';
+
+			return prefix + resolved;
 		}
-
-		const segments = event.url.pathname.slice(base.length).split('/').slice(2);
-		const prefix = segments.map(() => '..').join('/') || '.';
-
-		return prefix + resolved;
 	}
 
-	return resolved;
+	return base + resolved;
 }
 
 export { base, assets, resolve as resolveRoute };

--- a/packages/kit/test/apps/basics/src/hooks.server.js
+++ b/packages/kit/test/apps/basics/src/hooks.server.js
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 import { COOKIE_NAME } from './routes/cookies/shared';
 import { _set_from_init } from './routes/init-hooks/+page.server';
 import { getRequestEvent } from '$app/server';
+import { resolve } from '$app/paths';
 
 // @ts-ignore this doesn't exist in old Node
 Promise.withResolvers ??= () => {
@@ -15,6 +16,9 @@ Promise.withResolvers ??= () => {
 	});
 	return d;
 };
+
+// check that this doesn't throw when called outside an event context
+resolve('/');
 
 /**
  * Transform an error into a POJO, by copying its `name`, `message`


### PR DESCRIPTION
fixes #14513. (I also added a drive-by fix for the fact that non-relative resolution ignored `paths.base`.)

In the process of doing this, I realised that `resolve(...)` will give incorrect results when called in the context of a remote function, since the `pathname` is always `/` in that case. Not entirely sure how best to handle it — we should probably fall back to non-relative resolution in that case too? (Making it relative to the route from which the remote function was called isn't a solution, because then the result is non-deterministic and non-cacheable.)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
