### PR TITLE
feat(enhanced-img): use simple `img` tag instead of `picture` when only one format is specified

### DIFF
--- a/.changeset/shaky-bats-shake.md
+++ b/.changeset/shaky-bats-shake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/enhanced-img': minor
+---
+
+feat: use simple `img` tag instead of `picture` when only one format is specified

--- a/packages/enhanced-img/src/index.js
+++ b/packages/enhanced-img/src/index.js
@@ -53,8 +53,6 @@ function imagetools_plugin() {
 	};
 
 	// TODO: should we make formats or sizes configurable besides just letting people override defaultDirectives?
-	// TODO: generate img rather than picture if only a single format is provided
-	//     by resolving the directives for the URL in the preprocessor
 	return imagetools(imagetools_opts);
 }
 

--- a/packages/enhanced-img/test/Input.svelte
+++ b/packages/enhanced-img/test/Input.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-	import manual_image1 from './no.png';
-	import manual_image2 from './no.svg';
+	import manual_image1 from './no.png?enhanced';
+	import manual_image2 from './no.svg?enhanced';
+	import webp_image from './dev.png?format=webp&enhanced';
 
 	const src = manual_image1;
 	const images = [manual_image1, manual_image2];
@@ -14,6 +15,8 @@
 <img src="./dev.png" alt="non-enhanced test" />
 
 <enhanced:img src="./dev.png" alt="dev test" />
+
+<enhanced:img src="./dev.png?format=webp" alt="single format static test" />
 
 <div>
 	<enhanced:img src="./dev.png" alt="nested test" />
@@ -44,6 +47,8 @@
 <enhanced:img src="/src/dev.png" alt="absolute path test" />
 
 <enhanced:img {src} alt="attribute shorthand test" />
