### PR TITLE
Change enhance function return type to void | Promise<void>

### DIFF
--- a/.changeset/gold-carrots-guess.md
+++ b/.changeset/gold-carrots-guess.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Change enhance function return type from void to MaybePromise<void>.

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -2095,7 +2095,7 @@ export type RemoteForm<Input extends RemoteFormInput | void, Output> = {
 			submit: () => Promise<boolean> & {
 				updates: (...updates: RemoteQueryUpdate[]) => Promise<boolean>;
 			};
-		}) => void
+		}) => MaybePromise<void>
 	): {
 		method: 'POST';
 		action: string;

--- a/packages/kit/test/apps/async/src/routes/remote/form/for-duplicate/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/for-duplicate/+page.svelte
@@ -6,6 +6,10 @@
 <p id="count">{count.current}</p>
 
 <!-- this looks weird but forces the spread into being reactive -->
-<form {...increment.for((count.current || 1) && 'a').enhance(async ({ submit }) => await submit())}>
+<form
+	{...increment.for((count.current || 1) && 'a').enhance(async ({ submit }) => {
+		await submit();
+	})}
+>
 	<button type="submit" id="submit">Submit</button>
 </form>

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2069,7 +2069,7 @@ declare module '@sveltejs/kit' {
 				submit: () => Promise<boolean> & {
 					updates: (...updates: RemoteQueryUpdate[]) => Promise<boolean>;
 				};
-			}) => void
+			}) => MaybePromise<void>
 		): {
 			method: 'POST';
 			action: string;


### PR DESCRIPTION
closes #15700

The enhance function can be (and usually is) async. The return type must therefore not be `void` but `void | Promise<void>` to prevent triggering [`@typescript-eslint/no-misused-promises`](https://typescript-eslint.io/rules/no-misused-promises/)

The return type was changed from `void | Promise<void>` to `void` in #15530, which I think was a regression. This PR changes it back.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
