### PR TITLE
chore: centralize noops

### DIFF
--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -3,6 +3,7 @@ import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { installPolyfills } from '../../exports/node/polyfills.js';
 import { mkdirp, posixify, walk } from '../../utils/filesystem.js';
+import { noop } from '../../utils/functions.js';
 import { decode_uri, is_root_relative, resolve } from '../../utils/url.js';
 import { escape_html } from '../../utils/escape.js';
 import { logger } from '../utils.js';
@@ -69,7 +70,7 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env }) {
 					log.error(format(details));
 				};
 			case 'ignore':
-				return () => {};
+				return noop;
 			default:
 				// @ts-expect-error TS thinks T might be of a different kind, but it's not
 				return (details) => input({ ...details, message: format(details) });

--- a/packages/kit/src/core/utils.js
+++ b/packages/kit/src/core/utils.js
@@ -4,6 +4,7 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import colors from 'kleur';
 import { posixify, to_fs } from '../utils/filesystem.js';
+import { noop } from '../utils/functions.js';
 
 /**
  * Resolved path of the `runtime` directory
@@ -23,8 +24,6 @@ export const runtime_directory = posixify(fileURLToPath(new URL('../runtime', im
 export const runtime_base = runtime_directory.startsWith(process.cwd())
 	? `/${path.relative('.', runtime_directory)}`
 	: to_fs(runtime_directory);
-
-function noop() {}
 
 /** @param {{ verbose: boolean }} opts */
 export function logger({ verbose }) {

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -2,6 +2,7 @@ import { createReadStream } from 'node:fs';
 import { Readable } from 'node:stream';
 import * as set_cookie_parser from 'set-cookie-parser';
 import { SvelteKitError } from '../internal/index.js';
+import { noop } from '../../utils/functions.js';
 
 /**
  * @param {import('http').IncomingMessage} req
@@ -200,7 +201,7 @@ export async function setResponse(res, response) {
 
 		// If the reader has already been interrupted with an error earlier,
 		// then it will appear here, it is useless, but it needs to be catch.
-		reader.cancel(error).catch(() => {});
+		reader.cancel(error).catch(noop);
 		if (error) res.destroy(error);
 	};
 

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -1,5 +1,6 @@
 import * as devalue from 'devalue';
 import { BROWSER, DEV } from 'esm-env';
+import { noop } from '../../utils/functions.js';
 import { invalidateAll } from './navigation.js';
 import { app as client_app, applyAction } from '../client/client.js';
 import { app as server_app } from '../server/app.js';
@@ -76,7 +77,7 @@ function clone(element) {
  * @param {HTMLFormElement} form_element The form element
  * @param {import('@sveltejs/kit').SubmitFunction<Success, Failure>} submit Submit callback
  */
-export function enhance(form_element, submit = () => {}) {
+export function enhance(form_element, submit = noop) {
 	if (DEV && clone(form_element).method !== 'post') {
 		throw new Error('use:enhance can only be used on <form> fields with method="POST"');
 	}

--- a/packages/kit/src/runtime/app/server/remote/prerender.js
+++ b/packages/kit/src/runtime/app/server/remote/prerender.js
@@ -5,6 +5,7 @@ import { error, json } from '@sveltejs/kit';
 import { DEV } from 'esm-env';
 import { get_request_store } from '@sveltejs/kit/internal/server';
 import { stringify, stringify_remote_arg } from '../../../shared.js';
+import { noop } from '../../../../utils/functions.js';
 import { app_dir, base } from '$app/paths/internal/server';
 import {
 	create_validator,
@@ -153,7 +154,7 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 			return result;
 		})();
 
-		promise.catch(() => {});
+		promise.catch(noop);
 
 		return /** @type {RemoteResource<Output>} */ (promise);
 	};

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -4,6 +4,7 @@
 import { get_request_store } from '@sveltejs/kit/internal/server';
 import { create_remote_key, stringify, stringify_remote_arg } from '../../../shared.js';
 import { prerendering } from '__sveltekit/environment';
+import { noop } from '../../../../utils/functions.js';
 import { create_validator, get_cache, get_response, run_remote_function } from './shared.js';
 import { handle_error_and_jsonify } from '../../../server/utils.js';
 import { HttpError, SvelteKitError } from '@sveltejs/kit/internal';
@@ -382,8 +383,5 @@ function update_refresh_value(
 		refreshes[refreshes_key] = promise;
 	}
 
-	return promise.then(
-		() => {},
-		() => {}
-	);
+	return promise.then(noop, noop);
 }

