### PR TITLE
fix: round-trip `.as('hidden', booleanValue)` correctly

### DIFF
--- a/.changeset/fix-as-hidden-boolean-roundtrip.md
+++ b/.changeset/fix-as-hidden-boolean-roundtrip.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: `.as('hidden', booleanValue)` now round-trips correctly
+fix: correctly send `true` value to the server for 'submit' and 'hidden' form fields

--- a/.changeset/fix-as-hidden-boolean-roundtrip.md
+++ b/.changeset/fix-as-hidden-boolean-roundtrip.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: `.as('hidden', booleanValue)` now round-trips correctly

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -716,8 +716,11 @@ export function create_field_proxy(target, get_input, set_input, get_issues, pat
 							}
 						}
 
+						const value =
+							typeof input_value === 'boolean' ? (input_value ? 'on' : 'off') : input_value;
+
 						return Object.defineProperties(base_props, {
-							value: { value: input_value, enumerable: true }
+							value: { value, enumerable: true }
 						});
 					}
 

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -96,18 +96,6 @@ describe('convert_formdata', () => {
 		data.append(attack, 'bad');
 		expect(() => convert_formdata(data)).toThrow(/Invalid key "/);
 	});
-
-	// Regression test for https://github.com/sveltejs/kit/issues/15840
-	test('converts b: boolean fields', () => {
-		const data = new FormData();
-		data.append('b:flag_true', 'on');
-		data.append('b:flag_false', 'off');
-
-		expect(convert_formdata(data)).toEqual({
-			flag_true: true,
-			flag_false: false
-		});
-	});
 });
 
 describe('binary form serializer', () => {

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -96,6 +96,18 @@ describe('convert_formdata', () => {
 		data.append(attack, 'bad');
 		expect(() => convert_formdata(data)).toThrow(/Invalid key "/);
 	});
+
+	// Regression test for https://github.com/sveltejs/kit/issues/15840
+	test('converts b: boolean fields', () => {
+		const data = new FormData();
+		data.append('b:flag_true', 'on');
+		data.append('b:flag_false', 'off');
+
+		expect(convert_formdata(data)).toEqual({
+			flag_true: true,
+			flag_false: false
+		});
+	});
 });
 
 describe('binary form serializer', () => {

--- a/packages/kit/test/apps/async/src/routes/remote/form/as-value/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/as-value/+page.svelte
@@ -1,13 +1,20 @@
 <script>
-	import { as_value_form, get_values, reset_values } from './form.remote.ts';
+	import { as_value_form, get_values, get_hidden_values, reset_values } from './form.remote.ts';
 
 	const values = $derived(await get_values());
+	const hidden_values = $derived(await get_hidden_values());
 </script>
 
 {#each values as value (value.id)}
 	<div>
 		{value.text_field} - {value.number_field} - {value.select_field} - {value.color_field} - {value.range_field}
 		- {value.checkbox_field}
+	</div>
+{/each}
+
+{#each Object.entries(hidden_values) as [key, value] (key)}
+	<div id="hidden-{key}">
+		hidden {key}: {value}
 	</div>
 {/each}
 

--- a/packages/kit/test/apps/async/src/routes/remote/form/as-value/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/as-value/form.remote.ts
@@ -42,6 +42,12 @@ let values = structuredClone(default_values);
 
 export const get_values = query(() => values);
 
+let hidden_values: {
+	string?: string;
+	number?: number;
+	boolean?: boolean;
+} = {};
+
 export const as_value_form = form(ValueSchema, async (data) => {
 	const element = values.find((v) => v.id === data.id);
 	if (element) {
@@ -53,8 +59,12 @@ export const as_value_form = form(ValueSchema, async (data) => {
 		element.checkbox_field = data.checkbox_field;
 		await get_values().refresh();
 	}
+	hidden_values = data.hidden;
 });
+
+export const get_hidden_values = query(() => hidden_values);
 
 export const reset_values = form(async () => {
 	values = structuredClone(default_values);
+	hidden_values = {};
 });

--- a/packages/kit/test/apps/async/test/server.test.js
+++ b/packages/kit/test/apps/async/test/server.test.js
@@ -22,6 +22,7 @@ test.describe('remote functions', () => {
 		);
 		expect(code.includes('const with_read = prerender(')).toBe(false);
 	});
+
 	test("form doesn't refresh queries when not a remote request", async ({ page }) => {
 		await page.goto(`/remote/form/noop-refresh-non-enhanced/${Date.now()}${Math.random()}`);
 
@@ -32,5 +33,16 @@ test.describe('remote functions', () => {
 
 		// Should not have refreshed
 		await expect(count).toHaveText('Count: 0');
+	});
+
+	test(".as('hidden', value) is correctly received on the server", async ({ page }) => {
+		await page.goto('/remote/form/as-value');
+
+		const form1 = page.locator('form').nth(0);
+		await form1.locator('button').click();
+
+		await expect(page.locator('#hidden-string')).toHaveText('hidden string: string');
+		await expect(page.locator('#hidden-number')).toHaveText('hidden number: 1');
+		await expect(page.locator('#hidden-boolean')).toHaveText('hidden boolean: true');
 	});
 });


### PR DESCRIPTION
closes #15840

`.as('hidden', booleanValue)` (added in #15802, shipped in 2.60.0) renders correctly on the client — `<input value="true" name="b:flag">` — but the receive path was missed. `convert_formdata` only recognised the `'on'` literal that checkboxes emit, so the server-side `'true'` was coerced to `false`. The schema validates either way (`v.boolean()` accepts both), so handlers ran silently with the wrong data.

`'true'` always corrupts to `false`. `'false'` coincidentally lands as `false`. Number `.as('hidden', n)` is unaffected because `n:` keys go through a separate `parseFloat` branch.

The fix is one line in `convert_formdata` — accept both writers of `b:` keys. The added unit test would have caught this had it existed when #15802 landed; the e2e test added there only asserts schema validation (which passes either way).

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.