### PR TITLE
chore: switch to oxfmt

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,38 @@
+{
+	"useTabs": true,
+	"singleQuote": true,
+	"trailingComma": "none",
+	"printWidth": 100,
+	"plugins": ["prettier-plugin-svelte"],
+	"ignorePatterns": [
+		"**/CHANGELOG.md",
+		"**/vite.config.js.timestamp-*",
+		"**/.netlify/**",
+		"**/.svelte-kit/**",
+		"**/.custom-out-dir/**",
+		"**/test-results/**",
+		"**/.wrangler/**",
+		"documentation/**/*.md",
+		"packages/package/test/fixtures/**/expected/**/*",
+		"packages/package/test/watch/expected/**/*",
+		"packages/package/test/watch/package/**/*",
+		"packages/kit/src/core/postbuild/fixtures/**/*",
+		"packages/adapter-cloudflare/test/apps/workers/dist/**/*",
+		"packages/*/test/**/build/**"
+	],
+	"overrides": [
+		{
+			"files": ["*.svelte"],
+			"options": {
+				"bracketSameLine": false
+			}
+		},
+		{
+			"files": ["packages/*/README.md"],
+			"options": {
+				"useTabs": false,
+				"tabWidth": 2
+			}
+		}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@sveltejs/eslint-config": "catalog:",
 		"@svitejs/changesets-changelog-github-compact": "catalog:",
 		"eslint": "catalog:",
-		"prettier": "^3.6.0",
+		"oxfmt": "^0.27.0",
 		"prettier-plugin-svelte": "^3.4.0",
 		"typescript-eslint": "catalog:"
 	},

--- a/packages/adapter-auto/package.json
+++ b/packages/adapter-auto/package.json
@@ -11,14 +11,21 @@
 		"svelte",
 		"sveltekit"
 	],
+	"homepage": "https://svelte.dev/docs/kit/adapter-auto",
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/sveltejs/kit.git",
 		"directory": "packages/adapter-auto"
 	},
-	"license": "MIT",
-	"homepage": "https://svelte.dev/docs/kit/adapter-auto",
+	"files": [
+		"files",
+		"index.js",
+		"index.d.ts",
+		"adapters.js"
+	],
 	"type": "module",
+	"types": "index.d.ts",
 	"exports": {
 		".": {
 			"types": "./index.d.ts",
@@ -26,16 +33,9 @@
 		},
 		"./package.json": "./package.json"
 	},
-	"types": "index.d.ts",
-	"files": [
-		"files",
-		"index.js",
-		"index.d.ts",
-		"adapters.js"
-	],
 	"scripts": {
-		"lint": "prettier --check .",
-		"format": "pnpm lint --write",
+		"lint": "oxfmt --check .",
+		"format": "oxfmt --write .",
 		"check": "tsc",
 		"test": "vitest run"
 	},

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -10,22 +10,13 @@
 		"svelte",
 		"sveltekit"
 	],
+	"homepage": "https://svelte.dev/docs/kit/adapter-cloudflare",
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/sveltejs/kit.git",
 		"directory": "packages/adapter-cloudflare"
 	},
-	"license": "MIT",
-	"homepage": "https://svelte.dev/docs/kit/adapter-cloudflare",
-	"type": "module",
-	"exports": {
-		".": {
-			"types": "./index.d.ts",
-			"import": "./index.js"
-		},
-		"./package.json": "./package.json"
-	},
-	"types": "index.d.ts",
 	"files": [
 		"files",
 		"index.js",
@@ -33,10 +24,19 @@
 		"index.d.ts",
 		"ambient.d.ts"
 	],
+	"type": "module",
+	"types": "index.d.ts",
+	"exports": {
+		".": {
+			"types": "./index.d.ts",
+			"import": "./index.js"
+		},
+		"./package.json": "./package.json"
+	},
 	"scripts": {
 		"build": "esbuild src/worker.js --bundle --outfile=files/worker.js --external:SERVER --external:MANIFEST --external:cloudflare:workers --format=esm",
-		"lint": "prettier --check .",
-		"format": "pnpm lint --write",
+		"lint": "oxfmt --check .",
+		"format": "oxfmt --write .",
 		"check": "tsc --skipLibCheck",
 		"test:unit": "vitest run",
 		"test:e2e": "pnpm build && pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test",

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -22,9 +22,8 @@ const initialized = server.init({
 	env,
 	read: async (file) => {
 		const url = `${origin}/${file}`;
-		const response = await /** @type {{ ASSETS: { fetch: typeof fetch } }} */ (env).ASSETS.fetch(
-			url
-		);
+		const response =
+			await /** @type {{ ASSETS: { fetch: typeof fetch } }} */ (env).ASSETS.fetch(url);
 
 		if (!response.ok) {
 			throw new Error(

--- a/packages/adapter-cloudflare/test/apps/pages/package.json
+++ b/packages/adapter-cloudflare/test/apps/pages/package.json
@@ -2,6 +2,7 @@
 	"name": "test-cloudflare-pages",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -16,6 +17,5 @@
 		"svelte": "catalog:",
 		"vite": "catalog:",
 		"wrangler": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/adapter-cloudflare/test/apps/pages/server-side-dep/package.json
+++ b/packages/adapter-cloudflare/test/apps/pages/server-side-dep/package.json
@@ -4,8 +4,8 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"default": "./index.js",
-			"types": "./index.d.ts"
+			"types": "./index.d.ts",
+			"default": "./index.js"
 		}
 	}
 }

--- a/packages/adapter-cloudflare/test/apps/workers/package.json
+++ b/packages/adapter-cloudflare/test/apps/workers/package.json
@@ -2,6 +2,7 @@
 	"name": "test-cloudflare-workers",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -18,6 +19,5 @@
 		"svelte": "catalog:",
 		"vite": "catalog:",
 		"wrangler": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/adapter-cloudflare/test/apps/workers/server-side-dep/package.json
+++ b/packages/adapter-cloudflare/test/apps/workers/server-side-dep/package.json
@@ -4,8 +4,8 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"default": "./index.js",
-			"types": "./index.d.ts"
+			"types": "./index.d.ts",
+			"default": "./index.js"
 		}
 	}
 }

