### PR TITLE
feat: LiveQuery self-iterability

### DIFF
--- a/.changeset/feat-live-query-async-iterable.md
+++ b/.changeset/feat-live-query-async-iterable.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: live query instances are now themselves async-iterable

--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -288,7 +288,23 @@ If the connection drops, `connected` becomes `false`. SvelteKit will attempt to 
 
 Unlike `query`, live queries do not have a `refresh()` method, as they are self-updating.
 
-If you need direct, imperative access to the underlying stream of values (rather than the reactive `current` property), live queries expose a `.run()` method that returns an `AsyncGenerator<T>`. This can only be called outside render — in event handlers, `load` functions, and so on.
+If you need direct, imperative access to the underlying stream of values (rather than the reactive `current` property), live query instances are themselves [async-iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of). You can `for await` over the instance directly:
+
+```js
+// @errors: 7006
+import { getTime } from './time.remote.js';
+// ---cut---
+async function logTimes() {
+	for await (const value of getTime()) {
+		console.log(value);
+		if (someCondition) break;
+	}
+}
+```
+
+Multiple consumers of the same live query (whether reactive — via `await` or `current` — or imperative `for await` loops) share a single underlying connection. The first value yielded to a `for await` iterator is the most-recently-received value, if one is already available, mirroring the semantics of awaiting the resource directly. Subsequent yields fire whenever a new value arrives from the server. If values arrive faster than the consumer drains the iterator, only the latest pending value is kept — live streams are not event logs.
+
+On the server, `for await` likewise joins a per-request shared iteration of the underlying generator, so concurrent consumers within the same request don't run the user-defined generator multiple times.
 
 > [!NOTE] It's essential that you don't cache live query responses in a service worker, since the cloned response will continue streaming long after the page is closed. Make sure that your caching logic excludes any responses with a `Cache-Control` header that includes `no-store`.
 

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -2268,20 +2268,22 @@ export type RemoteQuery<T> = RemoteResource<T> & {
 	withOverride(update: (current: T) => T): RemoteQueryOverride;
 };
 
