### PR TITLE
fix(RemoteCommand): restore Awaited<Output> to unwrap Promise handlers

### DIFF
--- a/packages/kit/test/types/remote.test.ts
+++ b/packages/kit/test/types/remote.test.ts
@@ -330,6 +330,25 @@ function command_tests() {
 		void cmd(123);
 	}
 	void command_schema();
+
+	async function command_with_promise_handler() {
+		// Regression test for #15763
+		// When handler returns Promise<T>, output type should be Promise<T>, not Promise<Promise<T>>
+		const cmd = command(async () => ({ ok: true }));
+		const result: { ok: boolean } = await cmd();
+		result;
+		// @ts-expect-error
+		const wrong: Promise<{ ok: boolean }> = result;
+		wrong;
+
+		const cmdWithArg = command("unchecked", async (a: number) => ({ value: a }));
+		const result2: { value: number } = await cmdWithArg(5);
+		result2;
+		// @ts-expect-error
+		const wrong2: Promise<{ value: number }> = result2;
+		wrong2;
+	}
+	void command_with_promise_handler();
 }
 command_tests();
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2165,8 +2165,8 @@ declare module '@sveltejs/kit' {
 	 * The type of a remote `command` function. See [Remote functions](https://svelte.dev/docs/kit/remote-functions#command) for full documentation.
 	 */
 	export type RemoteCommand<Input, Output> = {
-		(arg: undefined extends Input ? Input | void : Input): Promise<Output> & {
-			updates(...updates: RemoteQueryUpdate[]): Promise<Output>;
+		(arg: undefined extends Input ? Input | void : Input): Promise<Awaited<Output>> & {
+			updates(...updates: RemoteQueryUpdate[]): Promise<Awaited<Output>>;
 		};
 		/** The number of pending command executions */
 		get pending(): number;


### PR DESCRIPTION
Fixes #15763

PR #15533 removed `Awaited<>` from RemoteCommand type signatures, causing Promise-returning handlers to produce `Promise<Promise<T>>` instead of `Promise<T>`.

When a command handler returns `Promise<T>`, the Output generic is inferred as `Promise<T>`. Without `Awaited<>`, this results in a nested Promise type.

Restoring `Awaited<Output>` in both the call signature and `updates()` method ensures proper Promise unwrapping, matching the behavior of `form()` and `query()`, which use `MaybePromise<Output>`.

## Changes
- Restore `Awaited<Output>` in RemoteCommand type definition (packages/kit/types/index.d.ts)
- Add regression test covering Promise-returning command handlers (packages/kit/test/types/remote.test.ts)