--- a/packages/adapter-netlify/package.json
+++ b/packages/adapter-netlify/package.json
@@ -10,14 +10,20 @@
 		"svelte",
 		"sveltekit"
 	],
+	"homepage": "https://svelte.dev/docs/kit/adapter-netlify",
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/sveltejs/kit.git",
 		"directory": "packages/adapter-netlify"
 	},
-	"license": "MIT",
-	"homepage": "https://svelte.dev/docs/kit/adapter-netlify",
+	"files": [
+		"files",
+		"index.js",
+		"index.d.ts"
+	],
 	"type": "module",
+	"types": "index.d.ts",
 	"exports": {
 		".": {
 			"types": "./index.d.ts",
@@ -25,18 +31,12 @@
 		},
 		"./package.json": "./package.json"
 	},
-	"types": "index.d.ts",
-	"files": [
-		"files",
-		"index.js",
-		"index.d.ts"
-	],
 	"scripts": {
 		"dev": "rollup -cw",
 		"build": "rollup -c",
 		"check": "tsc",
-		"lint": "prettier --check .",
-		"format": "pnpm lint --write",
+		"lint": "oxfmt --check .",
+		"format": "oxfmt --write .",
 		"test": "pnpm test:unit && pnpm test:integration",
 		"test:unit": "vitest run",
 		"test:integration": "pnpm build && pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test",

--- a/packages/adapter-netlify/test/apps/basic/package.json
+++ b/packages/adapter-netlify/test/apps/basic/package.json
@@ -2,6 +2,7 @@
 	"name": "test-netlify-basic",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -14,6 +15,5 @@
 		"@sveltejs/vite-plugin-svelte": "catalog:",
 		"svelte": "catalog:",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/adapter-netlify/test/apps/edge/package.json
+++ b/packages/adapter-netlify/test/apps/edge/package.json
@@ -2,6 +2,7 @@
 	"name": "test-netlify-edge",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -14,6 +15,5 @@
 		"@sveltejs/vite-plugin-svelte": "catalog:",
 		"svelte": "catalog:",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -10,14 +10,21 @@
 		"svelte",
 		"sveltekit"
 	],
+	"homepage": "https://svelte.dev/docs/kit/adapter-node",
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/sveltejs/kit.git",
 		"directory": "packages/adapter-node"
 	},
-	"license": "MIT",
-	"homepage": "https://svelte.dev/docs/kit/adapter-node",
+	"files": [
+		"files",
+		"index.js",
+		"index.d.ts",
+		"ambient.d.ts"
+	],
 	"type": "module",
+	"types": "index.d.ts",
 	"exports": {
 		".": {
 			"types": "./index.d.ts",
@@ -25,21 +32,20 @@
 		},
 		"./package.json": "./package.json"
 	},
-	"types": "index.d.ts",
-	"files": [
-		"files",
-		"index.js",
-		"index.d.ts",
-		"ambient.d.ts"
-	],
 	"scripts": {
 		"dev": "rollup -cw",
 		"build": "rollup -c",
 		"test": "vitest run",
 		"check": "tsc",
-		"lint": "prettier --check .",
-		"format": "pnpm lint --write",
+		"lint": "oxfmt --check .",
+		"format": "oxfmt --write .",
 		"prepublishOnly": "pnpm build"
+	},
+	"dependencies": {
+		"@rollup/plugin-commonjs": "^28.0.1",
+		"@rollup/plugin-json": "^6.1.0",
+		"@rollup/plugin-node-resolve": "^16.0.0",
+		"rollup": "^4.9.5"
 	},
 	"devDependencies": {
 		"@polka/url": "catalog:",
@@ -50,12 +56,6 @@
 		"sirv": "^3.0.2",
 		"typescript": "^5.3.3",
 		"vitest": "catalog:"
-	},
-	"dependencies": {
-		"@rollup/plugin-commonjs": "^28.0.1",
-		"@rollup/plugin-json": "^6.1.0",
-		"@rollup/plugin-node-resolve": "^16.0.0",
-		"rollup": "^4.9.5"
 	},
 	"peerDependencies": {
 		"@sveltejs/kit": "^2.4.0"

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -11,14 +11,20 @@
 		"svelte",
 		"sveltekit"
 	],
+	"homepage": "https://svelte.dev/docs/kit/adapter-static",
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/sveltejs/kit.git",
 		"directory": "packages/adapter-static"
 	},
-	"license": "MIT",
-	"homepage": "https://svelte.dev/docs/kit/adapter-static",
+	"files": [
+		"index.js",
+		"index.d.ts",
+		"platforms.js"
+	],
 	"type": "module",
+	"types": "index.d.ts",
 	"exports": {
 		".": {
 			"types": "./index.d.ts",
@@ -26,16 +32,10 @@
 		},
 		"./package.json": "./package.json"
 	},
-	"types": "index.d.ts",
-	"files": [
-		"index.js",
-		"index.d.ts",
-		"platforms.js"
-	],
 	"scripts": {
-		"lint": "prettier --check .",
+		"lint": "oxfmt --check .",
 		"check": "tsc",
-		"format": "pnpm lint --write",
+		"format": "oxfmt --write .",
 		"test": "pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test"
 	},
 	"devDependencies": {

--- a/packages/adapter-static/test/apps/prerendered/package.json
+++ b/packages/adapter-static/test/apps/prerendered/package.json
@@ -2,6 +2,7 @@
 	"name": "~TODO~",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -14,6 +15,5 @@
 		"sirv-cli": "catalog:",
 		"svelte": "catalog:",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/adapter-static/test/apps/spa/package.json
+++ b/packages/adapter-static/test/apps/spa/package.json
@@ -2,6 +2,7 @@
 	"name": "~TODO~",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build --mode staging",
@@ -14,6 +15,5 @@
 		"sirv-cli": "catalog:",
 		"svelte": "catalog:",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -10,22 +10,13 @@
 		"sveltekit",
 		"vercel"
 	],
