### PR TITLE
fix: query.live remote functions use SSE instead of ndjson stream (#15921)

### DIFF
--- a/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
@@ -4,7 +4,7 @@ import { get_remote_request_headers, handle_side_channel_response } from '../sha
 import * as devalue from 'devalue';
 import { HttpError } from '@sveltejs/kit/internal';
 import { noop } from '../../../../utils/functions.js';
-import { read_ndjson } from '../../ndjson.js';
+import { read_sse } from '../../sse.js';
 
 /**
  * @param {Response} response
@@ -38,11 +38,11 @@ async function get_stream_reader(response) {
 }
 
 /**
- * Yields deserialized results from a ReadableStream of newline-delimited JSON
+ * Yields deserialized results from a ReadableStream of Server-Sent Events
  * @param {ReadableStreamDefaultReader<Uint8Array>} reader
  */
-async function* read_live_ndjson(reader) {
-	for await (const node of read_ndjson(reader)) {
+async function* read_live_sse(reader) {
+	for await (const node of read_sse(reader)) {
 		if (node.type === 'result') {
 			yield devalue.parse(node.result, app.decoders);
 			continue;
@@ -80,7 +80,7 @@ export async function* create_live_iterator(
 
 		on_connect();
 
-		yield* read_live_ndjson(reader);
+		yield* read_live_sse(reader);
 	} finally {
 		try {
 			await reader?.cancel();

--- a/packages/kit/src/runtime/client/sse.js
+++ b/packages/kit/src/runtime/client/sse.js
@@ -1,0 +1,63 @@
+/**
+ * @param {string} block
+ * @returns {string | undefined}
+ */
+function parse_sse_event_data(block) {
+	const lines = block.split('\n');
+	let data = '';
+
+	for (const line of lines) {
+		if (line.startsWith('data:')) {
+			data += (data ? '\n' : '') + line.slice(5).trimStart();
+		}
+	}
+
+	return data || undefined;
+}
+
+/**
+ * Yields parsed JSON objects from a ReadableStream of Server-Sent Events.
+ * Each yielded value is the raw `JSON.parse`'d object from a `data:` field.
+ * @param {ReadableStreamDefaultReader<Uint8Array>} reader
+ */
+export async function* read_sse(reader) {
+	let done = false;
+	let buffer = '';
+	const decoder = new TextDecoder();
+
+	while (true) {
+		let split = buffer.indexOf('\n\n');
+		while (split !== -1) {
+			const block = buffer.slice(0, split);
+			buffer = buffer.slice(split + 2);
+
+			const data = parse_sse_event_data(block);
+			if (data) {
+				yield JSON.parse(data);
+			}
+
+			split = buffer.indexOf('\n\n');
+		}
+
+		if (done) {
+			const block = buffer.trim();
+			if (block) {
+				const data = parse_sse_event_data(block);
+				if (data) {
+					yield JSON.parse(data);
+				}
+			}
+			return;
+		}
+
+		const chunk = await reader.read();
+		done = chunk.done;
+		if (chunk.value) {
+			buffer += decoder.decode(chunk.value, { stream: true });
+		}
+
+		if (done) {
+			buffer += decoder.decode();
+		}
+	}
+}

--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -170,7 +170,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 			 * @param {any} payload
 			 */
 			function send(controller, payload) {
-				controller.enqueue(encoder.encode(JSON.stringify(payload) + '\n'));
+				controller.enqueue(encoder.encode('data: ' + JSON.stringify(payload) + '\n\n'));
 			}
 
 			let closed = false;
@@ -245,7 +245,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 				{
 					headers: {
 						'cache-control': 'private, no-store',
-						'content-type': 'application/x-ndjson'
+						'content-type': 'text/event-stream'
 					}
 				}
 			);


### PR DESCRIPTION
closes #15921

query.live had problems with some proxies on client side which blocked the stream indefinitely.
Now it uses SSE headers and data format (but kept usual `fetch`) and should bypass those proxies.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
