### PR TITLE
Encode named form action query parameters

### DIFF
--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -3,6 +3,7 @@ import { BROWSER, DEV } from 'esm-env';
 import { invalidateAll } from './navigation.js';
 import { app as client_app, applyAction } from '../client/client.js';
 import { app as server_app } from '../server/app.js';
+import { normalize_named_action_url } from '../../utils/url.js';
 
 export { applyAction };
 
@@ -126,10 +127,12 @@ export function enhance(form_element, submit = () => {}) {
 		event.preventDefault();
 
 		const action = new URL(
-			// We can't do submitter.formAction directly because that property is always set
-			event.submitter?.hasAttribute('formaction')
-				? /** @type {HTMLButtonElement | HTMLInputElement} */ (event.submitter).formAction
-				: clone(form_element).action
+			normalize_named_action_url(
+				// We can't do submitter.formAction directly because that property is always set
+				event.submitter?.hasAttribute('formaction')
+					? /** @type {HTMLButtonElement | HTMLInputElement} */ (event.submitter).formAction
+					: clone(form_element).action
+			)
 		);
 
 		const enctype = event.submitter?.hasAttribute('formenctype')

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -10,7 +10,9 @@ import {
 	decode_pathname,
 	strip_hash,
 	make_trackable,
-	normalize_path
+	normalize_path,
+	normalize_named_action_elements,
+	normalize_named_action_url
 } from '../../utils/url.js';
 import { dev_fetch, initial_fetch, lock_fetch, subsequent_fetch, unlock_fetch } from './fetcher.js';
 import { parse, parse_server_route } from './parse.js';
@@ -2048,6 +2050,7 @@ function setup_preload() {
 
 	function after_navigate() {
 		observer.disconnect();
+		normalize_named_action_elements(container);
 
 		for (const a of container.querySelectorAll('a')) {
 			const { url, external, download } = get_link_info(a, base, app.hash);
@@ -2698,7 +2701,9 @@ function _start_router() {
 
 		// It is impossible to use form actions with hash router, so we just ignore handling them here
 		const url = new URL(
-			(submitter?.hasAttribute('formaction') && submitter?.formAction) || form.action
+			normalize_named_action_url(
+				(submitter?.hasAttribute('formaction') && submitter?.formAction) || form.action
+			)
 		);
 
 		if (is_external_url(url, base, false)) return;

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -10,6 +10,7 @@ import { app, query_responses, _goto, set_nearest_error_page, invalidateAll } fr
 import { tick } from 'svelte';
 import { refresh_queries, release_overrides } from './shared.svelte.js';
 import { createAttachmentKey } from 'svelte/attachments';
+import { normalize_named_action_url } from '../../../utils/url.js';
 import {
 	convert_formdata,
 	flatten_issues,
@@ -287,10 +288,12 @@ export function form(id) {
 
 				// eslint-disable-next-line svelte/prefer-svelte-reactivity
 				const action = new URL(
-					// We can't do submitter.formAction directly because that property is always set
-					event.submitter?.hasAttribute('formaction')
-						? /** @type {HTMLButtonElement | HTMLInputElement} */ (event.submitter).formAction
-						: clone(form).action
+					normalize_named_action_url(
+						// We can't do submitter.formAction directly because that property is always set
+						event.submitter?.hasAttribute('formaction')
+							? /** @type {HTMLButtonElement | HTMLInputElement} */ (event.submitter).formAction
+							: clone(form).action
+					)
 				);
 
 				if (action.searchParams.get('/remote') !== action_id) {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -10,7 +10,7 @@ import { Csp } from './csp.js';
 import { uneval_action_response } from './actions.js';
 import { public_env } from '../../shared-server.js';
 import { SVELTE_KIT_ASSETS } from '../../../constants.js';
-import { SCHEME } from '../../../utils/url.js';
+import { normalize_named_action_attributes, SCHEME } from '../../../utils/url.js';
 import { create_server_routing_response, generate_route_object } from './server_routing.js';
 import { add_resolution_suffix } from '../../pathname.js';
 import { try_get_request_store, with_request_store } from '@sveltejs/kit/internal/server';
@@ -673,11 +673,12 @@ export async function render_response({
 	});
 
 	// TODO flush chunks as early as we can
-	const transformed =
+	const transformed = normalize_named_action_attributes(
 		(await resolve_opts.transformPageChunk({
 			html,
 			done: true
-		})) || '';
+		})) || ''
+	);
 
 	if (!chunks) {
 		headers.set('etag', `"${hash(transformed)}"`);

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -22,6 +22,180 @@ export function resolve(base, path) {
 	return url.protocol === internal.protocol ? url.pathname + url.search + url.hash : url.href;
 }
 
+/**
+ * Encodes named form action query parameter keys such as `?/login` to `?%2Flogin`.
+ * This keeps the URL semantically identical while avoiding raw `/` characters in the query string.
+ * @param {string} query
+ */
+function encode_named_action_query(query) {
+	const parts = query.split(/(&amp;|&)/);
+	let changed = false;
+
+	for (let i = 0; i < parts.length; i += 2) {
+		const segment = parts[i];
+		const equals = segment.indexOf('=');
+		const key = equals === -1 ? segment : segment.slice(0, equals);
+
+		if (key.startsWith('/')) {
+			parts[i] = encodeURIComponent(key) + segment.slice(key.length);
+			changed = true;
+		}
+	}
+
+	return changed ? parts.join('') : query;
+}
+
+/**
+ * @param {string} url
+ */
+export function normalize_named_action_url(url) {
+	const query_start = url.indexOf('?');
+	if (query_start === -1) return url;
+
+	const hash_start = url.indexOf('#', query_start);
+	const query_end = hash_start === -1 ? url.length : hash_start;
+	const query = url.slice(query_start + 1, query_end);
+	const normalized = encode_named_action_query(query);
+
+	return normalized === query
+		? url
+		: url.slice(0, query_start + 1) + normalized + url.slice(query_end);
+}
+
+/**
+ * @param {ParentNode} root
+ */
+export function normalize_named_action_elements(root) {
+	for (const form of root.querySelectorAll('form[action]')) {
+		const action = form.getAttribute('action');
+		if (!action) continue;
+
+		const normalized = normalize_named_action_url(action);
+		if (normalized !== action) {
+			form.setAttribute('action', normalized);
+		}
+	}
+
+	for (const element of root.querySelectorAll('button[formaction], input[formaction]')) {
+		const action = element.getAttribute('formaction');
+		if (!action) continue;
+
+		const normalized = normalize_named_action_url(action);
+		if (normalized !== action) {
+			element.setAttribute('formaction', normalized);
+		}
+	}
+}
+
+/**
+ * @param {string} tag
+ */
+function normalize_named_action_tag(tag) {
+	if (/^<\s*\//.test(tag) || !/^<\s*(form|button|input)\b/i.test(tag)) {
+		return tag;
+	}
+
+	return tag.replace(
+		/(\s)(action|formaction)=(["'])(.*?)\3/gi,
+		(match, space, name, quote, value) => {
+			const normalized = normalize_named_action_url(value);
+			return normalized === value ? match : `${space}${name}=${quote}${normalized}${quote}`;
+		}
+	);
+}
+
+/**
+ * @param {string} html
+ */
+export function normalize_named_action_attributes(html) {
+	let normalized = '';
+	let index = 0;
+	let raw_tag = '';
+	const lower = html.toLowerCase();
+
+	while (index < html.length) {
+		if (raw_tag) {
+			const closing = `</${raw_tag}`;
+			const raw_end = lower.indexOf(closing, index);
+
+			if (raw_end === -1) {
+				return normalized + html.slice(index);
+			}
+
+			normalized += html.slice(index, raw_end);
+			index = raw_end;
+			raw_tag = '';
+			continue;
+		}
+
+		const tag_start = html.indexOf('<', index);
+
+		if (tag_start === -1) {
+			return normalized + html.slice(index);
+		}
+
+		normalized += html.slice(index, tag_start);
+
+		if (html.startsWith('<!--', tag_start)) {
+			const comment_end = html.indexOf('-->', tag_start + 4);
+
+			if (comment_end === -1) {
+				return normalized + html.slice(tag_start);
+			}
+
+			normalized += html.slice(tag_start, comment_end + 3);
+			index = comment_end + 3;
+			continue;
+		}
+
+		let tag_end = -1;
+		let quote = '';
+
+		for (let i = tag_start + 1; i < html.length; i++) {
+			const char = html[i];
+
+			if (quote) {
+				if (char === quote) quote = '';
+				continue;
+			}
+
+			if (char === '"' || char === "'") {
+				quote = char;
+				continue;
+			}
+
+			if (char === '>') {
+				tag_end = i;
+				break;
+			}
+		}
+
+		if (tag_end === -1) {
+			return normalized + html.slice(tag_start);
+		}
+
+		const tag = html.slice(tag_start, tag_end + 1);
+		normalized += normalize_named_action_tag(tag);
+
+		const tag_name = /^<\s*([a-zA-Z][^\s/>]*)/.exec(tag)?.[1]?.toLowerCase();
+		const self_closing = /\/\s*>$/.test(tag);
+
+		if (
+			(tag_name === 'script' ||
+				tag_name === 'style' ||
+				tag_name === 'textarea' ||
+				tag_name === 'title') &&
+			!self_closing
+		) {
+			raw_tag = tag_name;
+		}
+
+		index = tag_end + 1;
+	}
+
+	return normalized;
+}
+
 /** @param {string} path */
 export function is_root_relative(path) {
 	return path[0] === '/' && path[1] !== '/';

--- a/packages/kit/src/utils/url.spec.js
+++ b/packages/kit/src/utils/url.spec.js
@@ -1,5 +1,12 @@
 import { assert, describe } from 'vitest';
-import { resolve, normalize_path, make_trackable, disable_search } from './url.js';
+import {
+	resolve,
+	normalize_path,
+	make_trackable,
+	disable_search,
+	normalize_named_action_url,
+	normalize_named_action_attributes
+} from './url.js';
 
 describe('resolve', (test) => {
 	test('resolves a root-relative path', () => {
@@ -95,6 +102,47 @@ describe('normalize_path', (test) => {
 			assert.equal(normalize_path(path, 'always'), always);
 			assert.equal(normalize_path(path, 'never'), never);
 		}
+	});
+});
+
+describe('normalize_named_action_url', (test) => {
+	test('encodes named action query parameters', () => {
+		assert.equal(normalize_named_action_url('?/login'), '?%2Flogin');
+		assert.equal(
+			normalize_named_action_url('/actions/enhance?/login&foo=bar'),
+			'/actions/enhance?%2Flogin&foo=bar'
+		);
+	});
+
+	test('preserves already encoded named action query parameters', () => {
+		assert.equal(normalize_named_action_url('?%2Flogin'), '?%2Flogin');
+	});
+
+	test('preserves html-escaped query separators', () => {
+		assert.equal(
+			normalize_named_action_url('/actions/enhance?/login&amp;foo=bar'),
+			'/actions/enhance?%2Flogin&amp;foo=bar'
+		);
+	});
+});
+
+describe('normalize_named_action_attributes', (test) => {
+	test('encodes named action attributes in form markup', () => {
+		assert.equal(
+			normalize_named_action_attributes(
+				'<form action="?/login"><button formaction="?/register"></button></form>'
+			),
+			'<form action="?%2Flogin"><button formaction="?%2Fregister"></button></form>'
+		);
+	});
+
+	test('does not rewrite raw script contents', () => {
+		assert.equal(
+			normalize_named_action_attributes(
+				'<script>const markup = `<form action="?/login">`;</script><form action="?/login"></form>'
+			),
+			'<script>const markup = `<form action="?/login">`;</script><form action="?%2Flogin"></form>'
+		);
 	});
 });
 

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -684,6 +684,15 @@ test.describe('Load', () => {
 
 		expect(await page.textContent('p')).toBe('hello world');
 	});
+
+	test('encodes named form action attributes in rendered HTML', async ({ request }) => {
+		const response = await request.get('/actions/enhance');
+		const html = await response.text();
+
+		expect(html).toContain('action="?%2Flogin"');
+		expect(html).toContain('formaction="?%2Fregister"');
+		expect(html).toContain('formaction="?%2Fsubmitter"');
+	});
 });
 
 test.describe('Routing', () => {

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1373,7 +1373,7 @@ test.describe('Actions', () => {
 		await page.locator('input[name="username"]').fill('foo');
 
 		const [request] = await Promise.all([
-			page.waitForRequest('/actions/enhance?/login'),
+			page.waitForRequest('/actions/enhance?%2Flogin'),
 			page.locator('button.form1').click()
 		]);
 


### PR DESCRIPTION
Fixes #15610.

## Summary
- encode named form action query keys like `?/login` before they are read from enhanced or router-intercepted forms
- normalize rendered `action` and `formaction` HTML attributes so SSR output is safe for intermediaries that reject raw `/` in query strings
- add focused URL helper coverage plus basics app regressions for the rendered HTML and enhanced submit request path

## Testing
- `corepack pnpm --dir packages/kit exec vitest --config kit.vitest.config.js run src/utils/url.spec.js`
- `Invoke-WebRequest -UseBasicParsing http://[::1]:4173/actions/enhance`
- focused Playwright browser script against the built preview confirming `http://[::1]:4173/actions/enhance?%2Flogin` and `content-type: application/x-www-form-urlencoded`
- `corepack pnpm exec prettier --check packages/kit/src/runtime/app/forms.js packages/kit/src/runtime/client/client.js packages/kit/src/runtime/client/remote-functions/form.svelte.js packages/kit/src/runtime/server/page/render.js packages/kit/src/utils/url.js packages/kit/src/utils/url.spec.js packages/kit/test/apps/basics/test/server.test.js packages/kit/test/apps/basics/test/test.js`
- `git diff --check`