### PR TITLE
chore: avoid importing types directly from Rollup

### DIFF
--- a/packages/kit/src/exports/vite/build/remote.js
+++ b/packages/kit/src/exports/vite/build/remote.js
@@ -1,5 +1,5 @@
 /** @import { ServerMetadata } from 'types' */
-/** @import { Rolldown } from 'vite' */
+/** @import { Rollup } from 'vite' */
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -13,7 +13,7 @@ import { import_peer } from '../../../utils/import.js';
  * @param {Array<{ hash: string, file: string }>} remotes
  * @param {ServerMetadata} metadata
  * @param {string} cwd
- * @param {Rolldown.OutputBundle} server_bundle
+ * @param {Rollup.OutputBundle} server_bundle
  * @param {NonNullable<import('vitest/config').ViteUserConfig['build']>['sourcemap']} sourcemap
  */
 export async function treeshake_prerendered_remotes(


### PR DESCRIPTION
This fixes a type error that happens in vite-ecosystem-ci https://github.com/vitejs/vite-ecosystem-ci/actions/runs/24066008373/job/70192137233

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
