### PR TITLE
fix: propagate remote function backend errors to the frontend

### DIFF
--- a/packages/kit/src/exports/internal/index.js
+++ b/packages/kit/src/exports/internal/index.js
@@ -1,17 +1,20 @@
-export class HttpError {
+export class HttpError extends Error {
 	/**
 	 * @param {number} status
 	 * @param {{message: string} extends App.Error ? (App.Error | string | undefined) : App.Error} body
 	 */
 	constructor(status, body) {
+		const normalized =
+			typeof body === 'string' ? { message: body } : body ?? { message: `Error: ${status}` };
+
+		const message =
+			typeof normalized?.message === 'string' ? normalized.message : `Error: ${status}`;
+
+		super(message);
+
+		this.name = 'HttpError';
 		this.status = status;
-		if (typeof body === 'string') {
-			this.body = { message: body };
-		} else if (body) {
-			this.body = body;
-		} else {
-			this.body = { message: `Error: ${status}` };
-		}
+		this.body = normalized;
 	}
 
 	toString() {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2706,7 +2706,7 @@ declare module '@sveltejs/kit' {
 	export type LessThan<TNumber extends number, TArray extends any[] = []> = TNumber extends TArray["length"] ? TArray[number] : LessThan<TNumber, [...TArray, TArray["length"]]>;
 	export type NumericRange<TStart extends number, TEnd extends number> = Exclude<TEnd | LessThan<TEnd>, LessThan<TStart>>;
 	export const VERSION: string;
-	class HttpError_1 {
+	class HttpError_1 extends Error {
 		
 		constructor(status: number, body: {
 			message: string;


### PR DESCRIPTION
<!-- Your PR description here -->
fix #14934 

This PR ensures that backend-thrown errors are propagated correctly to the frontend when using remote functions.
Previously, remote async functions that threw errors on the backend did not surface their actual error messages on the client. As a result, frontend try/catch logic always showed fallback messages instead of the message from the thrown error.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
