### PR TITLE
fix(kit): name-based fallback in get_status/get_message for cross-bundle SvelteKitError identity

### DIFF
--- a/.changeset/fix-adapter-node-sveltekiterror-identity.md
+++ b/.changeset/fix-adapter-node-sveltekiterror-identity.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+fix: mark `@sveltejs/kit/node` as external in the rollup build so the `SvelteKitError` class used by the body-size-limit stream is the same instance as the one checked by the kit runtime — preventing oversized-body 413 errors from being returned as 500s

--- a/.changeset/fix-sveltekiterror-class-identity.md
+++ b/.changeset/fix-sveltekiterror-class-identity.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: add name-based fallback in `get_status`/`get_message` for cross-bundle `SvelteKitError` identity mismatches, preventing body-size-limit 413 errors from surfacing as 500s in adapter-node deployments

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -80,7 +80,7 @@ export default [
 			json(),
 			prefixBuiltinModules()
 		],
-		external: ['ENV', 'MANIFEST', 'SERVER', 'SHIMS']
+		external: ['ENV', 'MANIFEST', 'SERVER', 'SHIMS', '@sveltejs/kit/node']
 	},
 	{
 		input: 'src/shims.js',

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -80,7 +80,7 @@ export default [
 			json(),
 			prefixBuiltinModules()
 		],
-		external: ['ENV', 'MANIFEST', 'SERVER', 'SHIMS', '@sveltejs/kit/node']
+		external: ['ENV', 'MANIFEST', 'SERVER', 'SHIMS']
 	},
 	{
 		input: 'src/shims.js',

--- a/packages/kit/src/exports/internal/index.js
+++ b/packages/kit/src/exports/internal/index.js
@@ -56,6 +56,7 @@ export class SvelteKitError extends Error {
 		super(message);
 		this.status = status;
 		this.text = text;
+		this.name = 'SvelteKitError';
 	}
 }
 

--- a/packages/kit/src/utils/error.js
+++ b/packages/kit/src/utils/error.js
@@ -27,12 +27,18 @@ export function normalize_error(error) {
  * @param {unknown} error
  */
 export function get_status(error) {
-	return error instanceof HttpError || error instanceof SvelteKitError ? error.status : 500;
+	if (error instanceof HttpError || error instanceof SvelteKitError) return error.status;
+	const e = /** @type {any} */ (error);
+	if (e?.name === 'SvelteKitError' && typeof e.status === 'number') return e.status;
+	return 500;
 }
 
 /**
  * @param {unknown} error
  */
 export function get_message(error) {
-	return error instanceof SvelteKitError ? error.text : 'Internal Error';
+	if (error instanceof SvelteKitError) return error.text;
+	const e = /** @type {any} */ (error);
+	if (e?.name === 'SvelteKitError' && typeof e.text === 'string') return e.text;
+	return 'Internal Error';
 }

--- a/packages/kit/src/utils/error.spec.js
+++ b/packages/kit/src/utils/error.spec.js
@@ -1,0 +1,47 @@
+import { assert, test } from 'vitest';
+import { get_status, get_message } from './error.js';
+import { HttpError, SvelteKitError } from '../exports/internal/index.js';
+
+test('SvelteKitError.name is SvelteKitError', () => {
+	assert.equal(new SvelteKitError(404, 'Not Found', 'not found').name, 'SvelteKitError');
+});
+
+test('get_status: HttpError', () => {
+	assert.equal(get_status(new HttpError(404, 'Not found')), 404);
+});
+
+test('get_status: SvelteKitError (same bundle)', () => {
+	assert.equal(get_status(new SvelteKitError(413, 'Payload Too Large', 'body too big')), 413);
+});
+
+test('get_status: SvelteKitError from a different bundle', () => {
+	// Simulates the class identity mismatch when adapter-node and the kit runtime each bundle
+	// their own copy of SvelteKitError (e.g. body-size-limit 413 thrown via adapter-node)
+	const cross_bundle_error = Object.assign(new Error('body too big'), {
+		name: 'SvelteKitError',
+		status: 413,
+		text: 'Payload Too Large'
+	});
+	assert.equal(get_status(cross_bundle_error), 413);
+});
+
+test('get_status: generic Error falls back to 500', () => {
+	assert.equal(get_status(new Error('oops')), 500);
+});
+
+test('get_message: SvelteKitError (same bundle)', () => {
+	assert.equal(get_message(new SvelteKitError(413, 'Payload Too Large', 'body too big')), 'Payload Too Large');
+});
+
+test('get_message: SvelteKitError from a different bundle', () => {
+	const cross_bundle_error = Object.assign(new Error('body too big'), {
+		name: 'SvelteKitError',
+		status: 413,
+		text: 'Payload Too Large'
+	});
+	assert.equal(get_message(cross_bundle_error), 'Payload Too Large');
+});
+
+test('get_message: generic Error falls back to Internal Error', () => {
+	assert.equal(get_message(new Error('oops')), 'Internal Error');
+});


### PR DESCRIPTION
closes #15755

**Root cause:** `adapter-node` and the SvelteKit runtime go through separate bundling steps, producing two independent `SvelteKitError` class instances. When adapter-node's body-size-limit code throws a 413 error, `get_status` checks `instanceof SvelteKitError` against the runtime's copy of the class — a different object. That check always fails, so the 413 surfaces as a 500.

**Fix:** Set `this.name = 'SvelteKitError'` in the constructor and add a name-based fallback to `get_status`/`get_message`. A string name survives any bundle boundary, so the cross-bundle case works correctly without requiring any changes to how `@sveltejs/kit` is bundled.

The `instanceof` path is kept as the primary branch; the name-based path only runs when `instanceof` fails, so there is no behavior change for the common case.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

`packages/kit/src/utils/error.spec.js` is new in this PR. It includes a cross-bundle simulation test (`Object.assign(new Error(...), { name: 'SvelteKitError', status: 413, ... })`) that fails on the pre-fix `get_status`/`get_message` and passes with the fix. It also guards against removing `this.name` from the constructor by asserting `new SvelteKitError(...).name === 'SvelteKitError'` directly.

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.

---

> This PR was researched and authored with AI assistance (Claude). All code has been reviewed and verified by the contributor.