--- a/packages/kit/src/runtime/app/server/remote/requested.js
+++ b/packages/kit/src/runtime/app/server/remote/requested.js
@@ -2,6 +2,7 @@
 /** @import { MaybePromise, RemoteQueryInternals } from 'types' */
 import { get_request_store } from '@sveltejs/kit/internal/server';
 import { create_remote_key, parse_remote_arg } from '../../../shared.js';
+import { noop } from '../../../../utils/functions.js';
 import { mark_argument_validated } from './query.js';
 
 /**
@@ -55,7 +56,7 @@ export function requested(query, limit = Infinity) {
 	 */
 	const record_failure = (payload, error) => {
 		const promise = Promise.reject(error);
-		promise.catch(() => {});
+		promise.catch(noop);
 
 		const key = create_remote_key(internals.id, payload);
 		refreshes[key] = promise;
@@ -156,7 +157,7 @@ async function* race_all(array, fn) {
 			value: result
 		}));
 
-		promise.catch(() => {});
+		promise.catch(noop);
 		pending.add(promise);
 	}
 

--- a/packages/kit/src/runtime/app/server/remote/shared.js
+++ b/packages/kit/src/runtime/app/server/remote/shared.js
@@ -3,6 +3,7 @@
 import { parse } from 'devalue';
 import { error } from '@sveltejs/kit';
 import { with_request_store, get_request_store } from '@sveltejs/kit/internal/server';
