### PR TITLE
chore: replace `als.enterWith` with `als.run`

### DIFF
--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -568,8 +568,10 @@ export async function dev(vite, vite_config, svelte_config, get_remotes) {
 
 						return fs.readFileSync(path.join(svelte_config.kit.files.assets, file));
 					},
-					before_handle: (event, config, prerender) => {
-						async_local_storage.enterWith({ event, config, prerender });
+					before_handle: async (event, config, prerender, handle) => {
+						// we need to use .run because .enterWith() is not supported in Cloudflare Workers
+						// see https://blog.cloudflare.com/workers-node-js-asynclocalstorage/
+						return await async_local_storage.run({ event, config, prerender }, handle);
 					},
 					emulator
 				});

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -40,8 +40,6 @@ import { get_remote_id, handle_remote_call } from './remote.js';
 import { record_span } from '../telemetry/record_span.js';
 import { otel } from '../telemetry/otel.js';
 
-/* global __SVELTEKIT_ADAPTER_NAME__ */
-
 /** @type {import('types').RequiredResolveOptions['transformPageChunk']} */
 const default_transform = ({ html }) => html;
 
@@ -393,131 +391,141 @@ export async function internal_respond(request, options, manifest, state) {
 					prerender = page_nodes.prerender();
 				}
 
-				if (state.before_handle) {
-					state.before_handle(event, config, prerender);
-				}
-
 				if (state.emulator?.platform) {
 					event.platform = await state.emulator.platform({ config, prerender });
 				}
+
+				if (state.before_handle) {
+					return await state.before_handle(event, config, prerender, handle);
+				}
 			}
 		}
 
