### PR TITLE
feat: Enable layout load functions to gate child routes

### DIFF
--- a/.changeset/dark-islands-obey.md
+++ b/.changeset/dark-islands-obey.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+Layout modules (+layout.js, +layout.server.js) can now export gate = true to block all descendant load functions from starting until the layout's own load resolves. Useful for auth guards and other layout-level checks that must complete before child data is fetched.

--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -403,6 +403,25 @@ In `+page.js` or `+layout.js` it will return data from parent `+layout.js` files
 
 Take care not to introduce waterfalls when using `await parent()`. Here, for example, `getData(params)` does not depend on the result of calling `parent()`, so we should call it first to avoid a delayed render.
 
+## Gate
+
+If you want all descendant `load` functions to wait for a layout's `load` to finish before they start — without requiring each child to call `await parent()` — you can export `gate = true` from the layout:
+
+```js
+/// file: +layout.server.js
+export const gate = true;
+
+/** @type {import('./$types').LayoutServerLoad} */
+export async function load({ locals }) {
+	if (!locals.user) redirect(307, '/login');
+	return { user: locals.user };
+}
+```
+
+With `gate = true`, all child `load` functions (both server and universal) will wait for the layout's `load` to resolve before starting. This is useful for auth guards and other checks that must complete before any child data is fetched, without forcing every child to explicitly call `await parent()`.
+
+`gate` can be exported from `+layout.js` or `+layout.server.js`. Multiple nested gates run sequentially — each gated layout waits for all gated ancestors above it to finish first.
+
 ```js
 /// file: +page.js
 // @filename: ambient.d.ts
@@ -711,7 +730,7 @@ To prevent data waterfalls and preserve layout `load` caches:
 - Use [hooks](hooks) to protect multiple routes before any `load` functions run
 - Use auth guards directly in `+page.server.js` `load` functions for route specific protection
 
-Putting an auth guard in `+layout.server.js` requires all child pages to call `await parent()` before protected code. Unless every child page depends on returned data from `await parent()`, the other options will be more performant.
+Putting an auth guard in `+layout.server.js` requires all child pages to call `await parent()` before protected code, unless you use [`gate`](#Loading-data-Gate) — which blocks all descendant loads from starting until the layout's `load` resolves, without requiring changes to each child.
 
 ## Using `getRequestEvent`
 

--- a/documentation/docs/20-core-concepts/40-page-options.md
+++ b/documentation/docs/20-core-concepts/40-page-options.md
@@ -221,6 +221,17 @@ export const config = {
 
 ...which results in the config value `{ runtime: 'edge', regions: ['us1', 'us2'], foo: { baz: true } }` for that page.
 
+## gate
+
+Exporting `gate = true` from a `+layout.js` or `+layout.server.js` causes all descendant `load` functions to wait for the layout's `load` to finish before they start. See [Gate](load#Loading-data-Gate) for details.
+
+```js
+/// file: +layout.server.js
+export const gate = true;
+```
+
+> [!NOTE] Unlike the other options, `gate` only applies to `+layout.js` and `+layout.server.js` — it is not valid on `+page.js` or `+page.server.js`.
+
 ## Further reading
 
 - [Tutorial: Page options](/tutorial/kit/page-options)

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -93,7 +93,8 @@ async function analyse({
 
 		metadata.nodes[node.index] = {
 			has_server_load: has_server_load(node),
-			has_universal_load: node.universal?.load !== undefined
+			has_universal_load: node.universal?.load !== undefined,
+			is_gate: !!(node.server?.gate || node.universal?.gate)
 		};
 	}
 

--- a/packages/kit/src/core/sync/write_client_manifest.js
+++ b/packages/kit/src/core/sync/write_client_manifest.js
@@ -55,6 +55,7 @@ export function write_client_manifest(kit, manifest_data, output, metadata) {
 		.join(',\n');
 
 	const layouts_with_server_load = new Set();
+	const layouts_with_gate = new Set();
 
 	let dictionary = dedent`
 		{
@@ -90,6 +91,10 @@ export function write_client_manifest(kit, manifest_data, output, metadata) {
 
 							let layout_has_server_load = false;
 
+							const layout_is_gate = metadata
+								? metadata[layout].is_gate
+								: !!manifest_data.nodes[layout].page_options?.gate;
+
 							if (metadata) {
 								layout_has_server_load = metadata[layout].has_server_load;
 							} else if (manifest_data.nodes[layout].server) {
@@ -98,6 +103,10 @@ export function write_client_manifest(kit, manifest_data, output, metadata) {
 
 							if (layout_has_server_load) {
 								layouts_with_server_load.add(layout);
+							}
+
+							if (layout_is_gate) {
+								layouts_with_gate.add(layout);
 							}
 						});
 
@@ -118,6 +127,10 @@ export function write_client_manifest(kit, manifest_data, output, metadata) {
 		const root_layout = layouts_with_server_load.has(0);
 		layouts_with_server_load.clear();
 		if (root_layout) layouts_with_server_load.add(0);
+
+		const root_layout_is_gate = layouts_with_gate.has(0);
+		layouts_with_gate.clear();
+		if (root_layout_is_gate) layouts_with_gate.add(0);
 	}
 
 	const client_hooks_file = resolve_entry(kit.files.hooks.client);
@@ -158,6 +171,8 @@ export function write_client_manifest(kit, manifest_data, output, metadata) {
 			];
 
 			export const server_loads = [${[...layouts_with_server_load].join(',')}];
+
+			export const gate_layouts = [${[...layouts_with_gate].join(',')}];
 
 			export const dictionary = ${dictionary};
 

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -168,10 +168,16 @@ export async function dev(vite, vite_config, svelte_config, get_remotes) {
 											pattern: route.pattern,
 											params: route.params,
 											layouts: route.page.layouts.map((l) =>
-												l !== undefined ? [!!manifest_data.nodes[l].server, l] : undefined
+												l !== undefined
+													? [
+															!!manifest_data.nodes[l].server,
+															!!manifest_data.nodes[l].page_options?.gate,
+															l
+														]
+													: undefined
 											),
 											errors: route.page.errors,
-											leaf: [!!manifest_data.nodes[route.page.leaf].server, route.page.leaf]
+											leaf: [!!manifest_data.nodes[route.page.leaf].server, false, route.page.leaf]
 										};
 									})
 								)

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1250,10 +1250,12 @@ async function kit({ svelte_config }) {
 									pattern: route.pattern,
 									params: route.params,
 									layouts: route.page.layouts.map((l) =>
-										l !== undefined ? [metadata.nodes[l].has_server_load, l] : undefined
+										l !== undefined
+											? [metadata.nodes[l].has_server_load, metadata.nodes[l].is_gate, l]
+											: undefined
 									),
 									errors: route.page.errors,
-									leaf: [metadata.nodes[route.page.leaf].has_server_load, route.page.leaf]
+									leaf: [metadata.nodes[route.page.leaf].has_server_load, false, route.page.leaf]
 								};
 							})
 						);

