### PR TITLE
fix: `.as('checkbox', value)` was completely broken

### DIFF
--- a/.changeset/sad-bottles-remain.md
+++ b/.changeset/sad-bottles-remain.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: `form.fields.foo.as('checkbox', default_value)` now works

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1957,7 +1957,9 @@ export type RemoteFormFieldValue = string | string[] | number | boolean | File |
 type AsArgs<Type extends keyof InputTypeMap, Value> = Type extends 'checkbox'
 	? Value extends string[]
 		? [type: Type, value: Value[number] | (string & {})]
-		: [type: Type] | [type: Type, value: Value | (string & {})]
+		: Value extends boolean
+			? [type: Type] | [type: Type, value: boolean]
+			: [type: Type] | [type: Type, value: Value | (string & {})]
 	: Type extends 'radio' | 'submit' | 'hidden'
 		? [type: Type, value: Value | (string & {})]
 		: Type extends 'file' | 'file multiple'

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -732,6 +732,17 @@ export function create_field_proxy(target, get_input, set_input, get_issues, pat
 							}
 						}
 
+						if (type === 'checkbox' && !is_array) {
+							return Object.defineProperties(base_props, {
+								checked: {
+									enumerable: true,
+									get() {
+										return get_value() ?? input_value;
+									}
+								}
+							});
+						}
+
 						return Object.defineProperties(base_props, {
 							value: { value: input_value ?? 'on', enumerable: true },
 							checked: {
@@ -743,11 +754,7 @@ export function create_field_proxy(target, get_input, set_input, get_issues, pat
 										return value === input_value;
 									}
 
-									if (is_array) {
-										return (value ?? []).includes(input_value);
-									}
-
-									return value;
+									return (value ?? []).includes(input_value);
 								}
 							}
 						});