+import { noop } from '../../../../utils/functions.js';
 import {
 	stringify_remote_arg,
 	create_remote_key,
@@ -93,7 +94,7 @@ export async function get_response(internals, arg, state, get_result) {
 			.then((value) => {
 				void unfriendly_hydratable(remote_key, () => stringify(value, state.transport));
 			})
-			.catch(() => {});
+			.catch(noop);
 	}
 
 	return entry.data;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -39,6 +39,7 @@ import {
 	PAGE_URL_KEY
 } from './constants.js';
 import { validate_page_exports } from '../../utils/exports.js';
+import { noop } from '../../utils/functions.js';
 import { compact } from '../../utils/array.js';
 import {
 	INVALIDATED_PARAM,
@@ -166,7 +167,7 @@ function native_navigation(url, replace = false) {
 	} else {
 		location.href = url.href;
 	}
-	return new Promise(() => {});
+	return new Promise(noop);
 }
 
 /**
@@ -181,8 +182,6 @@ async function update_service_worker() {
 		}
 	}
 }
-
-function noop() {}
 
 /** @type {import('types').CSRRoute[]} All routes of the app. Only available when kit.router.resolution=client */
 let routes;
@@ -940,7 +939,7 @@ async function load_node({ loader, parent, url, params, route, server_data_node 
 
 				return promise;
 			},
-			setHeaders: () => {}, // noop
+			setHeaders: noop,
 			depends,
 			parent() {
 				if (is_tracking) {
@@ -1118,8 +1117,8 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 	// preload modules to avoid waterfall, but handle rejections
 	// so they don't get reported to Sentry et al (we don't need
 	// to act on the failures at this point)
-	errors.forEach((loader) => loader?.().catch(() => {}));
-	loaders.forEach((loader) => loader?.[1]().catch(() => {}));
+	errors.forEach((loader) => loader?.().catch(noop));
+	loaders.forEach((loader) => loader?.[1]().catch(noop));
 
 	/** @type {import('types').ServerNodesResponse | import('types').ServerRedirectNode | null} */
 	let server_data = null;
@@ -1232,7 +1231,7 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 	});
 
 	// if we don't do this, rejections will be unhandled
-	for (const p of branch_promises) p.catch(() => {});
+	for (const p of branch_promises) p.catch(noop);
 
 	/** @type {Array<import('./types.js').BranchNode | undefined>} */
 	const branch = [];
@@ -3229,7 +3228,7 @@ function create_navigation(current, intent, url, type, target_scroll = null) {
 	});
 
 	// Handle any errors off-chain so that it doesn't show up as an unhandled rejection
-	complete.catch(() => {});
+	complete.catch(noop);
 
 	/** @type {(import('@sveltejs/kit').Navigation | import('@sveltejs/kit').AfterNavigate) & { type: T }} */
 	const navigation = /** @type {any} */ ({

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -1,11 +1,12 @@
 import { BROWSER, DEV } from 'esm-env';
+import { noop } from '../../utils/functions.js';
 import { hash } from '../../utils/hash.js';
 import { base64_decode } from '../utils.js';
 
 let loading = 0;
 
 /** @type {typeof fetch} */
-const native_fetch = BROWSER ? window.fetch : /** @type {any} */ (() => {});
+const native_fetch = BROWSER ? window.fetch : /** @type {any} */ (noop);
 
 export function lock_fetch() {
 	loading += 1;

--- a/packages/kit/src/runtime/client/remote-functions/query.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query.svelte.js
@@ -12,6 +12,7 @@ import {
 import * as devalue from 'devalue';
 import { HttpError, Redirect } from '@sveltejs/kit/internal';
 import { DEV } from 'esm-env';
+import { noop } from '../../../utils/functions.js';
 import { with_resolvers } from '../../../utils/promise.js';
 import { tick, untrack } from 'svelte';
 import { create_remote_key, stringify_remote_arg, unfriendly_hydratable } from '../../shared.js';
@@ -30,7 +31,7 @@ import { create_remote_key, stringify_remote_arg, unfriendly_hydratable } from '
  */
 function is_in_effect() {
 	try {
-		$effect.pre(() => {});
+		$effect.pre(noop);
 		return true;
 	} catch {
 		return false;
@@ -371,7 +372,7 @@ export class Query {
 
 		const promise = Promise.reject(error);
 
-		promise.catch(() => {});
+		promise.catch(noop);
 		this.#promise = promise;
 	}
 

--- a/packages/kit/src/runtime/client/utils.js
+++ b/packages/kit/src/runtime/client/utils.js
@@ -2,6 +2,7 @@ import { BROWSER, DEV } from 'esm-env';
 import { writable } from 'svelte/store';
 import { assets } from '$app/paths';
 import { version } from '__sveltekit/environment';
+import { noop } from '../../utils/functions.js';
 import { PRELOAD_PRIORITIES } from './constants.js';
 
 /* global __SVELTEKIT_APP_VERSION_FILE__, __SVELTEKIT_APP_VERSION_POLL_INTERVAL__ */
@@ -242,7 +243,7 @@ export function notifiable_store(value) {
 }
 
 export const updated_listener = {
-	v: () => {}
+	v: noop
 };
 
 export function create_updated_store() {

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -1,4 +1,5 @@
 import * as set_cookie_parser from 'set-cookie-parser';
+import { noop } from '../../utils/functions.js';
 import { respond } from './respond.js';
 import * as paths from '$app/paths/internal/server';
 import { read_implementation } from '__sveltekit/server';
@@ -175,11 +176,11 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 	};
 
 	// Don't make this function `async`! Otherwise, the user has to `catch` promises they use for streaming responses or else
-	// it will be an unhandled rejection. Instead, we add a `.catch(() => {})` ourselves below to prevent this from happening.
+	// it will be an unhandled rejection. Instead, we add a `.catch(noop)` ourselves below to prevent this from happening.
 	return (input, init) => {
 		// See docs in fetch.js for why we need to do this
 		const response = server_fetch(input, init);
-		response.catch(() => {});
+		response.catch(noop);
 		return response;
 	};
 }
@@ -210,7 +211,7 @@ async function internal_fetch(request, options, manifest, state) {
 			throw new DOMException('The operation was aborted.', 'AbortError');
 		}
 
-		let remove_abort_listener = () => {};
+		let remove_abort_listener = noop;
 		/** @type {Promise<never>} */
 		const abort_promise = new Promise((_, reject) => {
 			const on_abort = () => {

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -1,4 +1,5 @@
 /** @import { PromiseWithResolvers } from '../../utils/promise.js' */
+import { noop } from '../../utils/functions.js';
 import { with_resolvers } from '../../utils/promise.js';
 import { IN_WEBCONTAINER } from './constants.js';
 import { respond } from './respond.js';
@@ -126,7 +127,7 @@ export class Server {
 							console.error('Remote function schema validation failed:', issues);
 							return { message: 'Bad Request' };
 						}),
-					reroute: module.reroute || (() => {}),
+					reroute: module.reroute || noop,
 					transport: module.transport || {}
 				};
 
@@ -150,7 +151,7 @@ export class Server {
 						handleValidationError: () => {
 							return { message: 'Bad Request' };
 						},
-						reroute: () => {},
+						reroute: noop,
 						transport: {}
 					};
 

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -2,6 +2,7 @@ import { text } from '@sveltejs/kit';
 import { HttpError, Redirect } from '@sveltejs/kit/internal';
 import { compact } from '../../../utils/array.js';
 import { get_status, normalize_error } from '../../../utils/error.js';
+import { noop } from '../../../utils/functions.js';
 import { add_data_suffix } from '../../pathname.js';
 import { redirect_response, static_error_page, handle_error_and_jsonify } from '../utils.js';
 import {
@@ -239,8 +240,8 @@ export async function render_page(
 		});
 
 		// if we don't do this, rejections will be unhandled
-		for (const p of server_promises) p.catch(() => {});
-		for (const p of load_promises) p.catch(() => {});
+		for (const p of server_promises) p.catch(noop);
+		for (const p of load_promises) p.catch(noop);
 
 		for (let i = 0; i < nodes.data.length; i += 1) {
 			const node = nodes.data[i];

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -1,4 +1,5 @@
 import { DEV } from 'esm-env';
+import { noop } from '../../../utils/functions.js';
 import { disable_search, make_trackable } from '../../../utils/url.js';
 import { validate_depends, validate_load_response } from '../../shared.js';
 import { with_request_store, merge_tracing } from '@sveltejs/kit/internal/server';
@@ -243,7 +244,7 @@ export async function load_data({
 					route: event.route,
 					fetch: create_universal_fetch(event, state, fetched, csr, resolve_opts),
 					setHeaders: event.setHeaders,
-					depends: () => {},
+					depends: noop,
 					parent,
 					untrack: (fn) => fn(),
 					tracing: traced_event.tracing
@@ -477,11 +478,11 @@ export function create_universal_fetch(event, state, fetched, csr, resolve_opts)
 	};
 
 	// Don't make this function `async`! Otherwise, the user has to `catch` promises they use for streaming responses or else
-	// it will be an unhandled rejection. Instead, we add a `.catch(() => {})` ourselves below to this from happening.
+	// it will be an unhandled rejection. Instead, we add a `.catch(noop)` ourselves below to this from happening.
 	return (input, init) => {
 		// See docs in fetch.js for why we need to do this
 		const response = universal_fetch(input, init);
-		response.catch(() => {});
+		response.catch(noop);
 		return response;
 	};
 }

--- a/packages/kit/src/utils/functions.js
+++ b/packages/kit/src/utils/functions.js
@@ -1,3 +1,5 @@
+export function noop() {}
+
 /**
  * @template T
  * @param {() => T} fn


### PR DESCRIPTION
I got tired of seeing so many inline `() => {}` and multiple `noop` declarations -- this just pulls it out into a single util function and uses it everywhere.
