### PR TITLE
fix: abort navigation after async rendering if obsolete

### DIFF
--- a/.changeset/pink-maps-wave.md
+++ b/.changeset/pink-maps-wave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: abort navigation after async rendering if obsolete

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -675,7 +675,7 @@ async function initialize(result, target, hydrate) {
 	const style = document.querySelector('style[data-sveltekit]');
 	if (style) style.remove();
 
-	Object.assign(page, /** @type {import('@sveltejs/kit').Page} */ (result.props.page));
+	update(/** @type {import('@sveltejs/kit').Page} */ (result.props.page));
 
 	root = new app.root({
 		target,
@@ -1917,6 +1917,16 @@ async function navigate({
 	await svelte.tick();
 	await svelte.tick();
 
+	if (token !== nav_token) {
+		// a new navigation happened while we were waiting for the DOM to update, so abort
+		return;
+	}
+
+	// Check for async rendering error
+	if (navigation_result.props.page && rendering_error) {
+		Object.assign(navigation_result.props.page, rendering_error);
+	}
+
 	// we reset scroll before dealing with focus, to avoid a flash of unscrolled content
 	/** @type {Element | null | ''} */
 	let deep_linked = null;
@@ -1950,14 +1960,6 @@ async function navigate({
 	}
 
 	autoscroll = true;
-
-	if (navigation_result.props.page) {
-		// Check for async rendering error
-		if (rendering_error) {
-			Object.assign(navigation_result.props.page, rendering_error);
-		}
-		Object.assign(page, navigation_result.props.page);
-	}
 
 	is_navigating = false;
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1919,7 +1919,8 @@ async function navigate({
 
 	if (token !== nav_token) {
 		// a new navigation happened while we were waiting for the DOM to update, so abort
-		return;
+		nav.reject(new Error('navigation aborted'));
+		return false;
 	}
 
 	// Check for async rendering error


### PR DESCRIPTION
With async Svelte, rendering itself can take a bit, and during that time a new navigation could occur. We therefore have to check the navigation token once more. We also should only update the props.page once - the duplicative and now-deleted code was pre-`$app/state` and kept around without reason, now being wasteful at best and causing buggy rerenders at worst. Helps with the redirect test not failing anymore against latest Svelte.