--- a/packages/kit/src/exports/vite/static_analysis/index.js
+++ b/packages/kit/src/exports/vite/static_analysis/index.js
@@ -9,7 +9,8 @@ const valid_page_options_array = /** @type {const} */ ([
 	'trailingSlash',
 	'config',
 	'entries',
-	'load'
+	'load',
+	'gate'
 ]);
 
 /** @type {Set<string>} */

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -645,9 +645,9 @@ async function _preload_code(url) {
 
 	if (route) {
 		await Promise.all(
-			/** @type {[has_server_load: boolean, node_loader: import('types').CSRPageNodeLoader][]} */ (
+			/** @type {[has_server_load: boolean, is_gate: boolean, node_loader: import('types').CSRPageNodeLoader][]} */ (
 				[...route.layouts, route.leaf].filter(Boolean)
-			).map((load) => load[1]())
+			).map((load) => load[2]())
 		);
 	}
 }
@@ -1166,7 +1166,7 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 	// so they don't get reported to Sentry et al (we don't need
 	// to act on the failures at this point)
 	errors.forEach((loader) => loader?.().catch(noop));
-	loaders.forEach((loader) => loader?.[1]().catch(noop));
+	loaders.forEach((loader) => loader?.[2]().catch(noop));
 
 	/** @type {import('types').ServerNodesResponse | import('types').ServerRedirectNode | null} */
 	let server_data = null;
@@ -1182,7 +1182,7 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 
 			const invalid =
 				!!loader?.[0] &&