+	"homepage": "https://svelte.dev/docs/kit/adapter-vercel",
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/sveltejs/kit.git",
 		"directory": "packages/adapter-vercel"
 	},
-	"license": "MIT",
-	"homepage": "https://svelte.dev/docs/kit/adapter-vercel",
-	"type": "module",
-	"exports": {
-		".": {
-			"types": "./index.d.ts",
-			"import": "./index.js"
-		},
-		"./package.json": "./package.json"
-	},
-	"types": "index.d.ts",
 	"files": [
 		"files",
 		"index.js",
@@ -33,9 +24,18 @@
 		"index.d.ts",
 		"ambient.d.ts"
 	],
+	"type": "module",
+	"types": "index.d.ts",
+	"exports": {
+		".": {
+			"types": "./index.d.ts",
+			"import": "./index.js"
+		},
+		"./package.json": "./package.json"
+	},
 	"scripts": {
-		"lint": "prettier --check .",
-		"format": "pnpm lint --write",
+		"lint": "oxfmt --check .",
+		"format": "oxfmt --write .",
 		"check": "tsc",
 		"test": "vitest run"
 	},

--- a/packages/amp/package.json
+++ b/packages/amp/package.json
@@ -8,14 +8,19 @@
 		"svelte",
 		"sveltekit"
 	],
+	"homepage": "https://svelte.dev",
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/sveltejs/kit.git",
 		"directory": "packages/amp"
 	},
-	"license": "MIT",
-	"homepage": "https://svelte.dev",
+	"files": [
+		"index.js",
+		"index.d.ts"
+	],
 	"type": "module",
+	"types": "index.d.ts",
 	"exports": {
 		".": {
 			"types": "./index.d.ts",
@@ -23,15 +28,10 @@
 		},
 		"./package.json": "./package.json"
 	},
-	"types": "index.d.ts",
-	"files": [
-		"index.js",
-		"index.d.ts"
-	],
 	"scripts": {
 		"check": "tsc",
-		"lint": "prettier --check .",
-		"format": "pnpm lint --write"
+		"lint": "oxfmt --check .",
+		"format": "oxfmt --write ."
 	},
 	"devDependencies": {
 		"@sveltejs/kit": "workspace:^",

--- a/packages/enhanced-img/package.json
+++ b/packages/enhanced-img/package.json
@@ -2,41 +2,41 @@
 	"name": "@sveltejs/enhanced-img",
 	"version": "0.9.3",
 	"description": "Image optimization for your Svelte apps",
+	"keywords": [
+		"component",
+		"enhanced",
+		"image",
+		"plugin",
+		"preprocessor",
+		"svelte",
+		"sveltekit",
+		"vite"
+	],
+	"homepage": "https://svelte.dev/docs/kit/images#sveltejs-enhanced-img",
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/sveltejs/kit.git",
 		"directory": "packages/enhanced-img"
 	},
-	"keywords": [
-		"component",
-		"enhanced",
-		"image",
-		"preprocessor",
-		"plugin",
-		"svelte",
-		"sveltekit",
-		"vite"
-	],
-	"license": "MIT",
-	"homepage": "https://svelte.dev/docs/kit/images#sveltejs-enhanced-img",
-	"type": "module",
-	"scripts": {
-		"lint": "prettier --check .",
-		"check": "tsc",
-		"format": "prettier --write .",
-		"test": "pnpm test:unit && pnpm test:integration",
-		"test:unit": "vitest run",
-		"test:integration": "pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test"
-	},
 	"files": [
 		"src",
 		"types"
 	],
+	"type": "module",
+	"types": "types/index.d.ts",
 	"exports": {
 		"types": "./types/index.d.ts",
 		"import": "./src/index.js"
 	},
-	"types": "types/index.d.ts",
+	"scripts": {
+		"lint": "oxfmt --check .",
+		"check": "tsc",
+		"format": "oxfmt --write .",
+		"test": "pnpm test:unit && pnpm test:integration",
+		"test:unit": "vitest run",
+		"test:integration": "pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test"
+	},
 	"dependencies": {
 		"magic-string": "^0.30.5",
 		"sharp": "^0.34.1",

--- a/packages/enhanced-img/test/apps/basics/package.json
+++ b/packages/enhanced-img/test/apps/basics/package.json
@@ -2,6 +2,7 @@
 	"name": "enhanced-img-basics",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -14,6 +15,5 @@
 		"@sveltejs/vite-plugin-svelte": "catalog:",
 		"svelte": "catalog:",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -9,58 +9,12 @@
 		"sveltekit",
 		"vite"
 	],
+	"homepage": "https://svelte.dev",
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/sveltejs/kit.git",
 		"directory": "packages/kit"
-	},
-	"license": "MIT",
-	"homepage": "https://svelte.dev",
-	"type": "module",
-	"dependencies": {
-		"@standard-schema/spec": "^1.0.0",
-		"@sveltejs/acorn-typescript": "^1.0.5",
-		"@types/cookie": "^0.6.0",
-		"acorn": "^8.14.1",
-		"cookie": "^0.6.0",
-		"devalue": "^5.6.2",
-		"esm-env": "^1.2.2",
-		"kleur": "^4.1.5",
-		"magic-string": "^0.30.5",
-		"mrmime": "^2.0.0",
-		"sade": "^1.8.1",
-		"set-cookie-parser": "^2.6.0",
-		"sirv": "^3.0.0"
-	},
-	"devDependencies": {
-		"@opentelemetry/api": "^1.0.0",
-		"@playwright/test": "catalog:",
-		"@sveltejs/vite-plugin-svelte": "catalog:",
-		"@types/connect": "catalog:",
-		"@types/node": "catalog:",
-		"@types/set-cookie-parser": "catalog:",
-		"dts-buddy": "catalog:",
-		"rollup": "^4.14.2",
-		"svelte": "catalog:",
-		"svelte-preprocess": "catalog:",
-		"typescript": "^5.3.3",
-		"vite": "catalog:",
-		"vitest": "catalog:"
-	},
-	"peerDependencies": {
-		"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0",
-		"@opentelemetry/api": "^1.0.0",
-		"svelte": "^4.0.0 || ^5.0.0-next.0",
-		"typescript": "^5.3.3",
-		"vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0"
-	},
-	"peerDependenciesMeta": {
-		"@opentelemetry/api": {
-			"optional": true
-		},
-		"typescript": {
-			"optional": true
-		}
 	},
 	"bin": {
 		"svelte-kit": "svelte-kit.js"
@@ -73,26 +27,8 @@
 		"types",
 		"svelte-kit.js"
 	],
