### PR TITLE
chore: fix pnpm-lock.yaml

### DIFF
--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -277,6 +277,7 @@ test.describe('Navigation lifecycle functions', () => {
 	});
 
 	test('navigation.event is populated', async ({ page, clicknav }) => {
+		/** @type {string[]} */
 		const logs = [];
 
 		await page.goto('/navigation-lifecycle/before-navigate/event/a');

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -361,6 +361,7 @@ test.describe('Async', () => {
 
 		await page.goto('/path-base/on-navigate/a');
 
+		/** @type {string[]} */
 		const logs = [];
 		page.on('console', (msg) => {
 			logs.push(msg.text());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -633,27 +633,6 @@ importers:
         specifier: 'catalog:'
         version: 6.3.6(@types/node@18.19.119)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
 
-  packages/kit/test/apps/async:
-    devDependencies:
-      '@sveltejs/kit':
-        specifier: workspace:^
-        version: link:../../..
-      '@sveltejs/vite-plugin-svelte':
-        specifier: 'catalog:'
-        version: 6.0.0-next.3(svelte@5.42.2)(vite@6.3.6(@types/node@18.19.119)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
-      svelte:
-        specifier: 'catalog:'
-        version: 5.42.2
-      svelte-check:
-        specifier: 'catalog:'
-        version: 4.1.1(picomatch@4.0.3)(svelte@5.42.2)(typescript@5.8.3)
-      typescript:
-        specifier: ^5.5.4
-        version: 5.8.3
-      vite:
-        specifier: 'catalog:'
-        version: 6.3.6(@types/node@18.19.119)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
-
   packages/kit/test/apps/basics:
     devDependencies:
       '@opentelemetry/api':


### PR DESCRIPTION
Follow up to https://github.com/sveltejs/kit/pull/14644

This PR updates the `pnpm-lock.yaml` file which still includes references to the now deleted async test app. Also adds some types for some tests since TS 5.9 is erroring on arrays with no explicit type.

I also tried moving one of the async tests in the options test app over to basic but having `await` at the top-level of the script causes Svelte to complain because the experimental async option isn't always turned on.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
