### PR TITLE
docs: fix article typo in migration guide

### DIFF
--- a/documentation/docs/60-appendix/40-migrating.md
+++ b/documentation/docs/60-appendix/40-migrating.md
@@ -74,7 +74,7 @@ A common pattern in Sapper apps is to put your internal library in a directory i
 
 ### Renamed files
 
-Routes now are made up of the folder name exclusively to remove ambiguity, the folder names leading up to a `+page.svelte` correspond to the route. See [the routing docs](routing) for an overview. The following shows an old/new comparison:
+Routes now are made up of the folder name exclusively to remove ambiguity, the folder names leading up to a `+page.svelte` correspond to the route. See [the routing docs](routing) for an overview. The following shows a comparison between old and new routing structures:
 
 | Old                       | New                       |
 | ------------------------- | ------------------------- |

--- a/documentation/docs/60-appendix/40-migrating.md
+++ b/documentation/docs/60-appendix/40-migrating.md
@@ -74,7 +74,7 @@ A common pattern in Sapper apps is to put your internal library in a directory i
 
 ### Renamed files
 
-Routes now are made up of the folder name exclusively to remove ambiguity, the folder names leading up to a `+page.svelte` correspond to the route. See [the routing docs](routing) for an overview. The following shows a old/new comparison:
+Routes now are made up of the folder name exclusively to remove ambiguity, the folder names leading up to a `+page.svelte` correspond to the route. See [the routing docs](routing) for an overview. The following shows an old/new comparison:
 
 | Old                       | New                       |
 | ------------------------- | ------------------------- |


### PR DESCRIPTION
Related issue: N/A (trivial docs grammar fix)

Fixes a grammar issue in the migration guide by changing "a old/new comparison" to "an old/new comparison".

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs (N/A: trivial docs grammar fix)
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it. (N/A: docs-only)

### Tests
- [x] Not run (docs-only change).

### Changesets
- [x] No package behavior changed; changeset not needed.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
