### PR TITLE
fix: prevent code execution order issues around SvelteKit's `env` modules

### DIFF
--- a/.changeset/nasty-walls-learn.md
+++ b/.changeset/nasty-walls-learn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prevent code execution order issues around SvelteKit's `env` modules

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -731,7 +731,7 @@ async function kit({ svelte_config }) {
 
 			if (!is_outdated_rollup) {
 				// @ts-expect-error only exists in more recent Rollup versions https://rollupjs.org/configuration-options/#output-onlyexplicitmanualchunks
-				config.build.rollupOptions.onlyExplicitManualChunks = true;
+				config.build.rollupOptions.output.onlyExplicitManualChunks = true;
 			}
 		},
 


### PR DESCRIPTION
For real this time - #14632 did put it on the wrong object

Fixes #14590
