### PR TITLE
docs: document typed params in page props

### DIFF
--- a/documentation/docs/20-core-concepts/10-routing.md
+++ b/documentation/docs/20-core-concepts/10-routing.md
@@ -48,8 +48,9 @@ Pages can receive data from `load` functions via the `data` prop. They also rece
 	let { data, params } = $props();
 </script>
 
+<span>blog/{params.slug}</span>
+
 <h1>{data.title}</h1>
-<p>slug: {params.slug}</p>
 <div>{@html data.content}</div>
 ```
 


### PR DESCRIPTION
Closes #14066

This PR documents the typed `params` prop that was introduced in #13999.

Previously, the routing docs showed how to access typed `data` in `+page.svelte` via `PageProps`, but did not mention that `params` is also available and typed based on the route parameters. This made the feature difficult to discover for users working with parameterised routes.

This change:
- Updates the `+page.svelte` routing example to destructure `params` from `$props()`
- Demonstrates usage of `params` in a `[slug]` route
- Updates the `$types` section to explain that `PageProps` includes typed route parameters

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
