### PR TITLE
fix: `form.fields.set()` triggers `form.fields.value()` updates

### DIFF
--- a/.changeset/fluffy-lights-know.md
+++ b/.changeset/fluffy-lights-know.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: `form.fields.set()` triggers `form.fields.value()` updates

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -540,6 +540,15 @@ export function form(id) {
 							} else {
 								input = deep_set(input, path.map(String), value);
 							}
+
+							const copy = path.slice();
+
+							do {
+								const name = build_path_string(copy);
+
+								versions[name] ??= 0;
+								versions[name] += 1;
+							} while (copy.pop() !== undefined);
 						},
 						() => issues
 					)

--- a/packages/kit/test/apps/basics/src/routes/remote/form/set/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/remote/form/set/+page.svelte
@@ -1,0 +1,19 @@
+<script>
+	import { values } from './value.remote.js';
+</script>
+
+<h1>Remote Form Set Test</h1>
+
+<form {...values}>
+	<label>
+		Leaf:
+		<input {...values.fields.leaf.as('text')} />
+	</label>
+
+	<button>Submit</button>
+</form>
+
+<h2>Full Form Value</h2>
+<pre id="full-value">{JSON.stringify(values.fields.value(), null, '  ')}</pre>
+
+<button id="update-value" onclick={() => values.fields.leaf.set('new value')}>Update Value</button>

--- a/packages/kit/test/apps/basics/src/routes/remote/form/set/value.remote.ts
+++ b/packages/kit/test/apps/basics/src/routes/remote/form/set/value.remote.ts
@@ -1,0 +1,11 @@
+import { form } from '$app/server';
+import * as v from 'valibot';
+
+export const values = form(
+	v.object({
+		leaf: v.string()
+	}),
+	async (data) => {
+		return { success: true, data };
+	}
+);

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1982,6 +1982,26 @@ test.describe('remote functions', () => {
 		expect(JSON.parse(arrayValue)).toEqual([{ leaf: 'array-0-leaf' }, { leaf: 'array-1-leaf' }]);
 	});
 
+	test('form.fields.set() triggers form.fields.value() updates', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		if (!javaScriptEnabled) return;
+
+		await page.goto('/remote/form/set');
+
+		const before = await page.locator('#full-value').textContent();
+		expect(JSON.parse(before)).toEqual({});
+
+		await page.locator('#update-value').click();
+
+		const leafValue = await page.locator('input[name="leaf"]').inputValue();
+		expect(leafValue).toBe('new value');
+
+		const after = await page.locator('#full-value').textContent();
+		expect(JSON.parse(after)).toEqual({ leaf: 'new value' });
+	});
+
 	test('selects are not nuked when unrelated controls change', async ({
 		page,
 		javaScriptEnabled


### PR DESCRIPTION
fixes #14680 

The issue is basically that the `.set()` function does not trigger `.value()` to reactively update, because the `versions` state that `.value()` depends on is not updated. Even though the value has changed, it shows an incorrect state.

Example issue: https://stackblitz.com/edit/array-methods-308957-nxhl9tqu?file=src%2Froutes%2Ftest.remote.ts,src%2Froutes%2F%2Bpage.svelte

After fix: https://stackblitz.com/edit/array-methods-308957-ca6wdbqe?file=package.json,src%2Froutes%2F%2Bpage.svelte

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
