### PR TITLE
fix: do not preload route JS chunks in Link header when SSR is disabled

### DIFF
--- a/.changeset/fix-link-header-modulepreload-ssr-disabled.md
+++ b/.changeset/fix-link-header-modulepreload-ssr-disabled.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: do not include route JS chunks in the Link response header when SSR is disabled

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -277,7 +277,14 @@ export async function render_response({
 	}
 
 	for (const { node } of branch) {
-		for (const url of node.imports) modulepreloads.add(url);
+		// only preload route JS chunks when SSR is enabled — without SSR the page
+		// shell is empty and the route nodes are loaded lazily by the client entry,
+		// so listing them in the Link header just bloats it (can exceed nginx's
+		// default 4–8 KB proxy_buffer_size, causing 502s). Stylesheets and fonts
+		// still need to load eagerly to avoid FOUC during CSR boot (#15718).
+		if (page_config.ssr) {
+			for (const url of node.imports) modulepreloads.add(url);
+		}
 		for (const url of node.stylesheets) stylesheets.add(url);
 		for (const url of node.fonts) fonts.add(url);
 

--- a/packages/kit/test/apps/no-ssr/test/no-script.test.js
+++ b/packages/kit/test/apps/no-ssr/test/no-script.test.js
@@ -31,3 +31,18 @@ test('styles are loaded before CSR starts for prerendered routes', async ({ page
 	await page.goto('/styles/prerendered');
 	expect(requests.length).toBe(1);
 });
+
+test('does not include route modulepreloads in the Link response header when SSR is disabled', async ({
+	request
+}) => {
+	test.skip(!!process.env.DEV);
+
+	const response = await request.get('/');
+	const link = response.headers()['link'] ?? '';
+
+	// stylesheets and fonts may still appear (eager-load to avoid FOUC), but
+	// route node JS chunks must not — they bloat the header and can overflow
+	// reverse-proxy buffers (e.g. nginx default proxy_buffer_size). The page
+	// shell is empty when SSR is off, so route chunks load lazily via CSR.
+	expect(link).not.toContain('rel="modulepreload"');
+});

--- a/packages/kit/test/apps/no-ssr/test/no-script.test.js
+++ b/packages/kit/test/apps/no-ssr/test/no-script.test.js
@@ -32,7 +32,7 @@ test('styles are loaded before CSR starts for prerendered routes', async ({ page
 	expect(requests.length).toBe(1);
 });
 
-test('does not include route modulepreloads in the Link response header when SSR is disabled', async ({
+test('does not include route node modulepreloads in the Link response header when SSR is disabled', async ({
 	request
 }) => {
 	test.skip(!!process.env.DEV);
@@ -40,9 +40,10 @@ test('does not include route modulepreloads in the Link response header when SSR
 	const response = await request.get('/');
 	const link = response.headers()['link'] ?? '';
 
-	// stylesheets and fonts may still appear (eager-load to avoid FOUC), but
-	// route node JS chunks must not — they bloat the header and can overflow
-	// reverse-proxy buffers (e.g. nginx default proxy_buffer_size). The page
-	// shell is empty when SSR is off, so route chunks load lazily via CSR.
-	expect(link).not.toContain('rel="modulepreload"');
+	// client.imports (entry/start, entry/app, shared chunks) may still appear,
+	// but route-specific nodes/N.js chunks must not — they bloat the header
+	// and can overflow reverse-proxy buffers (e.g. nginx default
+	// proxy_buffer_size). The page shell is empty when SSR is off, so route
+	// chunks load lazily via CSR.
+	expect(link).not.toMatch(/\/nodes\/\d+\.[\w-]+\.js/);
 });


### PR DESCRIPTION
## Context

I maintain [Dockhand](https://github.com/Finsys/dockhand) (a SvelteKit-based Docker management UI). After upgrading from SvelteKit 2.50.0 to 2.60.1, every Dockhand deployment behind an nginx-based reverse proxy (Nginx Proxy Manager / OpenResty) started returning **502 Bad Gateway** on every page load. Direct access to the upstream worked fine; only proxied requests broke. Bug filed by a user: [Finsys/dockhand#1114](https://github.com/Finsys/dockhand/issues/1114).

nginx error log:
```
upstream sent too big header while reading response header from upstream
```

## Root cause

Dockhand sets `export const ssr = false;` in `+layout.ts` — it's a CSR-only SPA with a Node backend for API routes. PR #15718 (released in 2.51.0) moved the per-node loop out of the `if (page_config.ssr)` block so that **stylesheets and fonts** would load eagerly when SSR is disabled, preventing FOUC during CSR boot. That part was intentional and correct.

The same loop also added `node.imports` to `modulepreloads`, which feeds the `Link: rel=modulepreload` response header. When SSR is off the rendered HTML doesn't contain any `<link rel=\"modulepreload\">` tags — the page shell is empty until the client entry boots — but the Link header now lists every chunk in the matched route's branch.

For Dockhand routes with deep import graphs that means the Link header grew from <1 KB to 5-9 KB. That's fine on Traefik, Caddy, HAProxy (large default header buffers), but breaks nginx-based proxies where the default `proxy_buffer_size` is 4 KB on Linux / 8 KB on most distros.

## Measured impact

Comparing 1.0.30 (SvelteKit 2.60.1) to 1.0.31 (SvelteKit 2.50.0, same Dockhand commit otherwise):

| Route | Header size 2.60.1 | Chunks 2.60.1 | Header size 2.50.0 | Chunks 2.50.0 | Reduction |
|---|---|---|---|---|---|
| `/containers` | 9,462 B | 135 | ~765 B | ~9 | **-92%** |
| `/stacks` | 9,227 B | 132 | ~765 B | ~9 | **-92%** |
| `/settings` | 8,878 B | 127 | ~765 B | ~9 | **-91%** |
| `/images` | 7,750 B | 111 | ~765 B | ~9 | **-90%** |
| `/` (dashboard) | 7,283 B | 104 | ~765 B | ~9 | **-89%** |
| `/logs` | 6,765 B | 96 | ~765 B | ~9 | **-89%** |
| `/login` | 5,672 B | 81 | ~765 B | ~9 | **-86%** |

Reproduced behind an nginx with default buffers (the upstream Dockhand container was identical, only SvelteKit changed):

```
2.60.1: GET / → 502  ('upstream sent too big header')
2.50.0: GET / → 200
```

## Fix

Gate the `node.imports` addition on `page_config.ssr` — when SSR is off, the chunks aren't in the HTML and don't need to be advertised in the Link header (the client entry will import them lazily on boot). Stylesheets and fonts stay unconditional, preserving #15718's intent.

```diff
 for (const { node } of branch) {
-  for (const url of node.imports) modulepreloads.add(url);
+  if (page_config.ssr) {
+    for (const url of node.imports) modulepreloads.add(url);
+  }
   for (const url of node.stylesheets) stylesheets.add(url);
   for (const url of node.fonts) fonts.add(url);
   ...
 }
```

## Test

Added a regression test in `packages/kit/test/apps/no-ssr/test/no-script.test.js` that asserts the Link header does not contain `rel=\"modulepreload\"` entries when SSR is disabled.

## Closes

- Should fix [Finsys/dockhand#1114](https://github.com/Finsys/dockhand/issues/1114) and any other SvelteKit SPA deployed behind nginx with default proxy buffers.