### PR TITLE
fix: deduplicate `HEAD` entry in 405 response `allow` header

### DIFF
--- a/.changeset/salty-candles-chew.md
+++ b/.changeset/salty-candles-chew.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: avoid including `HEAD` twice when an unhandled HTTP method is used in a request to a `+server` handler that has both a `GET` handler and a `HEAD` handler

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -39,7 +39,11 @@ export function method_not_allowed(mod, method) {
 export function allowed_methods(mod) {
 	const allowed = ENDPOINT_METHODS.filter((method) => method in mod);
 
-	if ('GET' in mod || 'HEAD' in mod) allowed.push('HEAD');
+	// if there's no HEAD handler, but we have a GET handler, we respond to
+	// HEAD requests using the GET handler and omit the response body.
+	if (('GET' in mod && !('HEAD' in mod))) {
+		allowed.push('HEAD');
+	}
 
 	return allowed;
 }

--- a/packages/kit/test/apps/basics/src/routes/endpoint-output/head-handler/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-output/head-handler/+server.js
@@ -1,3 +1,9 @@
+// The GET handler is included alongside the HEAD handler to test that HEAD
+// is not included twice in the `allow` header list of allowed methods
+export function GET() {
+	return new Response('Hello world!');
+}
+
 /** @type {import('@sveltejs/kit').RequestHandler} */
 export function HEAD() {
 	return new Response('', {

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -281,6 +281,18 @@ test.describe('Endpoints', () => {
 		expect(allow_header).toMatch(/\bHEAD\b/);
 	});
 
+	test('405 allow header has no duplicate methods listed', async ({ request }) => {
+		const response = await request.post('/endpoint-output/head-handler');
+
+		expect(response.status()).toBe(405);
+
+		const allow_header = response.headers()['allow'];
+		const methods = allow_header.split(',').map((m) => m.trim());
+		const unique_methods = [...new Set(methods)];
+
+		expect(methods).toEqual(unique_methods);
+	});
+
 	// TODO all the remaining tests in this section are really only testing
 	// setResponse, since we're not otherwise changing anything on the response.
 	// might be worth making these unit tests instead


### PR DESCRIPTION
This PR fixes a bug that an LLM caught. The `allow` header includes `HEAD` twice when responding with a `405` if there's both a `GET` handler and a `HEAD` handler in a `+server.js` file. Ideally, we only include it once (either when there's just a `GET` handler or when there's an explicit `HEAD` handler).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