-	"scripts": {
-		"lint": "prettier --config ../../.prettierrc --check .",
-		"check": "tsc && cd ./test/types && tsc",
-		"check:all": "tsc && pnpm -r --filter=\"./**\" check",
-		"format": "prettier --config ../../.prettierrc --write .",
-		"test": "pnpm test:unit && pnpm test:integration",
-		"test:integration": "pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test",
-		"test:cross-platform:dev": "pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:cross-platform:dev",
-		"test:cross-platform:build": "pnpm test:unit && pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:cross-platform:build",
-		"test:server-side-route-resolution:dev": "pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:server-side-route-resolution:dev",
-		"test:server-side-route-resolution:build": "pnpm test:unit && pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:server-side-route-resolution:build",
-		"test:svelte-async:dev": "pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:svelte-async:dev",
-		"test:svelte-async:build": "pnpm test:unit && pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:svelte-async:build",
-		"test:unit:dev": "vitest --config kit.vitest.config.js run",
-		"test:unit:prod": "NODE_ENV=production vitest --config kit.vitest.config.js run csp.spec.js cookie.spec.js",
-		"test:unit": "pnpm test:unit:dev && pnpm test:unit:prod",
-		"prepublishOnly": "pnpm generate:types",
-		"generate:version": "node scripts/generate-version.js",
-		"generate:types": "node scripts/generate-dts.js"
-	},
+	"type": "module",
+	"types": "types/index.d.ts",
 	"imports": {
 		"#app/paths": {
 			"browser": "./src/runtime/app/paths/client.js",
@@ -130,7 +66,71 @@
 			"import": "./src/exports/vite/index.js"
 		}
 	},
-	"types": "types/index.d.ts",
+	"scripts": {
+		"lint": "oxfmt --check .",
+		"check": "tsc && cd ./test/types && tsc",
+		"check:all": "tsc && pnpm -r --filter=\"./**\" check",
+		"format": "oxfmt --write .",
+		"test": "pnpm test:unit && pnpm test:integration",
+		"test:integration": "pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test",
+		"test:cross-platform:dev": "pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:cross-platform:dev",
+		"test:cross-platform:build": "pnpm test:unit && pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:cross-platform:build",
+		"test:server-side-route-resolution:dev": "pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:server-side-route-resolution:dev",
+		"test:server-side-route-resolution:build": "pnpm test:unit && pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:server-side-route-resolution:build",
+		"test:svelte-async:dev": "pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:svelte-async:dev",
+		"test:svelte-async:build": "pnpm test:unit && pnpm -r --workspace-concurrency 1 --filter=\"./test/**\" test:svelte-async:build",
+		"test:unit:dev": "vitest --config kit.vitest.config.js run",
+		"test:unit:prod": "NODE_ENV=production vitest --config kit.vitest.config.js run csp.spec.js cookie.spec.js",
+		"test:unit": "pnpm test:unit:dev && pnpm test:unit:prod",
+		"prepublishOnly": "pnpm generate:types",
+		"generate:version": "node scripts/generate-version.js",
+		"generate:types": "node scripts/generate-dts.js"
+	},
+	"dependencies": {
+		"@standard-schema/spec": "^1.0.0",
+		"@sveltejs/acorn-typescript": "^1.0.5",
+		"@types/cookie": "^0.6.0",
+		"acorn": "^8.14.1",
+		"cookie": "^0.6.0",
+		"devalue": "^5.6.2",
+		"esm-env": "^1.2.2",
+		"kleur": "^4.1.5",
+		"magic-string": "^0.30.5",
+		"mrmime": "^2.0.0",
+		"sade": "^1.8.1",
+		"set-cookie-parser": "^2.6.0",
+		"sirv": "^3.0.0"
+	},
+	"devDependencies": {
+		"@opentelemetry/api": "^1.0.0",
+		"@playwright/test": "catalog:",
+		"@sveltejs/vite-plugin-svelte": "catalog:",
+		"@types/connect": "catalog:",
+		"@types/node": "catalog:",
+		"@types/set-cookie-parser": "catalog:",
+		"dts-buddy": "catalog:",
+		"rollup": "^4.14.2",
+		"svelte": "catalog:",
+		"svelte-preprocess": "catalog:",
+		"typescript": "^5.3.3",
+		"vite": "catalog:",
+		"vitest": "catalog:"
+	},
+	"peerDependencies": {
+		"@opentelemetry/api": "^1.0.0",
+		"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0",
+		"svelte": "^4.0.0 || ^5.0.0-next.0",
+		"typescript": "^5.3.3",
+		"vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0"
+	},
+	"peerDependenciesMeta": {
+		"@opentelemetry/api": {
+			"optional": true
+		},
+		"typescript": {
+			"optional": true
+		}
+	},
 	"engines": {
 		"node": ">=18.13"
 	}

--- a/packages/kit/src/exports/hooks/sequence.spec.js
+++ b/packages/kit/src/exports/hooks/sequence.spec.js
@@ -5,14 +5,11 @@ import { sequence } from './sequence.js';
 import { installPolyfills } from '../node/polyfills.js';
 import { noop_span } from '../../runtime/telemetry/noop.js';
 
