### PR TITLE
WIP don't reset form after enhanced form submit

### DIFF
--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -210,8 +210,6 @@ export function form(id) {
 						if (issues.$) {
 							release_overrides(updates);
 						} else {
-							input = {};
-
 							if (form_result.refreshes) {
 								refresh_queries(form_result.refreshes, updates);
 							} else {


### PR DESCRIPTION
Leaving this here as a note-to-self more than anything. We reset `input` after a successful submission, but that's incorrect — we should only be resetting `input` when the form is reset, which is the _default_ behaviour after a submission but not when you use `myform.enhance(...)`. In that case, the developer is responsible for resetting the form.

In any case, `input = {}` is incorrect — when the form is reset, we should use the actual values that are present (accounting for `defaultValue` and `<select>` initial options and so on). For that part, we will need to add a `reset` handler, but I don't want to tackle that until #14621 is merged.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
