### PR TITLE
fix: remove Content-Length dependency in binary form deserialization

### DIFF
--- a/.changeset/yellow-bananas-read.md
+++ b/.changeset/yellow-bananas-read.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: remove reliance on Content-Length header in deserialize_binary_form, which caused failures when proxies (e.g. Vercel, Azure) strip the header and use chunked transfer encoding

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -145,10 +145,6 @@ export async function deserialize_binary_form(request) {
 	if (!request.body) {
 		throw deserialize_error('no body');
 	}
-	const content_length = parseInt(request.headers.get('content-length') ?? '');
-	if (Number.isNaN(content_length)) {
-		throw deserialize_error('invalid Content-Length header');
-	}
 
 	const reader = request.body.getReader();
 
@@ -228,16 +224,11 @@ export async function deserialize_binary_form(request) {
 	}
 	const header_view = new DataView(header.buffer, header.byteOffset, header.byteLength);
 	const data_length = header_view.getUint32(1, true);
-
-	if (HEADER_BYTES + data_length > content_length) {
-		throw deserialize_error('data overflow');
-	}
-
 	const file_offsets_length = header_view.getUint16(5, true);
 
-	if (HEADER_BYTES + data_length + file_offsets_length > content_length) {
-		throw deserialize_error('file offset table overflow');
-	}
+	// Validation uses embedded binary header fields (data_length, file_offsets_length)
+	// rather than Content-Length, which proxies/middleboxes may strip or corrupt.
+	// See: https://github.com/sveltejs/kit/issues/15299
 
 	// Read the form data
 	const data_buffer = await get_buffer(HEADER_BYTES, data_length);
@@ -289,9 +280,6 @@ export async function deserialize_binary_form(request) {
 			file_offsets[index] = undefined;
 
 			offset += files_start_offset;
-			if (offset + size > content_length) {
-				throw deserialize_error('file data overflow');
-			}
 
 			file_spans.push({ offset, size });
 

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -221,93 +221,54 @@ describe('binary form serializer', () => {
 		expect(world_slice.type).toBe(file.type);
 	});
 
-	test('throws when Content-Length is invalid', async () => {
-		await expect(
-			deserialize_binary_form(
-				new Request('http://test', {
-					method: 'POST',
-					body: 'foo',
-					headers: {
-						'Content-Type': BINARY_FORM_CONTENT_TYPE
-					}
-				})
-			)
-		).rejects.toThrow('invalid Content-Length header');
-		await expect(
-			deserialize_binary_form(
-				new Request('http://test', {
-					method: 'POST',
-					body: 'foo',
-					headers: {
-						'Content-Type': BINARY_FORM_CONTENT_TYPE,
-						'Content-Length': 'invalid'
-					}
-				})
-			)
-		).rejects.toThrow('invalid Content-Length header');
-	});
-
-	test('data length check', async () => {
+	test('works without Content-Length header', async () => {
 		const { blob } = serialize_binary_form(
 			{
-				foo: 'bar'
+				foo: 'bar',
+				file: new File(['hello'], 'hello.txt', { type: 'text/plain' })
 			},
-			{}
+			{ validate_only: true }
 		);
-		await expect(
-			deserialize_binary_form(
-				new Request('http://test', {
-					method: 'POST',
-					body: blob,
-					headers: {
-						'Content-Type': BINARY_FORM_CONTENT_TYPE,
-						'Content-Length': (blob.size - 1).toString()
-					}
-				})
-			)
-		).rejects.toThrow('data overflow');
+		const res = await deserialize_binary_form(
+			new Request('http://test', {
+				method: 'POST',
+				body: blob,
+				headers: {
+					'Content-Type': BINARY_FORM_CONTENT_TYPE
+					// No Content-Length — simulates proxy stripping it
+				}
+			})
+		);
+		expect(res.data.foo).toBe('bar');
+		expect(res.data.file.name).toBe('hello.txt');
+		expect(res.data.file.size).toBe(5);
+		expect(await res.data.file.text()).toBe('hello');
+		expect(res.meta.validate_only).toBe(true);
 	});
 
-	test('file offset table length check', async () => {
+	test('works with Content-Length header', async () => {
 		const { blob } = serialize_binary_form(
 			{
-				file: new File([''], 'a.txt')
+				foo: 'bar',
+				file: new File(['hello'], 'hello.txt', { type: 'text/plain' })
 			},
-			{}
+			{ validate_only: true }
 		);
-		await expect(
-			deserialize_binary_form(
-				new Request('http://test', {
-					method: 'POST',
-					body: blob,
-					headers: {
-						'Content-Type': BINARY_FORM_CONTENT_TYPE,
-						'Content-Length': (blob.size - 1).toString()
-					}
-				})
-			)
-		).rejects.toThrow('file offset table overflow');
-	});
-
-	test('file length check', async () => {
-		const { blob } = serialize_binary_form(
-			{
-				file: new File(['a'], 'a.txt')
-			},
-			{}
+		const res = await deserialize_binary_form(
+			new Request('http://test', {
+				method: 'POST',
+				body: blob,
+				headers: {
+					'Content-Type': BINARY_FORM_CONTENT_TYPE,
+					'Content-Length': blob.size.toString()
+				}
+			})
 		);
-		await expect(
-			deserialize_binary_form(
-				new Request('http://test', {
-					method: 'POST',
-					body: blob,
-					headers: {
-						'Content-Type': BINARY_FORM_CONTENT_TYPE,
-						'Content-Length': (blob.size - 1).toString()
-					}
-				})
-			)
-		).rejects.toThrow('file data overflow');
+		expect(res.data.foo).toBe('bar');
+		expect(res.data.file.name).toBe('hello.txt');
+		expect(res.data.file.size).toBe(5);
+		expect(await res.data.file.text()).toBe('hello');
+		expect(res.meta.validate_only).toBe(true);
 	});
 
 	test('does not preallocate large buffers for incomplete bodies', async () => {


### PR DESCRIPTION
closes #15299
closes #15783

This PR removes the reliance on the `Content-Length` header in `deserialize_binary_form`. Proxies and middleboxes (such as Vercel, Azure) may strip the `Content-Length` header and use chunked transfer encoding instead, which caused the deserialization to throw "invalid Content-Length header".

The fix uses the embedded binary header fields (`data_length`, `file_offsets_length`) for validation instead of trusting `Content-Length`, which can be missing or corrupted by intermediaries.

**Changes:**
- Removed `Content-Length` parsing and validation in `deserialize_binary_form`
- Removed three overflow checks that compared against `content_length` ("data overflow", "file offset table overflow", "file data overflow")
- Added tests verifying deserialization works both with and without the `Content-Length` header

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.