### PR TITLE
chore: add parents to error nodes

### DIFF
--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -33,6 +33,7 @@ export default function create_manifest_data({
 	const matchers = create_matchers(config, cwd);
 	const { nodes, routes } = create_routes_and_nodes(cwd, config, fallback);
 
+	// validate matcher names used in parameterised routes
 	for (const route of routes) {
 		for (const param of route.params) {
 			if (param.matcher && !matchers[param.matcher]) {
@@ -51,6 +52,7 @@ export default function create_manifest_data({
 }
 
 /**
+ * Returns a list of files in the `static` directory.
  * @param {import('types').ValidatedConfig} config
  */
 export function create_assets(config) {
@@ -131,6 +133,7 @@ function create_routes_and_nodes(cwd, config, fallback) {
 	/** @type {import('types').PageNode[]} */
 	const nodes = [];
 
+	// create route data by processing files in `src/routes`
 	if (fs.existsSync(config.kit.files.routes)) {
 		/**
 		 * @param {number} depth
@@ -390,6 +393,7 @@ function create_routes_and_nodes(cwd, config, fallback) {
 
 	prevent_conflicts(routes);
 
+	// fallback root layout and root error components
 	const root = routes[0];
 
 	if (!root.layout?.component) {
@@ -398,10 +402,11 @@ function create_routes_and_nodes(cwd, config, fallback) {
 	}
 
 	if (!root.error?.component) {
-		if (!root.error) root.error = { depth: 0 };
+		if (!root.error) root.error = { depth: 0, parent: root.layout };
 		root.error.component = posixify(path.relative(cwd, `${fallback}/error.svelte`));
 	}
 
+	// populate the page nodes list
 	// we do layouts/errors first as they are more likely to be reused,
 	// and smaller indexes take fewer bytes. also, this guarantees that
 	// the default error/layout are 0/1
@@ -423,6 +428,7 @@ function create_routes_and_nodes(cwd, config, fallback) {
 
 	const node_analyser = create_node_analyser();
 
+	// add the related layout, page, and error nodes for a route
 	for (const route of routes) {
 		if (!route.leaf) continue;
 
@@ -467,6 +473,22 @@ function create_routes_and_nodes(cwd, config, fallback) {
 		}
 	}
 
+	// add parents to error nodes so that we can compute which page options apply to them
+	for (const route of routes) {
+		if (!route.error) continue;
+
+		/** @type {import('types').RouteData | null} */
+		let current_route = route;
+		while (current_route) {
+			if (current_route.layout) {
+				route.error.parent = current_route.layout;
+				break;
+			}
+			current_route = current_route.parent;
+		}
+	}
+
+	// compute the final page options for each page node
 	for (const node of nodes) {
 		node.page_options = node_analyser.get_page_options(node);
 	}
@@ -484,6 +506,7 @@ function create_routes_and_nodes(cwd, config, fallback) {
 }
 
 /**
+ * Determine if and how the file is relevant to the routing system.
  * @param {string} project_relative
  * @param {string} file
  * @param {string[]} component_extensions


### PR DESCRIPTION
This is a prerequisite to closing https://github.com/sveltejs/kit/issues/9703 and https://github.com/sveltejs/kit/issues/12578

https://github.com/sveltejs/kit/pull/13234 failed because we were missing two things:
1. Determining if page options for a node are dynamic or static
2. Parent node info for error nodes to determine their final page options

The first has been solved by our static analyser which sets it to `null` if it wasn't statically analysable.
The second is solved by this PR. I've chosen to split it out so that it's easier to review, but if it only makes sense to do in the actual PRs that closes both issues, let me know.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