--- a/packages/kit/test/apps/async/src/routes/remote/form/as-value/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/as-value/+page.svelte
@@ -7,33 +7,41 @@
 {#each values as value (value.id)}
 	<div>
 		{value.text_field} - {value.number_field} - {value.select_field} - {value.color_field} - {value.range_field}
+		- {value.checkbox_field}
 	</div>
 {/each}
 
-{#each values as value (value.id)}
-	<form
-		{...as_value_form.for(value.id).enhance(({ submit }) => {
-			// TODO: needed to keep the values when JS is enabled, remove when reset is implemented
-			submit();
-		})}
-	>
-		<input {...as_value_form.fields.text_field.as('text', value.text_field)} />
+<div class="forms">
+	{#each values as value (value.id)}
+		<form
+			class="form"
+			{...as_value_form.for(value.id).enhance(({ submit }) => {
+				// TODO: needed to keep the values when JS is enabled, remove when reset is implemented
+				submit();
+			})}
+		>
+			<input {...as_value_form.fields.text_field.as('text', value.text_field)} />
 
-		<input {...as_value_form.fields.number_field.as('number', value.number_field)} />
+			<input {...as_value_form.fields.number_field.as('number', value.number_field)} />
 
-		<select {...as_value_form.fields.select_field.as('select', value.select_field)}>
-			<option>apple</option>
-			<option>banana</option>
-			<option>cherry</option>
-		</select>
+			<select {...as_value_form.fields.select_field.as('select', value.select_field)}>
+				<option>apple</option>
+				<option>banana</option>
+				<option>cherry</option>
+			</select>
 
-		<input {...as_value_form.fields.color_field.as('color', value.color_field)} />
+			<input {...as_value_form.fields.color_field.as('color', value.color_field)} />
 
-		<input {...as_value_form.fields.range_field.as('range', value.range_field)} />
+			<input {...as_value_form.fields.range_field.as('range', value.range_field)} />
 
-		<button {...as_value_form.fields.id.as('submit', value.id)}>submit</button>
-	</form>
-{/each}
+			<label
+				>Checkbox
+				<input {...as_value_form.fields.checkbox_field.as('checkbox', value.checkbox_field)} />
+			</label>
+			<button {...as_value_form.fields.id.as('submit', value.id)}>submit</button>
+		</form>
+	{/each}
+</div>
 
 <div>
 	<p id="set-value-display">{as_value_form.fields.text_field.value()}</p>
@@ -49,3 +57,19 @@
 <form {...reset_values}>
 	<button id="reset-values" type="submit">reset</button>
 </form>
+
+<style>
+	.forms {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.25rem;
+	}
+	.form {
+		display: flex;
+		flex-direction: column;
+		max-width: 200px;
+		gap: 0.25rem;
+		padding: 0.5rem;
+		background: #eee;
+	}
+</style>

--- a/packages/kit/test/apps/async/src/routes/remote/form/as-value/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/as-value/form.remote.ts
@@ -7,7 +7,8 @@ const ValueSchema = v.object({
 	number_field: v.number(),
 	select_field: v.string(),
 	color_field: v.string(),
-	range_field: v.number()
+	range_field: v.number(),
+	checkbox_field: v.optional(v.boolean(), false)
 });
 
 const default_values: Array<v.InferInput<typeof ValueSchema>> = [
@@ -17,36 +18,21 @@ const default_values: Array<v.InferInput<typeof ValueSchema>> = [
 		number_field: 42,
 		select_field: 'apple',
 		color_field: '#ff0000',
-		range_field: 5
+		range_field: 5,
+		checkbox_field: true
 	},
 	{
 		id: '2',
 		text_field: 'Another example',
 		number_field: 100,
 		select_field: 'banana',
-		color_field: '#00ff00',
-		range_field: 8
+		color_field: '#ffff00',
+		range_field: 8,
+		checkbox_field: false
 	}
 ];
 
-let values: Array<v.InferInput<typeof ValueSchema>> = [
-	{
-		id: '1',
-		text_field: 'Example text',
-		number_field: 42,
-		select_field: 'apple',
-		color_field: '#ff0000',
-		range_field: 5
-	},
-	{
-		id: '2',
-		text_field: 'Another example',
-		number_field: 100,
-		select_field: 'banana',
-		color_field: '#00ff00',
-		range_field: 8
-	}
-];
+let values = structuredClone(default_values);
 
 export const get_values = query(() => values);
 
@@ -58,6 +44,7 @@ export const as_value_form = form(ValueSchema, async (data) => {
 		element.select_field = data.select_field;
 		element.color_field = data.color_field;
 		element.range_field = data.range_field;
+		element.checkbox_field = data.checkbox_field;
 	}
 });
 

--- a/packages/kit/test/apps/async/src/routes/remote/form/as-value/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/as-value/form.remote.ts
@@ -11,7 +11,7 @@ const ValueSchema = v.object({
 	checkbox_field: v.optional(v.boolean(), false)
 });
 
-const default_values: Array<v.InferInput<typeof ValueSchema>> = [
+const default_values: Array<v.InferOutput<typeof ValueSchema>> = [
 	{
 		id: '1',
 		text_field: 'Example text',

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -516,18 +516,25 @@ test.describe('remote function mutations', () => {
 
 		const form1 = page.locator('form').nth(0);
 
-		// initial values rendered correctly
-		await expect(form1.locator('input[name="text_field"]')).toHaveValue('Example text');
+		const text = form1.locator('input[name="text_field"]');
+		const checkbox = form1.locator('input[name="b:checkbox_field"]');
 
-		// change the text field and submit
-		await form1.locator('input[name="text_field"]').fill('Updated text');
+		// initial values rendered correctly
+		await expect(text).toHaveValue('Example text');
+
+		await expect(checkbox).toBeChecked();
+
+		// change the fields and submit
+		await text.fill('Updated text');
+		await checkbox.uncheck();
 		await form1.locator('button').click();
 
 		// after submission, the query refreshes and the display should update
 		await expect(page.locator('div').first()).toContainText('Updated text');
 
 		// the input value should reflect the updated data
-		await expect(form1.locator('input[name="text_field"]')).toHaveValue('Updated text');
+		await expect(text).toHaveValue('Updated text');
+		await expect(checkbox).not.toBeChecked();
 
 		// reset the values for the client tests
 		await page.click('#reset-values');

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -679,13 +679,15 @@ test.describe('remote functions', () => {
 		await expect(form1.locator('select[name="select_field"]')).toHaveValue('apple');
 		await expect(form1.locator('input[name="color_field"]')).toHaveValue('#ff0000');
 		await expect(form1.locator('input[name="n:range_field"]')).toHaveValue('5');
+		await expect(form1.locator('input[name="b:checkbox_field"]')).toBeChecked();
 
 		// second record values
 		await expect(form2.locator('input[name="text_field"]')).toHaveValue('Another example');
 		await expect(form2.locator('input[name="n:number_field"]')).toHaveValue('100');
 		await expect(form2.locator('select[name="select_field"]')).toHaveValue('banana');
-		await expect(form2.locator('input[name="color_field"]')).toHaveValue('#00ff00');
+		await expect(form2.locator('input[name="color_field"]')).toHaveValue('#ffff00');
 		await expect(form2.locator('input[name="n:range_field"]')).toHaveValue('8');
+		await expect(form2.locator('input[name="b:checkbox_field"]')).not.toBeChecked();
 	});
 });
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1931,7 +1931,9 @@ declare module '@sveltejs/kit' {
 	type AsArgs<Type extends keyof InputTypeMap, Value> = Type extends 'checkbox'
 		? Value extends string[]
 			? [type: Type, value: Value[number] | (string & {})]
-			: [type: Type] | [type: Type, value: Value | (string & {})]
+			: Value extends boolean
+				? [type: Type] | [type: Type, value: boolean]
+				: [type: Type] | [type: Type, value: Value | (string & {})]
 		: Type extends 'radio' | 'submit' | 'hidden'
 			? [type: Type, value: Value | (string & {})]
 			: Type extends 'file' | 'file multiple'


### PR DESCRIPTION
`form.fields.foo.as('checkbox', default_value)` previously both had a typescript error preventing it from being used, and also did not correctly set `checked` on the input element. This PR fixes both of those issues and updates tests.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
