### PR TITLE
breaking: move `adapter` to `vite.config.js`

### DIFF
--- a/.changeset/tidy-toes-sort.md
+++ b/.changeset/tidy-toes-sort.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: move `adapter` option from `svelte.config.js` to the SvelteKit Vite plugin in `vite.config.js`

--- a/documentation/docs/25-build-and-deploy/20-adapters.md
+++ b/documentation/docs/25-build-and-deploy/20-adapters.md
@@ -22,18 +22,22 @@ Your adapter is specified in `vite.config.js`:
 /// file: vite.config.js
 // @filename: ambient.d.ts
 declare module 'svelte-adapter-foo' {
-	const adapter: (opts: any) => import('@sveltejs/kit').Adapter;
+	const adapter: (opts?: any) => import('@sveltejs/kit').Adapter;
 	export default adapter;
 }
 
 // @filename: index.js
 // ---cut---
 import { sveltekit } from '@sveltejs/kit/vite';
-import adapter from 'svelte-adapter-foo';
++++import adapter from 'svelte-adapter-foo';+++
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit({ adapter: adapter() })]
+	plugins: [
+		sveltekit({
+			+++adapter: adapter()+++
+		})
+	]
 });
 ```
 

--- a/documentation/docs/25-build-and-deploy/20-adapters.md
+++ b/documentation/docs/25-build-and-deploy/20-adapters.md
@@ -16,10 +16,10 @@ Additional [community-provided adapters](/packages#sveltekit-adapters) exist for
 
 ## Using adapters
 
-Your adapter is specified in `svelte.config.js`:
+Your adapter is specified in `vite.config.js`:
 
 ```js
-/// file: svelte.config.js
+/// file: vite.config.js
 // @filename: ambient.d.ts
 declare module 'svelte-adapter-foo' {
 	const adapter: (opts: any) => import('@sveltejs/kit').Adapter;
@@ -28,19 +28,17 @@ declare module 'svelte-adapter-foo' {
 
 // @filename: index.js
 // ---cut---
+import { sveltekit } from '@sveltejs/kit/vite';
 import adapter from 'svelte-adapter-foo';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter({
-			// adapter options go here
-		})
-	}
-};
-
-export default config;
+export default defineConfig({
+	plugins: [sveltekit({ adapter: adapter() })]
+});
 ```
+
+> [!LEGACY]
+> The `adapter` option was moved to the SvelteKit Vite plugin in SvelteKit 3.0.0. In earlier versions, you had to add it to the `kit` property in the `svelte.config.js` file instead.
 
 ## Platform-specific context
 

--- a/documentation/docs/25-build-and-deploy/20-adapters.md
+++ b/documentation/docs/25-build-and-deploy/20-adapters.md
@@ -29,8 +29,8 @@ declare module 'svelte-adapter-foo' {
 // @filename: index.js
 // ---cut---
 import { sveltekit } from '@sveltejs/kit/vite';
-+++import adapter from 'svelte-adapter-foo';+++
 import { defineConfig } from 'vite';
++++import adapter from 'svelte-adapter-foo';+++
 
 export default defineConfig({
 	plugins: [

--- a/documentation/docs/25-build-and-deploy/40-adapter-node.md
+++ b/documentation/docs/25-build-and-deploy/40-adapter-node.md
@@ -6,22 +6,22 @@ To generate a standalone Node server, use [`adapter-node`](https://github.com/sv
 
 ## Usage
 
-Install with `npm i -D @sveltejs/adapter-node`, then add the adapter to your `svelte.config.js`:
+Install with `npm i -D @sveltejs/adapter-node`, then add the adapter to your `vite.config.js`:
 
 ```js
 // @errors: 2307
-/// file: svelte.config.js
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-node';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter()
-	}
-};
-
-export default config;
+export default defineConfig({
+	plugins: [sveltekit({ adapter: adapter() })]
+});
 ```
+
+> [!LEGACY]
+> The `adapter` option was moved to the SvelteKit Vite plugin in SvelteKit 3.0.0. In earlier versions, you had to add it to the `kit` property in the `svelte.config.js` file instead.
 
 ## Deploying
 
@@ -150,22 +150,23 @@ The adapter can be configured with various options:
 
 ```js
 // @errors: 2307
-/// file: svelte.config.js
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-node';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter({
-			// default options are shown
-			out: 'build',
-			precompress: true,
-			envPrefix: ''
-		})
-	}
-};
-
-export default config;
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+        // default options are shown
+        out: 'build',
+        precompress: true,
+        envPrefix: ''
+      })
+    })
+  ]
+});
 ```
 
 ### out

--- a/documentation/docs/25-build-and-deploy/50-adapter-static.md
+++ b/documentation/docs/25-build-and-deploy/50-adapter-static.md
@@ -8,28 +8,29 @@ This will prerender your entire site as a collection of static files. If you'd l
 
 ## Usage
 
-Install with `npm i -D @sveltejs/adapter-static`, then add the adapter to your `svelte.config.js`:
+Install with `npm i -D @sveltejs/adapter-static`, then add the adapter to your `vite.config.js`:
 
 ```js
-/// file: svelte.config.js
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-static';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter({
-			// default options are shown. On some platforms
-			// these options are set automatically — see below
-			pages: 'build',
-			assets: 'build',
-			fallback: undefined,
-			precompress: false,
-			strict: true
-		})
-	}
-};
-
-export default config;
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+        // default options are shown. On some platforms
+        // these options are set automatically — see below
+        pages: 'build',
+        assets: 'build',
+        fallback: undefined,
+        precompress: false,
+        strict: true
+      })
+    })
+  ]
+});
 ```
 
 ...and add the [`prerender`](page-options#prerender) option to your root layout:
@@ -46,6 +47,9 @@ export const prerender = true;
 
 > [!NOTE] You must ensure SvelteKit's [`ssr`](page-options#ssr) option isn't set to `false`. Otherwise, prerendering will save an empty 'shell' page instead of the fully rendered content.
 
+> [!LEGACY]
+> The `adapter` option was moved to the SvelteKit Vite plugin in SvelteKit 3.0.0. In earlier versions, you had to add it to the `kit` property in the `svelte.config.js` file instead.
+
 ## Zero-config support
 
 Some platforms have zero-config support (more to come in future):
@@ -55,17 +59,18 @@ Some platforms have zero-config support (more to come in future):
 On these platforms, you should omit the adapter options so that `adapter-static` can provide the optimal configuration:
 
 ```js
-/// file: svelte.config.js
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-static';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter(---{...}---)
-	}
-};
-
-export default config;
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter(---{...}---)
+    })
+  ]
+});
 ```
 
 ## Options
@@ -103,14 +108,9 @@ A config for GitHub Pages might look like the following:
 ```js
 // @errors: 2322
 /// file: svelte.config.js
-import adapter from '@sveltejs/adapter-static';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter({
-			fallback: '404.html'
-		}),
 		paths: {
 			base: process.argv.includes('dev') ? '' : process.env.BASE_PATH
 		}
