### PR TITLE
chore: disable automatic vercel deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
The Agent project we set up is basically publishing nothing right now, but it means it creates a failed check on every fork PR.