### PR TITLE
Add Deno adapter to @sveltejs/auto-adapter

### DIFF
--- a/.changeset/slick-cloths-film.md
+++ b/.changeset/slick-cloths-film.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-auto': minor
+---
+
+feat: add support for Deno Deploy

--- a/documentation/docs/25-build-and-deploy/30-adapter-auto.md
+++ b/documentation/docs/25-build-and-deploy/30-adapter-auto.md
@@ -10,6 +10,7 @@ When you create a new SvelteKit project with `npx sv create`, it installs [`adap
 - [`svelte-adapter-azure-swa`](https://github.com/geoffrich/svelte-adapter-azure-swa) for [Azure Static Web Apps](https://docs.microsoft.com/en-us/azure/static-web-apps/)
 - [`svelte-kit-sst`](https://github.com/sst/v2/tree/master/packages/svelte-kit-sst) for [AWS via SST](https://sst.dev/docs/start/aws/svelte)
 - [`@sveltejs/adapter-node`](adapter-node) for [Google Cloud Run](https://cloud.google.com/run)
+- [`@deno/svelte-adapter`](https://github.com/denoland/svelte-adapter) for [Deno Deploy](https://deno.com/deploy)
 
 It's recommended to install the appropriate adapter to your `devDependencies` once you've settled on a target environment, since this will add the adapter to your lockfile and slightly improve install times on CI.
 

--- a/packages/adapter-auto/adapters.js
+++ b/packages/adapter-auto/adapters.js
@@ -38,5 +38,11 @@ export const adapters = [
 		test: () => !!process.env.GCP_BUILDPACKS,
 		module: '@sveltejs/adapter-node',
 		version: '5'
+	},
+	{
+		name: 'Deno Deploy',
+		test: () => !!process.env.DENO_DEPLOY,
+		module: '@deno/svelte-adapter',
+		version: '0.1'
 	}
 ];


### PR DESCRIPTION
Adds support for detecting Deno Deploy in the auto-adapter, using
`@deno/svelte-adapter@0.1`.