-				(previous?.loader !== loader[1] ||
+				(previous?.loader !== loader[2] ||
 					has_changed(
 						parent_invalid,
 						route_changed,
@@ -1228,6 +1228,22 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 
 	let parent_changed = false;
 
+	// Pre-create deferred promises for gated layouts so we can await them inside
+	// the branch_promises map without hitting the TDZ of branch_promises itself.
+	/** @type {Array<{ promise: Promise<any>, resolve: (v: any) => void, reject: (e: any) => void } | null>} */
+	const gate_deferreds = loaders.map((loader) => {
+		if (!loader?.[1]) return null;
+		/** @type {(v: any) => void} */
+		let resolve = /** @type {any} */ (undefined);
+		/** @type {(e: any) => void} */
+		let reject = /** @type {any} */ (undefined);
+		const promise = new Promise((res, rej) => {
+			resolve = res;
+			reject = rej;
+		});
+		return { promise, resolve, reject };
+	});
+
 	const branch_promises = loaders.map(async (loader, i) => {
 		if (!loader) return;
 
@@ -1239,7 +1255,7 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 		// reuse data from previous load if it's still valid
 		const valid =
 			(!server_data_node || server_data_node.type === 'skip') &&
-			loader[1] === previous?.loader &&
+			loader[2] === previous?.loader &&
 			!has_changed(
 				parent_changed,
 				route_changed,
@@ -1257,25 +1273,43 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 			throw server_data_node;
 		}
 
-		return load_node({
-			loader: loader[1],
-			url,
-			params,
-			route,
-			parent: async () => {
-				const data = {};
-				for (let j = 0; j < i; j += 1) {
-					Object.assign(data, (await branch_promises[j])?.data);
-				}
-				return data;
-			},
-			server_data_node: create_data_node(
-				// server_data_node is undefined if it wasn't reloaded from the server;
-				// and if current loader uses server data, we want to reuse previous data.
-				server_data_node === undefined && loader[0] ? { type: 'skip' } : (server_data_node ?? null),
-				loader[0] ? previous?.server : undefined
-			)
-		});
+		// Wait for any gated ancestor to complete before starting this load.
+		// Uses gate_deferreds (pre-initialized) rather than branch_promises directly
+		// to avoid accessing branch_promises while it's still in the TDZ.
+		for (let j = 0; j < i; j += 1) {
+			const gd = gate_deferreds[j];
+			if (gd) await gd.promise;
+		}
+
+		let result;
+		try {
+			result = await load_node({
+				loader: loader[2],
+				url,
+				params,
+				route,
+				parent: async () => {
+					const data = {};
+					for (let j = 0; j < i; j += 1) {
+						Object.assign(data, (await branch_promises[j])?.data);
+					}
+					return data;
+				},
+				server_data_node: create_data_node(
+					// server_data_node is undefined if it wasn't reloaded from the server;
+					// and if current loader uses server data, we want to reuse previous data.
+					server_data_node === undefined && loader[0]
+						? { type: 'skip' }
+						: (server_data_node ?? null),
+					loader[0] ? previous?.server : undefined
+				)
+			});
+		} catch (e) {
+			gate_deferreds[i]?.reject(e);
+			throw e;
+		}
+		gate_deferreds[i]?.resolve(result);
+		return result;
 	});
 
 	// if we don't do this, rejections will be unhandled

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1269,7 +1269,10 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 				previous.universal?.uses,
 				params
 			);
-		if (valid) return previous;
+		if (valid) {
+			gate_deferreds[i]?.resolve(previous);
+			return previous;
+		}
 
 		parent_changed = true;
 

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -39,7 +39,7 @@ import {
 	SNAPSHOT_KEY,
 	PAGE_URL_KEY
 } from './constants.js';
-import { validate_page_exports } from '../../utils/exports.js';
+import { validate_layout_exports, validate_page_exports } from '../../utils/exports.js';
 import { noop } from '../../utils/functions.js';
 import { compact } from '../../utils/array.js';
 import {
@@ -865,10 +865,11 @@ async function get_navigation_result_from_branch({
  *   params: Record<string, string>;
  *   route: { id: string | null };
  * 	 server_data_node: import('./types.js').DataNode | null;
+ *   is_leaf?: boolean;
  * }} options
  * @returns {Promise<import('./types.js').BranchNode>}
  */
-async function load_node({ loader, parent, url, params, route, server_data_node }) {
+async function load_node({ loader, parent, url, params, route, server_data_node, is_leaf }) {
 	/** @type {Record<string, any> | null} */
 	let data = null;
 
@@ -887,7 +888,11 @@ async function load_node({ loader, parent, url, params, route, server_data_node 
 	const node = await loader();
 
 	if (DEV) {
-		validate_page_exports(node.universal);
+		if (is_leaf) {
+			validate_page_exports(node.universal);
+		} else {
+			validate_layout_exports(node.universal);
+		}
 
 		if (node.universal && app.hash) {
 			const options = Object.keys(node.universal).filter((o) => o !== 'load');
@@ -1288,6 +1293,7 @@ async function load_route({ id, invalidating, url, params, route, preload }) {
 				url,
 				params,
 				route,
+				is_leaf: i === loaders.length - 1,
 				parent: async () => {
 					const data = {};
 					for (let j = 0; j < i; j += 1) {
@@ -1475,6 +1481,7 @@ async function load_root_error_page({ status, error, url, route }) {
 			url,
 			params,
 			route,
+			is_leaf: false,
 			parent: () => Promise.resolve({}),
 			server_data_node: create_data_node(server_data_node)
 		});
@@ -2996,6 +3003,7 @@ async function _hydrate(
 				url,
 				params,
 				route,
+				is_leaf: i === node_ids.length - 1,
 				parent: async () => {
 					const data = {};
 					for (let j = 0; j < i; j += 1) {

--- a/packages/kit/src/runtime/client/parse.js
+++ b/packages/kit/src/runtime/client/parse.js
@@ -4,8 +4,9 @@ import { exec, parse_route_id } from '../../utils/routing.js';
  * @param {import('./types.js').SvelteKitApp} app
  * @returns {import('types').CSRRoute[]}
  */
-export function parse({ nodes, server_loads, dictionary, matchers }) {
+export function parse({ nodes, server_loads, gate_layouts, dictionary, matchers }) {
 	const layouts_with_server_load = new Set(server_loads);
+	const layouts_with_gate = new Set(gate_layouts);
 
 	return Object.entries(dictionary).map(([id, [leaf, layouts, errors]]) => {
 		const { pattern, params } = parse_route_id(id);
@@ -36,24 +37,26 @@ export function parse({ nodes, server_loads, dictionary, matchers }) {
 
 	/**
 	 * @param {number} id
-	 * @returns {[boolean, import('types').CSRPageNodeLoader]}
+	 * @returns {[boolean, boolean, import('types').CSRPageNodeLoader]}
 	 */
 	function create_leaf_loader(id) {
 		// whether or not the route uses the server data is
 		// encoded using the ones' complement, to save space
 		const uses_server_data = id < 0;
 		if (uses_server_data) id = ~id;
-		return [uses_server_data, nodes[id]];
+		return [uses_server_data, false, nodes[id]];
 	}
 
 	/**
 	 * @param {number | undefined} id
-	 * @returns {[boolean, import('types').CSRPageNodeLoader] | undefined}
+	 * @returns {[boolean, boolean, import('types').CSRPageNodeLoader] | undefined}
 	 */
 	function create_layout_loader(id) {
 		// whether or not the layout uses the server data is
 		// encoded in the layouts array, to save space
-		return id === undefined ? id : [layouts_with_server_load.has(id), nodes[id]];
+		return id === undefined
+			? id
+			: [layouts_with_server_load.has(id), layouts_with_gate.has(id), nodes[id]];
 	}
 }
 
@@ -71,7 +74,7 @@ export function parse_server_route({ nodes, id, leaf, layouts, errors }, app_nod
 		// Code elsewhere in client.js relies on this referential equality to determine
 		// if a loader is different and should therefore (re-)run.
 		errors: errors.map((n) => (n ? (app_nodes[n] ||= nodes[n]) : undefined)),
-		layouts: layouts.map((n) => (n ? [n[0], (app_nodes[n[1]] ||= nodes[n[1]])] : undefined)),
-		leaf: [leaf[0], (app_nodes[leaf[1]] ||= nodes[leaf[1]])]
+		layouts: layouts.map((n) => (n ? [n[0], n[1], (app_nodes[n[2]] ||= nodes[n[2]])] : undefined)),
+		leaf: [leaf[0], leaf[1], (app_nodes[leaf[2]] ||= nodes[leaf[2]])]
 	};
 }

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -29,6 +29,12 @@ export interface SvelteKitApp {
 	server_loads: number[];
 
 	/**
+	 * A list of all layout node ids that export `gate = true`.
+	 * Gates block descendant load functions and renders until they resolve.
+	 */
+	gate_layouts: number[];
+
+	/**
 	 * A map of `[routeId: string]: [leaf, layouts, errors]` tuples, which
 	 * is parsed into an array of routes on startup. The numbers refer to the indices in `nodes`.
 	 * If the leaf number is negative, it means it does use a server load function and the complement is the node index.

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -47,7 +47,13 @@ export async function render_data(
 
 		const new_event = { ...event, url };
 
-		const functions = node_ids.map((n, i) => {
+		// Pre-load all nodes in parallel to detect gate status before starting loads.
+		// Nodes are small cached JS modules so this is essentially free.
+		const loaded_nodes = await Promise.all(
+			node_ids.map((id) => (id == undefined ? Promise.resolve(null) : manifest._.nodes[id]()))
+		);
+
+		const functions = node_ids.map((_n, i) => {
 			return once(async () => {
 				try {
 					if (aborted) {
@@ -56,8 +62,15 @@ export async function render_data(
 						});
 					}
 
-					// == because it could be undefined (in dev) or null (in build, because of JSON.stringify)
-					const node = n == undefined ? n : await manifest._.nodes[n]();
+					const node = loaded_nodes[i] ?? undefined;
+
+					// Wait for any gated ancestor to finish before starting this load.
+					for (let j = 0; j < i; j += 1) {
+						if (loaded_nodes[j]?.server?.gate) {
+							await functions[j]();
+						}
+					}
+
 					// load this. for the child, return as is. for the final result, stream things
 					return load_server_data({
 						event: new_event,

--- a/packages/kit/src/runtime/server/page/index.js
+++ b/packages/kit/src/runtime/server/page/index.js
@@ -190,6 +190,13 @@ export async function render_page(
 						throw action_result.error;
 					}
 
+					// Wait for any gated ancestor server loads to complete before starting this one.
+					for (let j = 0; j < i; j += 1) {
+						if (nodes.data[j]?.server?.gate) {
+							await server_promises[j];
+						}
+					}
+
 					const server_data = await load_server_data({
 						event,
 						event_state,
@@ -225,6 +232,13 @@ export async function render_page(
 			if (load_error) throw load_error;
 			return Promise.resolve().then(async () => {
 				try {
+					// Wait for any gated ancestor loads to complete before starting this one.
+					for (let j = 0; j < i; j += 1) {
+						if (nodes.data[j]?.server?.gate || nodes.data[j]?.universal?.gate) {
+							await load_promises[j];
+						}
+					}
+
 					return await load_data({
 						event,
 						event_state,

--- a/packages/kit/src/runtime/server/page/server_routing.js
+++ b/packages/kit/src/runtime/server/page/server_routing.js
@@ -13,7 +13,7 @@ import { get_relative_path } from '../../utils.js';
 export function generate_route_object(route, url, manifest) {
 	const { errors, layouts, leaf } = route;
 
-	const nodes = [...errors, ...layouts.map((l) => l?.[1]), leaf[1]]
+	const nodes = [...errors, ...layouts.map((l) => l?.[2]), leaf[2]]
 		.filter((n) => typeof n === 'number')
 		.map((n) => `'${n}': () => ${create_client_import(manifest._.client.nodes?.[n], url)}`)
 		.join(',\n\t\t');
@@ -113,7 +113,7 @@ function create_css_import(route, url, manifest) {
 
 	let css = '';
 
-	for (const node of [...errors, ...layouts.map((l) => l?.[1]), leaf[1]]) {
+	for (const node of [...errors, ...layouts.map((l) => l?.[2]), leaf[2]]) {
 		if (typeof node !== 'number') continue;
 		const node_css = manifest._.client.css?.[node];
 		for (const css_path of node_css ?? []) {

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -123,14 +123,16 @@ export type CSRPageNodeLoader = () => Promise<CSRPageNode>;
 
 /**
  * Definition of a client side route.
- * The boolean in the tuples indicates whether the route has a server load.
+ * The booleans in the layout tuples indicate whether the route has a server load and whether it is a gate.
  */
 export type CSRRoute = {
 	id: string;
 	exec(path: string): undefined | Record<string, string>;
 	errors: Array<CSRPageNodeLoader | undefined>;
-	layouts: Array<[has_server_load: boolean, node_loader: CSRPageNodeLoader] | undefined>;
-	leaf: [has_server_load: boolean, node_loader: CSRPageNodeLoader];
+	layouts: Array<
+		[has_server_load: boolean, is_gate: boolean, node_loader: CSRPageNodeLoader] | undefined
+	>;
+	leaf: [has_server_load: boolean, is_gate: boolean, node_loader: CSRPageNodeLoader];
 };
 
 /**
@@ -139,8 +141,8 @@ export type CSRRoute = {
 export type CSRRouteServer = {
 	id: string;
 	errors: Array<number | undefined>;
-	layouts: Array<[has_server_load: boolean, node_id: number] | undefined>;
-	leaf: [has_server_load: boolean, node_id: number];
+	layouts: Array<[has_server_load: boolean, is_gate: boolean, node_id: number] | undefined>;
+	leaf: [has_server_load: boolean, is_gate: boolean, node_id: number];
 	nodes: Record<string, CSRPageNodeLoader>;
 };
 
@@ -406,6 +408,7 @@ export interface ServerMetadata {
 		/** Also `true` when using `trailingSlash`, because we need to do a server request in that case to get its value. */
 		has_server_load: boolean;
 		has_universal_load: boolean;
+		is_gate: boolean;
 	}>;
 	routes: Map<string, ServerMetadataRoute>;
 	/** For each hashed remote file, a map of export name -> { type, dynamic }, where `dynamic` is `false` for non-dynamic prerender functions */
@@ -443,6 +446,7 @@ export interface UniversalNode {
 	trailingSlash?: TrailingSlash;
 	config?: any;
 	entries?: PrerenderEntryGenerator;
+	gate?: boolean;
 }
 
 export interface ServerNode {
@@ -454,6 +458,7 @@ export interface ServerNode {
 	actions?: Actions;
 	config?: any;
 	entries?: PrerenderEntryGenerator;
+	gate?: boolean;
 }
 
 export interface SSRNode {
@@ -543,8 +548,8 @@ export interface SSRClientRoute {
 	pattern: RegExp;
 	params: RouteParam[];
 	errors: Array<number | undefined>;
-	layouts: Array<[has_server_load: boolean, node_id: number] | undefined>;
-	leaf: [has_server_load: boolean, node_id: number];
+	layouts: Array<[has_server_load: boolean, is_gate: boolean, node_id: number] | undefined>;
+	leaf: [has_server_load: boolean, is_gate: boolean, node_id: number];
 }
 
 export interface SSRState {

--- a/packages/kit/src/utils/exports.js
+++ b/packages/kit/src/utils/exports.js
@@ -60,7 +60,7 @@ function hint_for_supported_files(key, ext = '.js') {
 	}
 }
 
-const valid_layout_exports = new Set([
+const valid_shared_exports = new Set([
 	'load',
 	'prerender',
 	'csr',
@@ -68,9 +68,10 @@ const valid_layout_exports = new Set([
 	'trailingSlash',
 	'config'
 ]);
-const valid_page_exports = new Set([...valid_layout_exports, 'entries']);
-const valid_layout_server_exports = new Set([...valid_layout_exports]);
-const valid_page_server_exports = new Set([...valid_layout_server_exports, 'actions', 'entries']);
+const valid_layout_exports = new Set([...valid_shared_exports, 'gate']);
+const valid_page_exports = new Set([...valid_shared_exports, 'entries']);
+const valid_layout_server_exports = new Set([...valid_shared_exports, 'gate']);
+const valid_page_server_exports = new Set([...valid_shared_exports, 'actions', 'entries']);
 const valid_server_exports = new Set([
 	'GET',
 	'POST',

--- a/packages/kit/src/utils/exports.spec.js
+++ b/packages/kit/src/utils/exports.spec.js
@@ -30,7 +30,8 @@ test('validates +layout.js', () => {
 		csr: false,
 		ssr: false,
 		trailingSlash: false,
-		config: {}
+		config: {},
+		gate: true
 	});
 
 	validate_layout_exports({
@@ -41,7 +42,7 @@ test('validates +layout.js', () => {
 		validate_layout_exports({
 			answer: 42
 		});
-	}, "Invalid export 'answer' (valid exports are load, prerender, csr, ssr, trailingSlash, config, or anything with a '_' prefix)");
+	}, "Invalid export 'answer' (valid exports are load, prerender, csr, ssr, trailingSlash, config, gate, or anything with a '_' prefix)");
 
 	check_error(() => {
 		validate_layout_exports(
@@ -103,7 +104,8 @@ test('validates +layout.server.js', () => {
 		csr: false,
 		ssr: false,
 		trailingSlash: false,
-		config: {}
+		config: {},
+		gate: true
 	});
 
 	validate_layout_server_exports({
@@ -114,7 +116,7 @@ test('validates +layout.server.js', () => {
 		validate_layout_server_exports({
 			answer: 42
 		});
-	}, "Invalid export 'answer' (valid exports are load, prerender, csr, ssr, trailingSlash, config, or anything with a '_' prefix)");
+	}, "Invalid export 'answer' (valid exports are load, prerender, csr, ssr, trailingSlash, config, gate, or anything with a '_' prefix)");
 
 	check_error(() => {
 		validate_layout_exports(

--- a/packages/kit/test/apps/basics/src/routes/load/gate/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/gate/+page.svelte
@@ -1,0 +1,3 @@
+<a href="/load/gate/server">server gate</a>
+<a href="/load/gate/universal">universal gate</a>
+<a href="/load/gate/nested/inner">nested gate</a>

--- a/packages/kit/test/apps/basics/src/routes/load/gate/nested/+layout.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/gate/nested/+layout.server.js
@@ -1,0 +1,8 @@
+export const gate = true;
+
+/** @type {import('./$types').LayoutServerLoad} */
+export async function load({ locals }) {
+	await new Promise((r) => setTimeout(r, 20));
+	/** @type {any} */ (locals).outer_done = true;
+	return {};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/gate/nested/inner/+layout.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/gate/nested/inner/+layout.server.js
@@ -1,0 +1,10 @@
+export const gate = true;
+
+/** @type {import('./$types').LayoutServerLoad} */
+export async function load({ locals }) {
+	// outer gate must have finished before this runs
+	/** @type {any} */ (locals).inner_saw_outer = /** @type {any} */ (locals).outer_done === true;
+	await new Promise((r) => setTimeout(r, 10));
+	/** @type {any} */ (locals).inner_done = true;
+	return {};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/gate/nested/inner/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/gate/nested/inner/+page.server.js
@@ -1,0 +1,7 @@
+/** @type {import('./$types').PageServerLoad} */
+export async function load({ locals }) {
+	return {
+		inner_saw_outer: /** @type {any} */ (locals).inner_saw_outer === true,
+		page_saw_inner: /** @type {any} */ (locals).inner_done === true
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/gate/nested/inner/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/gate/nested/inner/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	let { data } = $props();
+</script>
+
+<p id="inner-saw-outer">{String(data.inner_saw_outer)}</p>
+<p id="page-saw-inner">{String(data.page_saw_inner)}</p>

--- a/packages/kit/test/apps/basics/src/routes/load/gate/redirect/+layout.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/gate/redirect/+layout.server.js
@@ -1,0 +1,11 @@
+import { redirect } from '@sveltejs/kit';
+
+export const gate = true;
+
+/** @type {import('./$types').LayoutServerLoad} */
+export async function load({ url }) {
+	if (!url.searchParams.has('authed')) {
+		redirect(303, '/load/gate/redirect?authed=1');
+	}
+	return {};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/gate/redirect/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/gate/redirect/+page.server.js
@@ -1,0 +1,5 @@
+/** @type {import('./$types').PageServerLoad} */
+export async function load({ locals }) {
+	/** @type {any} */ (locals).page_load_ran = true;
+	return { loaded: true };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/gate/redirect/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/gate/redirect/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { data } = $props();
+</script>
+
+<h1>{String(data.loaded)}</h1>

--- a/packages/kit/test/apps/basics/src/routes/load/gate/server/+layout.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/gate/server/+layout.server.js
@@ -1,0 +1,10 @@
+export const gate = true;
+
+/** @type {import('./$types').LayoutServerLoad} */
+export async function load({ locals }) {
+	// small delay to ensure the page load would see layout_done = false
+	// if it ran in parallel
+	await new Promise((r) => setTimeout(r, 20));
+	/** @type {any} */ (locals).gate_layout_done = true;
+	return { from_layout: 'layout_data' };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/gate/server/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/gate/server/+page.server.js
@@ -1,0 +1,6 @@
+/** @type {import('./$types').PageServerLoad} */
+export async function load({ locals }) {
+	return {
+		layout_was_done: /** @type {any} */ (locals).gate_layout_done === true
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/gate/server/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/gate/server/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { data } = $props();
+</script>
+
+<h1>{String(data.layout_was_done)}</h1>

--- a/packages/kit/test/apps/basics/src/routes/load/gate/universal/+layout.js
+++ b/packages/kit/test/apps/basics/src/routes/load/gate/universal/+layout.js
@@ -1,0 +1,7 @@
+export const gate = true;
+
+/** @type {import('./$types').LayoutLoad} */
+export async function load() {
+	await new Promise((r) => setTimeout(r, 20));
+	return { layout_seq: 1 };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/gate/universal/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/gate/universal/+page.js
@@ -1,0 +1,4 @@
+/** @type {import('./$types').PageLoad} */
+export async function load() {
+	return { from_page: 'page_data' };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/gate/universal/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/gate/universal/+page.svelte
@@ -3,3 +3,4 @@
 </script>
 
 <h1>{data.layout_seq}:{data.from_page}</h1>
+<a href="/load/gate">back</a>

--- a/packages/kit/test/apps/basics/src/routes/load/gate/universal/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/gate/universal/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { data } = $props();
+</script>
+
+<h1>{data.layout_seq}:{data.from_page}</h1>

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -413,6 +413,25 @@ test.describe('Load', () => {
 			}
 		});
 
+		test('cached universal gate does not hang descendant loads', async ({
+			page,
+			javaScriptEnabled,
+			clicknav
+		}) => {
+			if (!javaScriptEnabled) return;
+
+			// SSR load hydrates current.branch with the universal gate layout
+			await page.goto('/load/gate/universal');
+			expect(await page.textContent('h1')).toBe('1:page_data');
+
+			// Navigate away, then back via client-side nav.
+			// On the way back, the layout load is valid (cached) and returns early —
+			// gate_deferreds[i] must still be resolved or the page load hangs forever.
+			await clicknav('[href="/load/gate"]');
+			await clicknav('[href="/load/gate/universal"]');
+			expect(await page.textContent('h1')).toBe('1:page_data');
+		});
+
 		test('nested gates run sequentially', async ({ page, javaScriptEnabled, clicknav }) => {
 			await page.goto('/load/gate/nested/inner');
 			expect(await page.textContent('#inner-saw-outer')).toBe('true');

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -386,6 +386,53 @@ test.describe('Load', () => {
 		}
 	});
 
+	test.describe('gate', () => {
+		test('server gate blocks child load until layout resolves', async ({
+			page,
+			javaScriptEnabled,
+			clicknav
+		}) => {
+			await page.goto('/load/gate/server');
+			expect(await page.textContent('h1')).toBe('true');
+
+			if (javaScriptEnabled) {
+				await page.goto('/load/gate');
+				await clicknav('[href="/load/gate/server"]');
+				expect(await page.textContent('h1')).toBe('true');
+			}
+		});
+
+		test('universal gate renders correctly', async ({ page, javaScriptEnabled, clicknav }) => {
+			await page.goto('/load/gate/universal');
+			expect(await page.textContent('h1')).toBe('1:page_data');
+
+			if (javaScriptEnabled) {
+				await page.goto('/load/gate');
+				await clicknav('[href="/load/gate/universal"]');
+				expect(await page.textContent('h1')).toBe('1:page_data');
+			}
+		});
+
+		test('nested gates run sequentially', async ({ page, javaScriptEnabled, clicknav }) => {
+			await page.goto('/load/gate/nested/inner');
+			expect(await page.textContent('#inner-saw-outer')).toBe('true');
+			expect(await page.textContent('#page-saw-inner')).toBe('true');
+
+			if (javaScriptEnabled) {
+				await page.goto('/load/gate');
+				await clicknav('[href="/load/gate/nested/inner"]');
+				expect(await page.textContent('#inner-saw-outer')).toBe('true');
+				expect(await page.textContent('#page-saw-inner')).toBe('true');
+			}
+		});
+
+		test('gate redirects before child load runs', async ({ page }) => {
+			await page.goto('/load/gate/redirect');
+			expect(page.url()).toContain('authed=1');
+			expect(await page.textContent('h1')).toBe('true');
+		});
+	});
+
 	test('fetch accepts a Request object', async ({ page, clicknav }) => {
 		await page.goto('/load');
 		await clicknav('[href="/load/fetch-request"]');

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2696,6 +2696,7 @@ declare module '@sveltejs/kit' {
 		trailingSlash?: TrailingSlash;
 		config?: any;
 		entries?: PrerenderEntryGenerator;
+		gate?: boolean;
 	}
 
 	interface ServerNode {
@@ -2707,6 +2708,7 @@ declare module '@sveltejs/kit' {
 		actions?: Actions;
 		config?: any;
 		entries?: PrerenderEntryGenerator;
+		gate?: boolean;
 	}
 
 	interface SSRNode {
@@ -2766,8 +2768,8 @@ declare module '@sveltejs/kit' {
 		pattern: RegExp;
 		params: RouteParam[];
 		errors: Array<number | undefined>;
-		layouts: Array<[has_server_load: boolean, node_id: number] | undefined>;
-		leaf: [has_server_load: boolean, node_id: number];
+		layouts: Array<[has_server_load: boolean, is_gate: boolean, node_id: number] | undefined>;
+		leaf: [has_server_load: boolean, is_gate: boolean, node_id: number];
 	}
 
 	type ValidatedConfig = Config & {
@@ -2913,7 +2915,7 @@ declare module '@sveltejs/kit' {
 	export type NumericRange<TStart extends number, TEnd extends number> = Exclude<TEnd | LessThan<TEnd>, LessThan<TStart>>;
 	type ValidPageOption = (typeof valid_page_options_array)[number];
 	type PageOptions = Partial<Record<ValidPageOption, any>>;
-	const valid_page_options_array: readonly ["ssr", "prerender", "csr", "trailingSlash", "config", "entries", "load"];
+	const valid_page_options_array: readonly ["ssr", "prerender", "csr", "trailingSlash", "config", "entries", "load", "gate"];
 	export const VERSION: string;
 	class HttpError_1 {
 		


### PR DESCRIPTION
Adds a `gate` export to `+layout.js` and `+layout.server.js` that blocks
descendant load functions from starting until the layout's load resolves.
Nested gates chain sequentially.

fixes #15830

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
