### PR TITLE
fix: ensure version is defined when using $app/env with explicit env vars

### DIFF
--- a/.changeset/wide-otters-shout.md
+++ b/.changeset/wide-otters-shout.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: ensure `version` is defined when importing from `$app/env` with explicit environment variables

--- a/packages/kit/src/runtime/app/env/index.js
+++ b/packages/kit/src/runtime/app/env/index.js
@@ -1,5 +1,2 @@
 export { BROWSER as browser, DEV as dev } from 'esm-env';
 export { building, version } from './internal.js';
-
-// force the Vite client to load, so that defines are definitely defined
-import.meta.hot;

--- a/packages/kit/src/runtime/app/env/index.js
+++ b/packages/kit/src/runtime/app/env/index.js
@@ -1,2 +1,5 @@
 export { BROWSER as browser, DEV as dev } from 'esm-env';
 export { building, version } from './internal.js';
+
+// force the Vite client to load, so that defines are definitely defined
+import.meta.hot;

--- a/packages/kit/src/runtime/app/environment/index.js
+++ b/packages/kit/src/runtime/app/environment/index.js
@@ -5,6 +5,3 @@ if (__SVELTEKIT_EXPERIMENTAL_EXPLICIT_ENVIRONMENT_VARIABLES__) {
 		'Cannot import `$app/environment` when `experimental.explicitEnvironmentVariables` is enabled. Use `$app/env` instead.'
 	);
 }
-
-// force the Vite client to load, so that defines are definitely defined
-import.meta.hot;

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -634,8 +634,11 @@ export async function render_response({
 					}`);
 		}
 
+		// we need to eagerly import the Vite client module in development to ensure
+		// that Vite global constant replacements are initialised before our code runs
 		const init_app = `
 				{
+					${DEV ? `import('${paths.base}/@vite/client')` : ''}
 					${blocks.join('\n\n\t\t\t\t\t')}
 				}
 			`;

--- a/packages/kit/test/apps/options-2/src/hooks.client.js
+++ b/packages/kit/test/apps/options-2/src/hooks.client.js
@@ -1,0 +1,6 @@
+import { version } from '$app/env';
+
+// Regression guard for #15971: this import runs before the router is initialized.
+// Without the fix it throws `__SVELTEKIT_APP_VERSION__ is not defined` when
+// `experimental.explicitEnvironmentVariables` is enabled. `void` keeps the import.
+void version;

--- a/packages/kit/test/apps/options-2/test/test.js
+++ b/packages/kit/test/apps/options-2/test/test.js
@@ -184,3 +184,17 @@ test.describe("bundleStrategy: 'single'", () => {
 		await expect(page.locator('h1', { hasText: 'It works!' })).toBeVisible();
 	});
 });
+
+test.describe('$app/env', () => {
+	// regression test for https://github.com/sveltejs/kit/issues/15971:
+	// importing `$app/env` before the router is initialized (e.g. in
+	// hooks.client.js) must not throw `__SVELTEKIT_APP_VERSION__ is not defined`
+	test('version is defined when imported during client init', async ({ page }) => {
+		/** @type {string[]} */
+		const errors = [];
+		page.on('pageerror', (error) => errors.push(error.message));
+		await page.goto('/basepath');
+		await page.waitForTimeout(500);
+		expect(errors.filter((message) => message.includes('__SVELTEKIT_APP_VERSION__'))).toEqual([]);
+	});
+});

--- a/packages/kit/test/apps/options-2/test/test.js
+++ b/packages/kit/test/apps/options-2/test/test.js
@@ -189,12 +189,14 @@ test.describe('$app/env', () => {
 	// regression test for https://github.com/sveltejs/kit/issues/15971:
 	// importing `$app/env` before the router is initialized (e.g. in
 	// hooks.client.js) must not throw `__SVELTEKIT_APP_VERSION__ is not defined`
-	test('version is defined when imported during client init', async ({ page }) => {
-		/** @type {string[]} */
-		const errors = [];
-		page.on('pageerror', (error) => errors.push(error.message));
-		await page.goto('/basepath');
-		await page.waitForTimeout(500);
-		expect(errors.filter((message) => message.includes('__SVELTEKIT_APP_VERSION__'))).toEqual([]);
+	test('version is defined when imported during client init', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		test.skip(!javaScriptEnabled || !process.env.DEV);
+
+		await page.goto('/basepath', { wait_for_started: false });
+		await expect(page.locator('body.started')).toBeVisible();
+		expect(await page.pageErrors()).toHaveLength(0);
 	});
 });


### PR DESCRIPTION
When `experimental.explicitEnvironmentVariables` is enabled, `$app/environment` throws and apps import from `$app/env` instead. `$app/env` re-exports `version` from `internal.js` (`export const version = __SVELTEKIT_APP_VERSION__`), but unlike `$app/environment` it never references `import.meta.hot`, so Vite doesn't force its client to load. If `$app/env` is imported before the Vite client has loaded, `version` evaluates while the define is missing and the browser throws:

```
ReferenceError: __SVELTEKIT_APP_VERSION__ is not defined
```

This happens when `$app/env` is imported early, e.g. from `hooks.client.js`. Importing it from a route component is too late to hit it, since the client is already up by then, which is why it's intermittent. I ran into it in a real app after enabling `experimental.explicitEnvironmentVariables`.

It came in with #15934, which moved `version` onto the `__SVELTEKIT_APP_VERSION__` define and added `import.meta.hot` to `$app/environment`, but not to the newly split `$app/env`.

The fix mirrors `$app/environment`. I left that file's `import.meta.hot` in place to keep this minimal, though it's now redundant with this one.

Added a regression test in `options-2`: an early `$app/env` import in `hooks.client.js` plus a load of the page. It fails on `main` (the app never finishes hydrating) and passes with this change.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
