### PR TITLE
fix: recreate nullish deep_set containers

### DIFF
--- a/.changeset/forty-countries-push.md
+++ b/.changeset/forty-countries-push.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: let `deep_set` recreate nullish intermediate containers

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -510,11 +510,11 @@ export function deep_set(object, keys, value) {
 		const exists = Object.hasOwn(current, key);
 		const inner = current[key];
 
-		if (exists && is_array !== Array.isArray(inner)) {
+		if (exists && inner != null && is_array !== Array.isArray(inner)) {
 			throw new Error(`Invalid array key ${keys[i + 1]}`);
 		}
 
-		if (!exists) {
+		if (!exists || inner == null) {
 			current[key] = is_array ? [] : {};
 		}
 

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -765,4 +765,20 @@ describe('deep_set', () => {
 		// @ts-ignore
 		expect(Object.prototype.toString.property).toBeUndefined();
 	});
+
+	test.each([undefined, null])('rehydrates nullish object containers (%s)', (initial) => {
+		const target = { nested: initial };
+
+		deep_set(target, ['nested', 'name'], 'hello');
+
+		expect(target).toEqual({ nested: { name: 'hello' } });
+	});
+
+	test.each([undefined, null])('rehydrates nullish array containers (%s)', (initial) => {
+		const target = { nested: initial };
+
+		deep_set(target, ['nested', '0'], 'hello');
+
+		expect(target).toEqual({ nested: ['hello'] });
+	});
 });


### PR DESCRIPTION
closes #15599

## Summary
- recreate intermediate containers when an existing `deep_set` key is `null` or `undefined`
- keep the invalid array-key guard for non-nullish existing containers
- add regression coverage for both object and array paths through nullish parents

## Testing
- corepack pnpm lint
- corepack pnpm check
- corepack pnpm -F @sveltejs/kit test:unit