### PR TITLE
fix: reduce pending count even if form with enhance was never submitted

### DIFF
--- a/.changeset/plain-laws-look.md
+++ b/.changeset/plain-laws-look.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: reduce pending count even if form with enhance was never submitted

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -157,16 +157,25 @@ export function form(id) {
 				}
 			}
 
+			let submitted_form = false;
+
 			try {
 				await callback({
 					form,
 					data,
-					submit: () => submit(form_data)
+					submit: () => {
+						submitted_form = true;
+						return submit(form_data);
+					}
 				});
 			} catch (e) {
 				const error = e instanceof HttpError ? e.body : { message: /** @type {any} */ (e).message };
 				const status = e instanceof HttpError ? e.status : 500;
 				void set_nearest_error_page(error, status);
+			} finally {
+				if (!submitted_form) {
+					pending_count--;
+				}
 			}
 		}
 

--- a/packages/kit/test/apps/async/src/routes/remote/form/skip-submit/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/skip-submit/+page.svelte
@@ -1,0 +1,27 @@
+<script>
+	import { set_message } from './form.remote.ts';
+
+	let should_submit = $state(false);
+
+	const pendings_arr = [];
+	const pendings = $derived.by(() => {
+		pendings_arr.push(set_message.pending);
+		return pendings_arr.join(', ');
+	});
+</script>
+
+<label>
+	<input type="checkbox" bind:checked={should_submit} data-should-submit />
+	should submit
+</label>
+
+<form
+	{...set_message.enhance(async ({ submit }) => {
+		if (!should_submit) return;
+		await submit();
+	})}
+>
+	<button>submit</button>
+</form>
+
+<p data-pending>{pendings}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/form/skip-submit/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/skip-submit/form.remote.ts
@@ -1,0 +1,5 @@
+import { form } from '$app/server';
+
+export const set_message = form(async () => {
+	/** not actually needed */
+});

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -307,6 +307,22 @@ test.describe('remote function mutations', () => {
 		await expect(page.locator('#command-pending')).toHaveText('Command pending: 0');
 	});
 
+	test('form pending resets when enhance callback skips submit', async ({ page }) => {
+		await page.goto('/remote/form/skip-submit');
+
+		await expect(page.locator('[data-pending]')).toHaveText('0');
+		await page.click('button');
+
+		// pending goes to 1 but then back to 0 once enhance finish runs without invoking submit()
+		await expect(page.locator('[data-pending]')).toHaveText('0, 1, 0');
+
+		await page.locator('[data-should-submit]').check();
+
+		await page.click('button');
+
+		await expect(page.locator('[data-pending]')).toHaveText('0, 1, 0, 1, 0');
+	});
+
 	// TODO once we have async SSR adjust the test and move this into test.js
 	test('query.batch works', async ({ page }) => {
 		await page.goto('/remote/batch');


### PR DESCRIPTION
Closes #15519

Currently, if you have an `enhance` function, and you conditionally invoke `submit` the `pending` value never goes down 

[REPL](https://www.sveltelab.dev/0nm8kvdifh025lx)

```svelte
<script>
	import { set_message } from './form.remote.js';

	let should_submit = $state(false);

	const pendings_arr = [];
	const pendings = $derived.by(() => {
		pendings_arr.push(set_message.pending);
		return pendings_arr.join(', ');
	});
</script>

<label>
	<input type="checkbox" bind:checked={should_submit} data-should-submit />
	should submit
</label>

<form
	{...set_message.enhance(async ({ submit }) => {
		if (!should_submit) return;
		await submit();
	})}
>
	<button>submit</button>
</form>

<p data-pending>{pendings}</p>
```
if you left the checkbox unchecked and submit multiple times, the value of pending will go higher and higher.

This fixes that by checking if the submit function was invoked and decreasing pending in a finally block