### PR TITLE
docs: fix wording in command comment

### DIFF
--- a/packages/kit/src/runtime/client/remote-functions/command.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/command.svelte.js
@@ -35,7 +35,7 @@ export function command(id) {
 		// Increment pending count when command starts
 		pending_count++;
 
-		// Noone should call commands during rendering but belts and braces.
+		// No one should call commands during rendering but belts and braces.
 		// Do this here, after await Svelte' reactivity context is gone.
 		const headers = {
 			'Content-Type': 'application/json',

--- a/packages/kit/src/runtime/client/remote-functions/command.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/command.svelte.js
@@ -35,8 +35,8 @@ export function command(id) {
 		// Increment pending count when command starts
 		pending_count++;
 
-		// No one should call commands during rendering but belts and braces.
-		// Do this here, after await Svelte' reactivity context is gone.
+		// No one should call commands during rendering, but this is belt and braces.
+		// Do this here, after Svelte's reactivity context is gone.
 		const headers = {
 			'Content-Type': 'application/json',
 			...get_remote_request_headers()


### PR DESCRIPTION
Related issue: N/A (trivial comment wording fix)

Fixes a typo in a runtime client comment by changing `Noone` to `No one`.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs (N/A: trivial wording fix)
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it. (N/A: comment-only)

### Tests
- [x] Not run (comment-only change).

### Changesets
- [x] No package behavior changed; changeset not needed.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
