### PR TITLE
fix: smooth scroll to deep link

### DIFF
--- a/.changeset/stale-things-mix.md
+++ b/.changeset/stale-things-mix.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: smoothscroll to deep link

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1718,8 +1718,6 @@ async function navigate({
 				x: pageXOffset + left,
 				y: pageYOffset + top
 			};
-
-			console.log(scroll);
 		} else {
 			scrollTo(0, 0);
 		}

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1712,6 +1712,8 @@ async function navigate({
 			// CSS properties.
 			deep_linked.scrollIntoView();
 
+			// Get target position at this point because with smooth scrolling the scroll position
+			// retrieved from current x/y above might be wrong (since we might not have arrived at the destination yet)
 			const { top, left } = deep_linked.getBoundingClientRect();
 
 			scroll = {

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1700,7 +1700,7 @@ async function navigate({
 	await tick();
 
 	// we reset scroll before dealing with focus, to avoid a flash of unscrolled content
-	const scroll = popped ? popped.scroll : noscroll ? scroll_state() : null;
+	let scroll = popped ? popped.scroll : noscroll ? scroll_state() : null;
 
 	if (autoscroll) {
 		const deep_linked = url.hash && document.getElementById(get_id(url));
@@ -1711,6 +1711,15 @@ async function navigate({
 			// because it natively supports the `scroll-margin` and `scroll-behavior`
 			// CSS properties.
 			deep_linked.scrollIntoView();
+
+			const { top, left } = deep_linked.getBoundingClientRect();
+
+			scroll = {
+				x: pageXOffset + left,
+				y: pageYOffset + top
+			};
+
+			console.log(scroll);
 		} else {
 			scrollTo(0, 0);
 		}
@@ -1724,7 +1733,7 @@ async function navigate({
 		document.activeElement !== document.body;
 
 	if (!keepfocus && !changed_focus) {
-		reset_focus(url);
+		reset_focus(url, scroll);
 	}
 
 	autoscroll = true;
@@ -2464,7 +2473,7 @@ function _start_router() {
 				// /#top and click on a link that goes to /#top. In those cases just go to
 				// the top of the page, and avoid a history change.
 				if (hash === '' || (hash === 'top' && a.ownerDocument.getElementById('top') === null)) {
-					window.scrollTo({ top: 0 });
+					scrollTo({ top: 0 });
 				} else {
 					const element = a.ownerDocument.getElementById(decodeURIComponent(hash));
 					if (element) {
@@ -2923,8 +2932,9 @@ let resetting_focus = false;
 
 /**
  * @param {URL} url
+ * @param {{ x: number, y: number } | null} scroll
  */
-function reset_focus(url) {
+function reset_focus(url, scroll = null) {
 	const autofocus = document.querySelector('[autofocus]');
 	if (autofocus) {
 		// @ts-ignore
@@ -2936,7 +2946,7 @@ function reset_focus(url) {
 		// starting point to the fragment identifier.
 		const id = get_id(url);
 		if (id && document.getElementById(id)) {
-			const { x, y } = scroll_state();
+			const { x, y } = scroll ?? scroll_state();
 
 			// `element.focus()` doesn't work on Safari and Firefox Ubuntu so we need
 			// to use this hack with `location.replace()` instead.


### PR DESCRIPTION
This addresses a very finicky and hard-to-reproduce (and test for, unfortunately) bug: when navigating to a hash fragment on another page, the captured scroll position is wrong if the page has `scroll-behavior: smooth`, because it gets captured at the _start_ of the scroll rather than the end.

If my understanding is correct, the buggy sequence of events is:

- we navigate, and update the DOM
- we scroll to the desired place (either a previous scroll position, if navigating via `popstate`, or the position of a deep-linked element, or `0, 0`
- we reset focus:
  - we capture the scroll position (incorrectly in the `smooth` case)
  - reset everything
  - scroll back to the desired scroll position
 
This PR changes the behaviour slightly: where appropriate, it passes the desired scroll state to `reset_focus` so that we end up in the correct place.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