+
+<enhanced:img src={webp_image} alt="single format dynamic test" />
 
 {#each images as image}
 	<enhanced:img src={image} alt="opt-in test" />

--- a/packages/enhanced-img/test/Output.svelte
+++ b/packages/enhanced-img/test/Output.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	
-	import manual_image1 from './no.png';
+	import manual_image1 from './no.png?enhanced';
 	
-	import manual_image2 from './no.svg';
+	import manual_image2 from './no.svg?enhanced';
+	
+	import webp_image from './dev.png?format=webp&enhanced';
 
 	const src = manual_image1;
 	const images = [manual_image1, manual_image2];
@@ -16,6 +18,8 @@
 <img src="./dev.png" alt="non-enhanced test" />
 
 <picture><source srcset="/1 1440w, /2 960w" type="image/avif" /><source srcset="/3 1440w, /4 960w" type="image/webp" /><source srcset="5 1440w, /6 960w" type="image/png" /><img src="/7" alt="dev test" width=1440 height=1440 /></picture>
+
+<img src="/7" alt="single format static test" srcset="/3 1440w, /4 960w" width=1440 height=1440 />
 
 <div>
 	<picture><source srcset="/1 1440w, /2 960w" type="image/avif" /><source srcset="/3 1440w, /4 960w" type="image/webp" /><source srcset="5 1440w, /6 960w" type="image/png" /><img src="/7" alt="nested test" width=1440 height=1440 /></picture>
@@ -45,12 +49,36 @@
 		<img src={src} alt="attribute shorthand test" />
 	{/if}
 {:else}
-	<picture>
-		{#each Object.entries(src.sources) as [format, srcset]}
-			<source {srcset} type={'image/' + format} />
-		{/each}
-		<img src={src.img.src} alt="attribute shorthand test" width={src.img.w} height={src.img.h} />
-	</picture>
+	{#if Object.keys(src.sources).length === 1}
+		<img src={src.img.src} alt="attribute shorthand test" srcset={Object.values(src.sources)[0]} width={src.img.w} height={src.img.h} />
+	{:else}
+		<picture>
+			{#each Object.entries(src.sources) as [format, srcset]}
+				<source {srcset} type={'image/' + format} />
+			{/each}
+			<img src={src.img.src} alt="attribute shorthand test" width={src.img.w} height={src.img.h} />
+		</picture>
+	{/if}
+{/if}
+
+{#if typeof webp_image === 'string'}
+	{#if 
+	import.meta.env.DEV && false}
+		{webp_image} was not enhanced. Cannot determine dimensions.
+	{:else}
+		<img src={webp_image} alt="single format dynamic test" />
+	{/if}
+{:else}
+	{#if Object.keys(webp_image.sources).length === 1}
+		<img src={webp_image.img.src} alt="single format dynamic test" srcset={Object.values(webp_image.sources)[0]} width={webp_image.img.w} height={webp_image.img.h} />
+	{:else}
+		<picture>
+			{#each Object.entries(webp_image.sources) as [format, srcset]}
+				<source {srcset} type={'image/' + format} />
+			{/each}
+			<img src={webp_image.img.src} alt="single format dynamic test" width={webp_image.img.w} height={webp_image.img.h} />
+		</picture>
+	{/if}
 {/if}
 
 {#each images as image}
@@ -62,12 +90,16 @@
 		<img src={image} alt="opt-in test" />
 	{/if}
 {:else}
-	<picture>
-		{#each Object.entries(image.sources) as [format, srcset]}
-			<source {srcset} type={'image/' + format} />
-		{/each}
-		<img src={image.img.src} alt="opt-in test" width={image.img.w} height={image.img.h} />
-	</picture>
+	{#if Object.keys(image.sources).length === 1}
+		<img src={image.img.src} alt="opt-in test" srcset={Object.values(image.sources)[0]} width={image.img.w} height={image.img.h} />
+	{:else}
+		<picture>
+			{#each Object.entries(image.sources) as [format, srcset]}
+				<source {srcset} type={'image/' + format} />
+			{/each}
+			<img src={image.img.src} alt="opt-in test" width={image.img.w} height={image.img.h} />
+		</picture>
+	{/if}
 {/if}
 {/each}
 
@@ -80,12 +112,16 @@
 		<img src={get_image(i)} alt="opt-in test" />
 	{/if}
 {:else}
-	<picture>
-		{#each Object.entries(get_image(i).sources) as [format, srcset]}
-			<source {srcset} type={'image/' + format} />
-		{/each}
-		<img src={get_image(i).img.src} alt="opt-in test" width={get_image(i).img.w} height={get_image(i).img.h} />
-	</picture>
+	{#if Object.keys(get_image(i).sources).length === 1}
+		<img src={get_image(i).img.src} alt="opt-in test" srcset={Object.values(get_image(i).sources)[0]} width={get_image(i).img.w} height={get_image(i).img.h} />
+	{:else}
+		<picture>
+			{#each Object.entries(get_image(i).sources) as [format, srcset]}
+				<source {srcset} type={'image/' + format} />
+			{/each}
+			<img src={get_image(i).img.src} alt="opt-in test" width={get_image(i).img.w} height={get_image(i).img.h} />
+		</picture>
+	{/if}
 {/if}
 {/each}
 

--- a/packages/enhanced-img/test/Output.svelte
+++ b/packages/enhanced-img/test/Output.svelte
@@ -48,17 +48,15 @@
 	{:else}
 		<img src={src} alt="attribute shorthand test" />
 	{/if}
+{:else if Object.keys(src.sources).length === 1}
+	<img src={src.img.src} alt="attribute shorthand test" srcset={Object.values(src.sources)[0]} width={src.img.w} height={src.img.h} />
 {:else}
-	{#if Object.keys(src.sources).length === 1}
-		<img src={src.img.src} alt="attribute shorthand test" srcset={Object.values(src.sources)[0]} width={src.img.w} height={src.img.h} />
-	{:else}
-		<picture>
-			{#each Object.entries(src.sources) as [format, srcset]}
-				<source {srcset} type={'image/' + format} />
-			{/each}
-			<img src={src.img.src} alt="attribute shorthand test" width={src.img.w} height={src.img.h} />
-		</picture>
-	{/if}
+	<picture>
+		{#each Object.entries(src.sources) as [format, srcset]}
+			<source {srcset} type={'image/' + format} />
+		{/each}
+		<img src={src.img.src} alt="attribute shorthand test" width={src.img.w} height={src.img.h} />
+	</picture>
 {/if}
 
 {#if typeof webp_image === 'string'}
@@ -68,17 +66,15 @@
 	{:else}
 		<img src={webp_image} alt="single format dynamic test" />
 	{/if}
+{:else if Object.keys(webp_image.sources).length === 1}
+	<img src={webp_image.img.src} alt="single format dynamic test" srcset={Object.values(webp_image.sources)[0]} width={webp_image.img.w} height={webp_image.img.h} />
 {:else}
-	{#if Object.keys(webp_image.sources).length === 1}
-		<img src={webp_image.img.src} alt="single format dynamic test" srcset={Object.values(webp_image.sources)[0]} width={webp_image.img.w} height={webp_image.img.h} />
-	{:else}
-		<picture>
-			{#each Object.entries(webp_image.sources) as [format, srcset]}
-				<source {srcset} type={'image/' + format} />
-			{/each}
-			<img src={webp_image.img.src} alt="single format dynamic test" width={webp_image.img.w} height={webp_image.img.h} />
-		</picture>
-	{/if}
+	<picture>
+		{#each Object.entries(webp_image.sources) as [format, srcset]}
+			<source {srcset} type={'image/' + format} />
+		{/each}
+		<img src={webp_image.img.src} alt="single format dynamic test" width={webp_image.img.w} height={webp_image.img.h} />
+	</picture>
 {/if}
 
 {#each images as image}
@@ -89,17 +85,15 @@
 	{:else}
 		<img src={image} alt="opt-in test" />
 	{/if}
+{:else if Object.keys(image.sources).length === 1}
+	<img src={image.img.src} alt="opt-in test" srcset={Object.values(image.sources)[0]} width={image.img.w} height={image.img.h} />
 {:else}
-	{#if Object.keys(image.sources).length === 1}
-		<img src={image.img.src} alt="opt-in test" srcset={Object.values(image.sources)[0]} width={image.img.w} height={image.img.h} />
-	{:else}
-		<picture>
-			{#each Object.entries(image.sources) as [format, srcset]}
-				<source {srcset} type={'image/' + format} />
-			{/each}
-			<img src={image.img.src} alt="opt-in test" width={image.img.w} height={image.img.h} />
-		</picture>
-	{/if}
+	<picture>
+		{#each Object.entries(image.sources) as [format, srcset]}
+			<source {srcset} type={'image/' + format} />
+		{/each}
+		<img src={image.img.src} alt="opt-in test" width={image.img.w} height={image.img.h} />
+	</picture>
 {/if}
 {/each}
 
@@ -111,17 +105,15 @@
 	{:else}
 		<img src={get_image(i)} alt="opt-in test" />
 	{/if}
+{:else if Object.keys(get_image(i).sources).length === 1}
+	<img src={get_image(i).img.src} alt="opt-in test" srcset={Object.values(get_image(i).sources)[0]} width={get_image(i).img.w} height={get_image(i).img.h} />
 {:else}
-	{#if Object.keys(get_image(i).sources).length === 1}
-		<img src={get_image(i).img.src} alt="opt-in test" srcset={Object.values(get_image(i).sources)[0]} width={get_image(i).img.w} height={get_image(i).img.h} />
-	{:else}
-		<picture>
-			{#each Object.entries(get_image(i).sources) as [format, srcset]}
-				<source {srcset} type={'image/' + format} />
-			{/each}
-			<img src={get_image(i).img.src} alt="opt-in test" width={get_image(i).img.w} height={get_image(i).img.h} />
-		</picture>
-	{/if}
+	<picture>
+		{#each Object.entries(get_image(i).sources) as [format, srcset]}
+			<source {srcset} type={'image/' + format} />
+		{/each}
+		<img src={get_image(i).img.src} alt="opt-in test" width={get_image(i).img.w} height={get_image(i).img.h} />
+	</picture>
 {/if}
 {/each}
 

--- a/packages/enhanced-img/test/markup-plugin.spec.js
+++ b/packages/enhanced-img/test/markup-plugin.spec.js
@@ -10,7 +10,9 @@ it('Image preprocess snapshot test', async () => {
 	const vite_plugin = image_plugin({
 		name: 'vite-imagetools-mock',
 		load(id) {
-			if (id.includes('dev')) {
+			if (id.includes('format=webp')) {
+				return 'export default {sources:{webp:"/3 1440w, /4 960w"},img:{src:"/7",w:1440,h:1440}};';
+			} else if (id.includes('dev')) {
 				return 'export default {sources:{avif:"/1 1440w, /2 960w",webp:"/3 1440w, /4 960w",png:"5 1440w, /6 960w"},img:{src:"/7",w:1440,h:1440}};';
 			} else if (id.includes('prod')) {
 				return 'export default {sources:{avif:"__VITE_ASSET__2AM7_y_a__ 1440w, __VITE_ASSET__2AM7_y_b__ 960w",webp:"__VITE_ASSET__2AM7_y_c__ 1440w, __VITE_ASSET__2AM7_y_d__ 960w",png:"__VITE_ASSET__2AM7_y_e__ 1440w, __VITE_ASSET__2AM7_y_f__ 960w"},img:{src:"__VITE_ASSET__2AM7_y_g__",w:1440,h:1440}};';


### PR DESCRIPTION
I personally want this feature and there was a `// TODO` for it in the code, so I decided to implement it.

- Update markup generation to output a plain `<img>` (instead of `<picture>`) when enhanced output contains exactly one source format.
- The single-format `<img>` includes `srcset`.
- Extend `serialize_img_attributes` to handle `srcset` consistently with existing `src`/dimension behavior (replace if present, append if missing).

## Tests
- Add unit fixture coverage for single-format output using `?format=webp` (static and dynamic inputs).
- Update the imagetools mock to return a one-format payload for `format=webp`.


---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
