### PR TITLE
Change error message to 'Internal Server Error'

### DIFF
--- a/packages/kit/src/utils/error.js
+++ b/packages/kit/src/utils/error.js
@@ -34,5 +34,5 @@ export function get_status(error) {
  * @param {unknown} error
  */
 export function get_message(error) {
-	return error instanceof SvelteKitError ? error.text : 'Internal Error';
+	return error instanceof SvelteKitError ? error.text : 'Internal Server Error';
 }


### PR DESCRIPTION
###### (No issue referenced as this is an issue and pr in one)

When a general error with no description (`SvelteKitError.prototype.text`) occurs, it says "500\nInternal Error" on the screen.  
"Internal Error" is ambiguous to the average user (e.g. it could also mean it's an internal browser error).  
I suggest using the standard "Internal Server Error" message as per [RFC 9110 Section 15.6.1](https://www.rfc-editor.org/rfc/rfc9110#section-15.6.1).

To that end, I have made a single line change to `utils/error.js` that changes the default/fallback error message.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`
0 errors

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

I don't don't think this qualifies for changelog notes, but just in case here is the output of `pnpm changeset`:
```
---
'@sveltejs/kit': patch
---

Default error message changed from "Internal Error" to standard "Internal Server Error"
```

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
