### PR TITLE
fix: correctly type `form` remote functions that do not accept data

### DIFF
--- a/.changeset/lucky-humans-make.md
+++ b/.changeset/lucky-humans-make.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly type the `result` of `form` remote functions that do not accept data

--- a/packages/kit/src/runtime/app/server/remote/form.js
+++ b/packages/kit/src/runtime/app/server/remote/form.js
@@ -13,7 +13,7 @@ import { convert_formdata, flatten_issues } from '../../../utils.js';
  *
  * @template Output
  * @overload
- * @param {() => Output} fn
+ * @param {() => MaybePromise<Output>} fn
  * @returns {RemoteForm<void, Output>}
  * @since 2.27
  */

--- a/packages/kit/test/types/remote.test.ts
+++ b/packages/kit/test/types/remote.test.ts
@@ -301,6 +301,11 @@ function form_tests() {
 	f6.input!['array[0].array[]'] = [''];
 	// @ts-expect-error
 	f6.input!['array[0].prop'] = 123;
+
+	// doesn't use data
+	// eslint-disable-next-line @typescript-eslint/require-await --- we are testing that the async function does not cause `result` to be typed as a Promise
+	const f7 = form(async () => ({ success: true }));
+	f7.result?.success === true;
 }
 form_tests();
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3061,7 +3061,7 @@ declare module '$app/server' {
 	 *
 	 * @since 2.27
 	 */
-	export function form<Output>(fn: () => Output): RemoteForm<void, Output>;
+	export function form<Output>(fn: () => MaybePromise<Output>): RemoteForm<void, Output>;
 	/**
 	 * Creates a form object that can be spread onto a `<form>` element.
 	 *


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/14570

One of the overloads for the `form` remote function was missing a `MaybePromise` for the function return type. This PR fixes that.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
