### PR TITLE
chore: remove unnecessary arg in `build_server.js`

### DIFF
--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -66,7 +66,7 @@ async function analyse({
 	internal.set_read_implementation((file) => createReadableStream(`${server_root}/server/${file}`));
 
 	// first, build server nodes without the client manifest so we can analyse it
-	build_server_nodes(out, config, manifest_data, server_manifest, null, null, null, output_config);
+	build_server_nodes(out, config, manifest_data, server_manifest, null, null, null);
 
 	/** @type {import('types').ServerMetadata} */
 	const metadata = {

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -24,7 +24,6 @@ export default forked(import.meta.url, analyse);
  *   tracked_features: Record<string, string[]>;
  *   env: Record<string, string>;
  *   out: string;
- *   output_config: import('types').RecursiveRequired<import('types').ValidatedConfig['kit']['output']>;
  *   remotes: RemoteChunk[];
  * }} opts
  */
@@ -36,7 +35,6 @@ async function analyse({
 	tracked_features,
 	env,
 	out,
-	output_config,
 	remotes
 }) {
 	/** @type {import('@sveltejs/kit').SSRManifest} */

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -1,3 +1,5 @@
+/** @import { AssetDependencies, ManifestData, SSRNode, ValidatedKitConfig } from 'types' */
+/** @import { Manifest, Rollup } from 'vite' */
 import fs from 'node:fs';
 import { mkdirp } from '../../../utils/filesystem.js';
 import {
@@ -14,14 +16,36 @@ import { fix_css_urls } from '../../../utils/css.js';
 import { escape_for_interpolation } from '../../../utils/escape.js';
 
 /**
+ * @overload Build without the client manifest so we can analyse the nodes.
  * @param {string} out
- * @param {import('types').ValidatedKitConfig} kit
- * @param {import('types').ManifestData} manifest_data
- * @param {import('vite').Manifest} server_manifest
- * @param {import('vite').Manifest | null} client_manifest
+ * @param {ValidatedKitConfig} kit
+ * @param {ManifestData} manifest_data
+ * @param {Manifest} server_manifest
+ * @param {null} client_manifest
+ * @param {null} assets_path
+ * @param {null} client_chunks
+ * @returns {void}
+ */
+/**
+ * @overload Or build with the client manifest
+ * @param {string} out
+ * @param {ValidatedKitConfig} kit
+ * @param {ManifestData} manifest_data
+ * @param {Manifest} server_manifest
+ * @param {Manifest} client_manifest
+ * @param {string} assets_path
+ * @param {Rollup.RollupOutput['output']} client_chunks
+ * @returns {void}
+ */
+/**
+ * @param {string} out
+ * @param {ValidatedKitConfig} kit
+ * @param {ManifestData} manifest_data
+ * @param {Manifest} server_manifest
+ * @param {Manifest | null} client_manifest
  * @param {string | null} assets_path
- * @param {import('vite').Rollup.RollupOutput['output'] | null} client_chunks
- * @param {import('types').RecursiveRequired<import('types').ValidatedConfig['kit']['output']>} output_config
+ * @param {Rollup.RollupOutput['output'] | null} client_chunks
+ * @returns {void}
  */
 export function build_server_nodes(
 	out,
@@ -30,8 +54,7 @@ export function build_server_nodes(
 	server_manifest,
 	client_manifest,
 	assets_path,
-	client_chunks,
-	output_config
+	client_chunks
 ) {
 	mkdirp(`${out}/server/nodes`);
 	mkdirp(`${out}/server/stylesheets`);
@@ -49,7 +72,7 @@ export function build_server_nodes(
 	 */
 	let prepare_css_for_inlining = (css) => s(css);
 
-	if (client_chunks && kit.inlineStyleThreshold > 0 && output_config.bundleStrategy === 'split') {
+	if (client_chunks && kit.inlineStyleThreshold > 0 && kit.output.bundleStrategy === 'split') {
 		for (const chunk of client_chunks) {
 			if (chunk.type !== 'asset' || !chunk.fileName.endsWith('.css')) {
 				continue;
@@ -113,7 +136,7 @@ export function build_server_nodes(
 		const imports = [];
 
 		// String representation of
-		/** @type {import('types').SSRNode} */
+		/** @type {SSRNode} */
 		/** @type {string[]} */
 		const exports = [`export const index = ${i};`];
 
@@ -162,7 +185,7 @@ export function build_server_nodes(
 		if (
 			client_manifest &&
 			(node.universal || node.component) &&
-			output_config.bundleStrategy === 'split'
+			kit.output.bundleStrategy === 'split'
 		) {
 			const entry_path = `${normalizePath(kit.outDir)}/generated/client-optimized/nodes/${i}.js`;
 			const entry = find_deps(client_manifest, entry_path, true);
@@ -171,13 +194,13 @@ export function build_server_nodes(
 			// However, if it is not used during SSR (not present in the server manifest),
 			// then it can be lazily loaded in the browser.
 
-			/** @type {import('types').AssetDependencies | undefined} */
+			/** @type {AssetDependencies | undefined} */
 			let component;
 			if (node.component) {
 				component = find_deps(server_manifest, node.component, true);
 			}
 
-			/** @type {import('types').AssetDependencies | undefined} */
+			/** @type {AssetDependencies | undefined} */
 			let universal;
 			if (node.universal) {
 				universal = find_deps(server_manifest, node.universal, true);

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1308,8 +1308,7 @@ async function kit({ svelte_config }) {
 					server_manifest,
 					client_manifest,
 					assets_path,
-					client_chunks,
-					svelte_config.kit.output
+					client_chunks
 				);
 
 				// ...and prerender

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1109,7 +1109,6 @@ async function kit({ svelte_config }) {
 					tracked_features,
 					env: { ...env.private, ...env.public },
 					out,
-					output_config: svelte_config.output,
 					remotes
 				});
 


### PR DESCRIPTION
This PR:
- removes the `output_config` parameter because it's already accessible through the `kit` config parameter
- adds a jsdoc overload to differentiate a partial build and final build
- moves some type import to a type import declaration

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
