### PR TITLE
feat(vite): allow setting custom cwd path

### DIFF
--- a/.changeset/little-wombats-cover.md
+++ b/.changeset/little-wombats-cover.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+feat(vite): allow setting custom cwd path

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -131,10 +131,11 @@ const warning_preprocessor = {
 
 /**
  * Returns the SvelteKit Vite plugins.
+ * @param {{ cwd?: string }} [options]
  * @returns {Promise<import('vite').Plugin[]>}
  */
-export async function sveltekit() {
-	const svelte_config = await load_config();
+export async function sveltekit({ cwd } = {}) {
+	const svelte_config = await load_config({ cwd });
 
 	/** @type {import('@sveltejs/vite-plugin-svelte').Options['preprocess']} */
 	let preprocess = svelte_config.preprocess;
@@ -162,7 +163,7 @@ export async function sveltekit() {
 
 	const { svelte } = await import_peer('@sveltejs/vite-plugin-svelte');
 
-	return [...svelte(vite_plugin_svelte_options), ...(await kit({ svelte_config }))];
+	return [...svelte(vite_plugin_svelte_options), ...(await kit({ svelte_config, root: cwd }))];
 }
 
 // These variables live outside the `kit()` function because it is re-invoked by each Vite build
@@ -185,10 +186,10 @@ let build_metadata = undefined;
  * - https://rollupjs.org/guide/en/#build-hooks
  * - https://rollupjs.org/guide/en/#output-generation-hooks
  *
- * @param {{ svelte_config: import('types').ValidatedConfig }} options
+ * @param {{ svelte_config: import('types').ValidatedConfig, root?: string }} options
  * @return {Promise<import('vite').Plugin[]>}
  */
-async function kit({ svelte_config }) {
+async function kit({ svelte_config, root = cwd }) {
 	/** @type {import('vite')} */
 	const vite = await import_peer('vite');
 
@@ -276,7 +277,7 @@ async function kit({ svelte_config }) {
 						...get_config_aliases(kit)
 					]
 				},
-				root: cwd,
+				root,
 				server: {
 					cors: { preflightContinue: true },
 					fs: {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2861,7 +2861,9 @@ declare module '@sveltejs/kit/vite' {
 	/**
 	 * Returns the SvelteKit Vite plugins.
 	 * */
-	export function sveltekit(): Promise<import("vite").Plugin[]>;
+	export function sveltekit({ cwd }?: {
+		cwd?: string;
+	}): Promise<import("vite").Plugin[]>;
 
 	export {};
 }


### PR DESCRIPTION

closes #13748

I have a monorepo with a package being a sveltekit app. I do unit testing, but it was completely failing when running vitest from the monorepo due to aliases not working, and mainly, the vite sveltekit plugin not finding the svelte.config.js file. 

I fixed it with a patch allowing to override the cwd (solution proposed on the linked issue), and setting the cwd like this:

```js
const __dirname = path.dirname(fileURLToPath(import.meta.url));

export default defineConfig({
  plugins: [
    tailwindcss(),
      sveltekit({
      cwd: __dirname,
    }),
  ],
  test: {
    name: "redacted",
    projects: [
      {
        extends: "./vite.config.ts",
        test: {
          name: "client",
          browser: {
            enabled: true,
            provider: playwright(),
            instances: [{ browser: "chromium", headless: true }],
          },
          include: ["tests/**/*.svelte.test.ts"],
        },
      },
      {
        extends: "./vite.config.ts",
        test: {
          name: "server",
          environment: "node",
          include: ["tests/**/*.test.ts"],
          exclude: ["tests/**/*.svelte.test.ts"],
        },
      },
    ],
  },
});
```

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [X] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [X] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [X] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
