### PR TITLE
breaking: return bound `query` instance from `requested`

### DIFF
--- a/.changeset/proud-masks-taste.md
+++ b/.changeset/proud-masks-taste.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+breaking: require `limit` in `requested` (as originally intended)

--- a/.changeset/remote-query-function-validated-generic.md
+++ b/.changeset/remote-query-function-validated-generic.md
@@ -2,23 +2,4 @@
 "@sveltejs/kit": minor
 ---
 
-feat: `RemoteQueryFunction` gains an optional third generic parameter `Validated` (defaulting to `Input`) that represents the argument type after schema validation/transformation. For queries declared with a [Standard Schema](https://standardschema.dev/), it resolves to `InferOutput<Schema>`, so `requested()` now correctly types `arg` as the post-transform value instead of the pre-transform input.
-
-```ts
-import * as v from 'valibot';
-import { query } from '$app/server';
-
-const getPost = query(
-	v.pipe(v.number(), v.transform(String)),
-	async (id) => {/* ... */}
-);
-// getPost: RemoteQueryFunction<number, Post, string>
-//                              ^Input  ^Output ^Validated
-
-for (const { arg } of requested(getPost)) {
-	// arg is now typed as string (the post-transform value),
-	// previously it was incorrectly typed as number
-}
-```
-
-Existing code using `RemoteQueryFunction<Input, Output>` continues to work because the new parameter defaults to `Input`.
+feat: `RemoteQueryFunction` gains an optional third generic parameter `Validated` (defaulting to `Input`) that represents the argument type after schema validation/transformation

--- a/.changeset/remote-query-function-validated-generic.md
+++ b/.changeset/remote-query-function-validated-generic.md
@@ -1,0 +1,24 @@
+---
+"@sveltejs/kit": minor
+---
+
+feat: `RemoteQueryFunction` gains an optional third generic parameter `Validated` (defaulting to `Input`) that represents the argument type after schema validation/transformation. For queries declared with a [Standard Schema](https://standardschema.dev/), it resolves to `InferOutput<Schema>`, so `requested()` now correctly types `arg` as the post-transform value instead of the pre-transform input.
+
+```ts
+import * as v from 'valibot';
+import { query } from '$app/server';
+
+const getPost = query(
+	v.pipe(v.number(), v.transform(String)),
+	async (id) => {/* ... */}
+);
+// getPost: RemoteQueryFunction<number, Post, string>
+//                              ^Input  ^Output ^Validated
+
+for (const { arg } of requested(getPost)) {
+	// arg is now typed as string (the post-transform value),
+	// previously it was incorrectly typed as number
+}
+```
+
+Existing code using `RemoteQueryFunction<Input, Output>` continues to work because the new parameter defaults to `Input`.

--- a/.changeset/requested-returns-arg-query-entries.md
+++ b/.changeset/requested-returns-arg-query-entries.md
@@ -2,25 +2,4 @@
 "@sveltejs/kit": minor
 ---
 
-breaking: `requested(query)` now yields `{ arg, query }` entries instead of the validated argument. 
-
-Each `query` is a `RemoteQuery` bound to the client's original cache key, which ensures `refresh()` / `set()` update the correct client instance even when the query's schema transforms its input.
-
-Before:
-
-```js
-for (const arg of requested(getPost, 5)) {
-  void getPost(arg).refresh();
-}
-```
-
-After:
-
-```js
-for (const { arg, query } of requested(getPost, 5)) {
-  void query.refresh();
-  // use `arg` for any side effects (e.g. DB writes)
-}
-```
-
-`refreshAll()` is unchanged.
+breaking: `requested` now yields `{ arg, query }` entries instead of the validated argument

--- a/.changeset/requested-returns-arg-query-entries.md
+++ b/.changeset/requested-returns-arg-query-entries.md
@@ -1,0 +1,26 @@
+---
+"@sveltejs/kit": minor
+---
+
+breaking: `requested(query)` now yields `{ arg, query }` entries instead of the validated argument. 
+
+Each `query` is a `RemoteQuery` bound to the client's original cache key, which ensures `refresh()` / `set()` update the correct client instance even when the query's schema transforms its input.
+
+Before:
+
+```js
+for (const arg of requested(getPost, 5)) {
+  void getPost(arg).refresh();
+}
+```
+
+After:
+
+```js
+for (const { arg, query } of requested(getPost, 5)) {
+  void query.refresh();
+  // use `arg` for any side effects (e.g. DB writes)
+}
+```
+
+`refreshAll()` is unchanged.

--- a/.changeset/three-timers-destroy.md
+++ b/.changeset/three-timers-destroy.md
@@ -2,4 +2,4 @@
 "@sveltejs/kit": patch
 ---
 
-fix: ensure remote function queries update when using schema transforms
+fix: ensure remote query `refresh()` and `set()` use the original argument key when the query schema transforms its input

--- a/.changeset/three-timers-destroy.md
+++ b/.changeset/three-timers-destroy.md
@@ -1,5 +1,0 @@
----
-"@sveltejs/kit": patch
----
-
-fix: ensure remote query `refresh()` and `set()` use the original argument key when the query schema transforms its input

--- a/.changeset/three-timers-destroy.md
+++ b/.changeset/three-timers-destroy.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: ensure remote function queries update when using schema transforms

--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -972,8 +972,8 @@ export const createPost = form(
 	async (data) => {
 		// form logic goes here...
 
-		+++for (const arg of requested(getPosts, 1)) {+++
-		+++	void getPosts(arg).refresh();+++
+		+++for (const { query } of requested(getPosts, 1)) {+++
+		+++	void query.refresh();+++
 		+++}+++
 
 		// Redirect to the newly created page
@@ -982,7 +982,7 @@ export const createPost = form(
 );
 ```
 
-`requested` gives you access to the requested query arguments for the supplied query. It returns the *parsed* arguments for the query -- when these arguments are passed back into the query in `getPosts(arg).refresh()`, they will not be parsed again. If parsing an argument fails, that query will error, but the entire command will not fail. `requested`'s second parameter, `limit`, is the maximum number of items it will return. Any refresh requests beyond this limit will fail.
+`requested` gives you access to the queries the client requested to refresh. Each entry is an `{ arg, query }` object: `arg` is the argument passed to the query and validated using the query's schema, and `query` is a `RemoteQuery` already bound to the client's original cache key, so calling `query.refresh()` / `query.set(...)` updates the correct client instance. If parsing an argument fails, that query will error, but the entire command will not fail. `requested`'s second parameter, `limit`, is the maximum number of items it will return. Any refresh requests beyond this limit will fail.
 
 Additionally, `requested` allows a simple shorthand when all you want to do is refresh the requested query instances:
 
@@ -991,7 +991,7 @@ import type { RemoteQueryFunction } from '@sveltejs/kit';
 import { requested } from '$app/server';
 declare const getPosts: RemoteQueryFunction<any, any>;
 // ---cut---
-// this is the same as looping over the result and calling `void getPosts(arg).refresh()`.
+// this is the same as looping over the result and calling `void query.refresh()`.
 await requested(getPosts, 1).refreshAll();
 ```
 

--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -982,7 +982,9 @@ export const createPost = form(
 );
 ```
 
-`requested` gives you access to the queries the client requested to refresh. Each entry is an `{ arg, query }` object: `arg` is the argument passed to the query and validated using the query's schema, and `query` is a `RemoteQuery` already bound to the client's original cache key, so calling `query.refresh()` / `query.set(...)` updates the correct client instance. If parsing an argument fails, that query will error, but the entire command will not fail. `requested`'s second parameter, `limit`, is the maximum number of items it will return. Any refresh requests beyond this limit will fail.
+`requested` gives you access to the queries the client requested to refresh. Each entry is an `{ arg, query }` object: `arg` is the value the query's implementation function received — i.e. the argument *after* the schema has validated and (where applicable) transformed it — and `query` is a `RemoteQuery` already bound to the client's original cache key, so calling `query.refresh()` / `query.set(...)` updates the correct client instance. If parsing an argument fails, that query will error, but the entire command will not fail. `requested`'s second parameter, `limit`, is the maximum number of items it will return. Any refresh requests beyond this limit will fail.
+
+> [!NOTE] `limit` is required because the list of refresh requests is controlled by the client — each entry causes the server to validate an argument and usually re-fetch data, so an unbounded list is a denial-of-service risk. Choose a limit that reflects the worst case you're willing to handle per request. You _can_ pass `Infinity` if you have explicitly decided to accept any number of refreshes, but it is not recommended.
 
 Additionally, `requested` allows a simple shorthand when all you want to do is refresh the requested query instances:
 
@@ -994,6 +996,11 @@ declare const getPosts: RemoteQueryFunction<any, any>;
 // this is the same as looping over the result and calling `void query.refresh()`.
 await requested(getPosts, 1).refreshAll();
 ```
+
+> [!NOTE] Why does the command have to name every query it's willing to refresh? Two reasons:
+>
+> - **Bundle size.** If a command could implicitly refresh *any* query in your app, SvelteKit would have to include every query's code in the command's server bundle, because it can't know ahead of time which ones will be called.
+> - **Denial-of-service.** Any malicious user can inspect their network tab to discover which queries your app uses, then POST a command with a client-supplied list of thousands of refreshes. The only defence is for the server handler to declare which queries it is willing to refresh — and in what quantity (hence the required `limit`).
 
 ## prerender
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,7 +52,19 @@ export default [
 			'@typescript-eslint/await-thenable': 'error',
 			'@typescript-eslint/no-unused-expressions': 'off',
 			'@typescript-eslint/require-await': 'error',
-			'@typescript-eslint/no-floating-promises': 'error'
+			'@typescript-eslint/no-floating-promises': 'error',
+			'@typescript-eslint/no-unused-vars': [
+				'error',
+				{
+					args: 'all',
+					argsIgnorePattern: '^_',
+					caughtErrors: 'all',
+					caughtErrorsIgnorePattern: '^_',
+					destructuredArrayIgnorePattern: '^_',
+					varsIgnorePattern: '^_',
+					ignoreRestSiblings: true
+				}
+			]
 		},
 		ignores: [
 			'packages/adapter-cloudflare/test/apps/**/*',

--- a/packages/amp/index.js
+++ b/packages/amp/index.js
@@ -8,7 +8,7 @@ const boilerplate = `
 /** @param {string} html */
 export function transform(html) {
 	return html
-		.replace(/<style([^]+?)<\/style>/, (match, $1) => `<style amp-custom${$1}</style>`)
+		.replace(/<style([^]+?)<\/style>/, (_match, $1) => `<style amp-custom${$1}</style>`)
 		.replace(/<script[^]+?<\/script>/g, '')
 		.replace(/<link[^>]+>/g, (match) => {
 			if (/rel=('|")?stylesheet\1/.test(match)) {

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1452,16 +1452,27 @@ export interface Page<
  */
 export type ParamMatcher = (param: string) => boolean;
 
-export type RequestedResult<T> = Iterable<T> &
-	AsyncIterable<T> & {
+/**
+ * A single entry yielded by [`requested`](https://svelte.dev/docs/kit/$app-server#requested).
+ * `arg` is the validated argument (the input *after* the query's schema validated and
+ * transformed it, if applicable); `query` is a `RemoteQuery` bound to the client's
+ * original cache key, so `refresh()` / `set()` will update the correct client entry.
+ */
+export type RequestedEntry<Validated, Output> = {
+	arg: Validated;
+	query: RemoteQuery<Output>;
+};
+
+export type RequestedResult<Validated, Output> = Iterable<RequestedEntry<Validated, Output>> &
+	AsyncIterable<RequestedEntry<Validated, Output>> & {
 		/**
 		 * Call `refresh` on all queries selected by this `requested` invocation.
 		 * This is identical to:
 		 * ```ts
 		 * import { requested } from '$app/server';
 		 *
-		 * for await (const arg of requested(query, ...) {
-		 *   void query(arg).refresh();
+		 * for await (const { query } of requested(getPost, ...)) {
+		 *   void query.refresh();
 		 * }
 		 * ```
 		 */
@@ -2221,9 +2232,27 @@ export type RemotePrerenderFunction<Input, Output> = (
 
 /**
  * The return value of a remote `query` function. See [Remote functions](https://svelte.dev/docs/kit/remote-functions#query) for full documentation.
+ *
+ * The optional `Validated` generic parameter represents the argument type *after* the
+ * query's schema has validated and (optionally) transformed it — this is the type the
+ * query's implementation function receives on the server, and the type yielded by
+ * [`requested`](https://svelte.dev/docs/kit/$app-server#requested). For queries declared
+ * with [Standard Schema](https://standardschema.dev/) it differs from `Input` when the
+ * schema contains a transform (e.g. `v.pipe(v.number(), v.transform(String))` has
+ * `Input = number` but `Validated = string`). For `'unchecked'` validators and queries
+ * without arguments it defaults to `Input`.
  */
-export type RemoteQueryFunction<Input, Output> = (
+export type RemoteQueryFunction<Input, Output, Validated = Input> = ((
 	arg: undefined extends Input ? Input | void : Input
-) => RemoteQuery<Output>;
+) => RemoteQuery<Output>) & {
+	/**
+	 * Phantom property that exists for type inference only — it is never set at
+	 * runtime, hence the `?`. Used by
+	 * [`requested`](https://svelte.dev/docs/kit/$app-server#requested) to recover
+	 * the post-validation argument type. Do not read this property; it will always
+	 * be `undefined`. Prefixed with `~` to sort to the bottom of IntelliSense.
+	 */
+	readonly ['~validated']?: Validated;
+};
 
 export * from './index.js';

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -2242,17 +2242,8 @@ export type RemotePrerenderFunction<Input, Output> = (
  * `Input = number` but `Validated = string`). For `'unchecked'` validators and queries
  * without arguments it defaults to `Input`.
  */
-export type RemoteQueryFunction<Input, Output, Validated = Input> = ((
+export type RemoteQueryFunction<Input, Output, _Validated = Input> = (
 	arg: undefined extends Input ? Input | void : Input
-) => RemoteQuery<Output>) & {
-	/**
-	 * Phantom property that exists for type inference only — it is never set at
-	 * runtime, hence the `?`. Used by
-	 * [`requested`](https://svelte.dev/docs/kit/$app-server#requested) to recover
-	 * the post-validation argument type. Do not read this property; it will always
-	 * be `undefined`. Prefixed with `~` to sort to the bottom of IntelliSense.
-	 */
-	readonly ['~validated']?: Validated;
-};
+) => RemoteQuery<Output>;
 
 export * from './index.js';

--- a/packages/kit/src/runtime/app/server/remote/prerender.js
+++ b/packages/kit/src/runtime/app/server/remote/prerender.js
@@ -92,14 +92,13 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 		/** @type {Promise<Output> & Partial<RemoteResource<Output>>} */
 		const promise = (async () => {
 			const { event, state } = get_request_store();
-			const payload = stringify_remote_arg(arg, state.transport);
+			const key = stringify_remote_arg(arg, state.transport);
 			const id = __.id;
-			const url = `${base}/${app_dir}/remote/${id}${payload ? `/${payload}` : ''}`;
+			const url = `${base}/${app_dir}/remote/${id}${key ? `/${key}` : ''}`;
 
 			if (!state.prerendering && !DEV && !event.isRemoteRequest) {
 				try {
-					return await get_response(__, arg, state, async () => {
-						const key = stringify_remote_arg(arg, state.transport);
+					return await get_response(__, key, state, async () => {
 						const cache = get_cache(__, state);
 
 						// TODO adapters can provide prerendered data more efficiently than
@@ -132,7 +131,7 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 				return /** @type {Promise<any>} */ (state.prerendering.remote_responses.get(url));
 			}
 
-			const promise = get_response(__, arg, state, () =>
+			const promise = get_response(__, key, state, () =>
 				run_remote_function(event, state, false, () => validate(arg), fn)
 			);
 

--- a/packages/kit/src/runtime/app/server/remote/prerender.js
+++ b/packages/kit/src/runtime/app/server/remote/prerender.js
@@ -92,18 +92,18 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 		/** @type {Promise<Output> & Partial<RemoteResource<Output>>} */
 		const promise = (async () => {
 			const { event, state } = get_request_store();
-			const key = stringify_remote_arg(arg, state.transport);
+			const payload = stringify_remote_arg(arg, state.transport);
 			const id = __.id;
-			const url = `${base}/${app_dir}/remote/${id}${key ? `/${key}` : ''}`;
+			const url = `${base}/${app_dir}/remote/${id}${payload ? `/${payload}` : ''}`;
 
 			if (!state.prerendering && !DEV && !event.isRemoteRequest) {
 				try {
-					return await get_response(__, key, state, async () => {
+					return await get_response(__, payload, state, async () => {
 						const cache = get_cache(__, state);
 
 						// TODO adapters can provide prerendered data more efficiently than
 						// fetching from the public internet
-						const promise = (cache[key] ??= {
+						const promise = (cache[payload] ??= {
 							serialize: true,
 							data: fetch(new URL(url, event.url.origin).href).then(async (response) => {
 								if (!response.ok) {
@@ -131,7 +131,7 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 				return /** @type {Promise<any>} */ (state.prerendering.remote_responses.get(url));
 			}
 
-			const promise = get_response(__, key, state, () =>
+			const promise = get_response(__, payload, state, () =>
 				run_remote_function(event, state, false, () => validate(arg), fn)
 			);
 

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -74,10 +74,19 @@ export function query(validate_or_fn, maybe_fn) {
 		}
 
 		const { event, state } = get_request_store();
-		// if the user got this argument from `requested(query)`, it will have already passed validation
-		const is_validated = is_validated_argument(__, state, arg);
 
-		return create_query_resource(__, arg, state, () =>
+		// If the user got this argument from `requested(query)`, it has already passed
+		// validation and may have been transformed by the schema. In that case we need
+		// to use the original raw argument as the cache key so that it matches the key
+		// the client uses.
+		const validated_args = state.remote.validated?.get(__.id);
+		const is_validated = validated_args?.has(arg) ?? false;
+		const key = stringify_remote_arg(
+			is_validated ? validated_args?.get(arg) : arg,
+			state.transport
+		);
+
+		return create_query_resource(__, key, state, () =>
 			run_remote_function(event, state, false, () => (is_validated ? arg : validate(arg)), fn)
 		);
 	};
@@ -90,41 +99,21 @@ export function query(validate_or_fn, maybe_fn) {
 /**
  * @param {RemoteQueryInternals} __
  * @param {RequestState} state
- * @param {any} arg
- */
-function is_validated_argument(__, state, arg) {
-	return state.remote.validated?.get(__.id)?.has(arg) ?? false;
-}
-
-/**
- * @param {RemoteQueryInternals} __
- * @param {RequestState} state
- * @param {any} arg
+ * @param {any} validated_arg
  * @param {any} raw_arg
  */
-export function mark_argument_validated(__, state, arg, raw_arg) {
+export function mark_argument_validated(__, state, validated_arg, raw_arg) {
 	const validated = (state.remote.validated ??= new Map());
 	let validated_args = validated.get(__.id);
 
 	if (!validated_args) {
-		validated_args = new Set();
+		validated_args = new Map();
 		validated.set(__.id, validated_args);
 	}
 
-	validated_args.add(arg);
+	validated_args.set(validated_arg, raw_arg);
 
-	/** @type {Map<string, Map<any, any>>} */
-	const raw = (state.remote.raw_args ??= new Map());
-	let raw_args = raw.get(__.id);
-
-	if (!raw_args) {
-		raw_args = new Map();
-		raw.set(__.id, raw_args);
-	}
-
-	raw_args.set(arg, raw_arg);
-
-	return arg;
+	return validated_arg;
 }
 
 /**
@@ -219,12 +208,14 @@ function batch(validate_or_fn, maybe_fn) {
 		}
 
 		const { event, state } = get_request_store();
+		// batched queries do not participate in `requested(...)`, so `arg` is
+		// always the raw user-supplied value and can be used for the cache key directly
+		const key = stringify_remote_arg(arg, state.transport);
 
-		return create_query_resource(__, arg, state, () => {
+		return create_query_resource(__, key, state, () => {
 			// Collect all the calls to the same query in the same macrotask,
 			// then execute them as one backend request.
 			return new Promise((resolve, reject) => {
-				const key = stringify_remote_arg(arg, state.transport);
 				const entry = batching.get(key);
 
 				if (entry) {
@@ -288,17 +279,17 @@ function batch(validate_or_fn, maybe_fn) {
 
 /**
  * @param {RemoteInternals} __
- * @param {any} arg
+ * @param {string} key — the stringified raw argument (i.e. the cache key the client will use)
  * @param {RequestState} state
  * @param {() => Promise<any>} fn
  * @returns {RemoteQuery<any>}
  */
-function create_query_resource(__, arg, state, fn) {
+function create_query_resource(__, key, state, fn) {
 	/** @type {Promise<any> | null} */
 	let promise = null;
 
 	const get_promise = () => {
-		return (promise ??= get_response(__, arg, state, fn));
+		return (promise ??= get_response(__, key, state, fn));
 	};
 
 	return {
@@ -315,8 +306,7 @@ function create_query_resource(__, arg, state, fn) {
 		loading: true,
 		ready: false,
 		refresh() {
-			const refresh_arg = state.remote.raw_args?.get(__.id)?.get(arg) ?? arg;
-			const refresh_context = get_refresh_context(__, 'refresh', refresh_arg);
+			const refresh_context = get_refresh_context(__, 'refresh', key);
 			const is_immediate_refresh = !refresh_context.cache[refresh_context.cache_key];
 			const value = is_immediate_refresh ? get_promise() : fn();
 			return update_refresh_value(refresh_context, value, is_immediate_refresh);
@@ -330,11 +320,11 @@ function create_query_resource(__, arg, state, fn) {
 					'On the server, .run() can only be called in universal `load` functions. Anywhere else, just await the query directly'
 				);
 			}
-			return get_response(__, arg, state, fn);
+			return get_response(__, key, state, fn);
 		},
 		/** @param {any} value */
 		set(value) {
-			return update_refresh_value(get_refresh_context(__, 'set', arg), value);
+			return update_refresh_value(get_refresh_context(__, 'set', key), value);
 		},
 		/** @type {Promise<any>['then']} */
 		then(onfulfilled, onrejected) {
@@ -355,10 +345,10 @@ Object.defineProperty(query, 'batch', { value: batch, enumerable: true });
 /**
  * @param {RemoteInternals} __
  * @param {'set' | 'refresh'} action
- * @param {any} [arg]
+ * @param {string} cache_key — the stringified raw argument
  * @returns {{ __: RemoteInternals; state: any; refreshes: Record<string, Promise<any>>; cache: Record<string, { serialize: boolean; data: any }>; refreshes_key: string; cache_key: string }}
  */
-function get_refresh_context(__, action, arg) {
+function get_refresh_context(__, action, cache_key) {
 	const { state } = get_request_store();
 	const { refreshes } = state.remote;
 
@@ -370,7 +360,6 @@ function get_refresh_context(__, action, arg) {
 	}
 
 	const cache = get_cache(__, state);
-	const cache_key = stringify_remote_arg(arg, state.transport);
 	const refreshes_key = create_remote_key(__.id, cache_key);
 
 	return { __, state, refreshes, refreshes_key, cache, cache_key };

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -100,8 +100,9 @@ function is_validated_argument(__, state, arg) {
  * @param {RemoteQueryInternals} __
  * @param {RequestState} state
  * @param {any} arg
+ * @param {any} raw_arg
  */
-export function mark_argument_validated(__, state, arg) {
+export function mark_argument_validated(__, state, arg, raw_arg) {
 	const validated = (state.remote.validated ??= new Map());
 	let validated_args = validated.get(__.id);
 
@@ -111,6 +112,18 @@ export function mark_argument_validated(__, state, arg) {
 	}
 
 	validated_args.add(arg);
+
+	/** @type {Map<string, Map<any, any>>} */
+	const raw = (state.remote.raw_args ??= new Map());
+	let raw_args = raw.get(__.id);
+
+	if (!raw_args) {
+		raw_args = new Map();
+		raw.set(__.id, raw_args);
+	}
+
+	raw_args.set(arg, raw_arg);
+
 	return arg;
 }
 
@@ -302,7 +315,8 @@ function create_query_resource(__, arg, state, fn) {
 		loading: true,
 		ready: false,
 		refresh() {
-			const refresh_context = get_refresh_context(__, 'refresh', arg);
+			const refresh_arg = state.remote.raw_args?.get(__.id)?.get(arg) ?? arg;
+			const refresh_context = get_refresh_context(__, 'refresh', refresh_arg);
 			const is_immediate_refresh = !refresh_context.cache[refresh_context.cache_key];
 			const value = is_immediate_refresh ? get_promise() : fn();
 			return update_refresh_value(refresh_context, value, is_immediate_refresh);

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -43,7 +43,7 @@ import { HttpError, SvelteKitError } from '@sveltejs/kit/internal';
  * @overload
  * @param {Schema} schema
  * @param {(arg: StandardSchemaV1.InferOutput<Schema>) => MaybePromise<Output>} fn
- * @returns {RemoteQueryFunction<StandardSchemaV1.InferInput<Schema>, Output>}
+ * @returns {RemoteQueryFunction<StandardSchemaV1.InferInput<Schema>, Output, StandardSchemaV1.InferOutput<Schema>>}
  * @since 2.27
  */
 /**
@@ -63,7 +63,19 @@ export function query(validate_or_fn, maybe_fn) {
 	const validate = create_validator(validate_or_fn, maybe_fn);
 
 	/** @type {RemoteQueryInternals} */
-	const __ = { type: 'query', id: '', name: '', validate };
+	const __ = {
+		type: 'query',
+		id: '',
+		name: '',
+		validate,
+		bind(payload, validated_arg) {
+			const { event, state } = get_request_store();
+
+			return create_query_resource(__, payload, state, () =>
+				run_remote_function(event, state, false, () => validated_arg, fn)
+			);
+		}
+	};
 
 	/** @type {RemoteQueryFunction<Input, Output> & { __: RemoteQueryInternals }} */
 	const wrapper = (arg) => {
@@ -74,46 +86,16 @@ export function query(validate_or_fn, maybe_fn) {
 		}
 
 		const { event, state } = get_request_store();
+		const payload = stringify_remote_arg(arg, state.transport);
 
-		// If the user got this argument from `requested(query)`, it has already passed
-		// validation and may have been transformed by the schema. In that case we need
-		// to use the original raw argument as the cache key so that it matches the key
-		// the client uses.
-		const validated_args = state.remote.validated?.get(__.id);
-		const is_validated = validated_args?.has(arg) ?? false;
-		const key = stringify_remote_arg(
-			is_validated ? validated_args?.get(arg) : arg,
-			state.transport
-		);
-
-		return create_query_resource(__, key, state, () =>
-			run_remote_function(event, state, false, () => (is_validated ? arg : validate(arg)), fn)
+		return create_query_resource(__, payload, state, () =>
+			run_remote_function(event, state, false, () => validate(arg), fn)
 		);
 	};
 
 	Object.defineProperty(wrapper, '__', { value: __ });
 
 	return wrapper;
-}
-
-/**
- * @param {RemoteQueryInternals} __
- * @param {RequestState} state
- * @param {any} validated_arg
- * @param {any} raw_arg
- */
-export function mark_argument_validated(__, state, validated_arg, raw_arg) {
-	const validated = (state.remote.validated ??= new Map());
-	let validated_args = validated.get(__.id);
-
-	if (!validated_args) {
-		validated_args = new Map();
-		validated.set(__.id, validated_args);
-	}
-
-	validated_args.set(validated_arg, raw_arg);
-
-	return validated_arg;
 }
 
 /**
@@ -139,7 +121,7 @@ export function mark_argument_validated(__, state, validated_arg, raw_arg) {
  * @overload
  * @param {Schema} schema
  * @param {(args: StandardSchemaV1.InferOutput<Schema>[]) => MaybePromise<(arg: StandardSchemaV1.InferOutput<Schema>, idx: number) => Output>} fn
- * @returns {RemoteQueryFunction<StandardSchemaV1.InferInput<Schema>, Output>}
+ * @returns {RemoteQueryFunction<StandardSchemaV1.InferInput<Schema>, Output, StandardSchemaV1.InferOutput<Schema>>}
  * @since 2.35
  */
 /**
@@ -210,20 +192,20 @@ function batch(validate_or_fn, maybe_fn) {
 		const { event, state } = get_request_store();
 		// batched queries do not participate in `requested(...)`, so `arg` is
 		// always the raw user-supplied value and can be used for the cache key directly
-		const key = stringify_remote_arg(arg, state.transport);
+		const payload = stringify_remote_arg(arg, state.transport);
 
-		return create_query_resource(__, key, state, () => {
+		return create_query_resource(__, payload, state, () => {
 			// Collect all the calls to the same query in the same macrotask,
 			// then execute them as one backend request.
 			return new Promise((resolve, reject) => {
-				const entry = batching.get(key);
+				const entry = batching.get(payload);
 
 				if (entry) {
 					entry.resolvers.push({ resolve, reject });
 					return;
 				}
 
-				batching.set(key, {
+				batching.set(payload, {
 					arg,
 					resolvers: [{ resolve, reject }]
 				});
@@ -279,17 +261,17 @@ function batch(validate_or_fn, maybe_fn) {
 
 /**
  * @param {RemoteInternals} __
- * @param {string} key — the stringified raw argument (i.e. the cache key the client will use)
+ * @param {string} payload — the stringified raw argument (i.e. the cache key the client will use)
  * @param {RequestState} state
  * @param {() => Promise<any>} fn
  * @returns {RemoteQuery<any>}
  */
-function create_query_resource(__, key, state, fn) {
+function create_query_resource(__, payload, state, fn) {
 	/** @type {Promise<any> | null} */
 	let promise = null;
 
 	const get_promise = () => {
-		return (promise ??= get_response(__, key, state, fn));
+		return (promise ??= get_response(__, payload, state, fn));
 	};
 
 	return {
@@ -306,8 +288,8 @@ function create_query_resource(__, key, state, fn) {
 		loading: true,
 		ready: false,
 		refresh() {
-			const refresh_context = get_refresh_context(__, 'refresh', key);
-			const is_immediate_refresh = !refresh_context.cache[refresh_context.cache_key];
+			const refresh_context = get_refresh_context(__, 'refresh', payload);
+			const is_immediate_refresh = !refresh_context.cache[refresh_context.payload];
 			const value = is_immediate_refresh ? get_promise() : fn();
 			return update_refresh_value(refresh_context, value, is_immediate_refresh);
 		},
@@ -320,11 +302,11 @@ function create_query_resource(__, key, state, fn) {
 					'On the server, .run() can only be called in universal `load` functions. Anywhere else, just await the query directly'
 				);
 			}
-			return get_response(__, key, state, fn);
+			return get_response(__, payload, state, fn);
 		},
 		/** @param {any} value */
 		set(value) {
-			return update_refresh_value(get_refresh_context(__, 'set', key), value);
+			return update_refresh_value(get_refresh_context(__, 'set', payload), value);
 		},
 		/** @type {Promise<any>['then']} */
 		then(onfulfilled, onrejected) {
@@ -345,10 +327,10 @@ Object.defineProperty(query, 'batch', { value: batch, enumerable: true });
 /**
  * @param {RemoteInternals} __
  * @param {'set' | 'refresh'} action
- * @param {string} cache_key — the stringified raw argument
- * @returns {{ __: RemoteInternals; state: any; refreshes: Record<string, Promise<any>>; cache: Record<string, { serialize: boolean; data: any }>; refreshes_key: string; cache_key: string }}
+ * @param {string} payload — the stringified raw argument
+ * @returns {{ __: RemoteInternals; state: any; refreshes: Record<string, Promise<any>>; cache: Record<string, { serialize: boolean; data: any }>; refreshes_key: string; payload: string }}
  */
-function get_refresh_context(__, action, cache_key) {
+function get_refresh_context(__, action, payload) {
 	const { state } = get_request_store();
 	const { refreshes } = state.remote;
 
@@ -360,26 +342,26 @@ function get_refresh_context(__, action, cache_key) {
 	}
 
 	const cache = get_cache(__, state);
-	const refreshes_key = create_remote_key(__.id, cache_key);
+	const refreshes_key = create_remote_key(__.id, payload);
 
-	return { __, state, refreshes, refreshes_key, cache, cache_key };
+	return { __, state, refreshes, refreshes_key, cache, payload };
 }
 
 /**
- * @param {{ __: RemoteInternals; refreshes: Record<string, Promise<any>>; cache: Record<string, { serialize: boolean; data: any }>; refreshes_key: string; cache_key: string }} context
+ * @param {{ __: RemoteInternals; refreshes: Record<string, Promise<any>>; cache: Record<string, { serialize: boolean; data: any }>; refreshes_key: string; payload: string }} context
  * @param {any} value
  * @param {boolean} [is_immediate_refresh=false]
  * @returns {Promise<void>}
  */
 function update_refresh_value(
-	{ __, refreshes, refreshes_key, cache, cache_key },
+	{ __, refreshes, refreshes_key, cache, payload },
 	value,
 	is_immediate_refresh = false
 ) {
 	const promise = Promise.resolve(value);
 
 	if (!is_immediate_refresh) {
-		cache[cache_key] = { serialize: true, data: promise };
+		cache[payload] = { serialize: true, data: promise };
 	}
 
 	if (__.id) {

--- a/packages/kit/src/runtime/app/server/remote/requested.js
+++ b/packages/kit/src/runtime/app/server/remote/requested.js
@@ -85,7 +85,7 @@ export function requested(query, limit = Infinity) {
 						);
 					}
 
-					yield mark_argument_validated(internals, state, validated);
+					yield mark_argument_validated(internals, state, validated, parsed);
 				} catch (error) {
 					record_failure(payload, error);
 					continue;
@@ -97,7 +97,7 @@ export function requested(query, limit = Infinity) {
 				try {
 					const parsed = parse_remote_arg(payload, state.transport);
 					const validated = await internals.validate(parsed);
-					return mark_argument_validated(internals, state, validated);
+					return mark_argument_validated(internals, state, validated, parsed);
 				} catch (error) {
 					record_failure(payload, error);
 					throw new Error(`Skipping ${internals.name}(${payload})`, { cause: error });

--- a/packages/kit/src/runtime/app/server/remote/requested.js
+++ b/packages/kit/src/runtime/app/server/remote/requested.js
@@ -40,10 +40,10 @@ import { noop } from '../../../../utils/functions.js';
  * @template Output
  * @template [Validated=Input]
  * @param {RemoteQueryFunction<Input, Output, Validated>} query
- * @param {number} [limit=Infinity]
+ * @param {number} limit
  * @returns {RequestedResult<Validated, Output>}
  */
-export function requested(query, limit = Infinity) {
+export function requested(query, limit) {
 	const { state } = get_request_store();
 	const internals = /** @type {RemoteQueryInternals | undefined} */ (/** @type {any} */ (query).__);
 

--- a/packages/kit/src/runtime/app/server/remote/requested.js
+++ b/packages/kit/src/runtime/app/server/remote/requested.js
@@ -3,23 +3,28 @@
 import { get_request_store } from '@sveltejs/kit/internal/server';
 import { create_remote_key, parse_remote_arg } from '../../../shared.js';
 import { noop } from '../../../../utils/functions.js';
-import { mark_argument_validated } from './query.js';
 
 /**
  * In the context of a remote `command` or `form` request, returns an iterable
- * of the client-requested refreshes' validated arguments up to the supplied limit.
- * Arguments that fail validation or exceed the limit are recorded as failures in
+ * of `{ arg, query }` entries for the refreshes requested by the client, up to
+ * the supplied `limit`. Each `query` is a `RemoteQuery` bound to the original
+ * client-side cache key, so `refresh()` / `set()` propagate correctly even when
+ * the query's schema transforms the input. `arg` is the *validated* argument,
+ * i.e. the value after the schema has run (so `InferOutput<Schema>` for queries
+ * declared with a Standard Schema).
+ *
+ * Arguments that fail validation or exceed `limit` are recorded as failures in
  * the response to the client.
  *
  * @example
  * ```ts
  * import { requested } from '$app/server';
  *
- * for (const arg of requested(getPost, 5)) {
- * 	// it's safe to throw away this promise -- SvelteKit
- * 	// will await it for us and handle any errors by sending
- * 	// them to the client.
- * 	void getPost(arg).refresh();
+ * for (const { arg, query } of requested(getPost, 5)) {
+ * 	// `arg` is the validated argument; `query` is bound to the client's
+ * 	// cache key. It's safe to throw away this promise -- SvelteKit will
+ * 	// await it and forward any errors to the client.
+ * 	void query.refresh();
  * }
  * ```
  *
@@ -33,9 +38,10 @@ import { mark_argument_validated } from './query.js';
  *
  * @template Input
  * @template Output
- * @param {RemoteQueryFunction<Input, Output>} query
+ * @template [Validated=Input]
+ * @param {RemoteQueryFunction<Input, Output, Validated>} query
  * @param {number} [limit=Infinity]
- * @returns {RequestedResult<Input>}
+ * @returns {RequestedResult<Validated, Output>}
  */
 export function requested(query, limit = Infinity) {
 	const { state } = get_request_store();
@@ -85,7 +91,7 @@ export function requested(query, limit = Infinity) {
 						);
 					}
 
-					yield mark_argument_validated(internals, state, validated, parsed);
+					yield { arg: validated, query: internals.bind(payload, validated) };
 				} catch (error) {
 					record_failure(payload, error);
 					continue;
@@ -97,7 +103,7 @@ export function requested(query, limit = Infinity) {
 				try {
 					const parsed = parse_remote_arg(payload, state.transport);
 					const validated = await internals.validate(parsed);
-					return mark_argument_validated(internals, state, validated, parsed);
+					return { arg: validated, query: internals.bind(payload, validated) };
 				} catch (error) {
 					record_failure(payload, error);
 					throw new Error(`Skipping ${internals.name}(${payload})`, { cause: error });
@@ -105,8 +111,8 @@ export function requested(query, limit = Infinity) {
 			});
 		},
 		async refreshAll() {
-			for await (const arg of this) {
-				void query(arg).refresh();
+			for await (const { query } of this) {
+				void query.refresh();
 			}
 		}
 	};

--- a/packages/kit/src/runtime/app/server/remote/shared.js
+++ b/packages/kit/src/runtime/app/server/remote/shared.js
@@ -63,18 +63,18 @@ export function create_validator(validate_or_fn, maybe_fn) {
  *
  * @template {MaybePromise<any>} T
  * @param {RemoteInternals} internals
- * @param {string} key — the stringified raw argument (i.e. the cache key the client will use)
+ * @param {string} payload — the stringified raw argument (i.e. the cache key the client will use)
  * @param {RequestState} state
  * @param {() => Promise<T>} get_result
  * @returns {Promise<T>}
  */
-export async function get_response(internals, key, state, get_result) {
+export async function get_response(internals, payload, state, get_result) {
 	// wait a beat, in case `myQuery().set(...)` or `myQuery().refresh()` is immediately called
 	// eslint-disable-next-line @typescript-eslint/await-thenable
 	await 0;
 
 	const cache = get_cache(internals, state);
-	const entry = (cache[key] ??= {
+	const entry = (cache[payload] ??= {
 		serialize: false,
 		data: get_result()
 	});
@@ -82,7 +82,7 @@ export async function get_response(internals, key, state, get_result) {
 	entry.serialize ||= !!state.is_in_universal_load;
 
 	if (state.is_in_render && internals.id) {
-		const remote_key = create_remote_key(internals.id, key);
+		const remote_key = create_remote_key(internals.id, payload);
 
 		Promise.resolve(entry.data)
 			.then((value) => {

--- a/packages/kit/src/runtime/app/server/remote/shared.js
+++ b/packages/kit/src/runtime/app/server/remote/shared.js
@@ -4,12 +4,7 @@ import { parse } from 'devalue';
 import { error } from '@sveltejs/kit';
 import { with_request_store, get_request_store } from '@sveltejs/kit/internal/server';
 import { noop } from '../../../../utils/functions.js';
-import {
-	stringify_remote_arg,
-	create_remote_key,
-	stringify,
-	unfriendly_hydratable
-} from '../../../shared.js';
+import { create_remote_key, stringify, unfriendly_hydratable } from '../../../shared.js';
 
 /**
  * @param {any} validate_or_fn
@@ -68,18 +63,17 @@ export function create_validator(validate_or_fn, maybe_fn) {
  *
  * @template {MaybePromise<any>} T
  * @param {RemoteInternals} internals
- * @param {any} arg
+ * @param {string} key — the stringified raw argument (i.e. the cache key the client will use)
  * @param {RequestState} state
  * @param {() => Promise<T>} get_result
  * @returns {Promise<T>}
  */
-export async function get_response(internals, arg, state, get_result) {
+export async function get_response(internals, key, state, get_result) {
 	// wait a beat, in case `myQuery().set(...)` or `myQuery().refresh()` is immediately called
 	// eslint-disable-next-line @typescript-eslint/await-thenable
 	await 0;
 
 	const cache = get_cache(internals, state);
-	const key = stringify_remote_arg(arg, state.transport);
 	const entry = (cache[key] ??= {
 		serialize: false,
 		data: get_result()

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -158,7 +158,12 @@ export async function internal_respond(request, options, manifest, state) {
 			 * A map of remote function ID to objects that have passed validation;
 			 * used to prevent revalidating parameters returned from `requested`
 			 */
-			validated: null
+			validated: null,
+			/**
+			 * A map of remote function ID to raw arguments passed to the function;
+			 * Used to generate the cache_key, ensuring queries are refreshed correctly based on their original input
+			 */
+			raw_args: null
 		},
 		is_in_remote_function: false,
 		is_in_render: false,

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -153,15 +153,7 @@ export async function internal_respond(request, options, manifest, state) {
 			/** A map of remote function key to corresponding single-flight-mutation promise */
 			refreshes: null,
 			/** A map of remote function ID to payloads requested for refreshing by the client */
-			requested: null,
-			/**
-			 * A map of remote function ID to a map of validated argument to the
-			 * corresponding raw (pre-validation) argument. Membership of the inner
-			 * map is used to prevent revalidating parameters returned from `requested`,
-			 * and the mapping is used to key caches/refreshes by the raw argument
-			 * (the one the client uses) rather than the possibly-transformed one.
-			 */
-			validated: null
+			requested: null
 		},
 		is_in_remote_function: false,
 		is_in_render: false,

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -155,15 +155,13 @@ export async function internal_respond(request, options, manifest, state) {
 			/** A map of remote function ID to payloads requested for refreshing by the client */
 			requested: null,
 			/**
-			 * A map of remote function ID to objects that have passed validation;
-			 * used to prevent revalidating parameters returned from `requested`
+			 * A map of remote function ID to a map of validated argument to the
+			 * corresponding raw (pre-validation) argument. Membership of the inner
+			 * map is used to prevent revalidating parameters returned from `requested`,
+			 * and the mapping is used to key caches/refreshes by the raw argument
+			 * (the one the client uses) rather than the possibly-transformed one.
 			 */
-			validated: null,
-			/**
-			 * A map of remote function ID to raw arguments passed to the function;
-			 * Used to generate the cache_key, ensuring queries are refreshed correctly based on their original input
-			 */
-			raw_args: null
+			validated: null
 		},
 		is_in_remote_function: false,
 		is_in_render: false,

--- a/packages/kit/src/runtime/shared.js
+++ b/packages/kit/src/runtime/shared.js
@@ -1,6 +1,6 @@
 /** @import { Transport } from '@sveltejs/kit' */
 import * as devalue from 'devalue';
-import { base64_decode, base64_encode, text_decoder } from './utils.js';
+import { base64_decode, base64_encode, text_decoder, text_encoder } from './utils.js';
 import * as svelte from 'svelte';
 
 /**
@@ -261,7 +261,7 @@ export function stringify_remote_arg(value, transport, sort = true) {
 		create_remote_arg_reducers(transport, sort, new Map())
 	);
 
-	const bytes = new TextEncoder().encode(json_string);
+	const bytes = text_encoder.encode(json_string);
 	return base64_encode(bytes).replaceAll('=', '').replaceAll('+', '-').replaceAll('/', '_');
 }
 

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -663,8 +663,7 @@ export interface RequestState {
 		forms: null | Map<any, any>;
 		refreshes: null | Record<string, Promise<any>>;
 		requested: null | Map<string, string[]>;
-		validated: null | Map<string, Set<any>>;
-		raw_args: null | Map<string, Map<any, any>>;
+		validated: null | Map<string, Map<any, any>>;
 	};
 	readonly is_in_remote_function: boolean;
 	readonly is_in_render: boolean;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -22,7 +22,8 @@ import {
 	ClientInit,
 	Transport,
 	HandleValidationError,
-	RemoteFormIssue
+	RemoteFormIssue,
+	RemoteQuery
 } from '@sveltejs/kit';
 import {
 	HttpMethod,
@@ -593,6 +594,14 @@ interface BaseRemoteInternals {
 export interface RemoteQueryInternals extends BaseRemoteInternals {
 	type: 'query';
 	validate: (arg?: any) => MaybePromise<any>;
+	/**
+	 * Creates a `RemoteQuery` bound directly to a specific client payload (the
+	 * stringified raw argument) and a pre-validated argument, skipping the query
+	 * wrapper's re-validation step. Used by `requested(query)` to ensure
+	 * `refresh()` / `set()` target the same cache key the client is listening on
+	 * even when the schema transforms the input.
+	 */
+	bind(payload: string, arg: any): RemoteQuery<any>;
 }
 export interface RemoteQueryLiveInternals extends BaseRemoteInternals {
 	type: 'query_live';
@@ -663,7 +672,6 @@ export interface RequestState {
 		forms: null | Map<any, any>;
 		refreshes: null | Record<string, Promise<any>>;
 		requested: null | Map<string, string[]>;
-		validated: null | Map<string, Map<any, any>>;
 	};
 	readonly is_in_remote_function: boolean;
 	readonly is_in_render: boolean;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -664,6 +664,7 @@ export interface RequestState {
 		refreshes: null | Record<string, Promise<any>>;
 		requested: null | Map<string, string[]>;
 		validated: null | Map<string, Set<any>>;
+		raw_args: null | Map<string, Map<any, any>>;
 	};
 	readonly is_in_remote_function: boolean;
 	readonly is_in_render: boolean;

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -138,12 +138,12 @@ export function make_trackable(url, callback, search_params_callback, allow_hash
 
 	if (!BROWSER) {
 		// @ts-ignore
-		tracked[Symbol.for('nodejs.util.inspect.custom')] = (depth, opts, inspect) => {
+		tracked[Symbol.for('nodejs.util.inspect.custom')] = (_depth, opts, inspect) => {
 			return inspect(url, opts);
 		};
 
 		// @ts-ignore
-		tracked.searchParams[Symbol.for('nodejs.util.inspect.custom')] = (depth, opts, inspect) => {
+		tracked.searchParams[Symbol.for('nodejs.util.inspect.custom')] = (_depth, opts, inspect) => {
 			return inspect(url.searchParams, opts);
 		};
 	}
@@ -194,7 +194,7 @@ export function disable_search(url) {
 function allow_nodejs_console_log(url) {
 	if (!BROWSER) {
 		// @ts-ignore
-		url[Symbol.for('nodejs.util.inspect.custom')] = (depth, opts, inspect) => {
+		url[Symbol.for('nodejs.util.inspect.custom')] = (_depth, opts, inspect) => {
 			return inspect(new URL(url), opts);
 		};
 	}

--- a/packages/kit/test/apps/async/src/routes/remote/form/transform/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/transform/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { get_transformed_data, update_data } from './form.remote.ts';
+	import { get_transformed_data, update_data, set_data } from './form.remote.ts';
 
 	const key = 42;
 	const result = $derived(await get_transformed_data(key));
@@ -11,4 +11,8 @@
 
 <button id="update-btn" onclick={() => update_data().updates(get_transformed_data(key))}>
 	Update and Refresh All
+</button>
+
+<button id="set-btn" onclick={() => set_data().updates(get_transformed_data(key))}>
+	Set via requested
 </button>

--- a/packages/kit/test/apps/async/src/routes/remote/form/transform/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/transform/+page.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { get_transformed_data, update_data } from './form.remote.ts';
+
+	const key = 42;
+	const result = $derived(await get_transformed_data(key));
+</script>
+
+<h1>Transform Refresh Test</h1>
+
+<p id="result">{result}</p>
+
+<button id="update-btn" onclick={() => update_data().updates(get_transformed_data(key))}>
+	Update and Refresh All
+</button>

--- a/packages/kit/test/apps/async/src/routes/remote/form/transform/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/transform/form.remote.ts
@@ -1,0 +1,20 @@
+import { query, command, requested } from '$app/server';
+import * as v from 'valibot';
+
+let count = 0;
+
+export const get_transformed_data = query(
+	v.pipe(
+		v.number(),
+		v.transform((n) => String(n)) // Transforms number to string
+	),
+	(transformed_value) => {
+		return `Count for ${transformed_value} is ${count}`;
+	}
+);
+
+export const update_data = command(async () => {
+	count++;
+
+	await requested(get_transformed_data, 1).refreshAll();
+});

--- a/packages/kit/test/apps/async/src/routes/remote/form/transform/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/transform/form.remote.ts
@@ -20,7 +20,7 @@ export const update_data = command(async () => {
 });
 
 export const set_data = command(async () => {
-	for await (const arg of requested(get_transformed_data, 1)) {
-		get_transformed_data(arg).set(`Set value for ${arg}`);
+	for await (const { arg, query } of requested(get_transformed_data, 1)) {
+		query.set(`Set value for ${arg}`);
 	}
 });

--- a/packages/kit/test/apps/async/src/routes/remote/form/transform/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/transform/form.remote.ts
@@ -18,3 +18,9 @@ export const update_data = command(async () => {
 
 	await requested(get_transformed_data, 1).refreshAll();
 });
+
+export const set_data = command(async () => {
+	for await (const arg of requested(get_transformed_data, 1)) {
+		get_transformed_data(arg).set(`Set value for ${arg}`);
+	}
+});

--- a/packages/kit/test/apps/async/src/routes/remote/query-command.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/query-command.remote.js
@@ -25,7 +25,7 @@ export const set_count = command('unchecked', async ({ c, slow = false, deferred
 	}
 	count = c;
 
-	for (const { query } of requested(get_count)) {
+	for (const { query } of requested(get_count, Infinity)) {
 		await query.refresh();
 	}
 
@@ -34,7 +34,7 @@ export const set_count = command('unchecked', async ({ c, slow = false, deferred
 
 export const set_count_refresh_all = command('unchecked', async (c) => {
 	count = c;
-	await requested(get_count).refreshAll();
+	await requested(get_count, Infinity).refreshAll();
 	return c;
 });
 
@@ -53,7 +53,7 @@ export const set_count_partial_refresh = command('unchecked', async (c) => {
 	count = c;
 	should_fail_flaky = true;
 
-	for (const { query } of requested(get_flaky_count)) {
+	for (const { query } of requested(get_flaky_count, Infinity)) {
 		await query.refresh();
 	}
 
@@ -63,7 +63,7 @@ export const set_count_partial_refresh = command('unchecked', async (c) => {
 export const set_count_partial_refresh_all = command('unchecked', async (c) => {
 	count = c;
 	should_fail_flaky = true;
-	await requested(get_flaky_count).refreshAll();
+	await requested(get_flaky_count, Infinity).refreshAll();
 	return c;
 });
 

--- a/packages/kit/test/apps/async/src/routes/remote/query-command.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/query-command.remote.js
@@ -25,8 +25,8 @@ export const set_count = command('unchecked', async ({ c, slow = false, deferred
 	}
 	count = c;
 
-	for (const arg of requested(get_count)) {
-		await get_count(arg).refresh();
+	for (const { query } of requested(get_count)) {
+		await query.refresh();
 	}
 
 	return count;
@@ -53,8 +53,8 @@ export const set_count_partial_refresh = command('unchecked', async (c) => {
 	count = c;
 	should_fail_flaky = true;
 
-	for (const key of requested(get_flaky_count)) {
-		await get_flaky_count(key).refresh();
+	for (const { query } of requested(get_flaky_count)) {
+		await query.refresh();
 	}
 
 	return c;

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -435,9 +435,7 @@ test.describe('remote function mutations', () => {
 		await expect(page.locator('#result')).toHaveText('Count for 42 is 1');
 	});
 
-	test('.set() works with schema transforms when arg comes from requested()', async ({
-		page
-	}) => {
+	test('.set() works with schema transforms when arg comes from requested()', async ({ page }) => {
 		await page.goto('/remote/form/transform');
 
 		await expect(page.locator('#result')).toHaveText(/Count for 42 is \d+/);

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -426,6 +426,26 @@ test.describe('remote function mutations', () => {
 		await expect(page.locator('#phrase')).toHaveText('i am your father');
 	});
 
+	test('refreshAll works with schema transforms (number to string)', async ({ page }) => {
+		await page.goto('/remote/form/transform');
+
+		await expect(page.locator('#result')).toHaveText('Count for 42 is 0');
+
+		await page.click('#update-btn');
+		await expect(page.locator('#result')).toHaveText('Count for 42 is 1');
+	});
+
+	test('.set() works with schema transforms when arg comes from requested()', async ({
+		page
+	}) => {
+		await page.goto('/remote/form/transform');
+
+		await expect(page.locator('#result')).toHaveText(/Count for 42 is \d+/);
+
+		await page.click('#set-btn');
+		await expect(page.locator('#result')).toHaveText('Set value for 42');
+	});
+
 	test.describe('query runtime guardrails', () => {
 		test('query created outside tracking context can run but cannot expose reactive state', async ({
 			page

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -687,18 +687,6 @@ test.describe('remote functions', () => {
 		await expect(form2.locator('input[name="color_field"]')).toHaveValue('#00ff00');
 		await expect(form2.locator('input[name="n:range_field"]')).toHaveValue('8');
 	});
-
-	test('refreshAll works with schema transforms (number to string)', async ({
-		page,
-		javaScriptEnabled
-	}) => {
-		if (!javaScriptEnabled) return;
-
-		await page.goto('/remote/form/transform');
-
-		await page.click('#update-btn');
-		await expect(page.locator('#result')).toHaveText('Count for 42 is 1');
-	});
 });
 
 test.describe('server error boundaries', () => {

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -687,6 +687,18 @@ test.describe('remote functions', () => {
 		await expect(form2.locator('input[name="color_field"]')).toHaveValue('#00ff00');
 		await expect(form2.locator('input[name="n:range_field"]')).toHaveValue('8');
 	});
+
+	test('refreshAll works with schema transforms (number to string)', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		if (!javaScriptEnabled) return;
+
+		await page.goto('/remote/form/transform');
+
+		await page.click('#update-btn');
+		await expect(page.locator('#result')).toHaveText('Count for 42 is 1');
+	});
 });
 
 test.describe('server error boundaries', () => {

--- a/packages/kit/test/types/remote.test.ts
+++ b/packages/kit/test/types/remote.test.ts
@@ -172,19 +172,22 @@ function command_tests() {
 		const wrong: number = await cmd();
 		wrong;
 
-		for (const value of requested(q)) {
-			const output: void = value;
-			output;
+		for (const { arg, query: bound } of requested(q)) {
+			const arg_output: void = arg;
+			arg_output;
+			void bound.refresh();
 		}
 
-		for await (const value of requested(q)) {
-			const output: void = value;
-			output;
+		for await (const { arg, query: bound } of requested(q)) {
+			const arg_output: void = arg;
+			arg_output;
+			void bound.refresh();
 		}
 
-		for (const value of requested(q, 1)) {
-			const output: void = value;
-			output;
+		for (const { arg, query: bound } of requested(q, 1)) {
+			const arg_output: void = arg;
+			arg_output;
+			void bound.refresh();
 		}
 
 		const refreshes = requested(q);
@@ -192,6 +195,36 @@ function command_tests() {
 		refreshed;
 	}
 	void command_without_args();
+
+	async function requested_validated_type_tracks_schema_output() {
+		// schema2 declares InferInput = string, InferOutput = number, so `arg`
+		// in `requested(...)` must be `number` (the post-validation / post-transform
+		// value), NOT the pre-validation `string`.
+		const q = query(schema2, (a) => a);
+		for (const { arg, query: bound } of requested(q)) {
+			const arg_output: number = arg;
+			arg_output;
+			void bound.refresh();
+			// @ts-expect-error — `arg` is number, not string
+			const wrong: string = arg;
+			wrong;
+		}
+
+		// `'unchecked'` queries: `arg` is the caller's Input type
+		const unchecked = query('unchecked', (a: number) => a);
+		for (const { arg } of requested(unchecked)) {
+			const arg_output: number = arg;
+			arg_output;
+		}
+
+		// Queries without arguments: `arg` is `void`
+		const no_arg = query(() => 'hi');
+		for (const { arg } of requested(no_arg)) {
+			const arg_output: void = arg;
+			arg_output;
+		}
+	}
+	void requested_validated_type_tracks_schema_output();
 
 	async function command_with_optional_arg() {
 		const q = command(schema3, () => 'Hello world');

--- a/packages/kit/test/types/remote.test.ts
+++ b/packages/kit/test/types/remote.test.ts
@@ -172,13 +172,13 @@ function command_tests() {
 		const wrong: number = await cmd();
 		wrong;
 
-		for (const { arg, query: bound } of requested(q)) {
+		for (const { arg, query: bound } of requested(q, 5)) {
 			const arg_output: void = arg;
 			arg_output;
 			void bound.refresh();
 		}
 
-		for await (const { arg, query: bound } of requested(q)) {
+		for await (const { arg, query: bound } of requested(q, 5)) {
 			const arg_output: void = arg;
 			arg_output;
 			void bound.refresh();
@@ -190,7 +190,10 @@ function command_tests() {
 			void bound.refresh();
 		}
 
-		const refreshes = requested(q);
+		// @ts-expect-error — `limit` is required
+		requested(q);
+
+		const refreshes = requested(q, 5);
 		const refreshed: Promise<void> = refreshes.refreshAll();
 		refreshed;
 	}
@@ -201,7 +204,7 @@ function command_tests() {
 		// in `requested(...)` must be `number` (the post-validation / post-transform
 		// value), NOT the pre-validation `string`.
 		const q = query(schema2, (a) => a);
-		for (const { arg, query: bound } of requested(q)) {
+		for (const { arg, query: bound } of requested(q, 5)) {
 			const arg_output: number = arg;
 			arg_output;
 			void bound.refresh();
@@ -212,14 +215,14 @@ function command_tests() {
 
 		// `'unchecked'` queries: `arg` is the caller's Input type
 		const unchecked = query('unchecked', (a: number) => a);
-		for (const { arg } of requested(unchecked)) {
+		for (const { arg } of requested(unchecked, 5)) {
 			const arg_output: number = arg;
 			arg_output;
 		}
 
 		// Queries without arguments: `arg` is `void`
 		const no_arg = query(() => 'hi');
-		for (const { arg } of requested(no_arg)) {
+		for (const { arg } of requested(no_arg, 5)) {
 			const arg_output: void = arg;
 			arg_output;
 		}

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3473,7 +3473,7 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function requested<Input, Output, Validated = Input>(query: RemoteQueryFunction<Input, Output, Validated>, limit?: number): RequestedResult<Validated, Output>;
+	export function requested<Input, Output, Validated = Input>(query: RemoteQueryFunction<Input, Output, Validated>, limit: number): RequestedResult<Validated, Output>;
 	type RemotePrerenderInputsGenerator<Input = any> = () => MaybePromise<Input[]>;
 	type MaybePromise<T> = T | Promise<T>;
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2216,7 +2216,7 @@ declare module '@sveltejs/kit' {
 	 * `Input = number` but `Validated = string`). For `'unchecked'` validators and queries
 	 * without arguments it defaults to `Input`.
 	 */
-	export type RemoteQueryFunction<Input, Output, Validated = Input> = (
+	export type RemoteQueryFunction<Input, Output, _Validated = Input> = (
 		arg: undefined extends Input ? Input | void : Input
 	) => RemoteQuery<Output>;
 	interface AdapterEntry {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2216,18 +2216,9 @@ declare module '@sveltejs/kit' {
 	 * `Input = number` but `Validated = string`). For `'unchecked'` validators and queries
 	 * without arguments it defaults to `Input`.
 	 */
-	export type RemoteQueryFunction<Input, Output, Validated = Input> = ((
+	export type RemoteQueryFunction<Input, Output, Validated = Input> = (
 		arg: undefined extends Input ? Input | void : Input
-	) => RemoteQuery<Output>) & {
-		/**
-		 * Phantom property that exists for type inference only — it is never set at
-		 * runtime, hence the `?`. Used by
-		 * [`requested`](https://svelte.dev/docs/kit/$app-server#requested) to recover
-		 * the post-validation argument type. Do not read this property; it will always
-		 * be `undefined`. Prefixed with `~` to sort to the bottom of IntelliSense.
-		 */
-		readonly ['~validated']?: Validated;
-	};
+	) => RemoteQuery<Output>;
 	interface AdapterEntry {
 		/**
 		 * A string that uniquely identifies an HTTP service (e.g. serverless function) and is used for deduplication.

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1426,16 +1426,27 @@ declare module '@sveltejs/kit' {
 	 */
 	export type ParamMatcher = (param: string) => boolean;
 
-	export type RequestedResult<T> = Iterable<T> &
-		AsyncIterable<T> & {
+	/**
+	 * A single entry yielded by [`requested`](https://svelte.dev/docs/kit/$app-server#requested).
+	 * `arg` is the validated argument (the input *after* the query's schema validated and
+	 * transformed it, if applicable); `query` is a `RemoteQuery` bound to the client's
+	 * original cache key, so `refresh()` / `set()` will update the correct client entry.
+	 */
+	export type RequestedEntry<Validated, Output> = {
+		arg: Validated;
+		query: RemoteQuery<Output>;
+	};
+
+	export type RequestedResult<Validated, Output> = Iterable<RequestedEntry<Validated, Output>> &
+		AsyncIterable<RequestedEntry<Validated, Output>> & {
 			/**
 			 * Call `refresh` on all queries selected by this `requested` invocation.
 			 * This is identical to:
 			 * ```ts
 			 * import { requested } from '$app/server';
 			 *
-			 * for await (const arg of requested(query, ...) {
-			 *   void query(arg).refresh();
+			 * for await (const { query } of requested(getPost, ...)) {
+			 *   void query.refresh();
 			 * }
 			 * ```
 			 */
@@ -2195,10 +2206,28 @@ declare module '@sveltejs/kit' {
 
 	/**
 	 * The return value of a remote `query` function. See [Remote functions](https://svelte.dev/docs/kit/remote-functions#query) for full documentation.
+	 *
+	 * The optional `Validated` generic parameter represents the argument type *after* the
+	 * query's schema has validated and (optionally) transformed it — this is the type the
+	 * query's implementation function receives on the server, and the type yielded by
+	 * [`requested`](https://svelte.dev/docs/kit/$app-server#requested). For queries declared
+	 * with [Standard Schema](https://standardschema.dev/) it differs from `Input` when the
+	 * schema contains a transform (e.g. `v.pipe(v.number(), v.transform(String))` has
+	 * `Input = number` but `Validated = string`). For `'unchecked'` validators and queries
+	 * without arguments it defaults to `Input`.
 	 */
-	export type RemoteQueryFunction<Input, Output> = (
+	export type RemoteQueryFunction<Input, Output, Validated = Input> = ((
 		arg: undefined extends Input ? Input | void : Input
-	) => RemoteQuery<Output>;
+	) => RemoteQuery<Output>) & {
+		/**
+		 * Phantom property that exists for type inference only — it is never set at
+		 * runtime, hence the `?`. Used by
+		 * [`requested`](https://svelte.dev/docs/kit/$app-server#requested) to recover
+		 * the post-validation argument type. Do not read this property; it will always
+		 * be `undefined`. Prefixed with `~` to sort to the bottom of IntelliSense.
+		 */
+		readonly ['~validated']?: Validated;
+	};
 	interface AdapterEntry {
 		/**
 		 * A string that uniquely identifies an HTTP service (e.g. serverless function) and is used for deduplication.
@@ -3392,7 +3421,7 @@ declare module '$app/server' {
 	 *
 	 * @since 2.27
 	 */
-	export function query<Schema extends StandardSchemaV1, Output>(schema: Schema, fn: (arg: StandardSchemaV1.InferOutput<Schema>) => MaybePromise<Output>): RemoteQueryFunction<StandardSchemaV1.InferInput<Schema>, Output>;
+	export function query<Schema extends StandardSchemaV1, Output>(schema: Schema, fn: (arg: StandardSchemaV1.InferOutput<Schema>) => MaybePromise<Output>): RemoteQueryFunction<StandardSchemaV1.InferInput<Schema>, Output, StandardSchemaV1.InferOutput<Schema>>;
 	export namespace query {
 		/**
 		 * Creates a batch query function that collects multiple calls and executes them in a single request
@@ -3409,23 +3438,29 @@ declare module '$app/server' {
 		 *
 		 * @since 2.35
 		 */
-		function batch<Schema extends StandardSchemaV1, Output>(schema: Schema, fn: (args: StandardSchemaV1.InferOutput<Schema>[]) => MaybePromise<(arg: StandardSchemaV1.InferOutput<Schema>, idx: number) => Output>): RemoteQueryFunction<StandardSchemaV1.InferInput<Schema>, Output>;
+		function batch<Schema extends StandardSchemaV1, Output>(schema: Schema, fn: (args: StandardSchemaV1.InferOutput<Schema>[]) => MaybePromise<(arg: StandardSchemaV1.InferOutput<Schema>, idx: number) => Output>): RemoteQueryFunction<StandardSchemaV1.InferInput<Schema>, Output, StandardSchemaV1.InferOutput<Schema>>;
 	}
 	/**
 	 * In the context of a remote `command` or `form` request, returns an iterable
-	 * of the client-requested refreshes' validated arguments up to the supplied limit.
-	 * Arguments that fail validation or exceed the limit are recorded as failures in
+	 * of `{ arg, query }` entries for the refreshes requested by the client, up to
+	 * the supplied `limit`. Each `query` is a `RemoteQuery` bound to the original
+	 * client-side cache key, so `refresh()` / `set()` propagate correctly even when
+	 * the query's schema transforms the input. `arg` is the *validated* argument,
+	 * i.e. the value after the schema has run (so `InferOutput<Schema>` for queries
+	 * declared with a Standard Schema).
+	 *
+	 * Arguments that fail validation or exceed `limit` are recorded as failures in
 	 * the response to the client.
 	 *
 	 * @example
 	 * ```ts
 	 * import { requested } from '$app/server';
 	 *
-	 * for (const arg of requested(getPost, 5)) {
-	 * 	// it's safe to throw away this promise -- SvelteKit
-	 * 	// will await it for us and handle any errors by sending
-	 * 	// them to the client.
-	 * 	void getPost(arg).refresh();
+	 * for (const { arg, query } of requested(getPost, 5)) {
+	 * 	// `arg` is the validated argument; `query` is bound to the client's
+	 * 	// cache key. It's safe to throw away this promise -- SvelteKit will
+	 * 	// await it and forward any errors to the client.
+	 * 	void query.refresh();
 	 * }
 	 * ```
 	 *
@@ -3438,7 +3473,7 @@ declare module '$app/server' {
 	 * ```
 	 *
 	 * */
-	export function requested<Input, Output>(query: RemoteQueryFunction<Input, Output>, limit?: number): RequestedResult<Input>;
+	export function requested<Input, Output, Validated = Input>(query: RemoteQueryFunction<Input, Output, Validated>, limit?: number): RequestedResult<Validated, Output>;
 	type RemotePrerenderInputsGenerator<Input = any> = () => MaybePromise<Input[]>;
 	type MaybePromise<T> = T | Promise<T>;
 


### PR DESCRIPTION
Alternative to #15738
Closes https://github.com/sveltejs/kit/issues/15696

I realized while reviewing that there's a fundamental problem: If the query's validator lossily changes the input, there's no way to map the validated input back to the correct argument. Consider a validator that calls `Math.floor` on its input number, then consider the following:

```ts
// from the client, we request `query(1.2)` and `query(1.8)`,
// but both `arg`s are `1`
for await (const arg of requested(my_query, 5)) {
  // there is no way to map `1` back to the original inputs;
  // only 1.8 would actually be refreshed because it wrote
  // to the `validated` cache last
  void my_query(arg).refresh();
}
```

This realization in hand, I further realized the only way to make this work is to somehow preserve the mapping of input arguments to validated arguments. The best way to do that is to return a bound instance of the query from `requested`:

```ts
for await (const { arg, query } of requested(my_query, 5)) {
  void query.refresh();
}
```

Problem solved; the `query` internally maintains the map of input argument => validated argument. The `arg` is still the validated argument in case you need to do something like `if (arg.id === id)`.