### PR TITLE
docs: remove `@example` blocks to allow docs to deploy

### DIFF
--- a/.changeset/petite-lions-heal.md
+++ b/.changeset/petite-lions-heal.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+docs: remove `@example` blocks to allow docs to deploy

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1971,19 +1971,6 @@ type InvalidField<T> =
  * If an issue is a `string`, it applies to the form as a whole (and will show up in `fields.allIssues()`)
  * Access properties to create field-specific issues: `invalid.fieldName('message')`.
  * The type structure mirrors the input data structure for type-safe field access.
- *
- * @example
- * ```ts
- * invalid('Username or password is invalid');
- * ```
- *
- * @example
- * ```ts
- * invalid(
- *   invalid.username('Username is taken'),
- *   invalid.items[0].qty('Insufficient stock')
- * );
- * ```
  */
 export type Invalid<Input = any> = ((...issues: Array<string | StandardSchemaV1.Issue>) => never) &
 	InvalidField<Input>;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1947,19 +1947,6 @@ declare module '@sveltejs/kit' {
 	 * If an issue is a `string`, it applies to the form as a whole (and will show up in `fields.allIssues()`)
 	 * Access properties to create field-specific issues: `invalid.fieldName('message')`.
 	 * The type structure mirrors the input data structure for type-safe field access.
-	 *
-	 * @example
-	 * ```ts
-	 * invalid('Username or password is invalid');
-	 * ```
-	 *
-	 * @example
-	 * ```ts
-	 * invalid(
-	 *   invalid.username('Username is taken'),
-	 *   invalid.items[0].qty('Insufficient stock')
-	 * );
-	 * ```
 	 */
 	export type Invalid<Input = any> = ((...issues: Array<string | StandardSchemaV1.Issue>) => never) &
 		InvalidField<Input>;


### PR DESCRIPTION
Turns out these get transformed in a way that breaks the docs. At some point we should look into it but for now the most pragmatic thing is to remove them — there are examples in the actual docs