@@ -118,6 +118,23 @@ const config = {
 };
 
 export default config;
+```
+
+```js
+/// file: vite.config.js
+import adapter from '@sveltejs/adapter-static';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+        fallback: '404.html'
+      })
+    })
+  ]
+});
 ```
 
 You can use GitHub actions to automatically deploy your site to GitHub Pages when you make a change. Here's an example workflow:

--- a/documentation/docs/25-build-and-deploy/55-single-page-apps.md
+++ b/documentation/docs/25-build-and-deploy/55-single-page-apps.md
@@ -16,22 +16,23 @@ First, disable SSR for the pages you don't want to prerender. These pages will b
 export const ssr = false;
 ```
 
-If you don't have any server-side logic (i.e. `+page.server.js`, `+layout.server.js` or `+server.js` files) you can use [`adapter-static`](adapter-static) to create your SPA. Install `adapter-static` with `npm i -D @sveltejs/adapter-static` and add it to your `svelte.config.js` with the `fallback` option:
+If you don't have any server-side logic (i.e. `+page.server.js`, `+layout.server.js` or `+server.js` files) you can use [`adapter-static`](adapter-static) to create your SPA. Install `adapter-static` with `npm i -D @sveltejs/adapter-static` and add it to your `vite.config.js` with the `fallback` option:
 
 ```js
-/// file: svelte.config.js
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-static';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter({
-			fallback: '200.html' // may differ from host to host
-		})
-	}
-};
-
-export default config;
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+				fallback: '200.html' // may differ from host to host
+      })
+    })
+  ]
+});
 ```
 
 The `fallback` page is an HTML page created by SvelteKit from your page template (e.g. `app.html`) that loads your app and navigates to the correct route. For example [Surge](https://surge.sh/help/adding-a-200-page-for-client-side-routing), a static web host, lets you add a `200.html` file that will handle any requests that don't correspond to static assets or prerendered pages.
@@ -39,6 +40,9 @@ The `fallback` page is an HTML page created by SvelteKit from your page template
 On some hosts it may be something else entirely — consult your platform's documentation. We recommend avoiding `index.html` if possible as it may conflict with prerendering.
 
 > [!NOTE] Note that the fallback page will always contain absolute asset paths (i.e. beginning with `/` rather than `.`) regardless of the value of [`paths.relative`](configuration#paths), since it is used to respond to requests for arbitrary paths.
+
+> [!LEGACY]
+> The `adapter` option was moved to the SvelteKit Vite plugin in SvelteKit 3.0.0. In earlier versions, you had to add it to the `kit` property in the `svelte.config.js` file instead.
 
 ## Prerendering individual pages
 

--- a/documentation/docs/25-build-and-deploy/60-adapter-cloudflare.md
+++ b/documentation/docs/25-build-and-deploy/60-adapter-cloudflare.md
@@ -14,34 +14,39 @@ This adapter will be installed by default when you use [`adapter-auto`](adapter-
 
 ## Usage
 
-Install with `npm i -D @sveltejs/adapter-cloudflare`, then add the adapter to your `svelte.config.js`:
+Install with `npm i -D @sveltejs/adapter-cloudflare`, then add the adapter to your `vite.config.js`:
 
 ```js
-/// file: svelte.config.js
+// @errors: 2307
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-cloudflare';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter({
-			// See below for an explanation of these options
-			config: undefined,
-			platformProxy: {
-				configPath: undefined,
-				environment: undefined,
-				persist: undefined
-			},
-			fallback: 'plaintext',
-			routes: {
-				include: ['/*'],
-				exclude: ['<all>']
-			}
-		})
-	}
-};
-
-export default config;
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+				// See below for an explanation of these options
+				config: undefined,
+				platformProxy: {
+					configPath: undefined,
+					environment: undefined,
+					persist: undefined
+				},
+				fallback: 'plaintext',
+				routes: {
+					include: ['/*'],
+					exclude: ['<all>']
+				}
+      })
+    })
+  ]
+});
 ```
+
+> [!LEGACY]
+> The `adapter` option was moved to the SvelteKit Vite plugin in SvelteKit 3.0.0. In earlier versions, you had to add it to the `kit` property in the `svelte.config.js` file instead.
 
 ## Options
 
@@ -222,16 +227,31 @@ Cloudflare no longer recommends using [Workers Sites](https://developers.cloudfl
 // @errors: 2307
 /// file: svelte.config.js
 ---import adapter from '@sveltejs/adapter-cloudflare-workers';---
-+++import adapter from '@sveltejs/adapter-cloudflare';+++
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter()
+		---adapter: adapter()---
 	}
 };
 
 export default config;
+```
+
+```js
+// @errors: 2307
+/// file: vite.config.js
++++import adapter from '@sveltejs/adapter-cloudflare';+++
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      +++adapter: adapter()+++
+    })
+  ]
+});
 ```
 
 ### wrangler.toml

--- a/documentation/docs/25-build-and-deploy/80-adapter-netlify.md
+++ b/documentation/docs/25-build-and-deploy/80-adapter-netlify.md
@@ -8,30 +8,30 @@ This adapter will be installed by default when you use [`adapter-auto`](adapter-
 
 ## Usage
 
-Install with `npm i -D @sveltejs/adapter-netlify`, then add the adapter to your `svelte.config.js`:
+Install with `npm i -D @sveltejs/adapter-netlify`, then add the adapter to your `vite.config.js`:
 
 ```js
-/// file: svelte.config.js
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-netlify';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		// default options are shown
-		adapter: adapter({
-			// if true, will create a Netlify Edge Function rather
-			// than using standard Node-based functions
-			edge: false,
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+				// if true, will create a Netlify Edge Function rather
+				// than using standard Node-based functions
+				edge: false,
 
-			// if true, will split your app into multiple functions
-			// instead of creating a single one for the entire app.
-			// if `edge` is true, this option cannot be used
-			split: false
-		})
-	}
-};
-
-export default config;
+				// if true, will split your app into multiple functions
+				// instead of creating a single one for the entire app.
+				// if `edge` is true, this option cannot be used
+				split: false
+      })
+    })
+  ]
+});
 ```
 
 Then, make sure you have a [netlify.toml](https://docs.netlify.com/configure-builds/file-based-configuration) file in the project root. This will determine where to write static assets based on the `build.publish` settings, as per this sample configuration:
@@ -44,6 +44,9 @@ Then, make sure you have a [netlify.toml](https://docs.netlify.com/configure-bui
 
 If the `netlify.toml` file or the `build.publish` value is missing, a default value of `"build"` will be used. Note that if you have set the publish directory in the Netlify UI to something else then you will need to set it in `netlify.toml` too, or use the default value of `"build"`.
 
+> [!LEGACY]
+> The `adapter` option was moved to the SvelteKit Vite plugin in SvelteKit 3.0.0. In earlier versions, you had to add it to the `kit` property in the `svelte.config.js` file instead.
+
 ### Node version
 
 New projects will use the current Node LTS version by default. However, if you're upgrading a project you created a while ago it may be stuck on an older version. See [the Netlify docs](https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-and-javascript) for details on manually specifying a current Node version.
@@ -53,21 +56,23 @@ New projects will use the current Node LTS version by default. However, if you'r
 SvelteKit supports [Netlify Edge Functions](https://docs.netlify.com/build/edge-functions/overview/). If you pass the option `edge: true` to the `adapter` function, server-side rendering will happen in a Deno-based edge function that's deployed close to the site visitor. If set to `false` (the default), the site will deploy to Node-based Netlify Functions.
 
 ```js
