### PR TITLE
breaking: move `adapter` to `vite.config.ts`

### DIFF
--- a/.changeset/tidy-toes-sort.md
+++ b/.changeset/tidy-toes-sort.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: move `adapter` option from `svelte.config.js` to the SvelteKit Vite plugin in `vite.config.js`

--- a/documentation/docs/25-build-and-deploy/20-adapters.md
+++ b/documentation/docs/25-build-and-deploy/20-adapters.md
@@ -16,33 +16,35 @@ Additional [community-provided adapters](/packages#sveltekit-adapters) exist for
 
 ## Using adapters
 
-Your adapter is specified in `svelte.config.js`:
+Your adapter is specified in `vite.config.js`:
 
 ```js
-/// file: svelte.config.js
+/// file: vite.config.js
 // @filename: ambient.d.ts
 declare module 'svelte-adapter-foo' {
-	const adapter: (opts: any) => import('@sveltejs/kit').Adapter;
+	const adapter: (opts?: any) => import('@sveltejs/kit').Adapter;
 	export default adapter;
 }
 
+// @errors: 2554
 // @filename: index.js
 // ---cut---
-import adapter from 'svelte-adapter-foo';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
++++import adapter from 'svelte-adapter-foo';+++
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter({
-			// adapter options go here
+export default defineConfig({
+	plugins: [
+		sveltekit({
+			+++adapter: adapter()+++
 		})
-	}
-};
-
-export default config;
+	]
+});
 ```
+
+> [!LEGACY]
+> The `adapter` option was moved to the SvelteKit Vite plugin in SvelteKit 3.0.0. In earlier versions, you had to add it to the `kit` property in the `svelte.config.js` file instead.
 
 ## Platform-specific context
 
 Some adapters may have access to additional information about the request. For example, Cloudflare Workers can access an `env` object containing KV namespaces etc. This can be passed to the `RequestEvent` used in [hooks](hooks) and [server routes](routing#server) as the `platform` property — consult each adapter's documentation to learn more.
-

--- a/documentation/docs/25-build-and-deploy/40-adapter-node.md
+++ b/documentation/docs/25-build-and-deploy/40-adapter-node.md
@@ -6,22 +6,22 @@ To generate a standalone Node server, use [`adapter-node`](https://github.com/sv
 
 ## Usage
 
-Install with `npm i -D @sveltejs/adapter-node`, then add the adapter to your `svelte.config.js`:
+Install with `npm i -D @sveltejs/adapter-node`, then add the adapter to your `vite.config.js`:
 
 ```js
-// @errors: 2307
-/// file: svelte.config.js
+// @errors: 2307 2554
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-node';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter()
-	}
-};
-
-export default config;
+export default defineConfig({
+	plugins: [sveltekit({ adapter: adapter() })]
+});
 ```
+
+> [!LEGACY]
+> The `adapter` option was moved to the SvelteKit Vite plugin in SvelteKit 3.0.0. In earlier versions, you had to add it to the `kit` property in the `svelte.config.js` file instead.
 
 ## Deploying
 
@@ -149,23 +149,24 @@ The number of seconds for [`keepAliveTimeout`](https://nodejs.org/api/http.html#
 The adapter can be configured with various options:
 
 ```js
-// @errors: 2307
-/// file: svelte.config.js
+// @errors: 2307 2554
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-node';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter({
-			// default options are shown
-			out: 'build',
-			precompress: true,
-			envPrefix: ''
-		})
-	}
-};
-
-export default config;
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+        // default options are shown
+        out: 'build',
+        precompress: true,
+        envPrefix: ''
+      })
+    })
+  ]
+});
 ```
 
 ### out

--- a/documentation/docs/25-build-and-deploy/40-adapter-node.md
+++ b/documentation/docs/25-build-and-deploy/40-adapter-node.md
@@ -156,16 +156,16 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  plugins: [
-    sveltekit({
-      adapter: adapter({
-        // default options are shown
-        out: 'build',
-        precompress: true,
-        envPrefix: ''
-      })
-    })
-  ]
+	plugins: [
+		sveltekit({
+			adapter: adapter({
+				// default options are shown
+				out: 'build',
+				precompress: true,
+				envPrefix: ''
+			})
+		})
+	]
 });
 ```
 
@@ -207,8 +207,8 @@ You can listen to the `sveltekit:shutdown` event which is emitted after the HTTP
 ```js
 // @errors: 2304
 process.on('sveltekit:shutdown', async (reason) => {
-  await jobs.stop();
-  await db.close();
+	await jobs.stop();
+	await db.close();
 });
 ```
 

--- a/documentation/docs/25-build-and-deploy/50-adapter-static.md
+++ b/documentation/docs/25-build-and-deploy/50-adapter-static.md
@@ -8,29 +8,30 @@ This will prerender your entire site as a collection of static files. If you'd l
 
 ## Usage
 
-Install with `npm i -D @sveltejs/adapter-static`, then add the adapter to your `svelte.config.js`:
+Install with `npm i -D @sveltejs/adapter-static`, then add the adapter to your `vite.config.js`:
 
 ```js
 // @errors: 2307
-/// file: svelte.config.js
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-static';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter({
-			// default options are shown. On some platforms
-			// these options are set automatically — see below
-			pages: 'build',
-			assets: 'build',
-			fallback: undefined,
-			precompress: false,
-			strict: true
-		})
-	}
-};
-
-export default config;
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+        // default options are shown. On some platforms
+        // these options are set automatically — see below
+        pages: 'build',
+        assets: 'build',
+        fallback: undefined,
+        precompress: false,
+        strict: true
+      })
+    })
+  ]
+});
 ```
 
 ...and add the [`prerender`](page-options#prerender) option to your root layout:
@@ -47,6 +48,9 @@ export const prerender = true;
 
 > [!NOTE] You must ensure SvelteKit's [`ssr`](page-options#ssr) option isn't set to `false`. Otherwise, prerendering will save an empty 'shell' page instead of the fully rendered content.
 
+> [!LEGACY]
+> The `adapter` option was moved to the SvelteKit Vite plugin in SvelteKit 3.0.0. In earlier versions, you had to add it to the `kit` property in the `svelte.config.js` file instead.
+
 ## Zero-config support
 
 Some platforms have zero-config support (more to come in future):
@@ -57,17 +61,18 @@ On these platforms, you should omit the adapter options so that `adapter-static`
 
 ```js
 // @errors: 2307
-/// file: svelte.config.js
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-static';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter(---{...}---)
-	}
-};
-
-export default config;
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter(---{...}---)
+    })
+  ]
+});
 ```
 
 ## Options
@@ -105,14 +110,9 @@ A config for GitHub Pages might look like the following:
 ```js
 // @errors: 2307 2322
 /// file: svelte.config.js
-import adapter from '@sveltejs/adapter-static';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter({
-			fallback: '404.html'
-		}),
 		paths: {
 			base: process.argv.includes('dev') ? '' : process.env.BASE_PATH
 		}
@@ -120,6 +120,24 @@ const config = {
 };
 
 export default config;
