### PR TITLE
feat: allow 'submit' and 'hidden' form fields to accept numbers and booleans

### DIFF
--- a/.changeset/cool-clouds-occur.md
+++ b/.changeset/cool-clouds-occur.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: allow 'submit' and 'hidden' form fields to accept numbers and booleans

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1905,8 +1905,8 @@ type InputTypeMap = {
 	checkbox: boolean | string[];
 	radio: string;
 	file: File;
-	hidden: string;
-	submit: string;
+	hidden: string | number | boolean;
+	submit: string | number | boolean;
 	button: string;
 	reset: string;
 	image: string;
@@ -1997,11 +1997,15 @@ type AsArgs<Type extends keyof InputTypeMap, Value> = Type extends 'checkbox'
 		: Value extends boolean
 			? [type: Type] | [type: Type, value: boolean]
 			: [type: Type] | [type: Type, value: Value | (string & {})]
-	: Type extends 'radio' | 'submit' | 'hidden'
-		? [type: Type, value: Value | (string & {})]
-		: Type extends 'file' | 'file multiple'
-			? [type: Type]
-			: [type: Type] | [type: Type, value: Value | (string & {})];
+	: Type extends 'submit' | 'hidden'
+		? Value extends string
+			? [type: Type, value: Value | (string & {})]
+			: [type: Type, value: Value]
+		: Type extends 'radio'
+			? [type: Type, value: Value | (string & {})]
+			: Type extends 'file' | 'file multiple'
+				? [type: Type]
+				: [type: Type] | [type: Type, value: Value | (string & {})];
 
 /**
  * Form field accessor type that provides name(), value(), and issues() methods

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -602,6 +602,23 @@ export function deep_get(object, path) {
 }
 
 /**
+ *
+ * @param {string} field_type
+ * @param {boolean} is_array
+ * @param {unknown} input_value
+ */
+function get_type_prefix(field_type, is_array, input_value) {
+	if (field_type === 'number' || field_type === 'range') return 'n:';
+	if (field_type === 'checkbox' && !is_array) return 'b:';
+	if (field_type === 'hidden' || field_type === 'submit') {
+		const input_type = typeof input_value;
+		if (input_type === 'number') return 'n:';
+		if (input_type === 'boolean') return 'b:';
+	}
+	return '';
+}
+
+/**
  * Creates a proxy-based field accessor for form data
  * @param {any} target - Function or empty POJO
  * @param {() => Record<string, any>} get_input - Function to get current input data
@@ -674,12 +691,7 @@ export function create_field_proxy(target, get_input, set_input, get_issues, pat
 						type === 'select multiple' ||
 						(type === 'checkbox' && typeof input_value === 'string');
 
-					const prefix =
-						type === 'number' || type === 'range'
-							? 'n:'
-							: type === 'checkbox' && !is_array
-								? 'b:'
-								: '';
+					const prefix = get_type_prefix(type, is_array, input_value);
 
 					// Base properties for all input types
 					/** @type {Record<string, any>} */

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -711,7 +711,7 @@ export function create_field_proxy(target, get_input, set_input, get_issues, pat
 					// Handle submit and hidden inputs
 					if (type === 'submit' || type === 'hidden') {
 						if (DEV) {
-							if (!input_value) {
+							if (input_value === null || input_value === undefined) {
 								throw new Error(`\`${type}\` inputs must have a value`);
 							}
 						}

--- a/packages/kit/test/apps/async/src/routes/remote/form/as-value/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/as-value/+page.svelte
@@ -14,6 +14,10 @@
 <div class="forms">
 	{#each values as value (value.id)}
 		<form class="form" {...as_value_form.for(value.id)}>
+			<input {...as_value_form.fields.hidden.string.as('hidden', 'string')} />
+			<input {...as_value_form.fields.hidden.number.as('hidden', 1)} />
+			<input {...as_value_form.fields.hidden.boolean.as('hidden', true)} />
+
 			<input {...as_value_form.fields.text_field.as('text', value.text_field)} />
 
 			<input {...as_value_form.fields.number_field.as('number', value.number_field)} />

--- a/packages/kit/test/apps/async/src/routes/remote/form/as-value/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/as-value/form.remote.ts
@@ -8,10 +8,16 @@ const ValueSchema = v.object({
 	select_field: v.string(),
 	color_field: v.string(),
 	range_field: v.number(),
-	checkbox_field: v.optional(v.boolean(), false)
+	checkbox_field: v.optional(v.boolean(), false),
+
+	hidden: v.object({
+		string: v.string(),
+		number: v.number(),
+		boolean: v.boolean()
+	})
 });
 
-const default_values: Array<v.InferOutput<typeof ValueSchema>> = [
+const default_values: Array<Omit<v.InferOutput<typeof ValueSchema>, 'hidden'>> = [
 	{
 		id: '1',
 		text_field: 'Example text',

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1879,8 +1879,8 @@ declare module '@sveltejs/kit' {
 		checkbox: boolean | string[];
 		radio: string;
 		file: File;
-		hidden: string;
-		submit: string;
+		hidden: string | number | boolean;
+		submit: string | number | boolean;
 		button: string;
 		reset: string;
 		image: string;
@@ -1971,11 +1971,15 @@ declare module '@sveltejs/kit' {
 			: Value extends boolean
 				? [type: Type] | [type: Type, value: boolean]
 				: [type: Type] | [type: Type, value: Value | (string & {})]
-		: Type extends 'radio' | 'submit' | 'hidden'
-			? [type: Type, value: Value | (string & {})]
-			: Type extends 'file' | 'file multiple'
-				? [type: Type]
-				: [type: Type] | [type: Type, value: Value | (string & {})];
+		: Type extends 'submit' | 'hidden'
+			? Value extends string
+				? [type: Type, value: Value | (string & {})]
+				: [type: Type, value: Value]
+			: Type extends 'radio'
+				? [type: Type, value: Value | (string & {})]
+				: Type extends 'file' | 'file multiple'
+					? [type: Type]
+					: [type: Type] | [type: Type, value: Value | (string & {})];
 
 	/**
 	 * Form field accessor type that provides name(), value(), and issues() methods


### PR DESCRIPTION
There's no reason not to allow `<input type="hidden">` to accept numbers and booleans - this is a big ergonomic improvement for little effort:

<table><thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody><tr>
<td>

```ts
export const f = form(v.object({
  id: v.pipe(v.string(), v.toNumber())
}), /* ... */);
```
```svelte
<form {...f}>
  <input 
    {...f.fields.id.as('hidden', some_id.toString())}
  />
</form>
```

</td>
<td>


```ts
export const f = form(v.object({
  id: v.number(),
}), /* ... */);
```
```svelte
<form {...f}>
  <input 
    {...f.fields.id.as('hidden', some_id)}
  />
</form>
```

</td></tr></tbody></table>

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
