### PR TITLE
docs: params prop

### DIFF
--- a/documentation/docs/20-core-concepts/10-routing.md
+++ b/documentation/docs/20-core-concepts/10-routing.md
@@ -57,7 +57,7 @@ As of 2.24, pages also receive a `params` prop which is typed based on the route
 ```svelte
 <!--- file: src/routes/blog/[slug]/+page.svelte --->
 <script>
-	import { getPost } from '$lib/server/db';
+	import { getPost } from '../blog.remote';
 
 	/** @type {import('./$types').PageProps} */
 	let { params } = $props();


### PR DESCRIPTION
reverts #15284 per https://github.com/sveltejs/svelte.dev/pull/1781#pullrequestreview-3774527415 and adds an example of using `params`. (This page will get a lot simpler when remote functions are stable)