### PR TITLE
fix: wait a tick before collecting form data for validation

### DIFF
--- a/.changeset/kind-emus-run.md
+++ b/.changeset/kind-emus-run.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: wait a tick before collecting form data for validation

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -512,12 +512,19 @@ export function form(id) {
 
 					const id = ++validate_id;
 
+					// wait a tick in case the user is calling validate() right after set() which takes time to propagate
+					await tick();
+
 					const form_data = new FormData(element, submitter);
 
 					/** @type {readonly StandardSchemaV1.Issue[]} */
 					let array = [];
 
 					const validated = await preflight_schema?.['~standard'].validate(convert(form_data));
+
+					if (validate_id !== id) {
+						return;
+					}
 
 					if (validated?.issues) {
 						array = validated.issues;


### PR DESCRIPTION
This way when you're doing
```ts
myForm.fields.foo.set('bar')
myForm.validate();
```
you'll validate on the up-to-date data

closes #14630

Don't think we need a test for this.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
