### PR TITLE
fix: use `$derived` for form fields

### DIFF
--- a/.changeset/honest-shoes-jam.md
+++ b/.changeset/honest-shoes-jam.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: use `$derived` for form fields

--- a/packages/kit/src/runtime/form-utils.svelte.js
+++ b/packages/kit/src/runtime/form-utils.svelte.js
@@ -198,15 +198,10 @@ export function create_field_proxy(target, get_input, set_input, get_issues, pat
 				return create_field_proxy(set_func, get_input, set_input, get_issues, [...path, prop]);
 			}
 
+			const value = $derived(deep_get(get_input(), path));
+
 			if (prop === 'value') {
-				const value_func = function () {
-					// TODO Ideally we'd create a $derived just above and use it here but we can't because of push_reaction which prevents
-					// changes to deriveds created within an effect to rerun the effect - an argument for
-					// reverting that change in async mode?
-					// TODO we did that in Svelte now; bump Svelte version and use $derived here
-					return deep_get(get_input(), path);
-				};
-				return create_field_proxy(value_func, get_input, set_input, get_issues, [...path, prop]);
+				return create_field_proxy(() => value, get_input, set_input, get_issues, [...path, prop]);
 			}
 
 			if (prop === 'issues' || prop === 'allIssues') {
@@ -269,8 +264,7 @@ export function create_field_proxy(target, get_input, set_input, get_issues, pat
 							value: {
 								enumerable: true,
 								get() {
-									const input = get_input();
-									return deep_get(input, path);
+									return value;
 								}
 							}
 						});
@@ -293,9 +287,6 @@ export function create_field_proxy(target, get_input, set_input, get_issues, pat
 							checked: {
 								enumerable: true,
 								get() {
-									const input = get_input();
-									const value = deep_get(input, path);
-
 									if (type === 'radio') {
 										return value === input_value;
 									}
@@ -317,9 +308,6 @@ export function create_field_proxy(target, get_input, set_input, get_issues, pat
 							files: {
 								enumerable: true,
 								get() {
-									const input = get_input();
-									const value = deep_get(input, path);
-
 									// Convert File/File[] to FileList-like object
 									if (value instanceof File) {
 										// In browsers, we can create a proper FileList using DataTransfer
@@ -358,9 +346,6 @@ export function create_field_proxy(target, get_input, set_input, get_issues, pat
 						value: {
 							enumerable: true,
 							get() {
-								const input = get_input();
-								const value = deep_get(input, path);
-
 								return value != null ? String(value) : '';
 							}
 						}

--- a/packages/kit/test/apps/basics/src/routes/remote/form/select-untouched/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/remote/form/select-untouched/+page.svelte
@@ -1,0 +1,15 @@
+<script>
+	import { myform } from './form.remote.js';
+</script>
+
+<form {...myform}>
+	<input {...myform.fields.message.as('text')} />
+
+	<select {...myform.fields.number.as('select')}>
+		<option>one</option>
+		<option>two</option>
+		<option>three</option>
+	</select>
+
+	<button>submit</button>
+</form>

--- a/packages/kit/test/apps/basics/src/routes/remote/form/select-untouched/form.remote.ts
+++ b/packages/kit/test/apps/basics/src/routes/remote/form/select-untouched/form.remote.ts
@@ -1,0 +1,10 @@
+import { form } from '$app/server';
+import * as v from 'valibot';
+
+export const myform = form(
+	v.object({
+		message: v.string(),
+		number: v.picklist(['one', 'two', 'three'])
+	}),
+	(_data) => {}
+);

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1968,6 +1968,18 @@ test.describe('remote functions', () => {
 		const arrayValue = await page.locator('#array-value').textContent();
 		expect(JSON.parse(arrayValue)).toEqual([{ leaf: 'array-0-leaf' }, { leaf: 'array-1-leaf' }]);
 	});
+
+	test('selects are not nuked when unrelated controls change', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		if (!javaScriptEnabled) return;
+
+		await page.goto('/remote/form/select-untouched');
+
+		await page.fill('input', 'hello');
+		await expect(page.locator('select')).toHaveValue('one');
+	});
 });
 
 test.describe('params prop', () => {


### PR DESCRIPTION
This closes a TODO, and insodoing fixes an actual bug — if you edit a form that contains a select, the `value` getter will re-run (because `input` has changed) and nuke the select because the model value is typically `undefined` to start with.

Unfortunately it doesn't quite work, because an effect doesn't depend on the `$derived` values that were created inside it. So when you do `{field.value()}`, you're creating a derived and then immediately (trying to) depend on it. I'm not immediately sure what footwork would be required to work around that, or if it indicates that it _should_ be possible for an effect to depend on a derived it created. So I'm leaving this in draft for now.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