-const dummy_event = vi.hoisted(
-	() =>
-		/** @type {RequestEvent} */ ({
-			tracing: {
-				root: {}
-			}
-		})
-);
+const dummy_event = vi.hoisted(() => /** @type {RequestEvent} */ ({
+	tracing: {
+		root: {}
+	}
+}));
 
 vi.mock(import('@sveltejs/kit/internal/server'), async (actualPromise) => {
 	const actual = await actualPromise();

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -98,7 +98,7 @@ export function make_trackable(url, callback, search_params_callback, allow_hash
 		value: new Proxy(tracked.searchParams, {
 			get(obj, key) {
 				if (key === 'get' || key === 'getAll' || key === 'has') {
-					return (/** @type {string} */ param, /** @type {string[]} */ ...rest) => {
+					return (/** @type {string} */ param /** @type {string[]} */, ...rest) => {
 						search_params_callback(param);
 						return obj[key](param, ...rest);
 					};

--- a/packages/kit/test/apps/amp/package.json
+++ b/packages/kit/test/apps/amp/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "test-amp",
-	"private": true,
 	"version": "0.0.1",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -21,6 +22,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/apps/async/package.json
+++ b/packages/kit/test/apps/async/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "test-async",
-	"private": true,
 	"version": "0.0.1",
+	"private": true,
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/packages/kit/test/apps/basics/package.json
+++ b/packages/kit/test/apps/basics/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "test-basics",
-	"private": true,
 	"version": "0.0.2-next.0",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -33,6 +34,5 @@
 		"valibot": "catalog:",
 		"vite": "catalog:",
 		"vitest": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1224,8 +1224,9 @@ test.describe('env', () => {
 		expect(
 			await page.evaluate(
 				() =>
-					/** @type {Window & typeof globalThis & { PUBLIC_DYNAMIC: string }} */ (window)
-						.PUBLIC_DYNAMIC
+					/** @type {Window & typeof globalThis & { PUBLIC_DYNAMIC: string }} */ (
+						window
+					).PUBLIC_DYNAMIC
 			)
 		).toBe('accessible anywhere/evaluated at run time');
 	});

--- a/packages/kit/test/apps/dev-only/_test_dependencies/cjs-only/package.json
+++ b/packages/kit/test/apps/dev-only/_test_dependencies/cjs-only/package.json
@@ -1,10 +1,10 @@
 {
+	"name": "e2e-test-dep-cjs-only",
 	"version": "1.0.0",
 	"private": true,
-	"name": "e2e-test-dep-cjs-only",
-	"main": "index.js",
 	"files": [
 		"index.js"
 	],
-	"type": "commonjs"
+	"type": "commonjs",
+	"main": "index.js"
 }

--- a/packages/kit/test/apps/dev-only/package.json
+++ b/packages/kit/test/apps/dev-only/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "test-dev-only",
-	"private": true,
 	"version": "0.0.2-next.0",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -27,6 +28,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/apps/embed/package.json
+++ b/packages/kit/test/apps/embed/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "test-embed",
-	"private": true,
 	"version": "0.0.1",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -19,6 +20,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/apps/hash-based-routing/package.json
+++ b/packages/kit/test/apps/hash-based-routing/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "test-hash-based-routing",
-	"private": true,
 	"version": "0.0.1",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -19,6 +20,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/apps/no-ssr/package.json
+++ b/packages/kit/test/apps/no-ssr/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "test-no-ssr",
-	"private": true,
 	"version": "0.0.1",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -19,6 +20,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/apps/options-2/package.json
+++ b/packages/kit/test/apps/options-2/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "test-options-2",
-	"private": true,
 	"version": "0.0.1",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -21,6 +22,5 @@
 		"typescript": "^5.5.4",
 		"valibot": "catalog:",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/apps/options-3/package.json
+++ b/packages/kit/test/apps/options-3/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "test-options-3",
-	"private": true,
 	"version": "0.0.1",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -18,6 +19,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/apps/options/package.json
+++ b/packages/kit/test/apps/options/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "test-options",
-	"private": true,
 	"version": "0.0.1",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev -c vite.custom.config.js",
 		"build": "vite build -c vite.custom.config.js --mode custom",
@@ -22,6 +23,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/apps/prerendered-app-error-pages/package.json
+++ b/packages/kit/test/apps/prerendered-app-error-pages/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "test-prerendered-app-error-pages",
-	"private": true,
 	"version": "0.0.1",
+	"private": true,
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/packages/kit/test/apps/writes/package.json
+++ b/packages/kit/test/apps/writes/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "test-writes",
-	"private": true,
 	"version": "0.0.2-next.0",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -19,6 +20,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/package.json
+++ b/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "prerenderable-incorrect-fragment",
-	"private": true,
 	"version": "0.0.1",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -17,6 +18,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/build-errors/apps/prerender-remote-function-error/package.json
+++ b/packages/kit/test/build-errors/apps/prerender-remote-function-error/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "prerenderable-remote-function-error",
-	"private": true,
 	"version": "0.0.1",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -17,6 +18,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/package.json
+++ b/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "prerenderable-incorrect-fragment",
-	"private": true,
 	"version": "0.0.1",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -17,6 +18,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/package.json
+++ b/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "prerenderable-not-prerendered",
-	"private": true,
 	"version": "0.0.1",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -17,6 +18,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/build-errors/apps/private-dynamic-env-dynamic-import/package.json
+++ b/packages/kit/test/build-errors/apps/private-dynamic-env-dynamic-import/package.json
@@ -2,6 +2,7 @@
 	"name": "private-dynamic-env-dynamic-import",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -17,6 +18,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/build-errors/apps/private-dynamic-env/package.json
+++ b/packages/kit/test/build-errors/apps/private-dynamic-env/package.json
@@ -2,6 +2,7 @@
 	"name": "private-dynamic-env",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -17,6 +18,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/build-errors/apps/private-static-env-dynamic-import/package.json
+++ b/packages/kit/test/build-errors/apps/private-static-env-dynamic-import/package.json
@@ -2,6 +2,7 @@
 	"name": "private-static-env-dynamic-import",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -17,6 +18,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/build-errors/apps/private-static-env/package.json
+++ b/packages/kit/test/build-errors/apps/private-static-env/package.json
@@ -2,6 +2,7 @@
 	"name": "private-static-env",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -17,6 +18,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/build-errors/apps/server-only-folder-dynamic-import/package.json
+++ b/packages/kit/test/build-errors/apps/server-only-folder-dynamic-import/package.json
@@ -2,6 +2,7 @@
 	"name": "server-only-folder-dynamic-import",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -17,6 +18,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/build-errors/apps/server-only-folder/package.json
+++ b/packages/kit/test/build-errors/apps/server-only-folder/package.json
@@ -2,6 +2,7 @@
 	"name": "server-only-folder",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -17,6 +18,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/build-errors/apps/server-only-module-dynamic-import/package.json
+++ b/packages/kit/test/build-errors/apps/server-only-module-dynamic-import/package.json
@@ -2,6 +2,7 @@
 	"name": "server-only-module-dynamic-import",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -17,6 +18,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/build-errors/apps/server-only-module/package.json
+++ b/packages/kit/test/build-errors/apps/server-only-module/package.json
@@ -2,6 +2,7 @@
 	"name": "server-only-module",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -17,6 +18,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/build-errors/apps/service-worker-dynamic-public-env/package.json
+++ b/packages/kit/test/build-errors/apps/service-worker-dynamic-public-env/package.json
@@ -2,6 +2,7 @@
 	"name": "service-worker-dynamic-public-env",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -17,6 +18,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/build-errors/apps/service-worker-private-env/package.json
+++ b/packages/kit/test/build-errors/apps/service-worker-private-env/package.json
@@ -2,6 +2,7 @@
 	"name": "service-worker-private-env",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -17,6 +18,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/build-errors/apps/syntax-error/package.json
+++ b/packages/kit/test/build-errors/apps/syntax-error/package.json
@@ -2,6 +2,7 @@
 	"name": "syntax-error",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -15,6 +16,5 @@
 		"svelte-check": "catalog:",
 		"typescript": "^5.5.4",
 		"vite": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/build-errors/package.json
+++ b/packages/kit/test/build-errors/package.json
@@ -1,12 +1,12 @@
 {
 	"name": "test-build-errors",
-	"private": true,
 	"version": "0.0.0-next.0",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"test": "vitest run",
 		"test:cross-platform:build": "vitest run"
 	},
-	"type": "module",
 	"devDependencies": {
 		"vitest": "catalog:"
 	}

--- a/packages/kit/test/prerendering/basics/package.json
+++ b/packages/kit/test/prerendering/basics/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "prerendering-test-basics",
-	"private": true,
 	"version": "0.0.2-next.0",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "rm -rf ./missing_ids && mkdir ./missing_ids && vite build",
@@ -18,6 +19,5 @@
 		"typescript": "^5.5.4",
 		"vite": "catalog:",
 		"vitest": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/prerendering/options/package.json
+++ b/packages/kit/test/prerendering/options/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "prerendering-test-options",
-	"private": true,
 	"version": "0.0.1",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -17,6 +18,5 @@
 		"typescript": "^5.5.4",
 		"vite": "catalog:",
 		"vitest": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/kit/test/prerendering/paths-base/package.json
+++ b/packages/kit/test/prerendering/paths-base/package.json
@@ -1,7 +1,8 @@
 {
 	"name": "prerendering-test-paths-base",
-	"private": true,
 	"version": "0.0.1",
+	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -17,6 +18,5 @@
 		"typescript": "^5.5.4",
 		"vite": "catalog:",
 		"vitest": "catalog:"
-	},
-	"type": "module"
+	}
 }

--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -2,11 +2,6 @@
 	"name": "@sveltejs/package",
 	"version": "2.5.7",
 	"description": "The fastest way to build Svelte packages",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/sveltejs/kit.git",
-		"directory": "packages/package"
-	},
 	"keywords": [
 		"build",
 		"bundle",
@@ -16,9 +11,30 @@
 		"svelte",
 		"tool"
 	],
-	"license": "MIT",
 	"homepage": "https://svelte.dev",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/sveltejs/kit.git",
+		"directory": "packages/package"
+	},
+	"bin": {
+		"svelte-package": "svelte-package.js"
+	},
+	"files": [
+		"src"
+	],
 	"type": "module",
+	"exports": {
+		"./package.json": "./package.json"
+	},
+	"scripts": {
+		"lint": "oxfmt --check .",
+		"check": "tsc",
+		"check:all": "tsc && pnpm -r --filter=\"./**\" check",
+		"format": "oxfmt --write .",
+		"test": "vitest run"
+	},
 	"dependencies": {
 		"chokidar": "^5.0.0",
 		"kleur": "^4.1.5",
@@ -38,22 +54,6 @@
 	},
 	"peerDependencies": {
 		"svelte": "^3.44.0 || ^4.0.0 || ^5.0.0-next.1"
-	},
-	"bin": {
-		"svelte-package": "svelte-package.js"
-	},
-	"files": [
-		"src"
-	],
-	"scripts": {
-		"lint": "prettier --check .",
-		"check": "tsc",
-		"check:all": "tsc && pnpm -r --filter=\"./**\" check",
-		"format": "pnpm lint --write",
-		"test": "vitest run"
-	},
-	"exports": {
-		"./package.json": "./package.json"
 	},
 	"engines": {
 		"node": "^16.14 || >=18"

--- a/packages/package/test/errors/no-lib-folder/package.json
+++ b/packages/package/test/errors/no-lib-folder/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "error-no-lib-folder",
-	"private": true,
 	"version": "1.0.0",
+	"private": true,
 	"description": "validate no lib folder error output"
 }

--- a/packages/package/test/fixtures/assets/package.json
+++ b/packages/package/test/fixtures/assets/package.json
@@ -1,15 +1,15 @@
 {
 	"name": "assets",
-	"private": true,
 	"version": "1.0.0",
+	"private": true,
 	"description": "no tampering assets",
-	"peerDependencies": {
-		"svelte": "^4.0.0"
-	},
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		}
+	},
+	"peerDependencies": {
+		"svelte": "^4.0.0"
 	}
 }

--- a/packages/package/test/fixtures/emitTypes-false/package.json
+++ b/packages/package/test/fixtures/emitTypes-false/package.json
@@ -1,15 +1,15 @@
 {
 	"name": "emit-types",
-	"private": true,
 	"version": "1.0.0",
+	"private": true,
 	"description": "emitTypes settings disabled",
 	"type": "module",
-	"peerDependencies": {
-		"svelte": "^4.0.0"
-	},
 	"exports": {
 		".": {
 			"svelte": "./dist/index.js"
 		}
+	},
+	"peerDependencies": {
+		"svelte": "^4.0.0"
 	}
 }

--- a/packages/package/test/fixtures/javascript/package.json
+++ b/packages/package/test/fixtures/javascript/package.json
@@ -1,15 +1,15 @@
 {
 	"name": "javascript",
-	"private": true,
 	"version": "1.0.0",
+	"private": true,
 	"description": "standard javascript package",
-	"peerDependencies": {
-		"svelte": "^4.0.0"
-	},
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		}
+	},
+	"peerDependencies": {
+		"svelte": "^4.0.0"
 	}
 }

