### PR TITLE
docs: clarify that ssr must be enabled for prerendering in adapter-static

### DIFF
--- a/documentation/docs/25-build-and-deploy/50-adapter-static.md
+++ b/documentation/docs/25-build-and-deploy/50-adapter-static.md
@@ -44,6 +44,8 @@ export const prerender = true;
 
 > [!NOTE] You must ensure SvelteKit's [`trailingSlash`](page-options#trailingSlash) option is set appropriately for your environment. If your host does not render `/a.html` upon receiving a request for `/a` then you will need to set `trailingSlash: 'always'` in your root layout to create `/a/index.html` instead.
 
+> [!NOTE] Make sure that [`ssr`](page-options#ssr) is not set to `false` in your root layout or pages, otherwise they will be output as empty shell pages. `adapter-static` relies on the server-side render pass at build time to generate the HTML content of your pages. `ssr` is `true` by default — if you previously set it to `false`, remove that setting for prerendering to work as expected.
+
 ## Zero-config support
 
 Some platforms have zero-config support (more to come in future):


### PR DESCRIPTION
Add a note to the adapter-static documentation clarifying that `ssr` must not be set to `false` for prerendering to generate actual page content. Without SSR, `adapter-static` outputs empty shell pages since it relies on the server-side render pass at build time.

This is a common source of confusion — users who set `ssr = false` expect `prerender = true` to generate static content, but instead get empty pages with only client-side JS.

Closes #14471