### PR TITLE
fix: preserve $page.state when calling invalidate or invalidateAll

### DIFF
--- a/.changeset/fix-page-state-invalidate.md
+++ b/.changeset/fix-page-state-invalidate.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: preserve `$page.state` when calling `invalidate` or `invalidateAll`

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -372,7 +372,7 @@ export async function start(_app, _target, hydrate) {
 	_start_router();
 }
 
-async function _invalidate(include_load_functions = true, reset_page_state = true) {
+async function _invalidate(include_load_functions = true, reset_page_state = false) {
 	// Accept all invalidations as they come, don't swallow any while another invalidation
 	// is running because subsequent invalidations may make earlier ones outdated,
 	// but batch multiple synchronous invalidations.

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1615,6 +1615,21 @@ test.describe('Shallow routing', () => {
 		await expect(page.locator('span')).not.toHaveText(now);
 	});
 
+	test('Preserves page state when invalidating', async ({ page }) => {
+		await page.goto('/shallow-routing/push-state');
+		await expect(page.locator('p')).toHaveText('active: false');
+
+		await page.locator('[data-id="one"]').click();
+		await expect(page.locator('p')).toHaveText('active: true');
+
+		const now = /** @type {string} */ (await page.locator('span').textContent());
+
+		await page.locator('[data-id="invalidate"]').click();
+		await expect(page.locator('span')).not.toHaveText(now);
+		// page.state should be preserved after invalidation (#11783)
+		await expect(page.locator('p')).toHaveText('active: true');
+	});
+
 	test('Does not navigate when going back to shallow route', async ({ baseURL, page }) => {
 		await page.goto('/shallow-routing/push-state');
 		await page.locator('[data-id="two"]').click();


### PR DESCRIPTION
## Summary

`$page.state` (shallow routing state set via `pushState`/`replaceState`) was incorrectly being cleared whenever `invalidate()` or `invalidateAll()` was called. These functions are meant to re-run load functions, not affect navigation state.

### Root cause

The internal `_invalidate()` function defaulted to `reset_page_state = true`, which causes the state to be wiped after `load_route()` creates a new page object with `state: {}`. Meanwhile, `refreshAll()` already correctly passes `reset_page_state = false`.

### Fix

Changed the default parameter from `reset_page_state = true` to `reset_page_state = false`, so `invalidate()` and `invalidateAll()` preserve the existing `$page.state` — consistent with `refreshAll()`.

Fixes #11783

## Test plan

- [x] Added test "Preserves page state when invalidating" — sets state via `pushState`, calls `invalidateAll`, verifies state is preserved and load function re-ran
- [x] All 34 existing invalidation tests pass
- [x] All 31 existing state-related tests pass
- [x] All 10 shallow routing tests pass
- [x] All 417 unit tests pass