-/// file: svelte.config.js
+// @errors: 2307
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-netlify';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter({
-			// will create a Netlify Edge Function using Deno-based
-			// rather than using standard Node-based functions
-			edge: true
-		})
-	}
-};
-
-export default config;
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+				// will create a Netlify Edge Function using Deno-based
+				// rather than using standard Node-based functions
+				edge: true
+      })
+    })
+  ]
+});
 ```
 
 ## Netlify alternatives to SvelteKit functionality

--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -8,23 +8,27 @@ This adapter will be installed by default when you use [`adapter-auto`](adapter-
 
 ## Usage
 
-Install with `npm i -D @sveltejs/adapter-vercel`, then add the adapter to your `svelte.config.js`:
+Install with `npm i -D @sveltejs/adapter-vercel`, then add the adapter to your `vite.config.js`:
 
 ```js
-/// file: svelte.config.js
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-vercel';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter({
-			// see below for options that can be set here
-		})
-	}
-};
-
-export default config;
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+				// see below for options that can be set here
+      })
+    })
+  ]
+});
 ```
+
+> [!LEGACY]
+> The `adapter` option was moved to the SvelteKit Vite plugin in SvelteKit 3.0.0. In earlier versions, you had to add it to the `kit` property in the `svelte.config.js` file instead.
 
 ## Deployment configuration
 
@@ -64,24 +68,25 @@ If your functions need to access data in a specific region, it's recommended tha
 You may set the `images` config to control how Vercel builds your images. See the [image configuration reference](https://vercel.com/docs/build-output-api/v3/configuration#images) for full details. As an example, you may set:
 
 ```js
-/// file: svelte.config.js
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-vercel';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter({
-			images: {
-				sizes: [640, 828, 1200, 1920, 3840],
-				formats: ['image/avif', 'image/webp'],
-				minimumCacheTTL: 300,
-				domains: ['example-app.vercel.app'],
-			}
-		})
-	}
-};
-
-export default config;
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+				images: {
+					sizes: [640, 828, 1200, 1920, 3840],
+					formats: ['image/avif', 'image/webp'],
+					minimumCacheTTL: 300,
+					domains: ['example-app.vercel.app'],
+				}
+      })
+    })
+  ]
+});
 ```
 
 ## Incremental Static Regeneration

--- a/documentation/docs/40-best-practices/07-images.md
+++ b/documentation/docs/40-best-practices/07-images.md
@@ -39,14 +39,17 @@ npm i -D @sveltejs/enhanced-img
 Adjust `vite.config.js`:
 
 ```js
-import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '@sveltejs/adapter-node';
 +++import { enhancedImages } from '@sveltejs/enhanced-img';+++
+import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
 	plugins: [
 		+++enhancedImages(), // must come before the SvelteKit plugin+++
-		sveltekit()
+		sveltekit({
+			adapter: adapter()
+		})
 	]
 });
 ```

--- a/documentation/docs/60-appendix/10-faq.md
+++ b/documentation/docs/60-appendix/10-faq.md
@@ -151,18 +151,14 @@ export function GET({ params, url }) {
 
 ## How do I use middleware?
 
-`adapter-node` builds a middleware that you can use with your own server for production mode. In dev, you can add middleware to Vite by using a Vite plugin. For example:
+`@sveltejs/adapter-node` builds a middleware that you can use with your own server for production mode. In dev, you can add middleware to Vite by using a Vite plugin. For example:
 
 ```js
-// @errors: 2322
-// @filename: ambient.d.ts
-declare module '@sveltejs/kit/vite'; // TODO this feels unnecessary, why can't it 'see' the declarations?
-
-// @filename: index.js
-// ---cut---
+import adapter from '@sveltejs/adapter-node';
 import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('vite').Plugin} */
++++/** @type {import('vite').Plugin} */
 const myPlugin = {
 	name: 'log-request-middleware',
 	configureServer(server) {
@@ -171,14 +167,16 @@ const myPlugin = {
 			next();
 		});
 	}
-};
+};+++
 
-/** @type {import('vite').UserConfig} */
-const config = {
-	plugins: [myPlugin, sveltekit()]
-};
-
-export default config;
+export default defineConfig({
+	plugins: [
+		+++myPlugin,+++
+		sveltekit({
+			adapter: adapter()
+		})
+	]
+});
 ```
 
 See [Vite's `configureServer` docs](https://vitejs.dev/guide/api-plugin.html#configureserver) for more details including how to control ordering.

--- a/documentation/docs/98-reference/50-configuration.md
+++ b/documentation/docs/98-reference/50-configuration.md
@@ -6,25 +6,16 @@ Your project's configuration lives in a `svelte.config.js` file at the root of y
 
 ```js
 /// file: svelte.config.js
