### PR TITLE
fix: remove check for svelte.config.js before running `sync`

### DIFF
--- a/.changeset/better-cooks-rush.md
+++ b/.changeset/better-cooks-rush.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: remove check for svelte.config.js before running `sync`

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -73,14 +73,6 @@ if (!command) {
 }
 
 if (command === 'sync') {
-	const config_files = ['js', 'ts']
-		.map((ext) => `svelte.config.${ext}`)
-		.filter((f) => fs.existsSync(f));
-	if (config_files.length === 0) {
-		console.warn(`Missing Svelte config file in ${process.cwd()} — skipping`);
-		process.exit(0);
-	}
-
 	try {
 		const config = await load_config();
 		const sync = await import('./core/sync/sync.js');


### PR DESCRIPTION
https://github.com/sveltejs/kit/pull/15944#issuecomment-4606871416

We missed a spot in #15944 — `svelte-kit sync` shouldn't check to see if a `svelte.config.js` exists, it should delegate to `load_config`.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
