### PR TITLE
breaking: remove the deprecated CSRF  option

### DIFF
--- a/.changeset/gentle-radios-go.md
+++ b/.changeset/gentle-radios-go.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: remove the deprecated CSRF `checkOrigin` option in favor of `trustedOrigins`

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -68,7 +68,7 @@ const get_defaults = (prefix = '') => ({
 			reportOnly: directive_defaults
 		},
 		csrf: {
-			checkOrigin: true,
+			checkOrigin: undefined,
 			trustedOrigins: []
 		},
 		embedded: false,
@@ -100,13 +100,14 @@ const get_defaults = (prefix = '') => ({
 		},
 		inlineStyleThreshold: 0,
 		moduleExtensions: ['.js', '.ts'],
-		output: { bundleStrategy: 'split' },
+		output: { bundleStrategy: 'split', preloadStrategy: undefined },
 		outDir: join(prefix, '.svelte-kit'),
 		router: {
 			type: 'pathname',
 			resolution: 'client'
 		},
 		serviceWorker: {
+			options: undefined,
 			register: true
 		},
 		typescript: {},

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -109,10 +109,8 @@ const options = object(
 			}),
 
 			csrf: object({
-				checkOrigin: deprecate(
-					boolean(true),
-					(keypath) =>
-						`\`${keypath}\` has been deprecated in favour of \`csrf.trustedOrigins\`. It will be removed in a future version`
+				checkOrigin: removed(
+					(keypath) => `\`${keypath}\` has been removed in favour of \`csrf.trustedOrigins\``
 				),
 				trustedOrigins: string_array([])
 			}),
@@ -159,6 +157,9 @@ const options = object(
 			outDir: string('.svelte-kit'),
 
 			output: object({
+				preloadStrategy: removed(
+					(keypath) => `\`${keypath}\` has been removed. modulepreload will always be used`
+				),
 				bundleStrategy: list(['split', 'single', 'inline'])
 			}),
 
@@ -332,6 +333,21 @@ function deprecate(
 		}
 
 		return fn(input, keypath);
+	};
+}
+
+/**
+ * @param {(keypath: string) => string} get_message
+ * @returns {Validator}
+ */
+function removed(
+	get_message = (keypath) =>
+		`The \`${keypath}\` option has been removed. Please see the list of breaking changes for your major release`
+) {
+	return (input, keypath) => {
+		if (typeof input !== 'undefined') {
+			throw new Error(get_message(keypath));
+		}
 	};
 }
 

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -39,7 +39,7 @@ export const options = {
 	app_template_contains_nonce: ${template.includes('%sveltekit.nonce%')},
 	async: ${s(!!config.compilerOptions?.experimental?.async)},
 	csp: ${s(config.kit.csp)},
-	csrf_check_origin: ${s(config.kit.csrf.checkOrigin && !config.kit.csrf.trustedOrigins.includes('*'))},
+	csrf_check_origin: ${s(!config.kit.csrf.trustedOrigins.includes('*'))},
 	csrf_trusted_origins: ${s(config.kit.csrf.trustedOrigins)},
 	embedded: ${config.kit.embedded},
 	env_public_prefix: '${config.kit.env.publicPrefix}',

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -421,7 +421,7 @@ export interface KitConfig {
 		 *
 		 * To allow people to make `POST`, `PUT`, `PATCH`, or `DELETE` requests with a `Content-Type` of `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain` to your app from other origins, you will need to disable this option. Be careful!
 		 * @default true
-		 * @deprecated Use `trustedOrigins: ['*']` instead
+		 * @deprecated removed in 3.0. Use `trustedOrigins: ['*']` instead
 		 */
 		checkOrigin?: boolean;
 		/**

--- a/packages/kit/test/apps/basics/svelte.config.js
+++ b/packages/kit/test/apps/basics/svelte.config.js
@@ -38,7 +38,6 @@ const config = {
 		},
 
 		csrf: {
-			checkOrigin: true,
 			trustedOrigins: ['https://trusted.example.com', 'https://payment-gateway.test']
 		},
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -395,7 +395,7 @@ declare module '@sveltejs/kit' {
 			 *
 			 * To allow people to make `POST`, `PUT`, `PATCH`, or `DELETE` requests with a `Content-Type` of `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain` to your app from other origins, you will need to disable this option. Be careful!
 			 * @default true
-			 * @deprecated Use `trustedOrigins: ['*']` instead
+			 * @deprecated removed in 3.0. Use `trustedOrigins: ['*']` instead
 			 */
 			checkOrigin?: boolean;
 			/**


### PR DESCRIPTION
Left it in the types so that it shows up in the reference docs for users who are still on SvelteKit 2