+```
+
+```js
+// @errors: 2307
+/// file: vite.config.js
+import adapter from '@sveltejs/adapter-static';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+        fallback: '404.html'
+      })
+    })
+  ]
+});
 ```
 
 You can use GitHub actions to automatically deploy your site to GitHub Pages when you make a change. Here's an example workflow:

--- a/documentation/docs/25-build-and-deploy/50-adapter-static.md
+++ b/documentation/docs/25-build-and-deploy/50-adapter-static.md
@@ -130,13 +130,13 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  plugins: [
-    sveltekit({
-      adapter: adapter({
-        fallback: '404.html'
-      })
-    })
-  ]
+	plugins: [
+		sveltekit({
+			adapter: adapter({
+				fallback: '404.html'
+			})
+		})
+	]
 });
 ```
 

--- a/documentation/docs/25-build-and-deploy/55-single-page-apps.md
+++ b/documentation/docs/25-build-and-deploy/55-single-page-apps.md
@@ -16,23 +16,24 @@ First, disable SSR for the pages you don't want to prerender. These pages will b
 export const ssr = false;
 ```
 
-If you don't have any server-side logic (i.e. `+page.server.js`, `+layout.server.js` or `+server.js` files) you can use [`adapter-static`](adapter-static) to create your SPA. Install `adapter-static` with `npm i -D @sveltejs/adapter-static` and add it to your `svelte.config.js` with the `fallback` option:
+If you don't have any server-side logic (i.e. `+page.server.js`, `+layout.server.js` or `+server.js` files) you can use [`adapter-static`](adapter-static) to create your SPA. Install `adapter-static` with `npm i -D @sveltejs/adapter-static` and add it to your `vite.config.js` with the `fallback` option:
 
 ```js
 // @errors: 2307
-/// file: svelte.config.js
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-static';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter({
-			fallback: '200.html' // may differ from host to host
-		})
-	}
-};
-
-export default config;
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+				fallback: '200.html' // may differ from host to host
+      })
+    })
+  ]
+});
 ```
 
 The `fallback` page is an HTML page created by SvelteKit from your page template (e.g. `app.html`) that loads your app and navigates to the correct route. For example [Surge](https://surge.sh/help/adding-a-200-page-for-client-side-routing), a static web host, lets you add a `200.html` file that will handle any requests that don't correspond to static assets or prerendered pages.
@@ -40,6 +41,9 @@ The `fallback` page is an HTML page created by SvelteKit from your page template
 On some hosts it may be something else entirely — consult your platform's documentation. We recommend avoiding `index.html` if possible as it may conflict with prerendering.
 
 > [!NOTE] Note that the fallback page will always contain absolute asset paths (i.e. beginning with `/` rather than `.`) regardless of the value of [`paths.relative`](configuration#paths), since it is used to respond to requests for arbitrary paths.
+
+> [!LEGACY]
+> The `adapter` option was moved to the SvelteKit Vite plugin in SvelteKit 3.0.0. In earlier versions, you had to add it to the `kit` property in the `svelte.config.js` file instead.
 
 ## Prerendering individual pages
 

--- a/documentation/docs/25-build-and-deploy/55-single-page-apps.md
+++ b/documentation/docs/25-build-and-deploy/55-single-page-apps.md
@@ -26,13 +26,13 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  plugins: [
-    sveltekit({
-      adapter: adapter({
+	plugins: [
+		sveltekit({
+			adapter: adapter({
 				fallback: '200.html' // may differ from host to host
-      })
-    })
-  ]
+			})
+		})
+	]
 });
 ```
 

--- a/documentation/docs/25-build-and-deploy/60-adapter-cloudflare.md
+++ b/documentation/docs/25-build-and-deploy/60-adapter-cloudflare.md
@@ -14,35 +14,39 @@ This adapter will be installed by default when you use [`adapter-auto`](adapter-
 
 ## Usage
 
-Install with `npm i -D @sveltejs/adapter-cloudflare`, then add the adapter to your `svelte.config.js`:
+Install with `npm i -D @sveltejs/adapter-cloudflare`, then add the adapter to your `vite.config.js`:
 
 ```js
 // @errors: 2307
-/// file: svelte.config.js
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-cloudflare';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter({
-			// See below for an explanation of these options
-			config: undefined,
-			platformProxy: {
-				configPath: undefined,
-				environment: undefined,
-				persist: undefined
-			},
-			fallback: 'plaintext',
-			routes: {
-				include: ['/*'],
-				exclude: ['<all>']
-			}
-		})
-	}
-};
-
-export default config;
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+				// See below for an explanation of these options
+				config: undefined,
+				platformProxy: {
+					configPath: undefined,
+					environment: undefined,
+					persist: undefined
+				},
+				fallback: 'plaintext',
+				routes: {
+					include: ['/*'],
+					exclude: ['<all>']
+				}
+      })
+    })
+  ]
+});
 ```
+
+> [!LEGACY]
+> The `adapter` option was moved to the SvelteKit Vite plugin in SvelteKit 3.0.0. In earlier versions, you had to add it to the `kit` property in the `svelte.config.js` file instead.
 
 ## Options
 
@@ -223,16 +227,31 @@ Cloudflare no longer recommends using [Workers Sites](https://developers.cloudfl
 // @errors: 2307
 /// file: svelte.config.js
 ---import adapter from '@sveltejs/adapter-cloudflare-workers';---
-+++import adapter from '@sveltejs/adapter-cloudflare';+++
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter()
+		---adapter: adapter()---
 	}
 };
 
 export default config;
+```
+
+```js
+// @errors: 2307
+/// file: vite.config.js
++++import adapter from '@sveltejs/adapter-cloudflare';+++
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      +++adapter: adapter()+++
+    })
+  ]
+});
 ```
 
 ### wrangler.toml

--- a/documentation/docs/25-build-and-deploy/60-adapter-cloudflare.md
+++ b/documentation/docs/25-build-and-deploy/60-adapter-cloudflare.md
@@ -24,9 +24,9 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  plugins: [
-    sveltekit({
-      adapter: adapter({
+	plugins: [
+		sveltekit({
+			adapter: adapter({
 				// See below for an explanation of these options
 				config: undefined,
 				platformProxy: {
@@ -39,9 +39,9 @@ export default defineConfig({
 					include: ['/*'],
 					exclude: ['<all>']
 				}
-      })
-    })
-  ]
+			})
+		})
+	]
 });
 ```
 
