### PR TITLE
fix(kit): update cookie dependency to 1.1.1

### DIFF
--- a/.changeset/lucky-plants-bathe.md
+++ b/.changeset/lucky-plants-bathe.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: update kit to cookie 1.x with compatible exported cookie option types

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -20,9 +20,8 @@
 	"dependencies": {
 		"@standard-schema/spec": "^1.0.0",
 		"@sveltejs/acorn-typescript": "^1.0.5",
-		"@types/cookie": "^0.6.0",
 		"acorn": "^8.14.1",
-		"cookie": "^0.6.0",
+		"cookie": "^1.1.1",
 		"devalue": "^5.6.4",
 		"esm-env": "^1.2.2",
 		"kleur": "^4.1.5",

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -260,19 +260,22 @@ export interface Config extends SvelteConfig {
 	[key: string]: any;
 }
 
+export type CookieParseOptions = import('cookie').ParseOptions;
+export type CookieSerializeOptions = import('cookie').SerializeOptions;
+
 export interface Cookies {
 	/**
 	 * Gets a cookie that was previously set with `cookies.set`, or from the request headers.
 	 * @param name the name of the cookie
 	 * @param opts the options, passed directly to `cookie.parse`. See documentation [here](https://github.com/jshttp/cookie#cookieparsestr-options)
 	 */
-	get: (name: string, opts?: import('cookie').CookieParseOptions) => string | undefined;
+	get: (name: string, opts?: CookieParseOptions) => string | undefined;
 
 	/**
 	 * Gets all cookies that were previously set with `cookies.set`, or from the request headers.
 	 * @param opts the options, passed directly to `cookie.parse`. See documentation [here](https://github.com/jshttp/cookie#cookieparsestr-options)
 	 */
-	getAll: (opts?: import('cookie').CookieParseOptions) => Array<{ name: string; value: string }>;
+	getAll: (opts?: CookieParseOptions) => Array<{ name: string; value: string }>;
 
 	/**
 	 * Sets a cookie. This will add a `set-cookie` header to the response, but also make the cookie available via `cookies.get` or `cookies.getAll` during the current request.
@@ -284,11 +287,7 @@ export interface Cookies {
 	 * @param value the cookie value
 	 * @param opts the options, passed directly to `cookie.serialize`. See documentation [here](https://github.com/jshttp/cookie#cookieserializename-value-options)
 	 */
-	set: (
-		name: string,
-		value: string,
-		opts: import('cookie').CookieSerializeOptions & { path: string }
-	) => void;
+	set: (name: string, value: string, opts: CookieSerializeOptions & { path: string }) => void;
 
 	/**
 	 * Deletes a cookie by setting its value to an empty string and setting the expiry date in the past.
@@ -297,7 +296,7 @@ export interface Cookies {
 	 * @param name the name of the cookie
 	 * @param opts the options, passed directly to `cookie.serialize`. The `path` must match the path of the cookie you want to delete. See documentation [here](https://github.com/jshttp/cookie#cookieserializename-value-options)
 	 */
-	delete: (name: string, opts: import('cookie').CookieSerializeOptions & { path: string }) => void;
+	delete: (name: string, opts: CookieSerializeOptions & { path: string }) => void;
 
 	/**
 	 * Serialize a cookie name-value pair into a `Set-Cookie` header string, but don't apply it to the response.
@@ -313,7 +312,7 @@ export interface Cookies {
 	serialize: (
 		name: string,
 		value: string,
-		opts: import('cookie').CookieSerializeOptions & { path: string }
+		opts: CookieSerializeOptions & { path: string }
 	) => string;
 }
 

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -1,4 +1,4 @@
-import { parse, serialize } from 'cookie';
+import { parseCookie as parse, stringifySetCookie as serialize } from 'cookie';
 import { DEV } from 'esm-env';
 import { normalize_path, resolve } from '../../utils/url.js';
 import { add_data_suffix } from '../pathname.js';
@@ -57,7 +57,7 @@ export function get_cookies(request, url) {
 	/** @type {Map<string, import('./page/types.js').Cookie>} */
 	const new_cookies = new Map();
 
-	/** @type {import('cookie').CookieSerializeOptions} */
+	/** @type {import('cookie').SerializeOptions} */
 	const defaults = {
 		httpOnly: true,
 		sameSite: 'lax',
@@ -73,7 +73,7 @@ export function get_cookies(request, url) {
 
 		/**
 		 * @param {string} name
-		 * @param {import('cookie').CookieParseOptions} [opts]
+		 * @param {import('cookie').ParseOptions} [opts]
 		 */
 		get(name, opts) {
 			// Look for the most specific matching cookie from new_cookies
@@ -115,7 +115,7 @@ export function get_cookies(request, url) {
 		},
 
 		/**
-		 * @param {import('cookie').CookieParseOptions} [opts]
+		 * @param {import('cookie').ParseOptions} [opts]
 		 */
 		getAll(opts) {
 			const cookies = parse(header, { decode: opts?.decode });
@@ -142,7 +142,9 @@ export function get_cookies(request, url) {
 				cookies[c.name] = c.value;
 			}
 
-			return Object.entries(cookies).map(([name, value]) => ({ name, value }));
+			return Object.entries(cookies).flatMap(([name, value]) =>
+				value === undefined ? [] : [{ name, value }]
+			);
 		},
 
 		/**
@@ -201,10 +203,14 @@ export function get_cookies(request, url) {
 	 */
 	function get_cookie_header(destination, header) {
 		/** @type {Record<string, string>} */
-		const combined_cookies = {
-			// cookies sent by the user agent have lowest precedence
-			...initial_cookies
-		};
+		const combined_cookies = {};
+
+		// cookies sent by the user agent have lowest precedence
+		for (const [name, value] of Object.entries(initial_cookies)) {
+			if (value !== undefined) {
+				combined_cookies[name] = value;
+			}
+		}
 
 		// cookies previous set during this event with cookies.set have higher precedence
 		for (const cookie of new_cookies.values()) {
@@ -219,7 +225,10 @@ export function get_cookies(request, url) {
 		if (header) {
 			const parsed = parse(header, { decode: (value) => value });
 			for (const name in parsed) {
-				combined_cookies[name] = parsed[name];
+				const value = parsed[name];
+				if (value !== undefined) {
+					combined_cookies[name] = value;
+				}
 			}
 		}
 

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -164,7 +164,7 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 						set_internal(name, value, {
 							path,
 							encode: (value) => value,
-							.../** @type {import('cookie').CookieSerializeOptions} */ (options)
+							.../** @type {import('cookie').SerializeOptions} */ (options)
 						});
 					}
 				}

--- a/packages/kit/src/runtime/server/page/types.d.ts
+++ b/packages/kit/src/runtime/server/page/types.d.ts
@@ -1,4 +1,4 @@
-import { CookieSerializeOptions } from 'cookie';
+import type { SerializeOptions as CookieSerializeOptions } from 'cookie';
 import {
 	CspDirectives,
 	ServerDataNode,

--- a/packages/kit/test/types/cookies.test.ts
+++ b/packages/kit/test/types/cookies.test.ts
@@ -1,0 +1,18 @@
+import * as Kit from '@sveltejs/kit';
+
+declare const cookies: Kit.Cookies;
+
+const parse_options: Kit.CookieParseOptions = {
+	decode: (value) => value
+};
+
+const serialize_options: Kit.CookieSerializeOptions = {
+	httpOnly: true,
+	secure: true
+};
+
+cookies.get('session', parse_options);
+cookies.getAll(parse_options);
+cookies.set('session', 'value', { ...serialize_options, path: '/' });
+cookies.delete('session', { ...serialize_options, path: '/' });
+cookies.serialize('session', 'value', { ...serialize_options, path: '/' });

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -234,19 +234,22 @@ declare module '@sveltejs/kit' {
 		[key: string]: any;
 	}
 
+	export type CookieParseOptions = import('cookie').ParseOptions;
+	export type CookieSerializeOptions = import('cookie').SerializeOptions;
+
 	export interface Cookies {
 		/**
 		 * Gets a cookie that was previously set with `cookies.set`, or from the request headers.
 		 * @param name the name of the cookie
 		 * @param opts the options, passed directly to `cookie.parse`. See documentation [here](https://github.com/jshttp/cookie#cookieparsestr-options)
 		 */
-		get: (name: string, opts?: import('cookie').CookieParseOptions) => string | undefined;
+		get: (name: string, opts?: CookieParseOptions) => string | undefined;
 
 		/**
 		 * Gets all cookies that were previously set with `cookies.set`, or from the request headers.
 		 * @param opts the options, passed directly to `cookie.parse`. See documentation [here](https://github.com/jshttp/cookie#cookieparsestr-options)
 		 */
-		getAll: (opts?: import('cookie').CookieParseOptions) => Array<{ name: string; value: string }>;
+		getAll: (opts?: CookieParseOptions) => Array<{ name: string; value: string }>;
 
 		/**
 		 * Sets a cookie. This will add a `set-cookie` header to the response, but also make the cookie available via `cookies.get` or `cookies.getAll` during the current request.
@@ -258,11 +261,7 @@ declare module '@sveltejs/kit' {
 		 * @param value the cookie value
 		 * @param opts the options, passed directly to `cookie.serialize`. See documentation [here](https://github.com/jshttp/cookie#cookieserializename-value-options)
 		 */
-		set: (
-			name: string,
-			value: string,
-			opts: import('cookie').CookieSerializeOptions & { path: string }
-		) => void;
+		set: (name: string, value: string, opts: CookieSerializeOptions & { path: string }) => void;
 
 		/**
 		 * Deletes a cookie by setting its value to an empty string and setting the expiry date in the past.
@@ -271,7 +270,7 @@ declare module '@sveltejs/kit' {
 		 * @param name the name of the cookie
 		 * @param opts the options, passed directly to `cookie.serialize`. The `path` must match the path of the cookie you want to delete. See documentation [here](https://github.com/jshttp/cookie#cookieserializename-value-options)
 		 */
-		delete: (name: string, opts: import('cookie').CookieSerializeOptions & { path: string }) => void;
+		delete: (name: string, opts: CookieSerializeOptions & { path: string }) => void;
 
 		/**
 		 * Serialize a cookie name-value pair into a `Set-Cookie` header string, but don't apply it to the response.
@@ -287,7 +286,7 @@ declare module '@sveltejs/kit' {
 		serialize: (
 			name: string,
 			value: string,
-			opts: import('cookie').CookieSerializeOptions & { path: string }
+			opts: CookieSerializeOptions & { path: string }
 		) => string;
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,15 +541,12 @@ importers:
       '@sveltejs/acorn-typescript':
         specifier: ^1.0.5
         version: 1.0.9(acorn@8.16.0)
-      '@types/cookie':
-        specifier: ^0.6.0
-        version: 0.6.0
       acorn:
         specifier: ^8.14.1
         version: 8.16.0
       cookie:
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^1.1.1
+        version: 1.1.1
       devalue:
         specifier: ^5.6.4
         version: 5.6.4
@@ -3205,9 +3202,6 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
-  '@types/cookie@0.6.0':
-    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
-
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -3694,16 +3688,12 @@ packages:
   cookie-es@1.2.2:
     resolution: {integrity: sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==}
 
-  cookie@0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
-    engines: {node: '>= 0.6'}
-
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
-  cookie@1.0.2:
-    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
   copy-file@11.0.0:
@@ -7079,7 +7069,7 @@ snapshots:
     dependencies:
       '@netlify/dev-utils': 4.3.3
       '@netlify/redirect-parser': 15.0.3
-      cookie: 1.0.2
+      cookie: 1.1.1
       jsonwebtoken: 9.0.3
       netlify-redirector: 0.5.0
 
@@ -7730,8 +7720,6 @@ snapshots:
     dependencies:
       '@types/node': 18.19.119
 
-  '@types/cookie@0.6.0': {}
-
   '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
@@ -8325,11 +8313,9 @@ snapshots:
 
   cookie-es@1.2.2: {}
 
-  cookie@0.6.0: {}
-
   cookie@0.7.2: {}
 
-  cookie@1.0.2: {}
+  cookie@1.1.1: {}
 
   copy-file@11.0.0:
     dependencies:


### PR DESCRIPTION
closes #15629

### Please don't delete this checklist! Before opening your PR, please make sure you have:

- [x] Run the relevant package tests with `pnpm -F @sveltejs/kit test:unit`
- [x] Run `pnpm lint`
- [x] Run `pnpm check`
- [x] Added a changeset
- [x] Referenced an issue where this was discussed ahead of time

### What does this PR do?

This updates `@sveltejs/kit` from `cookie@^0.6.0` to `cookie@^1.1.1` and removes `@types/cookie`, which is no longer needed because `cookie@1.1.1` now ships its own types.

To keep Kit's public type surface stable, this also exports `CookieParseOptions` and `CookieSerializeOptions` from `@sveltejs/kit` and updates the public `Cookies` interface to use those aliases instead of the removed `cookie` 0.6 type names.

Internally, the runtime now imports `parseCookie` and `stringifySetCookie` from the `cookie@1.1.1` API surface, and filters out `undefined` values returned by the newer parse typings before combining request and response cookie state.

### Why was this change needed?

`cookie@0.6.0` is outdated and flagged by dependency audits. A plain bump to `cookie@^1.1.1` is not enough because `cookie@1.1.1` removed the old `CookieParseOptions` / `CookieSerializeOptions` type names that Kit currently references in its public and internal types.

For the valid cookie flows that Kit relies on, `cookie@0.6.0` and `cookie@1.1.1` produce the same outputs for normal header parsing and standard `serialize` usage, so the migration pressure here is mostly on the type surface rather than on runtime behavior.

### How was this tested?

- `pnpm format`
- `pnpm lint`
- `pnpm check`
- `pnpm -F @sveltejs/kit test:unit`
- side-by-side `cookie@0.6.0` vs `cookie@1.1.1` checks for valid parse/serialize cases used by Kit

I also added a type regression test in `packages/kit/test/types/cookies.test.ts` covering the exported cookie option aliases and their use through the public `Cookies` API.
