### PR TITLE
fix: throw on external links in `resolve`

### DIFF
--- a/.changeset/resolve-throws-on-external-urls.md
+++ b/.changeset/resolve-throws-on-external-urls.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: throw an error when `resolve` is called with an external URL

--- a/packages/kit/src/runtime/app/paths/client.js
+++ b/packages/kit/src/runtime/app/paths/client.js
@@ -52,6 +52,13 @@ const pathname_prefix = hash_routing ? '#' : '';
  * @returns {ResolvedPathname}
  */
 export function resolve(...args) {
+	if (!args[0].startsWith('/')) {
+		throw new Error(
+			`Cannot use \`resolve(...)\` with a non-absolute pathname or route ID (got "${args[0]}"). ` +
+				'`resolve` is only for internal pathnames and route IDs; external URLs should be used directly.'
+		);
+	}
+
 	// The type error is correct here, and if someone doesn't pass params when they should there's a runtime error,
 	// but we don't want to adjust the internal resolve_route function to accept `undefined`, hence the type cast.
 	return (

--- a/packages/kit/src/runtime/app/paths/server.js
+++ b/packages/kit/src/runtime/app/paths/server.js
@@ -13,6 +13,13 @@ export function asset(file) {
 
 /** @type {import('./client.js').resolve} */
 export function resolve(id, params) {
+	if (!id.startsWith('/')) {
+		throw new Error(
+			`Cannot use \`resolve(...)\` with a non-absolute pathname or route ID (got "${id}"). ` +
+				'`resolve` is only for internal pathnames and route IDs; external URLs should be used directly.'
+		);
+	}
+
 	const resolved = resolve_route(id, /** @type {Record<string, string>} */ (params));
 
 	if (relative) {


### PR DESCRIPTION
Closes #15714

`resolve` should not accept external links; the whole point of it is to resolve internal links.
