### PR TITLE
fix: prevent access of Svelte 5-only `untrack` function

### DIFF
--- a/.changeset/thick-ideas-mate.md
+++ b/.changeset/thick-ideas-mate.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prevent access of Svelte 5-only `untrack` function

--- a/packages/kit/src/runtime/form-utils.svelte.js
+++ b/packages/kit/src/runtime/form-utils.svelte.js
@@ -3,7 +3,9 @@
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 
 import { DEV } from 'esm-env';
-import { untrack } from 'svelte';
+import * as svelte from 'svelte';
+// Svelte 4 and under don't have `untrack` - you'll not be able to use remote functions with Svelte 4 but this will still be loaded
+const untrack = svelte.untrack ?? ((value) => value());
 
 /**
  * Sets a value in a nested object using a path string, not mutating the original object but returning a new object


### PR DESCRIPTION
Fixes #14657

<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
