### PR TITLE
fix: link stylesheets and fonts in the head even when SSR is disabled

### DIFF
--- a/.changeset/silver-animals-buy.md
+++ b/.changeset/silver-animals-buy.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: avoid FOUC for CSR-only pages by loading styles and fonts before CSR starts

--- a/packages/adapter-static/test/apps/spa/src/routes/+layout.svelte
+++ b/packages/adapter-static/test/apps/spa/src/routes/+layout.svelte
@@ -4,3 +4,9 @@
 </nav>
 
 <slot />
+
+<style>
+	nav {
+		background-color: lightblue;
+	}
+</style>

--- a/packages/adapter-static/test/apps/spa/test/test.js
+++ b/packages/adapter-static/test/apps/spa/test/test.js
@@ -33,3 +33,19 @@ test('uses correct environment variables for fallback page (mode = staging)', as
 	await page.goto('/fallback/x/y/z');
 	expect(await page.textContent('b')).toEqual('42');
 });
+
+test.describe(() => {
+	// this has to be inside a test.describe block or at the top-level of the module
+	test.use({ javaScriptEnabled: false });
+
+	test('fallback page includes root layout styles before CSR starts', async ({ page }) => {
+		/** @type {string[]} */
+		const requests = [];
+		page.on('request', (request) => {
+			const url = request.url();
+			if (url.endsWith('.css')) requests.push(url);
+		});
+		await page.goto('/');
+		expect(requests.length).toBe(1);
+	});
+});

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -137,6 +137,8 @@ export async function render_page(
 			}
 
 			return await render_response({
+				// provide nodes without running load functions so that the styles and
+				// fonts are linked in the head before CSR takes over
 				branch: compact(nodes.data).map((node) => {
 					return {
 						node,

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -1,3 +1,5 @@
+/** @import { ActionResult, RequestEvent, SSRManifest } from '@sveltejs/kit' */
+/** @import { PageNodeIndexes, RequestState, RequiredResolveOptions, ServerDataNode, SSRComponent, SSRNode, SSROptions, SSRState } from 'types' */
 import { text } from '@sveltejs/kit';
 import { HttpError, Redirect } from '@sveltejs/kit/internal';
 import { compact } from '../../../utils/array.js';
@@ -25,14 +27,14 @@ import { PageNodes } from '../../../utils/page_nodes.js';
 const MAX_DEPTH = 10;
 
 /**
- * @param {import('@sveltejs/kit').RequestEvent} event
- * @param {import('types').RequestState} event_state
- * @param {import('types').PageNodeIndexes} page
- * @param {import('types').SSROptions} options
- * @param {import('@sveltejs/kit').SSRManifest} manifest
- * @param {import('types').SSRState} state
+ * @param {RequestEvent} event
+ * @param {RequestState} event_state
+ * @param {PageNodeIndexes} page
+ * @param {SSROptions} options
+ * @param {SSRManifest} manifest
+ * @param {SSRState} state
  * @param {import('../../../utils/page_nodes.js').PageNodes} nodes
- * @param {import('types').RequiredResolveOptions} resolve_opts
+ * @param {RequiredResolveOptions} resolve_opts
  * @returns {Promise<Response>}
  */
 export async function render_page(
@@ -58,11 +60,11 @@ export async function render_page(
 	}
 
 	try {
-		const leaf_node = /** @type {import('types').SSRNode} */ (nodes.page());
+		const leaf_node = /** @type {SSRNode} */ (nodes.page());
 
 		let status = 200;
 
-		/** @type {import('@sveltejs/kit').ActionResult | undefined} */
+		/** @type {ActionResult | undefined} */
 		let action_result = undefined;
 
 		if (is_action_request(event)) {
@@ -135,7 +137,13 @@ export async function render_page(
 			}
 
 			return await render_response({
-				branch: [],
+				branch: compact(nodes.data).map((node) => {
+					return {
+						node,
+						data: null,
+						server_data: null
+					};
+				}),
 				fetched,
 				page_config: {
 					ssr: false,
@@ -165,7 +173,7 @@ export async function render_page(
 				? server_data_serializer_json(event, event_state, options)
 				: null;
 
-		/** @type {Array<Promise<import('types').ServerDataNode | null>>} */
+		/** @type {Array<Promise<ServerDataNode | null>>} */
 		const server_promises = nodes.data.map((node, i) => {
 			if (load_error) {
 				// if an error happens immediately, don't bother with the rest of the nodes
@@ -359,7 +367,7 @@ export async function render_page(
 			},
 			status,
 			error: null,
-			branch: !ssr ? [] : compact(branch),
+			branch: compact(branch),
 			action_result,
 			fetched,
 			data_serializer: !ssr ? server_data_serializer(event, event_state, options) : data_serializer,
@@ -388,14 +396,14 @@ export async function render_page(
 
 /**
  *
- * @param {import('types').SSROptions} options
+ * @param {SSROptions} options
  * @param {boolean} ssr
  * @param {Array<import('./types.js').Loaded | null>} branch
- * @param {import('types').PageNodeIndexes} page
- * @param {import('@sveltejs/kit').SSRManifest} manifest
+ * @param {PageNodeIndexes} page
+ * @param {SSRManifest} manifest
  */
 async function load_error_components(options, ssr, branch, page, manifest) {
-	/** @type {Array<import('types').SSRComponent | undefined> | undefined} */
+	/** @type {Array<SSRComponent | undefined> | undefined} */
 	let error_components;
 
 	if (options.server_error_boundaries && ssr) {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -267,25 +267,25 @@ export async function render_response({
 
 			paths.reset(); // just in case `options.root.render(...)` failed
 		}
-
-		for (const { node } of branch) {
-			for (const url of node.imports) modulepreloads.add(url);
-			for (const url of node.stylesheets) stylesheets.add(url);
-			for (const url of node.fonts) fonts.add(url);
-
-			if (node.inline_styles && !client.inline) {
-				Object.entries(await node.inline_styles()).forEach(([filename, css]) => {
-					if (typeof css === 'string') {
-						inline_styles.set(filename, css);
-						return;
-					}
-
-					inline_styles.set(filename, css(`${assets}/${paths.app_dir}/immutable/assets`, assets));
-				});
-			}
-		}
 	} else {
 		rendered = { head: '', html: '', css: { code: '', map: null }, hashes: { script: [] } };
+	}
+
+	for (const { node } of branch) {
+		for (const url of node.imports) modulepreloads.add(url);
+		for (const url of node.stylesheets) stylesheets.add(url);
+		for (const url of node.fonts) fonts.add(url);
+
+		if (node.inline_styles && !client.inline) {
+			Object.entries(await node.inline_styles()).forEach(([filename, css]) => {
+				if (typeof css === 'string') {
+					inline_styles.set(filename, css);
+					return;
+				}
+
+				inline_styles.set(filename, css(`${assets}/${paths.app_dir}/immutable/assets`, assets));
+			});
+		}
 	}
 
 	const head = new Head(rendered.head, !!state.prerendering);

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -566,16 +566,14 @@ export async function internal_respond(request, options, manifest, state) {
 					page_config: { ssr: false, csr: true },
 					status: 200,
 					error: null,
-					branch: page_nodes
-						? [
-								// include the root layout because it applies to every page
-								{
-									node: /** @type {SSRNode} */ (page_nodes.data[0]),
-									data: null,
-									server_data: null
-								}
-							]
-						: [],
+					branch: [
+						// include the root layout because it applies to every page
+						{
+							node: /** @type {SSRNode} */ (await manifest._.nodes[0]()),
+							data: null,
+							server_data: null
+						}
+					],
 					fetched: [],
 					resolve_opts,
 					data_serializer: server_data_serializer(event, event_state, options)

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -1,4 +1,4 @@
-/** @import { RequestState } from 'types' */
+/** @import { RequestState, SSRNode } from 'types' */
 import { DEV } from 'esm-env';
 import { json, text } from '@sveltejs/kit';
 import { Redirect, SvelteKitError } from '@sveltejs/kit/internal';
@@ -566,7 +566,16 @@ export async function internal_respond(request, options, manifest, state) {
 					page_config: { ssr: false, csr: true },
 					status: 200,
 					error: null,
-					branch: [],
+					branch: page_nodes
+						? [
+								// include the root layout because it applies to every page
+								{
+									node: /** @type {SSRNode} */ (page_nodes.data[0]),
+									data: null,
+									server_data: null
+								}
+							]
+						: [],
 					fetched: [],
 					resolve_opts,
 					data_serializer: server_data_serializer(event, event_state, options)

--- a/packages/kit/src/utils/page_nodes.js
+++ b/packages/kit/src/utils/page_nodes.js
@@ -6,6 +6,7 @@ import {
 } from './exports.js';
 
 export class PageNodes {
+	/** All layout nodes and the page node, if any */
 	data;
 
 	/**

--- a/packages/kit/test/apps/no-ssr/src/routes/styles/+page.svelte
+++ b/packages/kit/test/apps/no-ssr/src/routes/styles/+page.svelte
@@ -1,0 +1,7 @@
+<p>I should be blue</p>
+
+<style>
+	p {
+		color: blue;
+	}
+</style>

--- a/packages/kit/test/apps/no-ssr/src/routes/styles/prerendered/+page.js
+++ b/packages/kit/test/apps/no-ssr/src/routes/styles/prerendered/+page.js
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/packages/kit/test/apps/no-ssr/src/routes/styles/prerendered/+page.svelte
+++ b/packages/kit/test/apps/no-ssr/src/routes/styles/prerendered/+page.svelte
@@ -1,0 +1,7 @@
+<p>I should be red</p>
+
+<style>
+	p {
+		color: red;
+	}
+</style>

--- a/packages/kit/test/apps/no-ssr/test/no-script.test.js
+++ b/packages/kit/test/apps/no-ssr/test/no-script.test.js
@@ -1,0 +1,33 @@
+import process from 'node:process';
+import { expect } from '@playwright/test';
+import { test } from '../../../utils.js';
+
+test.skip(({ javaScriptEnabled }) => javaScriptEnabled);
+
+test.describe.configure({ mode: 'parallel' });
+
+test('styles are loaded before CSR starts for non-prerendered routes', async ({ page }) => {
+	test.skip(!!process.env.DEV);
+
+	/** @type {string[]} */
+	const requests = [];
+	page.on('request', (request) => {
+		const url = request.url();
+		if (url.endsWith('.css')) requests.push(url);
+	});
+	await page.goto('/styles');
+	expect(requests.length).toBe(1);
+});
+
+test('styles are loaded before CSR starts for prerendered routes', async ({ page }) => {
+	test.skip(!!process.env.DEV);
+
+	/** @type {string[]} */
+	const requests = [];
+	page.on('request', (request) => {
+		const url = request.url();
+		if (url.endsWith('.css')) requests.push(url);
+	});
+	await page.goto('/styles/prerendered');
+	expect(requests.length).toBe(1);
+});


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/13307
related to https://github.com/rust-lang/crates.io/issues/13436

This PR ensures that stylesheets and fonts are eagerly loaded even if SSR is disabled. This helps prevent FOUC. In the case of fallback pages, we only load the root layout which already applies to every page and is safe to load even if we don't know what route is being rendered until CSR kicks in. 

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
