### PR TITLE
fix: only match rest params with matchers when the matcher matches

### DIFF
--- a/.changeset/spotty-bears-doubt.md
+++ b/.changeset/spotty-bears-doubt.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: only match rest params with matchers when the matcher matches

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -162,8 +162,12 @@ export function exec(match, params, matchers) {
 
 		// if `value` is undefined, it means this is an optional or rest parameter
 		if (value === undefined) {
-			if (param.rest) result[param.name] = '';
-			continue;
+			if (param.rest) {
+				// We need to allow the matcher to run so that it can decide if this optional rest param should be allowed to match
+				value = '';
+			} else {
+				continue;
+			}
 		}
 
 		if (!param.matcher || matchers[param.matcher](value)) {

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -246,6 +246,26 @@ describe('exec', () => {
 			expected: undefined
 		},
 		{
+			route: '/[...a=doesntmatch]/[b]',
+			path: '/foo',
+			expected: undefined
+		},
+		{
+			route: '/[...a=matches]/[b]',
+			path: '/foo',
+			expected: { a: '', b: 'foo' }
+		},
+		{
+			route: '/[...a=doesntmatch]/[b]/[c]',
+			path: '/foo/bar',
+			expected: undefined
+		},
+		{
+			route: '/[...a=matches]/[b]/[c]',
+			path: '/foo/bar',
+			expected: { a: '', b: 'foo', c: 'bar' }
+		},
+		{
 			route: '/[...catchall]',
 			path: '/\n',
 			expected: { catchall: '\n' }


### PR DESCRIPTION
Closes #15204. Previously, when we encountered a rest param, we wouldn't even run the matcher when we encountered a route that didn't need the rest part of the route definition. Now, we run the matcher and reject the route. Below is a more comprehensive, AI-generated summary:

# Issue #15204: Route Matching with Rest Params and Matchers

## The Problem

Route matching behaves unexpectedly with non-trailing rest params that have a matcher attached. When the rest param captures zero segments, the matcher is never invoked.

## The Route Structure

Consider the route `/[...a=m]/[b]` from the issue:

- `[...a=m]` is a **rest parameter** with a matcher `m`
- `[b]` is a **required parameter**

## How the Regex Matching Works

When SvelteKit parses this route, it creates a regex pattern:

```
^(?:/([^]*))?/([^/]+?)/?$
```

Breaking this down:

- `(?:/([^]*))?` — captures the rest param `a` (optional, can match zero or more path segments)
- `/([^/]+?)` — captures the required param `b` (exactly one path segment)

## What Happens When `/robots.txt` is Matched

When the path `/robots.txt` is tested against this regex:

```javascript
const match = /^(?:\/([^]*))?\/([^/]+?)\/?$/.exec('/robots.txt');
// Result: ['/robots.txt', undefined, 'robots.txt']
```

The captured groups are:

- **Group 1 (for `a`)**: `undefined` — the rest param didn't match any segments
- **Group 2 (for `b`)**: `'robots.txt'` — the required param matched

## The Bug in the Original Code

The `exec` function in `packages/kit/src/utils/routing.js` processes these captured values against the route params. Here's what the **original code** did:

```javascript
// if `value` is undefined, it means this is an optional or rest parameter
if (value === undefined) {
    if (param.rest) result[param.name] = '';  // Sets a = ''
    continue;  // SKIPS everything below, including matcher check!
}

// Matcher check happens HERE (line 169)
if (!param.matcher || matchers[param.matcher](value)) {
    result[param.name] = value;
    ...
}
```

When processing param `a`:

1. `value = undefined` (from the regex capture)
2. `param.rest` is `true`
3. Sets `result['a'] = ''`
4. **`continue`** immediately jumps to the next iteration
5. **The matcher `m` is never called!**

So the route matched with `{ a: '', b: 'robots.txt' }` even though the matcher should have rejected the empty string.

## The Fix

The fix changes the flow so the matcher still gets checked:

```javascript
if (value === undefined) {
    if (param.rest) {
        value = '';  // Set value to empty string...
        // NO continue here - falls through to matcher check below!
    } else {
        continue;
    }
}

// Now this code runs for rest params with value = ''
if (!param.matcher || matchers[param.matcher](value)) {
    result[param.name] = value;
    ...
}
```

Now when processing param `a`:

1. `value = undefined`
2. `param.rest` is `true`
3. Sets `value = ''` (not `result['a']` yet!)
4. **Falls through** to line 169
5. Calls `matchers['m']('')` — **the matcher now gets invoked!**
6. If matcher returns `false`, the route doesn't match (returns `undefined` at line 199)

## Visual Summary

```
Original:                           Fixed:
─────────────────────────────────   ─────────────────────────────────
value = undefined                   value = undefined
         │                                   │
         ▼                                   ▼
   is param.rest?                      is param.rest?
    yes │                               yes │
        ▼                                   ▼
  result[a] = ''                       value = ''
        │                                   │
        ▼                                   ▼
    continue ──────► next param       check matcher(value)
                                            │
                                      returns false
                                            │
                                            ▼
                                    route doesn't match!
```

The key insight is that `continue` was bypassing the matcher check entirely. The fix ensures the code path flows through the matcher validation for rest parameters, even when they capture nothing.

