### PR TITLE
fix: skip comment lines when parsing _redirects file

### DIFF
--- a/.changeset/fix-redirects-comments.md
+++ b/.changeset/fix-redirects-comments.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+fix: skip comment lines in `_redirects` file

--- a/packages/adapter-cloudflare/utils.js
+++ b/packages/adapter-cloudflare/utils.js
@@ -65,7 +65,7 @@ export function parse_redirects(file_contents) {
 
 	for (const line of file_contents.split('\n')) {
 		const content = line.trim();
-		if (!content) continue;
+		if (!content || content.startsWith('#')) continue;
 
 		const [pathname] = line.split(' ');
 		// pathnames with placeholders are not supported

--- a/packages/adapter-cloudflare/utils.spec.js
+++ b/packages/adapter-cloudflare/utils.spec.js
@@ -148,6 +148,19 @@ describe('validates Wrangler config', () => {
 	});
 });
 
+test('ignores comments in _redirects file', () => {
+	const redirects = parse_redirects(
+		`
+# This is a comment
+/home301 / 301
+  # Indented comment
+/blog/* https://blog.my.domain/:splat
+`.trim()
+	);
+
+	expect(redirects).toEqual(['/home301', '/blog/*']);
+});
+
 test('parses _redirects file', () => {
 	const redirects = parse_redirects(
 		`


### PR DESCRIPTION
## Description

`parse_redirects()` in `adapter-cloudflare` does not skip comment lines (starting with `#`) in the `_redirects` file. Per the [Cloudflare documentation](https://developers.cloudflare.com/pages/configuration/redirects/), lines starting with `#` are treated as comments.

When a `_redirects` file contains comments like:

```
# Redirects for Cloudflare Pages
/old /new 301
```

The `#` character is extracted as a pathname and added to the `_routes.json` exclude array, causing Cloudflare Pages deployments to fail with:

```
Error 8000057: Rules must start with '/'
```

## Fix

Added a single check in `parse_redirects()` to skip lines where the trimmed content starts with `#`.

## Test

Added a test case that verifies comments (both at the start of a line and indented) are properly ignored.

Closes #15324

---

### Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.