### PR TITLE
fix: support `exactOptionalPropertyTypes` for optional route params

### DIFF
--- a/.changeset/few-penguins-grab.md
+++ b/.changeset/few-penguins-grab.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: support `exactOptionalPropertyTypes` for optional route params

--- a/packages/kit/src/core/sync/write_non_ambient.js
+++ b/packages/kit/src/core/sync/write_non_ambient.js
@@ -204,7 +204,7 @@ function generate_app_types(manifest_data, config) {
 		if (route.params.length > 0) {
 			const params = route.params.map((p) => {
 				const type = get_matcher_type(p.matcher);
-				return `${p.name}${p.optional ? '?:' : ':'} ${type}`;
+				return `${p.name}${p.optional ? '?:' : ':'} ${type}${p.optional ? ' | undefined' : ''}`;
 			});
 			const route_type = `${s(route.id)}: { ${params.join('; ')} }`;
 
@@ -225,7 +225,7 @@ function generate_app_types(manifest_data, config) {
 			const params = Array.from(layout_params)
 				.map(([name, { optional, matchers }]) => {
 					const type = get_matchers_type(matchers);
-					return `${name}${optional ? '?:' : ':'} ${type}`;
+					return `${name}${optional ? '?:' : ':'} ${type}${optional ? ' | undefined' : ''}`;
 				})
 				.join('; ');
 

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -609,7 +609,7 @@ function generate_params_type(params, outdir, config) {
 					param.matcher
 						? `MatcherParam<typeof import('${path_to_matcher(param.matcher)}').match>`
 						: 'string'
-				}`
+				}${param.optional ? ' | undefined' : ''}`
 		)
 		.join('; ')} }`;
 }

--- a/packages/kit/src/core/sync/write_types/test/app-types/+page.js
+++ b/packages/kit/src/core/sync/write_types/test/app-types/+page.js
@@ -35,18 +35,32 @@ noMatcherPageParams.locale = 'fr'; // any string
 /** @type {import('$app/types').RouteParams<'/matcher-test/with-matcher/[[locale=locale]]'>} */
 const withMatcherPageParams = {};
 
+/** @type {import('$app/types').RouteParams<'/matcher-test/with-matcher/[[locale=locale]]'>} */
+const withMatcherPageParamsWithUndefined = {
+	locale: undefined
+};
+
 // @ts-expect-error locale should be "en" or "nb"
 withMatcherPageParams.locale = 'fr';
+withMatcherPageParams.locale = undefined; // okay
 withMatcherPageParams.locale = 'en'; // okay
 withMatcherPageParams.locale = 'nb'; // okay
+withMatcherPageParamsWithUndefined.locale = 'en'; // okay
 
 /** @type {import('$app/types').LayoutParams<'/matcher-test/with-matcher'>} */
 const withMatcherLayoutParams = {};
 
+/** @type {import('$app/types').LayoutParams<'/matcher-test/with-matcher'>} */
+const withMatcherLayoutParamsWithUndefined = {
+	locale: undefined
+};
+
 // @ts-expect-error locale should be "en" or "nb"
 withMatcherLayoutParams.locale = 'fr';
+withMatcherLayoutParams.locale = undefined; // okay
 withMatcherLayoutParams.locale = 'en'; // okay
 withMatcherLayoutParams.locale = 'nb'; // okay
+withMatcherLayoutParamsWithUndefined.locale = 'nb'; // okay
 
 /** @type {import('$app/types').LayoutParams<'/matcher-test'>} */
 const matcherParentLayoutParams = {};

--- a/packages/kit/src/core/sync/write_types/test/app-types/tsconfig.json
+++ b/packages/kit/src/core/sync/write_types/test/app-types/tsconfig.json
@@ -2,7 +2,9 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
+		"exactOptionalPropertyTypes": true,
 		"noEmit": true,
+		"strictNullChecks": true,
 		"target": "es2022",
 		"module": "es2022",
 		"moduleResolution": "bundler",


### PR DESCRIPTION
Closes #15453

Updates generated route parameter types so optional params are emitted as `?: T | undefined` in both route-local `$types` and `$app/types`, which makes them compatible with TypeScript’s `exactOptionalPropertyTypes` setting without changing existing matcher constraints.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
