### PR TITLE
chore: cross-reference AGENTS.md, CONTRIBUTING.md, and PR template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This guide is for AI coding agents working in the SvelteKit monorepo.
 
-**Important:** Read and follow `CONTRIBUTING.md` as well - it contains essential information about testing, code structure, and contribution guidelines that applies here.
+**Important:** Read and follow [`CONTRIBUTING.md`](./CONTRIBUTING.md) as well - it contains essential information about testing, code structure, and contribution guidelines that applies here.
 
 ## Quick Reference
 
@@ -48,6 +48,8 @@ pnpm test:others
 ```
 
 ### Pre-submission Checklist
+
+Before opening a PR, **all of these must pass** (see also the [PR template](./.github/PULL_REQUEST_TEMPLATE.md)):
 
 1. `pnpm run format` - Auto-format code
 2. `pnpm run lint` - Check code style (don't cancel early)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Issues with the [**soon**](https://github.com/sveltejs/kit/issues?q=is%3Aissue+i
 
 ## Testing
 
-Run `pnpm test:kit` to run the tests from the `packages/kit` directory. You can also run `pnpm test:others` to run tests from all packages __except__ the `packages/kit` directory. Browser tests live in subdirectories of `packages/kit/test` such as `packages/kit/test/apps/basics`.
+Run `pnpm test:kit` to run the tests from the `packages/kit` directory. You can also run `pnpm test:others` to run tests from all packages **except** the `packages/kit` directory. Browser tests live in subdirectories of `packages/kit/test` such as `packages/kit/test/apps/basics`.
 
 You can run the tests for only a single package by first moving to that directory. E.g. `cd packages/kit`.
 
@@ -111,6 +111,10 @@ If you would like to test local changes to Vite or another dependency, you can b
 All documentation for SvelteKit is in the [`documentation` directory](https://github.com/sveltejs/kit/tree/main/documentation), and any improvements should be made as a Pull Request to this repository. The site itself is located in the [`sveltejs/svelte.dev` repo](https://github.com/sveltejs/svelte.dev) and can be run locally to preview changes.
 
 ## Sending PRs
+
+When you open a PR, the [PR template](./.github/PULL_REQUEST_TEMPLATE.md) includes a checklist. Please read it carefully and don't delete it.
+
+**Run tests locally before submitting.** CI runs the full suite, but catching failures early saves time for everyone. At a minimum, run `pnpm format`, `pnpm lint`, `pnpm check`, and `pnpm -F @sveltejs/kit test:unit`.
 
 ### Coding style
 


### PR DESCRIPTION
Small docs twaeks make AGENTS.md, CONTRIBUTING.md, and the PR template aware of each other.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits
- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.