### PR TITLE
chore: fix IDE typescript errors

### DIFF
--- a/packages/kit/test/build-errors/tsconfig.json
+++ b/packages/kit/test/build-errors/tsconfig.json
@@ -4,7 +4,9 @@
 		"checkJs": true,
 		"noEmit": true,
 		"target": "esnext",
-		"moduleResolution": "node"
+		"module": "node16",
+		"moduleResolution": "node16",
+		"types": ["node"]
 	},
 	"include": ["./*"]
 }

--- a/packages/kit/test/github-flaky-warning-reporter.js
+++ b/packages/kit/test/github-flaky-warning-reporter.js
@@ -1,8 +1,8 @@
+/** @import { Reporter, TestCase } from '@playwright/test/reporter' */
 import { appendFileSync } from 'node:fs';
 
 /**
- * @class
- * @implements {import('@playwright/test/reporter').Reporter}
+ * @implements {Reporter}
  */
 export default class GithubFlakyWarningReporter {
 	/**
@@ -14,7 +14,7 @@ export default class GithubFlakyWarningReporter {
 		this._flaky = [];
 	}
 	/**
-	 * @param test {import('@playwright/test/reporter').TestCase}
+	 * @param {TestCase} test
 	 */
 	onTestEnd(test) {
 		if (test.outcome() === 'flaky') {

--- a/packages/kit/test/tsconfig.json
+++ b/packages/kit/test/tsconfig.json
@@ -4,7 +4,9 @@
 		"checkJs": true,
 		"noEmit": true,
 		"target": "esnext",
-		"moduleResolution": "node"
+		"module": "node16",
+		"moduleResolution": "node16",
+		"types": ["node"]
 	},
 	"include": ["./*", "./mocks/**/*", "./prerendering/*"]
 }

--- a/packages/kit/test/types.d.ts
+++ b/packages/kit/test/types.d.ts
@@ -7,7 +7,7 @@ import {
 	Page
 } from '@playwright/test';
 import { IncomingMessage, ServerResponse } from 'node:http';
-import '../types/index';
+import '../types/index.d.ts';
 import { AfterNavigate, BeforeNavigate } from '@sveltejs/kit';
 
 export const test: TestType<

--- a/packages/kit/test/utils.js
+++ b/packages/kit/test/utils.js
@@ -1,7 +1,7 @@
-/** @import { SpanData, SpanTree } from './types' */
+/** @import { SpanData, SpanTree } from './types.js' */
 // This helps `pnpm check` pass in the test apps without having to include
 // the ambient.d.ts file in each of their tsconfig.json files.
-/** @import {} from './ambient' */
+/** @import {} from './ambient.js' */
 
 import fs from 'node:fs';
 import http from 'node:http';
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig, test as base, devices } from '@playwright/test';
 import { number_from_env } from '../../../test-utils/index.js';
 
-/** @type {import('./types')['test']} */
+/** @type {typeof import('./types.js')['test']} */
 export const test = base.extend({
 	app: ({ page }, use) => {
 		// these are assumed to have been put in the global scope by the layout


### PR DESCRIPTION
This PR fixes some TypeScript errors that only show when viewing files in the IDE with TypeScript 6 or 7 because they’re not checked when running `pnpm check`