### PR TITLE
chore: prevent two concurrent running release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+concurrency:
+  # prevent two release workflows from running at once
+  # race conditions here can result in releases failing
+  group: ${{ github.workflow }}
+
 permissions: {}
 jobs:
   release:


### PR DESCRIPTION
If two concurrent `release` jobs are run on `main` - one to publish a new release, and a second one that adds to the next release - then a race condition can result in the first release not getting published. This should hopefully address that by ensuring that only one `release` job can run at once.

Side effects of this: Merging multiple PRs to `main` will be a little slower in updating the release PR. And GH will only queue a single run additional. If a third PR is merge while the first is still running, I believe the third one will be canceled and will need to be manually rerun.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
