### PR TITLE
breaking: set `"moduleResolution": "nodenext"` in generated base `tsconfig.json`

### DIFF
--- a/.changeset/silver-yaks-see.md
+++ b/.changeset/silver-yaks-see.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: set `"moduleResolution": "nodenext"` in generated base `tsconfig.json`. Apps should override this to `"module": "esnext"` and `"moduleResolution": "bundler"` in their `tsconfig.json` while libraries should leave it set to the new default of `nodenext`

--- a/packages/kit/src/core/sync/write_tsconfig.js
+++ b/packages/kit/src/core/sync/write_tsconfig.js
@@ -116,8 +116,8 @@ export function get_tsconfig(kit) {
 			// This is required for svelte-package to work as expected
 			// Can be overwritten
 			lib: ['esnext', 'DOM', 'DOM.Iterable'],
-			moduleResolution: 'bundler',
-			module: 'esnext',
+			moduleResolution: 'nodenext',
+			module: 'nodenext',
 			noEmit: true, // prevent tsconfig error "overwriting input files" - Vite handles the build and ignores this
 			target: 'esnext'
 		},

--- a/packages/kit/src/core/sync/write_types/test/actions/tsconfig.json
+++ b/packages/kit/src/core/sync/write_types/test/actions/tsconfig.json
@@ -5,7 +5,7 @@
 		"noEmit": true,
 		"strict": true,
 		"target": "es2022",
-		"module": "es2022",
+		"module": "esnext",
 		"moduleResolution": "bundler",
 		"allowSyntheticDefaultImports": true,
 		"baseUrl": ".",

--- a/packages/kit/src/core/sync/write_types/test/app-types/tsconfig.json
+++ b/packages/kit/src/core/sync/write_types/test/app-types/tsconfig.json
@@ -5,8 +5,8 @@
 		"noEmit": true,
 		"strict": true,
 		"target": "es2022",
