### PR TITLE
chore: fix serialize_data comment typo

### DIFF
--- a/packages/kit/src/runtime/server/page/serialize_data.js
+++ b/packages/kit/src/runtime/server/page/serialize_data.js
@@ -6,7 +6,7 @@ import { hash } from '../../../utils/hash.js';
  *
  * The first closes the script element, so everything after is treated as raw HTML.
  * The second disables further parsing until `-->`, so the script element might be unexpectedly
- * kept open until an unrelated HTML comment in the page.
+ * kept open up until an unrelated HTML comment in the page.
  *
  * U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR are escaped for the sake of pre-2018
  * browsers.


### PR DESCRIPTION
Related issue: none. This is a small comment-only fix.

- Removes a duplicated `until` in `packages/kit/src/runtime/server/page/serialize_data.js`.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.

### Validation
- `git diff --check`
- No tests added; comment-only change.
