### PR TITLE
docs: correct minor typos in docs and test descriptions

### DIFF
--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -159,7 +159,7 @@ export const getTodo = query(v.string(), (id) => {
 });
 ```
 
-...but it is called with something that doesn't match the schema — such as a number (e.g `await getTodos(1)`) — then validation will fail, the server will respond with a [400 status code](https://http.dog/400), and the function will throw with the message 'Bad Request'.
+...but it is called with something that doesn't match the schema — such as a number (e.g. `await getTodos(1)`) — then validation will fail, the server will respond with a [400 status code](https://http.dog/400), and the function will throw with the message 'Bad Request'.
 
 To customise this message and add additional properties to the error object, implement `handleValidationError`:
 

--- a/packages/kit/src/runtime/server/page/load_data.spec.js
+++ b/packages/kit/src/runtime/server/page/load_data.spec.js
@@ -30,7 +30,7 @@ test('sets body to empty when mode is no-cors', async () => {
 	assert.equal(text, '');
 });
 
-test('keeps body when mode isnt no-cors on same domain', async () => {
+test("keeps body when mode isn't no-cors on same domain", async () => {
 	const fetch = create_fetch({});
 	const response = await fetch('https://domain-a.com');
 	const text = await response.text();

--- a/packages/kit/src/runtime/server/page/serialize_data.spec.js
+++ b/packages/kit/src/runtime/server/page/serialize_data.spec.js
@@ -81,7 +81,7 @@ test('computes ttl using cache-control and age headers', () => {
 	);
 });
 
-test('doesnt compute ttl when vary * header is present', () => {
+test("doesn't compute ttl when vary * header is present", () => {
 	const raw = 'an "attr" & a \ud800';
 	const escaped = 'an &quot;attr&quot; &amp; a &#55296;';
 	const response_body = '';


### PR DESCRIPTION
- Add missing period after "e.g" in hooks documentation (followup to #14873)
- Fix missing apostrophes in test descriptions ("doesnt" → "doesn't", "isnt" → "isn't")