### PR TITLE
fix: HMR for `query`

### DIFF
--- a/.changeset/cute-bushes-hope.md
+++ b/.changeset/cute-bushes-hope.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: HMR for `query`

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -770,8 +770,14 @@ async function kit({ svelte_config }) {
 				return `export const ${name} = ${namespace}.${type}('${remote.hash}/${name}');`;
 			});
 
+			let result = `import * as ${namespace} from '__sveltekit/remote';\n\n${exports.join('\n')}\n`;
+
+			if (dev_server) {
+				result += `\nimport.meta.hot?.accept();\n`;
+			}
+
 			return {
-				code: `import * as ${namespace} from '__sveltekit/remote';\n\n${exports.join('\n')}\n`
+				code: result
 			};
 		},
 

--- a/packages/kit/src/runtime/client/remote-functions/query.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query.svelte.js
@@ -14,6 +14,7 @@ import { DEV } from 'esm-env';
  */
 export function query(id) {
 	if (DEV) {
+		// If this reruns as part of HMR, refresh the query
 		for (const [key, entry] of query_map) {
 			if (key === id || key.startsWith(id + '/')) {
 				// use optional chaining in case a prerender function was turned into a query

--- a/packages/kit/src/runtime/client/remote-functions/query.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query.svelte.js
@@ -1,17 +1,27 @@
 /** @import { RemoteQueryFunction } from '@sveltejs/kit' */
 /** @import { RemoteFunctionResponse } from 'types' */
 import { app_dir, base } from '$app/paths/internal/client';
-import { app, goto, remote_responses } from '../client.js';
+import { app, goto, query_map, remote_responses } from '../client.js';
 import { tick } from 'svelte';
 import { create_remote_function, remote_request } from './shared.svelte.js';
 import * as devalue from 'devalue';
 import { HttpError, Redirect } from '@sveltejs/kit/internal';
+import { DEV } from 'esm-env';
 
 /**
  * @param {string} id
  * @returns {RemoteQueryFunction<any, any>}
  */
 export function query(id) {
+	if (DEV) {
+		for (const [key, entry] of query_map) {
+			if (key === id || key.startsWith(id + '/')) {
+				// use optional chaining in case a prerender function was turned into a query
+				entry.resource.refresh?.();
+			}
+		}
+	}
+
 	return create_remote_function(id, (cache_key, payload) => {
 		return new Query(cache_key, async () => {
 			if (Object.hasOwn(remote_responses, cache_key)) {


### PR DESCRIPTION
At present, if you have something like this...

```svelte
<script>
  import { foo } from './data.remote';
</script>

<p>{await foo()}</p>
```

...nothing immediately changes if you change the return value of `foo` — you have to reload the page to see the new data. This is unsatisfying.

With this PR, hot updates are accepted by the transformed remote module, and upon creating the replacement query we refresh anything that's currently referenced in an effect. The end result is HMR for queries.

Unfortunately this approach _doesn't_ extend to `prerender`, because prerender functions don't use state and thus cannot be reactively updated. We could change that, but we would only want to change it in dev, and it would be a whole thing. Maybe we'll want to do that at some point anyway though.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
