### PR TITLE
docs: initialize Sentry in `init` hooks

### DIFF
--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -215,7 +215,10 @@ declare module '@sentry/sveltekit' {
 // ---cut---
 import * as Sentry from '@sentry/sveltekit';
 
-Sentry.init({/*...*/})
+/** @type {import('@sveltejs/kit').ServerInit} */
+export function init() {
+	Sentry.init({/*...*/});
+}
 
 /** @type {import('@sveltejs/kit').HandleServerError} */
 export async function handleError({ error, event, status, message }) {
@@ -246,7 +249,10 @@ declare module '@sentry/sveltekit' {
 // ---cut---
 import * as Sentry from '@sentry/sveltekit';
 
-Sentry.init({/*...*/})
+/** @type {import('@sveltejs/kit').ClientInit} */
+export function init() {
+	Sentry.init({/*...*/});
+}
 
 /** @type {import('@sveltejs/kit').HandleClientError} */
 export async function handleError({ error, event, status, message }) {


### PR DESCRIPTION
Confirmed that this works. https://github.com/hyunbinseo/svelte-kit-template/commit/b91b668df2877146cbf4bd35903336fbbf15ed5e

```js
import * as Sentry from '@sentry/sveltekit';

/** @type {import('@sveltejs/kit').ServerInit} */
export function init() {
  Sentry.init({/*...*/});
}
```

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
