### PR TITLE
fix: regression where routes starting and ending with a route group are not found

### DIFF
--- a/.changeset/spicy-geese-shake.md
+++ b/.changeset/spicy-geese-shake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: regression where routes starting and ending with a route group are not matched correctly

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -3,7 +3,7 @@ import { decode_params } from './url.js';
 
 const param_pattern = /^(\[)?(\.\.\.)?(\w+)(?:=(\w+))?(\])?$/;
 
-const root_group_pattern = /^\/\((?:.+)\)$/;
+const root_group_pattern = /^\/\((?:[^)]+)\)$/;
 
 /**
  * Creates the regex pattern, extracts parameter names, and generates types for a route

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -274,6 +274,16 @@ describe('exec', () => {
 			route: '/[[...catchall]]',
 			path: '/\n',
 			expected: { catchall: '\n' }
+		},
+		{
+			route: '/(group)/[[optional]]',
+			path: '/',
+			expected: {}
+		},
+		{
+			route: '/(group1)/[slug]/(group2)',
+			path: '/123',
+			expected: { slug: '123' }
 		}
 	];
 


### PR DESCRIPTION
closes #15901 

Regression was caused by https://github.com/sveltejs/kit/pull/15861/changes#diff-a1a15b06db23e414ab4202232607550bcac6cfe2b0809777468e8dabb922b276R17 which greedily matches routes such as `/(group1)/anything/(group2)` rather than just `/(group)` routes. Added a unit test to ensure this doesn't regress

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
