### PR TITLE
fix: prevent code execution order issues around SvelteKit's `env` modules

### DIFF
--- a/.changeset/light-poets-retire.md
+++ b/.changeset/light-poets-retire.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prevent code execution order issues around SvelteKit's `env` modules

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -41,6 +41,7 @@ import {
 import { import_peer } from '../../utils/import.js';
 import { compact } from '../../utils/array.js';
 import { should_ignore } from './static_analysis/utils.js';
+import { rollupVersion } from 'vite';
 
 const cwd = process.cwd();
 
@@ -675,6 +676,15 @@ async function kit({ svelte_config }) {
 			// Set up manualChunks to isolate *.remote.ts files
 			const { manualChunks } = config.build.rollupOptions.output;
 
+			const [major, minor] = rollupVersion.split('.').map(Number);
+			const is_outdated_rollup = major === 4 && minor < 52;
+			if (is_outdated_rollup) {
+				console.warn(
+					'Rollup >=4.52.0 is recommended when using SvelteKit remote functions as it fixes some bugs related to code-splitting. Current version: ' +
+						rollupVersion
+				);
+			}
+
 			config.build.rollupOptions.output = {
 				...config.build.rollupOptions.output,
 				manualChunks(id, meta) {
@@ -685,8 +695,19 @@ async function kit({ svelte_config }) {
 						return `remote-${hash(relative)}`;
 					}
 
-					if (imported_by_remotes.has(id)) {
-						return `chunk-${uid++}`;
+					// With onlyExplicitManualChunks Rollup will keep any manual chunk's dependencies out of that chunk.
+					// This option only exists on more recent Rollup versions; use this as a fallback for older versions.
+					if (is_outdated_rollup) {
+						// Prevent core runtime and env from ending up in a remote chunk, which could break because of initialization order
+						if (id === `${runtime_directory}/app/server/index.js`) {
+							return 'app-server';
+						}
+						if (id === `${runtime_directory}/shared-server.js`) {
+							return 'app-shared-server';
+						}
+						if (imported_by_remotes.has(id)) {
+							return `chunk-${uid++}`;
+						}
 					}
 
 					// If there was an existing manualChunks function, call it
@@ -707,6 +728,11 @@ async function kit({ svelte_config }) {
 					}
 				}
 			};
+
+			if (!is_outdated_rollup) {
+				// @ts-expect-error only exists in more recent Rollup versions https://rollupjs.org/configuration-options/#output-onlyexplicitmanualchunks
+				config.build.rollupOptions.onlyExplicitManualChunks = true;
+			}
 		},
 
 		configureServer(_dev_server) {


### PR DESCRIPTION
With #14571 we hoped to have solved the chunk/code execution order issues, but they snuck back in.

The problem, it turns out (read https://rollupjs.org/configuration-options/#output-manualchunks very carefully), is that dependencies of a manual chunk might get pulled into that manual chunk, too. If the dependency happens to be our env module, this can cause issues since the module might eagerly access the env.

Luckily Rollup has recently solved this via a dedicated option (that will be the default in version 5 and is hence deprecated right away) named `onlyExplicitManualChunks` (https://github.com/rollup/rollup/pull/6087). This solves our problems around chunk ordering. For users not on the latest version yet we do a best-effort fallback by extracting env into its own chunk. This should solve most issues people encounter but the general problem can still occur, which is only fixed with the new option (hence we warn if the rollup version is not up to date).

Fixes #14590

<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
