### PR TITLE
fix: wait for commit promise instead of `settled`

### DIFF
--- a/.changeset/eager-experts-roll.md
+++ b/.changeset/eager-experts-roll.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: wait for commit promise instead of `settled`


### PR DESCRIPTION
Since we now fork every time, we should wait on the commit promise rather than `settled` (there are technically a couple of svelte versions where `settled` is there and works but not `fork` so maybe we could also wait for `settled` concurrently, but I'd say it's probably overkill).

Without this, #14800 is basically non-useful since settled resolves immediately if we invoke it after awaiting `load_cache_fork`😅

P.s. for some reason running the test locally I see a bunch of failing tests...but that's also true before the change so 🤷🏼 
---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
