### PR TITLE
breaking: require newer versions of Svelte and Vite

### DIFF
--- a/.changeset/early-worlds-slide.md
+++ b/.changeset/early-worlds-slide.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: require `@sveltejs/vite-plugin-svelte` v7

--- a/.changeset/heavy-showers-leave.md
+++ b/.changeset/heavy-showers-leave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: require Svelte 5

--- a/.changeset/nine-coins-cheer.md
+++ b/.changeset/nine-coins-cheer.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: require Vite 8

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -45,11 +45,11 @@
 		"vitest": "catalog:"
 	},
 	"peerDependencies": {
-		"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0",
+		"@sveltejs/vite-plugin-svelte": "^7.0.0",
 		"@opentelemetry/api": "^1.0.0",
-		"svelte": "^4.0.0 || ^5.0.0-next.0",
+		"svelte": "^5.0.0",
 		"typescript": "^5.3.3",
-		"vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0"
+		"vite": "^8.0.0"
 	},
 	"peerDependenciesMeta": {
 		"@opentelemetry/api": {


### PR DESCRIPTION
Just bumping the peer deps here for a clean PR and changelog. Makes it easy to do multiple Vite upgrades later. E.g. Vite 8 beta, Vite 8 final, etc.