### PR TITLE
feat: export `EnhancedImgAttributes` type

### DIFF
--- a/.changeset/nine-glasses-explode.md
+++ b/.changeset/nine-glasses-explode.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/enhanced-img": patch
+---
+
+feat: export `EnhancedImgAttributes` type

--- a/.changeset/nine-glasses-explode.md
+++ b/.changeset/nine-glasses-explode.md
@@ -1,5 +1,5 @@
 ---
-"@sveltejs/enhanced-img": patch
+"@sveltejs/enhanced-img": minor
 ---
 
 feat: export `EnhancedImgAttributes` type

--- a/packages/enhanced-img/types/index.d.ts
+++ b/packages/enhanced-img/types/index.d.ts
@@ -5,7 +5,7 @@ import './ambient.js';
 
 export { Picture };
 
-type EnhancedImgAttributes = Omit<HTMLImgAttributes, 'src'> & { src: string | Picture };
+export type EnhancedImgAttributes = Omit<HTMLImgAttributes, 'src'> & { src: string | Picture };
 
 // https://svelte.dev/docs/svelte/typescript#enhancing-built-in-dom-types
 declare module 'svelte/elements' {

--- a/packages/enhanced-img/types/index.d.ts
+++ b/packages/enhanced-img/types/index.d.ts
@@ -5,12 +5,44 @@ import './ambient.js';
 
 export { Picture };
 
-export type EnhancedImgAttributes = Omit<HTMLImgAttributes, 'src'> & { src: string | Picture };
+export type EnhancedImgAttributes = Omit<HTMLImgAttributes, 'src'> & {
+	/**
+	 * When [dynamically choosing an image](https://svelte.dev/docs/kit/images#sveltejs-enhanced-img-Dynamically-choosing-an-image)
+	 * for use with `<enhanced:img>`, the `src` must be a `Picture` object created with `?enhanced`, rather than a string:
+	 *
+	 * ```js
+	 * import hero from '$lib/assets/hero.jpg?enhanced';
+	 * ```
+	 *
+	 * Note that this object is created automatically if you use `<enhanced:img>` directly:
+	 *
+	 * ```svelte
+	 * <enhanced:img src="$lib/assets/hero.jpg" alt="..." />
+	 * ```
+	 */
+	src: Picture;
+};
 
 // https://svelte.dev/docs/svelte/typescript#enhancing-built-in-dom-types
 declare module 'svelte/elements' {
 	export interface SvelteHTMLElements {
-		'enhanced:img': EnhancedImgAttributes;
+		'enhanced:img': Omit<HTMLImgAttributes, 'src'> & {
+			/**
+			 * If the `src` is a string, it will be treated as an asset import relative to the current module:
+			 *
+			 * ```svelte
+			 * <enhanced:img src="$lib/assets/hero.jpg" alt="..." />
+			 * ```
+			 *
+			 * When [dynamically choosing an image](https://svelte.dev/docs/kit/images#sveltejs-enhanced-img-Dynamically-choosing-an-image)
+			 * (i.e. `src={...}`) it must be a `Picture` object created with `?enhanced`:
+			 *
+			 * ```js
+			 * import hero from '$lib/assets/hero.jpg?enhanced';
+			 * ```
+			 */
+			src: string | Picture;
+		};
 	}
 }
 


### PR DESCRIPTION
closes #<!-- Add the related issue number here. Repeat this line for each additional issue it closes -->

This PR exports the `EnhancedImgAttributes` type, making it easier to build custom image components with proper typing.

For example, you can create a wrapper component around `<enhanced:img>` like this:
```svelte
<script lang="ts">
  import type { EnhancedImgAttributes } from "@sveltejs/enhanced-img";

  let { src, ...props }: EnhancedImgAttributes = $props();
</script>

<enhanced:img {src} {...props} />
```

This approach ensures your custom component stays fully compatible with all supported attributes, while keeping type safety and autocomplete intact.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
