### PR TITLE
feat: use SSE in `query.live` to avoid weird middleman quirks with normal streamed responses

### DIFF
--- a/.changeset/fast-bugs-fry.md
+++ b/.changeset/fast-bugs-fry.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: use SSE for `query.live`

--- a/.changeset/fast-bugs-fry.md
+++ b/.changeset/fast-bugs-fry.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/kit': minor
+'@sveltejs/kit': patch
 ---
 
-feat: use SSE for `query.live`
+fix: use SSE for `query.live`

--- a/packages/kit/src/runtime/client/ndjson.js
+++ b/packages/kit/src/runtime/client/ndjson.js
@@ -1,42 +1,15 @@
+import { read_stream } from './stream.js';
+
 /**
  * Yields parsed JSON objects from a ReadableStream of newline-delimited JSON.
  * Each yielded value is the raw `JSON.parse`'d object — callers handle deserialization.
  * @param {ReadableStreamDefaultReader<Uint8Array>} reader
  */
 export async function* read_ndjson(reader) {
-	let done = false;
-	let buffer = '';
-	const decoder = new TextDecoder();
-
-	while (true) {
-		let split = buffer.indexOf('\n');
-		while (split !== -1) {
-			const line = buffer.slice(0, split).trim();
-			buffer = buffer.slice(split + 1);
-
-			if (line) {
-				yield JSON.parse(line);
-			}
-
-			split = buffer.indexOf('\n');
-		}
-
-		if (done) {
-			const line = buffer.trim();
-			if (line) {
-				yield JSON.parse(line);
-			}
-			return;
-		}
-
-		const chunk = await reader.read();
-		done = chunk.done;
-		if (chunk.value) {
-			buffer += decoder.decode(chunk.value, { stream: true });
-		}
-
-		if (done) {
-			buffer += decoder.decode();
+	for await (const block of read_stream(reader, '\n')) {
+		const line = block.trim();
+		if (line) {
+			yield JSON.parse(line);
 		}
 	}
 }

--- a/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
@@ -38,22 +38,6 @@ async function get_stream_reader(response) {
 }
 
 /**
- * Yields deserialized results from a ReadableStream of Server-Sent Events
- * @param {ReadableStreamDefaultReader<Uint8Array>} reader
- */
-async function* read_live_sse(reader) {
-	for await (const node of read_sse(reader)) {
-		if (node.type === 'result') {
-			yield devalue.parse(node.result, app.decoders);
-			continue;
-		}
-
-		await handle_side_channel_response(node);
-		throw new HttpError(500, 'Invalid query.live response');
-	}
-}
-
-/**
  * @template T
  * @param {string} id
  * @param {string} payload
@@ -76,11 +60,20 @@ export async function* create_live_iterator(
 			headers: get_remote_request_headers(),
 			signal: controller.signal
 		});
+
 		reader = await get_stream_reader(response);
 
 		on_connect();
 
-		yield* read_live_sse(reader);
+		for await (const node of read_sse(reader)) {
+			if (node.type === 'result') {
+				yield devalue.parse(node.result, app.decoders);
+				continue;
+			}
+
+			await handle_side_channel_response(node);
+			throw new HttpError(500, 'Invalid query.live response');
+		}
 	} finally {
 		try {
 			await reader?.cancel();

--- a/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
@@ -52,17 +52,15 @@ export async function* create_live_iterator(
 	on_connect = noop
 ) {
 	const url = `${base}/${app_dir}/remote/${id}${payload ? `?payload=${payload}` : ''}`;
-	/** @type {ReadableStreamDefaultReader<Uint8Array> | null} */
-	let reader = null;
+
+	const response = await fetch(url, {
+		headers: get_remote_request_headers(),
+		signal: controller.signal
+	});
+
+	const reader = await get_stream_reader(response);
 
 	try {
-		const response = await fetch(url, {
-			headers: get_remote_request_headers(),
-			signal: controller.signal
-		});
-
-		reader = await get_stream_reader(response);
-
 		on_connect();
 
 		for await (const node of read_sse(reader)) {
@@ -76,7 +74,7 @@ export async function* create_live_iterator(
 		}
 	} finally {
 		try {
-			await reader?.cancel();
+			await reader.cancel();
 		} catch {
 			// already closed
 		}

--- a/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
@@ -7,37 +7,6 @@ import { noop } from '../../../../utils/functions.js';
 import { read_sse } from '../../sse.js';
 
 /**
- * @param {Response} response
- * @returns {Promise<ReadableStreamDefaultReader<Uint8Array>>}
- */
-async function get_stream_reader(response) {
-	const content_type = response.headers.get('content-type') ?? '';
-
-	if (response.ok && content_type.includes('application/json')) {
-		// we can end up here if we e.g. redirect in `handle`
-		const result = await response.json();
-		await handle_side_channel_response(result);
-		throw new HttpError(500, 'Invalid query.live response');
-	}
-
-	if (!response.ok) {
-		const result = await response.json().catch(() => ({
-			type: 'error',
-			status: response.status,
-			error: response.statusText
-		}));
-
-		throw new HttpError(result.status ?? response.status ?? 500, result.error);
-	}
-
-	if (!response.body) {
-		throw new Error('Expected query.live response body to be a ReadableStream');
-	}
-
-	return response.body.getReader();
-}
-
-/**
  * @template T
  * @param {string} id
  * @param {string} payload
@@ -58,7 +27,28 @@ export async function* create_live_iterator(
 		signal: controller.signal
 	});
 
-	const reader = await get_stream_reader(response);
+	if (!response.ok) {
+		const result = await response.json().catch(() => ({
+			type: 'error',
+			status: response.status,
+			error: response.statusText
+		}));
+
+		throw new HttpError(result.status ?? response.status ?? 500, result.error);
+	}
+
+	if (response.headers.get('content-type')?.includes('application/json')) {
+		// we can end up here if we e.g. redirect in `handle`
+		const result = await response.json();
+		await handle_side_channel_response(result);
+		throw new HttpError(500, 'Invalid query.live response');
+	}
+
+	if (!response.body) {
+		throw new Error('Expected query.live response body to be a ReadableStream');
+	}
+
+	const reader = response.body.getReader();
 
 	try {
 		on_connect();

--- a/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/iterator.js
@@ -4,7 +4,7 @@ import { get_remote_request_headers, handle_side_channel_response } from '../sha
 import * as devalue from 'devalue';
 import { HttpError } from '@sveltejs/kit/internal';
 import { noop } from '../../../../utils/functions.js';
-import { read_ndjson } from '../../ndjson.js';
+import { read_sse } from '../../sse.js';
 
 /**
  * @param {Response} response
@@ -38,11 +38,11 @@ async function get_stream_reader(response) {
 }
 
 /**
- * Yields deserialized results from a ReadableStream of newline-delimited JSON
+ * Yields deserialized results from a ReadableStream of Server-Sent Events
  * @param {ReadableStreamDefaultReader<Uint8Array>} reader
  */
-async function* read_live_ndjson(reader) {
-	for await (const node of read_ndjson(reader)) {
+async function* read_live_sse(reader) {
+	for await (const node of read_sse(reader)) {
 		if (node.type === 'result') {
 			yield devalue.parse(node.result, app.decoders);
 			continue;
@@ -80,7 +80,7 @@ export async function* create_live_iterator(
 
 		on_connect();
 
-		yield* read_live_ndjson(reader);
+		yield* read_live_sse(reader);
 	} finally {
 		try {
 			await reader?.cancel();

--- a/packages/kit/src/runtime/client/sse.js
+++ b/packages/kit/src/runtime/client/sse.js
@@ -1,0 +1,63 @@
+/**
+ * @param {string} block
+ * @returns {string | undefined}
+ */
+function parse_sse_event_data(block) {
+	const lines = block.split('\n');
+	let data = '';
+
+	for (const line of lines) {
+		if (line.startsWith('data:')) {
+			data += (data ? '\n' : '') + line.slice(5).trimStart();
+		}
+	}
+
+	return data || undefined;
+}
+
+/**
+ * Yields parsed JSON objects from a ReadableStream of Server-Sent Events.
+ * Each yielded value is the raw `JSON.parse`'d object from a `data:` field.
+ * @param {ReadableStreamDefaultReader<Uint8Array>} reader
+ */
+export async function* read_sse(reader) {
+	let done = false;
+	let buffer = '';
+	const decoder = new TextDecoder();
+
+	while (true) {
+		let split = buffer.indexOf('\n\n');
+		while (split !== -1) {
+			const block = buffer.slice(0, split);
+			buffer = buffer.slice(split + 2);
+
+			const data = parse_sse_event_data(block);
+			if (data) {
+				yield JSON.parse(data);
+			}
+
+			split = buffer.indexOf('\n\n');
+		}
+
+		if (done) {
+			const block = buffer.trim();
+			if (block) {
+				const data = parse_sse_event_data(block);
+				if (data) {
+					yield JSON.parse(data);
+				}
+			}
+			return;
+		}
+
+		const chunk = await reader.read();
+		done = chunk.done;
+		if (chunk.value) {
+			buffer += decoder.decode(chunk.value, { stream: true });
+		}
+
+		if (done) {
+			buffer += decoder.decode();
+		}
+	}
+}

--- a/packages/kit/src/runtime/client/sse.js
+++ b/packages/kit/src/runtime/client/sse.js
@@ -1,3 +1,5 @@
+import { read_stream } from './stream.js';
+
 /**
  * @param {string} block
  * @returns {string | undefined}
@@ -21,43 +23,10 @@ function parse_sse_event_data(block) {
  * @param {ReadableStreamDefaultReader<Uint8Array>} reader
  */
 export async function* read_sse(reader) {
-	let done = false;
-	let buffer = '';
-	const decoder = new TextDecoder();
-
-	while (true) {
-		let split = buffer.indexOf('\n\n');
-		while (split !== -1) {
-			const block = buffer.slice(0, split);
-			buffer = buffer.slice(split + 2);
-
-			const data = parse_sse_event_data(block);
-			if (data) {
-				yield JSON.parse(data);
-			}
-
-			split = buffer.indexOf('\n\n');
-		}
-
-		if (done) {
-			const block = buffer.trim();
-			if (block) {
-				const data = parse_sse_event_data(block);
-				if (data) {
-					yield JSON.parse(data);
-				}
-			}
-			return;
-		}
-
-		const chunk = await reader.read();
-		done = chunk.done;
-		if (chunk.value) {
-			buffer += decoder.decode(chunk.value, { stream: true });
-		}
-
-		if (done) {
-			buffer += decoder.decode();
+	for await (const block of read_stream(reader, '\n\n')) {
+		const data = parse_sse_event_data(block);
+		if (data) {
+			yield JSON.parse(data);
 		}
 	}
 }

--- a/packages/kit/src/runtime/client/stream.js
+++ b/packages/kit/src/runtime/client/stream.js
@@ -1,0 +1,38 @@
+/**
+ * Reads from a stream, decoding it as text and yielding each block of content
+ * separated by `delimiter`. The trailing block (if any) is yielded once the
+ * stream closes.
+ * @param {ReadableStreamDefaultReader<Uint8Array>} reader
+ * @param {string} delimiter
+ */
+export async function* read_stream(reader, delimiter) {
+	let done = false;
+	let buffer = '';
+	const decoder = new TextDecoder();
+
+	while (true) {
+		let split = buffer.indexOf(delimiter);
+		while (split !== -1) {
+			yield buffer.slice(0, split);
+			buffer = buffer.slice(split + delimiter.length);
+			split = buffer.indexOf(delimiter);
+		}
+
+		if (done) {
+			if (buffer) {
+				yield buffer;
+			}
+			return;
+		}
+
+		const chunk = await reader.read();
+		done = chunk.done;
+		if (chunk.value) {
+			buffer += decoder.decode(chunk.value, { stream: true });
+		}
+
+		if (done) {
+			buffer += decoder.decode();
+		}
+	}
+}

--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -170,7 +170,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 			 * @param {any} payload
 			 */
 			function send(controller, payload) {
-				controller.enqueue(encoder.encode(JSON.stringify(payload) + '\n'));
+				controller.enqueue(encoder.encode('data: ' + JSON.stringify(payload) + '\n\n'));
 			}
 
 			let closed = false;
@@ -245,7 +245,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 				{
 					headers: {
 						'cache-control': 'private, no-store',
-						'content-type': 'application/x-ndjson'
+						'content-type': 'text/event-stream'
 					}
 				}
 			);


### PR DESCRIPTION
closes #15956
closes #15921
closes (maybe) #15790?

Some middlemen (antivirus, nginx) do weird buffer-y things with streamed responses, in spite of the no-store cache directives we use. SSE is more universal and seems to bypass some of these behaviors. TBD on whether this works for the nginx issue.

Due to weird GitHub quirks I couldn't push to @IAkumaI's branch. This still contains his commits.