### PR TITLE
chore: fix Node 18 CI by changing .remote.js import to .remote.ts

### DIFF
--- a/packages/kit/test/apps/async/src/routes/remote/form/preflight-pending/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/preflight-pending/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { create } from './form.remote.js';
+	import { create } from './form.remote.ts';
 	import * as v from 'valibot';
 
 	const passing_schema = v.pipeAsync(

--- a/packages/kit/test/apps/async/tsconfig.json
+++ b/packages/kit/test/apps/async/tsconfig.json
@@ -5,6 +5,9 @@
 		"esModuleInterop": true,
 		"noEmit": true,
 		"resolveJsonModule": true,
+		// TODO: remove when we start SvelteKit 3.0
+		// concession change for vite5, importing a .remote.ts as .remote.js doesn't
+		// work on node 18, allowing .ts import and changing the imported suffix works.
 		"allowImportingTsExtensions": true
 	},
 	"extends": "./.svelte-kit/tsconfig.json"


### PR DESCRIPTION
Quick fix to stop CI from failing. Node 18 doesn't like importing .ts files as .js. See https://github.com/sveltejs/kit/pull/15208/changes#r2737134500

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
