### PR TITLE
fix: use name-based fallback in get_status/get_message when SvelteKitError crosses a bundle boundary

### DIFF
--- a/.changeset/fix-sveltekiterror-class-identity.md
+++ b/.changeset/fix-sveltekiterror-class-identity.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: preserve the status code of `HttpError` and `SvelteKitError` thrown across a bundle boundary (e.g. when an adapter inlines its own `@sveltejs/kit` copy), instead of reporting them as a generic 500

--- a/packages/kit/src/exports/index.js
+++ b/packages/kit/src/exports/index.js
@@ -88,8 +88,12 @@ export function error(status, body) {
  * @return {e is (HttpError & { status: T extends undefined ? never : T })}
  */
 export function isHttpError(e, status) {
-	if (!(e instanceof HttpError)) return false;
-	return !status || e.status === status;
+	const err = /** @type {any} */ (e);
+	// Name-based fallback covers cross-bundle instanceof failures (e.g. adapter-node inlining its own @sveltejs/kit copy)
+	const isHttp =
+		e instanceof HttpError || (err?.name === 'HttpError' && Number.isFinite(err.status));
+	if (!isHttp) return false;
+	return !status || err.status === status;
 }
 
 /**

--- a/packages/kit/src/exports/internal/index.js
+++ b/packages/kit/src/exports/internal/index.js
@@ -6,6 +6,7 @@ export class HttpError {
 	 * @param {{message: string} extends App.Error ? (App.Error | string | undefined) : App.Error} body
 	 */
 	constructor(status, body) {
+		this.name = 'HttpError';
 		this.status = status;
 		if (typeof body === 'string') {
 			this.body = { message: body };
@@ -54,6 +55,7 @@ export class SvelteKitError extends Error {
 	 */
 	constructor(status, text, message) {
 		super(message);
+		this.name = 'SvelteKitError';
 		this.status = status;
 		this.text = text;
 	}

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -12,8 +12,8 @@ import {
 	run_remote_generator
 } from './shared.js';
 import { handle_error_and_jsonify } from '../../../server/utils.js';
-import { HttpError, SvelteKitError } from '@sveltejs/kit/internal';
 import { noop } from '../../../../utils/functions.js';
+import { get_status } from '../../../../utils/error.js';
 import { SharedIterator } from '../../../../utils/shared-iterator.js';
 
 /**
@@ -331,10 +331,7 @@ function batch(validate_or_fn, maybe_fn) {
 								return {
 									type: 'error',
 									error: await handle_error_and_jsonify(event, state, options, error),
-									status:
-										error instanceof HttpError || error instanceof SvelteKitError
-											? error.status
-											: 500
+									status: get_status(error)
 								};
 							}
 						})
@@ -361,8 +358,7 @@ function batch(validate_or_fn, maybe_fn) {
 		const payload = stringify_remote_arg(arg, state.transport);
 
 		return create_query_resource(__, payload, state, () =>
-			// Collect all the calls to the same query in the same macrotask,
-			// then execute them as one backend request.
+			// Collect all the calls to the same query in the same macrotask, then execute them as one backend request.
 			enqueue(payload, () => validate(arg))
 		);
 	};
@@ -388,9 +384,7 @@ function create_query_resource(__, payload, state, fn) {
 	};
 
 	const populate_hydratable = () => {
-		// accessing data properties needs to kick off the work
-		// so that it gets seeded in the hydration cache
-		// and becomes available on the client
+		// accessing data properties needs to kick off the work so that it gets seeded in the hydration cache and becomes available on the client
 		void (__.id && state.is_in_render && get_promise());
 	};
 
@@ -422,8 +416,7 @@ function create_query_resource(__, payload, state, fn) {
 		refresh() {
 			const { event } = get_request_store();
 			if (!event.isRemoteRequest) {
-				// If the form submission is not a remote request, refreshing the data is
-				// useless, because it can't be returned to the client.
+				// If the form submission is not a remote request, refreshing the data is useless, because it can't be returned to the client.
 				return Promise.resolve();
 			}
 			const refresh_context = get_refresh_context(__, 'refresh', payload);
@@ -570,8 +563,7 @@ function create_live_query_resource(__, payload, state, signal, get_generator) {
  */
 function create_shared_live_iterator(signal, get_generator) {
 	return new SharedIterator((instance) => {
-		// Don't bother starting the pump if the request has already been
-		// aborted between cache creation and first subscription.
+		// Don't bother starting the pump if the request has already been aborted between cache creation and first subscription.
 		if (signal.aborted) {
 			instance.done();
 			return noop;
@@ -579,10 +571,7 @@ function create_shared_live_iterator(signal, get_generator) {
 
 		const generator = get_generator();
 
-		// Set to `true` when we deliberately close the generator (because every
-		// subscriber has unsubscribed, or the request was aborted). The pump's
-		// `generator.next()` will reject as a result; we use this flag to swallow that
-		// abort error rather than surfacing it through `instance.fail()`.
+		// Set to `true` when we deliberately close the generator (because every subscriber has unsubscribed, or the request was aborted). The pump's `generator.next()` will reject as a result; we use this flag to swallow that abort error rather than surfacing it through `instance.fail()`.
 		let aborted = false;
 
 		const close = () => {
@@ -590,10 +579,7 @@ function create_shared_live_iterator(signal, get_generator) {
 			void generator.return().catch(noop);
 		};
 
-		// On request abort, tear down the pump and notify subscribers. `done()` is
-		// used (rather than `fail()`) because an aborted request is a normal
-		// termination — there's no error to surface to user code that's already
-		// been disconnected from the client.
+		// On request abort, tear down the pump and notify subscribers. `done()` is used (rather than `fail()`) because an aborted request is a normal termination — there's no error to surface to user code that's already been disconnected from the client.
 		signal.addEventListener('abort', () => (close(), instance.done()), { once: true });
 
 		void (async () => {
@@ -667,8 +653,6 @@ function update_refresh_value(
 
 	promise.catch(noop);
 
-	// we return an immediately-resolving promise so that the `refresh()` signature is consistent,
-	// but it doesn't delay anything if awaited inside a command. this way, people aren't
-	// penalised if they do `await q1.refresh(); await q2.refresh()`
+	// we return an immediately-resolving promise so that the `refresh()` signature is consistent, but it doesn't delay anything if awaited inside a command. this way, people aren't penalised if they do `await q1.refresh(); await q2.refresh()`
 	return Promise.resolve();
 }

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -1,6 +1,6 @@
 import { text } from '@sveltejs/kit';
-import { HttpError, SvelteKitError, Redirect } from '@sveltejs/kit/internal';
-import { normalize_error } from '../../../utils/error.js';
+import { Redirect } from '@sveltejs/kit/internal';
+import { get_status_if_known, normalize_error } from '../../../utils/error.js';
 import { once } from '../../../utils/functions.js';
 import { server_data_serializer_json } from '../page/data_serializer.js';
 import { load_server_data } from '../page/load_data.js';
@@ -110,10 +110,7 @@ export async function render_data(
 					return /** @type {import('types').ServerErrorNode} */ ({
 						type: 'error',
 						error: await handle_error_and_jsonify(event, event_state, options, error),
-						status:
-							error instanceof HttpError || error instanceof SvelteKitError
-								? error.status
-								: undefined
+						status: get_status_if_known(error)
 					});
 				})
 			)
@@ -124,8 +121,7 @@ export async function render_data(
 		const { data, chunks } = data_serializer.get_data();
 
 		if (!chunks) {
-			// use a normal JSON response where possible, so we get `content-length`
-			// and can use browser JSON devtools for easier inspecting
+			// use a normal JSON response where possible, so we get `content-length` and can use browser JSON devtools for easier inspecting
 			return json_response(data);
 		}
 
@@ -143,8 +139,7 @@ export async function render_data(
 			}),
 			{
 				headers: {
-					// we use a proprietary content type to prevent buffering.
-					// the `text` prefix makes it inspectable
+					// we use a proprietary content type to prevent buffering. the `text` prefix makes it inspectable
 					'content-type': 'text/sveltekit-data',
 					'cache-control': 'private, no-store'
 				}

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -1,7 +1,7 @@
 /** @import { ActionResult, RequestEvent, SSRManifest } from '@sveltejs/kit' */
 /** @import { PageNodeIndexes, RequestState, RequiredResolveOptions, ServerDataNode, SSRComponent, SSRNode, SSROptions, SSRState } from 'types' */
 import { text } from '@sveltejs/kit';
-import { HttpError, Redirect } from '@sveltejs/kit/internal';
+import { Redirect } from '@sveltejs/kit/internal';
 import { compact } from '../../../utils/array.js';
 import { get_status, normalize_error } from '../../../utils/error.js';
 import { noop } from '../../../utils/functions.js';
@@ -88,9 +88,7 @@ export async function render_page(
 			}
 		}
 
-		// it's crucial that we do this before returning the non-SSR response, otherwise
-		// SvelteKit will erroneously believe that the path has been prerendered,
-		// causing functions to be omitted from the manifest generated later
+		// it's crucial that we do this before returning the non-SSR response, otherwise SvelteKit will erroneously believe that the path has been prerendered, causing functions to be omitted from the manifest generated later
 		const should_prerender = nodes.prerender();
 		if (should_prerender) {
 			const mod = leaf_node.server;
@@ -104,8 +102,7 @@ export async function render_page(
 			});
 		}
 
-		// if we fetch any endpoints while loading data for this page, they should
-		// inherit the prerender option of the page
+		// if we fetch any endpoints while loading data for this page, they should inherit the prerender option of the page
 		state.prerender_default = should_prerender;
 
 		const should_prerender_data = nodes.should_prerender_data();
@@ -117,12 +114,9 @@ export async function render_page(
 		const ssr = nodes.ssr();
 		const csr = nodes.csr();
 
-		// renders an empty 'shell' page if SSR is turned off and if there is
-		// no server data to prerender. As a result, the load functions and rendering
-		// only occur client-side.
+		// renders an empty 'shell' page if SSR is turned off and if there is no server data to prerender. As a result, the load functions and rendering only occur client-side.
 		if (ssr === false && !(state.prerendering && should_prerender_data)) {
-			// if the user makes a request through a non-enhanced form, the returned value is lost
-			// because there is no SSR or client-side handling of the response
+			// if the user makes a request through a non-enhanced form, the returned value is lost because there is no SSR or client-side handling of the response
 			if (DEV && action_result && !event.request.headers.has('x-sveltekit-action')) {
 				if (action_result.type === 'error') {
 					console.warn(
@@ -329,13 +323,11 @@ export async function render_page(
 						}
 					}
 
-					// if we're still here, it means the error happened in the root layout,
-					// which means we have to fall back to error.html
+					// if we're still here, it means the error happened in the root layout, which means we have to fall back to error.html
 					return static_error_page(options, status, error.message);
 				}
 			} else {
-				// push an empty slot so we can rewind past gaps to the
-				// layout that corresponds with an +error.svelte page
+				// push an empty slot so we can rewind past gaps to the layout that corresponds with an +error.svelte page
 				branch.push(null);
 			}
 		}
@@ -381,15 +373,14 @@ export async function render_page(
 			return redirect_response(e.status, e.location);
 		}
 
-		// if we end up here, it means the data loaded successfully
-		// but the page failed to render, or that a prerendering error occurred
+		// if we end up here, it means the data loaded successfully but the page failed to render, or that a prerendering error occurred
 		return await respond_with_error({
 			event,
 			event_state,
 			options,
 			manifest,
 			state,
-			status: e instanceof HttpError ? e.status : 500,
+			status: get_status(e),
 			error: e,
 			resolve_opts
 		});

--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -2,13 +2,13 @@
 /** @import { RemoteFormInternals, RemoteFunctionResponse, RemoteInternals, RequestState, SSROptions } from 'types' */
 
 import { json, error } from '@sveltejs/kit';
-import { HttpError, Redirect, SvelteKitError } from '@sveltejs/kit/internal';
+import { Redirect, SvelteKitError } from '@sveltejs/kit/internal';
 import { with_request_store, merge_tracing } from '@sveltejs/kit/internal/server';
 import { app_dir, base } from '$app/paths/internal/server';
 import { is_form_content_type } from '../../utils/http.js';
 import { parse_remote_arg, split_remote_key, stringify } from '../shared.js';
 import { handle_error_and_jsonify } from './utils.js';
-import { normalize_error } from '../../utils/error.js';
+import { get_status, normalize_error } from '../../utils/error.js';
 import { check_incorrect_fail_use } from './page/actions.js';
 import { DEV } from 'esm-env';
 import { record_span } from '../telemetry/record_span.js';
@@ -108,8 +108,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 			const { data, meta, form_data } = await deserialize_binary_form(event.request);
 			state.remote.requested = create_requested_map(meta.remote_refreshes);
 
-			// If this is a keyed form instance (created via form.for(key)), add the key to the form data (unless already set)
-			// Note that additional_args will only be set if the form is not enhanced, as enhanced forms transfer the key inside `data`.
+			// If this is a keyed form instance (created via form.for(key)), add the key to the form data (unless already set). Note that additional_args will only be set if the form is not enhanced, as enhanced forms transfer the key inside `data`.
 			if (additional_args && !('id' in data)) {
 				data.id = JSON.parse(decodeURIComponent(additional_args));
 			}
@@ -223,10 +222,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 										location: error.location
 									});
 								} else {
-									const status =
-										error instanceof HttpError || error instanceof SvelteKitError
-											? error.status
-											: 500;
+									const status = get_status(error);
 
 									send(controller, {
 										type: 'error',
@@ -281,8 +277,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 			);
 		}
 
-		const status =
-			error instanceof HttpError || error instanceof SvelteKitError ? error.status : 500;
+		const status = get_status(error);
 
 		return json(
 			/** @type {RemoteFunctionResponse} */ ({
@@ -291,8 +286,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 				status
 			}),
 			{
-				// By setting a non-200 during prerendering we fail the prerender process (unless handleHttpError handles it).
-				// Errors at runtime will be passed to the client and are handled there
+				// By setting a non-200 during prerendering we fail the prerender process (unless handleHttpError handles it). Errors at runtime will be passed to the client and are handled there
 				status: state.prerendering ? status : undefined,
 				headers: {
 					'cache-control': 'private, no-store'
@@ -312,8 +306,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 				try {
 					return [key, { type: 'result', data: await promise }];
 				} catch (error) {
-					const status =
-						error instanceof HttpError || error instanceof SvelteKitError ? error.status : 500;
+					const status = get_status(error);
 
 					return [
 						key,
@@ -385,8 +378,7 @@ async function handle_remote_form_post_internal(event, state, manifest, id) {
 
 	if (!form) {
 		event.setHeaders({
-			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405
-			// "The server must generate an Allow header field in a 405 status code response"
+			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405 "The server must generate an Allow header field in a 405 status code response"
 			allow: 'GET'
 		});
 		return {
@@ -415,8 +407,7 @@ async function handle_remote_form_post_internal(event, state, manifest, id) {
 
 		await with_request_store({ event, state }, () => fn(data, meta, form_data));
 
-		// We don't want the data to appear on `let { form } = $props()`, which is why we're not returning it.
-		// It is instead available on `myForm.result`, setting of which happens within the remote `form` function.
+		// We don't want the data to appear on `let { form } = $props()`, which is why we're not returning it. It is instead available on `myForm.result`, setting of which happens within the remote `form` function.
 		return {
 			type: 'success',
 			status: 200

--- a/packages/kit/src/runtime/server/utils.js
+++ b/packages/kit/src/runtime/server/utils.js
@@ -2,9 +2,8 @@
 import * as devalue from 'devalue';
 import { DEV } from 'esm-env';
 import { json, text } from '@sveltejs/kit';
-import { HttpError } from '@sveltejs/kit/internal';
 import { with_request_store } from '@sveltejs/kit/internal/server';
-import { coalesce_to_error, get_message, get_status } from '../../utils/error.js';
+import { coalesce_to_error, get_message, get_status, is_http_error } from '../../utils/error.js';
 import { negotiate } from '../../utils/http.js';
 import { fix_stack_trace } from '../shared-server.js';
 import { ENDPOINT_METHODS } from '../../constants.js';
@@ -73,7 +72,10 @@ export function static_error_page(options, status, message) {
  * @param {unknown} error
  */
 export async function handle_fatal_error(event, state, options, error) {
-	error = error instanceof HttpError ? error : coalesce_to_error(error);
+	// Detect HttpError by name as well as instanceof — a cross-bundle HttpError would otherwise be
+	// collapsed into a generic Error by coalesce_to_error before get_status could read its status.
+	// A SvelteKitError extends Error and so passes through coalesce_to_error unchanged.
+	error = is_http_error(error) ? error : coalesce_to_error(error);
 	const status = get_status(error);
 	const body = await handle_error_and_jsonify(event, state, options, error);
 
@@ -100,7 +102,7 @@ export async function handle_fatal_error(event, state, options, error) {
  * @returns {Promise<App.Error>}
  */
 export async function handle_error_and_jsonify(event, state, options, error) {
-	if (error instanceof HttpError) {
+	if (is_http_error(error)) {
 		// @ts-expect-error custom user errors may not have a message field if App.Error is overwritten
 		return { message: 'Unknown Error', ...error.body };
 	}

--- a/packages/kit/src/runtime/server/utils.spec.js
+++ b/packages/kit/src/runtime/server/utils.spec.js
@@ -1,0 +1,58 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import { handle_fatal_error } from './utils.js';
+
+describe('handle_fatal_error', () => {
+	beforeAll(() => {
+		// @ts-expect-error build-time global, injected by the Vite plugin in real builds
+		globalThis.__SVELTEKIT_DEV__ = false;
+	});
+
+	afterAll(() => {
+		// @ts-expect-error reset the build-time global so it doesn't leak into other suites
+		delete globalThis.__SVELTEKIT_DEV__;
+	});
+
+	/** A minimal RequestEvent that negotiates a JSON response so we never hit the HTML error template. */
+	function json_event() {
+		return /** @type {any} */ ({
+			request: new Request('https://example.test', { headers: { accept: 'application/json' } }),
+			isDataRequest: false
+		});
+	}
+
+	test('preserves the status of a native HttpError', async () => {
+		const { HttpError } = await import('../../exports/internal/index.js');
+		const response = await handle_fatal_error(
+			json_event(),
+			/** @type {any} */ ({}),
+			/** @type {any} */ ({}),
+			new HttpError(404, 'Not Found')
+		);
+		expect(response.status).toBe(404);
+	});
+
+	test('preserves the status of a cross-bundle HttpError (name fallback)', async () => {
+		// Simulates an HttpError thrown from a different @sveltejs/kit copy (e.g. adapter-node inlining
+		// its own bundle): instanceof fails, but .name/.status/.body are intact. Before the fix this was
+		// collapsed to a generic Error by coalesce_to_error and reported as 500.
+		const foreign = { name: 'HttpError', status: 404, body: { message: 'Not Found' } };
+		const response = await handle_fatal_error(
+			json_event(),
+			/** @type {any} */ ({}),
+			/** @type {any} */ ({}),
+			foreign
+		);
+		expect(response.status).toBe(404);
+	});
+
+	test('still reports a plain Error as 500', async () => {
+		const options = /** @type {any} */ ({ hooks: { handleError: () => undefined } });
+		const response = await handle_fatal_error(
+			json_event(),
+			/** @type {any} */ ({}),
+			options,
+			new Error('boom')
+		);
+		expect(response.status).toBe(500);
+	});
+});

--- a/packages/kit/src/runtime/telemetry/record_span.js
+++ b/packages/kit/src/runtime/telemetry/record_span.js
@@ -1,5 +1,6 @@
 /** @import { RecordSpan } from 'types' */
-import { HttpError, Redirect } from '@sveltejs/kit/internal';
+import { Redirect } from '@sveltejs/kit/internal';
+import { is_http_error } from '../../utils/error.js';
 import { noop_span } from './noop.js';
 import { otel } from './otel.js';
 
@@ -15,7 +16,7 @@ export async function record_span({ name, attributes, fn }) {
 		try {
 			return await fn(span);
 		} catch (error) {
-			if (error instanceof HttpError) {
+			if (is_http_error(error)) {
 				span.setAttributes({
 					[`${name}.result.type`]: 'known_error',
 					[`${name}.result.status`]: error.status,

--- a/packages/kit/src/utils/error.js
+++ b/packages/kit/src/utils/error.js
@@ -37,14 +37,51 @@ export function normalize_error(error) {
 
 /**
  * @param {unknown} error
+ * @returns {number | undefined}
+ */
+export function get_status_if_known(error) {
+	if (error instanceof HttpError || error instanceof SvelteKitError) return error.status;
+	// Fallback for cross-bundle instanceof failures (e.g. adapter-node inlining its own @sveltejs/kit copy); Number.isFinite rejects NaN
+	const e = /** @type {any} */ (error);
+	if (
+		e != null &&
+		(e.name === 'SvelteKitError' || e.name === 'HttpError') &&
+		Number.isFinite(e.status)
+	) {
+		return e.status;
+	}
+	return undefined;
+}
+
+/**
+ * @param {unknown} error
  */
 export function get_status(error) {
-	return error instanceof HttpError || error instanceof SvelteKitError ? error.status : 500;
+	return get_status_if_known(error) ?? 500;
+}
+
+/**
+ * Detects {@link HttpError} instances, including across bundle boundaries where
+ * `instanceof` fails (e.g. adapter-node inlining its own `@sveltejs/kit` copy)
+ * @param {unknown} error
+ * @returns {error is HttpError}
+ */
+export function is_http_error(error) {
+	if (error instanceof HttpError) return true;
+	// Require a `body` too: this predicate narrows to `HttpError`, whose consumers read
+	// `error.body.message`. A genuine HttpError always has a body (the constructor defaults
+	// it), so this only rejects hand-spoofed objects, not real cross-bundle instances.
+	const e = /** @type {any} */ (error);
+	return e != null && e.name === 'HttpError' && Number.isFinite(e.status) && e.body != null;
 }
 
 /**
  * @param {unknown} error
  */
 export function get_message(error) {
-	return error instanceof SvelteKitError ? error.text : 'Internal Error';
+	if (error instanceof SvelteKitError) return error.text;
+	// Fallback for cross-bundle instanceof failures; HttpError omitted — it has no text field
+	const e = /** @type {any} */ (error);
+	if (e != null && e.name === 'SvelteKitError' && typeof e.text === 'string') return e.text;
+	return 'Internal Error';
 }

--- a/packages/kit/src/utils/error.spec.js
+++ b/packages/kit/src/utils/error.spec.js
@@ -1,0 +1,176 @@
+import { describe, test, expect } from 'vitest';
+import { get_status, get_status_if_known, get_message, is_http_error } from './error.js';
+import { HttpError, SvelteKitError } from '../exports/internal/index.js';
+
+describe('get_status', () => {
+	test('returns status from HttpError', () => {
+		expect(get_status(new HttpError(404, 'Not Found'))).toBe(404);
+	});
+
+	test('returns status from SvelteKitError', () => {
+		expect(get_status(new SvelteKitError(413, 'Payload Too Large', 'Request body too large'))).toBe(
+			413
+		);
+	});
+
+	test('returns 500 for plain Error', () => {
+		expect(get_status(new Error('oops'))).toBe(500);
+	});
+
+	test('returns 500 for null', () => {
+		expect(get_status(null)).toBe(500);
+	});
+
+	test('returns 500 for undefined', () => {
+		expect(get_status(undefined)).toBe(500);
+	});
+
+	test('falls back to name check when instanceof fails (SvelteKitError across bundle boundary)', () => {
+		// Simulates a SvelteKitError from a different @sveltejs/kit copy (e.g. adapter-node); instanceof fails but .name is preserved
+		const foreign = {
+			name: 'SvelteKitError',
+			status: 413,
+			text: 'Payload Too Large',
+			message: 'Request body too large'
+		};
+		expect(get_status(foreign)).toBe(413);
+	});
+
+	test('falls back to name check when instanceof fails (HttpError across bundle boundary)', () => {
+		const foreign = { name: 'HttpError', status: 404, body: { message: 'Not Found' } };
+		expect(get_status(foreign)).toBe(404);
+	});
+
+	test('returns 500 when status is NaN (typeof NaN === "number" but Number.isFinite rejects it)', () => {
+		const foreign = { name: 'SvelteKitError', status: NaN, text: 'Bad' };
+		expect(get_status(foreign)).toBe(500);
+	});
+
+	test('returns 500 when status is a string', () => {
+		const foreign = { name: 'SvelteKitError', status: '413', text: 'Bad' };
+		expect(get_status(foreign)).toBe(500);
+	});
+});
+
+describe('get_status_if_known', () => {
+	test('returns status from HttpError', () => {
+		expect(get_status_if_known(new HttpError(404, 'Not Found'))).toBe(404);
+	});
+
+	test('returns status from SvelteKitError', () => {
+		expect(
+			get_status_if_known(new SvelteKitError(413, 'Payload Too Large', 'Request body too large'))
+		).toBe(413);
+	});
+
+	test('returns undefined for plain Error', () => {
+		expect(get_status_if_known(new Error('oops'))).toBeUndefined();
+	});
+
+	test('returns undefined for null', () => {
+		expect(get_status_if_known(null)).toBeUndefined();
+	});
+
+	test('falls back to name check when instanceof fails (SvelteKitError across bundle boundary)', () => {
+		const foreign = {
+			name: 'SvelteKitError',
+			status: 413,
+			text: 'Payload Too Large',
+			message: 'Request body too large'
+		};
+		expect(get_status_if_known(foreign)).toBe(413);
+	});
+
+	test('falls back to name check when instanceof fails (HttpError across bundle boundary)', () => {
+		const foreign = { name: 'HttpError', status: 404, body: { message: 'Not Found' } };
+		expect(get_status_if_known(foreign)).toBe(404);
+	});
+
+	test('returns undefined when status is NaN', () => {
+		const foreign = { name: 'SvelteKitError', status: NaN, text: 'Bad' };
+		expect(get_status_if_known(foreign)).toBeUndefined();
+	});
+});
+
+describe('get_message', () => {
+	test('returns text from SvelteKitError', () => {
+		expect(
+			get_message(new SvelteKitError(413, 'Payload Too Large', 'Request body too large'))
+		).toBe('Payload Too Large');
+	});
+
+	test('returns Internal Error for plain Error', () => {
+		expect(get_message(new Error('oops'))).toBe('Internal Error');
+	});
+
+	test('returns Internal Error for null', () => {
+		expect(get_message(null)).toBe('Internal Error');
+	});
+
+	test('falls back to name check when instanceof fails (SvelteKitError across bundle boundary)', () => {
+		const foreign = {
+			name: 'SvelteKitError',
+			status: 413,
+			text: 'Payload Too Large',
+			message: 'Request body too large'
+		};
+		expect(get_message(foreign)).toBe('Payload Too Large');
+	});
+
+	test('returns Internal Error when text is not a string', () => {
+		const foreign = { name: 'SvelteKitError', status: 413, text: 42 };
+		expect(get_message(foreign)).toBe('Internal Error');
+	});
+});
+
+describe('error branding', () => {
+	// The cross-bundle fallback in get_status/get_status_if_known/get_message/is_http_error keys off
+	// `error.name`, so the constructors must brand instances with a stable name. If these regress the
+	// fallback silently stops working across bundle boundaries.
+	test('HttpError instances are branded with name "HttpError"', () => {
+		expect(new HttpError(404, 'Not Found').name).toBe('HttpError');
+	});
+
+	test('SvelteKitError instances are branded with name "SvelteKitError"', () => {
+		expect(new SvelteKitError(413, 'Payload Too Large', 'Request body too large').name).toBe(
+			'SvelteKitError'
+		);
+	});
+});
+
+describe('is_http_error', () => {
+	test('returns true for HttpError', () => {
+		expect(is_http_error(new HttpError(404, 'Not Found'))).toBe(true);
+	});
+
+	test('returns false for SvelteKitError', () => {
+		expect(
+			is_http_error(new SvelteKitError(413, 'Payload Too Large', 'Request body too large'))
+		).toBe(false);
+	});
+
+	test('returns false for plain Error', () => {
+		expect(is_http_error(new Error('oops'))).toBe(false);
+	});
+
+	test('returns false for null', () => {
+		expect(is_http_error(null)).toBe(false);
+	});
+
+	test('falls back to name check when instanceof fails (HttpError across bundle boundary)', () => {
+		const foreign = { name: 'HttpError', status: 404, body: { message: 'Not Found' } };
+		expect(is_http_error(foreign)).toBe(true);
+	});
+
+	test('returns false for a name-branded object without a finite status', () => {
+		expect(is_http_error({ name: 'HttpError' })).toBe(false);
+		expect(is_http_error({ name: 'HttpError', status: NaN })).toBe(false);
+	});
+
+	test('returns false for a name-branded object without a body', () => {
+		// The predicate narrows to HttpError, whose consumers read error.body.message; a spoofed
+		// object with a finite status but no body would make those reads throw. A genuine HttpError
+		// always has a body (the constructor defaults it), so this only rejects spoofs.
+		expect(is_http_error({ name: 'HttpError', status: 404 })).toBe(false);
+	});
+});

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2956,6 +2956,7 @@ declare module '@sveltejs/kit' {
 		constructor(status: number, body: {
 			message: string;
 		} extends App.Error ? (App.Error | string | undefined) : App.Error);
+		name: string;
 		status: number;
 		body: App.Error;
 		toString(): string;


### PR DESCRIPTION
closes #15755

`get_status` and `get_message` in `utils/error.js` use `instanceof SvelteKitError` to decide whether to return the error's status code and text. When adapter-node bundles its own copy of `@sveltejs/kit`, the error object was created by one copy of the class but checked against another, so `instanceof` fails and the fallback 500 is returned instead of the real status. A 413, 404, or 405 silently became a 500.

The fix has two parts. First, both `SvelteKitError` and `HttpError` now set `this.name` in their constructors. That's a plain string on the instance, so it crosses any bundle boundary. Second, `get_status` and `get_message` fall back to checking `error.name` when `instanceof` fails, the same way Node.js uses `error.code` strings instead of class identity for system errors. The status fallback also guards with `Number.isFinite`, so a `NaN` status can't slip through (`typeof NaN === 'number'` is true).

The same inline `instanceof` pattern was duplicated across the server runtime, each copy re-deriving the status the same buggy way and sharing the same blind spot: an error from a second bundle fails every check and collapses to 500. They now all route through the helpers. `data/index.js` uses a new `get_status_if_known`, which returns `number | undefined` rather than defaulting to 500, because the data error node needs `undefined` for non-SvelteKit errors. `page/index.js` had a third variant, `e instanceof HttpError ? e.status : 500`, that didn't check for `SvelteKitError` at all, so a `SvelteKitError` there was dropped to 500 outright; it calls `get_status` now. `remote.js` had three copies (the live-query catch, the outer catch, and the single-flight inner catch) and `query.js` had one in the batch error handler; all four call `get_status`.

`isHttpError` in the public API gets the same name-based fallback, so user code calling it on an error that crossed a bundle boundary gets the right answer.

A previous attempt (#15776) tried to mark `@sveltejs/kit/node` as external in the adapter-node rollup config. That didn't work because the second rollup pass in `adapter/index.js` bundles `@sveltejs/kit` from devDependencies anyway, leaving two separate class instances regardless.

Tests cover `get_status`, `get_status_if_known`, and `get_message` across the normal path, the cross-bundle fallback, and the NaN and non-string edge cases. Multiline `//` comments in the touched files were collapsed to single lines along the way.