### PR TITLE
feat: allow to control query lifetime

### DIFF
--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -221,6 +221,28 @@ Any query can be re-fetched via its `refresh` method, which retrieves the latest
 
 > [!NOTE] Queries are cached while they're on the page, meaning `getPosts() === getPosts()`. This means you don't need a reference like `const posts = getPosts()` in order to update the query.
 
+### Query lifetime
+
+By default, a query is considered stale after 60 minutes, does not refresh on client-side navigation, and is retained in the client cache for up to 5 navigations or 10 minutes after nothing on the page references it. You can override this from inside the query function with `query.lifetime(...)`:
+
+```js
+/// file: src/routes/data.remote.js
+import { query } from '$app/server';
+
+export const getPosts = query(async () => {
+	query.lifetime({
+		staleAfter: '5s',
+		refreshAfter: '10s',
+		refreshOnNavigation: true,
+		bfcache: { limit: 5, maxAge: '10s' }
+	});
+
+	return getPostsFromDatabase();
+});
+```
+
+Time values can be a number of seconds, or a string ending in `s` or `m`. `staleAfter` controls when reusing a still-referenced query should trigger a refresh, `refreshAfter` schedules a refresh while the query remains referenced, and `refreshOnNavigation` refreshes after client-side navigations. Set `bfcache: false` to remove a query from the client cache as soon as it is no longer referenced, or provide `limit` and `maxAge` to keep it around temporarily.
+
 ## query.batch
 
 `query.batch` works like `query` except that it batches requests that happen within the same macrotask. This solves the so-called n+1 problem: rather than each query resulting in a separate database call (for example), simultaneous queries are grouped together.

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -352,6 +352,22 @@ export interface KitCacheMetadata {
 	tags: string[];
 }
 
+export interface QueryLifetime {
+	/** If a referenced query is reused after this many seconds, it will be refreshed. If omitted, it never goes stale. */
+	staleAfter?: `${number}m` | `${number}s` | number;
+	/** If a query remains referenced for this many seconds, it will be refreshed. If omitted, it never refreshes automatically. */
+	refreshAfter?: `${number}m` | `${number}s` | number;
+	/** Whether the query should refresh after client-side navigations. */
+	refreshOnNavigation?: boolean;
+	/** How long to retain the query in the client cache after it is no longer referenced. */
+	bfcache?:
+		| {
+				limit: number;
+				maxAge: `${number}m` | `${number}s` | number;
+		  }
+		| false;
+}
+
 /**
  * Custom query cache integration. Export `get`, `set`, and `invalidate` from `kit.cache.path`.
  */

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -1,5 +1,5 @@
 /** @import { RemoteLiveQuery, RemoteLiveQueryFunction, RemoteQuery, RemoteQueryFunction } from '@sveltejs/kit' */
-/** @import { RemoteInternals, MaybePromise, RequestState, RemoteQueryLiveInternals, RemoteQueryBatchInternals, RemoteQueryInternals, RemoteLiveQueryUserFunctionReturnType } from 'types' */
+/** @import { RemoteInternals, MaybePromise, RequestState, RemoteQueryLiveInternals, RemoteQueryBatchInternals, RemoteQueryInternals, RemoteLiveQueryUserFunctionReturnType, QueryLifetime, NormalizedQueryLifetime, QueryLifetimeTime } from 'types' */
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 import { get_request_store } from '@sveltejs/kit/internal/server';
 import { create_remote_key, stringify, stringify_remote_arg } from '../../../shared.js';
@@ -17,6 +17,16 @@ import { handle_error_and_jsonify } from '../../../server/utils.js';
 import { HttpError, SvelteKitError } from '@sveltejs/kit/internal';
 import { noop } from '../../../../utils/functions.js';
 import { create_request_cache, get_request_cache_options } from '../../../server/cache.js';
