### PR TITLE
fix: ignore paths.base under Vitest to avoid vite-node module resolution failures

### DIFF
--- a/.changeset/fix-vitest-base-path-conflict.md
+++ b/.changeset/fix-vitest-base-path-conflict.md
@@ -1,0 +1,7 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't apply `paths.base` to Vite config when running under Vitest
+
+When `kit.paths.base` was set to a prefix of the project's filesystem path (e.g. `/Users`), Vite would strip that prefix from the URLs vite-node uses to fetch modules over HTTP, causing `ERR_MODULE_NOT_FOUND` failures. Under Vitest, `base` is now forced to `/` so module resolution works regardless of the configured base path.

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -988,7 +988,12 @@ async function kit({ svelte_config }) {
 				} else {
 					new_config = {
 						appType: 'custom',
-						base: kit_paths_base,
+						// When running under Vitest, don't apply kit.paths.base — vite-node
+						// serves filesystem modules over HTTP and Vite will strip the base
+						// prefix from those URLs, breaking module resolution when the base
+						// happens to match the start of the project path (e.g. "/Users").
+						// See https://github.com/sveltejs/kit/issues/13737
+						base: process.env.VITEST ? '/' : kit_paths_base,
 						build: {
 							rollupOptions: {
 								// Vite dependency crawler needs an explicit JS entry point


### PR DESCRIPTION
### Description

Fixes #13737.

When `kit.paths.base` is set to a value that happens to be a prefix of the project's filesystem path (e.g. `base: "/Users"` on macOS, or `base: "/home"` on Linux), running Vitest fails with errors like:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/ubl/kit-repro-sk/node_modules/vitest/dist/spy.js'
```

### Cause

In non-build mode, the Vite plugin sets `base: kit.paths.base`. vite-node fetches modules over HTTP using absolute filesystem paths as URLs. Vite strips the configured `base` prefix from those URLs, so when the project path starts with that prefix the resulting URL no longer resolves to a real file.

### Fix

When `process.env.VITEST` is set, force `base` to `/` so vite-node's filesystem URLs are left intact. This matches the intent of the existing `order: 'pre'` treatment on the config hook (added for Vitest compatibility in #15623) — Vitest doesn't override `base` itself, so kit has to opt out.

### Reproduction

Clone https://github.com/neknalb/vitest-base-path-bug and run `npm test` — fails on `main`, passes with this change.

### Changesets

- [x] Patch changeset included.