### PR TITLE
Fix: provide cache to reroute hook

### DIFF
--- a/.changeset/tame-things-shop.md
+++ b/.changeset/tame-things-shop.md
@@ -1,0 +1,9 @@
+---
+'@sveltejs/kit': patch
+---
+
+Fix: provide cache to reroute
+
+This provides cache as an argument to reroute and doesn't affect the default caching behavior, but enables the choice of which routes should be cached and which ones should always run the hook.
+
+This is important (among other things) because you might depend on the reroute hook to access different layouts, contexts or other features depending on client state. Especially now that the fetch also allows forwarding of cookies to the backend.

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -971,7 +971,7 @@ export type ClientInit = () => MaybePromise<void>;
  * The [`reroute`](https://svelte.dev/docs/kit/hooks#Universal-hooks-reroute) hook allows you to modify the URL before it is used to determine which route to render.
  * @since 2.3.0
  */
-export type Reroute = (event: { url: URL; fetch: typeof fetch }) => MaybePromise<void | string>;
+export type Reroute = (event: { url: URL; fetch: typeof fetch; cache?: Map<string, Promise<URL>>;}) => MaybePromise<void | string>;
 
 /**
  * The [`transport`](https://svelte.dev/docs/kit/hooks#Universal-hooks-transport) hook allows you to transport custom types across the server/client boundary.

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1355,7 +1355,8 @@ async function get_rerouted_url(url) {
 					url: new URL(url),
 					fetch: async (input, init) => {
 						return resolve_fetch_url(input, init, url).promise;
-					}
+					},
+					cache: reroute_cache
 				})) ?? url;
 
 			if (typeof rerouted === 'string') {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -947,7 +947,7 @@ declare module '@sveltejs/kit' {
 	 * The [`reroute`](https://svelte.dev/docs/kit/hooks#Universal-hooks-reroute) hook allows you to modify the URL before it is used to determine which route to render.
 	 * @since 2.3.0
 	 */
-	export type Reroute = (event: { url: URL; fetch: typeof fetch }) => MaybePromise<void | string>;
+	export type Reroute = (event: { url: URL; fetch: typeof fetch; cache?: Map<string, Promise<URL>>;}) => MaybePromise<void | string>;
 
 	/**
 	 * The [`transport`](https://svelte.dev/docs/kit/hooks#Universal-hooks-transport) hook allows you to transport custom types across the server/client boundary.


### PR DESCRIPTION
This PR fixes #13653 by allowing the `reroute` hook to control route caching behavior through a `cache` parameter. By passing the cache Map reference (`Map<string, Promise<URL>>`) to the hook, developers can selectively clear cache entries (e.g., by looping through specific routes or clearing all entries) to force the hook to re-run on subsequent requests. This is useful when rerouting depends on client state (cookies, headers, etc.) to determine layouts or route handling.

In two projects, I was already using the `reroute` hook for this type of behavior, but after updating from 2.18, the `reroute_cache` broke my apps. I tested this patch manually by applying it directly to `node_modules` in both projects, and it successfully allows fine-grained control over which routes bypass the cache.
---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
  > Tested manually in two existing projects by patching `node_modules`. The feature works as expected, allowing selective cache invalidation. I'm open to add automated tests if maintainers provide guidance on the preferred test structure for this behavior.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
