### PR TITLE
fix: allow use of `$app/env/public` in service workers

### DIFF
--- a/.changeset/thirty-corners-tie.md
+++ b/.changeset/thirty-corners-tie.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow use of `$app/env/public` in service workers

--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -233,6 +233,8 @@ export function create_sveltekit_env_browser(variables, env, prelude) {
 	const issues = {};
 
 	const exports = Object.entries(variables).map(([name, config]) => {
+		// TODO should we exclude private vars here?
+
 		if (config.static) {
 			const value = validate(variables, env[name], name, issues);
 			return `export const ${name} = ${devalue.uneval(value)};\n`;
@@ -244,6 +246,44 @@ export function create_sveltekit_env_browser(variables, env, prelude) {
 	handle_issues(issues);
 
 	return `${prelude}\n\n${exports.join('')}`;
+}
+
+/**
+ * Creates the `__sveltekit/env/service-worker` module used in development
+ * (but not in prod, which goes through build_service_worker instead)
+ * @param {Record<string, EnvVarConfig<any>> | null} variables
+ * @param {Record<string, string>} env
+ * @param {string} global
+ */
+export function create_sveltekit_env_service_worker_dev(variables, env, global) {
+	if (!variables) {
+		return `${global} = { env: {} }`;
+	}
+
+	/** @type {string[]} */
+	const properties = [];
+
+	/** @type {Record<string, StandardSchemaV1.Issue[]>} */
+	const issues = {};
+
+	for (const [name, config] of Object.entries(variables)) {
+		if (!config.public) continue;
+
+		const value = validate(variables, env[name], name, issues);
+		properties.push(`${name}: ${devalue.uneval(value)}`);
+	}
+
+	handle_issues(issues);
+
+	return dedent`
+		globalThis.__SVELTEKIT_EXPERIMENTAL_EXPLICIT_ENVIRONMENT_VARIABLES__ = true;
+
+		${global} = {
+			env: {
+				${properties.join(',\n\t\t')}
+			}
+		};
+	`;
 }
 
 /** @param {string} description */

--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -222,9 +222,9 @@ export function create_sveltekit_env(variables, env, entry) {
  * Creates the `__sveltekit/env/browser` module
  * @param {Record<string, EnvVarConfig<any>> | null} variables
  * @param {Record<string, string>} env
- * @param {string} global
+ * @param {string} prelude
  */
-export function create_sveltekit_env_browser(variables, env, global) {
+export function create_sveltekit_env_browser(variables, env, prelude) {
 	if (!variables) {
 		return '';
 	}
@@ -243,7 +243,7 @@ export function create_sveltekit_env_browser(variables, env, global) {
 
 	handle_issues(issues);
 
-	return `const env = ${global}.env;\n\n${exports.join('')}`;
+	return `${prelude}\n\n${exports.join('')}`;
 }
 
 /** @param {string} description */

--- a/packages/kit/src/exports/vite/build/build_service_worker.js
+++ b/packages/kit/src/exports/vite/build/build_service_worker.js
@@ -99,7 +99,7 @@ export async function build_service_worker(
 				// TODO ideally we would only add the `importScripts` if there are dynamic vars that are known to be used
 				return create_sveltekit_env_browser(
 					env_config,
-					env,
+					env.all,
 					`importScripts('${kit.paths.base}/${kit.appDir}/env.script.js'); const env = globalThis.__sveltekit_sw.env;`
 				);
 			}

--- a/packages/kit/src/exports/vite/build/build_service_worker.js
+++ b/packages/kit/src/exports/vite/build/build_service_worker.js
@@ -109,7 +109,7 @@ export async function build_service_worker(
 			const relative = normalize_id(id, normalized_lib, normalized_cwd);
 			const stripped = strip_virtual_prefix(relative);
 			throw new Error(
-				`Cannot import ${stripped} into service-worker code. Only the modules $service-worker and $env/static/public are available in service workers.`
+				`Cannot import ${stripped} into service-worker code. Only the modules $service-worker, $env/static/public and $app/env/public are available in service workers.`
 			);
 		}
 	};

--- a/packages/kit/src/exports/vite/build/build_service_worker.js
+++ b/packages/kit/src/exports/vite/build/build_service_worker.js
@@ -96,6 +96,7 @@ export async function build_service_worker(
 			}
 
 			if (id === '\0virtual:app/env/public') {
+				// TODO ideally we would only add the `importScripts` if there are dynamic vars that are known to be used
 				return create_sveltekit_env_browser(
 					env_config,
 					env,

--- a/packages/kit/src/exports/vite/build/build_service_worker.js
+++ b/packages/kit/src/exports/vite/build/build_service_worker.js
@@ -4,7 +4,7 @@ import process from 'node:process';
 import * as vite from 'vite';
 import { dedent } from '../../../core/sync/utils.js';
 import { s } from '../../../utils/misc.js';
-import { get_config_aliases, strip_virtual_prefix, normalize_id } from '../utils.js';
+import { get_config_aliases, strip_virtual_prefix, get_env, normalize_id } from '../utils.js';
 import { create_static_module, create_sveltekit_env_browser } from '../../../core/env.js';
 import { env_static_public, service_worker } from '../module_ids.js';
 
@@ -20,7 +20,6 @@ const is_rolldown = !!vite.rolldownVersion;
  * @param {import('types').Prerendered} prerendered
  * @param {import('vite').Manifest} client_manifest
  * @param {Record<string, EnvVarConfig<any>> | null} env_config
- * @param {Record<string, any>} env
  */
 export async function build_service_worker(
 	out,
@@ -30,8 +29,7 @@ export async function build_service_worker(
 	service_worker_entry_file,
 	prerendered,
 	client_manifest,
-	env_config,
-	env
+	env_config
 ) {
 	const build = new Set();
 	for (const key in client_manifest) {
@@ -67,6 +65,8 @@ export async function build_service_worker(
 
 		export const version = ${s(kit.version.name)};
 	`;
+
+	const env = get_env(kit.env, vite_config.mode);
 
 	/**
 	 * @type {import('vite').Plugin}

--- a/packages/kit/src/exports/vite/build/build_service_worker.js
+++ b/packages/kit/src/exports/vite/build/build_service_worker.js
@@ -1,10 +1,11 @@
+/** @import { EnvVarConfig } from '@sveltejs/kit' */
 import fs from 'node:fs';
 import process from 'node:process';
 import * as vite from 'vite';
 import { dedent } from '../../../core/sync/utils.js';
 import { s } from '../../../utils/misc.js';
-import { get_config_aliases, strip_virtual_prefix, get_env, normalize_id } from '../utils.js';
-import { create_static_module } from '../../../core/env.js';
+import { get_config_aliases, strip_virtual_prefix, normalize_id } from '../utils.js';
+import { create_static_module, create_sveltekit_env_browser } from '../../../core/env.js';
 import { env_static_public, service_worker } from '../module_ids.js';
 
 // @ts-ignore `vite.rolldownVersion` only exists in `rolldown-vite`
@@ -18,6 +19,8 @@ const is_rolldown = !!vite.rolldownVersion;
  * @param {string} service_worker_entry_file
  * @param {import('types').Prerendered} prerendered
  * @param {import('vite').Manifest} client_manifest
+ * @param {Record<string, EnvVarConfig<any>> | null} env_config
+ * @param {Record<string, any>} env
  */
 export async function build_service_worker(
 	out,
@@ -26,7 +29,9 @@ export async function build_service_worker(
 	manifest_data,
 	service_worker_entry_file,
 	prerendered,
-	client_manifest
+	client_manifest,
+	env_config,
+	env
 ) {
 	const build = new Set();
 	for (const key in client_manifest) {
@@ -63,8 +68,6 @@ export async function build_service_worker(
 		export const version = ${s(kit.version.name)};
 	`;
 
-	const env = get_env(kit.env, vite_config.mode);
-
 	/**
 	 * @type {import('vite').Plugin}
 	 */
@@ -89,6 +92,14 @@ export async function build_service_worker(
 					'$env/static/public',
 					env.public,
 					kit.experimental.explicitEnvironmentVariables
+				);
+			}
+
+			if (id === '\0virtual:app/env/public') {
+				return create_sveltekit_env_browser(
+					env_config,
+					env,
+					`importScripts('${kit.paths.base}/${kit.appDir}/env.script.js'); const env = globalThis.__sveltekit_sw.env;`
 				);
 			}
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -17,7 +17,8 @@ import {
 	create_sveltekit_env,
 	create_sveltekit_env_browser,
 	create_static_module,
-	resolve_explicit_env_entry
+	resolve_explicit_env_entry,
+	create_sveltekit_env_service_worker_dev
 } from '../../core/env.js';
 import * as sync from '../../core/sync/sync.js';
 import { create_assets } from '../../core/sync/create_manifest_data/index.js';
@@ -630,12 +631,7 @@ async function kit({ svelte_config }) {
 					);
 
 				case sveltekit_env_service_worker:
-					return dedent`
-						import { env } from '${runtime_env_module}';
-
-						globalThis.__SVELTEKIT_EXPERIMENTAL_EXPLICIT_ENVIRONMENT_VARIABLES__ = true;
-						${global} = { env };
-					`;
+					return create_sveltekit_env_service_worker_dev(explicit_env_config, env.all, global);
 
 				case sveltekit_server: {
 					return dedent`
@@ -916,55 +912,15 @@ async function kit({ svelte_config }) {
 	const plugin_service_worker_env = {
 		name: 'vite-plugin-sveltekit-service-worker-env',
 
-		resolveId: {
-			filter: {
-				id: new RegExp(runtime_env_module.replaceAll('/', '\\/'))
-			},
-
-			handler(id) {
-				return { id };
-			}
-		},
-
-		load: {
-			filter: {
-				id: runtime_env_module
-			},
-			handler() {
-				const properties = [];
-
-				/** @type {Record<string, StandardSchemaV1.Issue[]>} */
-				const issues = {};
-
-				if (explicit_env_config === null) {
-					return '';
-				}
-
-				for (const [name, config] of Object.entries(explicit_env_config)) {
-					if (!config.public) continue;
-
-					const value = config.schema
-						? validate(explicit_env_config, env.all[name], name, issues)
-						: env.all[name];
-
-					properties.push(`${name}: ${devalue.uneval(value)}`);
-				}
-
-				handle_issues(issues);
-
-				return dedent`
-					export const env = {
-						${properties.join(',\n')}
-					};
-				`;
-			}
-		},
-
 		transform: {
 			filter: {
 				id: service_worker_entry_file || '<skip>'
 			},
 			handler(code) {
+				// in dev, we prepend the service worker with an import that
+				// configures `env`, in case `$app/env/public` is imported,
+				// in prod, where we currently use non-module service
+				// workers, we have to use `importScripts` instead
 				return {
 					code: `import '__sveltekit/env/service-worker';\n${code}`
 				};

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1,4 +1,3 @@
-/** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 /** @import { EnvVarConfig } from '@sveltejs/kit' */
 /** @import { Options, SvelteConfig } from '@sveltejs/vite-plugin-svelte' */
 /** @import { PreprocessorGroup } from 'svelte/compiler' */
@@ -8,7 +7,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
-import * as devalue from 'devalue';
 import colors from 'kleur';
 
 import { copy, mkdirp, posixify, read, resolve_entry, rimraf } from '../../utils/filesystem.js';
@@ -58,7 +56,6 @@ import { import_peer } from '../../utils/import.js';
 import { compact } from '../../utils/array.js';
 import { should_ignore, has_children } from './static_analysis/utils.js';
 import { treeshake_prerendered_remotes } from './build/remote.js';
-import { handle_issues, validate } from '../internal/env.js';
 
 const cwd = posixify(process.cwd());
 
@@ -260,8 +257,6 @@ async function kit({ svelte_config }) {
 
 	const service_worker_entry_file = resolve_entry(kit.files.serviceWorker);
 	const parsed_service_worker = path.parse(kit.files.serviceWorker);
-
-	const runtime_env_module = `${svelte_config.kit.paths.base}/${svelte_config.kit.appDir}/env.js`;
 
 	const normalized_cwd = vite.normalizePath(cwd);
 	const normalized_lib = vite.normalizePath(kit.files.lib);
@@ -1477,8 +1472,7 @@ async function kit({ svelte_config }) {
 						service_worker_entry_file,
 						prerendered,
 						client_manifest,
-						explicit_env_config,
-						env.all
+						explicit_env_config
 					);
 				}
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -557,7 +557,7 @@ async function kit({ svelte_config }) {
 							id,
 							normalized_lib,
 							normalized_cwd
-						)} into service-worker code. Only the modules $service-worker and $env/static/public are available in service workers.`
+						)} into service-worker code. Only the modules $service-worker, $env/static/public and $app/env/public are available in service workers.`
 					);
 				}
 			}

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1,3 +1,4 @@
+/** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 /** @import { EnvVarConfig } from '@sveltejs/kit' */
 /** @import { Options, SvelteConfig } from '@sveltejs/vite-plugin-svelte' */
 /** @import { PreprocessorGroup } from 'svelte/compiler' */
@@ -7,7 +8,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
-
+import * as devalue from 'devalue';
 import colors from 'kleur';
 
 import { copy, mkdirp, posixify, read, resolve_entry, rimraf } from '../../utils/filesystem.js';
@@ -49,12 +50,14 @@ import {
 	service_worker,
 	sveltekit_env,
 	sveltekit_env_browser,
+	sveltekit_env_service_worker,
 	sveltekit_server
 } from './module_ids.js';
 import { import_peer } from '../../utils/import.js';
 import { compact } from '../../utils/array.js';
 import { should_ignore, has_children } from './static_analysis/utils.js';
 import { treeshake_prerendered_remotes } from './build/remote.js';
+import { handle_issues, validate } from '../internal/env.js';
 
 const cwd = posixify(process.cwd());
 
@@ -256,6 +259,8 @@ async function kit({ svelte_config }) {
 
 	const service_worker_entry_file = resolve_entry(kit.files.serviceWorker);
 	const parsed_service_worker = path.parse(kit.files.serviceWorker);
+
+	const runtime_env_module = `${svelte_config.kit.paths.base}/${svelte_config.kit.appDir}/env.js`;
 
 	const normalized_cwd = vite.normalizePath(cwd);
 	const normalized_lib = vite.normalizePath(kit.files.lib);
@@ -544,7 +549,13 @@ async function kit({ svelte_config }) {
 					parsed_importer.dir === parsed_service_worker.dir &&
 					parsed_importer.name === parsed_service_worker.name;
 
-				if (importer_is_service_worker && id !== '$service-worker' && id !== '$env/static/public') {
+				if (
+					importer_is_service_worker &&
+					id !== '$service-worker' &&
+					id !== '$env/static/public' &&
+					id !== 'virtual:$app/env/public' &&
+					id !== '__sveltekit/env/service-worker'
+				) {
 					throw new Error(
 						`Cannot import ${normalize_id(
 							id,
@@ -612,7 +623,19 @@ async function kit({ svelte_config }) {
 					return create_sveltekit_env(explicit_env_config, env.all, explicit_env_entry);
 
 				case sveltekit_env_browser:
-					return create_sveltekit_env_browser(explicit_env_config, env.all, global);
+					return create_sveltekit_env_browser(
+						explicit_env_config,
+						env.all,
+						`const env = ${global}.env;`
+					);
+
+				case sveltekit_env_service_worker:
+					return dedent`
+						import { env } from '${runtime_env_module}';
+
+						globalThis.__SVELTEKIT_EXPERIMENTAL_EXPLICIT_ENVIRONMENT_VARIABLES__ = true;
+						${global} = { env };
+					`;
 
 				case sveltekit_server: {
 					return dedent`
@@ -886,6 +909,66 @@ async function kit({ svelte_config }) {
 			return {
 				code: result
 			};
+		}
+	};
+
+	/** @type {Plugin} */
+	const plugin_service_worker_env = {
+		name: 'vite-plugin-sveltekit-service-worker-env',
+
+		resolveId: {
+			filter: {
+				id: new RegExp(runtime_env_module.replaceAll('/', '\\/'))
+			},
+
+			handler(id) {
+				return { id };
+			}
+		},
+
+		load: {
+			filter: {
+				id: runtime_env_module
+			},
+			handler() {
+				const properties = [];
+
+				/** @type {Record<string, StandardSchemaV1.Issue[]>} */
+				const issues = {};
+
+				if (explicit_env_config === null) {
+					return '';
+				}
+
+				for (const [name, config] of Object.entries(explicit_env_config)) {
+					if (!config.public) continue;
+
+					const value = config.schema
+						? validate(explicit_env_config, env.all[name], name, issues)
+						: env.all[name];
+
+					properties.push(`${name}: ${devalue.uneval(value)}`);
+				}
+
+				handle_issues(issues);
+
+				return dedent`
+					export const env = {
+						${properties.join(',\n')}
+					};
+				`;
+			}
+		},
+
+		transform: {
+			filter: {
+				id: service_worker_entry_file || '<skip>'
+			},
+			handler(code) {
+				return {
+					code: `import '__sveltekit/env/service-worker';\n${code}`
+				};
+			}
 		}
 	};
 
@@ -1437,7 +1520,9 @@ async function kit({ svelte_config }) {
 						manifest_data,
 						service_worker_entry_file,
 						prerendered,
-						client_manifest
+						client_manifest,
+						explicit_env_config,
+						env.all
 					);
 				}
 
@@ -1494,6 +1579,9 @@ async function kit({ svelte_config }) {
 		kit.experimental.remoteFunctions && plugin_remote,
 		plugin_virtual_modules,
 		plugin_guard,
+		kit.experimental.explicitEnvironmentVariables &&
+			service_worker_entry_file &&
+			plugin_service_worker_env,
 		plugin_compile
 	].filter((p) => !!p);
 }

--- a/packages/kit/src/exports/vite/module_ids.js
+++ b/packages/kit/src/exports/vite/module_ids.js
@@ -8,6 +8,7 @@ export const env_dynamic_public = '\0virtual:env/dynamic/public';
 
 export const sveltekit_env = '\0virtual:__sveltekit/env';
 export const sveltekit_env_browser = '\0virtual:__sveltekit/env/browser';
+export const sveltekit_env_service_worker = '\0virtual:__sveltekit/env/service-worker';
 
 export const service_worker = '\0virtual:service-worker';
 

--- a/packages/kit/src/runtime/server/env_module.js
+++ b/packages/kit/src/runtime/server/env_module.js
@@ -3,7 +3,7 @@ import { public_env } from '../shared-server.js';
 import { explicit_public_env } from '__sveltekit/env';
 
 /** @type {string} */
-let body;
+let payload;
 
 /** @type {string} */
 let etag;
@@ -16,11 +16,13 @@ let headers;
  * @returns {Response}
  */
 export function get_public_env(request) {
+	const script = request.url.endsWith('.script.js');
+
 	const env = __SVELTEKIT_EXPERIMENTAL_EXPLICIT_ENVIRONMENT_VARIABLES__
-		? explicit_public_env
+		? explicit_public_env // TODO can we strip out static vars?
 		: public_env;
 
-	body ??= `export const env=${devalue.uneval(env)}`;
+	payload ??= devalue.uneval(env);
 	etag ??= `W/${Date.now()}`;
 	headers ??= new Headers({
 		'content-type': 'application/javascript; charset=utf-8',
@@ -31,5 +33,9 @@ export function get_public_env(request) {
 		return new Response(undefined, { status: 304, headers });
 	}
 
-	return new Response(body, { headers });
+	if (script) {
+		return new Response(`globalThis.__sveltekit_sw={env:${payload}}`, { headers });
+	}
+
+	return new Response(`export const env=${payload}`, { headers });
 }

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -317,7 +317,7 @@ export async function internal_respond(request, options, manifest, state) {
 		return resolve_route(resolved_path, new URL(request.url), manifest);
 	}
 
-	if (resolved_path === `/${app_dir}/env.js`) {
+	if (resolved_path === `/${app_dir}/env.js` || resolved_path === `/${app_dir}/env.script.js`) {
 		return get_public_env(request);
 	}
 


### PR DESCRIPTION
This adds `$app/env/public` support to service workers. I'm trying to create as few conflicts with the `version-3` branch as possible, so I haven't added tests here — instead, we'll switch the existing tests over to this approach on that branch.

In dev, it prepends the transformed `service-worker.js` with a virtual module import that makes env vars available to `$app/env/public` if that module gets imported. In prod, it uses `importScripts` instead, since we currently use non-module service workers. (Perhaps we change that in v3? [They're now Baseline](https://caniuse.com/wf-js-modules-service-workers), albeit only since January when Firefox added support.)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
