### PR TITLE
docs(adapter-node): list which env vars custom servers must implement

### DIFF
--- a/documentation/docs/25-build-and-deploy/40-adapter-node.md
+++ b/documentation/docs/25-build-and-deploy/40-adapter-node.md
@@ -273,3 +273,7 @@ app.listen(3000, () => {
 	console.log('listening on port 3000');
 });
 ```
+
+> [!NOTE] When you use `handler.js` in a custom server, only the environment variables read by the handler itself take effect: `ORIGIN`, `PROTOCOL_HEADER`, `HOST_HEADER`, `PORT_HEADER`, `ADDRESS_HEADER`, `XFF_DEPTH`, and `BODY_SIZE_LIMIT`.
+>
+> The server-lifecycle variables (`PORT`, `HOST`, `SOCKET_PATH`, `SHUTDOWN_TIMEOUT`, `IDLE_TIMEOUT`, `KEEP_ALIVE_TIMEOUT`, `HEADERS_TIMEOUT`, `LISTEN_PID`, `LISTEN_FDS`) are only honored by the default `node build` server. Implement them yourself in a custom server if you need the same behavior — for example, the snippet above listens on a hardcoded `3000` regardless of `PORT`.


### PR DESCRIPTION
closes #15734

When you set up a custom server using `handler.js` from `@sveltejs/adapter-node`, only the request-handling environment variables (e.g. `ORIGIN`, `BODY_SIZE_LIMIT`) actually do anything. The server-lifecycle ones (`PORT`, `HOST`, `SOCKET_PATH`, the various timeouts, and the socket-activation pair) are read by `index.js` (the default `node build` server) and have to be implemented manually if you want them in a custom server. The current docs don't mention this, and the existing code example hardcodes port 3000 without flagging that it's ignoring `PORT`.

Added a note right after the custom-server code example listing both sets explicitly. Cross-checked the variable lists against the source in `packages/adapter-node/src/handler.js` and `packages/adapter-node/src/index.js`.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`. N/A — docs-only change.

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset. N/A — docs-only.

### Edits
- [x] Please ensure that 'Allow edits from maintainers' is checked.