### PR TITLE
fix: apply queries refreshed in a form remote function when a redirect is thrown

### DIFF
--- a/.changeset/silent-webs-laugh.md
+++ b/.changeset/silent-webs-laugh.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: apply queries refreshed in a form remote function when a redirect is thrown

--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -108,6 +108,8 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 
 			const { data, meta, form_data } = await deserialize_binary_form(event.request);
 
+			form_client_refreshes = meta.remote_refreshes;
+
 			// If this is a keyed form instance (created via form.for(key)), add the key to the form data (unless already set)
 			// Note that additional_args will only be set if the form is not enhanced, as enhanced forms transfer the key inside `data`.
 			if (additional_args && !('id' in data)) {


### PR DESCRIPTION
ESLint 10 caught that `form_client_refreshes` was unused. I'm not super familiar with remote functions, but am assuming it's a bug that it wasn't used