### PR TITLE
fix: avoid generating `_app/env.js` if unused

### DIFF
--- a/.changeset/shiny-clouds-behave.md
+++ b/.changeset/shiny-clouds-behave.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: avoid generating the `_app/env.js` module if public dynamic environment variables are not used by the app

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -185,6 +185,8 @@ export function create_builder({
 		},
 
 		generateEnvModule() {
+			if (!build_data.client?.uses_env_dynamic_public) return;
+
 			const dest = `${config.kit.outDir}/output/prerendered/dependencies/${config.kit.appDir}/env.js`;
 			const env = get_env(config.kit.env, vite_config.mode);
 

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -141,7 +141,7 @@ export interface Builder {
 	generateFallback: (dest: string) => Promise<void>;
 
 	/**
-	 * Generate a module exposing build-time environment variables as `$env/dynamic/public`.
+	 * Generate a module exposing build-time environment variables as `$env/dynamic/public` if the app uses it.
 	 */
 	generateEnvModule: () => void;
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -116,7 +116,7 @@ declare module '@sveltejs/kit' {
 		generateFallback: (dest: string) => Promise<void>;
 
 		/**
-		 * Generate a module exposing build-time environment variables as `$env/dynamic/public`.
+		 * Generate a module exposing build-time environment variables as `$env/dynamic/public` if the app uses it.
 		 */
 		generateEnvModule: () => void;
 


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/13551

We already have a condition that's false if the app doesn't use public dynamic environment variables. This PR uses that to avoid generating the file if so. This mostly affects the static adapter

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.
	- no test unless we want to set up a new static adapter test app. The existing ones both use public dynamic env vars and test for it

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
