### PR TITLE
fix: use Object.hasOwn for manifest._.server_assets lookups (adapter-cloudflare + kit core)

### DIFF
--- a/.changeset/adapter-cloudflare-server-assets-own-property.md
+++ b/.changeset/adapter-cloudflare-server-assets-own-property.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+fix: use `Object.hasOwn` for `server_assets` lookup so request paths matching `Object.prototype` keys (e.g. `/constructor`, `/__proto__`, `/toString`) are not misrouted to `env.ASSETS.fetch`

--- a/.changeset/adapter-cloudflare-server-assets-own-property.md
+++ b/.changeset/adapter-cloudflare-server-assets-own-property.md
@@ -1,5 +1,6 @@
 ---
 '@sveltejs/adapter-cloudflare': patch
+'@sveltejs/kit': patch
 ---
 
-fix: use `Object.hasOwn` for `server_assets` lookup so request paths matching `Object.prototype` keys (e.g. `/constructor`, `/__proto__`, `/toString`) are not misrouted to `env.ASSETS.fetch`
+fix: use `Object.hasOwn` for `manifest._.server_assets` lookups so request paths matching `Object.prototype` keys (e.g. `/constructor`, `/__proto__`, `/toString`) are not treated as static assets. Applies to the Cloudflare adapter worker, the server-side `fetch` shim, the `$app/server` `read()` helper, and the Vite dev/preview `read` callbacks.