-// @filename: ambient.d.ts
-declare module '@sveltejs/adapter-auto' {
-	const plugin: () => import('@sveltejs/kit').Adapter;
-	export default plugin;
-}
-
-// @filename: index.js
-// ---cut---
-import adapter from '@sveltejs/adapter-auto';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter()
-	}
+	kit: { }
 };
 
 export default config;
 ```
+
+> [!LEGACY]
+> The `adapter` option was moved to the SvelteKit Vite plugin in SvelteKit 3.0.0. In earlier versions, you had to add it to the `kit` property in the `svelte.config.js` file instead.
 
 ## Config
 

--- a/packages/adapter-cloudflare/test/apps/pages/svelte.config.js
+++ b/packages/adapter-cloudflare/test/apps/pages/svelte.config.js
@@ -1,10 +1,6 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter()
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/adapter-cloudflare/test/apps/pages/vite.config.js
+++ b/packages/adapter-cloudflare/test/apps/pages/vite.config.js
@@ -1,11 +1,12 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
 	build: {
 		minify: false
 	},
-	plugins: [sveltekit()]
+	plugins: [sveltekit({ adapter: adapter() })]
 };
 
 export default config;

--- a/packages/adapter-cloudflare/test/apps/workers/svelte.config.js
+++ b/packages/adapter-cloudflare/test/apps/workers/svelte.config.js
@@ -1,12 +1,6 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter({
-			config: 'config/wrangler.jsonc'
-		})
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/adapter-cloudflare/test/apps/workers/vite.config.js
+++ b/packages/adapter-cloudflare/test/apps/workers/vite.config.js
@@ -1,11 +1,18 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
 	build: {
 		minify: false
 	},
-	plugins: [sveltekit()]
+	plugins: [
+		sveltekit({
+			adapter: adapter({
+				config: 'config/wrangler.jsonc'
+			})
+		})
+	]
 };
 
 export default config;

--- a/packages/adapter-netlify/test/apps/basic/svelte.config.js
+++ b/packages/adapter-netlify/test/apps/basic/svelte.config.js
@@ -1,10 +1,6 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter()
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/adapter-netlify/test/apps/basic/vite.config.ts
+++ b/packages/adapter-netlify/test/apps/basic/vite.config.ts
@@ -1,11 +1,16 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import type { UserConfig } from 'vite';
+import adapter from '../../../index.js';
 
 const config: UserConfig = {
 	build: {
 		minify: false
 	},
-	plugins: [sveltekit()]
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	]
 };
 
 export default config;

--- a/packages/adapter-netlify/test/apps/edge/svelte.config.js
+++ b/packages/adapter-netlify/test/apps/edge/svelte.config.js
@@ -1,12 +1,6 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter({
-			edge: true
-		})
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/adapter-netlify/test/apps/edge/vite.config.ts
+++ b/packages/adapter-netlify/test/apps/edge/vite.config.ts
@@ -1,11 +1,18 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import type { UserConfig } from 'vite';
+import adapter from '../../../index.js';
 
 const config: UserConfig = {
 	build: {
 		minify: false
 	},
-	plugins: [sveltekit()]
+	plugins: [
+		sveltekit({
+			adapter: adapter({
+				edge: true
+			})
+		})
+	]
 };
 
 export default config;

--- a/packages/adapter-netlify/test/apps/instrumentation/svelte.config.js
+++ b/packages/adapter-netlify/test/apps/instrumentation/svelte.config.js
@@ -1,9 +1,6 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter(),
 		experimental: {
 			instrumentation: {
 				server: true

--- a/packages/adapter-netlify/test/apps/instrumentation/vite.config.ts
+++ b/packages/adapter-netlify/test/apps/instrumentation/vite.config.ts
@@ -1,11 +1,16 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import type { UserConfig } from 'vite';
+import adapter from '../../../index.js';
 
 const config: UserConfig = {
 	build: {
 		minify: false
 	},
-	plugins: [sveltekit()]
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	]
 };
 
 export default config;

--- a/packages/adapter-netlify/test/apps/split/svelte.config.js
+++ b/packages/adapter-netlify/test/apps/split/svelte.config.js
@@ -1,10 +1,7 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	compilerOptions: { experimental: { async: true } },
 	kit: {
-		adapter: adapter({ split: true }),
 		experimental: {
 			remoteFunctions: true
 		}

--- a/packages/adapter-netlify/test/apps/split/vite.config.ts
+++ b/packages/adapter-netlify/test/apps/split/vite.config.ts
@@ -1,11 +1,16 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import type { UserConfig } from 'vite';
+import adapter from '../../../index.js';
 
 const config: UserConfig = {
 	build: {
 		minify: false
 	},
-	plugins: [sveltekit()]
+	plugins: [
+		sveltekit({
+			adapter: adapter({ split: true })
+		})
+	]
 };
 
 export default config;

--- a/packages/adapter-static/test/apps/prerendered/svelte.config.js
+++ b/packages/adapter-static/test/apps/prerendered/svelte.config.js
@@ -1,7 +1,6 @@
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/adapter-static/test/apps/prerendered/svelte.config.js
+++ b/packages/adapter-static/test/apps/prerendered/svelte.config.js
@@ -1,9 +1,6 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter()
 	}
 };
 

--- a/packages/adapter-static/test/apps/prerendered/vite.config.js
+++ b/packages/adapter-static/test/apps/prerendered/vite.config.js
@@ -1,11 +1,16 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
 	build: {
 		minify: false
 	},
-	plugins: [sveltekit()]
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	]
 };
 
 export default config;

--- a/packages/adapter-static/test/apps/spa/svelte.config.js
+++ b/packages/adapter-static/test/apps/spa/svelte.config.js
@@ -1,12 +1,6 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter({
-			fallback: '200.html'
-		})
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/adapter-static/test/apps/spa/vite.config.js
+++ b/packages/adapter-static/test/apps/spa/vite.config.js
@@ -1,11 +1,18 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
 	build: {
 		minify: false
 	},
-	plugins: [sveltekit()]
+	plugins: [
+		sveltekit({
+			adapter: adapter({
+				fallback: '200.html'
+			})
+		})
+	]
 };
 
 export default config;

--- a/packages/adapter-vercel/test/apps/basic/svelte.config.js
+++ b/packages/adapter-vercel/test/apps/basic/svelte.config.js
@@ -1,10 +1,6 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter()
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/adapter-vercel/test/apps/basic/vite.config.ts
+++ b/packages/adapter-vercel/test/apps/basic/vite.config.ts
@@ -1,6 +1,11 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
+import adapter from '../../../index.js';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	]
 });

--- a/packages/kit/src/core/adapt/index.js
+++ b/packages/kit/src/core/adapt/index.js
@@ -1,7 +1,9 @@
+/** @import { Adapter } from '@sveltejs/kit' */
 import { styleText } from 'node:util';
 import { create_builder } from './builder.js';
 
 /**
+ * @param {Adapter} adapter
  * @param {import('types').ValidatedConfig} config
  * @param {import('types').BuildData} build_data
  * @param {import('types').ServerMetadata} server_metadata
@@ -13,6 +15,7 @@ import { create_builder } from './builder.js';
  * @param {string} out
  */
 export async function adapt(
+	adapter,
 	config,
 	build_data,
 	server_metadata,
@@ -24,7 +27,7 @@ export async function adapt(
 	out
 ) {
 	// This is only called when adapter is truthy, so the cast is safe
-	const { name, adapt } = /** @type {import('@sveltejs/kit').Adapter} */ (config.kit.adapter);
+	const { name, adapt } = (adapter);
 
 	console.log(styleText(['bold', 'cyan'], `\n> Using ${name}`));
 

--- a/packages/kit/src/core/adapt/index.js
+++ b/packages/kit/src/core/adapt/index.js
@@ -27,7 +27,7 @@ export async function adapt(
 	out
 ) {
 	// This is only called when adapter is truthy, so the cast is safe
-	const { name, adapt } = (adapter);
+	const { name, adapt } = adapter;
 
 	console.log(styleText(['bold', 'cyan'], `\n> Using ${name}`));
 

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -55,7 +55,6 @@ const directive_defaults = {
 const get_defaults = (prefix = '') => ({
 	extensions: ['.svelte'],
 	kit: {
-		adapter: null,
 		alias: {},
 		appDir: '_app',
 		csp: {

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -1,6 +1,7 @@
 /** @import { Validator } from './types.js' */
 
 import process from 'node:process';
+import { dedent } from '../sync/utils.js';
 
 const directives = object({
 	'child-src': string_array(),
@@ -58,11 +59,19 @@ const options = object(
 		}),
 
 		kit: object({
-			adapter: removed(
-				(keypath) =>
-					`\`${keypath}\` has been removed. Instead, pass your adapter to the \`sveltekit\` Vite plugin in the \`vite.config.js\` file. For example:\n\n` +
-					`+++import adapter from '@sveltejs/adapter-auto';+++\n\nexport default defineConfig({\n  plugins: [sveltekit( +++{ adapter }+++ )]\n});`
-			),
+			adapter: removed((keypath) => {
+				return dedent`
+						${keypath} has been removed. Instead, pass your adapter to the \`sveltekit\` Vite plugin in the \`vite.config.js\` file. For example:
+
+						import { defineConfig } from 'vite';
+						import { sveltekit } from '@sveltejs/kit/vite';
+						+++import adapter from '@sveltejs/adapter-auto';+++
+
+						export default defineConfig({
+						  plugins: [sveltekit( +++{ adapter: adapter() }+++ )]
+						});
+					`;
+			}),
 
 			alias: validate({}, (input, keypath) => {
 				if (typeof input !== 'object') {
@@ -347,7 +356,7 @@ function removed(
  * @param {boolean} [allow_unknown]
  * @returns {Validator}
  */
-function object(children, allow_unknown = false) {
+export function object(children, allow_unknown = false) {
 	return (input, keypath) => {
 		/** @type {Record<string, any>} */
 		const output = {};
@@ -387,7 +396,7 @@ function object(children, allow_unknown = false) {
  * @param {(value: any, keypath: string) => any} fn
  * @returns {Validator}
  */
-function validate(fallback, fn) {
+export function validate(fallback, fn) {
 	return (input, keypath) => {
 		return input === undefined ? fallback : fn(input, keypath);
 	};

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -58,20 +58,11 @@ const options = object(
 		}),
 
 		kit: object({
-			adapter: validate(null, (input, keypath) => {
-				if (typeof input !== 'object' || !input.adapt) {
-					let message = `${keypath} should be an object with an "adapt" method`;
-
-					if (Array.isArray(input) || typeof input === 'string') {
-						// for the early adapter adopters
-						message += ', rather than the name of an adapter';
-					}
-
-					throw new Error(`${message}. See https://svelte.dev/docs/kit/adapters`);
-				}
-
-				return input;
-			}),
+			adapter: removed(
+				(keypath) =>
+					`\`${keypath}\` has been removed. Instead, pass your adapter to the \`sveltekit\` Vite plugin in the \`vite.config.js\` file. For example:\n\n` +
+					`+++import adapter from '@sveltejs/adapter-auto';+++\n\nexport default defineConfig({\n  plugins: [sveltekit( +++{ adapter }+++ )]\n});`
+			),
 
 			alias: validate({}, (input, keypath) => {
 				if (typeof input !== 'object') {

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -68,7 +68,7 @@ const options = object(
 						+++import adapter from '@sveltejs/adapter-auto';+++
 
 						export default defineConfig({
-						  plugins: [sveltekit( +++{ adapter: adapter() }+++ )]
+						  plugins: [sveltekit(+++{ adapter: adapter() }+++)]
 						});
 					`;
 			}),

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -323,7 +323,7 @@ export interface KitConfig {
 	/**
 	 * Your [adapter](https://svelte.dev/docs/kit/adapters) is run when executing `vite build`. It determines how the output is converted for different platforms.
 	 * @default undefined
-	 * @deprecated removed in 3.0. Adapters should now be passed to the `sveltekit` Vite plugin in `vite.config.js`
+	 * @deprecated removed in 3.0.0. Adapters should now be passed to the `sveltekit` Vite plugin in `vite.config.js`
 	 */
 	adapter?: Adapter;
 	/**
@@ -907,6 +907,15 @@ export interface KitConfig {
 		 */
 		pollInterval?: number;
 	};
+}
+
+export interface KitViteConfig {
+	/**
+	 * Your [adapter](https://svelte.dev/docs/kit/adapters) is run when executing `vite build`. It determines how the output is converted for different platforms.
+	 * @since 3.0.0
+	 * @default undefined
+	 */
+	adapter?: Adapter;
 }
 
 /**

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -319,9 +319,11 @@ export interface Cookies {
 }
 
 export interface KitConfig {
+	// TODO: remove this in 4.0
 	/**
 	 * Your [adapter](https://svelte.dev/docs/kit/adapters) is run when executing `vite build`. It determines how the output is converted for different platforms.
 	 * @default undefined
+	 * @deprecated removed in 3.0. Adapters should now be passed to the `sveltekit` Vite plugin in `vite.config.js`
 	 */
 	adapter?: Adapter;
 	/**

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -348,15 +348,6 @@ function kit({ svelte_config, adapter }) {
 				({ kit } = svelte_config);
 				out = `${kit.outDir}/output`;
 
-				// TODO: remove this in 4.0
-				// @ts-expect-error kit.adapter existed prior to 3.0
-				if (kit.adapter) {
-					throw new Error(
-						`Your adapter must be passed to the \`sveltekit\` Vite plugin in the \`vite.config.js\` file instead of the \`svelte.config.js\` file. For example:\n\n` +
-							`+++import adapter from '@sveltejs/adapter-auto';+++\n\nexport default defineConfig({\n  plugins: [sveltekit( +++{ adapter }+++ )]\n});`
-					);
-				}
-
 				version_hash = hash(kit.version.name);
 
 				env = get_env(kit.env, vite_config_env.mode);

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -164,12 +164,12 @@ let vite_plugin_svelte;
 
 /**
  * Returns the SvelteKit Vite plugins.
- * @param {unknown} opts
+ * @param {KitViteConfig} [config]
  * @returns {Promise<PluginOption[]>}
  */
-export async function sveltekit(opts) {
+export async function sveltekit(config) {
 	/** @type {KitViteConfig} */
-	const validated = options(opts, 'options');
+	const validated = options(config, 'options');
 
 	// the config options will be set only after the Vite `config` hook runs
 	// because we need to find `svelte.config.js` relative to `vite.config.root`

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1,4 +1,4 @@
-/** @import { Adapter } from '@sveltejs/kit' */
+/** @import { Adapter, KitViteConfig } from '@sveltejs/kit' */
 /** @import { Options } from '@sveltejs/vite-plugin-svelte' */
 /** @import { PreprocessorGroup } from 'svelte/compiler' */
 /** @import { ValidatedConfig, ValidatedKitConfig } from 'types' */
@@ -67,6 +67,7 @@ import { load_config } from '../../core/config/index.js';
 import { treeshake_prerendered_remotes } from './build/remote.js';
 import { runtime_directory } from '../../runtime/utils.js';
 import { SVELTE_KIT_ASSETS } from '../../constants.js';
+import options from './options.js';
 
 const cwd = process.cwd();
 
@@ -163,11 +164,13 @@ let vite_plugin_svelte;
 
 /**
  * Returns the SvelteKit Vite plugins.
- * @param {object} options
- * @param {Adapter} [options.adapter] Your [adapter](https://svelte.dev/docs/kit/adapters) is run when executing `vite build`. It determines how the output is converted for different platforms. @default undefined
+ * @param {unknown} opts
  * @returns {Promise<PluginOption[]>}
  */
-export async function sveltekit({ adapter }) {
+export async function sveltekit(opts) {
+	/** @type {KitViteConfig} */
+	const validated = options(opts, 'options');
+
 	// the config options will be set only after the Vite `config` hook runs
 	// because we need to find `svelte.config.js` relative to `vite.config.root`
 	const svelte_config = /** @type {ValidatedConfig} */ ({});
@@ -184,7 +187,7 @@ export async function sveltekit({ adapter }) {
 	return [
 		plugin_svelte_config({ vite_plugin_svelte_options, svelte_config }),
 		vite_plugin_svelte.svelte(vite_plugin_svelte_options),
-		kit({ svelte_config, adapter })
+		kit({ svelte_config, adapter: validated.adapter })
 	];
 }
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1,5 +1,7 @@
+/** @import { Adapter } from '@sveltejs/kit' */
 /** @import { Options } from '@sveltejs/vite-plugin-svelte' */
 /** @import { PreprocessorGroup } from 'svelte/compiler' */
+/** @import { ValidatedConfig, ValidatedKitConfig } from 'types' */
 /** @import { ConfigEnv, Plugin, PluginOption, ResolvedConfig, UserConfig, Manifest, EnvironmentOptions, Rolldown } from 'vite' */
 /** @import { ModuleRunner } from 'vite/module-runner' */
 import fs from 'node:fs';
@@ -161,12 +163,11 @@ let vite_plugin_svelte;
 
 /**
  * Returns the SvelteKit Vite plugins.
- * @param {{
- *   adapter?: import('@sveltejs/kit').Adapter;
- * }=} options
+ * @param {object} options
+ * @param {Adapter} [options.adapter] Your [adapter](https://svelte.dev/docs/kit/adapters) is run when executing `vite build`. It determines how the output is converted for different platforms. @default undefined
  * @returns {Promise<PluginOption[]>}
  */
-export async function sveltekit(options = {}) {
+export async function sveltekit({ adapter }) {
 	// the config options will be set only after the Vite `config` hook runs
 	// because we need to find `svelte.config.js` relative to `vite.config.root`
 	const svelte_config = /** @type {import('types').ValidatedConfig} */ ({});
@@ -183,7 +184,7 @@ export async function sveltekit(options = {}) {
 	return [
 		plugin_svelte_config({ vite_plugin_svelte_options, svelte_config }),
 		vite_plugin_svelte.svelte(vite_plugin_svelte_options),
-		kit({ svelte_config, adapter_in_vite_config: options.adapter })
+		kit({ svelte_config, adapter })
 	];
 }
 
@@ -263,15 +264,15 @@ function revive_functions(value) {
  * - https://rolldown.rs/apis/plugin-api#output-generation-hooks
  *
  * @param {object} opts
- * @param {import('types').ValidatedConfig} opts.svelte_config options are only resolved after the Vite `config` hook runs
- * @param {import('@sveltejs/kit').Adapter | undefined} opts.adapter_in_vite_config True if an adapter was passed to the Vite plugin
+ * @param {ValidatedConfig} opts.svelte_config options are only resolved after the Vite `config` hook runs
+ * @param {Adapter | undefined} opts.adapter
  * @return {PluginOption[]}
  */
-function kit({ svelte_config, adapter_in_vite_config }) {
+function kit({ svelte_config, adapter }) {
 	/** @type {typeof import('vite')} */
 	let vite;
 
-	/** @type {import('types').ValidatedKitConfig} */
+	/** @type {ValidatedKitConfig} */
 	let kit;
 	/** @type {string} */
 	let out;
@@ -344,19 +345,15 @@ function kit({ svelte_config, adapter_in_vite_config }) {
 				vite_config_env = config_env;
 				is_build = config_env.command === 'build';
 
-				// if the adapter vite plugins store some values at the module level, we
-				// should use the adapter instance passed through the vite config to
-				// avoid losing those values
-				if (adapter_in_vite_config) svelte_config.kit.adapter = adapter_in_vite_config;
-
 				({ kit } = svelte_config);
 				out = `${kit.outDir}/output`;
 
-				if (kit.adapter?.vite?.plugins && !adapter_in_vite_config) {
-					// TODO: use the actual pathname of the user's svelte config file in the error message example
+				// TODO: remove this in 4.0
+				// @ts-expect-error kit.adapter existed prior to 3.0
+				if (kit.adapter) {
 					throw new Error(
-						`${kit.adapter.name} requires the adapter to be passed to the \`sveltekit\` Vite plugin in the \`vite.config.js\` file. For example:\n\n` +
-							`+++import svelteConfig from './svelte.config.js';+++\n\nexport default defineConfig({\n  plugins: [sveltekit( +++{ adapter: svelteConfig.kit?.adapter  }+++ )]\n});`
+						`Your adapter must be passed to the \`sveltekit\` Vite plugin in the \`vite.config.js\` file instead of the \`svelte.config.js\` file. For example:\n\n` +
+							`+++import adapter from '@sveltejs/adapter-auto';+++\n\nexport default defineConfig({\n  plugins: [sveltekit( +++{ adapter }+++ )]\n});`
 					);
 				}
 
@@ -492,7 +489,7 @@ function kit({ svelte_config, adapter_in_vite_config }) {
 
 					new_config.define = {
 						...define,
-						__SVELTEKIT_ADAPTER_NAME__: s(kit.adapter?.name),
+						__SVELTEKIT_ADAPTER_NAME__: s(adapter?.name),
 						__SVELTEKIT_APP_VERSION_FILE__: s(`${kit.appDir}/version.json`),
 						__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: s(kit.version.pollInterval)
 					};
@@ -1447,7 +1444,6 @@ function kit({ svelte_config, adapter_in_vite_config }) {
 
 					// ...and the server instrumentation file
 					if (server_instrumentation_file) {
-						const { adapter } = kit;
 						if (adapter && !adapter.supports?.instrumentation?.()) {
 							throw new Error(`${server_instrumentation_file} is unsupported in ${adapter.name}.`);
 						}
@@ -1676,7 +1672,7 @@ function kit({ svelte_config, adapter_in_vite_config }) {
 		 * @see https://vitejs.dev/guide/api-plugin.html#configurepreviewserver
 		 */
 		configurePreviewServer(vite) {
-			if (kit.adapter?.vite?.plugins) return;
+			if (adapter?.vite?.plugins) return;
 
 			return preview(vite, vite_config, svelte_config);
 		},
@@ -2017,9 +2013,10 @@ function kit({ svelte_config, adapter_in_vite_config }) {
 					`\nRun ${styleText(['bold', 'cyan'], 'npm run preview')} to preview your production build locally.`
 				);
 
-				if (kit.adapter) {
+				if (adapter) {
 					const { adapt } = await import('../../core/adapt/index.js');
 					await adapt(
+						adapter,
 						svelte_config,
 						build_data,
 						metadata,
@@ -2058,7 +2055,7 @@ function kit({ svelte_config, adapter_in_vite_config }) {
 
 	return [
 		plugin_setup,
-		adapter_in_vite_config?.vite?.plugins ? undefined : plugin_node_environment,
+		adapter?.vite?.plugins ? undefined : plugin_node_environment,
 		plugin_remote,
 		plugin_server_filesystem,
 		plugin_dev_ssr,
@@ -2067,7 +2064,7 @@ function kit({ svelte_config, adapter_in_vite_config }) {
 		plugin_service_worker,
 		plugin_compile,
 		plugin_adapter,
-		adapter_in_vite_config?.vite?.plugins
+		adapter?.vite?.plugins
 	].filter(Boolean);
 }
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -170,7 +170,7 @@ let vite_plugin_svelte;
 export async function sveltekit({ adapter }) {
 	// the config options will be set only after the Vite `config` hook runs
 	// because we need to find `svelte.config.js` relative to `vite.config.root`
-	const svelte_config = /** @type {import('types').ValidatedConfig} */ ({});
+	const svelte_config = /** @type {ValidatedConfig} */ ({});
 
 	/** @type {Options} */
 	const vite_plugin_svelte_options = {
@@ -198,7 +198,7 @@ function resolve_root(vite_config) {
  * of our other plugins try to access the config objects
  * @param {{
  *   vite_plugin_svelte_options: import('@sveltejs/vite-plugin-svelte').Options;
- * 	 svelte_config: import('types').ValidatedConfig;
+ * 	 svelte_config: ValidatedConfig;
  * }} options
  * @return {Plugin}
  */
@@ -2105,7 +2105,7 @@ function find_overridden_config(config, resolved_config, enforced_config, path, 
 }
 
 /**
- * @param {import('types').ValidatedConfig} config
+ * @param {ValidatedConfig} config
  * @returns {string}
  */
 function create_service_worker_module(config) {

--- a/packages/kit/src/exports/vite/options.js
+++ b/packages/kit/src/exports/vite/options.js
@@ -6,7 +6,7 @@ import { object, validate } from '../../core/config/options.js';
 const options = object({
 	adapter: validate(null, (input, keypath) => {
 		if (typeof input !== 'object' || !input.adapt) {
-			let message = `${keypath} should be an object with an "adapt" method`;
+			const message = `${keypath} should be an object with an "adapt" method`;
 			throw new Error(`${message}. See https://svelte.dev/docs/kit/adapters`);
 		}
 

--- a/packages/kit/src/exports/vite/options.js
+++ b/packages/kit/src/exports/vite/options.js
@@ -7,12 +7,6 @@ const options = object({
 	adapter: validate(null, (input, keypath) => {
 		if (typeof input !== 'object' || !input.adapt) {
 			let message = `${keypath} should be an object with an "adapt" method`;
-
-			if (Array.isArray(input) || typeof input === 'string') {
-				// for the early adapter adopters
-				message += ', rather than the name of an adapter';
-			}
-
 			throw new Error(`${message}. See https://svelte.dev/docs/kit/adapters`);
 		}
 

--- a/packages/kit/src/exports/vite/options.js
+++ b/packages/kit/src/exports/vite/options.js
@@ -1,0 +1,23 @@
+/** @import { Validator } from '../../core/config/types.js' */
+
+import { object, validate } from '../../core/config/options.js';
+
+/** @type {Validator} */
+const options = object({
+	adapter: validate(null, (input, keypath) => {
+		if (typeof input !== 'object' || !input.adapt) {
+			let message = `${keypath} should be an object with an "adapt" method`;
+
+			if (Array.isArray(input) || typeof input === 'string') {
+				// for the early adapter adopters
+				message += ', rather than the name of an adapter';
+			}
+
+			throw new Error(`${message}. See https://svelte.dev/docs/kit/adapters`);
+		}
+
+		return input;
+	})
+});
+
+export default options;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -607,9 +607,8 @@ export type ValidatedConfig = Config & {
 	extensions: string[];
 };
 
-export type ValidatedKitConfig = Omit<RecursiveRequired<KitConfig>, 'adapter'> & {
-	adapter?: Adapter;
-};
+// TODO: remove the omit in 4.0
+export type ValidatedKitConfig = Omit<RecursiveRequired<KitConfig>, 'adapter'>;
 
 export type BinaryFormMeta = {
 	remote_refreshes?: string[];

--- a/packages/kit/test/apps/basics/svelte.config.js
+++ b/packages/kit/test/apps/basics/svelte.config.js
@@ -3,23 +3,6 @@ import process from 'node:process';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: {
-			name: 'test-adapter',
-			adapt(builder) {
-				builder.instrument({
-					entrypoint: `${builder.getServerDirectory()}/index.js`,
-					instrumentation: `${builder.getServerDirectory()}/instrumentation.server.js`,
-					module: {
-						exports: ['Server']
-					}
-				});
-			},
-			supports: {
-				read: () => true,
-				instrumentation: () => true
-			}
-		},
-
 		experimental: {
 			remoteFunctions: true,
 			tracing: {

--- a/packages/kit/test/apps/basics/vite.config.js
+++ b/packages/kit/test/apps/basics/vite.config.js
@@ -13,7 +13,26 @@ export default defineConfig({
 		// the reload confuses Playwright
 		include: ['cookie']
 	},
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit({
+			adapter: {
+				name: 'test-adapter',
+				adapt(builder) {
+					builder.instrument({
+						entrypoint: `${builder.getServerDirectory()}/index.js`,
+						instrumentation: `${builder.getServerDirectory()}/instrumentation.server.js`,
+						module: {
+							exports: ['Server']
+						}
+					});
+				},
+				supports: {
+					read: () => true,
+					instrumentation: () => true
+				}
+			}
+		})
+	],
 	server: {
 		fs: {
 			allow: [path.resolve('../../../src')]

--- a/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/svelte.config.js
+++ b/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/svelte.config.js
@@ -1,10 +1,6 @@
-import adapter from '../../../../../adapter-auto/index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter()
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/vite.config.js
+++ b/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/vite.config.js
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../../../adapter-auto/index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
@@ -11,7 +12,11 @@ const config = {
 
 	logLevel: 'silent',
 
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	],
 
 	server: {
 		fs: {

--- a/packages/kit/test/build-errors/apps/prerender-remote-function-error/svelte.config.js
+++ b/packages/kit/test/build-errors/apps/prerender-remote-function-error/svelte.config.js
@@ -1,10 +1,6 @@
-import adapter from '../../../../../adapter-auto/index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter(),
-
 		experimental: {
 			remoteFunctions: true
 		}

--- a/packages/kit/test/build-errors/apps/prerender-remote-function-error/vite.config.js
+++ b/packages/kit/test/build-errors/apps/prerender-remote-function-error/vite.config.js
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../../../adapter-auto/index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
@@ -11,7 +12,11 @@ const config = {
 
 	logLevel: 'silent',
 
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	],
 
 	server: {
 		fs: {

--- a/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/svelte.config.js
+++ b/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/svelte.config.js
@@ -1,10 +1,6 @@
-import adapter from '../../../../../adapter-auto/index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter()
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/vite.config.js
+++ b/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/vite.config.js
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../../../adapter-auto/index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
@@ -11,7 +12,11 @@ const config = {
 
 	logLevel: 'silent',
 
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	],
 
 	server: {
 		fs: {

--- a/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/svelte.config.js
+++ b/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/svelte.config.js
@@ -1,10 +1,6 @@
-import adapter from '../../../../../adapter-auto/index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter()
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/vite.config.js
+++ b/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/vite.config.js
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../../../adapter-auto/index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
@@ -11,7 +12,11 @@ const config = {
 
 	logLevel: 'silent',
 
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	],
 
 	server: {
 		fs: {

--- a/packages/kit/test/prerendering/basics/svelte.config.js
+++ b/packages/kit/test/prerendering/basics/svelte.config.js
@@ -1,11 +1,8 @@
-import adapter from '../../../../adapter-static/index.js';
 import { writeFileSync } from 'node:fs';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter(),
-
 		prerender: {
 			handleHttpError: 'warn',
 			origin: 'http://prerender.origin',

--- a/packages/kit/test/prerendering/basics/vite.config.js
+++ b/packages/kit/test/prerendering/basics/vite.config.js
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../../adapter-static/index.js';
 
 /** @type {import('vitest/config').ViteUserConfig} */
 const config = {
@@ -11,7 +12,11 @@ const config = {
 
 	logLevel: 'silent',
 
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	],
 
 	define: {
 		'process.env.MY_ENV': '"MY_ENV DEFINED"'

--- a/packages/kit/test/prerendering/options/svelte.config.js
+++ b/packages/kit/test/prerendering/options/svelte.config.js
@@ -1,5 +1,3 @@
-import adapter from '../../../../adapter-static/index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	compilerOptions: {
@@ -9,10 +7,6 @@ const config = {
 	},
 
 	kit: {
-		adapter: adapter({
-			fallback: '200.html'
-		}),
-
 		csp: {
 			directives: {
 				'script-src': ['self']

--- a/packages/kit/test/prerendering/options/vite.config.js
+++ b/packages/kit/test/prerendering/options/vite.config.js
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../../adapter-static/index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
@@ -11,7 +12,13 @@ const config = {
 
 	logLevel: 'silent',
 
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit({
+			adapter: adapter({
+				fallback: '200.html'
+			})
+		})
+	],
 
 	server: {
 		fs: {

--- a/packages/kit/test/prerendering/paths-base/svelte.config.js
+++ b/packages/kit/test/prerendering/paths-base/svelte.config.js
@@ -1,10 +1,6 @@
-import adapter from '../../../../adapter-static/index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter(),
-
 		paths: {
 			base: '/path-base',
 			relative: false

--- a/packages/kit/test/prerendering/paths-base/vite.config.js
+++ b/packages/kit/test/prerendering/paths-base/vite.config.js
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../../adapter-static/index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
@@ -13,7 +14,11 @@ const config = {
 
 	logLevel: 'silent',
 
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	],
 
 	server: {
 		fs: {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -293,9 +293,11 @@ declare module '@sveltejs/kit' {
 	}
 
 	export interface KitConfig {
+		// TODO: remove this in 4.0
 		/**
 		 * Your [adapter](https://svelte.dev/docs/kit/adapters) is run when executing `vite build`. It determines how the output is converted for different platforms.
 		 * @default undefined
+		 * @deprecated removed in 3.0.0. Adapters should now be passed to the `sveltekit` Vite plugin in `vite.config.js`
 		 */
 		adapter?: Adapter;
 		/**
@@ -879,6 +881,15 @@ declare module '@sveltejs/kit' {
 			 */
 			pollInterval?: number;
 		};
+	}
+
+	export interface KitViteConfig {
+		/**
+		 * Your [adapter](https://svelte.dev/docs/kit/adapters) is run when executing `vite build`. It determines how the output is converted for different platforms.
+		 * @since 3.0.0
+		 * @default undefined
+		 */
+		adapter?: Adapter;
 	}
 
 	/**
@@ -2746,9 +2757,8 @@ declare module '@sveltejs/kit' {
 		extensions: string[];
 	};
 
-	type ValidatedKitConfig = Omit<RecursiveRequired<KitConfig>, 'adapter'> & {
-		adapter?: Adapter;
-	};
+	// TODO: remove the omit in 4.0
+	type ValidatedKitConfig = Omit<RecursiveRequired<KitConfig>, 'adapter'>;
 	/**
 	 * Throws an error with a HTTP status code and an optional message.
 	 * When called during request handling, this will cause SvelteKit to
@@ -2991,9 +3001,7 @@ declare module '@sveltejs/kit/vite' {
 	/**
 	 * Returns the SvelteKit Vite plugins.
 	 * */
-	export function sveltekit(options?: {
-		adapter?: import("@sveltejs/kit").Adapter;
-	} | undefined): Promise<PluginOption[]>;
+	export function sveltekit(opts: unknown): Promise<PluginOption[]>;
 
 	export {};
 }

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2997,11 +2997,12 @@ declare module '@sveltejs/kit/node' {
 }
 
 declare module '@sveltejs/kit/vite' {
+	import type { KitViteConfig } from '@sveltejs/kit';
 	import type { PluginOption } from 'vite';
 	/**
 	 * Returns the SvelteKit Vite plugins.
 	 * */
-	export function sveltekit(opts: unknown): Promise<PluginOption[]>;
+	export function sveltekit(config?: KitViteConfig): Promise<PluginOption[]>;
 
 	export {};
 }

--- a/playgrounds/basic/svelte.config.js
+++ b/playgrounds/basic/svelte.config.js
@@ -1,5 +1,3 @@
-import adapter from '@sveltejs/adapter-node';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	compilerOptions: {
@@ -9,7 +7,6 @@ const config = {
 	},
 
 	kit: {
-		adapter: adapter(),
 		experimental: {
 			remoteFunctions: true
 		}

--- a/playgrounds/basic/vite.config.js
+++ b/playgrounds/basic/vite.config.js
@@ -1,8 +1,9 @@
+import adapter from '@sveltejs/adapter-node';
 import { enhancedImages } from '@sveltejs/enhanced-img';
 import { sveltekit } from '@sveltejs/kit/vite';
 
 export default {
-	plugins: [enhancedImages(), sveltekit()],
+	plugins: [enhancedImages(), sveltekit({ adapter: adapter() })],
 	server: {
 		fs: {
 			allow: ['../../packages/kit']


### PR DESCRIPTION
Addresses https://github.com/sveltejs/kit/pull/15574#issuecomment-4348243340

This PR make the necessary changes to the docs, test apps, and kit code to warns users to move their adapter to the vite config file.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
