### PR TITLE
fix: don't warn about removed SSI comments in transformPageChunk

### DIFF
--- a/.changeset/fix-ssi-comment-warning.md
+++ b/.changeset/fix-ssi-comment-warning.md
@@ -1,0 +1,7 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: don't warn about removed SSI comments in `transformPageChunk`
+
+Server-side include (SSI) directives like `<!--#include virtual="..." -->` are HTML comments that are replaced by servers such as nginx. Previously, removing them in `transformPageChunk` would trigger a false positive warning about breaking Svelte's hydration. Since SSI comments always start with `<!--#` and Svelte's hydration comments never do, they can be safely excluded from the check.

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -691,7 +691,9 @@ export async function render_response({
 
 	if (DEV) {
 		if (page_config.csr) {
-			if (transformed.split('<!--').length < html.split('<!--').length) {
+			/** @param {string} str */
+			const count_non_ssi_comments = (str) => (str.match(/<!--(?!#)/g) ?? []).length;
+			if (count_non_ssi_comments(transformed) < count_non_ssi_comments(html)) {
 				// the \u001B stuff is ANSI codes, so that we don't need to add a library to the runtime
 				// https://svelte.dev/playground/1b3f49696f0c44c881c34587f2537aa2?version=4.2.19
 				console.warn(

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -15,7 +15,7 @@ import { create_server_routing_response, generate_route_object } from './server_
 import { add_resolution_suffix } from '../../pathname.js';
 import { try_get_request_store, with_request_store } from '@sveltejs/kit/internal/server';
 import { text_encoder } from '../../utils.js';
-import { get_global_name, handle_error_and_jsonify } from '../utils.js';
+import { count_non_ssi_comments, get_global_name, handle_error_and_jsonify } from '../utils.js';
 import { create_remote_key } from '../../shared.js';
 import { get_status } from '../../../utils/error.js';
 
@@ -691,8 +691,6 @@ export async function render_response({
 
 	if (DEV) {
 		if (page_config.csr) {
-			/** @param {string} str */
-			const count_non_ssi_comments = (str) => (str.match(/<!--(?!#)/g) ?? []).length;
 			if (count_non_ssi_comments(transformed) < count_non_ssi_comments(html)) {
 				// the \u001B stuff is ANSI codes, so that we don't need to add a library to the runtime
 				// https://svelte.dev/playground/1b3f49696f0c44c881c34587f2537aa2?version=4.2.19

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -251,3 +251,13 @@ export function get_node_type(node_id) {
 	const dot_parts = filename.split('.');
 	return dot_parts.slice(0, -1).join('.');
 }
+
+/**
+ * Counts HTML comments that are not SSI directives (which start with `<!--#`).
+ * Used to detect when `transformPageChunk` removes comments that Svelte needs for hydration.
+ * @param {string} str
+ * @returns {number}
+ */
+export function count_non_ssi_comments(str) {
+	return (str.match(/<!--(?!#)/g) ?? []).length;
+}


### PR DESCRIPTION
## Problem

When using server-side includes (SSI) — HTML comment directives like `<!--#include virtual="/header.html" -->` that are replaced by servers such as nginx — removing them in `transformPageChunk` triggers a false positive warning:

> Removing comments in `transformPageChunk` can break Svelte's hydration

SSI directives are intentionally removed/replaced by the server and have nothing to do with Svelte's hydration mechanism.

## Fix

Svelte's hydration comments (`<!--[-->`, `<!--]-->`, `<!---->`, etc.) never start with `<!--#`. SSI directives always start with `<!--#`. Using a negative lookahead regex (`<!--(?!#)`) to count only non-SSI comments means:

- Removing SSI comments in `transformPageChunk` → no warning
- Removing actual Svelte hydration comments → warning still fires correctly

### Changesets
- [x] Patch changeset added for `@sveltejs/kit`

### Tests
- [x] All existing unit tests pass (`pnpm -F @sveltejs/kit test:unit`)
- The warning logic is DEV-only and exercised through integration tests; no new unit test added as the fix is a one-liner regex change

---

Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits
- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.