--- a/packages/package/test/fixtures/preserve-output/package.json
+++ b/packages/package/test/fixtures/preserve-output/package.json
@@ -1,16 +1,16 @@
 {
 	"name": "preserve-output",
 	"private": true,
-	"type": "module",
 	"description": "with additional things running before svelte-package",
-	"peerDependencies": {
-		"svelte": "^4.0.0"
-	},
+	"type": "module",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		},
 		"./theme.css": "./dist/assets/theme.css"
+	},
+	"peerDependencies": {
+		"svelte": "^4.0.0"
 	}
 }

--- a/packages/package/test/fixtures/svelte-3-types/package.json
+++ b/packages/package/test/fixtures/svelte-3-types/package.json
@@ -1,16 +1,16 @@
 {
 	"name": "svelte-3-types",
-	"private": true,
 	"version": "1.0.0",
+	"private": true,
 	"description": "creates Svelte 3 backwards compatible types",
 	"type": "module",
-	"peerDependencies": {
-		"svelte": "^3.0.0 || ^4.0.0"
-	},
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		}
+	},
+	"peerDependencies": {
+		"svelte": "^3.0.0 || ^4.0.0"
 	}
 }

--- a/packages/package/test/fixtures/svelte-kit/package.json
+++ b/packages/package/test/fixtures/svelte-kit/package.json
@@ -1,16 +1,16 @@
 {
 	"name": "svelte-kit",
-	"private": true,
 	"version": "1.0.0",
-	"type": "module",
+	"private": true,
 	"description": "SvelteKit library project",
-	"peerDependencies": {
-		"svelte": "^4.0.0"
-	},
+	"type": "module",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		}
+	},
+	"peerDependencies": {
+		"svelte": "^4.0.0"
 	}
 }

