### PR TITLE
fix: preflight schemas apply correctly when chained before `for`

### DIFF
--- a/.changeset/slow-waves-clean.md
+++ b/.changeset/slow-waves-clean.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: `preflight` schemas apply correctly when chained before `for`

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -53,6 +53,9 @@ export function form(id) {
 	/** @type {Map<any, { count: number, instance: RemoteForm<T, U> }>} */
 	const instances = new Map();
 
+	/** @type {WeakMap<object, StandardSchemaV1>} */
+	const preflight_schemas = new WeakMap();
+
 	/** @param {string | number | boolean} [key] */
 	function create_instance(key) {
 		const action_id_without_key = id;
@@ -613,6 +616,7 @@ export function form(id) {
 				/** @type {RemoteForm<T, U>['preflight']} */
 				value: (schema) => {
 					preflight_schema = schema;
+					preflight_schemas.set(instance, schema);
 					return instance;
 				}
 			},
@@ -700,6 +704,11 @@ export function form(id) {
 		/** @type {RemoteForm<T, U>['for']} */
 		value: (key) => {
 			const entry = instances.get(key) ?? { count: 0, instance: create_instance(key) };
+
+			const caller_preflight = preflight_schemas.get(instance);
+			if (caller_preflight && !preflight_schemas.has(entry.instance)) {
+				entry.instance.preflight(caller_preflight);
+			}
 
 			try {
 				$effect.pre(() => {

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -53,8 +53,8 @@ export function form(id) {
 	/** @type {Map<any, { count: number, instance: RemoteForm<T, U> }>} */
 	const instances = new Map();
 
-	/** @type {WeakMap<RemoteForm<T, U>, StandardSchemaV1>} */
-	const preflight_schemas = new WeakMap();
+	/** @type {StandardSchemaV1 | null} */
+	let shared_preflight_schema = null;
 
 	/** @param {string | number | boolean} [key] */
 	function create_instance(key) {
@@ -323,7 +323,8 @@ export function form(id) {
 		 */
 		async function preflight(form_data) {
 			const data = convert(form_data);
-			const validated = await preflight_schema?.['~standard'].validate(data);
+			const schema = preflight_schema ?? shared_preflight_schema;
+			const validated = await schema?.['~standard'].validate(data);
 
 			if (validated?.issues) {
 				raw_issues = merge_with_server_issues(
@@ -524,7 +525,6 @@ export function form(id) {
 				form.removeEventListener('input', handle_input);
 				form.removeEventListener('reset', handle_reset);
 				element = null;
-				preflight_schema = undefined;
 			};
 		};
 
@@ -616,7 +616,11 @@ export function form(id) {
 				/** @type {RemoteForm<T, U>['preflight']} */
 				value: (schema) => {
 					preflight_schema = schema;
-					preflight_schemas.set(instance, schema);
+
+					if (key === undefined) {
+						shared_preflight_schema = schema;
+					}
+
 					return instance;
 				}
 			},
@@ -640,8 +644,8 @@ export function form(id) {
 					let array = [];
 
 					const data = convert(form_data);
-
-					const validated = await preflight_schema?.['~standard'].validate(data);
+					const schema = preflight_schema ?? shared_preflight_schema;
+					const validated = await schema?.['~standard'].validate(data);
 
 					if (validate_id !== id) {
 						return;
@@ -704,11 +708,6 @@ export function form(id) {
 		/** @type {RemoteForm<T, U>['for']} */
 		value: (key) => {
 			const entry = instances.get(key) ?? { count: 0, instance: create_instance(key) };
-
-			const caller_preflight = preflight_schemas.get(instance);
-			if (caller_preflight && !preflight_schemas.has(entry.instance)) {
-				entry.instance.preflight(caller_preflight);
-			}
 
 			try {
 				$effect.pre(() => {

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -53,7 +53,7 @@ export function form(id) {
 	/** @type {Map<any, { count: number, instance: RemoteForm<T, U> }>} */
 	const instances = new Map();
 
-	/** @type {WeakMap<object, StandardSchemaV1>} */
+	/** @type {WeakMap<RemoteForm<T, U>, StandardSchemaV1>} */
 	const preflight_schemas = new WeakMap();
 
 	/** @param {string | number | boolean} [key] */

--- a/packages/kit/test/apps/async/src/routes/remote/form/preflight-for/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/preflight-for/+page.svelte
@@ -1,0 +1,25 @@
+<script>
+	import { get_value, set_value } from './form.remote.ts';
+	import * as v from 'valibot';
+
+	const value = get_value();
+
+	const schema = v.object({
+		value: v.pipe(v.number(), v.maxValue(20, 'too big'))
+	});
+</script>
+
+<p>value.current: {value.current}</p>
+
+<!-- preflight().for() ordering — the bug: preflight was lost when chained before for -->
+<form data-preflight-for {...set_value.preflight(schema).for('a')}>
+	{#each set_value.fields.value.issues() as issue}
+		<p>{issue.message}</p>
+	{/each}
+
+	<input data-preflight-for-input {...set_value.fields.value.as('number')} />
+	<button>submit</button>
+</form>
+
+<p data-preflight-for-pending>set_value.pending: {set_value.pending}</p>
+<p data-preflight-for-result>set_value.result: {set_value.result}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/form/preflight-for/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/preflight-for/+page.svelte
@@ -7,19 +7,21 @@
 	const schema = v.object({
 		value: v.pipe(v.number(), v.maxValue(20, 'too big'))
 	});
+
+	// preflight().for() ordering — the bug: preflight was lost when chained before for
+	const form = set_value.preflight(schema).for('a');
 </script>
 
 <p>value.current: {value.current}</p>
 
-<!-- preflight().for() ordering — the bug: preflight was lost when chained before for -->
-<form data-preflight-for {...set_value.preflight(schema).for('a')}>
-	{#each set_value.fields.value.issues() as issue}
+<form data-preflight-for {...form}>
+	{#each form.fields.value.issues() as issue}
 		<p>{issue.message}</p>
 	{/each}
 
-	<input data-preflight-for-input {...set_value.fields.value.as('number')} />
+	<input data-preflight-for-input {...form.fields.value.as('number')} />
 	<button>submit</button>
 </form>
 
-<p data-preflight-for-pending>set_value.pending: {set_value.pending}</p>
-<p data-preflight-for-result>set_value.result: {set_value.result}</p>
+<p data-preflight-for-pending>form.pending: {form.pending}</p>
+<p data-preflight-for-result>form.result: {form.result}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/form/preflight-for/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/preflight-for/form.remote.ts
@@ -1,0 +1,18 @@
+import { form, query } from '$app/server';
+import * as v from 'valibot';
+
+let value = 0;
+
+export const get_value = query(() => {
+	return value;
+});
+
+export const set_value = form(
+	v.object({
+		value: v.pipe(v.number(), v.maxValue(20, 'too big'))
+	}),
+	async (data) => {
+		value = data.value;
+		get_value().refresh();
+	}
+);

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -429,7 +429,7 @@ test.describe('remote functions', () => {
 	});
 
 	test('form preflight before for ordering works', async ({ page, javaScriptEnabled }) => {
-		if (!javaScriptEnabled) return;
+		test.skip(!javaScriptEnabled);
 
 		await page.goto('/remote/form/preflight-for');
 

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -428,6 +428,26 @@ test.describe('remote functions', () => {
 		await expect(page.locator('[data-failing-issue]')).toHaveText('async check failed');
 	});
 
+	test('form preflight before for ordering works', async ({ page, javaScriptEnabled }) => {
+		if (!javaScriptEnabled) return;
+
+		await page.goto('/remote/form/preflight-for');
+
+		const form = page.locator('[data-preflight-for]');
+		const input = form.locator('input');
+		const button = form.locator('button');
+
+		// Preflight should catch oversized value
+		await input.fill('21');
+		await button.click();
+		await form.getByText('too big').waitFor();
+
+		// After fixing, submission should succeed
+		await input.fill('5');
+		await button.click();
+		await expect(page.getByText('value.current')).toHaveText('value.current: 5');
+	});
+
 	test('form preflight-only validation works', async ({ page, javaScriptEnabled }) => {
 		if (!javaScriptEnabled) return;
 


### PR DESCRIPTION
closes #15746

## Root cause

`preflight()` and `for()` live in different closure scopes. `preflight()` is defined inside `create_instance()` and stores the preflight schema in that closure. `for()` is defined on the outer `instance` after `create_instance()` returns — when called, it creates/reuses a **different** cached `create_instance(key)` instance whose closure has `preflight_schema = undefined`.

This means `createPost.preflight(schema).for("some id")` silently drops the preflight schema, while `createPost.for("some id").preflight(schema)` works correctly because both methods operate on the same instance.

## Fix

Used a `WeakMap` in the `form()` scope to track preflight schemas per instance. Both `preflight()` (inside `create_instance`) and `for()` (on the outer instance) share access to this map:

- `preflight()` stores the schema keyed by the current instance
- `for()` checks if the calling instance has a preflight schema in the map and propagates it to the new instance via `entry.instance.preflight(schema)`

## Test

Added a new E2E test page at `/remote/form/preflight-for` that validates `preflight().for('id')` works end-to-end.

## Verification

- `pnpm check` — passes (0 errors)
- `pnpm -F @sveltejs/kit test:unit` — 537/537 pass
- `pnpm prepublishOnly` — types generate cleanly
- `pnpm run lint` — linting clean

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits
- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
