### PR TITLE
fix: allow `query().current` and other data properties to work in non-reactive contexts

### DIFF
--- a/.changeset/dark-hats-grow.md
+++ b/.changeset/dark-hats-grow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow `query().current` to work in non-reactive contexts

--- a/.changeset/dark-hats-grow.md
+++ b/.changeset/dark-hats-grow.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: allow `query().current` to work in non-reactive contexts
+fix: allow `query().current`, `.error`, `.loading`, and `.ready` to work in non-reactive contexts

--- a/packages/kit/src/runtime/client/remote-functions/query.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query.svelte.js
@@ -504,7 +504,7 @@ class QueryProxy {
 		// TODO iterate on error messages
 		if (!this.#tracking) {
 			throw new Error(
-				'This query was not created in a reactive context and is limited to calling `.run`, `.refresh`, and `.set`.'
+				'This query was not created in a reactive context and is limited to calling `.current`, `.run`, `.refresh`, and `.set`.'
 			);
 		}
 
@@ -534,7 +534,7 @@ class QueryProxy {
 	}
 
 	get current() {
-		return this.#get_cached_query().current;
+		return this.#safe_get_cached_query()?.current;
 	}
 
 	get error() {

--- a/packages/kit/src/runtime/client/remote-functions/query.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query.svelte.js
@@ -500,35 +500,6 @@ class QueryProxy {
 		};
 	}
 
-	#get_cached_query() {
-		// TODO iterate on error messages
-		if (!this.#tracking) {
-			throw new Error(
-				'This query was not created in a reactive context and is limited to calling `.current`, `.run`, `.refresh`, and `.set`.'
-			);
-		}
-
-		if (!this.#active) {
-			throw new Error(
-				'This query instance is no longer active and can no longer be used for reactive state access. ' +
-					'This typically means you created the query in a tracking context and stashed it somewhere outside of a tracking context.'
-			);
-		}
-
-		const cached = query_map.get(this.#id)?.get(this.#payload);
-
-		if (!cached) {
-			// The only case where `this.#active` can be `true` is when we've added an entry to `query_map`, and the
-			// only way that entry can get removed is if this instance (and all others) have been deactivated.
-			// So if we get here, someone (us, check git blame and point fingers) did `entry.count -= 1` improperly.
-			throw new Error(
-				'No cached query found. This should be impossible. Please file a bug report.'
-			);
-		}
-
-		return cached.resource;
-	}
-
 	#safe_get_cached_query() {
 		return query_map.get(this.#id)?.get(this.#payload)?.resource;
 	}
@@ -538,15 +509,15 @@ class QueryProxy {
 	}
 
 	get error() {
-		return this.#get_cached_query().error;
+		return this.#safe_get_cached_query()?.error;
 	}
 
 	get loading() {
-		return this.#get_cached_query().loading;
+		return this.#safe_get_cached_query()?.loading ?? false;
 	}
 
 	get ready() {
-		return this.#get_cached_query().ready;
+		return this.#safe_get_cached_query()?.ready ?? false;
 	}
 
 	run() {
@@ -586,6 +557,35 @@ class QueryProxy {
 		Object.defineProperty(release, QUERY_OVERRIDE_KEY, { value: override[QUERY_OVERRIDE_KEY] });
 
 		return release;
+	}
+
+	#get_cached_query() {
+		// TODO iterate on error messages
+		if (!this.#tracking) {
+			throw new Error(
+				'This query was not created in a reactive context and cannot be awaited. Use `.run()` to execute the query instead.'
+			);
+		}
+
+		if (!this.#active) {
+			throw new Error(
+				'This query instance is no longer active and can no longer be awaited. ' +
+					'This typically means you created the query in a tracking context and stashed it somewhere outside of a tracking context.'
+			);
+		}
+
+		const cached = query_map.get(this.#id)?.get(this.#payload);
+
+		if (!cached) {
+			// The only case where `this.#active` can be `true` is when we've added an entry to `query_map`, and the
+			// only way that entry can get removed is if this instance (and all others) have been deactivated.
+			// So if we get here, someone (us, check git blame and point fingers) did `entry.count -= 1` improperly.
+			throw new Error(
+				'No cached query found. This should be impossible. Please file a bug report.'
+			);
+		}
+
+		return cached.resource;
 	}
 
 	/** @type {Query<T>['then']} */

--- a/packages/kit/test/apps/async/src/routes/remote/query-non-reactive/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/query-non-reactive/+page.svelte
@@ -1,14 +1,14 @@
 <script>
-	import { untrack } from 'svelte';
 	import { get_count } from '../query-command.remote.js';
 
-	let result = $state({
-		current: undefined,
-		error: undefined,
-		ready: undefined,
-		loading: undefined
-	});
+	/** @type {{ current?: unknown, error?: unknown; ready?: boolean; loading?: boolean }} */
+	let result = $state({});
 
+	/**
+	 * @template T
+	 * @param {T} value
+	 * @returns {T | 'undefined'}
+	 */
 	function undefined_to_string(value) {
 		return value === undefined ? 'undefined' : value;
 	}

--- a/packages/kit/test/apps/async/src/routes/remote/query-non-reactive/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/query-non-reactive/+page.svelte
@@ -1,0 +1,31 @@
+<script>
+	import { untrack } from 'svelte';
+	import { get_count } from '../query-command.remote.js';
+
+	let result = $state({
+		current: undefined,
+		error: undefined,
+		ready: undefined,
+		loading: undefined
+	});
+
+	function undefined_to_string(value) {
+		return value === undefined ? 'undefined' : value;
+	}
+
+	$effect(() => {
+		setTimeout(() => {
+			result = {
+				current: undefined_to_string(get_count().current),
+				error: undefined_to_string(get_count().error),
+				ready: get_count().ready,
+				loading: get_count().loading
+			};
+		});
+	});
+</script>
+
+<p id="current">{result.current}</p>
+<p id="error">{result.error}</p>
+<p id="ready">{result.ready}</p>
+<p id="loading">{result.loading}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/query-runtime-errors/not-tracked/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/query-runtime-errors/not-tracked/+page.svelte
@@ -35,7 +35,7 @@
 </button>
 
 <button
-	id="read-current"
+	id="read-await"
 	onclick={async () => {
 		try {
 			await stored;
@@ -45,5 +45,19 @@
 		}
 	}}
 >
-	read current
+	read via await
+</button>
+
+<button
+	id="read-current"
+	onclick={async () => {
+		try {
+			stored.current;
+			result = 'success! :)';
+		} catch (error) {
+			result = get_message(error);
+		}
+	}}
+>
+	read via .current
 </button>

--- a/packages/kit/test/apps/async/src/routes/remote/query-runtime-errors/not-tracked/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/query-runtime-errors/not-tracked/+page.svelte
@@ -35,7 +35,7 @@
 </button>
 
 <button
-	id="read-await"
+	id="read-current"
 	onclick={async () => {
 		try {
 			await stored;
@@ -45,19 +45,5 @@
 		}
 	}}
 >
-	read via await
-</button>
-
-<button
-	id="read-current"
-	onclick={async () => {
-		try {
-			stored.current;
-			result = 'success! :)';
-		} catch (error) {
-			result = get_message(error);
-		}
-	}}
->
-	read via .current
+	read current
 </button>

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -438,9 +438,13 @@ test.describe('remote function mutations', () => {
 			await page.click('#run');
 			await expect(page.locator('#result')).toHaveText('0');
 
-			await page.click('#read-current');
+			await page.click('#read-await');
 			await expect(page.locator('#result')).toContainText(
 				'This query was not created in a reactive context'
+			);
+			await page.click('#read-current');
+			await expect(page.locator('#result')).toContainText(
+				'success! :)'
 			);
 		});
 

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -443,9 +443,7 @@ test.describe('remote function mutations', () => {
 				'This query was not created in a reactive context'
 			);
 			await page.click('#read-current');
-			await expect(page.locator('#result')).toContainText(
-				'success! :)'
-			);
+			await expect(page.locator('#result')).toContainText('success! :)');
 		});
 
 		test('query becomes inactive after its tracking context is destroyed', async ({ page }) => {

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -438,12 +438,10 @@ test.describe('remote function mutations', () => {
 			await page.click('#run');
 			await expect(page.locator('#result')).toHaveText('0');
 
-			await page.click('#read-await');
+			await page.click('#read-current');
 			await expect(page.locator('#result')).toContainText(
 				'This query was not created in a reactive context'
 			);
-			await page.click('#read-current');
-			await expect(page.locator('#result')).toContainText('success! :)');
 		});
 
 		test('query becomes inactive after its tracking context is destroyed', async ({ page }) => {
@@ -467,6 +465,15 @@ test.describe('remote function mutations', () => {
 			await expect(page.locator('#error')).toContainText(
 				'On the client, .run() can only be called outside render'
 			);
+		});
+
+		test('non-reactive query can still access non-awaited properties', async ({ page }) => {
+			await page.goto('/remote/query-non-reactive');
+
+			await expect(page.locator('#current')).toContainText('undefined');
+			await expect(page.locator('#error')).toContainText('undefined');
+			await expect(page.locator('#ready')).toContainText('false');
+			await expect(page.locator('#loading')).toContainText('false');
 		});
 	});
 


### PR DESCRIPTION
As of #15533, `query().current` no longer works in non-reactive contexts. I believe this is unwanted behavior -- take the following scenario:

```svelte
<script>
  import { list_todos } from '$lib/todos.remote';
  $effect(() => {
    const events = subscribe_to_something_external();
    events.on('new-todo', (item) => {
      // I don't want to call `.run()` here, because if `list_todos`
      // is not currently used, I don't care about the result
      // (it would just waste a network request)
      const current = list_todos().current;
      if (!current) return;
      list_todos().set([data.item, ...current]);
    });

  });
</script>
```

This PR fixes it by simply restoring the old behavior of `.current` returning `undefined` if the query has not been called yet.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