--- a/packages/package/test/fixtures/tsconfig-specified/package.json
+++ b/packages/package/test/fixtures/tsconfig-specified/package.json
@@ -1,16 +1,16 @@
 {
 	"name": "typescript",
-	"private": true,
 	"version": "1.0.0",
+	"private": true,
 	"description": "typescript package using esnext",
 	"type": "module",
-	"peerDependencies": {
-		"svelte": "^4.0.0"
-	},
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		}
+	},
+	"peerDependencies": {
+		"svelte": "^4.0.0"
 	}
 }

--- a/packages/package/test/fixtures/typescript-declaration-map/package.json
+++ b/packages/package/test/fixtures/typescript-declaration-map/package.json
@@ -1,16 +1,16 @@
 {
 	"name": "typescript-declaration-map",
-	"private": true,
 	"version": "1.0.0",
+	"private": true,
 	"description": "standard typescript package with declarationMap:true",
 	"type": "module",
-	"peerDependencies": {
-		"svelte": "^5.0.0"
-	},
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		}
+	},
+	"peerDependencies": {
+		"svelte": "^5.0.0"
 	}
 }

--- a/packages/package/test/fixtures/typescript-esnext/package.json
+++ b/packages/package/test/fixtures/typescript-esnext/package.json
@@ -1,16 +1,16 @@
 {
 	"name": "typescript",
-	"private": true,
 	"version": "1.0.0",
+	"private": true,
 	"description": "typescript package using esnext",
 	"type": "module",
-	"peerDependencies": {
-		"svelte": "^4.0.0"
-	},
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		}
+	},
+	"peerDependencies": {
+		"svelte": "^4.0.0"
 	}
 }

--- a/packages/package/test/fixtures/typescript-nodenext/package.json
+++ b/packages/package/test/fixtures/typescript-nodenext/package.json
@@ -1,16 +1,16 @@
 {
 	"name": "typescript-nodenext",
-	"private": true,
 	"version": "1.0.0",
+	"private": true,
 	"description": "typescript package using nodenext",
 	"type": "module",
-	"peerDependencies": {
-		"svelte": "^4.0.0"
-	},
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		}
+	},
+	"peerDependencies": {
+		"svelte": "^4.0.0"
 	}
 }

--- a/packages/package/test/fixtures/typescript-svelte-config/package.json
+++ b/packages/package/test/fixtures/typescript-svelte-config/package.json
@@ -1,16 +1,16 @@
 {
 	"name": "typescript-nodenext",
-	"private": true,
 	"version": "1.0.0",
+	"private": true,
 	"description": "typescript package using nodenext",
 	"type": "module",
-	"peerDependencies": {
-		"svelte": "^4.0.0"
-	},
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		}
+	},
+	"peerDependencies": {
+		"svelte": "^4.0.0"
 	}
 }

--- a/packages/package/test/fixtures/typescript-ts-extension-rewrites/package.json
+++ b/packages/package/test/fixtures/typescript-ts-extension-rewrites/package.json
@@ -1,16 +1,16 @@
 {
 	"name": "typescript-ts-extension-rewrites",
-	"private": true,
 	"version": "1.0.0",
+	"private": true,
 	"description": "typescript package with extension rewrites, including to aliased import paths",
 	"type": "module",
-	"peerDependencies": {
-		"svelte": "^5.0.0"
-	},
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		}
+	},
+	"peerDependencies": {
+		"svelte": "^5.0.0"
 	}
 }

--- a/packages/package/test/watch/package.json
+++ b/packages/package/test/watch/package.json
@@ -1,13 +1,13 @@
 {
 	"name": "watch",
 	"type": "module",
-	"peerDependencies": {
-		"svelte": "^4.0.0"
-	},
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js"
 		}
