### PR TITLE
chore: fix "homepage" field in package.json

### DIFF
--- a/.changeset/deep-eagles-punch.md
+++ b/.changeset/deep-eagles-punch.md
@@ -1,0 +1,11 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+'@sveltejs/adapter-netlify': patch
+'@sveltejs/adapter-static': patch
+'@sveltejs/adapter-vercel': patch
+'@sveltejs/adapter-auto': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/enhanced-img': patch
+---
+
+chore: update "homepage" field in package.json

--- a/packages/adapter-auto/package.json
+++ b/packages/adapter-auto/package.json
@@ -17,7 +17,7 @@
 		"directory": "packages/adapter-auto"
 	},
 	"license": "MIT",
-	"homepage": "https://svelte.dev",
+	"homepage": "https://svelte.dev/docs/kit/adapter-auto",
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -16,7 +16,7 @@
 		"directory": "packages/adapter-cloudflare"
 	},
 	"license": "MIT",
-	"homepage": "https://svelte.dev",
+	"homepage": "https://svelte.dev/docs/kit/adapter-cloudflare",
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -16,7 +16,7 @@
 		"directory": "packages/adapter-netlify"
 	},
 	"license": "MIT",
-	"homepage": "https://svelte.dev",
+	"homepage": "https://svelte.dev/docs/kit/adapter-netlify",
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -16,7 +16,7 @@
 		"directory": "packages/adapter-node"
 	},
 	"license": "MIT",
-	"homepage": "https://svelte.dev",
+	"homepage": "https://svelte.dev/docs/kit/adapter-node",
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -17,7 +17,7 @@
 		"directory": "packages/adapter-static"
 	},
 	"license": "MIT",
-	"homepage": "https://svelte.dev",
+	"homepage": "https://svelte.dev/docs/kit/adapter-static",
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -16,7 +16,7 @@
 		"directory": "packages/adapter-vercel"
 	},
 	"license": "MIT",
-	"homepage": "https://svelte.dev",
+	"homepage": "https://svelte.dev/docs/kit/adapter-vercel",
 	"type": "module",
 	"exports": {
 		".": {

--- a/packages/enhanced-img/package.json
+++ b/packages/enhanced-img/package.json
@@ -18,7 +18,7 @@
 		"vite"
 	],
 	"license": "MIT",
-	"homepage": "https://svelte.dev",
+	"homepage": "https://svelte.dev/docs/kit/images#sveltejs-enhanced-img",
 	"type": "module",
 	"scripts": {
 		"lint": "prettier --check .",


### PR DESCRIPTION
This will enable the forthcoming `/packages` page on svelte.dev to link directly to the correct place