-		set_trailing_slash(trailing_slash);
+		async function handle() {
+			set_trailing_slash(trailing_slash);
 
-		if (state.prerendering && !state.prerendering.fallback && !state.prerendering.inside_reroute) {
-			disable_search(url);
-		}
+			if (
+				state.prerendering &&
+				!state.prerendering.fallback &&
+				!state.prerendering.inside_reroute
+			) {
+				disable_search(url);
+			}
 
-		const response = await record_span({
-			name: 'sveltekit.handle.root',
-			attributes: {
-				'http.route': event.route.id || 'unknown',
-				'http.method': event.request.method,
-				'http.url': event.url.href,
-				'sveltekit.is_data_request': is_data_request,
-				'sveltekit.is_sub_request': event.isSubRequest
-			},
-			fn: async (root_span) => {
-				const traced_event = {
-					...event,
-					tracing: {
-						enabled: __SVELTEKIT_SERVER_TRACING_ENABLED__,
-						root: root_span,
-						current: root_span
-					}
-				};
-
-				return await with_request_store({ event: traced_event, state: event_state }, () =>
-					options.hooks.handle({
-						event: traced_event,
-						resolve: (event, opts) => {
-							return record_span({
-								name: 'sveltekit.resolve',
-								attributes: {
-									'http.route': event.route.id || 'unknown'
-								},
-								fn: (resolve_span) => {
-									// counter-intuitively, we need to clear the event, so that it's not
-									// e.g. accessible when loading modules needed to handle the request
-									return with_request_store(null, () =>
-										resolve(merge_tracing(event, resolve_span), page_nodes, opts).then(
-											(response) => {
-												// add headers/cookies here, rather than inside `resolve`, so that we
-												// can do it once for all responses instead of once per `return`
-												for (const key in headers) {
-													const value = headers[key];
-													response.headers.set(key, /** @type {string} */ (value));
-												}
-
-												add_cookies_to_headers(response.headers, new_cookies.values());
-
-												if (state.prerendering && event.route.id !== null) {
-													response.headers.set('x-sveltekit-routeid', encodeURI(event.route.id));
-												}
-
-												resolve_span.setAttributes({
-													'http.response.status_code': response.status,
-													'http.response.body.size':
-														response.headers.get('content-length') || 'unknown'
-												});
-
-												return response;
-											}
-										)
-									);
-								}
-							});
+			const response = await record_span({
+				name: 'sveltekit.handle.root',
+				attributes: {
+					'http.route': event.route.id || 'unknown',
+					'http.method': event.request.method,
+					'http.url': event.url.href,
+					'sveltekit.is_data_request': is_data_request,
+					'sveltekit.is_sub_request': event.isSubRequest
+				},
+				fn: async (root_span) => {
+					const traced_event = {
+						...event,
+						tracing: {
+							enabled: __SVELTEKIT_SERVER_TRACING_ENABLED__,
+							root: root_span,
+							current: root_span
 						}
-					})
-				);
-			}
-		});
+					};
 
-		// respond with 304 if etag matches
-		if (response.status === 200 && response.headers.has('etag')) {
-			let if_none_match_value = request.headers.get('if-none-match');
+					return await with_request_store({ event: traced_event, state: event_state }, () =>
+						options.hooks.handle({
+							event: traced_event,
+							resolve: (event, opts) => {
+								return record_span({
+									name: 'sveltekit.resolve',
+									attributes: {
+										'http.route': event.route.id || 'unknown'
+									},
+									fn: (resolve_span) => {
+										// counter-intuitively, we need to clear the event, so that it's not
+										// e.g. accessible when loading modules needed to handle the request
+										return with_request_store(null, () =>
+											resolve(merge_tracing(event, resolve_span), page_nodes, opts).then(
+												(response) => {
+													// add headers/cookies here, rather than inside `resolve`, so that we
+													// can do it once for all responses instead of once per `return`
+													for (const key in headers) {
+														const value = headers[key];
+														response.headers.set(key, /** @type {string} */ (value));
+													}
 
-			// ignore W/ prefix https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match#directives
-			if (if_none_match_value?.startsWith('W/"')) {
-				if_none_match_value = if_none_match_value.substring(2);
-			}
+													add_cookies_to_headers(response.headers, new_cookies.values());
 
-			const etag = /** @type {string} */ (response.headers.get('etag'));
+													if (state.prerendering && event.route.id !== null) {
+														response.headers.set('x-sveltekit-routeid', encodeURI(event.route.id));
+													}
 
-			if (if_none_match_value === etag) {
-				const headers = new Headers({ etag });
+													resolve_span.setAttributes({
+														'http.response.status_code': response.status,
+														'http.response.body.size':
+															response.headers.get('content-length') || 'unknown'
+													});
 
-				// https://datatracker.ietf.org/doc/html/rfc7232#section-4.1 + set-cookie
-				for (const key of [
-					'cache-control',
-					'content-location',
-					'date',
-					'expires',
-					'vary',
-					'set-cookie'
-				]) {
-					const value = response.headers.get(key);
-					if (value) headers.set(key, value);
+													return response;
+												}
+											)
+										);
+									}
+								});
+							}
+						})
+					);
+				}
+			});
+
+			// respond with 304 if etag matches
+			if (response.status === 200 && response.headers.has('etag')) {
+				let if_none_match_value = request.headers.get('if-none-match');
+
+				// ignore W/ prefix https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match#directives
+				if (if_none_match_value?.startsWith('W/"')) {
+					if_none_match_value = if_none_match_value.substring(2);
 				}
 
-				return new Response(undefined, {
-					status: 304,
-					headers
-				});
+				const etag = /** @type {string} */ (response.headers.get('etag'));
+
+				if (if_none_match_value === etag) {
+					const headers = new Headers({ etag });
+
+					// https://datatracker.ietf.org/doc/html/rfc7232#section-4.1 + set-cookie
+					for (const key of [
+						'cache-control',
+						'content-location',
+						'date',
+						'expires',
+						'vary',
+						'set-cookie'
+					]) {
+						const value = response.headers.get(key);
+						if (value) headers.set(key, value);
+					}
+
+					return new Response(undefined, {
+						status: 304,
+						headers
+					});
+				}
 			}
+
+			// Edge case: If user does `return Response(30x)` in handle hook while processing a data request,
+			// we need to transform the redirect response to a corresponding JSON response.
+			if (is_data_request && response.status >= 300 && response.status <= 308) {
+				const location = response.headers.get('location');
+				if (location) {
+					return redirect_json_response(
+						new Redirect(/** @type {any} */ (response.status), location)
+					);
+				}
+			}
+
+			return response;
 		}
 
-		// Edge case: If user does `return Response(30x)` in handle hook while processing a data request,
-		// we need to transform the redirect response to a corresponding JSON response.
-		if (is_data_request && response.status >= 300 && response.status <= 308) {
-			const location = response.headers.get('location');
-			if (location) {
-				return redirect_json_response(new Redirect(/** @type {any} */ (response.status), location));
-			}
-		}
-
-		return response;
+		return await handle();
 	} catch (e) {
 		if (e instanceof Redirect) {
 			try {

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -180,7 +180,7 @@ export class InternalServer extends Server {
 		options: RequestOptions & {
 			prerendering?: PrerenderOptions;
 			/** @internal for saving dependencies during prerendering and generating fallback pages */
-			read: (file: string) => MaybePromise<Buffer<ArrayBuffer>>;
+			read: (file: string) => Buffer<ArrayBuffer>;
 			/** @internal used during development to check feature availability depending on the current route */
 			before_handle?: (
 				event: RequestEvent,
@@ -572,7 +572,7 @@ export interface SSRState {
 	 */
 	prerender_default?: PrerenderOption;
 	/** @internal reads from the filesystem when user code tries to fetch a static asset */
-	read?: (file: string) => MaybePromise<Buffer<ArrayBuffer>>;
+	read?: (file: string) => Buffer<ArrayBuffer>;
 	/**
 	 * Used to set up `__SVELTEKIT_TRACK__` which checks if a used feature is supported.
 	 * E.g. if `read` from `$app/server` is used, it checks whether the route's config is compatible.

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -179,9 +179,15 @@ export class InternalServer extends Server {
 		request: Request,
 		options: RequestOptions & {
 			prerendering?: PrerenderOptions;
-			read: (file: string) => NonSharedBuffer;
-			/** A hook called before `handle` during dev, so that `AsyncLocalStorage` can be populated. */
-			before_handle?: (event: RequestEvent, config: any, prerender: PrerenderOption) => void;
+			/** @internal for saving dependencies during prerendering and generating fallback pages */
+			read: (file: string) => MaybePromise<Buffer<ArrayBuffer>>;
+			/** @internal used during development to check feature availability depending on the current route */
+			before_handle?: (
+				event: RequestEvent,
+				config: any,
+				prerender: PrerenderOption,
+				handle: () => Promise<Response>
+			) => Promise<Response>;
 			emulator?: Emulator;
 		}
 	): Promise<Response>;
@@ -565,12 +571,18 @@ export interface SSRState {
 	 * prerender option is inherited by the endpoint, unless overridden.
 	 */
 	prerender_default?: PrerenderOption;
-	read?: (file: string) => NonSharedBuffer;
+	/** @internal reads from the filesystem when user code tries to fetch a static asset */
+	read?: (file: string) => MaybePromise<Buffer<ArrayBuffer>>;
 	/**
 	 * Used to set up `__SVELTEKIT_TRACK__` which checks if a used feature is supported.
 	 * E.g. if `read` from `$app/server` is used, it checks whether the route's config is compatible.
 	 */
-	before_handle?: (event: RequestEvent, config: any, prerender: PrerenderOption) => void;
+	before_handle?: (
+		event: RequestEvent,
+		config: any,
+		prerender: PrerenderOption,
+		handle: () => Promise<Response>
+	) => Promise<Response>;
 	emulator?: Emulator;
 }
 


### PR DESCRIPTION
split out from https://github.com/sveltejs/kit/pull/15574

This PR replaces our use of [`als.enterWith`](https://nodejs.org/api/async_context.html#asynclocalstorageenterwithstore) with the standard `als.run` because `enterWith` is not standard in other runtimes such as workerd (it's an experimental node feature). This change requires wrapping our server response code in a function and running async local storage with that function

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