@@ -221,23 +221,6 @@ Alternatively, you can [prerender](page-options#prerender) the routes in questio
 
 Cloudflare no longer recommends using [Workers Sites](https://developers.cloudflare.com/workers/configuration/sites/configuration/) and instead recommends using [Workers Static Assets](https://developers.cloudflare.com/workers/static-assets/). To migrate, replace `@sveltejs/adapter-cloudflare-workers` with `@sveltejs/adapter-cloudflare` and remove all `site` configuration settings from your Wrangler configuration file, then add the `assets.directory` and `assets.binding` configuration settings:
 
-### svelte.config.js
-
-```js
-// @errors: 2307
-/// file: svelte.config.js
----import adapter from '@sveltejs/adapter-cloudflare-workers';---
-
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		---adapter: adapter()---
-	}
-};
-
-export default config;
-```
-
 ```js
 // @errors: 2307
 /// file: vite.config.js
@@ -246,11 +229,11 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  plugins: [
-    sveltekit({
-      +++adapter: adapter()+++
-    })
-  ]
+	plugins: [
+		sveltekit({
+			+++adapter: adapter()+++
+		})
+	]
 });
 ```
 

--- a/documentation/docs/25-build-and-deploy/80-adapter-netlify.md
+++ b/documentation/docs/25-build-and-deploy/80-adapter-netlify.md
@@ -8,31 +8,31 @@ This adapter will be installed by default when you use [`adapter-auto`](adapter-
 
 ## Usage
 
-Install with `npm i -D @sveltejs/adapter-netlify`, then add the adapter to your `svelte.config.js`:
+Install with `npm i -D @sveltejs/adapter-netlify`, then add the adapter to your `vite.config.js`:
 
 ```js
 // @errors: 2307
-/// file: svelte.config.js
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-netlify';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		// default options are shown
-		adapter: adapter({
-			// if true, will create a Netlify Edge Function rather
-			// than using standard Node-based functions
-			edge: false,
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+				// if true, will create a Netlify Edge Function rather
+				// than using standard Node-based functions
+				edge: false,
 
-			// if true, will split your app into multiple functions
-			// instead of creating a single one for the entire app.
-			// if `edge` is true, this option cannot be used
-			split: false
-		})
-	}
-};
-
-export default config;
+				// if true, will split your app into multiple functions
+				// instead of creating a single one for the entire app.
+				// if `edge` is true, this option cannot be used
+				split: false
+      })
+    })
+  ]
+});
 ```
 
 Then, make sure you have a [netlify.toml](https://docs.netlify.com/configure-builds/file-based-configuration) file in the project root. This will determine where to write static assets based on the `build.publish` settings, as per this sample configuration:
@@ -45,6 +45,9 @@ Then, make sure you have a [netlify.toml](https://docs.netlify.com/configure-bui
 
 If the `netlify.toml` file or the `build.publish` value is missing, a default value of `"build"` will be used. Note that if you have set the publish directory in the Netlify UI to something else then you will need to set it in `netlify.toml` too, or use the default value of `"build"`.
 
+> [!LEGACY]
+> The `adapter` option was moved to the SvelteKit Vite plugin in SvelteKit 3.0.0. In earlier versions, you had to add it to the `kit` property in the `svelte.config.js` file instead.
+
 ### Node version
 
 New projects will use the current Node LTS version by default. However, if you're upgrading a project you created a while ago it may be stuck on an older version. See [the Netlify docs](https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-and-javascript) for details on manually specifying a current Node version.
@@ -55,21 +58,22 @@ SvelteKit supports [Netlify Edge Functions](https://docs.netlify.com/build/edge-
 
 ```js
 // @errors: 2307
-/// file: svelte.config.js
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-netlify';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter({
-			// will create a Netlify Edge Function using Deno-based
-			// rather than using standard Node-based functions
-			edge: true
-		})
-	}
-};
-
-export default config;
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+				// will create a Netlify Edge Function using Deno-based
+				// rather than using standard Node-based functions
+				edge: true
+      })
+    })
+  ]
+});
 ```
 
 ## Netlify alternatives to SvelteKit functionality

--- a/documentation/docs/25-build-and-deploy/80-adapter-netlify.md
+++ b/documentation/docs/25-build-and-deploy/80-adapter-netlify.md
@@ -18,9 +18,9 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  plugins: [
-    sveltekit({
-      adapter: adapter({
+	plugins: [
+		sveltekit({
+			adapter: adapter({
 				// if true, will create a Netlify Edge Function rather
 				// than using standard Node-based functions
 				edge: false,
@@ -29,9 +29,9 @@ export default defineConfig({
 				// instead of creating a single one for the entire app.
 				// if `edge` is true, this option cannot be used
 				split: false
-      })
-    })
-  ]
+			})
+		})
+	]
 });
 ```
 
@@ -64,15 +64,15 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  plugins: [
-    sveltekit({
-      adapter: adapter({
+	plugins: [
+		sveltekit({
+			adapter: adapter({
 				// will create a Netlify Edge Function using Deno-based
 				// rather than using standard Node-based functions
 				edge: true
-      })
-    })
-  ]
+			})
+		})
+	]
 });
 ```
 

--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -8,23 +8,28 @@ This adapter will be installed by default when you use [`adapter-auto`](adapter-
 
 ## Usage
 
-Install with `npm i -D @sveltejs/adapter-vercel`, then add the adapter to your `svelte.config.js`:
+Install with `npm i -D @sveltejs/adapter-vercel`, then add the adapter to your `vite.config.js`:
 
 ```js
-/// file: svelte.config.js
+// @errors: 2554
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-vercel';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter({
-			// see below for options that can be set here
-		})
-	}
-};
-
-export default config;
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+				// see below for options that can be set here
+      })
+    })
+  ]
+});
 ```
+
+> [!LEGACY]
+> The `adapter` option was moved to the SvelteKit Vite plugin in SvelteKit 3.0.0. In earlier versions, you had to add it to the `kit` property in the `svelte.config.js` file instead.
 
 ## Deployment configuration
 
@@ -64,24 +69,26 @@ If your functions need to access data in a specific region, it's recommended tha
 You may set the `images` config to control how Vercel builds your images. See the [image configuration reference](https://vercel.com/docs/build-output-api/v3/configuration#images) for full details. As an example, you may set:
 
 ```js
-/// file: svelte.config.js
+// @errors: 2554
+/// file: vite.config.js
 import adapter from '@sveltejs/adapter-vercel';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		adapter: adapter({
-			images: {
-				sizes: [640, 828, 1200, 1920, 3840],
-				formats: ['image/avif', 'image/webp'],
-				minimumCacheTTL: 300,
-				domains: ['example-app.vercel.app'],
-			}
-		})
-	}
-};
-
-export default config;
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      adapter: adapter({
+				images: {
+					sizes: [640, 828, 1200, 1920, 3840],
+					formats: ['image/avif', 'image/webp'],
+					minimumCacheTTL: 300,
+					domains: ['example-app.vercel.app'],
+				}
+      })
+    })
+  ]
+});
 ```
 
 ## Incremental Static Regeneration

--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -18,13 +18,13 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  plugins: [
-    sveltekit({
-      adapter: adapter({
+	plugins: [
+		sveltekit({
+			adapter: adapter({
 				// see below for options that can be set here
-      })
-    })
-  ]
+			})
+		})
+	]
 });
 ```
 
@@ -76,18 +76,18 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  plugins: [
-    sveltekit({
-      adapter: adapter({
+	plugins: [
+		sveltekit({
+			adapter: adapter({
 				images: {
 					sizes: [640, 828, 1200, 1920, 3840],
 					formats: ['image/avif', 'image/webp'],
 					minimumCacheTTL: 300,
 					domains: ['example-app.vercel.app'],
 				}
-      })
-    })
-  ]
+			})
+		})
+	]
 });
 ```
 

--- a/documentation/docs/40-best-practices/07-images.md
+++ b/documentation/docs/40-best-practices/07-images.md
@@ -39,14 +39,17 @@ npm i -D @sveltejs/enhanced-img
 Adjust `vite.config.js`:
 
 ```js
-import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '@sveltejs/adapter-node';
 +++import { enhancedImages } from '@sveltejs/enhanced-img';+++
+import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
 	plugins: [
 		+++enhancedImages(), // must come before the SvelteKit plugin+++
-		sveltekit()
+		sveltekit({
+			adapter: adapter()
+		})
 	]
 });
 ```

--- a/documentation/docs/40-best-practices/07-images.md
+++ b/documentation/docs/40-best-practices/07-images.md
@@ -39,7 +39,6 @@ npm i -D @sveltejs/enhanced-img
 Adjust `vite.config.js`:
 
 ```js
-import adapter from '@sveltejs/adapter-node';
 +++import { enhancedImages } from '@sveltejs/enhanced-img';+++
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
@@ -47,9 +46,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
 	plugins: [
 		+++enhancedImages(), // must come before the SvelteKit plugin+++
-		sveltekit({
-			adapter: adapter()
-		})
+		sveltekit({/* ... */})
 	]
 });
 ```

--- a/documentation/docs/60-appendix/10-faq.md
+++ b/documentation/docs/60-appendix/10-faq.md
@@ -151,13 +151,16 @@ export function GET({ params, url }) {
 
 ## How do I use middleware?
 
-`adapter-node` builds a middleware that you can use with your own server for production mode. In dev, you can add middleware to Vite by using a Vite plugin. For example:
+`@sveltejs/adapter-node` builds a middleware that you can use with your own server for production mode. In dev, you can add middleware to Vite by using a Vite plugin. For example:
 
 ```js
+// @errors: 2307
 /// file: vite.config.js
+import adapter from '@sveltejs/adapter-node';
 import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
 
-/** @type {import('vite').Plugin} */
++++/** @type {import('vite').Plugin} */
 const myPlugin = {
 	name: 'log-request-middleware',
 	configureServer(server) {
@@ -166,14 +169,16 @@ const myPlugin = {
 			next();
 		});
 	}
-};
+};+++
 
-/** @type {import('vite').UserConfig} */
-const config = {
-	plugins: [myPlugin, sveltekit()]
-};
-
-export default config;
+export default defineConfig({
+	plugins: [
+		+++myPlugin,+++
+		sveltekit({
+			adapter: adapter()
+		})
+	]
+});
 ```
 
 See [Vite's `configureServer` docs](https://vitejs.dev/guide/api-plugin.html#configureserver) for more details including how to control ordering.

--- a/documentation/docs/98-reference/50-configuration.md
+++ b/documentation/docs/98-reference/50-configuration.md
@@ -6,25 +6,16 @@ Your project's configuration lives in a `svelte.config.js` file at the root of y
 
 ```js
 /// file: svelte.config.js
-// @filename: ambient.d.ts
-declare module '@sveltejs/adapter-auto' {
-	const plugin: () => import('@sveltejs/kit').Adapter;
-	export default plugin;
-}
-
-// @filename: index.js
-// ---cut---
-import adapter from '@sveltejs/adapter-auto';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter()
-	}
+	kit: { }
 };
 
 export default config;
 ```
+
+> [!LEGACY]
+> The `adapter` option was moved to the SvelteKit Vite plugin in SvelteKit 3.0.0. In earlier versions, you had to add it to the `kit` property in the `svelte.config.js` file instead.
 
 ## Config
 

--- a/documentation/docs/98-reference/50-configuration.md
+++ b/documentation/docs/98-reference/50-configuration.md
@@ -8,7 +8,7 @@ Your project's configuration lives in a `svelte.config.js` file at the root of y
 /// file: svelte.config.js
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: { }
+	kit: {}
 };
 
 export default config;

--- a/packages/adapter-cloudflare/test/apps/pages/svelte.config.js
+++ b/packages/adapter-cloudflare/test/apps/pages/svelte.config.js
@@ -1,10 +1,6 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter()
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/adapter-cloudflare/test/apps/pages/vite.config.js
+++ b/packages/adapter-cloudflare/test/apps/pages/vite.config.js
@@ -1,11 +1,12 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
 	build: {
 		minify: false
 	},
-	plugins: [sveltekit()]
+	plugins: [sveltekit({ adapter: adapter() })]
 };
 
 export default config;

--- a/packages/adapter-cloudflare/test/apps/workers/svelte.config.js
+++ b/packages/adapter-cloudflare/test/apps/workers/svelte.config.js
@@ -1,12 +1,6 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter({
-			config: 'config/wrangler.jsonc'
-		})
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/adapter-cloudflare/test/apps/workers/vite.config.js
+++ b/packages/adapter-cloudflare/test/apps/workers/vite.config.js
@@ -1,11 +1,18 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
 	build: {
 		minify: false
 	},
-	plugins: [sveltekit()]
+	plugins: [
+		sveltekit({
+			adapter: adapter({
+				config: 'config/wrangler.jsonc'
+			})
+		})
+	]
 };
 
 export default config;

--- a/packages/adapter-netlify/test/apps/basic/svelte.config.js
+++ b/packages/adapter-netlify/test/apps/basic/svelte.config.js
@@ -1,10 +1,6 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter()
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/adapter-netlify/test/apps/basic/vite.config.ts
+++ b/packages/adapter-netlify/test/apps/basic/vite.config.ts
@@ -1,11 +1,16 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import type { UserConfig } from 'vite';
+import adapter from '../../../index.js';
 
 const config: UserConfig = {
 	build: {
 		minify: false
 	},
-	plugins: [sveltekit()]
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	]
 };
 
 export default config;

--- a/packages/adapter-netlify/test/apps/edge/svelte.config.js
+++ b/packages/adapter-netlify/test/apps/edge/svelte.config.js
@@ -1,12 +1,6 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter({
-			edge: true
-		})
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/adapter-netlify/test/apps/edge/vite.config.ts
+++ b/packages/adapter-netlify/test/apps/edge/vite.config.ts
@@ -1,11 +1,18 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import type { UserConfig } from 'vite';
+import adapter from '../../../index.js';
 
 const config: UserConfig = {
 	build: {
 		minify: false
 	},
-	plugins: [sveltekit()]
+	plugins: [
+		sveltekit({
+			adapter: adapter({
+				edge: true
+			})
+		})
+	]
 };
 
 export default config;

--- a/packages/adapter-netlify/test/apps/instrumentation/svelte.config.js
+++ b/packages/adapter-netlify/test/apps/instrumentation/svelte.config.js
@@ -1,9 +1,6 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter(),
 		experimental: {
 			instrumentation: {
 				server: true

--- a/packages/adapter-netlify/test/apps/instrumentation/vite.config.ts
+++ b/packages/adapter-netlify/test/apps/instrumentation/vite.config.ts
@@ -1,11 +1,16 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import type { UserConfig } from 'vite';
+import adapter from '../../../index.js';
 
 const config: UserConfig = {
 	build: {
 		minify: false
 	},
-	plugins: [sveltekit()]
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	]
 };
 
 export default config;

--- a/packages/adapter-netlify/test/apps/split/svelte.config.js
+++ b/packages/adapter-netlify/test/apps/split/svelte.config.js
@@ -1,10 +1,7 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	compilerOptions: { experimental: { async: true } },
 	kit: {
-		adapter: adapter({ split: true }),
 		experimental: {
 			remoteFunctions: true
 		}

--- a/packages/adapter-netlify/test/apps/split/vite.config.ts
+++ b/packages/adapter-netlify/test/apps/split/vite.config.ts
@@ -1,11 +1,16 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import type { UserConfig } from 'vite';
+import adapter from '../../../index.js';
 
 const config: UserConfig = {
 	build: {
 		minify: false
 	},
-	plugins: [sveltekit()]
+	plugins: [
+		sveltekit({
+			adapter: adapter({ split: true })
+		})
+	]
 };
 
 export default config;

--- a/packages/adapter-static/test/apps/prerendered/svelte.config.js
+++ b/packages/adapter-static/test/apps/prerendered/svelte.config.js
@@ -1,10 +1,6 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter()
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/adapter-static/test/apps/prerendered/vite.config.js
+++ b/packages/adapter-static/test/apps/prerendered/vite.config.js
@@ -1,11 +1,16 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
 	build: {
 		minify: false
 	},
-	plugins: [sveltekit()]
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	]
 };
 
 export default config;

--- a/packages/adapter-static/test/apps/spa/svelte.config.js
+++ b/packages/adapter-static/test/apps/spa/svelte.config.js
@@ -1,12 +1,6 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter({
-			fallback: '200.html'
-		})
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/adapter-static/test/apps/spa/vite.config.js
+++ b/packages/adapter-static/test/apps/spa/vite.config.js
@@ -1,11 +1,18 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
 	build: {
 		minify: false
 	},
-	plugins: [sveltekit()]
+	plugins: [
+		sveltekit({
+			adapter: adapter({
+				fallback: '200.html'
+			})
+		})
+	]
 };
 
 export default config;

--- a/packages/adapter-vercel/test/apps/basic/svelte.config.js
+++ b/packages/adapter-vercel/test/apps/basic/svelte.config.js
@@ -1,10 +1,6 @@
-import adapter from '../../../index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter()
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/adapter-vercel/test/apps/basic/vite.config.ts
+++ b/packages/adapter-vercel/test/apps/basic/vite.config.ts
@@ -1,6 +1,11 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
+import adapter from '../../../index.js';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	]
 });

