### PR TITLE
fix: ensure remote function queries update when using schema transfor…

### DIFF
--- a/.changeset/three-timers-destroy.md
+++ b/.changeset/three-timers-destroy.md
@@ -2,4 +2,4 @@
 "@sveltejs/kit": patch
 ---
 
-fix: ensure remote function queries update when using schema transforms
+fix: ensure remote query `refresh()` and `set()` use the original argument key when the query schema transforms its input

--- a/.changeset/three-timers-destroy.md
+++ b/.changeset/three-timers-destroy.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: ensure remote function queries update when using schema transforms

--- a/packages/kit/src/runtime/app/server/remote/prerender.js
+++ b/packages/kit/src/runtime/app/server/remote/prerender.js
@@ -92,14 +92,13 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 		/** @type {Promise<Output> & Partial<RemoteResource<Output>>} */
 		const promise = (async () => {
 			const { event, state } = get_request_store();
-			const payload = stringify_remote_arg(arg, state.transport);
+			const key = stringify_remote_arg(arg, state.transport);
 			const id = __.id;
-			const url = `${base}/${app_dir}/remote/${id}${payload ? `/${payload}` : ''}`;
+			const url = `${base}/${app_dir}/remote/${id}${key ? `/${key}` : ''}`;
 
 			if (!state.prerendering && !DEV && !event.isRemoteRequest) {
 				try {
-					return await get_response(__, arg, state, async () => {
-						const key = stringify_remote_arg(arg, state.transport);
+					return await get_response(__, key, state, async () => {
 						const cache = get_cache(__, state);
 
 						// TODO adapters can provide prerendered data more efficiently than
@@ -132,7 +131,7 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 				return /** @type {Promise<any>} */ (state.prerendering.remote_responses.get(url));
 			}
 
-			const promise = get_response(__, arg, state, () =>
+			const promise = get_response(__, key, state, () =>
 				run_remote_function(event, state, false, () => validate(arg), fn)
 			);
 

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -74,10 +74,19 @@ export function query(validate_or_fn, maybe_fn) {
 		}
 
 		const { event, state } = get_request_store();
-		// if the user got this argument from `requested(query)`, it will have already passed validation
-		const is_validated = is_validated_argument(__, state, arg);
 
-		return create_query_resource(__, arg, state, () =>
+		// If the user got this argument from `requested(query)`, it has already passed
+		// validation and may have been transformed by the schema. In that case we need
+		// to use the original raw argument as the cache key so that it matches the key
+		// the client uses.
+		const validated_args = state.remote.validated?.get(__.id);
+		const is_validated = validated_args?.has(arg) ?? false;
+		const key = stringify_remote_arg(
+			is_validated ? validated_args?.get(arg) : arg,
+			state.transport
+		);
+
+		return create_query_resource(__, key, state, () =>
 			run_remote_function(event, state, false, () => (is_validated ? arg : validate(arg)), fn)
 		);
 	};
@@ -90,41 +99,21 @@ export function query(validate_or_fn, maybe_fn) {
 /**
  * @param {RemoteQueryInternals} __
  * @param {RequestState} state
- * @param {any} arg
- */
-function is_validated_argument(__, state, arg) {
-	return state.remote.validated?.get(__.id)?.has(arg) ?? false;
-}
-
-/**
- * @param {RemoteQueryInternals} __
- * @param {RequestState} state
- * @param {any} arg
+ * @param {any} validated_arg
  * @param {any} raw_arg
  */
-export function mark_argument_validated(__, state, arg, raw_arg) {
+export function mark_argument_validated(__, state, validated_arg, raw_arg) {
 	const validated = (state.remote.validated ??= new Map());
 	let validated_args = validated.get(__.id);
 
 	if (!validated_args) {
-		validated_args = new Set();
+		validated_args = new Map();
 		validated.set(__.id, validated_args);
 	}
 
-	validated_args.add(arg);
+	validated_args.set(validated_arg, raw_arg);
 
-	/** @type {Map<string, Map<any, any>>} */
-	const raw = (state.remote.raw_args ??= new Map());
-	let raw_args = raw.get(__.id);
-
-	if (!raw_args) {
-		raw_args = new Map();
-		raw.set(__.id, raw_args);
-	}
-
-	raw_args.set(arg, raw_arg);
-
-	return arg;
+	return validated_arg;
 }
 
 /**
@@ -219,12 +208,14 @@ function batch(validate_or_fn, maybe_fn) {
 		}
 
 		const { event, state } = get_request_store();
+		// batched queries do not participate in `requested(...)`, so `arg` is
+		// always the raw user-supplied value and can be used for the cache key directly
+		const key = stringify_remote_arg(arg, state.transport);
 
-		return create_query_resource(__, arg, state, () => {
+		return create_query_resource(__, key, state, () => {
 			// Collect all the calls to the same query in the same macrotask,
 			// then execute them as one backend request.
 			return new Promise((resolve, reject) => {
-				const key = stringify_remote_arg(arg, state.transport);
 				const entry = batching.get(key);
 
 				if (entry) {
@@ -288,17 +279,17 @@ function batch(validate_or_fn, maybe_fn) {
 
 /**
  * @param {RemoteInternals} __
- * @param {any} arg
+ * @param {string} key — the stringified raw argument (i.e. the cache key the client will use)
  * @param {RequestState} state
  * @param {() => Promise<any>} fn
  * @returns {RemoteQuery<any>}
  */
-function create_query_resource(__, arg, state, fn) {
+function create_query_resource(__, key, state, fn) {
 	/** @type {Promise<any> | null} */
 	let promise = null;
 
 	const get_promise = () => {
-		return (promise ??= get_response(__, arg, state, fn));
+		return (promise ??= get_response(__, key, state, fn));
 	};
 
 	return {
@@ -315,8 +306,7 @@ function create_query_resource(__, arg, state, fn) {
 		loading: true,
 		ready: false,
 		refresh() {
-			const refresh_arg = state.remote.raw_args?.get(__.id)?.get(arg) ?? arg;
-			const refresh_context = get_refresh_context(__, 'refresh', refresh_arg);
+			const refresh_context = get_refresh_context(__, 'refresh', key);
 			const is_immediate_refresh = !refresh_context.cache[refresh_context.cache_key];
 			const value = is_immediate_refresh ? get_promise() : fn();
 			return update_refresh_value(refresh_context, value, is_immediate_refresh);
@@ -330,11 +320,11 @@ function create_query_resource(__, arg, state, fn) {
 					'On the server, .run() can only be called in universal `load` functions. Anywhere else, just await the query directly'
 				);
 			}
-			return get_response(__, arg, state, fn);
+			return get_response(__, key, state, fn);
 		},
 		/** @param {any} value */
 		set(value) {
-			return update_refresh_value(get_refresh_context(__, 'set', arg), value);
+			return update_refresh_value(get_refresh_context(__, 'set', key), value);
 		},
 		/** @type {Promise<any>['then']} */
 		then(onfulfilled, onrejected) {
@@ -355,10 +345,10 @@ Object.defineProperty(query, 'batch', { value: batch, enumerable: true });
 /**
  * @param {RemoteInternals} __
  * @param {'set' | 'refresh'} action
- * @param {any} [arg]
+ * @param {string} cache_key — the stringified raw argument
  * @returns {{ __: RemoteInternals; state: any; refreshes: Record<string, Promise<any>>; cache: Record<string, { serialize: boolean; data: any }>; refreshes_key: string; cache_key: string }}
  */
-function get_refresh_context(__, action, arg) {
+function get_refresh_context(__, action, cache_key) {
 	const { state } = get_request_store();
 	const { refreshes } = state.remote;
 
@@ -370,7 +360,6 @@ function get_refresh_context(__, action, arg) {
 	}
 
 	const cache = get_cache(__, state);
-	const cache_key = stringify_remote_arg(arg, state.transport);
 	const refreshes_key = create_remote_key(__.id, cache_key);
 
 	return { __, state, refreshes, refreshes_key, cache, cache_key };

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -100,8 +100,9 @@ function is_validated_argument(__, state, arg) {
  * @param {RemoteQueryInternals} __
  * @param {RequestState} state
  * @param {any} arg
+ * @param {any} raw_arg
  */
-export function mark_argument_validated(__, state, arg) {
+export function mark_argument_validated(__, state, arg, raw_arg) {
 	const validated = (state.remote.validated ??= new Map());
 	let validated_args = validated.get(__.id);
 
@@ -111,6 +112,18 @@ export function mark_argument_validated(__, state, arg) {
 	}
 
 	validated_args.add(arg);
+
+	/** @type {Map<string, Map<any, any>>} */
+	const raw = (state.remote.raw_args ??= new Map());
+	let raw_args = raw.get(__.id);
+
+	if (!raw_args) {
+		raw_args = new Map();
+		raw.set(__.id, raw_args);
+	}
+
+	raw_args.set(arg, raw_arg);
+
 	return arg;
 }
 
@@ -302,7 +315,8 @@ function create_query_resource(__, arg, state, fn) {
 		loading: true,
 		ready: false,
 		refresh() {
-			const refresh_context = get_refresh_context(__, 'refresh', arg);
+			const refresh_arg = state.remote.raw_args?.get(__.id)?.get(arg) ?? arg;
+			const refresh_context = get_refresh_context(__, 'refresh', refresh_arg);
 			const is_immediate_refresh = !refresh_context.cache[refresh_context.cache_key];
 			const value = is_immediate_refresh ? get_promise() : fn();
 			return update_refresh_value(refresh_context, value, is_immediate_refresh);

--- a/packages/kit/src/runtime/app/server/remote/requested.js
+++ b/packages/kit/src/runtime/app/server/remote/requested.js
@@ -85,7 +85,7 @@ export function requested(query, limit = Infinity) {
 						);
 					}
 
-					yield mark_argument_validated(internals, state, validated);
+					yield mark_argument_validated(internals, state, validated, parsed);
 				} catch (error) {
 					record_failure(payload, error);
 					continue;
@@ -97,7 +97,7 @@ export function requested(query, limit = Infinity) {
 				try {
 					const parsed = parse_remote_arg(payload, state.transport);
 					const validated = await internals.validate(parsed);
-					return mark_argument_validated(internals, state, validated);
+					return mark_argument_validated(internals, state, validated, parsed);
 				} catch (error) {
 					record_failure(payload, error);
 					throw new Error(`Skipping ${internals.name}(${payload})`, { cause: error });

--- a/packages/kit/src/runtime/app/server/remote/shared.js
+++ b/packages/kit/src/runtime/app/server/remote/shared.js
@@ -4,12 +4,7 @@ import { parse } from 'devalue';
 import { error } from '@sveltejs/kit';
 import { with_request_store, get_request_store } from '@sveltejs/kit/internal/server';
 import { noop } from '../../../../utils/functions.js';
-import {
-	stringify_remote_arg,
-	create_remote_key,
-	stringify,
-	unfriendly_hydratable
-} from '../../../shared.js';
+import { create_remote_key, stringify, unfriendly_hydratable } from '../../../shared.js';
 
 /**
  * @param {any} validate_or_fn
@@ -68,18 +63,17 @@ export function create_validator(validate_or_fn, maybe_fn) {
  *
  * @template {MaybePromise<any>} T
  * @param {RemoteInternals} internals
- * @param {any} arg
+ * @param {string} key — the stringified raw argument (i.e. the cache key the client will use)
  * @param {RequestState} state
  * @param {() => Promise<T>} get_result
  * @returns {Promise<T>}
  */
-export async function get_response(internals, arg, state, get_result) {
+export async function get_response(internals, key, state, get_result) {
 	// wait a beat, in case `myQuery().set(...)` or `myQuery().refresh()` is immediately called
 	// eslint-disable-next-line @typescript-eslint/await-thenable
 	await 0;
 
 	const cache = get_cache(internals, state);
-	const key = stringify_remote_arg(arg, state.transport);
 	const entry = (cache[key] ??= {
 		serialize: false,
 		data: get_result()

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -158,7 +158,12 @@ export async function internal_respond(request, options, manifest, state) {
 			 * A map of remote function ID to objects that have passed validation;
 			 * used to prevent revalidating parameters returned from `requested`
 			 */
-			validated: null
+			validated: null,
+			/**
+			 * A map of remote function ID to raw arguments passed to the function;
+			 * Used to generate the cache_key, ensuring queries are refreshed correctly based on their original input
+			 */
+			raw_args: null
 		},
 		is_in_remote_function: false,
 		is_in_render: false,

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -155,15 +155,13 @@ export async function internal_respond(request, options, manifest, state) {
 			/** A map of remote function ID to payloads requested for refreshing by the client */
 			requested: null,
 			/**
-			 * A map of remote function ID to objects that have passed validation;
-			 * used to prevent revalidating parameters returned from `requested`
+			 * A map of remote function ID to a map of validated argument to the
+			 * corresponding raw (pre-validation) argument. Membership of the inner
+			 * map is used to prevent revalidating parameters returned from `requested`,
+			 * and the mapping is used to key caches/refreshes by the raw argument
+			 * (the one the client uses) rather than the possibly-transformed one.
 			 */
-			validated: null,
-			/**
-			 * A map of remote function ID to raw arguments passed to the function;
-			 * Used to generate the cache_key, ensuring queries are refreshed correctly based on their original input
-			 */
-			raw_args: null
+			validated: null
 		},
 		is_in_remote_function: false,
 		is_in_render: false,

--- a/packages/kit/src/runtime/shared.js
+++ b/packages/kit/src/runtime/shared.js
@@ -1,6 +1,6 @@
 /** @import { Transport } from '@sveltejs/kit' */
 import * as devalue from 'devalue';
-import { base64_decode, base64_encode, text_decoder } from './utils.js';
+import { base64_decode, base64_encode, text_decoder, text_encoder } from './utils.js';
 import * as svelte from 'svelte';
 
 /**
@@ -261,7 +261,7 @@ export function stringify_remote_arg(value, transport, sort = true) {
 		create_remote_arg_reducers(transport, sort, new Map())
 	);
 
-	const bytes = new TextEncoder().encode(json_string);
+	const bytes = text_encoder.encode(json_string);
 	return base64_encode(bytes).replaceAll('=', '').replaceAll('+', '-').replaceAll('/', '_');
 }
 

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -663,8 +663,7 @@ export interface RequestState {
 		forms: null | Map<any, any>;
 		refreshes: null | Record<string, Promise<any>>;
 		requested: null | Map<string, string[]>;
-		validated: null | Map<string, Set<any>>;
-		raw_args: null | Map<string, Map<any, any>>;
+		validated: null | Map<string, Map<any, any>>;
 	};
 	readonly is_in_remote_function: boolean;
 	readonly is_in_render: boolean;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -664,6 +664,7 @@ export interface RequestState {
 		refreshes: null | Record<string, Promise<any>>;
 		requested: null | Map<string, string[]>;
 		validated: null | Map<string, Set<any>>;
+		raw_args: null | Map<string, Map<any, any>>;
 	};
 	readonly is_in_remote_function: boolean;
 	readonly is_in_render: boolean;

--- a/packages/kit/test/apps/async/src/routes/remote/form/transform/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/transform/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { get_transformed_data, update_data } from './form.remote.ts';
+	import { get_transformed_data, update_data, set_data } from './form.remote.ts';
 
 	const key = 42;
 	const result = $derived(await get_transformed_data(key));
@@ -11,4 +11,8 @@
 
 <button id="update-btn" onclick={() => update_data().updates(get_transformed_data(key))}>
 	Update and Refresh All
+</button>
+
+<button id="set-btn" onclick={() => set_data().updates(get_transformed_data(key))}>
+	Set via requested
 </button>

--- a/packages/kit/test/apps/async/src/routes/remote/form/transform/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/transform/+page.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { get_transformed_data, update_data } from './form.remote.ts';
+
+	const key = 42;
+	const result = $derived(await get_transformed_data(key));
+</script>
+
+<h1>Transform Refresh Test</h1>
+
+<p id="result">{result}</p>
+
+<button id="update-btn" onclick={() => update_data().updates(get_transformed_data(key))}>
+	Update and Refresh All
+</button>

--- a/packages/kit/test/apps/async/src/routes/remote/form/transform/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/transform/form.remote.ts
@@ -1,0 +1,20 @@
+import { query, command, requested } from '$app/server';
+import * as v from 'valibot';
+
+let count = 0;
+
+export const get_transformed_data = query(
+	v.pipe(
+		v.number(),
+		v.transform((n) => String(n)) // Transforms number to string
+	),
+	(transformed_value) => {
+		return `Count for ${transformed_value} is ${count}`;
+	}
+);
+
+export const update_data = command(async () => {
+	count++;
+
+	await requested(get_transformed_data, 1).refreshAll();
+});

--- a/packages/kit/test/apps/async/src/routes/remote/form/transform/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/transform/form.remote.ts
@@ -18,3 +18,9 @@ export const update_data = command(async () => {
 
 	await requested(get_transformed_data, 1).refreshAll();
 });
+
+export const set_data = command(async () => {
+	for await (const arg of requested(get_transformed_data, 1)) {
+		get_transformed_data(arg).set(`Set value for ${arg}`);
+	}
+});

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -426,6 +426,26 @@ test.describe('remote function mutations', () => {
 		await expect(page.locator('#phrase')).toHaveText('i am your father');
 	});
 
+	test('refreshAll works with schema transforms (number to string)', async ({ page }) => {
+		await page.goto('/remote/form/transform');
+
+		await expect(page.locator('#result')).toHaveText('Count for 42 is 0');
+
+		await page.click('#update-btn');
+		await expect(page.locator('#result')).toHaveText('Count for 42 is 1');
+	});
+
+	test('.set() works with schema transforms when arg comes from requested()', async ({
+		page
+	}) => {
+		await page.goto('/remote/form/transform');
+
+		await expect(page.locator('#result')).toHaveText(/Count for 42 is \d+/);
+
+		await page.click('#set-btn');
+		await expect(page.locator('#result')).toHaveText('Set value for 42');
+	});
+
 	test.describe('query runtime guardrails', () => {
 		test('query created outside tracking context can run but cannot expose reactive state', async ({
 			page

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -687,18 +687,6 @@ test.describe('remote functions', () => {
 		await expect(form2.locator('input[name="color_field"]')).toHaveValue('#00ff00');
 		await expect(form2.locator('input[name="n:range_field"]')).toHaveValue('8');
 	});
-
-	test('refreshAll works with schema transforms (number to string)', async ({
-		page,
-		javaScriptEnabled
-	}) => {
-		if (!javaScriptEnabled) return;
-
-		await page.goto('/remote/form/transform');
-
-		await page.click('#update-btn');
-		await expect(page.locator('#result')).toHaveText('Count for 42 is 1');
-	});
 });
 
 test.describe('server error boundaries', () => {

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -687,6 +687,18 @@ test.describe('remote functions', () => {
 		await expect(form2.locator('input[name="color_field"]')).toHaveValue('#00ff00');
 		await expect(form2.locator('input[name="n:range_field"]')).toHaveValue('8');
 	});
+
+	test('refreshAll works with schema transforms (number to string)', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		if (!javaScriptEnabled) return;
+
+		await page.goto('/remote/form/transform');
+
+		await page.click('#update-btn');
+		await expect(page.locator('#result')).toHaveText('Count for 42 is 1');
+	});
 });
 
 test.describe('server error boundaries', () => {


### PR DESCRIPTION
Closes #15696<!-- Add the related issue number here. Repeat this line for each additional issue it closes -->

If a remote function query has a validator that returns a value different from its original input, the generated cache key will use the validator’s output instead of the original input when refreshing the query. This can lead to queries not being refreshed correctly even when the same argument is passed.

I was not able to test these changes. I followed the CONTRIBUTING.md steps to add `pnpm.overrides` to the `package.json` of a test app but I got this error when trying to run it:
```
20:33:30 [vite] (ssr) Error when evaluating SSR module /@fs/D:/projects/kit/packages/kit/src/runtime/server/index.js: D:/projects/test/.svelte-kit/generated/root.svelte Invalid compiler option: runes should be true or false, if specified
https://svelte.dev/e/options_invalid_value
  Plugin: vite-plugin-svelte:compile
  File: D:/projects/test/.svelte-kit/generated/root.svelte
```

This is my first PR here so please be gentle :D

Thank you!

<!-- Explain the goal of the PR, why it is needed, and what has been changed to achieve that goal -->

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [X] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [X] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [X] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
