### PR TITLE
fix: allow optional remote form schema fields under `{exactOptionalPropertyTypes: true}`

### DIFF
--- a/.changeset/nice-mugs-mate.md
+++ b/.changeset/nice-mugs-mate.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: support `exactOptionalPropertyTypes` for optional form schema fields

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -2109,7 +2109,7 @@ type RecursiveFormFields = RemoteFormFieldContainer<any> & {
 type MaybeArray<T> = T | T[];
 
 export interface RemoteFormInput {
-	[key: string]: MaybeArray<string | number | boolean | File | RemoteFormInput>;
+	[key: string]: MaybeArray<string | number | boolean | File | RemoteFormInput> | undefined;
 }
 
 export interface RemoteFormIssue {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2083,7 +2083,7 @@ declare module '@sveltejs/kit' {
 	type MaybeArray<T> = T | T[];
 
 	export interface RemoteFormInput {
-		[key: string]: MaybeArray<string | number | boolean | File | RemoteFormInput>;
+		[key: string]: MaybeArray<string | number | boolean | File | RemoteFormInput> | undefined;
 	}
 
 	export interface RemoteFormIssue {


### PR DESCRIPTION
closes #15568

Naively allows `undefined` type in form input values to satisfy type checks when `exactOptionalPropertyTypes` is enabled.

This PR also adds previously-failing tests. To actually test for this, the TS compiler option `exactOptionalPropertyTypes: true` must be set.
Seems that the current testing strategy for the `test/types` file was to run `tsc`. Unfortunately this throws all sorts of errors when with `exactOptionalPropertyTypes` for the new file, because `tsc` doesn't limit that compiler option to just that one test file, but also to all other included/imported files, too. However, kit core was not written with that compiler option in mind, resulting in a lot of false negatives.
To bypass that issue and still add tests, I opted to move the type check automation from `tsc` to `vitest typecheck`. Technically Vitest's typecheck is still experimental, but we've been using it successfully for some time.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
