### PR TITLE
fix: preserve multiple Set-Cookie headers on 304 responses

### DIFF
--- a/.changeset/fix-set-cookie-304.md
+++ b/.changeset/fix-set-cookie-304.md
@@ -1,0 +1,10 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: preserve multiple `Set-Cookie` headers on 304 responses
+
+`Headers.get('set-cookie')` collapses multiple `Set-Cookie` values into a single
+comma-joined string, which browsers cannot parse. The 304 response path now
+iterates `Headers.getSetCookie()` and appends each cookie individually, so all
+cookies survive when a request matches `If-None-Match`.

--- a/.changeset/fix-set-cookie-304.md
+++ b/.changeset/fix-set-cookie-304.md
@@ -3,8 +3,3 @@
 ---
 
 fix: preserve multiple `Set-Cookie` headers on 304 responses
-
-`Headers.get('set-cookie')` collapses multiple `Set-Cookie` values into a single
-comma-joined string, which browsers cannot parse. The 304 response path now
-iterates `Headers.getSetCookie()` and appends each cookie individually, so all
-cookies survive when a request matches `If-None-Match`.

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -1,8 +1,8 @@
 import { createReadStream } from 'node:fs';
 import { Readable } from 'node:stream';
-import * as set_cookie_parser from 'set-cookie-parser';
 import { SvelteKitError } from '../internal/index.js';
 import { noop } from '../../utils/functions.js';
