### PR TITLE
fix: resolve user files with drive letter on Windows

### DIFF
--- a/.changeset/rude-eyes-smoke.md
+++ b/.changeset/rude-eyes-smoke.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: resolve paths to route files with the letter drive on Windows

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -101,7 +101,7 @@ export async function dev(vite, vite_config, svelte_config, get_remotes) {
 
 	/** @param {string} id */
 	async function resolve(id) {
-		const url = id.startsWith('..') ? to_fs(path.posix.resolve(id)) : `/${id}`;
+		const url = id.startsWith('..') ? to_fs(path.resolve(id)) : `/${id}`;
 
 		const module = await loud_ssr_load_module(url);
 


### PR DESCRIPTION
Hope this helps fix https://github.com/sveltejs/vite-plugin-svelte/pull/1328#issuecomment-4350677629

EDIT: It does!

We don't need the `path.posix.resolve` variant since `to_fs` already posixifies the path later (that code was also written almost 4 years ago). Using it causes Windows to omit the letter drive, which misaligns with Vite's own file resolution. I've verified it fixes the issue by running CI tests with it in https://github.com/sveltejs/vite-plugin-svelte/pull/1328

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
