### PR TITLE
fix: inject false for unchecked boolean checkboxes in remote form submission

### DIFF
--- a/.changeset/fix-unchecked-checkbox.md
+++ b/.changeset/fix-unchecked-checkbox.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: inject false for unchecked boolean checkboxes in remote form submission

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -348,7 +348,7 @@ export function form(id) {
 
 				event.preventDefault();
 
-				const form_data = new FormData(form, event.submitter);
+				const form_data = get_form_data(form, event.submitter);
 
 				if (DEV) {
 					validate_form_data(form_data, clone(form).enctype);
@@ -466,7 +466,7 @@ export function form(id) {
 					// the inputs are actually updated (so that it can be cancelled)
 					await tick();
 
-					input = convert_formdata(new FormData(form));
+					input = convert_formdata(get_form_data(form));
 				};
 
 				form.addEventListener('reset', handle_reset);
@@ -553,7 +553,7 @@ export function form(id) {
 						element.querySelector('button:not([type]), [type="submit"]')
 					);
 
-					const form_data = new FormData(element, default_submitter);
+					const form_data = get_form_data(element, default_submitter);
 
 					/** @type {InternalRemoteFormIssue[]} */
 					let array = [];
@@ -687,4 +687,26 @@ function validate_form_data(form_data, enctype) {
 			}
 		}
 	}
+}
+
+/**
+ * @param {HTMLFormElement} form
+ * @param {HTMLElement | null | undefined} [submitter]
+ */
+function get_form_data(form, submitter) {
+	const form_data = new FormData(form, submitter ?? undefined);
+
+	for (const element of form.elements) {
+		const input = /** @type {HTMLInputElement} */ (element);
+		if (
+			input.name &&
+			input.name.startsWith('b:') &&
+			!input.disabled &&
+			!form_data.has(input.name)
+		) {
+			form_data.append(input.name, 'false');
+		}
+	}
+
+	return form_data;
 }

--- a/packages/kit/test/apps/async/src/routes/remote/form/unchecked-checkbox/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/unchecked-checkbox/+page.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { submit, get_result } from './form.remote.js';
+</script>
+
+<form
+	{...submit.enhance(async ({ submit }) => {
+		await submit();
+	})}
+>
+	<input data-testid="checkbox" {...submit.fields.checkbox_field.as('checkbox')} />
+	<button id="submit">Submit</button>
+</form>
+
+<p id="result">{get_result().current}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/form/unchecked-checkbox/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/unchecked-checkbox/form.remote.ts
@@ -1,0 +1,16 @@
+import { form, query } from '$app/server';
+import * as v from 'valibot';
+
+let result = true;
+
+export const get_result = query(() => result);
+
+export const submit = form(
+	v.object({
+		checkbox_field: v.boolean()
+	}),
+	async (data) => {
+		result = data.checkbox_field;
+		get_result().refresh();
+	}
+);

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -796,6 +796,22 @@ test.describe('remote function mutations', () => {
 		// the value display should also show the updated value
 		await expect(page.locator('#set-value-display')).toHaveText('Set via method');
 	});
+
+	test('unchecked checkbox submits successfully', async ({ page }) => {
+		await page.goto('/remote/form/unchecked-checkbox');
+
+		// Checkbox is unchecked by default
+		await expect(page.locator('#result')).toHaveText('true'); // Initial state
+
+		// Test unchecked
+		await page.click('#submit');
+		await expect(page.locator('#result')).toHaveText('false'); // The form submission should succeed and update result to false
+
+		// Test checked
+		await page.locator('[data-testid="checkbox"]').check();
+		await page.click('#submit');
+		await expect(page.locator('#result')).toHaveText('true'); // The form submission should succeed and update result back to true
+	});
 });
 
 test.describe('client error boundaries', () => {


### PR DESCRIPTION
Fixes #15785.

In SvelteKit 2.59.0, unchecked checkboxes using `z.coerce.boolean()` failed to submit because the client-side form submission logic didn't account for `b:`-prefixed fields missing from `FormData`.

This PR adds a `get_form_data` helper in `form.svelte.js` that injects `'false'` into the `FormData` for any `b:`-prefixed input that is absent from the `FormData` (i.e. unchecked checkboxes).

A regression test has been added to `packages/kit/test/apps/async` to verify that unchecked checkboxes submit successfully.