+
+/** @type {NormalizedQueryLifetime} */
+export const DEFAULT_QUERY_LIFETIME = {
+	staleAfter: 60 * 60,
+	refreshOnNavigation: false,
+	bfcache: {
+		limit: 5,
+		maxAge: 10 * 60
+	}
+};
 
 /**
  * Creates a remote query. When called from the browser, the function will be invoked on the server via a `fetch` call.
@@ -79,15 +89,16 @@ export function query(validate_or_fn, maybe_fn) {
 		validate,
 		bind(payload, validated_arg) {
 			const { event, state } = get_request_store();
+			const query_id = create_remote_key(__.id, payload);
 
 			return create_query_resource(__, payload, state, () =>
 				run_remote_function(
 					event,
 					state,
 					false,
-					create_request_cache(state, create_remote_key(__.id, payload)),
+					create_request_cache(state, query_id),
 					() => validated_arg,
-					fn
+					(input) => with_lifetime_context(state, __.id ? query_id : null, () => fn(input))
 				)
 			);
 		}
@@ -127,7 +138,7 @@ export function query(validate_or_fn, maybe_fn) {
 					false,
 					cache,
 					() => validate(arg),
-					fn
+					(input) => with_lifetime_context(state, __.id ? query_id : null, () => fn(input))
 				);
 
 				const options = get_request_cache_options(cache);
@@ -159,11 +170,107 @@ function query_cache(input) {
 }
 
 /**
+ * Configure the lifetime of the currently executing query.
+ *
+ * @param {QueryLifetime} options
+ */
+function query_lifetime(options) {
+	const { state } = get_request_store();
+	const context = state.remote.lifetime_context;
+
+	if (!context) {
+		throw new Error('query.lifetime(...) can only be called while executing a query function');
+	}
+
+	const lifetime = normalize_query_lifetime(options);
+	state.remote.lifetimes ??= new Map();
+
+	for (const key of Array.isArray(context) ? context : [context]) {
+		state.remote.lifetimes.set(key, lifetime);
+	}
+}
+
+/**
  * @param {string[]} tags
  */
 async function invalidate_query_cache(tags) {
 	const { state } = get_request_store();
 	await state.cache.invalidate(tags);
+}
+
+/**
+ * @param {QueryLifetimeTime | undefined} value
+ * @returns {number | undefined}
+ */
+function normalize_lifetime_time(value) {
+	if (value === undefined) return undefined;
+
+	if (typeof value === 'number') {
+		if (value < 0 || !Number.isFinite(value)) {
+			throw new Error('query.lifetime(...) times must be finite, non-negative numbers');
+		}
+		return value;
+	}
+
+	const match = /^(\d+(?:\.\d+)?)([ms])$/.exec(value);
+	if (!match) {
+		throw new Error("query.lifetime(...) times must be numbers or strings like '10s' or '5m'");
+	}
+
+	const amount = Number(match[1]);
+	return match[2] === 'm' ? amount * 60 : amount;
+}
+
+/**
+ * @param {QueryLifetime} options
+ * @returns {NormalizedQueryLifetime}
+ */
+function normalize_query_lifetime(options) {
+	const bfcache_max_age =
+		options.bfcache && typeof options.bfcache === 'object'
+			? normalize_lifetime_time(options.bfcache.maxAge)
+			: undefined;
+
+	if (
+		options.bfcache &&
+		(!Number.isFinite(options.bfcache.limit) ||
+			options.bfcache.limit < 0 ||
+			bfcache_max_age === undefined)
+	) {
+		throw new Error('query.lifetime(...) bfcache requires a finite, non-negative limit and maxAge');
+	}
+
+	return {
+		staleAfter: normalize_lifetime_time(options.staleAfter),
+		refreshAfter: normalize_lifetime_time(options.refreshAfter),
+		refreshOnNavigation: options.refreshOnNavigation ?? false,
+		bfcache:
+			options.bfcache === undefined
+				? false
+				: options.bfcache === false
+					? false
+					: {
+							limit: options.bfcache.limit,
+							maxAge: /** @type {number} */ (bfcache_max_age)
+						}
+	};
+}
+
+/**
+ * @template T
+ * @param {RequestState} state
+ * @param {string | string[] | null} context
+ * @param {() => T} fn
+ * @returns {T}
+ */
+function with_lifetime_context(state, context, fn) {
+	const previous = state.remote.lifetime_context;
+	state.remote.lifetime_context = previous && context ? [] : context;
+	try {
+		return fn();
+	} finally {
+		state.remote.lifetime_context = previous;
+	}
 }
 
 /**
@@ -353,7 +460,7 @@ function batch(validate_or_fn, maybe_fn) {
 
 				try {
 					const cached = await Promise.all(
-						entries.map((entry, i) =>
+						entries.map(async (entry, i) =>
 							entry.read_cache
 								? deserialize_query_cache_entry(await state.remote.cache?.get(query_ids[i]))
 								: null
@@ -364,8 +471,9 @@ function batch(validate_or_fn, maybe_fn) {
 					const missing = [];
 
 					for (let i = 0; i < cached.length; i++) {
-						if (cached[i] !== null) {
-							const value = parse_remote_response(cached[i].response, state.transport);
+						const cached_entry = cached[i];
+						if (cached_entry !== null) {
+							const value = parse_remote_response(cached_entry.response, state.transport);
 							for (const resolver of entries[i].resolvers) {
 								resolver.resolve(value);
 							}
@@ -389,7 +497,11 @@ function batch(validate_or_fn, maybe_fn) {
 						cache,
 						async () => Promise.all(missing.map((entry) => entry.get_validated())),
 						async (input) => {
-							const get_result = await fn(input);
+							const get_result = await with_lifetime_context(
+								state,
+								__.id ? missing.map((entry) => entry.query_id) : null,
+								() => fn(input)
+							);
 
 							for (let i = 0; i < missing.length; i++) {
 								try {
@@ -449,8 +561,9 @@ function batch(validate_or_fn, maybe_fn) {
 			);
 
 			for (let i = 0; i < cached.length; i++) {
-				if (cached[i] !== null) {
-					results[i] = { type: 'result', data: cached[i].response };
+				const cached_entry = cached[i];
+				if (cached_entry !== null) {
+					results[i] = { type: 'result', data: cached_entry.response };
 				} else {
 					missing.push(i);
 				}
@@ -470,7 +583,11 @@ function batch(validate_or_fn, maybe_fn) {
 				cache,
 				async () => Promise.all(missing_args.map(validate)),
 				async (/** @type {any[]} */ input) => {
-					const get_result = await fn(input);
+					const get_result = await with_lifetime_context(
+						state,
+						__.id ? missing.map((index) => query_ids[index]) : null,
+						() => fn(input)
+					);
 
 					return Promise.all(
 						input.map(async (arg, i) => {
@@ -717,6 +834,7 @@ function create_live_query_resource(__, payload, state, get_first_value) {
 // Add batch as a property to the query function
 Object.defineProperty(query, 'batch', { value: batch, enumerable: true });
 Object.defineProperty(query, 'cache', { value: query_cache, enumerable: true });
+Object.defineProperty(query, 'lifetime', { value: query_lifetime, enumerable: true });
 Object.defineProperty(query_cache, 'invalidate', {
 	value: invalidate_query_cache,
 	enumerable: true

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -207,6 +207,14 @@ export let app;
 export let query_responses = {};
 
 /**
+ * Lifetime configuration serialized by query.lifetime(...) during SSR or remote endpoint calls.
+ * @type {Record<string, import('types').NormalizedQueryLifetime>}
+ */
+export let query_lifetimes = {};
+
+export let remote_query_navigation_version = 0;
+
+/**
  * Data that was serialized during SSR for prerender functions.
  * This persists across client-side navigations.
  * @type {Record<string, any>}
@@ -327,6 +335,7 @@ export async function start(_app, _target, hydrate) {
 
 	if (__SVELTEKIT_PAYLOAD__) {
 		query_responses = __SVELTEKIT_PAYLOAD__.query ?? {};
+		query_lifetimes = /** @type {any} */ (__SVELTEKIT_PAYLOAD__).lifetimes ?? {};
 		prerender_responses = __SVELTEKIT_PAYLOAD__.prerender ?? {};
 	}
 
@@ -487,6 +496,19 @@ async function _invalidate(include_load_functions = true, reset_page_state = tru
 function reset_invalidation() {
 	invalidated.length = 0;
 	force_invalidation = false;
+}
+
+/** @param {boolean} pending_only */
+function notify_remote_queries_of_navigation(pending_only = false) {
+	if (pending_only) {
+		remote_query_navigation_version += 1;
+	}
+
+	for (const entries of query_map.values()) {
+		for (const entry of entries.values()) {
+			entry.resource.notify_navigation(entry, pending_only);
+		}
+	}
 }
 
 /** @param {number} index */
@@ -1704,6 +1726,7 @@ async function navigate({
 
 	if (started && nav.navigation.type !== 'enter') {
 		stores.navigating.set((navigating.current = nav.navigation));
+		notify_remote_queries_of_navigation(true);
 	}
 
 	let navigation_result = intent && (await load_route(intent));
@@ -1975,6 +1998,7 @@ async function navigate({
 	after_navigate_callbacks.forEach((fn) =>
 		fn(/** @type {import('@sveltejs/kit').AfterNavigate} */ (nav.navigation))
 	);
+	notify_remote_queries_of_navigation();
 
 	stores.navigating.set((navigating.current = null));
 

--- a/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
@@ -2,7 +2,7 @@
 /** @import { RemoteFunctionResponse } from 'types' */
 import { app_dir, base } from '$app/paths/internal/client';
 import { app, goto } from '../client.js';
-import { get_remote_request_headers, QUERY_FUNCTION_ID } from './shared.svelte.js';
+import { apply_lifetimes, get_remote_request_headers, QUERY_FUNCTION_ID } from './shared.svelte.js';
 import { QueryProxy } from './query.svelte.js';
 import * as devalue from 'devalue';
 import { HttpError, Redirect } from '@sveltejs/kit/internal';
@@ -18,7 +18,7 @@ export function query_batch(id) {
 
 	/** @type {RemoteQueryFunction<any, any>} */
 	const wrapper = (arg) => {
-		return new QueryProxy(id, arg, async (key, payload) => {
+		const proxy = new QueryProxy(id, arg, async (key, payload) => {
 			const serialized = await unfriendly_hydratable(key, () => {
 				return new Promise((resolve, reject) => {
 					// create_remote_function caches identical calls, but in case a refresh to the same query is called multiple times this function
@@ -67,6 +67,10 @@ export function query_batch(id) {
 								throw new Redirect(307, result.location);
 							}
 
+							if (result.lifetimes) {
+								apply_lifetimes(result.lifetimes);
+							}
+
 							const results = devalue.parse(result.result, app.decoders);
 
 							// Resolve individual queries
@@ -97,6 +101,8 @@ export function query_batch(id) {
 
 			return devalue.parse(serialized, app.decoders);
 		});
+
+		return /** @type {any} */ (proxy); // TODO why is the cast necessary all of a sudden?
 	};
 
 	Object.defineProperty(wrapper, QUERY_FUNCTION_ID, { value: id });

--- a/packages/kit/src/runtime/client/remote-functions/query.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query.svelte.js
@@ -1,6 +1,13 @@
 /** @import { RemoteQueryFunction } from '@sveltejs/kit' */
+/** @import { NormalizedQueryLifetime } from 'types' */
 import { app_dir, base } from '$app/paths/internal/client';
-import { app, query_map, query_responses } from '../client.js';
+import {
+	app,
+	query_lifetimes,
+	query_map,
+	query_responses,
+	remote_query_navigation_version
+} from '../client.js';
 import {
 	get_remote_request_headers,
 	is_in_effect,
@@ -22,8 +29,21 @@ import { create_remote_key, stringify_remote_arg, unfriendly_hydratable } from '
  *   count: number;
  *   resource: Query<T>;
  *   cleanup: () => void;
+ *   evict: () => void;
+ *   evict_timeout: ReturnType<typeof setTimeout> | null;
+ *   inactive_navigations: number;
  * }} RemoteQueryCacheEntry
  */
+
+/** @type {NormalizedQueryLifetime} */
+const DEFAULT_QUERY_LIFETIME = {
+	staleAfter: 60 * 60,
+	refreshOnNavigation: false,
+	bfcache: {
+		limit: 5,
+		maxAge: 10 * 60
+	}
+};
 
 /**
  * @param {string} id
@@ -43,7 +63,7 @@ export function query(id) {
 
 	/** @type {RemoteQueryFunction<any, any>} */
 	const wrapper = (arg) => {
-		return new QueryProxy(id, arg, async (key, payload) => {
+		const proxy = new QueryProxy(id, arg, async (key, payload) => {
 			const url = `${base}/${app_dir}/remote/${id}${payload ? `?payload=${payload}` : ''}`;
 
 			const serialized = await unfriendly_hydratable(key, () =>
@@ -52,6 +72,7 @@ export function query(id) {
 
 			return devalue.parse(serialized, app.decoders);
 		});
+		return /** @type {any} */ (proxy); // TODO why is the cast necessary all of a sudden?
 	};
 
 	Object.defineProperty(wrapper, QUERY_FUNCTION_ID, { value: id });
@@ -64,6 +85,7 @@ export function query(id) {
 	return wrapper;
 }
 
+/**
  * The actual query instance. There should only ever be one active query instance per key.
  *
  * @template T
@@ -87,6 +109,13 @@ export class Query {
 	#promise = $state.raw(null);
 	/** @type {Array<(old: T) => T>} */
 	#overrides = $state([]);
+	#active = false;
+	#updated_at = 0;
+	#last_navigation_refresh_version = 0;
+	/** @type {NormalizedQueryLifetime | undefined} */
+	#lifetime = undefined;
+	/** @type {ReturnType<typeof setTimeout> | null} */
+	#refresh_timeout = null;
 
 	/** @type {T | undefined} */
 	#current = $derived.by(() => {
@@ -102,7 +131,9 @@ export class Query {
 	/** @type {Promise<T>['then']} */
 	// @ts-expect-error TS doesn't understand that the promise returns something
 	#then = $derived.by(() => {
+		console.trace('then', this.#key);
 		const p = this.#get_promise();
+		this.#promise;
 		this.#overrides.length;
 
 		return (resolve, reject) => {
@@ -123,6 +154,7 @@ export class Query {
 	constructor(key, fn) {
 		this.#key = key;
 		this.#fn = fn;
+		this.#consume_lifetime();
 	}
 
 	#get_promise() {
@@ -143,8 +175,57 @@ export class Query {
 		this.#latest.length = 0;
 	}
 
+	#get_lifetime() {
+		this.#consume_lifetime();
+		return this.#lifetime ?? DEFAULT_QUERY_LIFETIME;
+	}
+
+	#has_lifetime() {
+		this.#consume_lifetime();
+		return this.#lifetime !== undefined;
+	}
+
+	#consume_lifetime() {
+		if (Object.hasOwn(query_lifetimes, this.#key)) {
+			this.#lifetime = query_lifetimes[this.#key];
+			delete query_lifetimes[this.#key];
+		}
+	}
+
+	#clear_refresh_timer() {
+		if (this.#refresh_timeout) {
+			clearTimeout(this.#refresh_timeout);
+			this.#refresh_timeout = null;
+		}
+	}
+
+	#schedule_refresh() {
+		if (this.#refresh_timeout) return;
+
+		const refresh_after = this.#get_lifetime().refreshAfter;
+		if (!this.#active || refresh_after === undefined) return;
+
+		this.#refresh_timeout = setTimeout(() => {
+			this.#refresh_timeout = null;
+			if (this.#active) {
+				void this.refresh();
+			}
+		}, refresh_after * 1000);
+	}
+
+	#is_stale() {
+		const stale_after = this.#get_lifetime().staleAfter;
+		return (
+			this.#ready &&
+			!this.#loading &&
+			stale_after !== undefined &&
+			Date.now() - this.#updated_at >= stale_after * 1000
+		);
+	}
+
 	#run() {
 		this.#loading = true;
+		const navigation_version = remote_query_navigation_version;
 
 		const { promise, resolve, reject } = with_resolvers();
 
@@ -163,7 +244,17 @@ export class Query {
 					this.#loading = false;
 					this.#raw = value;
 					this.#error = undefined;
+					this.#updated_at = Date.now();
 				});
+
+				if (
+					!this.#has_lifetime() &&
+					navigation_version !== remote_query_navigation_version &&
+					this.#last_navigation_refresh_version !== remote_query_navigation_version
+				) {
+					this.#last_navigation_refresh_version = remote_query_navigation_version;
+					void this.refresh();
+				}
 
 				resolve(undefined);
 			})
@@ -254,6 +345,60 @@ export class Query {
 		return (this.#promise = this.#run());
 	}
 
+	activate() {
+		this.#active = true;
+		this.#schedule_refresh();
+	}
+
+	refresh_if_stale() {
+		if (this.#is_stale()) {
+			// Without the timeout this will not correctly trigger then/current etc,
+			// even if we would untrack to avoid the mutation validation error.
+			setTimeout(() => {
+				if (this.#active && this.#is_stale()) {
+					void this.refresh();
+				}
+			});
+		}
+	}
+
+	deactivate() {
+		this.#active = false;
+		this.#clear_refresh_timer();
+	}
+
+	get_bfcache() {
+		return this.#get_lifetime().bfcache;
+	}
+
+	/**
+	 * @param {RemoteQueryCacheEntry<T>} entry
+	 * @param {boolean} [pending_only]
+	 */
+	notify_navigation(entry, pending_only = false) {
+		if (entry.count === 0) {
+			if (pending_only) return;
+
+			const bfcache = this.#get_lifetime().bfcache;
+			if (bfcache === false) return entry.evict();
+
+			entry.inactive_navigations += 1;
+			if (entry.inactive_navigations >= bfcache.limit) {
+				entry.evict();
+			}
+			return;
+		}
+
+		const lifetime = this.#get_lifetime();
+		if (!pending_only && lifetime.refreshOnNavigation) {
+			setTimeout(() => {
+				if (this.#active) {
+					void this.refresh();
+				}
+			}, 0);
+		}
+	}
+
 	/**
 	 * @param {T} value
 	 */
@@ -263,6 +408,7 @@ export class Query {
 		this.#loading = false;
 		this.#error = undefined;
 		this.#raw = value;
+		this.#updated_at = Date.now();
 		this.#promise = Promise.resolve();
 	}
 
@@ -366,17 +512,47 @@ export class QueryProxy {
 			const c = (this_instance = {
 				count: 0,
 				resource: /** @type {Query<T>} */ (/** @type {unknown} */ (null)),
-				cleanup: /** @type {() => void} */ (/** @type {unknown} */ (null))
+				cleanup: /** @type {() => void} */ (/** @type {unknown} */ (null)),
+				evict: /** @type {() => void} */ (/** @type {unknown} */ (null)),
+				evict_timeout: null,
+				inactive_navigations: 0
 			});
 
 			c.cleanup = $effect.root(() => {
 				c.resource = new Query(this.#key, () => this.#fn(this.#key, this.#payload));
 			});
+			c.evict = () => {
+				const query_instances = query_map.get(this.#id);
+				const entry = query_instances?.get(this.#payload);
+				if (entry !== c || c.count !== 0) return;
+
+				if (c.evict_timeout) {
+					clearTimeout(c.evict_timeout);
+					c.evict_timeout = null;
+				}
+				c.resource.deactivate();
+				c.cleanup();
+				query_instances?.delete(this.#payload);
+				if (query_instances?.size === 0) {
+					query_map.delete(this.#id);
+				}
+			};
 
 			query_instances.set(this.#payload, this_instance);
 		}
 
+		if (this_instance.evict_timeout) {
+			clearTimeout(this_instance.evict_timeout);
+			this_instance.evict_timeout = null;
+		}
+		this_instance.inactive_navigations = 0;
+		const was_inactive = this_instance.count === 0;
 		this_instance.count += 1;
+		if (was_inactive) {
+			this_instance.resource.activate();
+		} else {
+			this_instance.resource.refresh_if_stale();
+		}
 
 		return this_instance;
 	}
@@ -391,16 +567,17 @@ export class QueryProxy {
 		entry.count -= 1;
 
 		return () => {
-			const query_instances = query_map.get(this.#id);
-			const this_instance = query_instances?.get(this.#payload);
+			if (entry.count !== 0) return;
 
-			if (this_instance?.count === 0) {
-				this_instance.cleanup();
-				query_instances?.delete(this.#payload);
+			entry.resource.deactivate();
+
+			const bfcache = entry.resource.get_bfcache();
+			if (bfcache === false) {
+				entry.evict();
+				return;
 			}
-			if (query_instances?.size === 0) {
-				query_map.delete(this.#id);
-			}
+
+			entry.evict_timeout = setTimeout(entry.evict, bfcache.maxAge * 1000);
 		};
 	}
 

--- a/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
@@ -1,7 +1,7 @@
 /** @import { RemoteFunctionResponse, RemoteSingleflightMap, RemoteSingleflightEntry } from 'types' */
 /** @import { RemoteQueryUpdate } from '@sveltejs/kit' */
 import * as devalue from 'devalue';
-import { app, goto, live_query_map, query_map } from '../client.js';
+import { app, goto, live_query_map, query_lifetimes, query_map } from '../client.js';
 import { HttpError, Redirect } from '@sveltejs/kit/internal';
 import { untrack } from 'svelte';
 import { create_remote_key, split_remote_key } from '../../shared.js';
@@ -79,6 +79,10 @@ export async function handle_side_channel_response(response) {
 
 	if (response.type === 'error') {
 		throw new HttpError(response.status ?? 500, response.error);
+	}
+
+	if (response.lifetimes) {
+		apply_lifetimes(response.lifetimes);
 	}
 
 	return response;
@@ -205,4 +209,17 @@ export const apply_reconnections = (stringified_reconnects) => {
 			resource?.fail(new HttpError(value.status ?? 500, value.error));
 		}
 	});
+};
+
+/**
+ * Apply lifetime metadata from the server to matching query keys
+ *
+ * @param {string} stringified_lifetimes
+ */
+export const apply_lifetimes = (stringified_lifetimes) => {
+	const lifetimes = /** @type {Record<string, import('types').NormalizedQueryLifetime>} */ (
+		devalue.parse(stringified_lifetimes, app.decoders)
+	);
+
+	Object.assign(query_lifetimes, lifetimes);
 };

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -506,6 +506,7 @@ export async function render_response({
 		const { remote } = event_state;
 
 		let serialized_query_data = '';
+		let serialized_lifetime_data = '';
 		let serialized_prerender_data = '';
 
 		if (remote.data) {
@@ -571,12 +572,19 @@ export async function render_response({
 				serialized_query_data = `${global}.query = ${devalue.uneval(query, replacer)};\n\n\t\t\t\t\t\t`;
 			}
 
+			if (remote.lifetimes?.size) {
+				serialized_lifetime_data = `${global}.lifetimes = ${devalue.uneval(
+					Object.fromEntries(remote.lifetimes),
+					replacer
+				)};\n\n\t\t\t\t\t\t`;
+			}
+
 			if (Object.keys(prerender).length > 0) {
 				serialized_prerender_data = `${global}.prerender = ${devalue.uneval(prerender, replacer)};\n\n\t\t\t\t\t\t`;
 			}
 		}
 
-		const serialized_remote_data = `${serialized_query_data}${serialized_prerender_data}`;
+		const serialized_remote_data = `${serialized_query_data}${serialized_lifetime_data}${serialized_prerender_data}`;
 
 		// `client.app` is a proxy for `bundleStrategy === 'split'`
 		const boot = client.inline

--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -81,7 +81,8 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 			return json(
 				/** @type {RemoteFunctionResponse} */ ({
 					type: 'result',
-					result: stringify(results, transport)
+					result: stringify(results, transport),
+					lifetimes: serialize_lifetimes(state.remote.lifetimes)
 				})
 			);
 		}
@@ -266,7 +267,9 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 		return json(
 			/** @type {RemoteFunctionResponse} */ ({
 				type: 'result',
-				result: stringify(data, transport)
+				result: stringify(data, transport),
+				lifetimes:
+					internals.type === 'query' ? serialize_lifetimes(state.remote.lifetimes) : undefined
 			})
 		);
 	} catch (error) {
@@ -276,7 +279,11 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 					type: 'redirect',
 					location: error.location,
 					refreshes: await serialize_singleflight(state.remote.refreshes),
-					reconnects: await serialize_singleflight(state.remote.reconnects)
+					reconnects: await serialize_singleflight(state.remote.reconnects),
+					lifetimes:
+						internals.type === 'query' || internals.type === 'query_batch'
+							? serialize_lifetimes(state.remote.lifetimes)
+							: undefined
 				})
 			);
 		}
@@ -328,6 +335,15 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 		);
 
 		return stringify(Object.fromEntries(results), transport);
+	}
+
+	/** @param {Map<string, import('types').NormalizedQueryLifetime> | null} map */
+	function serialize_lifetimes(map) {
+		if (!map || map.size === 0) {
+			return undefined;
+		}
+
+		return stringify(Object.fromEntries(map), transport);
 	}
 }
 

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -154,6 +154,8 @@ export async function internal_respond(request, options, manifest, state) {
 			/** A map of remote function key to corresponding single-flight-mutation promise */
 			refreshes: null,
 			reconnects: null,
+			lifetimes: null,
+			lifetime_context: null,
 			/** A map of remote function ID to payloads requested for refreshing by the client */
 			requested: null,
 			invalidations: null,

--- a/packages/kit/src/types/global-private.d.ts
+++ b/packages/kit/src/types/global-private.d.ts
@@ -35,6 +35,8 @@ declare global {
 		env?: Record<string, string>;
 		/** Serialized data from query/form/command functions */
 		query?: Record<string, any>;
+		/** Lifetime metadata from query functions */
+		lifetimes?: Record<string, import('types').NormalizedQueryLifetime>;
 		/** Serialized data from prerender functions */
 		prerender?: Record<string, any>;
 		/** Create a placeholder promise */

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -310,6 +310,8 @@ export type RemoteFunctionResponse =
 			refreshes?: string;
 			/** devalue'd Record<string, any> */
 			reconnects?: string;
+			/** devalue'd Record<string, QueryLifetime> */
+			lifetimes?: string;
 	  })
 	| ServerErrorNode
 	| {
@@ -319,6 +321,8 @@ export type RemoteFunctionResponse =
 			refreshes: string | undefined;
 			/** devalue'd Record<string, any> */
 			reconnects: string | undefined;
+			/** devalue'd Record<string, QueryLifetime> */
+			lifetimes?: string;
 	  };
 
 export type RemoteSingleflightResult = {
@@ -335,6 +339,32 @@ export type RemoteSingleflightError = {
 export type RemoteSingleflightEntry = RemoteSingleflightResult | RemoteSingleflightError;
 
 export type RemoteSingleflightMap = Record<string, RemoteSingleflightEntry>;
+
+export type QueryLifetimeTime = `${number}m` | `${number}s` | number;
+
+export interface QueryLifetime {
+	staleAfter?: QueryLifetimeTime;
+	refreshAfter?: QueryLifetimeTime;
+	refreshOnNavigation?: boolean;
+	bfcache?:
+		| {
+				limit: number;
+				maxAge: QueryLifetimeTime;
+		  }
+		| false;
+}
+
+export interface NormalizedQueryLifetime {
+	staleAfter?: number;
+	refreshAfter?: number;
+	refreshOnNavigation: boolean;
+	bfcache:
+		| {
+				limit: number;
+				maxAge: number;
+		  }
+		| false;
+}
 
 export type RemoteLiveQueryUserFunctionReturnType<Output> = MaybePromise<
 	| AsyncGenerator<Output>
@@ -718,6 +748,8 @@ export interface RequestState {
 		forms: null | Map<any, any>;
 		refreshes: null | Map<string, Promise<any>>;
 		reconnects: null | Map<string, Promise<any>>;
+		lifetimes: null | Map<string, NormalizedQueryLifetime>;
+		lifetime_context: null | string | string[];
 		requested: null | Map<string, string[]>;
 		/**
 		 * A list of promises to await for invalidations to complete.

--- a/packages/kit/test/apps/async/src/routes/remote/lifetime/+layout.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/lifetime/+layout.svelte
@@ -1,0 +1,22 @@
+<script>
+	import { navigation_count, pending_count } from './lifetime.remote.js';
+
+	let { children } = $props();
+	let show_pending = $state(false);
+
+	const nav = navigation_count();
+</script>
+
+<nav>
+	<a href="/remote/lifetime">lifetime home</a>
+	<a href="/remote/lifetime/other">lifetime other</a>
+</nav>
+
+<p id="navigation-count">{await nav}</p>
+
+<button id="start-pending" onclick={() => (show_pending = true)}>start pending query</button>
+{#if show_pending}
+	<p id="pending-count">{await pending_count()}</p>
+{/if}
+
+{@render children()}

--- a/packages/kit/test/apps/async/src/routes/remote/lifetime/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/lifetime/+page.svelte
@@ -1,0 +1,25 @@
+<script>
+	import { auto_count, bfcache_count, stale_count } from './lifetime.remote.js';
+
+	let show_stale_child = $state(false);
+	let show_bfcache = $state(true);
+
+	const auto = auto_count();
+	const stale = stale_count();
+</script>
+
+<p id="auto-count">{await auto}</p>
+<p id="stale-count">{await stale}</p>
+
+<button id="show-stale-child" onclick={() => (show_stale_child = true)}>show stale child</button>
+{#if show_stale_child}
+	<p id="stale-child-count">{await stale_count()}</p>
+{/if}
+
+<button id="toggle-bfcache" onclick={() => (show_bfcache = !show_bfcache)}>toggle bfcache</button>
+{#if show_bfcache}
+	<!-- {@const bfcache = bfcache_count()} TODO why does this fail -->
+	<p id="bfcache-count">{await bfcache_count()}</p>
+{:else}
+	<p id="bfcache-detached">detached</p>
+{/if}

--- a/packages/kit/test/apps/async/src/routes/remote/lifetime/lifetime.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/lifetime/lifetime.remote.js
@@ -1,0 +1,34 @@
+import { query } from '$app/server';
+
+const counts = {
+	nav: 0,
+	auto: 0,
+	stale: 0,
+	bfcache: 0,
+	pending: 0
+};
+
+export const navigation_count = query(() => {
+	query.lifetime({ refreshOnNavigation: true });
+	return ++counts.nav;
+});
+
+export const auto_count = query(() => {
+	query.lifetime({ refreshAfter: '0.2s', bfcache: false });
+	return ++counts.auto;
+});
+
+export const stale_count = query(() => {
+	query.lifetime({ staleAfter: '0.2s', bfcache: { limit: 5, maxAge: '5s' } });
+	return ++counts.stale;
+});
+
+export const bfcache_count = query(() => {
+	query.lifetime({ bfcache: { limit: 1, maxAge: '5s' } });
+	return ++counts.bfcache;
+});
+
+export const pending_count = query(async () => {
+	await new Promise((resolve) => setTimeout(resolve, 1000));
+	return ++counts.pending;
+});

--- a/packages/kit/test/apps/async/src/routes/remote/lifetime/other/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/lifetime/other/+page.svelte
@@ -1,0 +1,1 @@
+<p id="lifetime-other">other</p>

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -26,6 +26,35 @@ test.describe('remote functions', () => {
 		await page.getByRole('button', { name: 'Refresh' }).click();
 		await expect(page.locator('p')).toHaveText('foobaz');
 	});
+
+	test('query.lifetime controls refresh and client cache behavior', async ({ page, clicknav }) => {
+		await page.goto('/remote/lifetime');
+		await expect(page.locator('#navigation-count')).toHaveText('1');
+		await expect(page.locator('#auto-count')).toHaveText('1');
+		await expect(page.locator('#stale-count')).toHaveText('1');
+		await expect(page.locator('#bfcache-count')).toHaveText('1');
+
+		await expect
+			.poll(async () => Number(await page.locator('#auto-count').textContent()))
+			.toBeGreaterThan(1);
+
+		await page.waitForTimeout(250);
+		await page.locator('#show-stale-child').click();
+		await expect(page.locator('#stale-count')).toHaveText('2');
+		await expect(page.locator('#stale-child-count')).toHaveText('2');
+
+		await page.locator('#toggle-bfcache').click();
+		await expect(page.locator('#bfcache-detached')).toHaveText('detached');
+		await clicknav('a[href="/remote/lifetime/other"]', { waitForURL: '/remote/lifetime/other' });
+		await expect(page.locator('#navigation-count')).toHaveText('2');
+		await clicknav('a[href="/remote/lifetime"]', { waitForURL: '/remote/lifetime' });
+		await expect(page.locator('#bfcache-count')).toHaveText('2');
+
+		await page.locator('#start-pending').click();
+		await page.waitForTimeout(50);
+		await clicknav('a[href="/remote/lifetime/other"]', { waitForURL: '/remote/lifetime/other' });
+		await expect(page.locator('#pending-count')).toHaveText('2');
+	});
 });
 
 // have to run in serial because commands mutate in-memory data on the server (should fix this at some point)

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -326,6 +326,22 @@ declare module '@sveltejs/kit' {
 		tags: string[];
 	}
 
+	export interface QueryLifetime {
+		/** If a referenced query is reused after this many seconds, it will be refreshed. If omitted, it never goes stale. */
+		staleAfter?: `${number}m` | `${number}s` | number;
+		/** If a query remains referenced for this many seconds, it will be refreshed. If omitted, it never refreshes automatically. */
+		refreshAfter?: `${number}m` | `${number}s` | number;
+		/** Whether the query should refresh after client-side navigations. */
+		refreshOnNavigation?: boolean;
+		/** How long to retain the query in the client cache after it is no longer referenced. */
+		bfcache?:
+			| {
+					limit: number;
+					maxAge: `${number}m` | `${number}s` | number;
+			  }
+			| false;
+	}
+
 	/**
 	 * Custom query cache integration. Export `get`, `set`, and `invalidate` from `kit.cache.path`.
 	 */
@@ -3569,6 +3585,11 @@ declare module '$app/server' {
 			function invalidate(tags: string[]): Promise<void>;
 		}
 		/**
+		 * Configure the lifetime of the currently executing query.
+		 *
+		 * */
+		function lifetime(options: QueryLifetime): void;
+		/**
 		 * Creates a live remote query. When called from the browser, the function will be invoked on the server via a streaming `fetch` call.
 		 *
 		 * See [Remote functions](https://svelte.dev/docs/kit/remote-functions#query.live) for full documentation.
@@ -3650,6 +3671,20 @@ declare module '$app/server' {
 	 *
 	 * */
 	export function requested<Input, Output, Validated = Input>(query: RemoteLiveQueryFunction<Input, Output, Validated>, limit: number): LiveQueryRequestedResult<Validated, Output>;
+	type QueryLifetimeTime = `${number}m` | `${number}s` | number;
+
+	interface QueryLifetime {
+		staleAfter?: QueryLifetimeTime;
+		refreshAfter?: QueryLifetimeTime;
+		refreshOnNavigation?: boolean;
+		bfcache?:
+			| {
+					limit: number;
+					maxAge: QueryLifetimeTime;
+			  }
+			| false;
+	}
+
 	type RemoteLiveQueryUserFunctionReturnType<Output> = MaybePromise<
 		| AsyncGenerator<Output>
 		| AsyncIterator<Output>


### PR DESCRIPTION
SvelteKit remote query functions lack the capability to control how long they are fresh, how long they should be kept around after they are no longer used (bfcache behavior), and whether or not they should refresh after a certain time or after navigation. Therefore we introduce a new config-like function on the query function itself: `query.lifetime`. It is a function with the following signature:

```ts
interface QueryLifetime {
  staleAfter?: `${number}m` | `${number}s` | number, // if the client still has a reference to the query somewhere and calls the same query after the stale time it will do a new request. If not set never goes stale
  refreshAfter?: `${number}m` | `${number}s` | number, // if the client has a reference to the query somewhere for more than the specified time it will refresh the query. If not set never refreshes
  refreshOnNavigation?: boolean, // whether or not to do a refresh on client-side navigations. If not set false
  bfcache?: {
    limit: number, // after how many navigations the query should be deleted from the client cache
    maxAge: `${number}m` | `${number}s` | number  // after what time the query should be deleted from the client cache
    } | false // what to do when no reference to the client is held anymore. Default false i.e. deleted from cache directly, else behavior depends on limit/maxAge
  }
query.lifetime(options: QueryLifetime);
```

... where all the `${number}m` | `${number}s` | number fields mean "either do a string that says how many seconds or minutes, or pass a number which means how many seconds". Example:

```ts
import {query} from '$app/server';
const myQuery = query(() => {
  query.lifetime({ staleAfter: '5s', refreshAfter: '10s', refreshOnNavigation: true, bfcache: { limit: 5, maxAge: '10s' } });
  return someValue();
});
```

As you can see `query.lifetime(...)` needs to be called in the context of a query function.

The defaults are:
`{ staleAfter: '60m', refreshOnNavigation: false, bfcache: { limit: 5, maxAge: '10m' } }`

Implementation-wise this spans the client and the server.
- On the server it adds a new property `lifetime` onto `RequestState['remote']` which is a `Map<string, QueryLifetime>` (where string is the id+stringified-payload, similar to e.g. `RequestState['remote']['refreshes']`). This property is filled by a call to `query.lifetime(...)`.
- On the client it adds logic to read the config in `query.svelte.js` and act on it accordingly (i.e. notice when navigations occur, then refresh if needed / evict from bfcache if needed / etc)

closes https://github.com/sveltejs/kit/issues/15039

builds on top of #15678 (i.e. this PR is the merge target) but only to avoid some merge conflicts I anticipate; this PR should definitely go in after #15678.