### PR TITLE
fix: generate a placeholder tsconfig.json to squelch sync-time warnings

### DIFF
--- a/.changeset/old-mails-wait.md
+++ b/.changeset/old-mails-wait.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: generate a placeholder tsconfig.json to squelch sync-time warnings

--- a/packages/kit/src/cli.js
+++ b/packages/kit/src/cli.js
@@ -81,12 +81,42 @@ if (command === 'sync') {
 		process.exit(0);
 	}
 
+	// create placeholder .svelte-kit/tsconfig.json if necessary, to squelch warnings.
+	// this isn't bulletproof — if someone has some esoteric config, it will continue
+	// to harmlessly warn — but we handle the 90% case and clean up after ourselves
+	const sveltekit_dir = '.svelte-kit';
+	const base_tsconfig = `${sveltekit_dir}/tsconfig.json`;
+	const base_tsconfig_json = '{}';
+
+	const sveltekit_dir_exists = fs.existsSync(sveltekit_dir);
+	const base_tsconfig_exists = fs.existsSync(base_tsconfig);
+
+	if (!base_tsconfig_exists) {
+		try {
+			fs.mkdirSync('.svelte-kit');
+		} catch {
+			// ignore
+		}
+
+		fs.writeFileSync(base_tsconfig, base_tsconfig_json);
+	}
+
 	try {
 		const config = await load_config();
 		const sync = await import('./core/sync/sync.js');
 		sync.all_types(config, values.mode);
 	} catch (error) {
 		handle_error(error);
+	} finally {
+		// if we errored, or accidentally created the wrong file
+		// (could happen!) then clean up after ourselves
+		if (fs.readFileSync(base_tsconfig, 'utf-8') === base_tsconfig_json) {
+			fs.unlinkSync(base_tsconfig);
+		}
+
+		if (!sveltekit_dir_exists && fs.readdirSync(sveltekit_dir).length === 0) {
+			fs.rmSync(sveltekit_dir, { recursive: true });
+		}
 	}
 } else {
 	console.error(colors.bold().red(`> Unknown command: ${command}`));


### PR DESCRIPTION
`svelte-kit sync`, which runs when you install/clone a SvelteKit project, now loads the Vite config in order to read the project config. This results in this well-known but annoying warning:

```
▲ [WARNING] Cannot find base config file "./.svelte-kit/tsconfig.json" [tsconfig.json]

    tsconfig.json:2:12:
      2 │   "extends": "./.svelte-kit/tsconfig.json",
        ╵              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR squelches the warning by creating a placeholder `.svelte-kit/tsconfig.json` first. We can't prevent it happening when `vite dev` or `vite build` runs if the file didn't already exist, but it's much better than nothing.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
