### PR TITLE
fix: support instrumentation for `vite preview`

### DIFF
--- a/.changeset/loud-glasses-enter.md
+++ b/.changeset/loud-glasses-enter.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: support instrumentation for `vite preview`

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -35,6 +35,11 @@ export async function preview(vite, vite_config, svelte_config) {
 		throw new Error(`Server files not found at ${dir}, did you run \`build\` first?`);
 	}
 
+	const instrumentation = join(dir, 'instrumentation.server.js');
+	if (fs.existsSync(instrumentation)) {
+		await import(pathToFileURL(instrumentation).href);
+	}
+
 	/** @type {import('types').ServerInternalModule} */
 	const { set_assets } = await import(pathToFileURL(join(dir, 'internal.js')).href);
 


### PR DESCRIPTION
The `instrumentation.server.js` file is now imported when running `vite preview`.

Unfortunately, since it's not the first thing that's imported (all of Vite's depedencies are imported first), some instrumentation that rely on monkey-patching imports might not work properly, but at least we're importing it before the server code. This matches the existing behaviour of `vite dev` added in https://github.com/sveltejs/kit/pull/13899, see https://github.com/sveltejs/kit/blob/51214794b40b2fc533b06cb8344e84e661f90be0/packages/kit/src/exports/vite/dev/index.js#L507-L513

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
  - ~This seems like a small bug, so I thought it'd be easier to just make a PR.~
  - _Edit_: Whoops! We do already have an issue for this. This PR fixes https://github.com/sveltejs/kit/issues/14275.
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
  - I don't think we have any tests that run using `vite preview`, so I skipped this. But let me know if you want me to add one.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
  - `pnpm test` is failing for me even on the `main` branch, so I'm not 100% sure if this will work or not.

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
