### PR TITLE
fix: reuse hydrated remote query data

### DIFF
--- a/.changeset/bright-remote-cache.md
+++ b/.changeset/bright-remote-cache.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: reuse hydrated remote query data after async derived waterfalls

--- a/packages/kit/src/runtime/shared.js
+++ b/packages/kit/src/runtime/shared.js
@@ -317,5 +317,16 @@ export function unfriendly_hydratable(key, fn) {
 	if (!svelte.hydratable) {
 		throw new Error('Remote functions require Svelte 5.44.0 or later');
 	}
+
+	const store =
+		typeof window === 'undefined'
+			? undefined
+			: /** @type {{ __svelte?: { h?: Map<string, any> } }} */ (window).__svelte?.h;
+	if (store?.has(key)) {
+		const value = store.get(key);
+		store.delete(key);
+		return value;
+	}
+
 	return svelte.hydratable(key, fn);
 }

--- a/packages/kit/test/apps/async/src/routes/remote/query-derived-await-waterfall/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/query-derived-await-waterfall/+page.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { get_a, get_b } from './data.remote.js';
+
+	const a_query = $derived(get_a());
+	const b_query = $derived(get_b());
+
+	const a = $derived(await a_query);
+	const b = $derived(await b_query);
+</script>
+
+<p id="result">{a + b}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/query-derived-await-waterfall/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/query-derived-await-waterfall/data.remote.js
@@ -1,0 +1,8 @@
+import { query } from '$app/server';
+
+export const get_a = query(() => 1);
+
+export const get_b = query(async () => {
+	await new Promise((resolve) => setTimeout(resolve, 10));
+	return 2;
+});

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -69,6 +69,16 @@ test.describe('remote function mutations', () => {
 		expect(request_count).toBe(0);
 	});
 
+	test('hydrated data is reused across derived await waterfalls', async ({ page }) => {
+		let request_count = 0;
+		page.on('request', (r) => (request_count += r.url().includes('/_app/remote') ? 1 : 0));
+
+		await page.goto('/remote/query-derived-await-waterfall');
+		await expect(page.locator('#result')).toHaveText('3');
+		await page.waitForTimeout(100);
+		expect(request_count).toBe(0);
+	});
+
 	test('command returns correct sum but does not refresh data by default', async ({ page }) => {
 		await page.goto('/remote');
 		await expect(page.locator('#count-result')).toHaveText('0 / 0 (false)');


### PR DESCRIPTION
closes #15791

See #15791 for all the details, but essentially, the problem is that CSR will re-request hydrated derived remote functions, ignoring the hydratable cache.

Very possibly slop PR, my apologies if so! I'm totally inexperienced with Kit's internals, but I've been blocked on #15791 for a little while, and I figured I could give fixing it with Codex a shot. Here's my full conversation: https://pastes.dev/ZTYmShj1Iu

I read its output/diff, and it all seems to make sense, but I'm worried that the model looked in the completely wrong spot and isn't actually fixing the root issue. If that's the case, please feel free to close/disregard this PR. Just trying to help :-)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
