### PR TITLE
Testing fix for CVE-2026-40073

### DIFF
--- a/.changeset/silver-worms-juggle.md
+++ b/.changeset/silver-worms-juggle.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/kit': major
+'@sveltejs/kit': test
 ---
 
 test: add regression test for body size limit bypass via missing framing headers (test if CVE-2026-40073 was actually fixed)

--- a/.changeset/silver-worms-juggle.md
+++ b/.changeset/silver-worms-juggle.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+test: add regression test for body size limit bypass via missing framing headers (test if CVE-2026-40073 was actually fixed)

--- a/.changeset/silver-worms-juggle.md
+++ b/.changeset/silver-worms-juggle.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': test
----
-
-test: add regression test for body size limit bypass via missing framing headers (test if CVE-2026-40073 was actually fixed)

--- a/packages/kit/src/exports/node/index.spec.js
+++ b/packages/kit/src/exports/node/index.spec.js
@@ -79,3 +79,18 @@ test('rejects request bodies that exceed content-length', async () => {
 		message: 'request body size exceeded content-length of 4'
 	});
 });
+
+// Test for fix of CVE-2026-40073
+test('requests with no content-length and no transfer-encoding return null body', async () => {
+	const { request, req } = await create_request({
+		headers: {},
+		bodySizeLimit: 10
+	});
+
+	const text = request.text();
+
+	req.write(Buffer.from('0123456789a')); // 11 bytes, over limit
+	req.end();
+
+	await expect(text).resolves.toBe(''); // Should return an empty string if bug is actually fixed
+});


### PR DESCRIPTION
closes # CVE-2026-40073

When reviewing the fix for the body size limit bypass in the node adapter,
I noticed the existing test suite only covered the updated code paths 
(chunked encoding, valid Content-Length) but not the original bypass path.

This adds a test documenting that HTTP/1.1 requests with no `Content-Length` 
and no `Transfer-Encoding` header return an empty body rather than processing 
oversized input.

---
- [ ] It's really useful if your PR references an issue...
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test`...

### Changesets
- [x] If your PR makes a change...

### Edits
- [x] Please ensure that 'Allow edits from maintainers' is checked.