### PR TITLE
fix: force remote module chunks to isolate themselves

### DIFF
--- a/.changeset/puny-keys-poke.md
+++ b/.changeset/puny-keys-poke.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: force remote module chunks to isolate themselves

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -618,9 +618,26 @@ async function kit({ svelte_config }) {
 	/** @type {Array<{ hash: string, file: string }>} */
 	const remotes = [];
 
+	/**
+	 * A set of modules that imported by `.remote.ts` modules. By forcing these modules
+	 * into their own chunks, we ensure that each chunk created for a `.remote.ts`
+	 * module _only_ contains that module, hopefully avoiding any circular
+	 * dependency woes that arise from treating chunks as entries
+	 */
+	const imported_by_remotes = new Set();
+	let uid = 1;
+
 	/** @type {import('vite').Plugin} */
 	const plugin_remote = {
 		name: 'vite-plugin-sveltekit-remote',
+
+		moduleParsed(info) {
+			if (svelte_config.kit.moduleExtensions.some((ext) => info.id.endsWith(`.remote${ext}`))) {
+				for (const id of info.importedIds) {
+					imported_by_remotes.add(id);
+				}
+			}
+		},
 
 		config(config) {
 			if (!config.build?.ssr) {
@@ -657,6 +674,10 @@ async function kit({ svelte_config }) {
 						const relative = posixify(path.relative(cwd, id));
 
 						return `remote-${hash(relative)}`;
+					}
+
+					if (imported_by_remotes.has(id)) {
+						return `chunk-${uid++}`;
 					}
 
 					// If there was an existing manualChunks function, call it


### PR DESCRIPTION
This is my attempt to provide an alternative to #14456, which is extremely clever but makes me very nervous. It works, but as soon as another plugin tries the same trick (repeatedly getting a list of every module in the graph and loading it, until there are no new modules to load) you end up in a deadlock situation. The 30 second timeout really isn't a solution. It's almost certain that very few users would ever encounter this, but for the ones that did it would be a very confusing and annoying bug.

This PR sticks with the `manualChunks` trick, but adds another layer: any modules imported by `.remote.ts` files are _also_ put in their own chunks. This has the effect of forcing each chunk corresponding to a `.remote.ts` module to _only_ contain that module, and none of the dependencies that Rollup incorrectly deems safe to include in the chunk.

My hunch — or at least, my hope — is that Rollup gets confused about how to structure the graph because it's not expecting these chunks to be treated as entries (resulting in the bad kind of circular dependency) and that this change renders that moot. It's _possible_ that I haven't fixed it at all, but have rather pushed the bug 'one level down' so to speak, but I think it's worth a shot.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
