### PR TITLE
docs: clarify where route params are available

### DIFF
--- a/documentation/docs/30-advanced/10-advanced-routing.md
+++ b/documentation/docs/30-advanced/10-advanced-routing.md
@@ -22,6 +22,8 @@ If the number of route segments is unknown, you can use rest syntax — for exam
 }
 ```
 
+In `load` functions, `+server.js` handlers, and hooks that receive a `RequestEvent`, you can read these values from `event.params`. As of SvelteKit 2.24, pages also receive them as a `params` prop; for a broader introduction, see [Routing](routing).
+
 > [!NOTE] `src/routes/a/[...rest]/z/+page.svelte` will match `/a/z` (i.e. there's no parameter at all) as well as `/a/b/z` and `/a/b/c/z` and so on. Make sure you check that the value of the rest parameter is valid, for example using a [matcher](#Matching).
 
 ### 404 pages


### PR DESCRIPTION
## Summary
- add a direct note in the advanced routing page about where route parameters are available
- point readers to `event.params` in request-event-based code and the `params` prop in pages

Closes #13730