--- a/packages/adapter-cloudflare/src/worker.js
+++ b/packages/adapter-cloudflare/src/worker.js
@@ -72,8 +72,8 @@ export default {
 			is_static_asset =
 				manifest.assets.has(filename) ||
 				manifest.assets.has(filename + '/index.html') ||
-				filename in manifest._.server_assets ||
-				filename + '/index.html' in manifest._.server_assets;
+				Object.hasOwn(manifest._.server_assets, filename) ||
+				Object.hasOwn(manifest._.server_assets, filename + '/index.html');
 		}
 
 		let location = pathname.at(-1) === '/' ? stripped_pathname : pathname + '/';

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -562,7 +562,7 @@ export async function dev(vite, vite_config, svelte_config, get_remotes) {
 						throw new Error('Could not determine clientAddress');
 					},
 					read: (file) => {
-						if (file in manifest._.server_assets) {
+						if (Object.hasOwn(manifest._.server_assets, file)) {
 							return fs.readFileSync(from_fs(file));
 						}
 

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -212,7 +212,7 @@ export async function preview(vite, vite_config, svelte_config) {
 						throw new Error('Could not determine clientAddress');
 					},
 					read: (file) => {
-						if (file in manifest._.server_assets) {
+						if (Object.hasOwn(manifest._.server_assets, file)) {
 							return fs.readFileSync(join(dir, file));
 						}
 

--- a/packages/kit/src/runtime/app/server/index.js
+++ b/packages/kit/src/runtime/app/server/index.js
@@ -58,7 +58,7 @@ export function read(asset) {
 		DEV && asset.startsWith('/@fs') ? asset : asset.slice(base.length + 1)
 	);
 
-	if (file in manifest._.server_assets) {
+	if (Object.hasOwn(manifest._.server_assets, file)) {
 		const length = manifest._.server_assets[file];
 		const type = manifest.mimeTypes[file.slice(file.lastIndexOf('.'))];
 

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -88,9 +88,11 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 				).slice(1);
 				const filename_html = `${filename}/index.html`; // path may also match path/index.html
 
-				const is_asset = manifest.assets.has(filename) || filename in manifest._.server_assets;
+				const is_asset =
+					manifest.assets.has(filename) || Object.hasOwn(manifest._.server_assets, filename);
 				const is_asset_html =
-					manifest.assets.has(filename_html) || filename_html in manifest._.server_assets;
+					manifest.assets.has(filename_html) ||
+					Object.hasOwn(manifest._.server_assets, filename_html);
 
 				if (is_asset || is_asset_html) {
 					const file = is_asset ? filename : filename_html;
@@ -103,7 +105,7 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 						return new Response(state.read(file), {
 							headers: type ? { 'content-type': type } : {}
 						});
-					} else if (read_implementation && file in manifest._.server_assets) {
+					} else if (read_implementation && Object.hasOwn(manifest._.server_assets, file)) {
 						const length = manifest._.server_assets[file];
 						const type = manifest.mimeTypes[file.slice(file.lastIndexOf('.'))];
 


### PR DESCRIPTION
### Goal

`manifest._.server_assets` is built in `packages/kit/src/core/generate_manifest/index.js` as a plain `const files = {}` and emitted via `JSON.stringify`, so at runtime it inherits from `Object.prototype`. **Six different sites** in this repo do membership tests against it with the bare `in` operator, which traverses the prototype chain and therefore reports `true` for any path matching an `Object.prototype` member name (`/constructor`, `/__proto__`, `/toString`, `/hasOwnProperty`, `/valueOf`, `/isPrototypeOf`, `/propertyIsEnumerable`, `/__defineGetter__`, etc.). All six sites should use `Object.hasOwn` to consult only own properties.

### Affected sites (all in this PR)

| File | Effect of the bug |
|---|---|
| `packages/adapter-cloudflare/src/worker.js` | Cloudflare-deployed app: prototype-name paths are dispatched to `env.ASSETS.fetch` instead of `server.respond`, bypassing dynamic routes and the `hooks.server.js` chain. Confirmed on a live Worker (results below). |
| `packages/kit/src/runtime/server/fetch.js` | Server-side `fetch()` shim: a `+server.js` calling `fetch('/<proto-name>')` mistakenly takes the asset branch instead of the dynamic one. |
| `packages/kit/src/runtime/app/server/index.js` | `$app/server` `read()`: passes through to `manifest._.server_assets[file]` for proto-name `file`s, which yields `undefined` and ultimately a confusing error. |
| `packages/kit/src/exports/vite/preview/index.js` | `vite preview` `read` callback. |
| `packages/kit/src/exports/vite/dev/index.js` | `vite dev` `read` callback. |

### Reproduction (Cloudflare adapter site)

I deployed `@sveltejs/adapter-cloudflare@7.2.8` to a Cloudflare Worker with a catch-all `[...path]/+server.js` that returns `{routed_by: 'DYNAMIC_HANDLER'}` and a `hooks.server.js` that adds `x-hooks-server-fired: true` to every server-routed response. Curl results:

| Path | Status | x-hooks-server-fired |
|---|---|---|
| `/dynamic-route` | 200 | true |
| `/some-test-path` | 200 | true |
| `/constructor` | 404 | (absent) |
| `/__proto__` | 404 | (absent) |
| `/toString` | 404 | (absent) |
| `/hasOwnProperty` | 404 | (absent) |
| `/valueOf` | 404 | (absent) |
| `/isPrototypeOf` | 404 | (absent) |
| `/propertyIsEnumerable` | 404 | (absent) |
| `/__defineGetter__` | 404 | (absent) |

The 404 + absent hooks header on the prototype-name paths confirms `worker.js` dispatched those requests to `env.ASSETS.fetch` (no static asset matches → 404) instead of routing them to the dynamic SvelteKit handler.

### Fix

The same one-line swap at every site:

```diff
- file in manifest._.server_assets
+ Object.hasOwn(manifest._.server_assets, file)
```

This preserves the semantics for all legitimate own keys (including assets named `__proto__` or `constructor` if anyone files such a thing — `JSON.parse('{"__proto__":1}')` correctly creates an own property and `Object.hasOwn` correctly detects it) while excluding the inherited prototype members.

### Alternatives considered

- Build the manifest table as `Object.create(null)` in `packages/kit/src/core/generate_manifest/index.js` and emit it as `Object.assign(Object.create(null), { ... })`. More invasive but a stronger structural guarantee.
- Replace the type with `Map<string, number>` and use `Map#has`. Even more invasive.

The `Object.hasOwn` swap is the smallest change, matches a precedent fix in `vercel/ai` (commit `4181cfe`), and keeps the type unchanged.

---

Before submitting the PR, please make sure you do the following:
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Tests: I have not added a test. Happy to add one if maintainers prefer; suggested location: a unit test for `is_static_asset`-like routing decisions in `packages/adapter-cloudflare` and a fetch-shim test in `packages/kit/test`.

### Changesets
- [x] Patch changeset for `@sveltejs/adapter-cloudflare` and `@sveltejs/kit`.

### Edits
- [x] 'Allow edits from maintainers' is checked.