### PR TITLE
fix: reset form result on redirect

### DIFF
--- a/.changeset/spotty-islands-battle.md
+++ b/.changeset/spotty-islands-battle.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: reset form result on redirect

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -228,6 +228,7 @@ export function form(id) {
 
 					// reset issues in case it's a redirect or error (but issues passed in that case)
 					raw_issues = [];
+					result = undefined;
 
 					if (form_result.type === 'result') {
 						({ issues: raw_issues = [], result } = devalue.parse(form_result.result, app.decoders));

--- a/packages/kit/test/apps/async/src/routes/remote/form/reset-on-redirect/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/reset-on-redirect/+page.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { reset_form } from './form.remote';
+</script>
+
+<form {...reset_form}>
+	<button id="return" {...reset_form.fields.action.as('submit', 'return')}>Return</button>
+	<button id="redirect" {...reset_form.fields.action.as('submit', 'redirect')}>Redirect</button>
+</form>
+
+<div id="result">{reset_form.result}</div>

--- a/packages/kit/test/apps/async/src/routes/remote/form/reset-on-redirect/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/reset-on-redirect/form.remote.ts
@@ -1,0 +1,19 @@
+import { form, getRequestEvent } from '$app/server';
+import { redirect } from '@sveltejs/kit';
+import * as v from 'valibot';
+
+export const reset_form = form(
+	v.object({
+		action: v.picklist(['return', 'redirect'])
+	}),
+	(data) => {
+		const { url } = getRequestEvent();
+		switch (data.action) {
+			case 'return':
+				return 'hello world';
+			case 'redirect':
+				url.search += 'foo';
+				redirect(303, url.href);
+		}
+	}
+);

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -555,6 +555,16 @@ test.describe('client error boundaries', () => {
 		// The nested layout should still be visible
 		await expect(page.locator('#nested-layout')).toBeVisible();
 	});
+	test('redirecting from form clears result', async ({ page }) => {
+		await page.goto('/remote/form/reset-on-redirect');
+
+		const result = page.locator('#result');
+
+		await page.locator('#return').click();
+		await expect(result).toHaveText('hello world');
+		await page.locator('#redirect').click();
+		await expect(result).not.toHaveText('hello world');
+	});
 });
 
 test.describe('fork', () => {


### PR DESCRIPTION
Normal (non-enhanced) form behavior is to clear state when the form is submitted, regardless of whether the result is an error, a redirect, or a value. Currently, the previous `result` remains untouched, which is unexpected if the form redirects back to the same page it's on. This is a one-line fix.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
