### PR TITLE
feat(enhanced-img): allow configuring output formats (and quality) via enhancedImages(options)

### DIFF
--- a/.changeset/curly-melons-cheer.md
+++ b/.changeset/curly-melons-cheer.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/enhanced-img': minor
+---
+
+feat: allow configuring output `formats` and `quality` via `enhancedImages(options)`

--- a/packages/enhanced-img/src/index.js
+++ b/packages/enhanced-img/src/index.js
@@ -3,10 +3,11 @@ import { imagetools } from 'vite-imagetools';
 import { image_plugin } from './vite-plugin.js';
 
 /**
+ * @param {import('../types/index.js').EnhancedImgOptions} [options]
  * @returns {import('vite').Plugin[]}
  */
-export function enhancedImages() {
-	const imagetools_instance = imagetools_plugin();
+export function enhancedImages(options) {
+	const imagetools_instance = imagetools_plugin(options);
 	return !process.versions.webcontainer
 		? [image_plugin(imagetools_instance), imagetools_instance]
 		: [];
@@ -26,7 +27,11 @@ function fallback_format(meta) {
 	return 'jpg';
 }
 
-function imagetools_plugin() {
+/**
+ * @param {import('../types/index.js').EnhancedImgOptions} [options]
+ * @returns {import('vite').Plugin}
+ */
+function imagetools_plugin(options) {
 	/** @type {Partial<import('vite-imagetools').VitePluginOptions>} */
 	const imagetools_opts = {
 		defaultDirectives: async ({ pathname, searchParams: qs }, metadata) => {
@@ -41,10 +46,18 @@ function imagetools_plugin() {
 				return new URLSearchParams();
 			}
 
+			// When `formats` is provided, use it verbatim and skip the raster fallback. Otherwise
+			// keep the default `avif;webp;<fallback_format>` so behavior is unchanged when no options
+			// are passed.
+			const format = options?.formats
+				? options.formats.join(';')
+				: `avif;webp;${fallback_format(meta)}`;
+
 			const { widths, kind } = get_widths(width, qs.get('imgSizes'));
 			return new URLSearchParams({
 				as: 'picture',
-				format: `avif;webp;${fallback_format(meta)}`,
+				format,
+				...(options?.quality && { quality: options.quality.toString() }),
 				w: widths.join(';'),
 				...(kind === 'x' && !qs.has('w') && { basePixels: widths[0].toString() })
 			});
@@ -52,7 +65,6 @@ function imagetools_plugin() {
 		namedExports: false
 	};
 
-	// TODO: should we make formats or sizes configurable besides just letting people override defaultDirectives?
 	// TODO: generate img rather than picture if only a single format is provided
 	//     by resolving the directives for the URL in the preprocessor
 	return imagetools(imagetools_opts);

--- a/packages/enhanced-img/test/options.spec.js
+++ b/packages/enhanced-img/test/options.spec.js
@@ -1,0 +1,28 @@
+import { expect, it } from 'vitest';
+import { enhancedImages } from '../src/index.js';
+
+it('accepts no options and returns the markup + imagetools plugins', () => {
+	const plugins = enhancedImages();
+	// outside a webcontainer we expect both the markup preprocessor and the imagetools instance
+	expect(Array.isArray(plugins)).toBe(true);
+	expect(plugins.length).toBe(2);
+	expect(plugins[0].name).toBe('vite-plugin-enhanced-img-markup');
+});
+
+it('accepts a `formats` option without throwing', () => {
+	const plugins = enhancedImages({ formats: ['avif', 'webp'] });
+	expect(plugins.length).toBe(2);
+});
+
+it('accepts a `quality` option without throwing', () => {
+	const plugins = enhancedImages({ formats: ['avif', 'webp'], quality: 80 });
+	expect(plugins.length).toBe(2);
+});
+
+// TODO(sketch): assert the `format`/`quality` directives produced by the internal
+// `defaultDirectives` callback. That callback is not currently exported, so a precise test
+// would either export it (or a pure `resolve_directives({ formats, quality }, meta)` helper)
+// and assert:
+//   - no options          -> format === `avif;webp;${fallback_format(meta)}` (png when meta.hasAlpha)
+//   - { formats: [...] }   -> format === 'avif;webp' and NO raster fallback is appended
+//   - { quality: 80 }      -> directives include `quality=80`

--- a/packages/enhanced-img/types/index.d.ts
+++ b/packages/enhanced-img/types/index.d.ts
@@ -14,4 +14,20 @@ declare module 'svelte/elements' {
 	}
 }
 
-export function enhancedImages(): Promise<Plugin[]>;
+export interface EnhancedImgOptions {
+	/**
+	 * The output formats to generate, in order of preference, e.g. `['avif', 'webp']`. The browser
+	 * picks the first format it supports. When set, this replaces the default
+	 * `['avif', 'webp', <raster fallback>]`, so it can be used to drop the (often large) raster
+	 * fallback for projects that only target modern browsers. When omitted, the default formats are
+	 * used and a raster fallback (`png`/`jpg`/`gif`/`tiff`) is chosen based on the source image.
+	 */
+	formats?: string[];
+	/**
+	 * A uniform quality (`1`-`100`) applied to every generated format. When omitted, each format's
+	 * encoder default is used.
+	 */
+	quality?: number;
+}
+
+export function enhancedImages(options?: EnhancedImgOptions): Promise<Plugin[]>;


### PR DESCRIPTION
## Disclaimer:
I'm mostly a Kotlin engineer, and I've made this guiding a Codex instance. If I've done smth stupid, don't throw stones too large 😅, but I needed this for a god-forsaken wordpress plugin that imports a couple Svelte components as custom elements.

## Problem

`enhancedImages()` takes no options. Its output format set is hardcoded in
`packages/enhanced-img/src/index.js` → `imagetools_plugin()` → `defaultDirectives`,
which always emits `format: avif;webp;${fallback_format(meta)}`. `fallback_format`
returns `png` when the source has an alpha channel.

For projects whose source images have alpha, this generates multi-megabyte PNG
fallbacks across the whole width ladder. They're essentially never served — modern
browsers select AVIF — but they bloat every build and deploy. Today the only way
to opt out is to bypass `enhancedImages()` entirely and hand-wire `vite-imagetools`
with custom `defaultDirectives`.

This is the case flagged by the existing TODO in `src/index.js`:

> `// TODO: should we make formats or sizes configurable besides just letting people override defaultDirectives?`

## Change

`enhancedImages(options)` now accepts an optional options object:

- `formats?: string[]` — output formats in preference order (e.g. `['avif', 'webp']`).
  When set, it's used verbatim and the raster fallback append is skipped.
- `quality?: number` — uniform quality applied to every format.

```js
enhancedImages({ formats: ['avif', 'webp'] });
```

Threaded `enhancedImages(options)` → `imagetools_plugin(options)` → `defaultDirectives`,
where the `format` directive becomes `options.formats.join(';')` when provided,
otherwise the existing `avif;webp;<fallback_format>`.

## Backward compatibility

With no argument (the only call form that exists today) the produced
`URLSearchParams` is byte-identical to before — same keys, same order, same
`fallback_format` behavior. Purely additive `minor`.
