### PR TITLE
fix: use hasOwn check when deep-setting object properties

### DIFF
--- a/.changeset/solid-apples-clap.md
+++ b/.changeset/solid-apples-clap.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: use hasOwn check when deep-setting object properties

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -441,7 +441,7 @@ export function deep_set(object, keys, value) {
 		check_prototype_pollution(key);
 
 		const is_array = /^\d+$/.test(keys[i + 1]);
-		const exists = key in current;
+		const exists = Object.hasOwn(current, key);
 		const inner = current[key];
 
 		if (exists && is_array !== Array.isArray(inner)) {

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, test } from 'vitest';
 import {
 	BINARY_FORM_CONTENT_TYPE,
 	convert_formdata,
+	deep_set,
 	deserialize_binary_form,
 	serialize_binary_form,
 	split_path
@@ -241,5 +242,18 @@ describe('binary form serializer', () => {
 		);
 
 		expect(res.data).toEqual({ a: 1 });
+	});
+});
+
+describe('deep_set', () => {
+	test('always creates own property', () => {
+		const target = {};
+
+		deep_set(target, ['toString', 'property'], 'hello');
+
+		// @ts-ignore
+		expect(target.toString.property).toBe('hello');
+		// @ts-ignore
+		expect(Object.prototype.toString.property).toBeUndefined();
 	});
 });


### PR DESCRIPTION
replaces `key in current` with a stricter `Object.hasOwn(current, key)` check in case a property name collides with something on `Object.prototype`

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