+	},
+	"peerDependencies": {
+		"svelte": "^4.0.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,9 +134,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.34.0(jiti@2.4.2)
-      prettier:
-        specifier: ^3.6.0
-        version: 3.6.0
+      oxfmt:
+        specifier: ^0.27.0
+        version: 0.27.0
       prettier-plugin-svelte:
         specifier: ^3.4.0
         version: 3.4.0(prettier@3.6.0)(svelte@5.46.4)
@@ -2791,6 +2791,46 @@ packages:
     resolution: {integrity: sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==}
     engines: {node: '>=14'}
 
+  '@oxfmt/darwin-arm64@0.27.0':
+    resolution: {integrity: sha512-3vwqyzNlVTVFVzHMlrqxb4tgVgHp6FYS0uIxsIZ/SeEDG0azaqiOw/2t8LlJ9f72PKRLWSey+Ak99tiKgpbsnQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/darwin-x64@0.27.0':
+    resolution: {integrity: sha512-5u8mZVLm70v6l1wLZ2MmeNIEzGsruwKw5F7duePzpakPfxGtLpiFNUwe4aBUJULTP6aMzH+A4dA0JOn8lb7Luw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/linux-arm64-gnu@0.27.0':
+    resolution: {integrity: sha512-aql/LLYriX/5Ar7o5Qivnp/qMTUPNiOCr7cFLvmvzYZa3XL0H8XtbKUfIVm+9ILR0urXQzcml+L8pLe1p8sgEg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/linux-arm64-musl@0.27.0':
+    resolution: {integrity: sha512-6u/kNb7hubthg4u/pn3MK/GJLwPgjDvDDnjjr7TC0/OK/xztef8ToXmycxIQ9OeDNIJJf7Z0Ss/rHnKvQOWzRw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/linux-x64-gnu@0.27.0':
+    resolution: {integrity: sha512-EhvDfFHO1yrK/Cu75eU1U828lBsW2cV0JITOrka5AjR3PlmnQQ03Mr9ROkWkbPmzAMklXI4Q16eO+4n+7FhS1w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/linux-x64-musl@0.27.0':
+    resolution: {integrity: sha512-1pgjuwMT5sCekuteYZ7LkDsto7DJouaccwjozHqdWohSj2zJpFeSP2rMaC+6JJ1KD5r9HG9sWRuHZGEaoX9uOw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/win32-arm64@0.27.0':
+    resolution: {integrity: sha512-mmuEhXZEhAYAeyjVTWwGKIA3RSb2b/He9wrXkDJPhmqp8qISUzkVg1dQmLEt4hD+wI5rzR+6vchPt521tzuRDA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/win32-x64@0.27.0':
+    resolution: {integrity: sha512-cXKVkL1DuRq31QjwHqtBEUztyBmM9YZKdeFhsDLBURNdk1CFW42uWsmTsaqrXSoiCj7nCjfP0pwTOzxhQZra/A==}
+    cpu: [x64]
+    os: [win32]
+
   '@parcel/watcher-android-arm64@2.5.1':
     resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
     engines: {node: '>= 10.0.0'}
@@ -4908,6 +4948,11 @@ packages:
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
+  oxfmt@0.27.0:
+    resolution: {integrity: sha512-FHR0HR3WeMKBuVEQvW3EeiRZXs/cQzNHxGbhCoAIEPr1FVcOa9GCqrKJXPqv2jkzmCg6Wqot+DvN9RzemyFJhw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   p-event@6.0.1:
     resolution: {integrity: sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==}
     engines: {node: '>=16.17'}
@@ -5563,6 +5608,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.0.0:
+    resolution: {integrity: sha512-/RX9RzeH2xU5ADE7n2Ykvmi9ED3FBGPAjw9u3zucrNNaEBIO0HPSYgL0NT7+3p147ojeSdaVu08F6hjpv31HJg==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
@@ -7412,6 +7461,30 @@ snapshots:
   '@opentelemetry/semantic-conventions@1.28.0': {}
 
   '@opentelemetry/semantic-conventions@1.36.0': {}
+
+  '@oxfmt/darwin-arm64@0.27.0':
+    optional: true
+
+  '@oxfmt/darwin-x64@0.27.0':
+    optional: true
+
+  '@oxfmt/linux-arm64-gnu@0.27.0':
+    optional: true
+
+  '@oxfmt/linux-arm64-musl@0.27.0':
+    optional: true
+
+  '@oxfmt/linux-x64-gnu@0.27.0':
+    optional: true
+
+  '@oxfmt/linux-x64-musl@0.27.0':
+    optional: true
+
+  '@oxfmt/win32-arm64@0.27.0':
+    optional: true
+
+  '@oxfmt/win32-x64@0.27.0':
+    optional: true
 
   '@parcel/watcher-android-arm64@2.5.1':
     optional: true
@@ -9612,6 +9685,19 @@ snapshots:
 
   outdent@0.5.0: {}
 
+  oxfmt@0.27.0:
+    dependencies:
+      tinypool: 2.0.0
+    optionalDependencies:
+      '@oxfmt/darwin-arm64': 0.27.0
+      '@oxfmt/darwin-x64': 0.27.0
+      '@oxfmt/linux-arm64-gnu': 0.27.0
+      '@oxfmt/linux-arm64-musl': 0.27.0
+      '@oxfmt/linux-x64-gnu': 0.27.0
+      '@oxfmt/linux-x64-musl': 0.27.0
+      '@oxfmt/win32-arm64': 0.27.0
+      '@oxfmt/win32-x64': 0.27.0
+
   p-event@6.0.1:
     dependencies:
       p-timeout: 6.1.4
@@ -10311,6 +10397,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@2.0.0: {}
 
   tinyrainbow@3.0.3: {}
 


### PR DESCRIPTION
This is very noticeably faster!

blocked by https://github.com/oxc-project/oxc/issues/18589

as a follow-up, we should switch the `package` tests to use `oxfmt` rather than `prettier`