### PR TITLE
chore: fix symlink test always being skipped

### DIFF
--- a/packages/kit/src/core/sync/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.spec.js
@@ -111,7 +111,7 @@ test('creates routes', () => {
 });
 
 const symlink_survived_git = fs
-	.statSync(path.join(cwd, 'samples/symlinks/routes/foo'))
+	.lstatSync(path.join(cwd, 'samples/symlinks/routes/foo'))
 	.isSymbolicLink();
 
 const test_symlinks = symlink_survived_git ? test : test.skip;
@@ -122,21 +122,21 @@ test_symlinks('creates symlinked routes', () => {
 	expect(nodes.map(simplify_node)).toEqual([
 		default_layout,
 		default_error,
-		{ component: 'samples/symlinks/routes/foo/index.svelte' },
-		{ component: 'samples/symlinks/routes/index.svelte' }
+		{ component: 'samples/symlinks/routes/+page.svelte' },
+		{ component: 'samples/symlinks/routes/foo/+page.svelte' }
 	]);
 
-	expect(routes).toEqual([
+	expect(routes.map(simplify_route)).toEqual([
 		{
 			id: '/',
 			pattern: '/^/$/',
-			page: { layouts: [0], errors: [1], leaf: 1 }
+			page: { layouts: [0], errors: [1], leaf: 2 }
 		},
 
 		{
 			id: '/foo',
 			pattern: '/^/foo/?$/',
-			page: { layouts: [0], errors: [1], leaf: 2 }
+			page: { layouts: [0], errors: [1], leaf: 3 }
 		}
 	]);
 });


### PR DESCRIPTION
This PR fixes the symlink test so that it actually runs. It also updates it since the test result has been outdated for a long time (I'm not sure if the test ever worked...).

Apparently, `isSymbolicLink` only works if you first check the file with `lstatSync` and not `statSync`

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
