### PR TITLE
fix: normalize path separators before path.relative in Vite plugin on Windows

### DIFF
--- a/.changeset/fix-windows-path-separators.md
+++ b/.changeset/fix-windows-path-separators.md
@@ -3,10 +3,3 @@
 ---
 
 fix: normalize path separators before `path.relative` in Vite plugin on Windows
-
-On Windows, `kit.files.routes` uses native backslashes (from `path.resolve`) while
-internal kit asset paths may use forward slashes, causing `path.relative` to return
-an incorrect result. This produced invalid Rollup entry keys like
-`entries/pages/D_/path/to/project/...` and an `Invalid substitution for placeholder
-"[name]"` error during build. Wrapping both arguments with `path.normalize` ensures
-consistent separators on all platforms.

--- a/.changeset/fix-windows-path-separators.md
+++ b/.changeset/fix-windows-path-separators.md
@@ -1,0 +1,12 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: normalize path separators before `path.relative` in Vite plugin on Windows
+
+On Windows, `kit.files.routes` uses native backslashes (from `path.resolve`) while
+internal kit asset paths may use forward slashes, causing `path.relative` to return
+an incorrect result. This produced invalid Rollup entry keys like
+`entries/pages/D_/path/to/project/...` and an `Invalid substitution for placeholder
+"[name]"` error during build. Wrapping both arguments with `path.normalize` ensures
+consistent separators on all platforms.

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -19,6 +19,7 @@ import { preview } from './preview/index.js';
 import {
 	error_for_missing_config,
 	get_config_aliases,
+	get_entry_name,
 	get_env,
 	normalize_id,
 	stackless
@@ -835,12 +836,8 @@ async function kit({ svelte_config }) {
 					// add entry points for every endpoint...
 					manifest_data.routes.forEach((route) => {
 						if (route.endpoint) {
-							const resolved = path.resolve(route.endpoint.file);
-							const relative = decodeURIComponent(
-								path.relative(path.normalize(kit.files.routes), path.normalize(resolved))
-							);
-							const name = posixify(path.join('entries/endpoints', relative.replace(/\.js$/, '')));
-							input[name] = resolved;
+							const name = get_entry_name(kit.files.routes, route.endpoint.file, 'endpoint');
+							input[name] = path.resolve(route.endpoint.file);
 						}
 					});
 
@@ -848,14 +845,8 @@ async function kit({ svelte_config }) {
 					manifest_data.nodes.forEach((node) => {
 						for (const file of [node.component, node.universal, node.server]) {
 							if (file) {
-								const resolved = path.resolve(file);
-								const relative = decodeURIComponent(
-									path.relative(path.normalize(kit.files.routes), path.normalize(resolved))
-								);
-								const name = relative.startsWith('..')
-									? posixify(path.join('entries/fallbacks', path.basename(file)))
-									: posixify(path.join('entries/pages', relative.replace(/\.js$/, '')));
-								input[name] = resolved;
+								const name = get_entry_name(kit.files.routes, file, 'page');
+								input[name] = path.resolve(file);
 							}
 						}
 					});

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -836,7 +836,9 @@ async function kit({ svelte_config }) {
 					manifest_data.routes.forEach((route) => {
 						if (route.endpoint) {
 							const resolved = path.resolve(route.endpoint.file);
-							const relative = decodeURIComponent(path.relative(kit.files.routes, resolved));
+							const relative = decodeURIComponent(
+								path.relative(path.normalize(kit.files.routes), path.normalize(resolved))
+							);
 							const name = posixify(path.join('entries/endpoints', relative.replace(/\.js$/, '')));
 							input[name] = resolved;
 						}
@@ -847,8 +849,9 @@ async function kit({ svelte_config }) {
 						for (const file of [node.component, node.universal, node.server]) {
 							if (file) {
 								const resolved = path.resolve(file);
-								const relative = decodeURIComponent(path.relative(kit.files.routes, resolved));
-
+								const relative = decodeURIComponent(
+									path.relative(path.normalize(kit.files.routes), path.normalize(resolved))
+								);
 								const name = relative.startsWith('..')
 									? posixify(path.join('entries/fallbacks', path.basename(file)))
 									: posixify(path.join('entries/pages', relative.replace(/\.js$/, '')));

--- a/packages/kit/src/exports/vite/utils.js
+++ b/packages/kit/src/exports/vite/utils.js
@@ -161,6 +161,35 @@ export function normalize_id(id, lib, cwd) {
 }
 
 /**
+ * Compute the Rollup entry name for a route component or endpoint file.
+ *
+ * On Windows, `path.resolve` may return a path with forward slashes when the
+ * input already contained a drive-letter with a forward slash (e.g. from a
+ * posix-style kit-internal path). `kit.files.routes` uses native backslashes.
+ * Calling `path.normalize` on both arguments before `path.relative` ensures
+ * consistent separators so the `..` sentinel is detected correctly.
+ *
+ * @param {string} routes_dir - `kit.files.routes` (absolute, native separators)
+ * @param {string} file - the source file (may be posix-style on Windows)
+ * @param {'endpoint' | 'page'} kind
+ * @returns {string} entry name suitable for use as a Rollup input key
+ */
+export function get_entry_name(routes_dir, file, kind) {
+	const resolved = path.resolve(file);
+	const relative = decodeURIComponent(
+		path.relative(path.normalize(routes_dir), path.normalize(resolved))
+	);
+
+	if (kind === 'endpoint') {
+		return posixify(path.join('entries/endpoints', relative.replace(/\.js$/, '')));
+	}
+
+	return relative.startsWith('..')
+		? posixify(path.join('entries/fallbacks', path.basename(file)))
+		: posixify(path.join('entries/pages', relative.replace(/\.js$/, '')));
+}
+
+/**
  * For times when you need to throw an error, but without
  * displaying a useless stack trace (since the developer
  * can't do anything useful with it)

--- a/packages/kit/src/exports/vite/utils.spec.js
+++ b/packages/kit/src/exports/vite/utils.spec.js
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest';
 import { validate_config } from '../../core/config/index.js';
 import { posixify } from '../../utils/filesystem.js';
 import { dedent } from '../../core/sync/utils.js';
-import { get_config_aliases, error_for_missing_config } from './utils.js';
+import { get_config_aliases, get_entry_name, error_for_missing_config } from './utils.js';
 
 test('transform kit.alias to resolve.alias', () => {
 	const config = validate_config({
@@ -114,5 +114,38 @@ test('error_for_missing_config - handles special characters in feature name', ()
 			  special: { enabled: true }
 			}
 		`
+	);
+});
+
+// get_entry_name: simulate Windows mixed-separator scenario.
+// On Windows, kit.files.routes uses native backslashes while kit-internal
+// files may be resolved with forward slashes, causing path.relative to
+// return a wrong result and the '..' guard to never fire.
+test('get_entry_name - file inside routes produces entries/pages name', () => {
+	const routes = path.resolve('src/routes');
+	const file = path.join(routes, '+page.svelte');
+	expect(get_entry_name(routes, file, 'page')).toBe('entries/pages/+page.svelte');
+});
+
+test('get_entry_name - file inside routes strips .js extension', () => {
+	const routes = path.resolve('src/routes');
+	const file = path.join(routes, 'about/+page.server.js');
+	expect(get_entry_name(routes, file, 'page')).toBe('entries/pages/about/+page.server');
+});
+
+test('get_entry_name - endpoint file inside routes produces entries/endpoints name', () => {
+	const routes = path.resolve('src/routes');
+	const file = path.join(routes, 'api/+server.js');
+	expect(get_entry_name(routes, file, 'endpoint')).toBe('entries/endpoints/api/+server');
+});
+
+test('get_entry_name - file outside routes (e.g. kit internal) produces entries/fallbacks name', () => {
+	const routes = path.resolve('src/routes');
+	// Simulate a kit-internal file whose path uses forward slashes on Windows
+	// (e.g. from runtime_directory which stores posix-style paths)
+	const internal = path.resolve('node_modules/@sveltejs/kit/src/runtime/components/error.svelte');
+	const forwardSlashInternal = internal.split(path.sep).join('/');
+	expect(get_entry_name(routes, forwardSlashInternal, 'page')).toBe(
+		'entries/fallbacks/error.svelte'
 	);
 });


### PR DESCRIPTION
## Problem

On Windows, `bun run build` (and `npm run build`) fails with:

```Invalid substitution ./entries/pages/D_/path/to/project/node_modules/@sveltejs/kit/src/runtime/components/svelte-5/error.svelte for placeholder [name] in output.entryFileNames pattern, can be neither absolute nor relative path.```n
## Root cause

In `src/exports/vite/index.js`, two `path.relative` calls receive mixed separators on Windows: `kit.files.routes` uses backslashes (from `path.resolve`) while kit-internal asset paths use forward slashes. `path.relative` cannot determine the relationship, returns a wrong result, the `..` guard never fires, and Rollup gets an invalid entry key like `entries/pages/D_/...`.