### PR TITLE
fix: reinstate `$app/environment` as an alias for `$app/env`, in case dependencies import it

### DIFF
--- a/.changeset/pink-cobras-rush.md
+++ b/.changeset/pink-cobras-rush.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: reinstate `$app/environment` as an alias for `$app/env`, in case dependencies import it

--- a/packages/adapter-auto/adapters.js
+++ b/packages/adapter-auto/adapters.js
@@ -7,19 +7,19 @@ export const adapters = [
 		name: 'Vercel',
 		test: () => !!process.env.VERCEL,
 		module: '@sveltejs/adapter-vercel',
-		version: '6'
+		version: '7'
 	},
 	{
 		name: 'Cloudflare Pages',
 		test: () => !!process.env.CF_PAGES,
 		module: '@sveltejs/adapter-cloudflare',
-		version: '7'
+		version: '8'
 	},
 	{
 		name: 'Netlify',
 		test: () => !!process.env.NETLIFY,
 		module: '@sveltejs/adapter-netlify',
-		version: '6'
+		version: '7'
 	},
 	{
 		name: 'Azure Static Web Apps',
@@ -37,6 +37,6 @@ export const adapters = [
 		name: 'Google Cloud Run',
 		test: () => !!process.env.GCP_BUILDPACKS,
 		module: '@sveltejs/adapter-node',
-		version: '5'
+		version: '6'
 	}
 ];

--- a/packages/kit/src/runtime/app/environment/index.js
+++ b/packages/kit/src/runtime/app/environment/index.js
@@ -3,6 +3,6 @@ export * from '../env/index.js';
 
 if (dev) {
 	console.warn(
-		'`$app/environment` is now `$app/env`. If you are not importing this module directly, it means one of your dependencies is'
+		'`$app/environment` is now `$app/env`'
 	);
 }

--- a/packages/kit/src/runtime/app/environment/index.js
+++ b/packages/kit/src/runtime/app/environment/index.js
@@ -2,7 +2,5 @@ import { dev } from '../env/index.js';
 export * from '../env/index.js';
 
 if (dev) {
-	console.warn(
-		'`$app/environment` is now `$app/env`'
-	);
+	console.warn('`$app/environment` is now `$app/env`');
 }

--- a/packages/kit/src/runtime/app/environment/index.js
+++ b/packages/kit/src/runtime/app/environment/index.js
@@ -1,0 +1,8 @@
+import { dev } from '../env/index.js';
+export * from '../env/index.js';
+
+if (dev) {
+	console.warn(
+		'`$app/environment` is now `$app/env`. If you are not importing this module directly, it means one of your dependencies is'
+	);
+}


### PR DESCRIPTION
Stumbled on this while updating svelte.dev to use v3 — some dependencies (like Vercel Speed Insights) import `$app/environment`, so we need to keep it as an importable module (albeit one that will get red squigglies if you have it in your own code).

It's _possible_ that the same will be true of `$env/*`, but I doubt it

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
