### PR TITLE
fix: skip prebundling of .remote.js files

### DIFF
--- a/.changeset/late-ways-find.md
+++ b/.changeset/late-ways-find.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: skip prebundling of .remote.js files

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -298,6 +298,17 @@ async function kit({ svelte_config }) {
 						`${kit.files.routes}/**/+*.{svelte,js,ts}`,
 						`!${kit.files.routes}/**/+*server.*`
 					],
+					esbuildOptions: {
+						plugins: [
+							{
+								name: 'vite-plugin-sveltekit-setup:optimize',
+								setup(build) {
+									// treat .remote.js files as empty for the purposes of prebundling
+									build.onLoad({ filter: /\.remote\./ }, () => ({ contents: '' }));
+								}
+							}
+						]
+					},
 					exclude: [
 						// Without this SvelteKit will be prebundled on the client, which means we end up with two versions of Redirect etc.
 						// Also see https://github.com/sveltejs/kit/issues/5952#issuecomment-1218844057

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -306,7 +306,7 @@ async function kit({ svelte_config }) {
 									if (!kit.experimental.remoteFunctions) return;
 
 									const filter = new RegExp(
-										`.remote(${kit.moduleExtensions.join('|')})`.replaceAll('.', '\\.')
+										`.remote(${kit.moduleExtensions.join('|')})$`.replaceAll('.', '\\.')
 									);
 
 									// treat .remote.js files as empty for the purposes of prebundling

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -303,8 +303,14 @@ async function kit({ svelte_config }) {
 							{
 								name: 'vite-plugin-sveltekit-setup:optimize',
 								setup(build) {
+									if (!kit.experimental.remoteFunctions) return;
+
+									const filter = new RegExp(
+										`.remote(${kit.moduleExtensions.join('|')})`.replaceAll('.', '\\.')
+									);
+
 									// treat .remote.js files as empty for the purposes of prebundling
-									build.onLoad({ filter: /\.remote\./ }, () => ({ contents: '' }));
+									build.onLoad({ filter }, () => ({ contents: '' }));
 								}
 							}
 						]


### PR DESCRIPTION
Fixes at least part of #14519 — I couldn't get the repro to start up, because Vite's `optimizeDeps` step prebundles any dependencies it finds from `+page.svelte` and `+page.js` entry points. Import tracing should stop at `.remote.js` files, because these don't run in the client. This PR makes it so.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
