### PR TITLE
Ensure cache key generated during ssr matches what is generated durin…

### DIFF
--- a/.changeset/dry-ideas-ring.md
+++ b/.changeset/dry-ideas-ring.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Ensure cache key generated during ssr matches what is generated during hydration for remote query data

--- a/.changeset/dry-ideas-ring.md
+++ b/.changeset/dry-ideas-ring.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-Ensure cache key generated during ssr matches what is generated during hydration for remote query data
+fix: ensure cache key is consistent between client/server

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -90,11 +90,10 @@ export function query(validate_or_fn, maybe_fn) {
 				);
 			}
 
-			const cache = get_cache(__, state);
-			const key = stringify_remote_arg(arg, state.transport);
-
 			if (__.id) {
-				refreshes[__.id + '/' + key] = cache[key] = Promise.resolve(value);
+				const cache = get_cache(__, state);
+				const key = stringify_remote_arg(arg, state.transport);
+				refreshes[create_remote_cache_key(__.id, key)] = cache[key] = Promise.resolve(value);
 			}
 		};
 

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -16,6 +16,7 @@ import { add_resolution_suffix } from '../../pathname.js';
 import { with_request_store } from '@sveltejs/kit/internal/server';
 import { text_encoder } from '../../utils.js';
 import { get_global_name } from '../utils.js';
+import { create_remote_cache_key } from '../../shared.js';
 
 // TODO rename this function/module
 
@@ -493,7 +494,7 @@ export async function render_response({
 				if (!info.id) continue;
 
 				for (const key in cache) {
-					remote[key ? info.id + '/' + key : info.id] = await cache[key];
+					remote[create_remote_cache_key(info.id, key)] = await cache[key];
 				}
 			}
 


### PR DESCRIPTION
fixes #14562 

Use same function to generate cache keys for remote query data during ssr and hydration so the logic doesn't need to be duplicated. Fixes an issue where cache keys generated during serialization on the server don't match the cache key used to check the cache for serialized data during hydration.

Current behavior is that the when a query has no arguments, data is serialized with a cache key of the form 'XXXXX/queryName', and the client tries to get the data with a cache key of 'XXXXX/queryname/', so it always results in another round trip to the server during hydration because that key doesn't exist.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
