### PR TITLE
chore: rename some internals

### DIFF
--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -163,12 +163,12 @@ async function analyse({
 		const exports = new Map();
 
 		for (const name in functions) {
-			const info = /** @type {import('types').RemoteInfo} */ (functions[name].__);
-			const type = info.type;
+			const internals = /** @type {import('types').RemoteInternals} */ (functions[name].__);
+			const type = internals.type;
 
 			exports.set(name, {
 				type,
-				dynamic: type !== 'prerender' || info.dynamic
+				dynamic: type !== 'prerender' || internals.dynamic
 			});
 		}
 

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -496,7 +496,7 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env }) {
 	internal.set_manifest(manifest);
 	internal.set_read_implementation((file) => createReadableStream(`${out}/server/${file}`));
 
-	/** @type {Array<import('types').RemoteInfo & { type: 'prerender'}>} */
+	/** @type {Array<import('types').RemotePrerenderInternals>} */
 	const prerender_functions = [];
 
 	for (const loader of Object.values(manifest._.remotes)) {
@@ -549,13 +549,16 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env }) {
 	}
 
 	const transport = (await internal.get_hooks()).transport ?? {};
-	for (const info of prerender_functions) {
-		if (info.has_arg) {
-			for (const arg of (await info.inputs?.()) ?? []) {
-				void enqueue(null, remote_prefix + info.id + '/' + stringify_remote_arg(arg, transport));
+	for (const internals of prerender_functions) {
+		if (internals.has_arg) {
+			for (const arg of (await internals.inputs?.()) ?? []) {
+				void enqueue(
+					null,
+					remote_prefix + internals.id + '/' + stringify_remote_arg(arg, transport)
+				);
 			}
 		} else {
-			void enqueue(null, remote_prefix + info.id);
+			void enqueue(null, remote_prefix + internals.id);
 		}
 	}
 

--- a/packages/kit/src/exports/internal/remote-functions.js
+++ b/packages/kit/src/exports/internal/remote-functions.js
@@ -1,6 +1,6 @@
-/** @import { RemoteInfo } from 'types' */
+/** @import { RemoteInternals } from 'types' */
 
-/** @type {RemoteInfo['type'][]} */
+/** @type {RemoteInternals['type'][]} */
 const types = ['command', 'form', 'prerender', 'query', 'query_batch'];
 
 /**

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -759,7 +759,7 @@ async function kit({ svelte_config }) {
 
 			// For the client, read the exports and create a new module that only contains fetch functions with the correct metadata
 
-			/** @type {Map<string, import('types').RemoteInfo['type']>} */
+			/** @type {Map<string, import('types').RemoteInternals['type']>} */
 			const map = new Map();
 
 			// in dev, load the server module here (which will result in this hook

--- a/packages/kit/src/runtime/app/server/remote/command.js
+++ b/packages/kit/src/runtime/app/server/remote/command.js
@@ -1,5 +1,5 @@
 /** @import { RemoteCommand } from '@sveltejs/kit' */
-/** @import { RemoteInfo, MaybePromise } from 'types' */
+/** @import { MaybePromise, RemoteCommandInternals } from 'types' */
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 import { get_request_store } from '@sveltejs/kit/internal/server';
 import { create_validator, run_remote_function } from './shared.js';
@@ -58,10 +58,10 @@ export function command(validate_or_fn, maybe_fn) {
 	/** @type {(arg?: any) => MaybePromise<Input>} */
 	const validate = create_validator(validate_or_fn, maybe_fn);
 
-	/** @type {RemoteInfo} */
+	/** @type {RemoteCommandInternals} */
 	const __ = { type: 'command', id: '', name: '' };
 
-	/** @type {RemoteCommand<Input, Output> & { __: RemoteInfo }} */
+	/** @type {RemoteCommand<Input, Output> & { __: RemoteCommandInternals }} */
 	const wrapper = (arg) => {
 		const { event, state } = get_request_store();
 

--- a/packages/kit/src/runtime/app/server/remote/form.js
+++ b/packages/kit/src/runtime/app/server/remote/form.js
@@ -1,5 +1,5 @@
 /** @import { RemoteFormInput, RemoteForm, InvalidField } from '@sveltejs/kit' */
-/** @import { InternalRemoteFormIssue, MaybePromise, RemoteInfo } from 'types' */
+/** @import { InternalRemoteFormIssue, MaybePromise, RemoteFormInternals } from 'types' */
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 import { get_request_store } from '@sveltejs/kit/internal/server';
 import { DEV } from 'esm-env';
@@ -84,7 +84,7 @@ export function form(validate_or_fn, maybe_fn) {
 			}
 		});
 
-		/** @type {RemoteInfo} */
+		/** @type {RemoteFormInternals} */
 		const __ = {
 			type: 'form',
 			name: '',

--- a/packages/kit/src/runtime/app/server/remote/prerender.js
+++ b/packages/kit/src/runtime/app/server/remote/prerender.js
@@ -1,5 +1,5 @@
 /** @import { RemoteResource, RemotePrerenderFunction } from '@sveltejs/kit' */
-/** @import { RemotePrerenderInputsGenerator, RemoteInfo, MaybePromise } from 'types' */
+/** @import { RemotePrerenderInputsGenerator, RemotePrerenderInternals, MaybePromise } from 'types' */
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 import { error, json } from '@sveltejs/kit';
 import { DEV } from 'esm-env';
@@ -76,7 +76,7 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 	/** @type {(arg?: any) => MaybePromise<Input>} */
 	const validate = create_validator(validate_or_fn, maybe_fn);
 
-	/** @type {RemoteInfo} */
+	/** @type {RemotePrerenderInternals} */
 	const __ = {
 		type: 'prerender',
 		id: '',
@@ -86,7 +86,7 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 		dynamic: options?.dynamic
 	};
 
-	/** @type {RemotePrerenderFunction<Input, Output> & { __: RemoteInfo }} */
+	/** @type {RemotePrerenderFunction<Input, Output> & { __: RemotePrerenderInternals }} */
 	const wrapper = (arg) => {
 		/** @type {Promise<Output> & Partial<RemoteResource<Output>>} */
 		const promise = (async () => {

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -1,5 +1,5 @@
 /** @import { RemoteQuery, RemoteQueryFunction } from '@sveltejs/kit' */
-/** @import { RemoteInfo, MaybePromise, RequestState } from 'types' */
+/** @import { RemoteInternals, MaybePromise, RequestState, RemoteQueryBatchInternals, RemoteQueryInternals } from 'types' */
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 import { get_request_store } from '@sveltejs/kit/internal/server';
 import { create_remote_key, stringify, stringify_remote_arg } from '../../../shared.js';
@@ -61,10 +61,10 @@ export function query(validate_or_fn, maybe_fn) {
 	/** @type {(arg?: any) => MaybePromise<Input>} */
 	const validate = create_validator(validate_or_fn, maybe_fn);
 
-	/** @type {RemoteInfo} */
+	/** @type {RemoteQueryInternals} */
 	const __ = { type: 'query', id: '', name: '' };
 
-	/** @type {RemoteQueryFunction<Input, Output> & { __: RemoteInfo }} */
+	/** @type {RemoteQueryFunction<Input, Output> & { __: RemoteQueryInternals }} */
 	const wrapper = (arg) => {
 		if (prerendering) {
 			throw new Error(
@@ -126,7 +126,7 @@ function batch(validate_or_fn, maybe_fn) {
 	/** @type {(arg?: any) => MaybePromise<Input>} */
 	const validate = create_validator(validate_or_fn, maybe_fn);
 
-	/** @type {RemoteInfo & { type: 'query_batch' }} */
+	/** @type {RemoteQueryBatchInternals} */
 	const __ = {
 		type: 'query_batch',
 		id: '',
@@ -167,7 +167,7 @@ function batch(validate_or_fn, maybe_fn) {
 	/** @type {Map<string, { arg: any, resolvers: Array<{resolve: (value: any) => void, reject: (error: any) => void}> }>} */
 	let batching = new Map();
 
-	/** @type {RemoteQueryFunction<Input, Output> & { __: RemoteInfo }} */
+	/** @type {RemoteQueryFunction<Input, Output> & { __: RemoteQueryBatchInternals }} */
 	const wrapper = (arg) => {
 		if (prerendering) {
 			throw new Error(
@@ -244,7 +244,7 @@ function batch(validate_or_fn, maybe_fn) {
 }
 
 /**
- * @param {RemoteInfo} __
+ * @param {RemoteInternals} __
  * @param {any} arg
  * @param {RequestState} state
  * @param {() => Promise<any>} fn
@@ -309,10 +309,10 @@ function create_query_resource(__, arg, state, fn) {
 Object.defineProperty(query, 'batch', { value: batch, enumerable: true });
 
 /**
- * @param {RemoteInfo} __
+ * @param {RemoteInternals} __
  * @param {'set' | 'refresh'} action
  * @param {any} [arg]
- * @returns {{ __: RemoteInfo; state: any; refreshes: Record<string, Promise<any>>; cache: Record<string, { serialize: boolean; data: any }>; refreshes_key: string; cache_key: string }}
+ * @returns {{ __: RemoteInternals; state: any; refreshes: Record<string, Promise<any>>; cache: Record<string, { serialize: boolean; data: any }>; refreshes_key: string; cache_key: string }}
  */
 function get_refresh_context(__, action, arg) {
 	const { state } = get_request_store();
@@ -333,7 +333,7 @@ function get_refresh_context(__, action, arg) {
 }
 
 /**
- * @param {{ __: RemoteInfo; refreshes: Record<string, Promise<any>>; cache: Record<string, { serialize: boolean; data: any }>; refreshes_key: string; cache_key: string }} context
+ * @param {{ __: RemoteInternals; refreshes: Record<string, Promise<any>>; cache: Record<string, { serialize: boolean; data: any }>; refreshes_key: string; cache_key: string }} context
  * @param {any} value
  * @param {boolean} [is_immediate_refresh=false]
  * @returns {Promise<void>}

--- a/packages/kit/src/runtime/app/server/remote/shared.js
+++ b/packages/kit/src/runtime/app/server/remote/shared.js
@@ -1,5 +1,5 @@
 /** @import { RequestEvent } from '@sveltejs/kit' */
-/** @import { ServerHooks, MaybePromise, RequestState, RemoteInfo, RequestStore } from 'types' */
+/** @import { ServerHooks, MaybePromise, RequestState, RemoteInternals, RequestStore } from 'types' */
 import { parse } from 'devalue';
 import { error } from '@sveltejs/kit';
 import { with_request_store, get_request_store } from '@sveltejs/kit/internal/server';
@@ -66,18 +66,18 @@ export function create_validator(validate_or_fn, maybe_fn) {
  * Also saves an uneval'ed version of the result for later HTML inlining for hydration.
  *
  * @template {MaybePromise<any>} T
- * @param {RemoteInfo} info
+ * @param {RemoteInternals} internals
  * @param {any} arg
  * @param {RequestState} state
  * @param {() => Promise<T>} get_result
  * @returns {Promise<T>}
  */
-export async function get_response(info, arg, state, get_result) {
+export async function get_response(internals, arg, state, get_result) {
 	// wait a beat, in case `myQuery().set(...)` or `myQuery().refresh()` is immediately called
 	// eslint-disable-next-line @typescript-eslint/await-thenable
 	await 0;
 
-	const cache = get_cache(info, state);
+	const cache = get_cache(internals, state);
 	const key = stringify_remote_arg(arg, state.transport);
 	const entry = (cache[key] ??= {
 		serialize: false,
@@ -86,8 +86,8 @@ export async function get_response(info, arg, state, get_result) {
 
 	entry.serialize ||= !!state.is_in_universal_load;
 
-	if (state.is_in_render && info.id) {
-		const remote_key = create_remote_key(info.id, key);
+	if (state.is_in_render && internals.id) {
+		const remote_key = create_remote_key(internals.id, key);
 
 		Promise.resolve(entry.data)
 			.then((value) => {
@@ -168,15 +168,15 @@ export async function run_remote_function(event, state, allow_cookies, get_input
 }
 
 /**
- * @param {RemoteInfo} info
+ * @param {RemoteInternals} internals
  * @param {RequestState} state
  */
-export function get_cache(info, state = get_request_store().state) {
-	let cache = state.remote.data?.get(info);
+export function get_cache(internals, state = get_request_store().state) {
+	let cache = state.remote.data?.get(internals);
 
 	if (cache === undefined) {
 		cache = {};
-		(state.remote.data ??= new Map()).set(info, cache);
+		(state.remote.data ??= new Map()).set(internals, cache);
 	}
 
 	return cache;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -302,7 +302,7 @@ export let pending_invalidate;
 
 /**
  * @type {Map<string, RemoteQueryCacheEntry<any>>}
- * A map of id -> query info with all queries that currently exist in the app.
+ * A map of id -> query internals with all queries that currently exist in the app.
  */
 export const query_map = new Map();
 

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -515,19 +515,19 @@ export async function render_response({
 			/** @type {Record<string, any>} */
 			const prerender = {};
 
-			for (const [info, cache] of remote.data) {
+			for (const [internals, cache] of remote.data) {
 				// remote functions without an `id` aren't exported, and thus
 				// cannot be called from the client
-				if (!info.id) continue;
+				if (!internals.id) continue;
 
 				for (const key in cache) {
 					const entry = cache[key];
 
 					if (!entry.serialize) continue;
 
-					const remote_key = create_remote_key(info.id, key);
+					const remote_key = create_remote_key(internals.id, key);
 
-					const store = info.type === 'prerender' ? prerender : query;
+					const store = internals.type === 'prerender' ? prerender : query;
 
 					if (event_state.remote.refreshes?.[remote_key] !== undefined) {
 						// This entry was refreshed/set by a command or form action.

--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -1,5 +1,5 @@
 /** @import { ActionResult, RemoteForm, RequestEvent, SSRManifest } from '@sveltejs/kit' */
-/** @import { RemoteFunctionResponse, RemoteInfo, RequestState, SSROptions } from 'types' */
+/** @import { RemoteFormInternals, RemoteFunctionResponse, RemoteInternals, RequestState, SSROptions } from 'types' */
 
 import { json, error } from '@sveltejs/kit';
 import { HttpError, Redirect, SvelteKitError } from '@sveltejs/kit/internal';
@@ -48,20 +48,20 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 
 	if (!fn) error(404);
 
-	/** @type {RemoteInfo} */
-	const info = fn.__;
+	/** @type {RemoteInternals} */
+	const internals = fn.__;
 	const transport = options.hooks.transport;
 
 	event.tracing.current.setAttributes({
-		'sveltekit.remote.call.type': info.type,
-		'sveltekit.remote.call.name': info.name
+		'sveltekit.remote.call.type': internals.type,
+		'sveltekit.remote.call.name': internals.name
 	});
 
 	/** @type {string[] | undefined} */
 	let form_client_refreshes;
 
 	try {
-		if (info.type === 'query_batch') {
+		if (internals.type === 'query_batch') {
 			if (event.request.method !== 'POST') {
 				throw new SvelteKitError(
 					405,
@@ -77,7 +77,9 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 				payloads.map((payload) => parse_remote_arg(payload, transport))
 			);
 
-			const results = await with_request_store({ event, state }, () => info.run(args, options));
+			const results = await with_request_store({ event, state }, () =>
+				internals.run(args, options)
+			);
 
 			return json(
 				/** @type {RemoteFunctionResponse} */ ({
@@ -87,7 +89,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 			);
 		}
 
-		if (info.type === 'form') {
+		if (internals.type === 'form') {
 			if (event.request.method !== 'POST') {
 				throw new SvelteKitError(
 					405,
@@ -116,7 +118,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 				data.id = JSON.parse(decodeURIComponent(additional_args));
 			}
 
-			const fn = info.fn;
+			const fn = internals.fn;
 			const result = await with_request_store({ event, state }, () => fn(data, meta, form_data));
 
 			return json(
@@ -128,7 +130,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 			);
 		}
 
-		if (info.type === 'command') {
+		if (internals.type === 'command') {
 			/** @type {{ payload: string, refreshes: string[] }} */
 			const { payload, refreshes } = await event.request.json();
 			const arg = parse_remote_arg(payload, transport);
@@ -144,7 +146,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 		}
 
 		const payload =
-			info.type === 'prerender'
+			internals.type === 'prerender'
 				? additional_args
 				: /** @type {string} */ (
 						// new URL(...) necessary because we're hiding the URL from the user in the event object
@@ -282,7 +284,7 @@ async function handle_remote_form_post_internal(event, state, manifest, id) {
 	}
 
 	try {
-		const fn = /** @type {RemoteInfo & { type: 'form' }} */ (/** @type {any} */ (form).__).fn;
+		const fn = /** @type {RemoteFormInternals} */ (/** @type {any} */ (form).__).fn;
 
 		const { data, meta, form_data } = await deserialize_binary_form(event.request);
 

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -379,7 +379,7 @@ export interface ServerMetadata {
 	}>;
 	routes: Map<string, ServerMetadataRoute>;
 	/** For each hashed remote file, a map of export name -> { type, dynamic }, where `dynamic` is `false` for non-dynamic prerender functions */
-	remotes: Map<string, Map<string, { type: RemoteInfo['type']; dynamic: boolean }>>;
+	remotes: Map<string, Map<string, { type: RemoteInternals['type']; dynamic: boolean }>>;
 }
 
 export interface SSRComponent {
@@ -569,40 +569,52 @@ export type BinaryFormMeta = {
 	validate_only?: boolean;
 };
 
-export type RemoteInfo =
-	| {
-			type: 'query' | 'command';
-			id: string;
-			name: string;
-	  }
-	| {
-			/**
-			 * Corresponds to the name of the client-side exports (that's why we use underscores and not dots)
-			 */
-			type: 'query_batch';
-			id: string;
-			name: string;
-			/** Direct access to the function, for remote functions called from the client */
-			run: (args: any[], options: SSROptions) => Promise<any[]>;
-	  }
-	| {
-			type: 'form';
-			id: string;
-			name: string;
-			fn: (
-				body: Record<string, any>,
-				meta: BinaryFormMeta,
-				form_data: FormData | null
-			) => Promise<any>;
-	  }
-	| {
-			type: 'prerender';
-			id: string;
-			name: string;
-			has_arg: boolean;
-			dynamic?: boolean;
-			inputs?: RemotePrerenderInputsGenerator;
-	  };
+interface BaseRemoteInternals {
+	type: string;
+	id: string;
+	name: string;
+}
+
+export interface RemoteQueryInternals extends BaseRemoteInternals {
+	type: 'query';
+}
+export interface RemoteQueryLiveInternals extends BaseRemoteInternals {
+	type: 'query_live';
+	run(
+		event: RequestEvent,
+		state: RequestState,
+		arg: any
+	): Promise<{ iterator: AsyncIterator<any>; cancel: () => void }>;
+}
+
+export interface RemoteQueryBatchInternals extends BaseRemoteInternals {
+	type: 'query_batch';
+	run: (args: any[], options: SSROptions) => Promise<any[]>;
+}
+
+export interface RemoteCommandInternals extends BaseRemoteInternals {
+	type: 'command';
+}
+
+export interface RemoteFormInternals extends BaseRemoteInternals {
+	type: 'form';
+	fn(body: Record<string, any>, meta: BinaryFormMeta, form_data: FormData | null): Promise<any>;
+}
+
+export interface RemotePrerenderInternals extends BaseRemoteInternals {
+	type: 'prerender';
+	has_arg: boolean;
+	dynamic?: boolean;
+	inputs?: RemotePrerenderInputsGenerator;
+}
+
+export type RemoteInternals =
+	| RemoteQueryInternals
+	| RemoteQueryLiveInternals
+	| RemoteQueryBatchInternals
+	| RemoteCommandInternals
+	| RemoteFormInternals
+	| RemotePrerenderInternals;
 
 export interface InternalRemoteFormIssue extends RemoteFormIssue {
 	name: string;
@@ -628,7 +640,10 @@ export interface RequestState {
 		record_span: RecordSpan;
 	};
 	readonly remote: {
-		data: null | Map<RemoteInfo, Record<string, { serialize: boolean; data: MaybePromise<any> }>>;
+		data: null | Map<
+			RemoteInternals,
+			Record<string, { serialize: boolean; data: MaybePromise<any> }>
+		>;
 		forms: null | Map<any, any>;
 		refreshes: null | Record<string, Promise<any>>;
 	};


### PR DESCRIPTION
tightens up the types around remote functions (by separating out the different interfaces, so making type narrowing easier and more effective) and gives the internals a more sensible name