### PR TITLE
Revert "docs: initialize Sentry in `init` hooks"

### DIFF
--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -215,10 +215,7 @@ declare module '@sentry/sveltekit' {
 // ---cut---
 import * as Sentry from '@sentry/sveltekit';
 
-/** @type {import('@sveltejs/kit').ServerInit} */
-export function init() {
-	Sentry.init({/*...*/});
-}
+Sentry.init({/*...*/})
 
 /** @type {import('@sveltejs/kit').HandleServerError} */
 export async function handleError({ error, event, status, message }) {
@@ -249,10 +246,7 @@ declare module '@sentry/sveltekit' {
 // ---cut---
 import * as Sentry from '@sentry/sveltekit';
 
-/** @type {import('@sveltejs/kit').ClientInit} */
-export function init() {
-	Sentry.init({/*...*/});
-}
+Sentry.init({/*...*/})
 
 /** @type {import('@sveltejs/kit').HandleClientError} */
 export async function handleError({ error, event, status, message }) {


### PR DESCRIPTION
Reverts sveltejs/kit#15394. I was going to propose a different change — moving the `init` docs above `handleError`, so that at least we're introducing things in order — but honestly it's simpler to just revert. There is _no point_ wrapping this code in `init`, which exists to delay startup until some asynchronous work has completed (and even that only really exists because you can't yet reliably use top-level `await` everywhere)