-export type RemoteLiveQuery<T> = RemoteResource<T> & {
-	/**
-	 * Returns an async iterator with live updates.
-	 * Unlike awaiting the resource directly, this can only be used _outside_ render
-	 * (i.e. in load functions, event handlers and so on)
-	 */
-	run(): AsyncGenerator<T>;
-	/** `true` if the live stream is currently connected. */
-	readonly connected: boolean;
-	/** `true` once the current live stream iterator is done. */
-	readonly done: boolean;
-	/** Reconnects the live stream immediately. */
-	reconnect(): Promise<void>;
-};
+export type RemoteLiveQuery<T> = RemoteResource<T> &
+	AsyncIterable<T> & {
+		/**
+		 * @deprecated Use `for await (const value of liveQuery())` instead.
+		 *
+		 * Previously returned an async iterator with live updates. This method now
+		 * throws when invoked — live query instances are themselves async-iterable.
+		 */
+		run(): AsyncGenerator<T>;
+		/** `true` if the live stream is currently connected. */
+		readonly connected: boolean;
+		/** `true` once the current live stream iterator is done. */
+		readonly done: boolean;
+		/** Reconnects the live stream immediately. */
+		reconnect(): Promise<void>;
+	};
 
 export type RemoteQueryOverride = () => void;
 

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -2270,13 +2270,6 @@ export type RemoteQuery<T> = RemoteResource<T> & {
 
 export type RemoteLiveQuery<T> = RemoteResource<T> &
 	AsyncIterable<T> & {
-		/**
-		 * @deprecated Use `for await (const value of liveQuery())` instead.
-		 *
-		 * Previously returned an async iterator with live updates. This method now
-		 * throws when invoked — live query instances are themselves async-iterable.
-		 */
-		run(): AsyncGenerator<T>;
 		/** `true` if the live stream is currently connected. */
 		readonly connected: boolean;
 		/** `true` once the current live stream iterator is done. */

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -1,5 +1,5 @@
 /** @import { RemoteLiveQuery, RemoteLiveQueryFunction, RemoteQuery, RemoteQueryFunction } from '@sveltejs/kit' */
-/** @import { RemoteInternals, MaybePromise, RequestState, RemoteQueryLiveInternals, RemoteQueryBatchInternals, RemoteQueryInternals, RemoteLiveQueryUserFunctionReturnType, SharedServerLiveIterator } from 'types' */
+/** @import { RemoteInternals, MaybePromise, RequestState, RemoteQueryLiveInternals, RemoteQueryBatchInternals, RemoteQueryInternals, RemoteLiveQueryUserFunctionReturnType } from 'types' */
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 import { get_request_store } from '@sveltejs/kit/internal/server';
 import { create_remote_key, stringify, stringify_remote_arg } from '../../../shared.js';
@@ -553,7 +553,7 @@ function create_live_query_resource(__, payload, state, signal, get_generator) {
  * @param {RequestState} state
  * @param {AbortSignal} signal
  * @param {() => AsyncGenerator<any, void, void>} get_generator
- * @returns {SharedServerLiveIterator}
+ * @returns {SharedIterator<any>}
  */
 function get_or_create_shared_live_iterator(__, payload, state, signal, get_generator) {
 	const map = (state.remote.live_iterators ??= new Map());
@@ -586,7 +586,6 @@ function get_or_create_shared_live_iterator(__, payload, state, signal, get_gene
  *
  * @param {AbortSignal} signal
  * @param {() => AsyncGenerator<any, void, void>} get_generator
- * @returns {SharedServerLiveIterator}
  */
 function create_shared_live_iterator(signal, get_generator) {
 	return new SharedIterator((instance) => {

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -589,74 +589,52 @@ function get_or_create_shared_live_iterator(__, payload, state, signal, get_gene
  * @returns {SharedServerLiveIterator}
  */
 function create_shared_live_iterator(signal, get_generator) {
-	/** @type {AsyncGenerator<any, void, void> | null} */
-	let generator = null;
+	return new SharedIterator((instance) => {
+		// Don't bother starting the pump if the request has already been
+		// aborted between cache creation and first subscription.
+		if (signal.aborted) {
+			instance.done();
+			return noop;
+		}
 
-	// Set to `true` when we deliberately close the generator (because every
-	// subscriber has unsubscribed, or the request was aborted). The pump's
-	// `g.next()` will reject as a result; we use this flag to swallow that
-	// abort error rather than surfacing it through `fan_out.fail()`.
-	let aborted = false;
+		const generator = get_generator();
 
-	const close_generator = () => {
-		void generator?.return().catch(noop);
-		generator = null;
-		aborted = true;
-	};
+		// Set to `true` when we deliberately close the generator (because every
+		// subscriber has unsubscribed, or the request was aborted). The pump's
+		// `generator.next()` will reject as a result; we use this flag to swallow that
+		// abort error rather than surfacing it through `instance.fail()`.
+		let aborted = false;
 
-	const fan_out = new SharedIterator({
-		on_first_subscribe: () => {
-			// Don't bother starting the pump if the request has already been
-			// aborted between cache creation and first subscription.
-			if (signal.aborted) {
-				fan_out.done();
-				return;
-			}
+		const close = () => {
+			aborted = true;
+			void generator.return().catch(noop);
+		};
 
-			generator = get_generator();
-			const g = generator;
+		// On request abort, tear down the pump and notify subscribers. `done()` is
+		// used (rather than `fail()`) because an aborted request is a normal
+		// termination — there's no error to surface to user code that's already
+		// been disconnected from the client.
+		signal.addEventListener('abort', () => (close(), instance.done()), { once: true });
 
-			void (async () => {
-				try {
-					while (true) {
-						const result = await g.next();
-						if (result.done) {
-							fan_out.done();
-							return;
-						}
-						fan_out.push(result.value);
+		void (async () => {
+			try {
+				while (true) {
+					const result = await generator.next();
+					if (result.done) {
+						instance.done();
+						return;
 					}
-				} catch (error) {
-					if (!aborted) fan_out.fail(error);
-				} finally {
-					close_generator();
+					instance.push(result.value);
 				}
-			})();
-		},
-		on_last_unsubscribe: () => {
-			close_generator();
-		}
+			} catch (error) {
+				if (!aborted) instance.fail(error);
+			} finally {
+				close();
+			}
+		})();
+
+		return close;
 	});
-
-	// On request abort, tear down the pump and notify subscribers. `done()` is
-	// used (rather than `fail()`) because an aborted request is a normal
-	// termination — there's no error to surface to user code that's already
-	// been disconnected from the client.
-	const on_abort = () => {
-		close_generator();
-		fan_out.done();
-	};
-	if (signal.aborted) {
-		on_abort();
-	} else {
-		signal.addEventListener('abort', on_abort, { once: true });
-	}
-
-	return {
-		subscribe() {
-			return fan_out.subscribe();
-		}
-	};
 }
 
 // Add batch as a property to the query function

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -468,18 +468,10 @@ function create_live_query_resource(__, payload, state, signal, get_generator) {
 	let promise = null;
 
 	const get_first_value = async () => {
-		const generator = get_generator();
-		try {
-			const { value, done } = await generator.next();
-
-			if (done) {
-				throw new Error(`query.live '${__.name}' did not yield a value`);
-			}
-
+		for await (const value of get_generator()) {
 			return value;
-		} finally {
-			await generator.return(undefined);
 		}
+		throw new Error(`query.live '${__.name}' did not yield a value`);
 	};
 
 	const get_promise = () => {
@@ -535,9 +527,7 @@ function create_live_query_resource(__, payload, state, signal, get_generator) {
 			reconnects.set(create_remote_key(__.id, payload), get_promise());
 			return Promise.resolve();
 		},
-		/**
-		 * @deprecated Use `for await (const value of liveQuery())` instead.
-		 */
+		/** @ts-expect-error This method no longer exists */
 		run() {
 			throw new Error(
 				'`.run()` has been removed from live queries. Use `for await (const value of liveQuery())` instead.'
@@ -609,17 +599,13 @@ function create_shared_live_iterator(signal, get_generator) {
 	let aborted = false;
 
 	const close_generator = () => {
-		if (!generator) return;
-		const g = generator;
+		void generator?.return().catch(noop);
 		generator = null;
 		aborted = true;
-		g.return().catch(noop);
 	};
 
-	/** @type {SharedIterator<any>} */
 	const fan_out = new SharedIterator({
 		on_first_subscribe: () => {
-			if (generator) return;
 			// Don't bother starting the pump if the request has already been
 			// aborted between cache creation and first subscription.
 			if (signal.aborted) {

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -538,38 +538,19 @@ function create_live_query_resource(__, payload, state, signal, get_generator) {
 			return get_promise().then(onfulfilled, onrejected);
 		},
 		[Symbol.asyncIterator]() {
-			const shared = get_or_create_shared_live_iterator(__, payload, state, signal, get_generator);
-			return shared.subscribe();
+			const key = create_remote_key(__.id, payload);
+			const cache = (state.remote.live_iterators ??= new Map());
+			let cached = cache.get(key);
+			if (!cached) {
+				cached = create_shared_live_iterator(signal, get_generator);
+				cache.set(key, cached);
+			}
+			return cached.subscribe();
 		},
 		get [Symbol.toStringTag]() {
 			return 'LiveQueryResource';
 		}
 	};
-}
-
-/**
- * @param {RemoteQueryLiveInternals} __
- * @param {string} payload
- * @param {RequestState} state
- * @param {AbortSignal} signal
- * @param {() => AsyncGenerator<any, void, void>} get_generator
- * @returns {SharedIterator<any>}
- */
-function get_or_create_shared_live_iterator(__, payload, state, signal, get_generator) {
-	const map = (state.remote.live_iterators ??= new Map());
-	let by_payload = map.get(__.id);
-	if (!by_payload) {
-		by_payload = new Map();
-		map.set(__.id, by_payload);
-	}
-
-	let shared = by_payload.get(payload);
-	if (!shared) {
-		shared = create_shared_live_iterator(signal, get_generator);
-		by_payload.set(payload, shared);
-	}
-
-	return shared;
 }
 
 /**

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -1,5 +1,5 @@
 /** @import { RemoteLiveQuery, RemoteLiveQueryFunction, RemoteQuery, RemoteQueryFunction } from '@sveltejs/kit' */
-/** @import { RemoteInternals, MaybePromise, RequestState, RemoteQueryLiveInternals, RemoteQueryBatchInternals, RemoteQueryInternals, RemoteLiveQueryUserFunctionReturnType } from 'types' */
+/** @import { RemoteInternals, MaybePromise, RequestState, RemoteQueryLiveInternals, RemoteQueryBatchInternals, RemoteQueryInternals, RemoteLiveQueryUserFunctionReturnType, SharedServerLiveIterator } from 'types' */
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 import { get_request_store } from '@sveltejs/kit/internal/server';
 import { create_remote_key, stringify, stringify_remote_arg } from '../../../shared.js';
@@ -14,6 +14,7 @@ import {
 import { handle_error_and_jsonify } from '../../../server/utils.js';
 import { HttpError, SvelteKitError } from '@sveltejs/kit/internal';
 import { noop } from '../../../../utils/functions.js';
+import { SharedIterator } from '../../../../utils/shared-iterator.js';
 
 /**
  * Creates a remote query. When called from the browser, the function will be invoked on the server via a `fetch` call.
@@ -153,24 +154,6 @@ function live(validate_or_fn, maybe_fn) {
 	const run = (event, state, get_input) =>
 		run_remote_generator(event, state, false, get_input, fn, __.name);
 
-	/**
-	 * @param {any} generator
-	 * @returns {Promise<any>}
-	 */
-	const first_value = async (generator) => {
-		try {
-			const { value, done } = await generator.next();
-
-			if (done) {
-				throw new Error(`query.live '${__.name}' did not yield a value`);
-			}
-
-			return value;
-		} finally {
-			await generator.return(undefined);
-		}
-	};
-
 	/** @type {RemoteQueryLiveInternals} */
 	const __ = {
 		type: 'query_live',
@@ -181,8 +164,8 @@ function live(validate_or_fn, maybe_fn) {
 		bind(payload, validated_arg) {
 			const { event, state } = get_request_store();
 
-			return create_live_query_resource(__, payload, state, () =>
-				first_value(run(event, state, () => validated_arg))
+			return create_live_query_resource(__, payload, state, event.request.signal, () =>
+				run(event, state, () => validated_arg)
 			);
 		}
 	};
@@ -198,8 +181,8 @@ function live(validate_or_fn, maybe_fn) {
 		const { event, state } = get_request_store();
 		const payload = stringify_remote_arg(arg, state.transport);
 
-		return create_live_query_resource(__, payload, state, () =>
-			first_value(run(event, state, () => validate(arg)))
+		return create_live_query_resource(__, payload, state, event.request.signal, () =>
+			run(event, state, () => validate(arg))
 		);
 	};
 
@@ -476,12 +459,28 @@ function create_query_resource(__, payload, state, fn) {
  * @param {RemoteQueryLiveInternals} __
  * @param {string} payload — the stringified raw argument (i.e. the cache key the client will use)
  * @param {RequestState} state
- * @param {() => Promise<any>} get_first_value
+ * @param {AbortSignal} signal — the request signal; aborts in-flight iteration when the client disconnects
+ * @param {() => AsyncGenerator<any, void, void>} get_generator
  * @returns {RemoteLiveQuery<any>}
  */
-function create_live_query_resource(__, payload, state, get_first_value) {
+function create_live_query_resource(__, payload, state, signal, get_generator) {
 	/** @type {Promise<any> | null} */
 	let promise = null;
+
+	const get_first_value = async () => {
+		const generator = get_generator();
+		try {
+			const { value, done } = await generator.next();
+
+			if (done) {
+				throw new Error(`query.live '${__.name}' did not yield a value`);
+			}
+
+			return value;
+		} finally {
+			await generator.return(undefined);
+		}
+	};
 
 	const get_promise = () => {
 		return (promise ??= get_response(__, payload, state, get_first_value));
@@ -536,15 +535,140 @@ function create_live_query_resource(__, payload, state, get_first_value) {
 			reconnects.set(create_remote_key(__.id, payload), get_promise());
 			return Promise.resolve();
 		},
+		/**
+		 * @deprecated Use `for await (const value of liveQuery())` instead.
+		 */
 		run() {
-			throw new Error('Cannot call .run() on a live query on the server');
+			throw new Error(
+				'`.run()` has been removed from live queries. Use `for await (const value of liveQuery())` instead.'
+			);
 		},
 		/** @type {Promise<any>['then']} */
 		then(onfulfilled, onrejected) {
 			return get_promise().then(onfulfilled, onrejected);
 		},
+		[Symbol.asyncIterator]() {
+			const shared = get_or_create_shared_live_iterator(__, payload, state, signal, get_generator);
+			return shared.subscribe();
+		},
 		get [Symbol.toStringTag]() {
 			return 'LiveQueryResource';
+		}
+	};
+}
+
+/**
+ * @param {RemoteQueryLiveInternals} __
+ * @param {string} payload
+ * @param {RequestState} state
+ * @param {AbortSignal} signal
+ * @param {() => AsyncGenerator<any, void, void>} get_generator
+ * @returns {SharedServerLiveIterator}
+ */
+function get_or_create_shared_live_iterator(__, payload, state, signal, get_generator) {
+	const map = (state.remote.live_iterators ??= new Map());
+	let by_payload = map.get(__.id);
+	if (!by_payload) {
+		by_payload = new Map();
+		map.set(__.id, by_payload);
+	}
+
+	let shared = by_payload.get(payload);
+	if (!shared) {
+		shared = create_shared_live_iterator(signal, get_generator);
+		by_payload.set(payload, shared);
+	}
+
+	return shared;
+}
+
+/**
+ * Wraps a lazily-created live-query generator so that multiple `for await`
+ * consumers within the same request share one underlying iteration. The first
+ * subscriber starts the generator; values are broadcast to all subscribers
+ * via a `SharedIterator`. When the last subscriber unsubscribes, the generator
+ * is closed via `generator.return(undefined)`.
+ *
+ * If `signal` aborts (typically because the client has disconnected), the
+ * pump is torn down and any in-flight `next()` calls on consumer iterators
+ * resolve with `{ done: true }`, so suspended `for await` loops unwind
+ * cleanly rather than leaking.
+ *
+ * @param {AbortSignal} signal
+ * @param {() => AsyncGenerator<any, void, void>} get_generator
+ * @returns {SharedServerLiveIterator}
+ */
+function create_shared_live_iterator(signal, get_generator) {
+	/** @type {AsyncGenerator<any, void, void> | null} */
+	let generator = null;
+
+	// Set to `true` when we deliberately close the generator (because every
+	// subscriber has unsubscribed, or the request was aborted). The pump's
+	// `g.next()` will reject as a result; we use this flag to swallow that
+	// abort error rather than surfacing it through `fan_out.fail()`.
+	let aborted = false;
+
+	const close_generator = () => {
+		if (!generator) return;
+		const g = generator;
+		generator = null;
+		aborted = true;
+		g.return().catch(noop);
+	};
+
+	/** @type {SharedIterator<any>} */
+	const fan_out = new SharedIterator({
+		on_first_subscribe: () => {
+			if (generator) return;
+			// Don't bother starting the pump if the request has already been
+			// aborted between cache creation and first subscription.
+			if (signal.aborted) {
+				fan_out.done();
+				return;
+			}
+
+			generator = get_generator();
+			const g = generator;
+
+			void (async () => {
+				try {
+					while (true) {
+						const result = await g.next();
+						if (result.done) {
+							fan_out.done();
+							return;
+						}
+						fan_out.push(result.value);
+					}
+				} catch (error) {
+					if (!aborted) fan_out.fail(error);
+				} finally {
+					close_generator();
+				}
+			})();
+		},
+		on_last_unsubscribe: () => {
+			close_generator();
+		}
+	});
+
+	// On request abort, tear down the pump and notify subscribers. `done()` is
+	// used (rather than `fail()`) because an aborted request is a normal
+	// termination — there's no error to surface to user code that's already
+	// been disconnected from the client.
+	const on_abort = () => {
+		close_generator();
+		fan_out.done();
+	};
+	if (signal.aborted) {
+		on_abort();
+	} else {
+		signal.addEventListener('abort', on_abort, { once: true });
+	}
+
+	return {
+		subscribe() {
+			return fan_out.subscribe();
 		}
 	};
 }

--- a/packages/kit/src/runtime/client/remote-functions/cache.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/cache.svelte.js
@@ -1,4 +1,5 @@
 import { tick } from 'svelte';
+import { once } from '../../../utils/functions.js';
 
 /**
  * @template R
@@ -114,7 +115,7 @@ export class CacheController {
 	 */
 	manual_ref = (entry, id, payload) => {
 		entry.proxy_count++;
-		return () => this.deref(entry, id, payload);
+		return once(() => this.deref(entry, id, payload));
 	};
 
 	/**

--- a/packages/kit/src/runtime/client/remote-functions/query-live/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/instance.svelte.js
@@ -4,6 +4,7 @@ import * as devalue from 'devalue';
 import { HttpError, Redirect } from '@sveltejs/kit/internal';
 import { noop, once } from '../../../../utils/functions.js';
 import { with_resolvers } from '../../../../utils/promise.js';
+import { SharedIterator } from '../../../../utils/shared-iterator.js';
 import { tick } from 'svelte';
 import { unfriendly_hydratable } from '../../../shared.js';
 import { create_live_iterator } from './iterator.js';
@@ -11,6 +12,7 @@ import { create_live_iterator } from './iterator.js';
 /**
  * @template T
  * @implements {Promise<T>}
+ * @implements {AsyncIterable<T>}
  */
 export class LiveQuery {
 	#id;
@@ -42,6 +44,15 @@ export class LiveQuery {
 	 */
 	#interrupt = null;
 	#attempt = 0;
+
+	/**
+	 * Fan-out for `for await` consumers attached to this LiveQuery's shared
+	 * stream. New subscribers see the most-recently-emitted value (if any) as
+	 * their first yield. Subsequent yields fire whenever `set()` is called.
+	 *
+	 * @type {SharedIterator<T>}
+	 */
+	#fan_out = new SharedIterator();
 
 	/** @type {Promise<T>['then']} */
 	// @ts-expect-error TS doesn't understand that the promise returns something
@@ -130,6 +141,7 @@ export class LiveQuery {
 				}
 
 				this.#done = true;
+				this.#fan_out.done();
 			} catch (error) {
 				if (controller.signal.aborted) break;
 
@@ -220,7 +232,36 @@ export class LiveQuery {
 			window.removeEventListener('pageshow', this.#on_pageshow);
 		}
 
+		this.#fan_out.done();
+
 		void this.#interrupt?.();
+	}
+
+	/**
+	 * Iterate the stream of values yielded by this live query. Multiple
+	 * iterators share the underlying connection; the most-recently emitted value
+	 * (if any) is yielded first to each new iterator, mirroring the semantics
+	 * of awaiting the query directly.
+	 *
+	 * Backpressure note: if values arrive faster than the consumer drains, only
+	 * the latest pending value is kept. This matches the reactive `.current`
+	 * semantics — live streams are not event logs.
+	 *
+	 * @returns {AsyncGenerator<T, void, void>}
+	 */
+	[Symbol.asyncIterator]() {
+		this.#start();
+
+		// Seed the new iterator with the current value (if any) so the first
+		// `.next()` resolves synchronously — mirroring `await liveQuery()`
+		// semantics. If the query has hard-failed, `#fan_out` is already closed
+		// with the terminal error and `subscribe()` returns an iterator whose
+		// first `.next()` rejects.
+		return this.#fan_out.subscribe(
+			this.#ready && this.#error === undefined
+				? { initial_value: { value: /** @type {T} */ (this.#raw) } }
+				: undefined
+		);
 	}
 
 	get then() {
@@ -290,6 +331,10 @@ export class LiveQuery {
 		promise.catch(noop);
 		this.#done = false;
 		this.#attempt = 0;
+		// The previous fan-out may have been closed by `done()`/`fail()`. Future
+		// `for await` consumers need a fresh, open fan-out attached to the new
+		// `#main` lifetime.
+		this.#fan_out = new SharedIterator();
 		this.#main({ on_connect, on_connect_failed }).catch(noop);
 		await promise;
 	}
@@ -308,6 +353,8 @@ export class LiveQuery {
 		} else {
 			this.#promise = Promise.resolve();
 		}
+
+		this.#fan_out.push(value);
 	}
 
 	/** @param {unknown} error */
@@ -330,6 +377,8 @@ export class LiveQuery {
 			promise.catch(noop);
 			this.#promise = promise;
 		}
+
+		this.#fan_out.fail(error);
 	}
 
 	get [Symbol.toStringTag]() {

--- a/packages/kit/src/runtime/client/remote-functions/query-live/proxy.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/proxy.js
@@ -91,10 +91,15 @@ export class LiveQueryProxy {
 	/**
 	 * @returns {AsyncGenerator<T, void, void>}
 	 */
-	[Symbol.asyncIterator]() {
+	async *[Symbol.asyncIterator]() {
 		const entry = this.#get_cache_entry();
 		const release = cache.manual_ref(entry, this.#id, this.#payload);
-		return reffed_generator(entry.resource, release);
+
+		try {
+			yield* entry.resource;
+		} finally {
+			release();
+		}
 	}
 
 	get then() {

--- a/packages/kit/src/runtime/client/remote-functions/query-live/proxy.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/proxy.js
@@ -142,17 +142,3 @@ export class LiveQueryProxy {
 		return 'LiveQueryProxy';
 	}
 }
-
-/**
- * @template T
- * @param {AsyncIterable<T>} inner
- * @param {() => void} release
- * @returns {AsyncGenerator<T, void, void>}
- */
-async function* reffed_generator(inner, release) {
-	try {
-		yield* inner;
-	} finally {
-		release();
-	}
-}

--- a/packages/kit/src/runtime/client/remote-functions/query-live/proxy.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/proxy.js
@@ -1,18 +1,13 @@
 import { app, live_query_map } from '../../client.js';
-import {
-	is_in_effect,
-	pin_in_effect,
-	pin_while_resolving,
-	QUERY_RESOURCE_KEY
-} from '../shared.svelte.js';
+import { pin_in_effect, pin_while_resolving, QUERY_RESOURCE_KEY } from '../shared.svelte.js';
 import { create_remote_key, stringify_remote_arg } from '../../../shared.js';
 import { LiveQuery } from './instance.svelte.js';
 import { cache } from './cache.js';
-import { create_live_iterator } from './iterator.js';
 
 /**
  * @template T
  * @implements {Promise<T>}
+ * @implements {AsyncIterable<T>}
  */
 export class LiveQueryProxy {
 	#key;
@@ -39,7 +34,7 @@ export class LiveQueryProxy {
 		cache.ref(this, entry, this.#id, payload);
 	}
 
-	#get_cached_query() {
+	#get_cache_entry() {
 		const cached = live_query_map.get(this.#id)?.get(this.#payload);
 
 		if (!cached) {
@@ -48,7 +43,11 @@ export class LiveQueryProxy {
 			);
 		}
 
-		return cached.resource;
+		return cached;
+	}
+
+	#get_cached_query() {
+		return this.#get_cache_entry().resource;
 	}
 
 	get current() {
@@ -75,19 +74,27 @@ export class LiveQueryProxy {
 		return this.#get_cached_query().done;
 	}
 
+	/**
+	 * @deprecated Use `for await (const value of liveQuery())` instead.
+	 * @returns {AsyncGenerator<T>}
+	 */
 	run() {
-		// TODO; should this just hook into the existing iterator?
-		if (is_in_effect()) {
-			throw new Error(
-				'On the client, .run() can only be called outside render, e.g. in universal `load` functions and event handlers. In render, await the query directly'
-			);
-		}
-
-		return create_live_iterator(this.#id, this.#payload);
+		throw new Error(
+			'`.run()` has been removed from live queries. Use `for await (const value of liveQuery())` instead.'
+		);
 	}
 
 	reconnect() {
 		return this.#get_cached_query().reconnect();
+	}
+
+	/**
+	 * @returns {AsyncGenerator<T, void, void>}
+	 */
+	[Symbol.asyncIterator]() {
+		const entry = this.#get_cache_entry();
+		const release = cache.manual_ref(entry, this.#id, this.#payload);
+		return reffed_generator(entry.resource, release);
 	}
 
 	get then() {
@@ -128,5 +135,19 @@ export class LiveQueryProxy {
 
 	get [Symbol.toStringTag]() {
 		return 'LiveQueryProxy';
+	}
+}
+
+/**
+ * @template T
+ * @param {AsyncIterable<T>} inner
+ * @param {() => void} release
+ * @returns {AsyncGenerator<T, void, void>}
+ */
+async function* reffed_generator(inner, release) {
+	try {
+		yield* inner;
+	} finally {
+		release();
 	}
 }

--- a/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
@@ -6,7 +6,6 @@ import { HttpError, Redirect } from '@sveltejs/kit/internal';
 import { untrack } from 'svelte';
 import { create_remote_key, split_remote_key } from '../../shared.js';
 import { navigating, page } from '../state.svelte.js';
-import { noop } from '../../../utils/functions.js';
 
 /** Indicates a query function, as opposed to a query instance */
 export const QUERY_FUNCTION_ID = Symbol('sveltekit.query_function_id');
@@ -14,18 +13,6 @@ export const QUERY_FUNCTION_ID = Symbol('sveltekit.query_function_id');
 export const QUERY_OVERRIDE_KEY = Symbol('sveltekit.query_override_key');
 /** Indicates a query instance */
 export const QUERY_RESOURCE_KEY = Symbol('sveltekit.query_resource_key');
-
-/**
- * @returns {boolean} Returns `true` if we are in an effect
- */
-export function is_in_effect() {
-	try {
-		$effect.pre(noop);
-		return true;
-	} catch {
-		return false;
-	}
-}
 
 /**
  * If we're inside a reactive context, pin a cache entry for as long as the

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -151,7 +151,8 @@ export async function internal_respond(request, options, manifest, state) {
 			refreshes: null,
 			requested: null,
 			reconnects: null,
-			batches: null
+			batches: null,
+			live_iterators: null
 		},
 		is_in_remote_function: false,
 		is_in_render: false,

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -646,6 +646,17 @@ export interface RemoteQueryLiveInternals extends BaseRemoteInternals {
 	bind(payload: string, arg: any): RemoteLiveQuery<any>;
 }
 
+/**
+ * A reference-counted, per-request live-query iterator shared between multiple
+ * `for await` consumers within the same request. Lazily drives the underlying
+ * user generator on first subscription, fans every yielded value out to all
+ * subscribers, and tears the generator down once all subscribers have
+ * unsubscribed.
+ */
+export interface SharedServerLiveIterator {
+	subscribe(): AsyncGenerator<any, void, void>;
+}
+
 export interface RemoteQueryBatchInternals extends BaseRemoteInternals {
 	type: 'query_batch';
 	validate: (arg?: any) => MaybePromise<any>;
@@ -733,6 +744,13 @@ export interface RequestState {
 				}
 			>
 		>;
+		/**
+		 * A per-request cache of shared live-query iterators, keyed by remote id
+		 * and stringified argument payload. Used so that multiple `for await`
+		 * consumers of the same `query.live` call within one request multiplex a
+		 * single underlying user generator.
+		 */
+		live_iterators: null | Map<string, Map<string, SharedServerLiveIterator>>;
 	};
 	readonly is_in_remote_function: boolean;
 	readonly is_in_render: boolean;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -740,7 +740,7 @@ export interface RequestState {
 		 * consumers of the same `query.live` call within one request multiplex a
 		 * single underlying user generator.
 		 */
-		live_iterators: null | Map<string, Map<string, SharedIterator<any>>>;
+		live_iterators: null | Map<string, SharedIterator<any>>;
 	};
 	readonly is_in_remote_function: boolean;
 	readonly is_in_render: boolean;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -35,6 +35,7 @@ import {
 } from './private.js';
 import { Span } from '@opentelemetry/api';
 import type { PageOptions } from '../exports/vite/static_analysis/index.js';
+import { SharedIterator } from '../utils/shared-iterator.js';
 
 export interface ServerModule {
 	Server: typeof InternalServer;
@@ -646,17 +647,6 @@ export interface RemoteQueryLiveInternals extends BaseRemoteInternals {
 	bind(payload: string, arg: any): RemoteLiveQuery<any>;
 }
 
-/**
- * A reference-counted, per-request live-query iterator shared between multiple
- * `for await` consumers within the same request. Lazily drives the underlying
- * user generator on first subscription, fans every yielded value out to all
- * subscribers, and tears the generator down once all subscribers have
- * unsubscribed.
- */
-export interface SharedServerLiveIterator {
-	subscribe(): AsyncGenerator<any, void, void>;
-}
-
 export interface RemoteQueryBatchInternals extends BaseRemoteInternals {
 	type: 'query_batch';
 	validate: (arg?: any) => MaybePromise<any>;
@@ -750,7 +740,7 @@ export interface RequestState {
 		 * consumers of the same `query.live` call within one request multiplex a
 		 * single underlying user generator.
 		 */
-		live_iterators: null | Map<string, Map<string, SharedServerLiveIterator>>;
+		live_iterators: null | Map<string, Map<string, SharedIterator<any>>>;
 	};
 	readonly is_in_remote_function: boolean;
 	readonly is_in_render: boolean;

--- a/packages/kit/src/utils/shared-iterator.js
+++ b/packages/kit/src/utils/shared-iterator.js
@@ -1,0 +1,218 @@
+/**
+ * A pull-style async iterator that fans out a single stream of values to
+ * multiple `for await (...)` consumers. Each subscriber gets its own
+ * `AsyncGenerator` whose `.next()` resolves whenever a value is pushed via
+ * `push(value)`. Multiple consumers see the same values without each one
+ * driving an independent underlying source.
+ *
+ * Backpressure is **latest-wins**: if values arrive faster than a particular
+ * consumer drains its iterator, only the most-recently-pushed value is kept
+ * pending for that subscriber. Earlier undrained values are dropped. This is
+ * appropriate for live data streams (reactive state replication), not for
+ * event logs where every value must be delivered.
+ *
+ * Lifecycle hooks are exposed via the constructor:
+ *
+ *   - `on_first_subscribe()` is called when the subscriber count transitions
+ *     from 0 to 1 (e.g. to start a pump pulling from a real source).
+ *   - `on_last_unsubscribe()` is called when the subscriber count transitions
+ *     from non-zero back to 0 (e.g. to tear down that pump).
+ *
+ * Either hook may be omitted.
+ *
+ * The owner is responsible for calling `push(value)` to broadcast values,
+ * `done()` to signal natural completion to all subscribers, and `fail(error)`
+ * to broadcast a terminal error. After `done()` or `fail()`, the iterator
+ * rejects further `subscribe()` calls with the terminal state appropriately.
+ *
+ * @template T
+ */
+export class SharedIterator {
+	/**
+	 * @typedef {object} Subscriber
+	 * @property {{ value: any } | null} pending
+	 * @property {{ error: unknown } | null} pending_error
+	 * @property {boolean} finished
+	 * @property {((result: IteratorResult<any, void>) => void) | null} waiting_resolve
+	 * @property {((reason: unknown) => void) | null} waiting_reject
+	 */
+
+	/** @type {Set<Subscriber>} */
+	#subscribers = new Set();
+
+	/** @type {(() => void) | undefined} */
+	#on_first_subscribe;
+
+	/** @type {(() => void) | undefined} */
+	#on_last_unsubscribe;
+
+	/** Once `done()` or `fail()` has been broadcast, no new values are accepted. */
+	#closed = false;
+
+	/** @type {unknown} */
+	#terminal_error = undefined;
+
+	/**
+	 * @param {object} [hooks]
+	 * @param {() => void} [hooks.on_first_subscribe]
+	 * @param {() => void} [hooks.on_last_unsubscribe]
+	 */
+	constructor({ on_first_subscribe, on_last_unsubscribe } = {}) {
+		this.#on_first_subscribe = on_first_subscribe;
+		this.#on_last_unsubscribe = on_last_unsubscribe;
+	}
+
+	/** @param {T} value */
+	push(value) {
+		if (this.#closed) return;
+		for (const subscriber of this.#subscribers) {
+			if (subscriber.waiting_resolve) {
+				const resolve = subscriber.waiting_resolve;
+				subscriber.waiting_resolve = null;
+				subscriber.waiting_reject = null;
+				resolve({ value, done: false });
+			} else {
+				subscriber.pending = { value };
+			}
+		}
+	}
+
+	/**
+	 * Signal natural completion to all current subscribers, and to any future
+	 * subscriber (which will receive an immediately-done iterator).
+	 */
+	done() {
+		if (this.#closed) return;
+		this.#closed = true;
+		for (const subscriber of this.#subscribers) {
+			subscriber.finished = true;
+			if (subscriber.waiting_resolve) {
+				const resolve = subscriber.waiting_resolve;
+				subscriber.waiting_resolve = null;
+				subscriber.waiting_reject = null;
+				resolve({ value: undefined, done: true });
+			}
+		}
+		this.#subscribers.clear();
+	}
+
+	/**
+	 * Broadcast a terminal error. All current subscribers will reject their
+	 * next `.next()` call with `error`. Future subscribers will also reject
+	 * their first `.next()`.
+	 *
+	 * @param {unknown} error
+	 */
+	fail(error) {
+		if (this.#closed) return;
+		this.#closed = true;
+		this.#terminal_error = error;
+		for (const subscriber of this.#subscribers) {
+			subscriber.finished = true;
+			if (subscriber.waiting_reject) {
+				const reject = subscriber.waiting_reject;
+				subscriber.waiting_resolve = null;
+				subscriber.waiting_reject = null;
+				reject(error);
+			} else {
+				subscriber.pending_error = { error };
+			}
+		}
+		this.#subscribers.clear();
+	}
+
+	/**
+	 * Subscribe to the shared stream. Returns an `AsyncGenerator<T>` that
+	 * yields every value pushed after this call (and, if `initial_value` is
+	 * provided, that value as the first yield).
+	 *
+	 * @param {{ initial_value?: { value: T } }} [options]
+	 *   `initial_value` lets the caller seed the iterator with a synchronously-
+	 *   available current value before any new pushes arrive (e.g. the
+	 *   "last-seen value" of a reactive resource). Pass it wrapped in an
+	 *   object so `undefined` can be distinguished from "no initial value".
+	 * @returns {AsyncGenerator<T, void, void>}
+	 */
+	subscribe(options) {
+		/** @type {Subscriber} */
+		const subscriber = {
+			pending: options?.initial_value ? { value: options.initial_value.value } : null,
+			pending_error:
+				this.#closed && this.#terminal_error !== undefined ? { error: this.#terminal_error } : null,
+			finished: this.#closed && this.#terminal_error === undefined,
+			waiting_resolve: null,
+			waiting_reject: null
+		};
+
+		const should_start = this.#subscribers.size === 0 && !this.#closed;
+
+		if (!subscriber.finished && subscriber.pending_error === null) {
+			this.#subscribers.add(subscriber);
+		}
+
+		if (should_start) {
+			this.#on_first_subscribe?.();
+		}
+
+		const unsubscribe = () => {
+			subscriber.finished = true;
+			const was_present = this.#subscribers.delete(subscriber);
+
+			if (was_present && this.#subscribers.size === 0 && !this.#closed) {
+				this.#on_last_unsubscribe?.();
+			}
+		};
+
+		/** @type {AsyncGenerator<T, void, void>} */
+		const iterator = {
+			next() {
+				if (subscriber.pending_error) {
+					const { error } = subscriber.pending_error;
+					subscriber.pending_error = null;
+					unsubscribe();
+					return Promise.reject(error);
+				}
+
+				if (subscriber.pending) {
+					const { value } = subscriber.pending;
+					subscriber.pending = null;
+					return Promise.resolve({ value, done: false });
+				}
+
+				if (subscriber.finished) {
+					return Promise.resolve({ value: undefined, done: true });
+				}
+
+				return new Promise((resolve, reject) => {
+					subscriber.waiting_resolve = resolve;
+					subscriber.waiting_reject = reject;
+				});
+			},
+			return(value) {
+				unsubscribe();
+				if (subscriber.waiting_resolve) {
+					const resolve = subscriber.waiting_resolve;
+					subscriber.waiting_resolve = null;
+					subscriber.waiting_reject = null;
+					resolve({ value: undefined, done: true });
+				}
+				return Promise.resolve({ value: /** @type {void} */ (value), done: true });
+			},
+			throw(error) {
+				unsubscribe();
+				if (subscriber.waiting_reject) {
+					const reject = subscriber.waiting_reject;
+					subscriber.waiting_resolve = null;
+					subscriber.waiting_reject = null;
+					reject(error);
+				}
+				return Promise.reject(error);
+			},
+			[Symbol.asyncIterator]() {
+				return iterator;
+			}
+		};
+
+		return iterator;
+	}
+}

--- a/packages/kit/src/utils/shared-iterator.js
+++ b/packages/kit/src/utils/shared-iterator.js
@@ -13,9 +13,9 @@
  *
  * Lifecycle hooks are exposed via the constructor:
  *
- *   - `on_first_subscribe()` is called when the subscriber count transitions
+ *   - `start()` is called when the subscriber count transitions
  *     from 0 to 1 (e.g. to start a pump pulling from a real source).
- *   - `on_last_unsubscribe()` is called when the subscriber count transitions
+ *   - `stop()` is called when the subscriber count transitions
  *     from non-zero back to 0 (e.g. to tear down that pump).
  *
  * Either hook may be omitted.
@@ -40,11 +40,11 @@ export class SharedIterator {
 	/** @type {Set<Subscriber>} */
 	#subscribers = new Set();
 
-	/** @type {(() => void) | undefined} */
-	#on_first_subscribe;
+	/** @type {((instance: SharedIterator<T>) => (() => void)) | undefined} */
+	#start = undefined;
 
 	/** @type {(() => void) | undefined} */
-	#on_last_unsubscribe;
+	#stop = undefined;
 
 	/** Once `done()` or `fail()` has been broadcast, no new values are accepted. */
 	#closed = false;
@@ -53,13 +53,10 @@ export class SharedIterator {
 	#terminal_error = undefined;
 
 	/**
-	 * @param {object} [hooks]
-	 * @param {() => void} [hooks.on_first_subscribe]
-	 * @param {() => void} [hooks.on_last_unsubscribe]
+	 * @param {(instance: SharedIterator<T>) => (() => void)} [start]
 	 */
-	constructor({ on_first_subscribe, on_last_unsubscribe } = {}) {
-		this.#on_first_subscribe = on_first_subscribe;
-		this.#on_last_unsubscribe = on_last_unsubscribe;
+	constructor(start) {
+		this.#start = start;
 	}
 
 	/** @param {T} value */
@@ -144,22 +141,20 @@ export class SharedIterator {
 			waiting_reject: null
 		};
 
-		const should_start = this.#subscribers.size === 0 && !this.#closed;
-
 		if (!subscriber.finished && subscriber.pending_error === null) {
 			this.#subscribers.add(subscriber);
 		}
 
-		if (should_start) {
-			this.#on_first_subscribe?.();
+		if (!this.#closed) {
+			this.#stop ??= this.#start?.(this);
 		}
 
 		const unsubscribe = () => {
 			subscriber.finished = true;
 			const was_present = this.#subscribers.delete(subscriber);
 
-			if (was_present && this.#subscribers.size === 0 && !this.#closed) {
-				this.#on_last_unsubscribe?.();
+			if (was_present && this.#subscribers.size === 0) {
+				this.#stop?.();
 			}
 		};
 

--- a/packages/kit/src/utils/shared-iterator.spec.js
+++ b/packages/kit/src/utils/shared-iterator.spec.js
@@ -1,0 +1,177 @@
+import { describe, expect, test, vi } from 'vitest';
+import { SharedIterator } from './shared-iterator.js';
+
+/**
+ * @template T
+ * @param {AsyncGenerator<T>} iterator
+ * @param {number} [timeout_ms]
+ */
+async function next_with_timeout(iterator, timeout_ms = 100) {
+	return Promise.race([
+		iterator.next(),
+		new Promise((_, reject) =>
+			setTimeout(() => reject(new Error('timeout waiting for next()')), timeout_ms)
+		)
+	]);
+}
+
+describe('SharedIterator', () => {
+	test('a single subscriber receives broadcast values', async () => {
+		const shared = /** @type {SharedIterator<number>} */ (new SharedIterator());
+		const iter = shared.subscribe();
+
+		const a = iter.next();
+		shared.push(1);
+		expect(await a).toEqual({ value: 1, done: false });
+
+		const b = iter.next();
+		shared.push(2);
+		expect(await b).toEqual({ value: 2, done: false });
+
+		await iter.return();
+	});
+
+	test('multiple subscribers see the same pushed values', async () => {
+		const shared = /** @type {SharedIterator<string>} */ (new SharedIterator());
+		const a = shared.subscribe();
+		const b = shared.subscribe();
+
+		const na = a.next();
+		const nb = b.next();
+		shared.push('hello');
+		expect(await na).toEqual({ value: 'hello', done: false });
+		expect(await nb).toEqual({ value: 'hello', done: false });
+
+		await a.return();
+		await b.return();
+	});
+
+	test('initial_value is yielded first to new subscribers', async () => {
+		const shared = /** @type {SharedIterator<number>} */ (new SharedIterator());
+		const iter = shared.subscribe({ initial_value: { value: 42 } });
+
+		expect(await iter.next()).toEqual({ value: 42, done: false });
+
+		const next = iter.next();
+		shared.push(43);
+		expect(await next).toEqual({ value: 43, done: false });
+
+		await iter.return();
+	});
+
+	test('done() signals completion to all subscribers', async () => {
+		const shared = /** @type {SharedIterator<number>} */ (new SharedIterator());
+		const a = shared.subscribe();
+		const b = shared.subscribe();
+
+		const na = a.next();
+		const nb = b.next();
+		shared.done();
+
+		expect(await na).toEqual({ value: undefined, done: true });
+		expect(await nb).toEqual({ value: undefined, done: true });
+	});
+
+	test('fail() rejects pending and future next() calls with the error', async () => {
+		const shared = /** @type {SharedIterator<number>} */ (new SharedIterator());
+		const a = shared.subscribe();
+
+		const na = a.next();
+		const err = new Error('boom');
+		shared.fail(err);
+
+		await expect(na).rejects.toBe(err);
+	});
+
+	test('new subscribers after fail() reject on first next()', async () => {
+		const shared = /** @type {SharedIterator<number>} */ (new SharedIterator());
+		const err = new Error('boom');
+		shared.fail(err);
+
+		const iter = shared.subscribe();
+		await expect(iter.next()).rejects.toBe(err);
+	});
+
+	test('new subscribers after done() see immediately-done iterator', async () => {
+		const shared = /** @type {SharedIterator<number>} */ (new SharedIterator());
+		shared.done();
+
+		const iter = shared.subscribe();
+		expect(await iter.next()).toEqual({ value: undefined, done: true });
+	});
+
+	test('latest-wins backpressure: undrained pending value is overwritten', async () => {
+		const shared = /** @type {SharedIterator<number>} */ (new SharedIterator());
+		const iter = shared.subscribe();
+
+		shared.push(1);
+		shared.push(2);
+		shared.push(3);
+
+		expect(await iter.next()).toEqual({ value: 3, done: false });
+
+		await iter.return();
+	});
+
+	test('on_first_subscribe is called when count goes 0 -> 1', () => {
+		const on_first_subscribe = vi.fn();
+		const shared = /** @type {SharedIterator<number>} */ (
+			new SharedIterator({ on_first_subscribe })
+		);
+
+		expect(on_first_subscribe).not.toHaveBeenCalled();
+		const a = shared.subscribe();
+		expect(on_first_subscribe).toHaveBeenCalledTimes(1);
+
+		// Second subscribe doesn't fire the hook again
+		const b = shared.subscribe();
+		expect(on_first_subscribe).toHaveBeenCalledTimes(1);
+
+		void a.return();
+		void b.return();
+	});
+
+	test('on_last_unsubscribe is called when count returns to 0', async () => {
+		const on_last_unsubscribe = vi.fn();
+		const shared = /** @type {SharedIterator<number>} */ (
+			new SharedIterator({ on_last_unsubscribe })
+		);
+
+		const a = shared.subscribe();
+		const b = shared.subscribe();
+
+		await a.return();
+		expect(on_last_unsubscribe).not.toHaveBeenCalled();
+
+		await b.return();
+		expect(on_last_unsubscribe).toHaveBeenCalledTimes(1);
+	});
+
+	test('iterator.return() resolves a pending next() with done', async () => {
+		const shared = /** @type {SharedIterator<number>} */ (new SharedIterator());
+		const iter = shared.subscribe();
+
+		const pending = iter.next();
+		await iter.return();
+		expect(await pending).toEqual({ value: undefined, done: true });
+	});
+
+	test('iterator.throw() rejects a pending next() with the error', async () => {
+		const shared = /** @type {SharedIterator<number>} */ (new SharedIterator());
+		const iter = shared.subscribe();
+
+		const pending = iter.next();
+		const err = new Error('client-side throw');
+		await expect(iter.throw(err)).rejects.toBe(err);
+		await expect(pending).rejects.toBe(err);
+	});
+
+	test('push() after done() is a no-op', async () => {
+		const shared = /** @type {SharedIterator<number>} */ (new SharedIterator());
+		shared.done();
+		shared.push(1);
+
+		const iter = shared.subscribe();
+		expect(await next_with_timeout(iter)).toEqual({ value: undefined, done: true });
+	});
+});

--- a/packages/kit/src/utils/shared-iterator.spec.js
+++ b/packages/kit/src/utils/shared-iterator.spec.js
@@ -113,38 +113,39 @@ describe('SharedIterator', () => {
 		await iter.return();
 	});
 
-	test('on_first_subscribe is called when count goes 0 -> 1', () => {
-		const on_first_subscribe = vi.fn();
-		const shared = /** @type {SharedIterator<number>} */ (
-			new SharedIterator({ on_first_subscribe })
-		);
+	test('start is called when count goes 0 -> 1', () => {
+		const start = vi.fn(() => () => undefined);
+		const shared = /** @type {SharedIterator<number>} */ (new SharedIterator(start));
 
-		expect(on_first_subscribe).not.toHaveBeenCalled();
+		expect(start).not.toHaveBeenCalled();
 		const a = shared.subscribe();
-		expect(on_first_subscribe).toHaveBeenCalledTimes(1);
+		expect(start).toHaveBeenCalledTimes(1);
 
 		// Second subscribe doesn't fire the hook again
 		const b = shared.subscribe();
-		expect(on_first_subscribe).toHaveBeenCalledTimes(1);
+		expect(start).toHaveBeenCalledTimes(1);
 
 		void a.return();
 		void b.return();
 	});
 
-	test('on_last_unsubscribe is called when count returns to 0', async () => {
-		const on_last_unsubscribe = vi.fn();
+	test('stop is called when count returns to 0', async () => {
+		let stop;
+
 		const shared = /** @type {SharedIterator<number>} */ (
-			new SharedIterator({ on_last_unsubscribe })
+			new SharedIterator(() => {
+				return (stop = vi.fn());
+			})
 		);
 
 		const a = shared.subscribe();
 		const b = shared.subscribe();
 
 		await a.return();
-		expect(on_last_unsubscribe).not.toHaveBeenCalled();
+		expect(stop).not.toHaveBeenCalled();
 
 		await b.return();
-		expect(on_last_unsubscribe).toHaveBeenCalledTimes(1);
+		expect(stop).toHaveBeenCalledTimes(1);
 	});
 
 	test('iterator.return() resolves a pending next() with done', async () => {

--- a/packages/kit/test/apps/async/src/routes/remote/live/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/live/+page.svelte
@@ -19,6 +19,31 @@
 		const next = await get_stats();
 		stats = JSON.stringify(next);
 	}
+
+	let for_await_count = $state(0);
+	let for_await_values = $state('');
+	let stop_iteration: AbortController | null = null;
+
+	async function start_for_await() {
+		stop_iteration?.abort();
+		stop_iteration = new AbortController();
+		const signal = stop_iteration.signal;
+		for_await_count = 0;
+		for_await_values = '';
+		const collected: number[] = [];
+
+		try {
+			for await (const value of get_count()) {
+				if (signal.aborted) break;
+				for_await_count += 1;
+				collected.push(value);
+				for_await_values = collected.join(',');
+				if (for_await_count >= 3) break;
+			}
+		} catch (error) {
+			for_await_values = `error: ${(error as Error).message}`;
+		}
+	}
 </script>
 
 <button id="increment" onclick={() => increment()}>increment</button>
@@ -45,3 +70,7 @@
 	<p id="detached">detached</p>
 {/if}
 <p id="stats-value">{stats}</p>
+
+<button id="start-for-await" onclick={start_for_await}>start for-await</button>
+<p id="for-await-count">{for_await_count}</p>
+<p id="for-await-values">{for_await_values}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/validation/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/validation/+page.svelte
@@ -20,18 +20,11 @@
 	}
 
 	async function read_live(resource: RemoteLiveQuery<'success' | 'failure'>) {
-		const iterator = resource.run();
-
-		try {
-			const result = await iterator.next();
-			if (result.done) {
-				throw new Error('query.live did not yield a value');
-			}
-
-			return result.value;
-		} finally {
-			await iterator.return?.(undefined);
+		for await (const value of resource) {
+			return value;
 		}
+
+		throw new Error('query.live did not yield a value');
 	}
 
 	let status = $state('pending');
@@ -75,7 +68,7 @@
 		} catch {
 			try {
 				// @ts-expect-error
-				await validated_live_query_no_args('invalid').run().next();
+				await read_live(validated_live_query_no_args('invalid'));
 				status = 'error';
 			} catch {
 				try {
@@ -113,7 +106,7 @@
 
 			try {
 				// @ts-expect-error
-				await validated_live_query_with_arg(1).run().next();
+				await read_live(validated_live_query_with_arg(1));
 				status = 'error';
 			} catch (e) {
 				if (!isHttpError(e) || e.body.message !== 'Input must be a string') {

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -643,6 +643,28 @@ test.describe('remote function mutations', () => {
 		await expect(page.locator('#duplicate-updates')).toHaveText(String(before));
 	});
 
+	test('query.live is async-iterable and joins the shared cache stream', async ({ page }) => {
+		await page.goto('/remote/live');
+		await page.click('#reset');
+		await expect(page.locator('#count')).toHaveText('0');
+
+		await page.click('#start-for-await');
+
+		// the first value should be the current value (0) — emitted synchronously
+		// from the shared LiveQuery's cache rather than via a fresh connection.
+		await expect(page.locator('#for-await-count')).toHaveText('1');
+		await expect(page.locator('#for-await-values')).toHaveText('0');
+
+		await page.click('#increment');
+		await expect(page.locator('#for-await-count')).toHaveText('2');
+		await expect(page.locator('#for-await-values')).toHaveText('0,1');
+
+		await page.click('#increment');
+		// iteration breaks after 3 values
+		await expect(page.locator('#for-await-count')).toHaveText('3');
+		await expect(page.locator('#for-await-values')).toHaveText('0,1,2');
+	});
+
 	test('query.live cleans up server iterator on reload', async ({ page }) => {
 		await page.goto('/remote/live');
 		await page.click('#stats');

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -663,6 +663,8 @@ test.describe('remote function mutations', () => {
 		// iteration breaks after 3 values
 		await expect(page.locator('#for-await-count')).toHaveText('3');
 		await expect(page.locator('#for-await-values')).toHaveText('0,1,2');
+
+		await page.click('#reset');
 	});
 
 	test('query.live cleans up server iterator on reload', async ({ page }) => {

--- a/packages/kit/test/types/remote.test.ts
+++ b/packages/kit/test/types/remote.test.ts
@@ -119,8 +119,6 @@ function live_query_tests() {
 			break;
 		}
 
-		// `.run()` is deprecated but still typed; calling it throws at runtime.
-		const iterator: AsyncGenerator<string> = q().run();
 		iterator;
 
 		q().connected === true;

--- a/packages/kit/test/types/remote.test.ts
+++ b/packages/kit/test/types/remote.test.ts
@@ -113,7 +113,14 @@ function live_query_tests() {
 		const result: string = await q();
 		result;
 
-		const iterator: AsyncIterator<string> = await q().run();
+		for await (const value of q()) {
+			const _: string = value;
+			_;
+			break;
+		}
+
+		// `.run()` is deprecated but still typed; calling it throws at runtime.
+		const iterator: AsyncGenerator<string> = q().run();
 		iterator;
 
 		q().connected === true;

--- a/packages/kit/test/types/remote.test.ts
+++ b/packages/kit/test/types/remote.test.ts
@@ -119,8 +119,6 @@ function live_query_tests() {
 			break;
 		}
 
-		iterator;
-
 		q().connected === true;
 		q().done === false;
 		q().reconnect();

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2244,13 +2244,6 @@ declare module '@sveltejs/kit' {
 
 	export type RemoteLiveQuery<T> = RemoteResource<T> &
 		AsyncIterable<T> & {
-			/**
-			 * @deprecated Use `for await (const value of liveQuery())` instead.
-			 *
-			 * Previously returned an async iterator with live updates. This method now
-			 * throws when invoked — live query instances are themselves async-iterable.
-			 */
-			run(): AsyncGenerator<T>;
 			/** `true` if the live stream is currently connected. */
 			readonly connected: boolean;
 			/** `true` once the current live stream iterator is done. */

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2242,20 +2242,22 @@ declare module '@sveltejs/kit' {
 		withOverride(update: (current: T) => T): RemoteQueryOverride;
 	};
 
-	export type RemoteLiveQuery<T> = RemoteResource<T> & {
-		/**
-		 * Returns an async iterator with live updates.
-		 * Unlike awaiting the resource directly, this can only be used _outside_ render
-		 * (i.e. in load functions, event handlers and so on)
-		 */
-		run(): AsyncGenerator<T>;
-		/** `true` if the live stream is currently connected. */
-		readonly connected: boolean;
-		/** `true` once the current live stream iterator is done. */
-		readonly done: boolean;
-		/** Reconnects the live stream immediately. */
-		reconnect(): Promise<void>;
-	};
+	export type RemoteLiveQuery<T> = RemoteResource<T> &
+		AsyncIterable<T> & {
+			/**
+			 * @deprecated Use `for await (const value of liveQuery())` instead.
+			 *
+			 * Previously returned an async iterator with live updates. This method now
+			 * throws when invoked — live query instances are themselves async-iterable.
+			 */
+			run(): AsyncGenerator<T>;
+			/** `true` if the live stream is currently connected. */
+			readonly connected: boolean;
+			/** `true` once the current live stream iterator is done. */
+			readonly done: boolean;
+			/** Reconnects the live stream immediately. */
+			reconnect(): Promise<void>;
+		};
 
 	export type RemoteQueryOverride = () => void;
 


### PR DESCRIPTION
Deprecates `.run` and makes LiveQueries iterable themselves. LiveQueries now share a cache between instances and new subscriptions to that cache will join the in progress stream of values.