-		"module": "es2022",
-		"moduleResolution": "bundler",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
 		"allowSyntheticDefaultImports": true,
 		"baseUrl": ".",
 		"paths": {

--- a/packages/kit/src/core/sync/write_types/test/layout-advanced/tsconfig.json
+++ b/packages/kit/src/core/sync/write_types/test/layout-advanced/tsconfig.json
@@ -5,8 +5,8 @@
 		"noEmit": true,
 		"strict": true,
 		"target": "es2022",
-		"module": "es2022",
-		"moduleResolution": "bundler",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
 		"allowSyntheticDefaultImports": true,
 		"baseUrl": ".",
 		"paths": {

--- a/packages/kit/src/core/sync/write_types/test/layout/tsconfig.json
+++ b/packages/kit/src/core/sync/write_types/test/layout/tsconfig.json
@@ -5,8 +5,8 @@
 		"noEmit": true,
 		"strict": true,
 		"target": "es2022",
-		"module": "es2022",
-		"moduleResolution": "bundler",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
 		"allowSyntheticDefaultImports": true,
 		"baseUrl": ".",
 		"paths": {

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/tsconfig.json
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/tsconfig.json
@@ -5,8 +5,8 @@
 		"noEmit": true,
 		"strict": true,
 		"target": "es2022",
-		"module": "es2022",
-		"moduleResolution": "bundler",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
 		"allowSyntheticDefaultImports": true,
 		"baseUrl": ".",
 		"paths": {

--- a/packages/kit/src/core/sync/write_types/test/simple-page-server-and-shared/tsconfig.json
+++ b/packages/kit/src/core/sync/write_types/test/simple-page-server-and-shared/tsconfig.json
@@ -5,8 +5,8 @@
 		"noEmit": true,
 		"strict": true,
 		"target": "es2022",
-		"module": "es2022",
-		"moduleResolution": "bundler",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
 		"allowSyntheticDefaultImports": true,
 		"baseUrl": ".",
 		"paths": {

--- a/packages/kit/src/core/sync/write_types/test/simple-page-server-only/tsconfig.json
+++ b/packages/kit/src/core/sync/write_types/test/simple-page-server-only/tsconfig.json
@@ -5,8 +5,8 @@
 		"noEmit": true,
 		"strict": true,
 		"target": "es2022",
-		"module": "es2022",
-		"moduleResolution": "bundler",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
 		"allowSyntheticDefaultImports": true,
 		"baseUrl": ".",
 		"paths": {

--- a/packages/kit/src/core/sync/write_types/test/simple-page-shared-only/tsconfig.json
+++ b/packages/kit/src/core/sync/write_types/test/simple-page-shared-only/tsconfig.json
@@ -5,8 +5,8 @@
 		"noEmit": true,
 		"strict": true,
 		"target": "es2022",
-		"module": "es2022",
-		"moduleResolution": "bundler",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
 		"allowSyntheticDefaultImports": true,
 		"baseUrl": ".",
 		"paths": {

--- a/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/tsconfig.json
+++ b/packages/kit/src/core/sync/write_types/test/slugs-layout-not-all-pages-have-load/tsconfig.json
@@ -5,8 +5,8 @@
 		"noEmit": true,
 		"strict": true,
 		"target": "es2022",
-		"module": "es2022",
-		"moduleResolution": "bundler",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
 		"allowSyntheticDefaultImports": true,
 		"baseUrl": ".",
 		"paths": {

--- a/packages/kit/src/core/sync/write_types/test/slugs/tsconfig.json
+++ b/packages/kit/src/core/sync/write_types/test/slugs/tsconfig.json
@@ -5,8 +5,8 @@
 		"noEmit": true,
 		"strict": true,
 		"target": "es2022",
-		"module": "es2022",
-		"moduleResolution": "bundler",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
 		"allowSyntheticDefaultImports": true,
 		"baseUrl": ".",
 		"paths": {

--- a/packages/kit/test/apps/amp/tsconfig.json
+++ b/packages/kit/test/apps/amp/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"

--- a/packages/kit/test/apps/async/tsconfig.json
+++ b/packages/kit/test/apps/async/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"noEmit": true,
 		"resolveJsonModule": true

--- a/packages/kit/test/apps/basics/tsconfig.json
+++ b/packages/kit/test/apps/basics/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"noEmit": true,
 		"resolveJsonModule": true

--- a/packages/kit/test/apps/dev-only/tsconfig.json
+++ b/packages/kit/test/apps/dev-only/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"noEmit": true,
 		"resolveJsonModule": true

--- a/packages/kit/test/apps/embed/tsconfig.json
+++ b/packages/kit/test/apps/embed/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"noEmit": true,
 		"resolveJsonModule": true

--- a/packages/kit/test/apps/hash-based-routing/tsconfig.json
+++ b/packages/kit/test/apps/hash-based-routing/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"noEmit": true,
 		"resolveJsonModule": true

--- a/packages/kit/test/apps/no-ssr/tsconfig.json
+++ b/packages/kit/test/apps/no-ssr/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"noEmit": true,
 		"resolveJsonModule": true

--- a/packages/kit/test/apps/options-2/tsconfig.json
+++ b/packages/kit/test/apps/options-2/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"

--- a/packages/kit/test/apps/options-3/tsconfig.json
+++ b/packages/kit/test/apps/options-3/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"

--- a/packages/kit/test/apps/options/tsconfig.json
+++ b/packages/kit/test/apps/options/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"noEmit": true
 	},
 	"extends": "./.custom-out-dir/tsconfig.json"

--- a/packages/kit/test/apps/prerendered-app-error-pages/jsconfig.json
+++ b/packages/kit/test/apps/prerendered-app-error-pages/jsconfig.json
@@ -9,6 +9,7 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
+		"module": "esnext",
 		"moduleResolution": "bundler"
 	}
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias

--- a/packages/kit/test/apps/writes/tsconfig.json
+++ b/packages/kit/test/apps/writes/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"noEmit": true,
 		"resolveJsonModule": true

--- a/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"

--- a/packages/kit/test/build-errors/apps/prerender-remote-function-error/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/prerender-remote-function-error/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"

--- a/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"

--- a/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"

--- a/packages/kit/test/build-errors/apps/private-dynamic-env-dynamic-import/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/private-dynamic-env-dynamic-import/tsconfig.json
@@ -3,6 +3,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,

--- a/packages/kit/test/build-errors/apps/private-dynamic-env/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/private-dynamic-env/tsconfig.json
@@ -3,6 +3,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,

--- a/packages/kit/test/build-errors/apps/private-static-env-dynamic-import/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/private-static-env-dynamic-import/tsconfig.json
@@ -3,6 +3,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,

--- a/packages/kit/test/build-errors/apps/private-static-env/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/private-static-env/tsconfig.json
@@ -3,6 +3,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,

--- a/packages/kit/test/build-errors/apps/server-only-folder-dynamic-import/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/server-only-folder-dynamic-import/tsconfig.json
@@ -3,6 +3,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,

--- a/packages/kit/test/build-errors/apps/server-only-folder/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/server-only-folder/tsconfig.json
@@ -3,6 +3,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,

--- a/packages/kit/test/build-errors/apps/server-only-module-dynamic-import/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/server-only-module-dynamic-import/tsconfig.json
@@ -3,6 +3,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,

--- a/packages/kit/test/build-errors/apps/server-only-module/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/server-only-module/tsconfig.json
@@ -3,6 +3,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,

--- a/packages/kit/test/build-errors/apps/service-worker-dynamic-public-env/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/service-worker-dynamic-public-env/tsconfig.json
@@ -3,6 +3,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,

--- a/packages/kit/test/build-errors/apps/service-worker-private-env/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/service-worker-private-env/tsconfig.json
@@ -3,6 +3,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,

--- a/packages/kit/test/build-errors/apps/syntax-error/tsconfig.json
+++ b/packages/kit/test/build-errors/apps/syntax-error/tsconfig.json
@@ -3,6 +3,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,

--- a/packages/kit/test/prerendering/basics/tsconfig.json
+++ b/packages/kit/test/prerendering/basics/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"

--- a/packages/kit/test/prerendering/options/tsconfig.json
+++ b/packages/kit/test/prerendering/options/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"

--- a/packages/kit/test/prerendering/paths-base/tsconfig.json
+++ b/packages/kit/test/prerendering/paths-base/tsconfig.json
@@ -2,6 +2,8 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"noEmit": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/13028

If this is merged, we should update the application templates in `sv` (FYI @jycouet)