### PR TITLE
feat: use `read` to retrieve prerendered data

### DIFF
--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -57,8 +57,9 @@ export function read(asset) {
 	const file = decodeURIComponent(
 		DEV && asset.startsWith('/@fs') ? asset : asset.slice(base.length + 1)
 	);
+	const fileAsRoute = file.replace(/^\/?/, '/');
 
-	if (file in manifest._.server_assets) {
+	if (file in manifest._.server_assets || manifest._.prerendered_routes.has(fileAsRoute)) {
 		const length = manifest._.server_assets[file];
 		const type = manifest.mimeTypes[file.slice(file.lastIndexOf('.'))];
 

--- a/packages/kit/src/runtime/app/server/remote/prerender.js
+++ b/packages/kit/src/runtime/app/server/remote/prerender.js
@@ -102,8 +102,6 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 						const key = stringify_remote_arg(arg, state.transport);
 						const cache = get_cache(__, state);
 
-						// TODO adapters can provide prerendered data more efficiently than
-						// fetching from the public internet
 						const response = (cache[key] ??= read(url));
 						if (!response.ok) {
 							throw new Error('Prerendered response not found');


### PR DESCRIPTION
Resolves #15035
closes https://github.com/sveltejs/kit/issues/3850

This PR is **an attempt** at hopefully guiding someone in the right direction. I made a best effort to put forward a solution to the issue but ultimately I'm not super confident of the approach here and I'm not knowledgeable enough about the codebase to come up with a better one at this time. Hopefully, someone who knows this area better can take this and run with it, or at least provide some suggestions on how I can improve this more.

This solution solves the problem for cloudflare adapters and locally, but could break other implementations.

### Brief Restatement of Problem
when using cloudflare, and likely other adapters, Cloudflare Workers prevents us from making full fetch requests to the same worker, presumably to prevent untraceable infinite call loops? Instead, we're meant to use service bindings like `env.ASSETS.fetch()`.

### Solution
1. Replaced the prerendered remote function's fetch call with `$app/server`'s read. (there was already a TODO to allow adapters to inject their own methods here, I thought this might be a step in that direction)
2. Since prerendered routes are stored as files, I added an exception in the `$app/server` read function to allow prerendered routes as well as server assets found in the manifest

### Problems
1. I need help understanding what kinds of implications this could have. It feels like the first change is pretty isolated, tested that CSR and SSR both work now, but I don't know how this plays with other adapters. Help!
2. We don't store the prerendered assets' content lengths, which means that I'm not passing a Content-Length header in the response of the read function. I tried to add the prerendered asset to the `manifest._.server_assets` object but couldn't quite get there. Help!




---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
