### PR TITLE
fix: allow form fields to have hyphens in their names

### DIFF
--- a/.changeset/sad-lizards-share.md
+++ b/.changeset/sad-lizards-share.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow form fields to have hyphens in their name

--- a/packages/kit/src/runtime/utils.js
+++ b/packages/kit/src/runtime/utils.js
@@ -95,7 +95,7 @@ export function convert_formdata(data) {
 	return result;
 }
 
-const path_regex = /^[a-zA-Z_$]\w*(\.[a-zA-Z_$]\w*|\[\d+\])*$/;
+const path_regex = /^[a-zA-Z_$][\w-]*(\.[a-zA-Z_$][\w-]*|\[\d+\])*$/;
 
 /**
  * @param {string} path

--- a/packages/kit/src/runtime/utils.spec.js
+++ b/packages/kit/src/runtime/utils.spec.js
@@ -60,8 +60,16 @@ describe('split_path', () => {
 			output: ['foo']
 		},
 		{
+			input: 'foo-bar',
+			output: ['foo-bar']
+		},
+		{
 			input: 'foo.bar.baz',
 			output: ['foo', 'bar', 'baz']
+		},
+		{
+			input: 'foo-bar.bar-baz.foo-baz',
+			output: ['foo-bar', 'bar-baz', 'foo-baz']
 		},
 		{
 			input: 'foo[0][1][2]',
@@ -69,7 +77,7 @@ describe('split_path', () => {
 		}
 	];
 
-	const bad = ['[0]', 'foo.0', 'foo[bar]'];
+	const bad = ['[0]', 'foo.0', 'foo[bar]', 'foo-bar[baz]'];
 
 	for (const { input, output } of good) {
 		test(input, () => {


### PR DESCRIPTION
This change allows form field names to contain hyphens. Addresses #14567 

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [X] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [X] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
