### PR TITLE
chore: deprecate `Response` helpers

### DIFF
--- a/.changeset/shiny-feet-crash.md
+++ b/.changeset/shiny-feet-crash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+chore: deprecate `Response` helpers in favor of platform-provided alternatives

--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -134,6 +134,7 @@ export function isRedirect(e) {
  * Create a JSON `Response` object from the supplied data.
  * @param {any} data The value that will be serialized as JSON.
  * @param {ResponseInit} [init] Options such as `status` and `headers` that will be added to the response. `Content-Type: application/json` and `Content-Length` headers will be added automatically.
+ * @deprecated use `Response.json`
  */
 export function json(data, init) {
 	// TODO deprecate this in favour of `Response.json` when it's
@@ -162,6 +163,7 @@ export function json(data, init) {
  * Create a `Response` object from the supplied body.
  * @param {string} body The value that will be used as-is.
  * @param {ResponseInit} [init] Options such as `status` and `headers` that will be added to the response. A `Content-Length` header will be added automatically.
+ * @deprecated use `new Response`
  */
 export function text(body, init) {
 	const headers = new Headers(init?.headers);

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2700,12 +2700,14 @@ declare module '@sveltejs/kit' {
 	 * Create a JSON `Response` object from the supplied data.
 	 * @param data The value that will be serialized as JSON.
 	 * @param init Options such as `status` and `headers` that will be added to the response. `Content-Type: application/json` and `Content-Length` headers will be added automatically.
+	 * @deprecated use `Response.json`
 	 */
 	export function json(data: any, init?: ResponseInit): Response;
 	/**
 	 * Create a `Response` object from the supplied body.
 	 * @param body The value that will be used as-is.
 	 * @param init Options such as `status` and `headers` that will be added to the response. A `Content-Length` header will be added automatically.
+	 * @deprecated use `new Response`
 	 */
 	export function text(body: string, init?: ResponseInit): Response;
 	/**


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/12708