### PR TITLE
fix: restore correct `RemoteFormFields` typing for nullable array fields

### DIFF
--- a/.changeset/fix-remote-form-nullable-arrays.md
+++ b/.changeset/fix-remote-form-nullable-arrays.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: restore correct `RemoteFormFields` typing for nullable array fields (e.g. when a schema uses `.default([])`), so `.as('checkbox')` and friends work again

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -2013,11 +2013,15 @@ export type RemoteFormFields<T> =
 		? RecursiveFormFields
 		: NonNullable<T> extends string | number | boolean | File
 			? RemoteFormField<NonNullable<T>>
-			: // [T] is used to prevent distributing over union, only the last condition should distribute over unions
-				[T] extends [string[] | File[]]
-				? RemoteFormField<T> & { [K in number]: RemoteFormField<T[number]> }
-				: [T] extends [Array<infer U>]
-					? RemoteFormFieldContainer<T> & {
+			: // [NonNullable<T>] is used to prevent distributing over union while still allowing
+				// nullable wrappers (e.g. `string[] | undefined` from a schema with `.default([])`)
+				// to be treated as arrays; only the last condition should distribute over unions
+				[NonNullable<T>] extends [string[] | File[]]
+				? RemoteFormField<NonNullable<T>> & {
+						[K in number]: RemoteFormField<NonNullable<T>[number]>;
+					}
+				: [NonNullable<T>] extends [Array<infer U>]
+					? RemoteFormFieldContainer<NonNullable<T>> & {
 							[K in number]: RemoteFormFields<U>;
 						}
 					: RemoteFormFieldContainer<T> & {

--- a/packages/kit/test/types/remote.test.ts
+++ b/packages/kit/test/types/remote.test.ts
@@ -430,6 +430,41 @@ function form_tests() {
 	// @ts-expect-error
 	f6.input!['array[0].prop'] = 123;
 
+	// schema with optional array fields (e.g. Zod's `.default([])` produces an input
+	// type where the property is optional, so its value type is `string[] | undefined`).
+	// Regression test for #15722.
+	const f_optional_arrays = form(
+		null as any as StandardSchemaV1<{
+			strings?: string[];
+			files?: File[];
+			objects?: Array<{ prop: string }>;
+			nested?: { strings?: string[] };
+		}>,
+		(data) => {
+			data.strings?.[0] === 'a';
+			data.files?.[0] instanceof File;
+			data.objects?.[0].prop === 'a';
+			return { success: true };
+		}
+	);
+	// `.as()` should be available on optional string[] / File[] fields
+	f_optional_arrays.fields.strings.as('checkbox', 'value');
+	f_optional_arrays.fields.strings.as('select multiple');
+	f_optional_arrays.fields.files.as('file multiple');
+	// indexed access gives back a typed field
+	f_optional_arrays.fields.strings[0].as('text');
+	f_optional_arrays.fields.files[0].as('file');
+	// optional array of objects still exposes container methods and per-item fields
+	f_optional_arrays.fields.objects.allIssues();
+	f_optional_arrays.fields.objects[0].prop.as('text');
+	// nested optional array inside optional parent also works
+	f_optional_arrays.fields.nested.strings.as('checkbox', 'value');
+	f_optional_arrays.fields.nested.strings[0].as('text');
+	// @ts-expect-error
+	f_optional_arrays.fields.strings.as('number');
+	// @ts-expect-error
+	f_optional_arrays.fields.files.as('text');
+
 	// doesn't use data
 	const f9 = form(() => Promise.resolve({ success: true }));
 	f9.result?.success === true;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1987,11 +1987,15 @@ declare module '@sveltejs/kit' {
 			? RecursiveFormFields
 			: NonNullable<T> extends string | number | boolean | File
 				? RemoteFormField<NonNullable<T>>
-				: // [T] is used to prevent distributing over union, only the last condition should distribute over unions
-					[T] extends [string[] | File[]]
-					? RemoteFormField<T> & { [K in number]: RemoteFormField<T[number]> }
-					: [T] extends [Array<infer U>]
-						? RemoteFormFieldContainer<T> & {
+				: // [NonNullable<T>] is used to prevent distributing over union while still allowing
+					// nullable wrappers (e.g. `string[] | undefined` from a schema with `.default([])`)
+					// to be treated as arrays; only the last condition should distribute over unions
+					[NonNullable<T>] extends [string[] | File[]]
+					? RemoteFormField<NonNullable<T>> & {
+							[K in number]: RemoteFormField<NonNullable<T>[number]>;
+						}
+					: [NonNullable<T>] extends [Array<infer U>]
+						? RemoteFormFieldContainer<NonNullable<T>> & {
 								[K in number]: RemoteFormFields<U>;
 							}
 						: RemoteFormFieldContainer<T> & {


### PR DESCRIPTION
Closes #15722

#### Problem
Accessing `.as(...)` on a remote form field whose schema input type includes `undefined` (e.g. Zod's `z.something().array().default([])`, which produces `string[] | undefined` for `StandardSchemaV1.InferInput`) no longer typechecks.
```ts
const schema = z.object({
  policyAvailableAccessTypes: z.enum([...]).array().default(['unlimited'])
});
// `.as()` is missing from the type, even though it works at runtime
form.fields.policyAvailableAccessTypes.as('checkbox', 'unlimited');
Cause
Regression from #15687, which switched the array-detection branches of RemoteFormFields<T> from distributive (T extends string[] | File[]) to non-distributive ([T] extends [string[] | File[]]) to stop distribution over object unions.
With the new non-distributive check, [string[] | undefined] does not extend [string[] | File[]] (nor [Array<infer U>]), so nullable array types fall through to the generic object-property branch, which doesn't expose .as(...).
Fix
Wrap T in NonNullable<T> on the array-detection branches, consistent with how the primitive branch right above it already works:
: [NonNullable<T>] extends [string[] | File[]]
    ? RemoteFormField<NonNullable<T>> & { [K in number]: RemoteFormField<NonNullable<T>[number]> }
    : [NonNullable<T>] extends [Array<infer U>]
        ? RemoteFormFieldContainer<NonNullable<T>> & { [K in number]: RemoteFormFields<U> }
        : // object-union branch unchanged — still uses KeysOfUnion / ValueOfUnionKey on raw T
The final object-union branch is unchanged, so #15687's fix for discriminated-union objects is preserved.
