### PR TITLE
fix: avoid build warnings about undefined hooks on Windows

### DIFF
--- a/.changeset/icy-coins-fall.md
+++ b/.changeset/icy-coins-fall.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: avoid build warnings about undefined universal hooks

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -198,7 +198,10 @@ async function kit({ svelte_config }) {
 	const is_rolldown = !!vite.rolldownVersion;
 
 	const { kit } = svelte_config;
-	const out = `${kit.outDir}/output`;
+	/** `kit.outDir` but posix-ified */
+	const out_dir = posixify(kit.outDir);
+	/** The base directory for the Vite builds */
+	const out = `${out_dir}/output`;
 
 	const version_hash = hash(kit.version.name);
 
@@ -268,7 +271,7 @@ async function kit({ svelte_config }) {
 				const client_hooks = resolve_entry(kit.files.hooks.client);
 				if (client_hooks) allow.add(path.dirname(client_hooks));
 
-				const generated = path.posix.join(kit.outDir, 'generated');
+				const generated = path.posix.join(out_dir, 'generated');
 
 				// dev and preview config can be shared
 				/** @type {UserConfig} */
@@ -290,7 +293,7 @@ async function kit({ svelte_config }) {
 						watch: {
 							ignored: [
 								// Ignore all siblings of config.kit.outDir/generated
-								`${posixify(kit.outDir)}/!(generated)`
+								`${out_dir}/!(generated)`
 							]
 						}
 					},
@@ -448,7 +451,7 @@ async function kit({ svelte_config }) {
 
 		resolveId(id, importer) {
 			if (id === '__sveltekit/manifest') {
-				return `${kit.outDir}/generated/client-optimized/app.js`;
+				return `${out_dir}/generated/client-optimized/app.js`;
 			}
 
 			// If importing from a service-worker, only allow $service-worker & $env/static/public, but none of the other virtual modules.
@@ -840,7 +843,7 @@ async function kit({ svelte_config }) {
 
 					if (ssr) {
 						input.index = `${runtime_directory}/server/index.js`;
-						input.internal = `${kit.outDir}/generated/server/internal.js`;
+						input.internal = `${out_dir}/generated/server/internal.js`;
 						input['remote-entry'] = `${runtime_directory}/app/server/remote/index.js`;
 
 						// add entry points for every endpoint...
@@ -906,10 +909,10 @@ async function kit({ svelte_config }) {
 						input['bundle'] = `${runtime_directory}/client/bundle.js`;
 					} else {
 						input['entry/start'] = `${runtime_directory}/client/entry.js`;
-						input['entry/app'] = `${kit.outDir}/generated/client-optimized/app.js`;
+						input['entry/app'] = `${out_dir}/generated/client-optimized/app.js`;
 						manifest_data.nodes.forEach((node, i) => {
 							if (node.component || node.universal) {
-								input[`nodes/${i}`] = `${kit.outDir}/generated/client-optimized/nodes/${i}.js`;
+								input[`nodes/${i}`] = `${out_dir}/generated/client-optimized/nodes/${i}.js`;
 							}
 						});
 					}
@@ -954,7 +957,7 @@ async function kit({ svelte_config }) {
 										(is_rolldown
 											? warning.code === 'IMPORT_IS_UNDEFINED'
 											: warning.code === 'MISSING_EXPORT') &&
-										warning.id === `${kit.outDir}/generated/client-optimized/app.js`
+										warning.id === `${out_dir}/generated/client-optimized/app.js`
 									) {
 										// ignore e.g. undefined `handleError` hook when
 										// referencing `client_hooks.handleError`
@@ -1121,7 +1124,7 @@ async function kit({ svelte_config }) {
 				write_client_manifest(
 					kit,
 					manifest_data,
-					`${kit.outDir}/generated/client-optimized`,
+					`${out_dir}/generated/client-optimized`,
 					metadata.nodes
 				);
 
@@ -1209,7 +1212,7 @@ async function kit({ svelte_config }) {
 
 				if (svelte_config.kit.output.bundleStrategy === 'split') {
 					const start = deps_of(`${runtime_directory}/client/entry.js`);
-					const app = deps_of(`${kit.outDir}/generated/client-optimized/app.js`);
+					const app = deps_of(`${out_dir}/generated/client-optimized/app.js`);
 
 					build_data.client = {
 						start: start.file,
@@ -1228,11 +1231,11 @@ async function kit({ svelte_config }) {
 					if (svelte_config.kit.router.resolution === 'server') {
 						const nodes = manifest_data.nodes.map((node, i) => {
 							if (node.component || node.universal) {
-								const entry = `${kit.outDir}/generated/client-optimized/nodes/${i}.js`;
+								const entry = `${out_dir}/generated/client-optimized/nodes/${i}.js`;
 								const deps = deps_of(entry, true);
 								const file = resolve_symlinks(
 									client_manifest,
-									`${kit.outDir}/generated/client-optimized/nodes/${i}.js`
+									`${out_dir}/generated/client-optimized/nodes/${i}.js`
 								).chunk.file;
 
 								return { file, css: deps.stylesheets };


### PR DESCRIPTION
The windows path needs to be posixified so that we can correctly ignore the warning when we compare it against the Vite module id

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
