### PR TITLE
fix: allow `fetch` in remote function without emitting a warning

### DIFF
--- a/.changeset/weak-rings-open.md
+++ b/.changeset/weak-rings-open.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow `fetch` in remote function without emitting a warning

--- a/packages/kit/src/runtime/app/server/remote/shared.js
+++ b/packages/kit/src/runtime/app/server/remote/shared.js
@@ -1,5 +1,5 @@
 /** @import { RequestEvent } from '@sveltejs/kit' */
-/** @import { ServerHooks, MaybePromise, RequestState, RemoteInfo } from 'types' */
+/** @import { ServerHooks, MaybePromise, RequestState, RemoteInfo, RequestStore } from 'types' */
 import { parse } from 'devalue';
 import { error } from '@sveltejs/kit';
 import { with_request_store, get_request_store } from '@sveltejs/kit/internal/server';
@@ -103,42 +103,48 @@ export function parse_remote_response(data, transport) {
  * @param {(arg?: any) => T} fn
  */
 export async function run_remote_function(event, state, allow_cookies, arg, validate, fn) {
-	/** @type {RequestEvent} */
-	const cleansed = {
-		...event,
-		setHeaders: () => {
-			throw new Error('setHeaders is not allowed in remote functions');
-		},
-		cookies: {
-			...event.cookies,
-			set: (name, value, opts) => {
-				if (!allow_cookies) {
-					throw new Error('Cannot set cookies in `query` or `prerender` functions');
-				}
-
-				if (opts.path && !opts.path.startsWith('/')) {
-					throw new Error('Cookies set in remote functions must have an absolute path');
-				}
-
-				return event.cookies.set(name, value, opts);
+	/** @type {RequestStore} */
+	const store = {
+		event: {
+			...event,
+			setHeaders: () => {
+				throw new Error('setHeaders is not allowed in remote functions');
 			},
-			delete: (name, opts) => {
-				if (!allow_cookies) {
-					throw new Error('Cannot delete cookies in `query` or `prerender` functions');
-				}
+			cookies: {
+				...event.cookies,
+				set: (name, value, opts) => {
+					if (!allow_cookies) {
+						throw new Error('Cannot set cookies in `query` or `prerender` functions');
+					}
 
-				if (opts.path && !opts.path.startsWith('/')) {
-					throw new Error('Cookies deleted in remote functions must have an absolute path');
-				}
+					if (opts.path && !opts.path.startsWith('/')) {
+						throw new Error('Cookies set in remote functions must have an absolute path');
+					}
 
-				return event.cookies.delete(name, opts);
+					return event.cookies.set(name, value, opts);
+				},
+				delete: (name, opts) => {
+					if (!allow_cookies) {
+						throw new Error('Cannot delete cookies in `query` or `prerender` functions');
+					}
+
+					if (opts.path && !opts.path.startsWith('/')) {
+						throw new Error('Cookies deleted in remote functions must have an absolute path');
+					}
+
+					return event.cookies.delete(name, opts);
+				}
 			}
+		},
+		state: {
+			...state,
+			is_in_remote_function: true
 		}
 	};
 
 	// In two parts, each with_event, so that runtimes without async local storage can still get the event at the start of the function
-	const validated = await with_request_store({ event: cleansed, state }, () => validate(arg));
-	return with_request_store({ event: cleansed, state }, () => fn(validated));
+	const validated = await with_request_store(store, () => validate(arg));
+	return with_request_store(store, () => fn(validated));
 }
 
 /**

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -13,7 +13,7 @@ import { SVELTE_KIT_ASSETS } from '../../../constants.js';
 import { SCHEME } from '../../../utils/url.js';
 import { create_server_routing_response, generate_route_object } from './server_routing.js';
 import { add_resolution_suffix } from '../../pathname.js';
-import { with_request_store } from '@sveltejs/kit/internal/server';
+import { try_get_request_store, with_request_store } from '@sveltejs/kit/internal/server';
 import { text_encoder } from '../../utils.js';
 import { get_global_name } from '../utils.js';
 import { create_remote_cache_key } from '../../shared.js';
@@ -190,7 +190,7 @@ export async function render_response({
 						throw new Error(
 							`Cannot call \`fetch\` eagerly during server-side rendering with relative URL (${info}) — put your \`fetch\` calls inside \`onMount\` or a \`load\` function instead`
 						);
-					} else if (!warned) {
+					} else if (!warned && !try_get_request_store()?.state.is_in_remote_function) {
 						console.warn(
 							'Avoid calling `fetch` eagerly during server-side rendering — put your `fetch` calls inside `onMount` or a `load` function instead'
 						);

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -148,7 +148,8 @@ export async function internal_respond(request, options, manifest, state) {
 		handleValidationError: options.hooks.handleValidationError,
 		tracing: {
 			record_span
-		}
+		},
+		is_in_remote_function: false
 	};
 
 	/** @type {import('@sveltejs/kit').RequestEvent} */

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -604,6 +604,7 @@ export interface RequestState {
 	tracing: {
 		record_span: RecordSpan;
 	};
+	is_in_remote_function: boolean;
 	form_instances?: Map<any, any>;
 	remote_data?: Map<RemoteInfo, Record<string, MaybePromise<any>>>;
 	refreshes?: Record<string, Promise<any>>;


### PR DESCRIPTION
Ordinarily if a server-side `fetch` occurs outside a `load` function, we emit a warning that steers people towards using `event.fetch` instead. This makes sense in the old world, where fetches in universal loads are serialized, but not really in the new world — we want people to use regular `fetch` inside remote functions, because the return value of the function itself is the thing that gets serialized.

I also suspect that the `is_in_remote_function` state will come in handy in various ways.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
