### PR TITLE
fix: Skip failing tests on async

### DIFF
--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -731,6 +731,10 @@ test.describe('$app/environment', () => {
 
 test.describe('$app/paths', () => {
 	test('includes paths', async ({ page, javaScriptEnabled }) => {
+		test.skip(
+			process.env.SVELTE_ASYNC === 'true',
+			'does not work with async, should use new functions instead'
+		);
 		await page.goto('/paths');
 
 		let base = javaScriptEnabled ? '' : '.';
@@ -749,6 +753,10 @@ test.describe('$app/paths', () => {
 		page,
 		javaScriptEnabled
 	}) => {
+		test.skip(
+			process.env.SVELTE_ASYNC === 'true',
+			'does not work with async, should use new functions instead'
+		);
 		const absolute = `${baseURL}/favicon.png`;
 
 		await page.goto('/');


### PR DESCRIPTION
These tests are failing because there's an extra microtask in async svelte renders. This only affects users with `experimental.async` on, and they should be using the new, non-deprecated functions for this functionality.