### PR TITLE
fix: add `experimental.forkPreloads` flag

### DIFF
--- a/.changeset/tame-lights-push.md
+++ b/.changeset/tame-lights-push.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: put forking behind `experimental.enhancedPreloading`
+fix: put forking behind `experimental.forkPreloads`

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -81,7 +81,7 @@ const get_defaults = (prefix = '') => ({
 			tracing: { server: false },
 			instrumentation: { server: false },
 			remoteFunctions: false,
-			enhancedPreloading: false
+			forkPreloads: false
 		},
 		files: {
 			src: join(prefix, 'src'),
@@ -480,28 +480,28 @@ test('errors on invalid tracing values', () => {
 	}, /^config\.kit\.experimental\.tracing\.server should be true or false, if specified$/);
 });
 
-test('errors on invalid enhancedPreloading values', () => {
+test('errors on invalid forkPreloads values', () => {
 	assert.throws(() => {
 		validate_config({
 			kit: {
 				experimental: {
 					// @ts-expect-error - given value expected to throw
-					enhancedPreloading: 'true'
+					forkPreloads: 'true'
 				}
 			}
 		});
-	}, /^config\.kit\.experimental\.enhancedPreloading should be true or false, if specified$/);
+	}, /^config\.kit\.experimental\.forkPreloads should be true or false, if specified$/);
 
 	assert.throws(() => {
 		validate_config({
 			kit: {
 				experimental: {
 					// @ts-expect-error - given value expected to throw
-					enhancedPreloading: 1
+					forkPreloads: 1
 				}
 			}
 		});
-	}, /^config\.kit\.experimental\.enhancedPreloading should be true or false, if specified$/);
+	}, /^config\.kit\.experimental\.forkPreloads should be true or false, if specified$/);
 });
 
 test('uses src prefix for other kit.files options', async () => {

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -133,7 +133,7 @@ const options = object(
 					server: boolean(false)
 				}),
 				remoteFunctions: boolean(false),
-				enhancedPreloading: boolean(false)
+				forkPreloads: boolean(false)
 			}),
 
 			files: object({

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -507,10 +507,10 @@ export interface KitConfig {
 		remoteFunctions?: boolean;
 
 		/**
-		 * Whether to enable the experimental enhanced preloading feature using Svelte's fork API.
+		 * Whether to enable the experimental forked preloading feature using Svelte's fork API.
 		 * @default false
 		 */
-		enhancedPreloading?: boolean;
+		forkPreloads?: boolean;
 	};
 	/**
 	 * Where to find various files within your project.

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -346,7 +346,7 @@ async function kit({ svelte_config }) {
 				__SVELTEKIT_APP_DIR__: s(kit.appDir),
 				__SVELTEKIT_EMBEDDED__: s(kit.embedded),
 				__SVELTEKIT_EXPERIMENTAL__REMOTE_FUNCTIONS__: s(kit.experimental.remoteFunctions),
-				__SVELTEKIT_ENHANCED_PRELOADING__: s(kit.experimental.enhancedPreloading),
+				__SVELTEKIT_FORK_PRELOADS__: s(kit.experimental.forkPreloads),
 				__SVELTEKIT_PATHS_ASSETS__: s(kit.paths.assets),
 				__SVELTEKIT_PATHS_BASE__: s(kit.paths.base),
 				__SVELTEKIT_PATHS_RELATIVE__: s(kit.paths.relative),

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -532,7 +532,7 @@ async function _preload_data(intent) {
 			fork: null
 		};
 
-		if (__SVELTEKIT_ENHANCED_PRELOADING__ && svelte.fork) {
+		if (__SVELTEKIT_FORK_PRELOADS__ && svelte.fork) {
 			const lc = load_cache;
 
 			lc.fork = lc.promise.then((result) => {

--- a/packages/kit/src/types/global-private.d.ts
+++ b/packages/kit/src/types/global-private.d.ts
@@ -11,8 +11,8 @@ declare global {
 	const __SVELTEKIT_SERVER_TRACING_ENABLED__: boolean;
 	/** true if corresponding config option is set to true */
 	const __SVELTEKIT_EXPERIMENTAL__REMOTE_FUNCTIONS__: boolean;
-	/** True if `config.kit.experimental.enhancedPreloading` is `true` */
-	const __SVELTEKIT_ENHANCED_PRELOADING__: boolean;
+	/** True if `config.kit.experimental.forkPreloads` is `true` */
+	const __SVELTEKIT_FORK_PRELOADS__: boolean;
 	/** True if `config.kit.router.resolution === 'client'` */
 	const __SVELTEKIT_CLIENT_ROUTING__: boolean;
 	/** True if `config.kit.router.type === 'hash'` */

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -483,10 +483,10 @@ declare module '@sveltejs/kit' {
 			remoteFunctions?: boolean;
 
 			/**
-			 * Whether to enable the experimental enhanced preloading feature using Svelte's fork API.
+			 * Whether to enable the experimental forked preloading feature using Svelte's fork API.
 			 * @default false
 			 */
-			enhancedPreloading?: boolean;
+			forkPreloads?: boolean;
 		};
 		/**
 		 * Where to find various files within your project.


### PR DESCRIPTION
Adds a new experimental flag to gate the use of Svelte's `fork` API for preloading. The flag defaults to `false`, disabling the fork-based preloading behavior until explicitly enabled.

We're making this change because the current behaviour is buggy in some cases, such as when a `redirect` occurs when rendering the destination, and we don't want people to be prevented from updating to the latest version.

<!-- Your PR description here -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