--- a/packages/kit/src/core/adapt/index.js
+++ b/packages/kit/src/core/adapt/index.js
@@ -1,7 +1,9 @@
+/** @import { Adapter } from '@sveltejs/kit' */
 import { styleText } from 'node:util';
 import { create_builder } from './builder.js';
 
 /**
+ * @param {Adapter} adapter
  * @param {import('types').ValidatedConfig} config
  * @param {import('types').BuildData} build_data
  * @param {import('types').ServerMetadata} server_metadata
@@ -12,6 +14,7 @@ import { create_builder } from './builder.js';
  * @param {import('vite').ResolvedConfig} vite_config
  */
 export async function adapt(
+	adapter,
 	config,
 	build_data,
 	server_metadata,
@@ -21,8 +24,7 @@ export async function adapt(
 	remotes,
 	vite_config
 ) {
-	// This is only called when adapter is truthy, so the cast is safe
-	const { name, adapt } = /** @type {import('@sveltejs/kit').Adapter} */ (config.kit.adapter);
+	const { name, adapt } = adapter;
 
 	console.log(styleText(['bold', 'cyan'], `\n> Using ${name}`));
 

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -55,7 +55,6 @@ const directive_defaults = {
 const get_defaults = (prefix = '') => ({
 	extensions: ['.svelte'],
 	kit: {
-		adapter: null,
 		alias: {},
 		appDir: '_app',
 		csp: {

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -1,6 +1,7 @@
 /** @import { Validator } from './types.js' */
 
 import process from 'node:process';
+import { dedent } from '../sync/utils.js';
 
 const directives = object({
 	'child-src': string_array(),
@@ -58,19 +59,18 @@ const options = object(
 		}),
 
 		kit: object({
-			adapter: validate(null, (input, keypath) => {
-				if (typeof input !== 'object' || !input.adapt) {
-					let message = `${keypath} should be an object with an "adapt" method`;
+			adapter: removed((keypath) => {
+				return dedent`
+						${keypath} has been removed. Instead, pass your adapter to the \`sveltekit\` Vite plugin in the \`vite.config.js\` file. For example:
 
-					if (Array.isArray(input) || typeof input === 'string') {
-						// for the early adapter adopters
-						message += ', rather than the name of an adapter';
-					}
+						import { defineConfig } from 'vite';
+						import { sveltekit } from '@sveltejs/kit/vite';
+						+++import adapter from '@sveltejs/adapter-auto';+++
 
-					throw new Error(`${message}. See https://svelte.dev/docs/kit/adapters`);
-				}
-
-				return input;
+						export default defineConfig({
+						  plugins: [sveltekit(+++{ adapter: adapter() }+++)]
+						});
+					`;
 			}),
 
 			alias: validate({}, (input, keypath) => {
@@ -356,7 +356,7 @@ function removed(
  * @param {boolean} [allow_unknown]
  * @returns {Validator}
  */
-function object(children, allow_unknown = false) {
+export function object(children, allow_unknown = false) {
 	return (input, keypath) => {
 		/** @type {Record<string, any>} */
 		const output = {};
@@ -396,7 +396,7 @@ function object(children, allow_unknown = false) {
  * @param {(value: any, keypath: string) => any} fn
  * @returns {Validator}
  */
-function validate(fallback, fn) {
+export function validate(fallback, fn) {
 	return (input, keypath) => {
 		return input === undefined ? fallback : fn(input, keypath);
 	};

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -65,10 +65,10 @@ const options = object(
 
 						import { defineConfig } from 'vite';
 						import { sveltekit } from '@sveltejs/kit/vite';
-						+++import adapter from '@sveltejs/adapter-auto';+++
+						import adapter from '@sveltejs/adapter-auto';
 
 						export default defineConfig({
-						  plugins: [sveltekit(+++{ adapter: adapter() }+++)]
+							plugins: [sveltekit({ adapter: adapter() })]
 						});
 					`;
 			}),

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -1,6 +1,8 @@
+/** @import { Adapter } from '@sveltejs/kit' */
 /** @import { RemoteChunk } from 'types' */
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { resolveConfig } from 'vite';
 import { validate_server_exports } from '../../utils/exports.js';
 import { load_config } from '../config/index.js';
 import { forked } from '../../utils/fork.js';
@@ -45,6 +47,12 @@ async function analyse({
 
 	/** @type {import('types').ValidatedKitConfig} */
 	const config = (await load_config({ cwd: root })).kit;
+
+	const vite_config = await resolveConfig({}, 'build');
+	/** @type {Adapter | undefined} */
+	const adapter = vite_config.plugins.find(
+		(plugin) => plugin.name === 'vite-plugin-sveltekit-adapter'
+	)?.api?.adapter;
 
 	const server_root = join(config.outDir, 'output');
 
@@ -141,7 +149,7 @@ async function analyse({
 				server_manifest,
 				tracked_features
 			)) {
-				check_feature(route.id, route_config, feature, config.adapter);
+				check_feature(route.id, route_config, feature, adapter);
 			}
 		}
 

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -1,6 +1,8 @@
+/** @import { Adapter } from '@sveltejs/kit' */
 import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { resolveConfig } from 'vite';
 import { mkdirp, posixify, walk } from '../../utils/filesystem.js';
 import { noop } from '../../utils/functions.js';
 import { decode_uri, is_root_relative, resolve } from '../../utils/url.js';
@@ -121,7 +123,13 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env, roo
 		return { prerendered, prerender_map };
 	}
 
-	const emulator = await config.adapter?.emulate?.();
+	const vite_config = await resolveConfig({}, 'build');
+	/** @type {Adapter | undefined} */
+	const adapter = vite_config.plugins.find(
+		(plugin) => plugin.name === 'vite-plugin-sveltekit-adapter'
+	)?.api?.adapter;
+
+	const emulator = await adapter?.emulate?.();
 
 	/** @type {import('types').Logger} */
 	const log = logger({ verbose });

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -321,9 +321,11 @@ export interface Emulator {
 }
 
 export interface KitConfig {
+	// TODO: remove this in 4.0
 	/**
 	 * Your [adapter](https://svelte.dev/docs/kit/adapters) is run when executing `vite build`. It determines how the output is converted for different platforms.
 	 * @default undefined
+	 * @deprecated removed in 3.0.0. Adapters should now be passed to the `sveltekit` Vite plugin in `vite.config.js`
 	 */
 	adapter?: Adapter;
 	/**
@@ -907,6 +909,15 @@ export interface KitConfig {
 		 */
 		pollInterval?: number;
 	};
+}
+
+export interface KitViteConfig {
+	/**
+	 * Your [adapter](https://svelte.dev/docs/kit/adapters) is run when executing `vite build`. It determines how the output is converted for different platforms.
+	 * @since 3.0.0
+	 * @default undefined
+	 */
+	adapter?: Adapter;
 }
 
 /**

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -29,9 +29,10 @@ const vite_css_query_regex = /(?:\?|&)(?:raw|url|inline)(?:&|$)/;
  * @param {import('types').ValidatedConfig} svelte_config
  * @param {() => Array<{ hash: string, file: string }>} get_remotes
  * @param {string} root The project root directory
+ * @param {import('@sveltejs/kit').Adapter | undefined} adapter
  * @return {Promise<Promise<() => void>>}
  */
-export async function dev(vite, vite_config, svelte_config, get_remotes, root) {
+export async function dev(vite, vite_config, svelte_config, get_remotes, root, adapter) {
 	/** @type {AsyncLocalStorage<{ event: RequestEvent, config: any, prerender: PrerenderOption }>} */
 	const async_local_storage = new AsyncLocalStorage();
 
@@ -39,12 +40,7 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root) {
 		const context = async_local_storage.getStore();
 		if (!context || context.prerender === true) return;
 
-		check_feature(
-			/** @type {string} */ (context.event.route.id),
-			context.config,
-			label,
-			svelte_config.kit.adapter
-		);
+		check_feature(/** @type {string} */ (context.event.route.id), context.config, label, adapter);
 	};
 
 	const fetch = globalThis.fetch;
@@ -438,7 +434,7 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root) {
 	});
 
 	const env = loadEnv(vite_config.mode, svelte_config.kit.env.dir, '');
-	const emulator = await svelte_config.kit.adapter?.emulate?.();
+	const emulator = await adapter?.emulate?.();
 
 	return () => {
 		const serve_static_middleware = vite.middlewares.stack.find(

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1288,7 +1288,7 @@ function kit({ svelte_config, adapter }) {
 		 * @see https://vitejs.dev/guide/api-plugin.html#configureserver
 		 */
 		async configureServer(vite) {
-			return await dev(vite, vite_config, svelte_config, () => remotes, root);
+			return await dev(vite, vite_config, svelte_config, () => remotes, root, adapter);
 		},
 
 		/**
@@ -1296,7 +1296,7 @@ function kit({ svelte_config, adapter }) {
 		 * @see https://vitejs.dev/guide/api-plugin.html#configurepreviewserver
 		 */
 		configurePreviewServer(vite) {
-			return preview(vite, vite_config, svelte_config);
+			return preview(vite, vite_config, svelte_config, adapter);
 		},
 
 		renderChunk(code, chunk) {
@@ -1651,13 +1651,24 @@ function kit({ svelte_config, adapter }) {
 		}
 	};
 
+	/** @type {Plugin} */
+	const plugin_adapter = {
+		name: 'vite-plugin-sveltekit-adapter',
+		// expose the adapter so that forked processes (e.g. prerendering)
+		// can retrieve it by resolving the Vite config
+		api: {
+			adapter
+		}
+	};
+
 	return [
 		plugin_setup,
 		plugin_remote,
 		plugin_virtual_modules,
 		process.env.TEST !== 'true' ? plugin_guard : undefined,
 		plugin_service_worker,
-		plugin_compile
+		plugin_compile,
+		plugin_adapter
 	].filter((p) => !!p);
 }
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1654,6 +1654,7 @@ function kit({ svelte_config, adapter }) {
 	/** @type {Plugin} */
 	const plugin_adapter = {
 		name: 'vite-plugin-sveltekit-adapter',
+		apply: 'build',
 		// expose the adapter so that forked processes (e.g. prerendering)
 		// can retrieve it by resolving the Vite config
 		api: {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1,3 +1,4 @@
+/** @import { Adapter, KitViteConfig } from '@sveltejs/kit' */
 /** @import { Options } from '@sveltejs/vite-plugin-svelte' */
 /** @import { PreprocessorGroup } from 'svelte/compiler' */
 /** @import { ConfigEnv, Plugin, ResolvedConfig, UserConfig, ViteDevServer } from 'vite' */
@@ -47,6 +48,7 @@ import { compact } from '../../utils/array.js';
 import { should_ignore, has_children } from './static_analysis/utils.js';
 import { load_config } from '../../core/config/index.js';
 import { treeshake_prerendered_remotes } from './build/remote.js';
+import options from './options.js';
 
 const cwd = process.cwd();
 
@@ -140,9 +142,13 @@ let vite_plugin_svelte;
 
 /**
  * Returns the SvelteKit Vite plugins.
+ * @param {KitViteConfig} [config]
  * @returns {Promise<Plugin[]>}
  */
-export async function sveltekit() {
+export async function sveltekit(config) {
+	/** @type {KitViteConfig} */
+	const validated = options(config, 'options');
+
 	// the config options will be set only after the Vite `config` hook runs
 	// because we need to find `svelte.config.js` relative to `vite.config.root`
 	const svelte_config = /** @type {import('types').ValidatedConfig} */ ({});
@@ -159,7 +165,7 @@ export async function sveltekit() {
 	return [
 		plugin_svelte_config({ vite_plugin_svelte_options, svelte_config }),
 		...vite_plugin_svelte.svelte(vite_plugin_svelte_options),
-		...kit({ svelte_config })
+		...kit({ svelte_config, adapter: validated.adapter })
 	];
 }
 
@@ -228,10 +234,12 @@ function plugin_svelte_config({ vite_plugin_svelte_options, svelte_config }) {
  * - https://rolldown.rs/apis/plugin-api#build-hooks
  * - https://rolldown.rs/apis/plugin-api#output-generation-hooks
  *
- * @param {{ svelte_config: import('types').ValidatedConfig }} options
+ * @param {object} opts
+ * @param {import('types').ValidatedConfig} opts.svelte_config options are only resolved after the Vite `config` hook runs
+ * @param {Adapter | undefined} opts.adapter
  * @return {import('vite').Plugin[]}
  */
-function kit({ svelte_config }) {
+function kit({ svelte_config, adapter }) {
 	/** @type {typeof import('vite')} */
 	let vite;
 
@@ -431,7 +439,7 @@ function kit({ svelte_config }) {
 				if (is_build) {
 					new_config.define = {
 						...define,
-						__SVELTEKIT_ADAPTER_NAME__: s(kit.adapter?.name),
+						__SVELTEKIT_ADAPTER_NAME__: s(adapter?.name),
 						__SVELTEKIT_APP_VERSION_FILE__: s(`${kit.appDir}/version.json`),
 						__SVELTEKIT_APP_VERSION_POLL_INTERVAL__: s(kit.version.pollInterval)
 					};
@@ -1067,7 +1075,6 @@ function kit({ svelte_config }) {
 						path.join(kit.files.src, 'instrumentation.server')
 					);
 					if (server_instrumentation) {
-						const { adapter } = kit;
 						if (adapter && !adapter.supports?.instrumentation?.()) {
 							throw new Error(`${server_instrumentation} is unsupported in ${adapter.name}.`);
 						}
@@ -1620,9 +1627,10 @@ function kit({ svelte_config }) {
 				`\nRun ${styleText(['bold', 'cyan'], 'npm run preview')} to preview your production build locally.`
 			);
 
-			if (kit.adapter) {
+			if (adapter) {
 				const { adapt } = await import('../../core/adapt/index.js');
 				await adapt(
+					adapter,
 					svelte_config,
 					build_data,
 					metadata,

--- a/packages/kit/src/exports/vite/options.js
+++ b/packages/kit/src/exports/vite/options.js
@@ -6,7 +6,7 @@ import { object, validate } from '../../core/config/options.js';
 const options = object({
 	adapter: validate(undefined, (input, keypath) => {
 		if (typeof input !== 'object' || !input.adapt) {
-			const message = `The SvelteKit Vite plugin ${keypath} should be an object with an "adapt" method`;
+			const message = `The SvelteKit Vite plugin ${keypath} should be an object with an \`adapt\` method`;
 			throw new Error(`${message}. See https://svelte.dev/docs/kit/adapters`);
 		}
 

--- a/packages/kit/src/exports/vite/options.js
+++ b/packages/kit/src/exports/vite/options.js
@@ -1,0 +1,17 @@
+/** @import { Validator } from '../../core/config/types.js' */
+
+import { object, validate } from '../../core/config/options.js';
+
+/** @type {Validator} */
+const options = object({
+	adapter: validate(undefined, (input, keypath) => {
+		if (typeof input !== 'object' || !input.adapt) {
+			const message = `The SvelteKit Vite plugin ${keypath} should be an object with an "adapt" method`;
+			throw new Error(`${message}. See https://svelte.dev/docs/kit/adapters`);
+		}
+
+		return input;
+	})
+});
+
+export default options;

--- a/packages/kit/src/exports/vite/preview/index.js
+++ b/packages/kit/src/exports/vite/preview/index.js
@@ -16,8 +16,9 @@ import { is_chrome_devtools_request, not_found } from '../utils.js';
  * @param {import('vite').PreviewServer} vite
  * @param {import('vite').ResolvedConfig} vite_config
  * @param {import('types').ValidatedConfig} svelte_config
+ * @param {import('@sveltejs/kit').Adapter | undefined} adapter
  */
-export async function preview(vite, vite_config, svelte_config) {
+export async function preview(vite, vite_config, svelte_config, adapter) {
 	const { paths } = svelte_config.kit;
 	const base = paths.base;
 	const assets = paths.assets ? SVELTE_KIT_ASSETS : paths.base;
@@ -53,7 +54,7 @@ export async function preview(vite, vite_config, svelte_config) {
 		read: (file) => createReadableStream(`${dir}/${file}`)
 	});
 
-	const emulator = await svelte_config.kit.adapter?.emulate?.();
+	const emulator = await adapter?.emulate?.();
 
 	return () => {
 		// Remove the base middleware. It screws with the URL.

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -589,6 +589,7 @@ export type ValidatedConfig = Config & {
 	extensions: string[];
 };
 
+// TODO: remove the omit in 4.0
 export type ValidatedKitConfig = Omit<RecursiveRequired<KitConfig>, 'adapter'>;
 
 export type BinaryFormMeta = {

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -589,9 +589,7 @@ export type ValidatedConfig = Config & {
 	extensions: string[];
 };
 
-export type ValidatedKitConfig = Omit<RecursiveRequired<KitConfig>, 'adapter'> & {
-	adapter?: Adapter;
-};
+export type ValidatedKitConfig = Omit<RecursiveRequired<KitConfig>, 'adapter'>;
 
 export type BinaryFormMeta = {
 	remote_refreshes?: string[];

--- a/packages/kit/test/apps/basics/svelte.config.js
+++ b/packages/kit/test/apps/basics/svelte.config.js
@@ -3,30 +3,6 @@ import process from 'node:process';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: {
-			name: 'test-adapter',
-			adapt(builder) {
-				builder.instrument({
-					entrypoint: `${builder.getServerDirectory()}/index.js`,
-					instrumentation: `${builder.getServerDirectory()}/instrumentation.server.js`,
-					module: {
-						exports: ['Server']
-					}
-				});
-			},
-			emulate() {
-				return {
-					platform({ config, prerender }) {
-						return { config, prerender };
-					}
-				};
-			},
-			supports: {
-				read: () => true,
-				instrumentation: () => true
-			}
-		},
-
 		experimental: {
 			remoteFunctions: true,
 			tracing: {

--- a/packages/kit/test/apps/basics/vite.config.js
+++ b/packages/kit/test/apps/basics/vite.config.js
@@ -13,7 +13,33 @@ export default defineConfig({
 		// the reload confuses Playwright
 		include: ['cookie']
 	},
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit({
+			adapter: {
+				name: 'test-adapter',
+				adapt(builder) {
+					builder.instrument({
+						entrypoint: `${builder.getServerDirectory()}/index.js`,
+						instrumentation: `${builder.getServerDirectory()}/instrumentation.server.js`,
+						module: {
+							exports: ['Server']
+						}
+					});
+				},
+				emulate() {
+					return {
+						platform({ config, prerender }) {
+							return { config, prerender };
+						}
+					};
+				},
+				supports: {
+					read: () => true,
+					instrumentation: () => true
+				}
+			}
+		})
+	],
 	server: {
 		fs: {
 			allow: [path.resolve('../../../src')]

--- a/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/svelte.config.js
+++ b/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/svelte.config.js
@@ -1,10 +1,6 @@
-import adapter from '../../../../../adapter-auto/index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter()
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/vite.config.js
+++ b/packages/kit/test/build-errors/apps/prerender-entry-generator-mismatch/vite.config.js
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../../../adapter-auto/index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
@@ -11,7 +12,11 @@ const config = {
 
 	logLevel: 'silent',
 
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	],
 
 	server: {
 		fs: {

--- a/packages/kit/test/build-errors/apps/prerender-remote-function-error/svelte.config.js
+++ b/packages/kit/test/build-errors/apps/prerender-remote-function-error/svelte.config.js
@@ -1,10 +1,6 @@
-import adapter from '../../../../../adapter-auto/index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter(),
-
 		experimental: {
 			remoteFunctions: true
 		}

--- a/packages/kit/test/build-errors/apps/prerender-remote-function-error/vite.config.js
+++ b/packages/kit/test/build-errors/apps/prerender-remote-function-error/vite.config.js
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../../../adapter-auto/index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
@@ -11,7 +12,11 @@ const config = {
 
 	logLevel: 'silent',
 
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	],
 
 	server: {
 		fs: {

--- a/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/svelte.config.js
+++ b/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/svelte.config.js
@@ -1,10 +1,6 @@
-import adapter from '../../../../../adapter-auto/index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter()
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/vite.config.js
+++ b/packages/kit/test/build-errors/apps/prerenderable-incorrect-fragment/vite.config.js
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../../../adapter-auto/index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
@@ -11,7 +12,11 @@ const config = {
 
 	logLevel: 'silent',
 
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	],
 
 	server: {
 		fs: {

--- a/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/svelte.config.js
+++ b/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/svelte.config.js
@@ -1,10 +1,6 @@
-import adapter from '../../../../../adapter-auto/index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter()
-	}
+	kit: {}
 };
 
 export default config;

--- a/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/vite.config.js
+++ b/packages/kit/test/build-errors/apps/prerenderable-not-prerendered/vite.config.js
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../../../adapter-auto/index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
@@ -11,7 +12,11 @@ const config = {
 
 	logLevel: 'silent',
 
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	],
 
 	server: {
 		fs: {

--- a/packages/kit/test/prerendering/basics/svelte.config.js
+++ b/packages/kit/test/prerendering/basics/svelte.config.js
@@ -1,11 +1,8 @@
-import adapter from '../../../../adapter-static/index.js';
 import { writeFileSync } from 'node:fs';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter(),
-
 		prerender: {
 			handleHttpError: 'warn',
 			origin: 'http://prerender.origin',

--- a/packages/kit/test/prerendering/basics/vite.config.js
+++ b/packages/kit/test/prerendering/basics/vite.config.js
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../../adapter-static/index.js';
 
 /** @type {import('vitest/config').ViteUserConfig} */
 const config = {
@@ -11,7 +12,11 @@ const config = {
 
 	logLevel: 'silent',
 
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	],
 
 	define: {
 		'process.env.MY_ENV': '"MY_ENV DEFINED"'

--- a/packages/kit/test/prerendering/options/svelte.config.js
+++ b/packages/kit/test/prerendering/options/svelte.config.js
@@ -1,5 +1,3 @@
-import adapter from '../../../../adapter-static/index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	compilerOptions: {
@@ -9,10 +7,6 @@ const config = {
 	},
 
 	kit: {
-		adapter: adapter({
-			fallback: '200.html'
-		}),
-
 		csp: {
 			directives: {
 				'script-src': ['self']

--- a/packages/kit/test/prerendering/options/vite.config.js
+++ b/packages/kit/test/prerendering/options/vite.config.js
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../../adapter-static/index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
@@ -11,7 +12,13 @@ const config = {
 
 	logLevel: 'silent',
 
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit({
+			adapter: adapter({
+				fallback: '200.html'
+			})
+		})
+	],
 
 	server: {
 		fs: {

--- a/packages/kit/test/prerendering/paths-base/svelte.config.js
+++ b/packages/kit/test/prerendering/paths-base/svelte.config.js
@@ -1,10 +1,6 @@
-import adapter from '../../../../adapter-static/index.js';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		adapter: adapter(),
-
 		paths: {
 			base: '/path-base',
 			relative: false

--- a/packages/kit/test/prerendering/paths-base/vite.config.js
+++ b/packages/kit/test/prerendering/paths-base/vite.config.js
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { sveltekit } from '@sveltejs/kit/vite';
+import adapter from '../../../../adapter-static/index.js';
 
 /** @type {import('vite').UserConfig} */
 const config = {
@@ -13,7 +14,11 @@ const config = {
 
 	logLevel: 'silent',
 
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit({
+			adapter: adapter()
+		})
+	],
 
 	server: {
 		fs: {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2747,6 +2747,7 @@ declare module '@sveltejs/kit' {
 		extensions: string[];
 	};
 
+	// TODO: remove the omit in 4.0
 	type ValidatedKitConfig = Omit<RecursiveRequired<KitConfig>, 'adapter'>;
 	/**
 	 * Throws an error with a HTTP status code and an optional message.

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -295,9 +295,11 @@ declare module '@sveltejs/kit' {
 	}
 
 	export interface KitConfig {
+		// TODO: remove this in 4.0
 		/**
 		 * Your [adapter](https://svelte.dev/docs/kit/adapters) is run when executing `vite build`. It determines how the output is converted for different platforms.
 		 * @default undefined
+		 * @deprecated removed in 3.0.0. Adapters should now be passed to the `sveltekit` Vite plugin in `vite.config.js`
 		 */
 		adapter?: Adapter;
 		/**
@@ -881,6 +883,15 @@ declare module '@sveltejs/kit' {
 			 */
 			pollInterval?: number;
 		};
+	}
+
+	export interface KitViteConfig {
+		/**
+		 * Your [adapter](https://svelte.dev/docs/kit/adapters) is run when executing `vite build`. It determines how the output is converted for different platforms.
+		 * @since 3.0.0
+		 * @default undefined
+		 */
+		adapter?: Adapter;
 	}
 
 	/**
@@ -2736,9 +2747,7 @@ declare module '@sveltejs/kit' {
 		extensions: string[];
 	};
 
-	type ValidatedKitConfig = Omit<RecursiveRequired<KitConfig>, 'adapter'> & {
-		adapter?: Adapter;
-	};
+	type ValidatedKitConfig = Omit<RecursiveRequired<KitConfig>, 'adapter'>;
 	/**
 	 * Throws an error with a HTTP status code and an optional message.
 	 * When called during request handling, this will cause SvelteKit to
@@ -2977,11 +2986,12 @@ declare module '@sveltejs/kit/node' {
 }
 
 declare module '@sveltejs/kit/vite' {
+	import type { KitViteConfig } from '@sveltejs/kit';
 	import type { Plugin } from 'vite';
 	/**
 	 * Returns the SvelteKit Vite plugins.
 	 * */
-	export function sveltekit(): Promise<Plugin[]>;
+	export function sveltekit(config?: KitViteConfig): Promise<Plugin[]>;
 
 	export {};
 }

--- a/playgrounds/basic/svelte.config.js
+++ b/playgrounds/basic/svelte.config.js
@@ -1,5 +1,3 @@
-import adapter from '@sveltejs/adapter-node';
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	compilerOptions: {
@@ -9,7 +7,6 @@ const config = {
 	},
 
 	kit: {
-		adapter: adapter(),
 		experimental: {
 			remoteFunctions: true
 		}

--- a/playgrounds/basic/vite.config.js
+++ b/playgrounds/basic/vite.config.js
@@ -1,8 +1,9 @@
+import adapter from '@sveltejs/adapter-node';
 import { enhancedImages } from '@sveltejs/enhanced-img';
 import { sveltekit } from '@sveltejs/kit/vite';
 
 export default {
-	plugins: [enhancedImages(), sveltekit()],
+	plugins: [enhancedImages(), sveltekit({ adapter: adapter() })],
 	server: {
 		fs: {
 			allow: ['../../packages/kit']


### PR DESCRIPTION
#15574 has become somewhat overwhelming; thought I might experiment with extracting some of the changes into more manageable PRs that are useful independently of the env API stuff.

This PR moves the `adapter` option from `svelte.config.js` to `vite.config.ts`. This is valuable in its own right, since it makes it possible for adapters to include their own Vite plugins, without the need to awkwardly hack around the timing of config resolution (for example, you could imagine an adapter providing platform-specific routes in dev/preview). That part isn't implemented in this PR though, that can be a follow-up — for now, it just moves the option.

Draft because I had Opus do the work, and I haven't yet looked closely at the diff (either against `version-3`, or against `fetchable-dev-environment`)