### PR TITLE
fix: delete hydration cache on effect teardown

### DIFF
--- a/.changeset/thin-clubs-press.md
+++ b/.changeset/thin-clubs-press.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: delete hydration cache on effect teardown

--- a/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
@@ -2,7 +2,7 @@
 /** @import { RemoteFunctionResponse } from 'types' */
 /** @import { Query } from './query.svelte.js' */
 import * as devalue from 'devalue';
-import { app, goto, query_map } from '../client.js';
+import { app, goto, query_map, remote_responses } from '../client.js';
 import { HttpError, Redirect } from '@sveltejs/kit/internal';
 import { tick } from 'svelte';
 import { create_remote_cache_key, stringify_remote_arg } from '../../shared.js';
@@ -62,6 +62,7 @@ export function create_remote_function(id, create) {
 						void tick().then(() => {
 							if (!entry.count && entry === query_map.get(cache_key)) {
 								query_map.delete(cache_key);
+								delete remote_responses[cache_key];
 							}
 						});
 					}


### PR DESCRIPTION
We populate a hydration cache from the serialized remote function return values, and keep it around until the user navigates or a `refreshAll` happens. That covers most cases, but if a particular query is discarded _before_ navigation occurs, it should still be cleared. This makes it so.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
