### PR TITLE
docs: fix `query.live` snippet

### DIFF
--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -293,6 +293,7 @@ If you need direct, imperative access to the underlying stream of values (rather
 ```js
 // @filename: ambient.d.ts
 declare module './time.remote.js' {
+	import { RemoteLiveQueryFunction } from '@sveltejs/kit';
 	export const getTime: RemoteLiveQueryFunction<undefined, Date>;
 }
 // @filename: index.js

--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -291,7 +291,12 @@ Unlike `query`, live queries do not have a `refresh()` method, as they are self-
 If you need direct, imperative access to the underlying stream of values (rather than the reactive `current` property), live query instances are themselves [async-iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of). You can `for await` over the instance directly:
 
 ```js
-// @errors: 7006
+// @filename: ambient.d.ts
+declare module './time.remote.js' {
+	export const getTime: RemoteLiveQueryFunction<undefined, Date>;
+}
+// @filename: index.js
+// @errors: 7006 2304
 import { getTime } from './time.remote.js';
 // ---cut---
 async function logTimes() {

--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -296,8 +296,8 @@ declare module './time.remote.js' {
 	import { RemoteLiveQueryFunction } from '@sveltejs/kit';
 	export const getTime: RemoteLiveQueryFunction<undefined, Date>;
 }
-// @filename: index.js
 // @errors: 7006 2304
+// @filename: index.js
 import { getTime } from './time.remote.js';
 // ---cut---
 async function logTimes() {


### PR DESCRIPTION
There's a build error https://vercel.com/svelte/svelte-dev/4j33ArifQYHQpxFA6idpq9ev4K98#L445 where the condition isn't declared and the imported module isn't found. This PR squelches the condition type error and declares the imported module in an ambient file. Hopefully this helps the docs build

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
