### PR TITLE
fix(adapter-node): mark @sveltejs/kit/node as external to fix SvelteKitError 413-as-500 regression

### DIFF
--- a/.changeset/fix-adapter-node-sveltekiterror-identity.md
+++ b/.changeset/fix-adapter-node-sveltekiterror-identity.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+fix: mark `@sveltejs/kit/node` as external in the rollup build so the `SvelteKitError` class used by the body-size-limit stream is the same instance as the one checked by the kit runtime — preventing oversized-body 413 errors from being returned as 500s

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -80,7 +80,7 @@ export default [
 			json(),
 			prefixBuiltinModules()
 		],
-		external: ['ENV', 'MANIFEST', 'SERVER', 'SHIMS']
+		external: ['ENV', 'MANIFEST', 'SERVER', 'SHIMS', '@sveltejs/kit/node']
 	},
 	{
 		input: 'src/shims.js',


### PR DESCRIPTION
Closing — the fix is incorrect.

Making `@sveltejs/kit/node` external in the adapter-node rollup build doesn't resolve the class identity mismatch in the common case. The user's `npm run build` triggers a second rollup pass (in `packages/adapter-node/index.js`) that bundles `@sveltejs/kit` into `build/server/index.js` because it's typically in `devDependencies`. The handler and the runtime end up with two separate `SvelteKitError` class instances regardless, so `instanceof` still fails.

The correct fix is a name-based fallback in `get_status` / `get_message`: set `this.name = 'SvelteKitError'` in the constructor and check `error?.name === 'SvelteKitError'` as a backstop. That survives any number of rollup bundle boundaries.

Sorry for the noise.