### PR TITLE
feat: allow changing response http status code from `handleError`

### DIFF
--- a/.changeset/seven-mangos-cheat.md
+++ b/.changeset/seven-mangos-cheat.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': minor
 ---
 
-Allow Custom HTTP Status Codes
+feat: allow returning a custom HTTP status code from the `handleError` hook

--- a/.changeset/seven-mangos-cheat.md
+++ b/.changeset/seven-mangos-cheat.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+Allow Custom HTTP Status Codes

--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -186,7 +186,7 @@ If an [unexpected error](errors#Unexpected-errors) is thrown during loading, ren
 - you can log the error
 - you can generate a custom representation of the error that is safe to show to users, omitting sensitive details like messages and stack traces. The returned value, which defaults to `{ message }`, becomes the value of `$page.error`.
 
-For errors thrown from your code (or library code called by your code) the status will be 500 and the message will be "Internal Error". While `error.message` may contain sensitive information that should not be exposed to users, `message` is safe (albeit meaningless to the average user).
+For errors thrown from your code (or library code called by your code) the status will be 500 unless overriden `error.status` and the message will be "Internal Error". While `error.message` may contain sensitive information that should not be exposed to users, `message` is safe (albeit meaningless to the average user).
 
 To add more information to the `$page.error` object in a type-safe way, you can customize the expected shape by declaring an `App.Error` interface (which must include `message: string`, to guarantee sensible fallback behavior). This allows you to — for example — append a tracking ID for users to quote in correspondence with your technical support staff:
 

--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -185,8 +185,9 @@ If an [unexpected error](errors#Unexpected-errors) is thrown during loading, ren
 
 - you can log the error
 - you can generate a custom representation of the error that is safe to show to users, omitting sensitive details like messages and stack traces. The returned value, which defaults to `{ message }`, becomes the value of `$page.error`.
+- you can customise the status code of the response
 
-For errors thrown from your code (or library code called by your code) the status will be 500 unless overriden `error.status` and the message will be "Internal Error". While `error.message` may contain sensitive information that should not be exposed to users, `message` is safe (albeit meaningless to the average user).
+For errors thrown from your code (or library code called by your code) the status will default to 500 and the message will default to "Internal Error". While `error.message` may contain sensitive information that should not be exposed to users, `message` is safe (albeit meaningless to the average user).
 
 To add more information to the `$page.error` object in a type-safe way, you can customize the expected shape by declaring an `App.Error` interface (which must include `message: string`, to guarantee sensible fallback behavior). This allows you to — for example — append a tracking ID for users to quote in correspondence with your technical support staff:
 

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1513,6 +1513,26 @@ export interface RequestEvent<
 	 */
 	setHeaders: (headers: Record<string, string>) => void;
 	/**
+	 * Override the status code for error responses. This is useful when you want to customize the HTTP status code returned for an error, for example:
+	 *
+	 *	```js
+	 *	/// file: src/hooks.server.js
+	 *	export async function handleError({ error, event, status, message }) {
+	 *		// Return 503 Service Unavailable for database errors
+	 *		if (error.message.includes('database')) {
+	 *			event.setStatusCode(503);
+	 *		}
+	 *
+	 *		return {
+	 *			message: 'An error occurred'
+	 *		};
+	 *	}
+	 *	```
+	 *
+	 * This method can only be called from the `handleError` hook and only affects error responses.
+	 */
+	setStatusCode: (code: number) => void;
+	/**
 	 * The requested URL.
 	 */
 	url: URL;

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1529,7 +1529,7 @@ export interface RequestEvent<
 	 *	}
 	 *	```
 	 *
-	 * This method can only be called from the `handleError` hook and only affects error responses.
+	 * This method should only be called from the `handleError` hook and will only affect error responses.
 	 */
 	setStatusCode: (code: number) => void;
 	/**

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -36,13 +36,18 @@ export async function handle_action_json_request(event, event_state, options, se
 			`POST method not allowed. No form actions exist for ${DEV ? `the page at ${event.route.id}` : 'this page'}`
 		);
 
+		const error = await handle_error_and_jsonify(event, event_state, options, no_actions_error);
+
+		// Use custom status code if set via event.setStatusCode()
+		const status = event_state.error_status_code ?? no_actions_error.status;
+
 		return action_json(
 			{
 				type: 'error',
-				error: await handle_error_and_jsonify(event, event_state, options, no_actions_error)
+				error
 			},
 			{
-				status: no_actions_error.status,
+				status,
 				headers: {
 					// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405
 					// "The server must generate an Allow header field in a 405 status code response"
@@ -93,18 +98,23 @@ export async function handle_action_json_request(event, event_state, options, se
 			return action_json_redirect(err);
 		}
 
+		const error = await handle_error_and_jsonify(
+			event,
+			event_state,
+			options,
+			check_incorrect_fail_use(err)
+		);
+
+		// Use custom status code if set via event.setStatusCode()
+		const status = event_state.error_status_code ?? get_status(err);
+
 		return action_json(
 			{
 				type: 'error',
-				error: await handle_error_and_jsonify(
-					event,
-					event_state,
-					options,
-					check_incorrect_fail_use(err)
-				)
+				error
 			},
 			{
-				status: get_status(err)
+				status
 			}
 		);
 	}

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -270,7 +270,8 @@ export async function render_page(
 						return redirect_response(err.status, err.location);
 					}
 
-					const status = get_status(err);
+					// Use custom status code if set via event.setStatusCode()
+					const status = event_state.error_status_code ?? get_status(err);
 					const error = await handle_error_and_jsonify(event, event_state, options, err);
 
 					while (i--) {

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -90,6 +90,9 @@ export async function respond_with_error({
 			);
 		}
 
+		const error_body = await handle_error_and_jsonify(event, event_state, options, error);
+		const status = event_state.error_status_code ?? get_status(error);
+
 		return await render_response({
 			options,
 			manifest,
@@ -98,8 +101,8 @@ export async function respond_with_error({
 				ssr,
 				csr
 			},
-			status: event_state.error_status_code ?? status,
-			error: await handle_error_and_jsonify(event, event_state, options, error),
+			status,
+			error: error_body,
 			branch,
 			fetched,
 			event,

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -98,7 +98,7 @@ export async function respond_with_error({
 				ssr,
 				csr
 			},
-			status,
+			status: event_state.error_status_code ?? status,
 			error: await handle_error_and_jsonify(event, event_state, options, error),
 			branch,
 			fetched,
@@ -114,10 +114,8 @@ export async function respond_with_error({
 			return redirect_response(e.status, e.location);
 		}
 
-		return static_error_page(
-			options,
-			get_status(e),
-			(await handle_error_and_jsonify(event, event_state, options, e)).message
-		);
+		const status = get_status(e);
+		const error = await handle_error_and_jsonify(event, event_state, options, e);
+		return static_error_page(options, event_state.error_status_code ?? status, error.message);
 	}
 }

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -114,8 +114,8 @@ export async function respond_with_error({
 			return redirect_response(e.status, e.location);
 		}
 
-		const status = get_status(e);
+		const status = event_state.error_status_code ?? get_status(e);
 		const error = await handle_error_and_jsonify(event, event_state, options, e);
-		return static_error_page(options, event_state.error_status_code ?? status, error.message);
+		return static_error_page(options, status, error.message);
 	}
 }

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -193,6 +193,14 @@ export async function internal_respond(request, options, manifest, state) {
 				}
 			}
 		},
+		setStatusCode: (code) => {
+			if (typeof code !== 'number' || code < 100 || code > 599) {
+				throw new Error(
+					`Invalid status code: ${code}. Status code must be a number between 100 and 599`
+				);
+			}
+			event_state.error_status_code = code;
+		},
 		url,
 		isDataRequest: is_data_request,
 		isSubRequest: state.depth > 0,

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -84,8 +84,10 @@ export function static_error_page(options, status, message) {
  */
 export async function handle_fatal_error(event, state, options, error) {
 	error = error instanceof HttpError ? error : coalesce_to_error(error);
-	const status = get_status(error);
 	const body = await handle_error_and_jsonify(event, state, options, error);
+
+	// Use custom status code if set via event.setStatusCode()
+	const status = state.error_status_code ?? get_status(error);
 
 	// ideally we'd use sec-fetch-dest instead, but Safari — quelle surprise — doesn't support it
 	const type = negotiate(event.request.headers.get('accept') || 'text/html', [

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -611,6 +611,8 @@ export interface RequestState {
 	remote_data?: Map<RemoteInfo, Record<string, MaybePromise<any>>>;
 	refreshes?: Record<string, Promise<any>>;
 	is_endpoint_request?: boolean;
+	/** Custom status code set by event.setStatusCode() */
+	error_status_code?: number;
 }
 
 export interface RequestStore {

--- a/packages/kit/src/utils/error.js
+++ b/packages/kit/src/utils/error.js
@@ -32,8 +32,8 @@ export function get_status(error) {
 		return error.status;
 	}
 	// For overrides / custom error objects
-	if (typeof error === 'object' && error !== null && 'status' in error) {
-		return /** @type {{ status?: number }} */ (error).status ?? 500;
+	if (typeof error === 'object' && error !== null && 'status' in error && typeof error.status === 'number') {
+		return error.status;
 	}
 	return 500;
 }

--- a/packages/kit/src/utils/error.js
+++ b/packages/kit/src/utils/error.js
@@ -32,7 +32,12 @@ export function get_status(error) {
 		return error.status;
 	}
 	// For overrides / custom error objects
-	if (typeof error === 'object' && error !== null && 'status' in error && typeof error.status === 'number') {
+	if (
+		typeof error === 'object' &&
+		error !== null &&
+		'status' in error &&
+		typeof error.status === 'number'
+	) {
 		return error.status;
 	}
 	return 500;

--- a/packages/kit/src/utils/error.js
+++ b/packages/kit/src/utils/error.js
@@ -31,15 +31,6 @@ export function get_status(error) {
 	if (error instanceof HttpError || error instanceof SvelteKitError) {
 		return error.status;
 	}
-	// For overrides / custom error objects
-	if (
-		typeof error === 'object' &&
-		error !== null &&
-		'status' in error &&
-		typeof error.status === 'number'
-	) {
-		return error.status;
-	}
 	return 500;
 }
 

--- a/packages/kit/src/utils/error.js
+++ b/packages/kit/src/utils/error.js
@@ -25,13 +25,9 @@ export function normalize_error(error) {
 
 /**
  * @param {unknown} error
- * @returns {number}
  */
 export function get_status(error) {
-	if (error instanceof HttpError || error instanceof SvelteKitError) {
-		return error.status;
-	}
-	return 500;
+	return error instanceof HttpError || error instanceof SvelteKitError ? error.status : 500;
 }
 
 /**

--- a/packages/kit/src/utils/error.js
+++ b/packages/kit/src/utils/error.js
@@ -25,9 +25,17 @@ export function normalize_error(error) {
 
 /**
  * @param {unknown} error
+ * @returns {number}
  */
 export function get_status(error) {
-	return error instanceof HttpError || error instanceof SvelteKitError ? error.status : 500;
+	if (error instanceof HttpError || error instanceof SvelteKitError) {
+		return error.status;
+	}
+	// For overrides / custom error objects
+	if (typeof error === 'object' && error !== null && 'status' in error) {
+		return /** @type {{ status?: number }} */ (error).status ?? 500;
+	}
+	return 500;
 }
 
 /**

--- a/packages/kit/test/apps/basics/src/hooks.server.js
+++ b/packages/kit/test/apps/basics/src/hooks.server.js
@@ -57,6 +57,10 @@ export const handleError = ({ event, error: e, status, message }) => {
 		message = ev.locals.message;
 	}
 
+	if (event.url.pathname.startsWith('/errors/custom-error')) {
+		event.setStatusCode(422);
+	}
+
 	return event.url.pathname.endsWith('404-fallback')
 		? undefined
 		: { message: `${error.message} (${status} ${message})` };

--- a/packages/kit/test/apps/basics/src/routes/errors/custom-error/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/errors/custom-error/+server.js
@@ -1,0 +1,10 @@
+class CustomError extends Error {
+	constructor(message, errorOpts) {
+		super(message, errorOpts);
+		this.status = 422;
+	}
+}
+
+export function GET() {
+	throw new CustomError('Custom error');
+}

--- a/packages/kit/test/apps/basics/src/routes/errors/custom-error/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/errors/custom-error/+server.js
@@ -1,10 +1,6 @@
-class CustomError extends Error {
-	constructor(message, errorOpts) {
-		super(message, errorOpts);
-		this.status = 422;
-	}
-}
-
+/**
+ * This gets intercepted by the handleError hook and sets the status code to 422
+ */
 export function GET() {
-	throw new CustomError('Custom error');
+	throw new Error('Custom error');
 }

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -454,7 +454,6 @@ test.describe('Errors', () => {
 
 	test('custom error object', async ({ request }) => {
 		const response = await request.get('/errors/custom-error');
-		console.log(response.status());
 		expect(response.status()).toBe(422);
 	});
 

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -452,6 +452,12 @@ test.describe('Errors', () => {
 		expect(await response.text()).toMatch('thisvariableisnotdefined is not defined');
 	});
 
+	test('custom error object', async ({ request }) => {
+		const response = await request.get('/errors/custom-error');
+		console.log(response.status());
+		expect(response.status()).toBe(422);
+	});
+
 	test('returns 400 when accessing a malformed URI', async ({ page }) => {
 		const response = await page.goto('/%c0%ae%c0%ae/etc/passwd');
 		if (process.env.DEV) {

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -452,7 +452,7 @@ test.describe('Errors', () => {
 		expect(await response.text()).toMatch('thisvariableisnotdefined is not defined');
 	});
 
-	test('custom error object', async ({ request }) => {
+	test('handleError hook can set the response status', async ({ request }) => {
 		const response = await request.get('/errors/custom-error');
 		expect(response.status()).toBe(422);
 	});

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1505,7 +1505,7 @@ declare module '@sveltejs/kit' {
 		 *	}
 		 *	```
 		 *
-		 * This method can only be called from the `handleError` hook and only affects error responses.
+		 * This method should only be called from the `handleError` hook and will only affect error responses.
 		 */
 		setStatusCode: (code: number) => void;
 		/**

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1489,6 +1489,26 @@ declare module '@sveltejs/kit' {
 		 */
 		setHeaders: (headers: Record<string, string>) => void;
 		/**
+		 * Override the status code for error responses. This is useful when you want to customize the HTTP status code returned for an error, for example:
+		 *
+		 *	```js
+		 *	/// file: src/hooks.server.js
+		 *	export async function handleError({ error, event, status, message }) {
+		 *		// Return 503 Service Unavailable for database errors
+		 *		if (error.message.includes('database')) {
+		 *			event.setStatusCode(503);
+		 *		}
+		 *
+		 *		return {
+		 *			message: 'An error occurred'
+		 *		};
+		 *	}
+		 *	```
+		 *
+		 * This method can only be called from the `handleError` hook and only affects error responses.
+		 */
+		setStatusCode: (code: number) => void;
+		/**
 		 * The requested URL.
 		 */
 		url: URL;


### PR DESCRIPTION
closes #14442 

Allow Custom HTTP Status Codes From Error Handling

Allows custom http status codes from error objects allow for more robust error handling for production SvelteKit users. This is useful if you are using custom error handling, we allow errors to propagate from other services outside of SvelteKit.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
