### PR TITLE
fix: close `import * from '$app/env/public'` loophole

### DIFF
--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -291,20 +291,16 @@ export function create_sveltekit_env_public(variables, env, prelude) {
  * @param {string} global
  */
 export function create_sveltekit_env_service_worker_dev(variables, env, global) {
-	if (!variables) {
-		return `${global} = { env: {} }`;
-	}
-
 	/** @type {string[]} */
 	const properties = [];
 
 	/** @type {Record<string, StandardSchemaV1.Issue[]>} */
 	const issues = {};
 
-	for (const [name, config] of Object.entries(variables)) {
+	for (const [name, config] of Object.entries(variables ?? {})) {
 		if (!config.public) continue;
 
-		const value = validate(variables, env[name], name, issues);
+		const value = validate(variables ?? {}, env[name], name, issues);
 		properties.push(`${name}: ${devalue.uneval(value)}`);
 	}
 
@@ -315,7 +311,7 @@ export function create_sveltekit_env_service_worker_dev(variables, env, global) 
 
 		${global} = {
 			env: {
-				${properties.join(',\n\t\t')}
+				${properties.join(',\n\t\t') || '// empty'}
 			}
 		};
 	`;

--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -177,19 +177,20 @@ export function create_sveltekit_env(variables, env, entry) {
 
 	for (const [name, config] of Object.entries(variables ?? {})) {
 		if (config.static) {
-			const value = validate(variables ?? {}, env[name], name, issues);
-			declarations.push(`export const ${name} = ${devalue.uneval(value)};`);
-
 			if (config.public) {
-				declarations.push(`explicit_public_env.${name} = ${name};`);
+				const value = validate(variables ?? {}, env[name], name, issues);
+				declarations.push(`explicit_public_env.${name} = ${devalue.uneval(value)};`);
 			}
 		} else {
-			declarations.push(`export var ${name};`);
-			setters.push(`${name} = validate(variables, env.${name}, ${JSON.stringify(name)}, issues);`);
+			setters.push(
+				`const ${name} = validate(variables, env.${name}, ${JSON.stringify(name)}, issues);`
+			);
 
 			if (config.public) {
 				setters.push(`explicit_public_env.${name} = ${name};`);
 				setters.push(`rendered_env.${name} = ${name};`);
+			} else {
+				setters.push(`dynamic_private_env.${name} = ${name};`);
 			}
 		}
 	}
@@ -201,6 +202,7 @@ export function create_sveltekit_env(variables, env, entry) {
 		imports.join('\n'),
 		`const issues = {};`,
 		'export { variables }',
+		'export const dynamic_private_env = {};',
 		'export const explicit_public_env = {};',
 		'export const rendered_env = {};',
 		...declarations,
@@ -219,12 +221,11 @@ export function create_sveltekit_env(variables, env, entry) {
 }
 
 /**
- * Creates the `__sveltekit/env/browser` module
+ * Creates the `__sveltekit/env/private` module
  * @param {Record<string, EnvVarConfig<any>> | null} variables
  * @param {Record<string, string>} env
- * @param {string} prelude
  */
-export function create_sveltekit_env_browser(variables, env, prelude) {
+export function create_sveltekit_env_private(variables, env) {
 	if (!variables) {
 		return '';
 	}
@@ -232,16 +233,50 @@ export function create_sveltekit_env_browser(variables, env, prelude) {
 	/** @type {Record<string, StandardSchemaV1.Issue[]>} */
 	const issues = {};
 
-	const exports = Object.entries(variables).map(([name, config]) => {
-		// TODO should we exclude private vars here?
+	/** @type {string[]} */
+	const exports = [];
 
-		if (config.static) {
-			const value = validate(variables, env[name], name, issues);
-			return `export const ${name} = ${devalue.uneval(value)};\n`;
-		}
+	for (const [name, config] of Object.entries(variables)) {
+		if (config.public) continue;
 
-		return `export const ${name} = env.${name};\n`;
-	});
+		const value = config.static
+			? devalue.uneval(validate(variables, env[name], name, issues))
+			: `env.${name}`;
+
+		exports.push(`export const ${name} = ${value};\n`);
+	}
+
+	handle_issues(issues);
+
+	return `import { dynamic_private_env as env } from '__sveltekit/env';\n\n${exports.join('')}`;
+}
+
+/**
+ * Creates the `__sveltekit/env/public/*` modules
+ * @param {Record<string, EnvVarConfig<any>> | null} variables
+ * @param {Record<string, string>} env
+ * @param {string} prelude
+ */
+export function create_sveltekit_env_public(variables, env, prelude) {
+	if (!variables) {
+		return '';
+	}
+
+	/** @type {Record<string, StandardSchemaV1.Issue[]>} */
+	const issues = {};
+
+	/** @type {string[]} */
+	const exports = [];
+
+	for (const [name, config] of Object.entries(variables)) {
+		if (!config.public) continue;
+
+		const value = config.static
+			? devalue.uneval(validate(variables, env[name], name, issues))
+			: `env.${name}`;
+
+		exports.push(`export const ${name} = ${value};\n`);
+	}
 
 	handle_issues(issues);
 

--- a/packages/kit/src/exports/vite/build/build_service_worker.js
+++ b/packages/kit/src/exports/vite/build/build_service_worker.js
@@ -5,7 +5,7 @@ import * as vite from 'vite';
 import { dedent } from '../../../core/sync/utils.js';
 import { s } from '../../../utils/misc.js';
 import { get_config_aliases, strip_virtual_prefix, get_env, normalize_id } from '../utils.js';
-import { create_static_module, create_sveltekit_env_browser } from '../../../core/env.js';
+import { create_static_module, create_sveltekit_env_public } from '../../../core/env.js';
 import { env_static_public, service_worker } from '../module_ids.js';
 
 // @ts-ignore `vite.rolldownVersion` only exists in `rolldown-vite`
@@ -97,7 +97,7 @@ export async function build_service_worker(
 
 			if (id === '\0virtual:app/env/public') {
 				// TODO ideally we would only add the `importScripts` if there are dynamic vars that are known to be used
-				return create_sveltekit_env_browser(
+				return create_sveltekit_env_public(
 					env_config,
 					env.all,
 					`importScripts('${kit.paths.base}/${kit.appDir}/env.script.js'); const env = globalThis.__sveltekit_sw.env;`

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -13,10 +13,11 @@ import { copy, mkdirp, posixify, read, resolve_entry, rimraf } from '../../utils
 import {
 	create_dynamic_module,
 	create_sveltekit_env,
-	create_sveltekit_env_browser,
+	create_sveltekit_env_public,
 	create_static_module,
 	resolve_explicit_env_entry,
-	create_sveltekit_env_service_worker_dev
+	create_sveltekit_env_service_worker_dev,
+	create_sveltekit_env_private
 } from '../../core/env.js';
 import * as sync from '../../core/sync/sync.js';
 import { create_assets } from '../../core/sync/create_manifest_data/index.js';
@@ -48,9 +49,11 @@ import {
 	env_static_public,
 	service_worker,
 	sveltekit_env,
-	sveltekit_env_browser,
+	sveltekit_env_private,
 	sveltekit_env_service_worker,
-	sveltekit_server
+	sveltekit_server,
+	sveltekit_env_public_client,
+	sveltekit_env_public_server
 } from './module_ids.js';
 import { import_peer } from '../../utils/import.js';
 import { compact } from '../../utils/array.js';
@@ -515,7 +518,7 @@ async function kit({ svelte_config }) {
 					explicit_env_entry = resolved;
 					explicit_env_config = await sync.env(kit, explicit_env_entry, vite_config_env.mode);
 
-					for (const id of [sveltekit_env, sveltekit_env_browser]) {
+					for (const id of [sveltekit_env, sveltekit_env_public]) {
 						const module = server.moduleGraph.getModuleById(id);
 
 						if (module) {
@@ -618,12 +621,22 @@ async function kit({ svelte_config }) {
 				case sveltekit_env:
 					return create_sveltekit_env(explicit_env_config, env.all, explicit_env_entry);
 
-				case sveltekit_env_browser:
-					return create_sveltekit_env_browser(
+				case sveltekit_env_public_client:
+					return create_sveltekit_env_public(
 						explicit_env_config,
 						env.all,
 						`const env = ${global}.env;`
 					);
+
+				case sveltekit_env_public_server:
+					return create_sveltekit_env_public(
+						explicit_env_config,
+						env.all,
+						`import { rendered_env as env } from '__sveltekit/env';`
+					);
+
+				case sveltekit_env_private:
+					return create_sveltekit_env_private(explicit_env_config, env.all);
 
 				case sveltekit_env_service_worker:
 					return create_sveltekit_env_service_worker_dev(explicit_env_config, env.all, global);

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -518,7 +518,7 @@ async function kit({ svelte_config }) {
 					explicit_env_entry = resolved;
 					explicit_env_config = await sync.env(kit, explicit_env_entry, vite_config_env.mode);
 
-					for (const id of [sveltekit_env, sveltekit_env_public]) {
+					for (const id of [sveltekit_env, sveltekit_env_public_client]) {
 						const module = server.moduleGraph.getModuleById(id);
 
 						if (module) {

--- a/packages/kit/src/exports/vite/module_ids.js
+++ b/packages/kit/src/exports/vite/module_ids.js
@@ -7,7 +7,9 @@ export const env_dynamic_private = '\0virtual:env/dynamic/private';
 export const env_dynamic_public = '\0virtual:env/dynamic/public';
 
 export const sveltekit_env = '\0virtual:__sveltekit/env';
-export const sveltekit_env_browser = '\0virtual:__sveltekit/env/browser';
+export const sveltekit_env_public_client = '\0virtual:__sveltekit/env/public/client';
+export const sveltekit_env_public_server = '\0virtual:__sveltekit/env/public/server';
+export const sveltekit_env_private = '\0virtual:__sveltekit/env/private';
 export const sveltekit_env_service_worker = '\0virtual:__sveltekit/env/service-worker';
 
 export const service_worker = '\0virtual:service-worker';

--- a/packages/kit/src/runtime/app/env/private.js
+++ b/packages/kit/src/runtime/app/env/private.js
@@ -1,1 +1,1 @@
-export * from '__sveltekit/env';
+export * from '__sveltekit/env/private';

--- a/packages/kit/src/runtime/app/env/public/client.js
+++ b/packages/kit/src/runtime/app/env/public/client.js
@@ -1,4 +1,4 @@
-export * from '__sveltekit/env/browser';
+export * from '__sveltekit/env/public/client';
 
 if (!__SVELTEKIT_EXPERIMENTAL_EXPLICIT_ENVIRONMENT_VARIABLES__) {
 	throw new Error(

--- a/packages/kit/src/runtime/app/env/public/server.js
+++ b/packages/kit/src/runtime/app/env/public/server.js
@@ -1,4 +1,4 @@
-export * from '__sveltekit/env';
+export * from '__sveltekit/env/public/server';
 
 if (!__SVELTEKIT_EXPERIMENTAL_EXPLICIT_ENVIRONMENT_VARIABLES__) {
 	throw new Error(

--- a/packages/kit/src/runtime/server/env_module.js
+++ b/packages/kit/src/runtime/server/env_module.js
@@ -1,6 +1,6 @@
 import * as devalue from 'devalue';
 import { public_env } from '../shared-server.js';
-import { explicit_public_env } from '__sveltekit/env';
+import { rendered_env } from '__sveltekit/env';
 
 /** @type {string} */
 let payload;
@@ -18,9 +18,7 @@ let headers;
 export function get_public_env(request) {
 	const script = request.url.endsWith('.script.js');
 
-	const env = __SVELTEKIT_EXPERIMENTAL_EXPLICIT_ENVIRONMENT_VARIABLES__
-		? explicit_public_env // TODO can we strip out static vars?
-		: public_env;
+	const env = __SVELTEKIT_EXPERIMENTAL_EXPLICIT_ENVIRONMENT_VARIABLES__ ? rendered_env : public_env;
 
 	payload ??= devalue.uneval(env);
 	etag ??= `W/${Date.now()}`;

--- a/packages/kit/src/types/ambient-private.d.ts
+++ b/packages/kit/src/types/ambient-private.d.ts
@@ -20,7 +20,7 @@ declare module '__sveltekit/server' {
 }
 
 declare module '__sveltekit/env' {
-	// exported environment variables are defined in ambient.d.ts
+	// exported environment variables are defined in env.d.ts
 
 	/** Populate exported environment variables */
 	export function set_env(environment: Record<string, string>): void;
@@ -32,6 +32,14 @@ declare module '__sveltekit/env' {
 	export const rendered_env: Record<string, any>;
 }
 
-declare module '__sveltekit/env/browser' {
-	// exported environment variables are defined in ambient.d.ts
+declare module '__sveltekit/env/private' {
+	// exported environment variables are defined in env.d.ts
+}
+
+declare module '__sveltekit/env/public/client' {
+	// exported environment variables are defined in env.d.ts
+}
+
+declare module '__sveltekit/env/public/server' {
+	// exported environment variables are defined in env.d.ts
 }

--- a/packages/kit/test/apps/options-2/src/routes/env/import-all/+page.server.ts
+++ b/packages/kit/test/apps/options-2/src/routes/env/import-all/+page.server.ts
@@ -1,0 +1,7 @@
+import * as env from '$app/env/private';
+
+export function load() {
+	return {
+		env
+	};
+}

--- a/packages/kit/test/apps/options-2/src/routes/env/import-all/+page.server.ts
+++ b/packages/kit/test/apps/options-2/src/routes/env/import-all/+page.server.ts
@@ -2,6 +2,7 @@ import * as env from '$app/env/private';
 
 export function load() {
 	return {
-		env
+		// we need to do this dance to strip out Symbol keys in Node 18, apparently?
+		env: Object.fromEntries(Object.entries(env))
 	};
 }

--- a/packages/kit/test/apps/options-2/src/routes/env/import-all/+page.svelte
+++ b/packages/kit/test/apps/options-2/src/routes/env/import-all/+page.svelte
@@ -1,0 +1,8 @@
+<script>
+	import * as env from '$app/env/public';
+
+	let { data } = $props();
+</script>
+
+<pre data-private>{JSON.stringify(data.env)}</pre>
+<pre data-public>{JSON.stringify(env)}</pre>

--- a/packages/kit/test/apps/options-2/test/test.js
+++ b/packages/kit/test/apps/options-2/test/test.js
@@ -25,6 +25,20 @@ test.describe('env', () => {
 		await page.goto('/basepath');
 		await expect(page.locator('body')).toHaveAttribute('data-message', 'hello');
 	});
+
+	test('correct values are exported from $app/env/*', async ({ page }) => {
+		await page.goto('/basepath/env/import-all');
+
+		await expect(page.locator('[data-private]')).toHaveText(
+			JSON.stringify({
+				PRIVATE_EXPLICIT_ENV: 'secret resolved at runtime',
+				PRIVATE_STATIC_EXPLICIT_ENV: 'secret resolved at build time',
+				PRIVATE_VALIDATED_DEFAULT_ENV: 'foo'
+			})
+		);
+
+		await expect(page.locator('[data-public]')).toHaveText(JSON.stringify({ MESSAGE: 'hello' }));
+	});
 });
 
 test.describe('paths', () => {


### PR DESCRIPTION
Ensures that people can't import internal stuff with an `import *` import. No changeset because explicit env vars is unreleased

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
