### PR TITLE
Exclude deleted cookies from `Cookies#getAll`

### DIFF
--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -139,7 +139,11 @@ export function get_cookies(request, url) {
 
 			// Add the most specific cookies to the result
 			for (const c of lookup.values()) {
-				cookies[c.name] = c.value;
+				if (c.options.maxAge === 0) {
+					delete cookies[c.name];
+				} else {
+					cookies[c.name] = c.value;
+				}
 			}
 
 			return Object.entries(cookies).map(([name, value]) => ({ name, value }));

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -191,6 +191,14 @@ describe.skipIf(process.env.NODE_ENV !== 'production')('cookies in prod', () => 
 		]);
 	});
 
+	test('getAll excludes cookies deleted during the current event', () => {
+		const { cookies } = cookies_setup();
+
+		cookies.delete('a', { path: '/' });
+
+		expect(cookies.getAll()).toEqual([]);
+	});
+
 	test("set_internal isn't affected by defaults", () => {
 		const { cookies, new_cookies, set_internal } = cookies_setup({
 			href: 'https://example.com/a/b/c'


### PR DESCRIPTION

**Repo:** sveltejs/kit (⭐ 19000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +13/-1

## What
Updates the runtime cookie aggregation logic so `cookies.getAll()` treats `maxAge: 0` cookies as deleted instead of returning them with an empty value. The patch also adds a focused regression test covering a cookie that exists on the request header and is deleted during the current event.

## Why
`cookies.get()` already treats `maxAge: 0` as a deletion, but `cookies.getAll()` was still surfacing the deleted cookie. That inconsistency can leak stale cookie state to server code that relies on `getAll()` for a full snapshot, especially after calling `cookies.delete(...)` within the same request lifecycle.

## Testing
Targeted verification path: `NODE_ENV=production pnpm --dir packages/kit exec vitest --config kit.vitest.config.js run src/runtime/server/cookie.spec.js`.
I did not complete this locally because the clone has no installed dependencies and `pnpm` was blocked from creating its default home directory in the sandbox. The added regression test is in `packages/kit/src/runtime/server/cookie.spec.js`.

## Risk
Low / The change only affects `getAll()` handling of cookies already marked for deletion and aligns it with existing `get()` semantics.
