### PR TITLE
docs: fix explicit env vars docs version

### DIFF
--- a/.changeset/rich-dragons-rest.md
+++ b/.changeset/rich-dragons-rest.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+docs: adjust the release version of explicit env vars

--- a/documentation/docs/20-core-concepts/70-environment-variables.md
+++ b/documentation/docs/20-core-concepts/70-environment-variables.md
@@ -20,7 +20,7 @@ By default, every environment variable is implicitly available inside your app v
 
 ## Explicit environment variables
 
-As of SvelteKit 2.62, you can opt into _explicit_ environment variables, in which case you instead import environment variables from these modules:
+As of SvelteKit 2.63, you can opt into _explicit_ environment variables, in which case you instead import environment variables from these modules:
 
 - [`$app/env/private`]($app-env-private)
 - [`$app/env/public`]($app-env-public)

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -478,7 +478,7 @@ export interface KitConfig {
 	experimental?: {
 		/**
 		 * Whether to enable explicit environment variables using `src/env.js` or `src/env.ts`.
-		 * @since 2.62.0
+		 * @since 2.63.0
 		 * @default false
 		 */
 		explicitEnvironmentVariables?: boolean;

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -452,7 +452,7 @@ declare module '@sveltejs/kit' {
 		experimental?: {
 			/**
 			 * Whether to enable explicit environment variables using `src/env.js` or `src/env.ts`.
-			 * @since 2.62.0
+			 * @since 2.63.0
 			 * @default false
 			 */
 			explicitEnvironmentVariables?: boolean;


### PR DESCRIPTION
<!-- Explain the goal of the PR, why it is needed, and what has been changed to achieve that goal -->

#15934 was created before Kit 2.62 got released, thus its docs updates naturally indicated 2.62 as a target version. However, 2.62 got released before merging this PR (or not including it). As a result, the "since version" is erroneous.

This PR fixes this by bumping the numbers everywhere the original PR set them to 2.63, which actually includes the change.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
