### PR TITLE
docs: link routing 404 behavior to dedicated docs

### DIFF
--- a/documentation/docs/20-core-concepts/10-routing.md
+++ b/documentation/docs/20-core-concepts/10-routing.md
@@ -164,7 +164,7 @@ SvelteKit will 'walk up the tree' looking for the closest error boundary — if 
 
 If the error occurs inside a `load` function in `+layout(.server).js`, the closest error boundary in the tree is an `+error.svelte` file _above_ that layout (not next to it).
 
-If no route can be found (404), `src/routes/+error.svelte` (or the default error page, if that file does not exist) will be used.
+If no route can be found (404), `src/routes/+error.svelte` (or the default error page, if that file does not exist) will be used. If you need different 404 pages for different unknown routes, see [404 pages](advanced-routing#404-pages).
 
 > [!NOTE] `+error.svelte` is _not_ used when an error occurs inside [`handle`](hooks#Server-hooks-handle) or a [+server.js](#server) request handler.
 


### PR DESCRIPTION
## Summary
- add a pointer from the `+error.svelte` routing docs to the dedicated custom 404 pages section
- make it easier to discover how to handle different unknown-route 404s

Closes #12569