+import { get_set_cookies } from '../../utils/http.js';
 
 /**
  * @param {import('http').IncomingMessage} req
@@ -169,15 +169,7 @@ export async function getRequest({ request, base, bodySizeLimit }) {
 export async function setResponse(res, response) {
 	for (const [key, value] of response.headers) {
 		try {
-			res.setHeader(
-				key,
-				key === 'set-cookie'
-					? set_cookie_parser.splitCookiesString(
-							// This is absurd but necessary, TODO: investigate why
-							/** @type {string}*/ (response.headers.get(key))
-						)
-					: value
-			);
+			res.setHeader(key, key === 'set-cookie' ? get_set_cookies(response.headers) : value);
 		} catch (error) {
 			res.getHeaderNames().forEach((name) => res.removeHeader(name));
 			res.writeHead(500).end(String(error));

--- a/packages/kit/src/runtime/server/fetch.js
+++ b/packages/kit/src/runtime/server/fetch.js
@@ -1,5 +1,6 @@
 import * as set_cookie_parser from 'set-cookie-parser';
 import { noop } from '../../utils/functions.js';
+import { get_set_cookies } from '../../utils/http.js';
 import { respond } from './respond.js';
 import * as paths from '$app/paths/internal/server';
 import { read_implementation } from '__sveltekit/server';
@@ -152,22 +153,19 @@ export function create_fetch({ event, options, manifest, state, get_cookie_heade
 
 				const response = await internal_fetch(request, options, manifest, state);
 
-				const set_cookie = response.headers.get('set-cookie');
-				if (set_cookie) {
-					for (const str of set_cookie_parser.splitCookiesString(set_cookie)) {
-						const { name, value, ...options } = set_cookie_parser.parseString(str, {
-							decodeValues: false
-						});
+				for (const str of get_set_cookies(response.headers)) {
+					const { name, value, ...options } = set_cookie_parser.parseString(str, {
+						decodeValues: false
+					});
 
-						const path = options.path ?? (url.pathname.split('/').slice(0, -1).join('/') || '/');
+					const path = options.path ?? (url.pathname.split('/').slice(0, -1).join('/') || '/');
 
-						// options.sameSite is string, something more specific is required - type cast is safe
-						set_internal(name, value, {
-							path,
-							encode: (value) => value,
-							.../** @type {import('cookie').CookieSerializeOptions} */ (options)
-						});
-					}
+					// options.sameSite is string, something more specific is required - type cast is safe
+					set_internal(name, value, {
+						path,
+						encode: (value) => value,
+						.../** @type {import('cookie').CookieSerializeOptions} */ (options)
+					});
 				}
 
 				return response;

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -8,7 +8,7 @@ import { is_endpoint_request, render_endpoint } from './endpoint.js';
 import { render_page } from './page/index.js';
 import { render_response } from './page/render.js';
 import { respond_with_error } from './page/respond_with_error.js';
-import { is_form_content_type } from '../../utils/http.js';
+import { get_set_cookies, is_form_content_type } from '../../utils/http.js';
 import {
 	handle_fatal_error,
 	has_prerendered_path,
@@ -517,9 +517,7 @@ export async function internal_respond(request, options, manifest, state) {
 					if (value) headers.set(key, value);
 				}
 
-				// `Headers.get('set-cookie')` collapses multiple values into a single
-				// comma-joined string that browsers cannot parse correctly
-				for (const cookie of response.headers.getSetCookie()) {
+				for (const cookie of get_set_cookies(response.headers)) {
 					headers.append('set-cookie', cookie);
 				}
 

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -511,17 +511,16 @@ export async function internal_respond(request, options, manifest, state) {
 			if (if_none_match_value === etag) {
 				const headers = new Headers({ etag });
 
-				// https://datatracker.ietf.org/doc/html/rfc7232#section-4.1 + set-cookie
-				for (const key of [
-					'cache-control',
-					'content-location',
-					'date',
-					'expires',
-					'vary',
-					'set-cookie'
-				]) {
+				// https://datatracker.ietf.org/doc/html/rfc7232#section-4.1
+				for (const key of ['cache-control', 'content-location', 'date', 'expires', 'vary']) {
 					const value = response.headers.get(key);
 					if (value) headers.set(key, value);
+				}
+
+				// `Headers.get('set-cookie')` collapses multiple values into a single
+				// comma-joined string that browsers cannot parse correctly
+				for (const cookie of response.headers.getSetCookie()) {
+					headers.append('set-cookie', cookie);
 				}
 
 				return new Response(undefined, {

--- a/packages/kit/src/utils/http.js
+++ b/packages/kit/src/utils/http.js
@@ -1,3 +1,4 @@
+import * as set_cookie_parser from 'set-cookie-parser';
 import { BINARY_FORM_CONTENT_TYPE } from '../runtime/form-utils.js';
 
 /**
@@ -54,6 +55,26 @@ export function negotiate(accept, types) {
 	}
 
 	return accepted;
+}
+
+/**
+ * Reads all `Set-Cookie` headers as separate values. `Headers.get('set-cookie')`
+ * collapses them into a single comma-joined string that browsers cannot parse, so
+ * we use `Headers.getSetCookie()` where available and fall back to splitting the
+ * joined string otherwise.
+ *
+ * TODO 3.0 `getSetCookie` is available in Node 19.7+; once we drop support for
+ * older versions we can use it directly and remove the `splitCookiesString` fallback
+ * @param {Headers} headers
+ * @returns {string[]}
+ */
+export function get_set_cookies(headers) {
+	if (typeof headers.getSetCookie === 'function') {
+		return headers.getSetCookie();
+	}
+
+	const set_cookie = headers.get('set-cookie');
+	return set_cookie ? set_cookie_parser.splitCookiesString(set_cookie) : [];
 }
 
 /**

--- a/packages/kit/src/utils/http.spec.js
+++ b/packages/kit/src/utils/http.spec.js
@@ -1,5 +1,5 @@
 import { assert, test } from 'vitest';
-import { negotiate } from './http.js';
+import { get_set_cookies, negotiate } from './http.js';
 
 test('handle valid accept header value', () => {
 	const accept = 'text/html';
@@ -16,4 +16,21 @@ test('handle accept values with optional whitespace', () => {
 test('handle invalid accept header value', () => {
 	const accept = 'text/html,*';
 	assert.equal(negotiate(accept, ['text/html']), 'text/html');
+});
+
+test('get_set_cookies returns each set-cookie header separately', () => {
+	const headers = new Headers();
+	headers.append('set-cookie', 'session=abc123; Path=/; HttpOnly');
+	headers.append('set-cookie', 'csrf=xyz789; Path=/; SameSite=Strict');
+	headers.append('set-cookie', 'locale=en; Path=/');
+
+	assert.deepEqual(get_set_cookies(headers), [
+		'session=abc123; Path=/; HttpOnly',
+		'csrf=xyz789; Path=/; SameSite=Strict',
+		'locale=en; Path=/'
+	]);
+});
+
+test('get_set_cookies returns an empty array when there are no cookies', () => {
+	assert.deepEqual(get_set_cookies(new Headers()), []);
 });

--- a/packages/kit/test/apps/basics/src/routes/cookies/forwarded-in-etag-multiple/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/cookies/forwarded-in-etag-multiple/+page.server.js
@@ -1,0 +1,6 @@
+/** @type {import('./$types').PageServerLoad} */
+export function load({ cookies }) {
+	cookies.set('one', '1', { path: '', httpOnly: false });
+	cookies.set('two', '2', { path: '', httpOnly: false });
+	cookies.set('three', '3', { path: '', httpOnly: false });
+}

--- a/packages/kit/test/apps/basics/src/routes/cookies/forwarded-in-etag-multiple/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/cookies/forwarded-in-etag-multiple/+page.svelte
@@ -1,0 +1,27 @@
+<script>
+	import { onMount } from 'svelte';
+
+	/** @type {string} */
+	let cookies;
+
+	onMount(() => {
+		cookies = document.cookie
+			.split('; ')
+			.filter((c) => c.startsWith('one=') || c.startsWith('two=') || c.startsWith('three='))
+			.sort()
+			.join('; ');
+	});
+</script>
+
+<button
+	on:click={() => {
+		for (const name of ['one', 'two', 'three']) {
+			document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+		}
+		location.reload();
+	}}
+>
+	Delete cookies and reload the page
+</button>
+
+<p>{cookies}</p>

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -1188,6 +1188,13 @@ test.describe('cookies', () => {
 		await expect(page.locator('p')).toHaveText('foo=bar');
 	});
 
+	test('etag forwards multiple cookies', async ({ page }) => {
+		await page.goto('/cookies/forwarded-in-etag-multiple');
+		await expect(page.locator('p')).toHaveText('one=1; three=3; two=2');
+		await page.locator('button').click();
+		await expect(page.locator('p')).toHaveText('one=1; three=3; two=2');
+	});
+
 	test("fetch during SSR doesn't un- and re-escape cookies", async ({ page }) => {
 		await page.goto('/cookies/collect-without-re-escaping');
 		await expect(page.locator('p')).toHaveText('cookie-special-characters="foo"');


### PR DESCRIPTION
## Summary
Fixes #15527.

`Headers.get('set-cookie')` collapses multiple values into a single comma-joined string that browsers cannot parse, so the 304 path was silently dropping all cookies after the first (most visible on non-Node adapters, where `splitCookiesString` recovery doesn't exist).

Iterates `Headers.getSetCookie()` and appends each cookie individually, matching the pattern already used by `add_cookies_to_headers` in `cookie.js`.

## Test plan
- [x] New Playwright test `etag forwards multiple cookies` exercises the 304 path with three cookies
- [x] Existing `etag forwards cookies` test still passes
- [x] `pnpm -F @sveltejs/kit test:unit` passes