### PR TITLE
docs: use modern dynamic-component syntax in the {#await} FAQ example

### DIFF
--- a/documentation/docs/60-appendix/10-faq.md
+++ b/documentation/docs/60-appendix/10-faq.md
@@ -124,8 +124,8 @@ Finally, you may also consider using an `{#await}` block:
 
 {#await ComponentConstructor}
 	<p>Loading...</p>
-{:then component}
-	<svelte:component this={component} />
+{:then Component}
+	<Component />
 {:catch error}
 	<p>Something went wrong: {error.message}</p>
 {/await}

--- a/documentation/docs/60-appendix/10-faq.md
+++ b/documentation/docs/60-appendix/10-faq.md
@@ -117,9 +117,9 @@ Finally, you may also consider using an `{#await}` block:
 <script>
 	import { browser } from '$app/environment';
 
-	const promise = browser ?
-		import('./BrowserComponent.svelte') :
-		import('./ServerComponent.svelte');
+	const promise = browser
+		? import('./BrowserComponent.svelte')
+		: import('./ServerComponent.svelte');
 </script>
 
 {#await promise}

--- a/documentation/docs/60-appendix/10-faq.md
+++ b/documentation/docs/60-appendix/10-faq.md
@@ -117,15 +117,15 @@ Finally, you may also consider using an `{#await}` block:
 <script>
 	import { browser } from '$app/environment';
 
-	const ComponentConstructor = browser ?
-		import('some-browser-only-library').then((module) => module.Component) :
-		new Promise(() => {});
+	const promise = browser ?
+		import('./BrowserComponent.svelte') :
+		import('./ServerComponent.svelte');
 </script>
 
-{#await ComponentConstructor}
+{#await promise}
 	<p>Loading...</p>
-{:then Component}
-	<Component />
+{:then module}
+	<module.default />
 {:catch error}
 	<p>Something went wrong: {error.message}</p>
 {/await}


### PR DESCRIPTION
## Summary

The `{#await}` example in the FAQ entry _"How do I use a client-side library accessing `document` or `window`?"_ renders the resolved component with `<svelte:component>`:

```svelte
{:then component}
	<svelte:component this={component} />
```

`<svelte:component>` is **deprecated in Svelte 5 runes mode** — components are dynamic by default, so a capitalized variable can be rendered directly. SvelteKit 2 requires Svelte 5, so copying this example emits a deprecation warning.

## Change

Render the resolved constructor directly by capitalizing the `{:then}` binding:

```svelte
{:then Component}
	<Component />
```

This is the only `<svelte:component>` usage left in `documentation/docs/`. Docs-only change.
