### PR TITLE
breaking: remove the `preloadStrategy` option

### DIFF
--- a/.changeset/cuddly-radios-brush.md
+++ b/.changeset/cuddly-radios-brush.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: remove the `preloadStrategy` option. `modulepreload` will always be used

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -100,7 +100,7 @@ const get_defaults = (prefix = '') => ({
 		},
 		inlineStyleThreshold: 0,
 		moduleExtensions: ['.js', '.ts'],
-		output: { preloadStrategy: 'modulepreload', bundleStrategy: 'split' },
+		output: { bundleStrategy: 'split' },
 		outDir: join(prefix, '.svelte-kit'),
 		router: {
 			type: 'pathname',

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -159,7 +159,6 @@ const options = object(
 			outDir: string('.svelte-kit'),
 
 			output: object({
-				preloadStrategy: list(['modulepreload', 'preload-js', 'preload-mjs']),
 				bundleStrategy: list(['split', 'single', 'inline'])
 			}),
 

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -46,7 +46,6 @@ export const options = {
 	env_private_prefix: '${config.kit.env.privatePrefix}',
 	hash_routing: ${s(config.kit.router.type === 'hash')},
 	hooks: null, // added lazily, via \`get_hooks\`
-	preload_strategy: ${s(config.kit.output.preloadStrategy)},
 	root,
 	service_worker: ${has_service_worker},
 	service_worker_options: ${config.kit.serviceWorker.register ? s(config.kit.serviceWorker.options) : 'null'},

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -618,6 +618,7 @@ export interface KitConfig {
 		 * - `preload-mjs` - uses `<link rel="preload">` but with the `.mjs` extension which prevents double-parsing in Chromium. Some static webservers will fail to serve .mjs files with a `Content-Type: application/javascript` header, which will cause your application to break. If that doesn't apply to you, this is the option that will deliver the best performance for the largest number of users, until `modulepreload` is more widely supported.
 		 * @default "modulepreload"
 		 * @since 1.8.4
+		 * @deprecated removed in 3.0.0
 		 */
 		preloadStrategy?: 'modulepreload' | 'preload-js' | 'preload-mjs';
 		/**

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -886,9 +886,6 @@ async function kit({ svelte_config }) {
 					});
 				}
 
-				// see the kit.output.preloadStrategy option for details on why we have multiple options here
-				const ext = kit.output.preloadStrategy === 'preload-mjs' ? 'mjs' : 'js';
-
 				// We could always use a relative asset base path here, but it's better for performance not to.
 				// E.g. Vite generates `new URL('/asset.png', import.meta).href` for a relative path vs just '/asset.png'.
 				// That's larger and takes longer to run and also causes an HTML diff between SSR and client
@@ -912,8 +909,8 @@ async function kit({ svelte_config }) {
 							output: {
 								format: inline ? 'iife' : 'esm',
 								name: `__sveltekit_${version_hash}.app`,
-								entryFileNames: ssr ? '[name].js' : `${prefix}/[name].[hash].${ext}`,
-								chunkFileNames: ssr ? 'chunks/[name].js' : `${prefix}/chunks/[hash].${ext}`,
+								entryFileNames: ssr ? '[name].js' : `${prefix}/[name].[hash].js`,
+								chunkFileNames: ssr ? 'chunks/[name].js' : `${prefix}/chunks/[hash].js`,
 								assetFileNames: `${prefix}/assets/[name].[hash][extname]`,
 								hoistTransitiveImports: false,
 								sourcemapIgnoreList,

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -346,14 +346,8 @@ export async function render_response({
 			);
 
 			for (const path of included_modulepreloads) {
-				// see the kit.output.preloadStrategy option for details on why we have multiple options here
 				link_headers.add(`<${encodeURI(path)}>; rel="modulepreload"; nopush`);
-
-				if (options.preload_strategy !== 'modulepreload') {
-					head.add_script_preload(path);
-				} else {
-					head.add_link_tag(path, ['rel="modulepreload"']);
-				}
+				head.add_link_tag(path, ['rel="modulepreload"']);
 			}
 		}
 
@@ -709,13 +703,6 @@ class Head {
 	 */
 	add_stylesheet(href, attributes) {
 		this.#stylesheet_links.push(`<link href="${href}" ${attributes.join(' ')}>`);
-	}
-
-	/** @param {string} href */
-	add_script_preload(href) {
-		this.#script_preloads.push(
-			`<link rel="preload" as="script" crossorigin="anonymous" href="${href}">`
-		);
 	}
 
 	/**

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -459,7 +459,6 @@ export interface SSROptions {
 	env_private_prefix: string;
 	hash_routing: boolean;
 	hooks: ServerHooks;
-	preload_strategy: ValidatedConfig['kit']['output']['preloadStrategy'];
 	root: SSRComponent['default'];
 	service_worker: boolean;
 	service_worker_options: RegistrationOptions;

--- a/packages/kit/test/apps/options/svelte.config.js
+++ b/packages/kit/test/apps/options/svelte.config.js
@@ -26,9 +26,6 @@ const config = {
 		appDir: '_wheee/nested',
 		inlineStyleThreshold: 1024,
 		outDir: '.custom-out-dir',
-		output: {
-			preloadStrategy: 'preload-mjs'
-		},
 		paths: {
 			base: '/path-base',
 			// @ts-expect-error our env var string can't match the https template literal

--- a/packages/kit/test/apps/options/test/paths-assets.test.js
+++ b/packages/kit/test/apps/options/test/paths-assets.test.js
@@ -184,23 +184,4 @@ test.describe('inlineStyleThreshold', () => {
 		await expect(page.locator('#conditionally')).toBeVisible();
 		expect(await get_computed_style('#conditionally', 'color')).toBe('rgb(0, 0, 255)');
 	});
-
-	test('places preload links before inlined styles', async ({ request }) => {
-		// Skip in dev mode since inlineStyleThreshold works differently there
-		test.skip(!!process.env.DEV);
-
-		const response = await request.get('/path-base/base/');
-		const html = await response.text();
-
-		const preloadMatch = html.match(/<link[^>]+rel="preload"/);
-		const styleMatch = html.match(/<style[^>]*>/);
-
-		expect(preloadMatch).not.toBeNull();
-		expect(styleMatch).not.toBeNull();
-
-		const preloadIndex = html.indexOf(preloadMatch[0]);
-		const styleIndex = html.indexOf(styleMatch[0]);
-
-		expect(preloadIndex).toBeLessThan(styleIndex);
-	});
 });

--- a/packages/kit/test/apps/options/test/test.js
+++ b/packages/kit/test/apps/options/test/test.js
@@ -170,7 +170,7 @@ test.describe('trailingSlash', () => {
 		if (process.env.DEV) {
 			expect(requests.filter((req) => req.endsWith('.svelte')).length).toBe(1);
 		} else {
-			expect(requests.filter((req) => req.endsWith('.mjs')).length).toBeGreaterThan(0);
+			expect(requests.filter((req) => req.endsWith('.js')).length).toBeGreaterThan(0);
 		}
 
 		requests = [];
@@ -202,7 +202,7 @@ test.describe('trailingSlash', () => {
 		if (process.env.DEV) {
 			expect(requests.filter((req) => req.endsWith('.svelte')).length).toBe(1);
 		} else {
-			expect(requests.filter((req) => req.endsWith('.mjs')).length).toBeGreaterThan(0);
+			expect(requests.filter((req) => req.endsWith('.js')).length).toBeGreaterThan(0);
 		}
 
 		requests = [];

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -593,6 +593,7 @@ declare module '@sveltejs/kit' {
 			 * - `preload-mjs` - uses `<link rel="preload">` but with the `.mjs` extension which prevents double-parsing in Chromium. Some static webservers will fail to serve .mjs files with a `Content-Type: application/javascript` header, which will cause your application to break. If that doesn't apply to you, this is the option that will deliver the best performance for the largest number of users, until `modulepreload` is more widely supported.
 			 * @default "modulepreload"
 			 * @since 1.8.4
+			 * @deprecated removed in 3.0.0
 			 */
 			preloadStrategy?: 'modulepreload' | 'preload-js' | 'preload-mjs';
 			/**


### PR DESCRIPTION
Closes https://github.com/sveltejs/kit/issues/11190

`modulepreload` is now baseline 2023: https://caniuse.com/?search=modulepreload

I left the type so that it will show up in the docs still for users on older versions of Kit

Removed the test from the options app because `modulepreload` only gets written when not prerendering