### PR TITLE
chore: fix navigation type duplicated descriptions

### DIFF
--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1236,7 +1236,7 @@ export interface NavigationBase {
 	 */
 	to: NavigationTarget | null;
 	/**
-	 * Whether or not the navigation will result in the page being unloaded (i.e. not a client-side navigation)
+	 * Whether or not the navigation will result in the page being unloaded (i.e. not a client-side navigation).
 	 */
 	willUnload: boolean;
 	/**
@@ -1249,11 +1249,7 @@ export interface NavigationBase {
 export interface NavigationEnter extends NavigationBase {
 	/**
 	 * The type of navigation:
-	 * - `form`: The user submitted a `<form method="GET">`
-	 * - `leave`: The app is being left either because the tab is being closed or a navigation to a different document is occurring
-	 * - `link`: Navigation was triggered by a link click
-	 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
-	 * - `popstate`: Navigation was triggered by back/forward navigation
+	 * - `enter`: The app has hydrated/started
 	 */
 	type: 'enter';
 
@@ -1268,16 +1264,29 @@ export interface NavigationEnter extends NavigationBase {
 	event?: undefined;
 }
 
-export interface NavigationExternal extends NavigationBase {
+export type NavigationExternal = NavigationGoto | NavigationLeave;
+
+export interface NavigationGoto extends NavigationBase {
 	/**
 	 * The type of navigation:
-	 * - `form`: The user submitted a `<form method="GET">`
-	 * - `leave`: The app is being left either because the tab is being closed or a navigation to a different document is occurring
-	 * - `link`: Navigation was triggered by a link click
 	 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
-	 * - `popstate`: Navigation was triggered by back/forward navigation
 	 */
-	type: Exclude<NavigationType, 'enter' | 'popstate' | 'link' | 'form'>;
+	type: 'goto';
+
+	// TODO 3.0 remove this property, so that it only exists when type is 'popstate'
+	// (would possibly be a breaking change to do it prior to that)
+	/**
+	 * In case of a history back/forward navigation, the number of steps to go back/forward
+	 */
+	delta?: undefined;
+}
+
+export interface NavigationLeave extends NavigationBase {
+	/**
+	 * The type of navigation:
+	 * - `leave`: The app is being left either because the tab is being closed or a navigation to a different document is occurring
+	 */
+	type: 'leave';
 
 	// TODO 3.0 remove this property, so that it only exists when type is 'popstate'
 	// (would possibly be a breaking change to do it prior to that)
@@ -1291,10 +1300,6 @@ export interface NavigationFormSubmit extends NavigationBase {
 	/**
 	 * The type of navigation:
 	 * - `form`: The user submitted a `<form method="GET">`
-	 * - `leave`: The app is being left either because the tab is being closed or a navigation to a different document is occurring
-	 * - `link`: Navigation was triggered by a link click
-	 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
-	 * - `popstate`: Navigation was triggered by back/forward navigation
 	 */
 	type: 'form';
 
@@ -1314,10 +1319,6 @@ export interface NavigationFormSubmit extends NavigationBase {
 export interface NavigationPopState extends NavigationBase {
 	/**
 	 * The type of navigation:
-	 * - `form`: The user submitted a `<form method="GET">`
-	 * - `leave`: The app is being left either because the tab is being closed or a navigation to a different document is occurring
-	 * - `link`: Navigation was triggered by a link click
-	 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
 	 * - `popstate`: Navigation was triggered by back/forward navigation
 	 */
 	type: 'popstate';
@@ -1336,11 +1337,7 @@ export interface NavigationPopState extends NavigationBase {
 export interface NavigationLink extends NavigationBase {
 	/**
 	 * The type of navigation:
-	 * - `form`: The user submitted a `<form method="GET">`
-	 * - `leave`: The app is being left either because the tab is being closed or a navigation to a different document is occurring
 	 * - `link`: Navigation was triggered by a link click
-	 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
-	 * - `popstate`: Navigation was triggered by back/forward navigation
 	 */
 	type: 'link';
 
@@ -1377,13 +1374,6 @@ export type BeforeNavigate = Navigation & {
  * The argument passed to [`onNavigate`](https://svelte.dev/docs/kit/$app-navigation#onNavigate) callbacks.
  */
 export type OnNavigate = Navigation & {
-	/**
-	 * The type of navigation:
-	 * - `form`: The user submitted a `<form method="GET">`
-	 * - `link`: Navigation was triggered by a link click
-	 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
-	 * - `popstate`: Navigation was triggered by back/forward navigation
-	 */
 	type: Exclude<NavigationType, 'enter' | 'leave'>;
 	/**
 	 * Since `onNavigate` callbacks are called immediately before a client-side navigation, they will never be called with a navigation that unloads the page.
@@ -1395,14 +1385,6 @@ export type OnNavigate = Navigation & {
  * The argument passed to [`afterNavigate`](https://svelte.dev/docs/kit/$app-navigation#afterNavigate) callbacks.
  */
 export type AfterNavigate = (Navigation | NavigationEnter) & {
-	/**
-	 * The type of navigation:
-	 * - `enter`: The app has hydrated/started
-	 * - `form`: The user submitted a `<form method="GET">`
-	 * - `link`: Navigation was triggered by a link click
-	 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
-	 * - `popstate`: Navigation was triggered by back/forward navigation
-	 */
 	type: Exclude<NavigationType, 'leave'>;
 	/**
 	 * Since `afterNavigate` callbacks are called after a navigation completes, they will never be called with a navigation that unloads the page.

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1210,7 +1210,7 @@ declare module '@sveltejs/kit' {
 		 */
 		to: NavigationTarget | null;
 		/**
-		 * Whether or not the navigation will result in the page being unloaded (i.e. not a client-side navigation)
+		 * Whether or not the navigation will result in the page being unloaded (i.e. not a client-side navigation).
 		 */
 		willUnload: boolean;
 		/**
@@ -1223,11 +1223,7 @@ declare module '@sveltejs/kit' {
 	export interface NavigationEnter extends NavigationBase {
 		/**
 		 * The type of navigation:
-		 * - `form`: The user submitted a `<form method="GET">`
-		 * - `leave`: The app is being left either because the tab is being closed or a navigation to a different document is occurring
-		 * - `link`: Navigation was triggered by a link click
-		 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
-		 * - `popstate`: Navigation was triggered by back/forward navigation
+		 * - `enter`: The app has hydrated/started
 		 */
 		type: 'enter';
 
@@ -1242,16 +1238,29 @@ declare module '@sveltejs/kit' {
 		event?: undefined;
 	}
 
-	export interface NavigationExternal extends NavigationBase {
+	export type NavigationExternal = NavigationGoto | NavigationLeave;
+
+	export interface NavigationGoto extends NavigationBase {
 		/**
 		 * The type of navigation:
-		 * - `form`: The user submitted a `<form method="GET">`
-		 * - `leave`: The app is being left either because the tab is being closed or a navigation to a different document is occurring
-		 * - `link`: Navigation was triggered by a link click
 		 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
-		 * - `popstate`: Navigation was triggered by back/forward navigation
 		 */
-		type: Exclude<NavigationType, 'enter' | 'popstate' | 'link' | 'form'>;
+		type: 'goto';
+
+		// TODO 3.0 remove this property, so that it only exists when type is 'popstate'
+		// (would possibly be a breaking change to do it prior to that)
+		/**
+		 * In case of a history back/forward navigation, the number of steps to go back/forward
+		 */
+		delta?: undefined;
+	}
+
+	export interface NavigationLeave extends NavigationBase {
+		/**
+		 * The type of navigation:
+		 * - `leave`: The app is being left either because the tab is being closed or a navigation to a different document is occurring
+		 */
+		type: 'leave';
 
 		// TODO 3.0 remove this property, so that it only exists when type is 'popstate'
 		// (would possibly be a breaking change to do it prior to that)
@@ -1265,10 +1274,6 @@ declare module '@sveltejs/kit' {
 		/**
 		 * The type of navigation:
 		 * - `form`: The user submitted a `<form method="GET">`
-		 * - `leave`: The app is being left either because the tab is being closed or a navigation to a different document is occurring
-		 * - `link`: Navigation was triggered by a link click
-		 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
-		 * - `popstate`: Navigation was triggered by back/forward navigation
 		 */
 		type: 'form';
 
@@ -1288,10 +1293,6 @@ declare module '@sveltejs/kit' {
 	export interface NavigationPopState extends NavigationBase {
 		/**
 		 * The type of navigation:
-		 * - `form`: The user submitted a `<form method="GET">`
-		 * - `leave`: The app is being left either because the tab is being closed or a navigation to a different document is occurring
-		 * - `link`: Navigation was triggered by a link click
-		 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
 		 * - `popstate`: Navigation was triggered by back/forward navigation
 		 */
 		type: 'popstate';
@@ -1310,11 +1311,7 @@ declare module '@sveltejs/kit' {
 	export interface NavigationLink extends NavigationBase {
 		/**
 		 * The type of navigation:
-		 * - `form`: The user submitted a `<form method="GET">`
-		 * - `leave`: The app is being left either because the tab is being closed or a navigation to a different document is occurring
 		 * - `link`: Navigation was triggered by a link click
-		 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
-		 * - `popstate`: Navigation was triggered by back/forward navigation
 		 */
 		type: 'link';
 
@@ -1351,13 +1348,6 @@ declare module '@sveltejs/kit' {
 	 * The argument passed to [`onNavigate`](https://svelte.dev/docs/kit/$app-navigation#onNavigate) callbacks.
 	 */
 	export type OnNavigate = Navigation & {
-		/**
-		 * The type of navigation:
-		 * - `form`: The user submitted a `<form method="GET">`
-		 * - `link`: Navigation was triggered by a link click
-		 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
-		 * - `popstate`: Navigation was triggered by back/forward navigation
-		 */
 		type: Exclude<NavigationType, 'enter' | 'leave'>;
 		/**
 		 * Since `onNavigate` callbacks are called immediately before a client-side navigation, they will never be called with a navigation that unloads the page.
@@ -1369,14 +1359,6 @@ declare module '@sveltejs/kit' {
 	 * The argument passed to [`afterNavigate`](https://svelte.dev/docs/kit/$app-navigation#afterNavigate) callbacks.
 	 */
 	export type AfterNavigate = (Navigation | NavigationEnter) & {
-		/**
-		 * The type of navigation:
-		 * - `enter`: The app has hydrated/started
-		 * - `form`: The user submitted a `<form method="GET">`
-		 * - `link`: Navigation was triggered by a link click
-		 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
-		 * - `popstate`: Navigation was triggered by back/forward navigation
-		 */
 		type: Exclude<NavigationType, 'leave'>;
 		/**
 		 * Since `afterNavigate` callbacks are called after a navigation completes, they will never be called with a navigation that unloads the page.


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/15470

This PR ensures that the type descriptions for the various navigation types show up correctly in the IDE when hovering over the type. This results in _slightly_ worse docs when viewing the `OnNavigate` and `AfterNavigate` sections but the trade-off is worth it. We get the correct descriptions after type-narrowing too.

The thing about TypeScript and unions is that it tries to merge the description for similar properties. If you have something like:
```ts
type A = {
  /** foo */
  example: 'foo';
}

type B = {
  /** bar */
  example: 'bar';
}

type C = A | B;
```

The description for `C['example']` would be "foo bar".

However, if you have some overlap, TypeScript merges your descriptions as best as it can:

```ts
type A = {
  /**
  * This contains:
  * - foo
  */
  example: 'foo';
}

type B = {
  /**
  * This contains:
  * - bar
  */
  example: 'bar';
}

type C = A | B;
```

You'll end up with:
```
This contains:
- foo
- bar
```
which works nicely for us in our case.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Not sure if this needs a changeset since the user isn't really affected... Maybe it does? Might even be a breaking change? The types should still be equivalent though.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
