### PR TITLE
fix: omit empty file inputs from form data instead of including them as undefined

### DIFF
--- a/.changeset/slimy-files-rest.md
+++ b/.changeset/slimy-files-rest.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: omit empty `<input type="file">` fields from submitted form data instead of including them as `undefined`

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -59,7 +59,13 @@ export function convert_formdata(data) {
 			values = values.map((v) => v === 'on');
 		}
 
-		set_nested_value(result, key, is_array ? values : values[0]);
+		if (is_array) {
+			set_nested_value(result, key, values);
+		} else if (values.length > 0) {
+			// omit the key entirely when there's no value (e.g. an unselected
+			// `<input type="file">`), rather than setting it to `undefined`
+			set_nested_value(result, key, values[0]);
+		}
 	}
 
 	return result;

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -91,6 +91,18 @@ describe('convert_formdata', () => {
 		});
 	});
 
+	test('omits empty file inputs instead of setting them to undefined', () => {
+		const data = new FormData();
+		// an unselected `<input type="file">` submits an empty, nameless file
+		data.append('file', new File([], ''));
+		data.append('text', 'hello');
+
+		const converted = convert_formdata(data);
+
+		expect('file' in converted).toBe(false);
+		expect(converted).toStrictEqual({ text: 'hello' });
+	});
+
 	test.each(POLLUTION_ATTACKS)('prevents prototype pollution: %s', (attack) => {
 		const data = new FormData();
 		data.append(attack, 'bad');


### PR DESCRIPTION
An unselected `<input type="file">` submits an empty, nameless file. `convert_formdata` filters it out, but then falls through to the generic `values[0]` assignment, so the field comes back as `{ file: undefined }` instead of being omitted. That breaks validators that treat optional keys differently from `undefined` (e.g. ArkType).

This omits a non-array key when it has no value after filtering — which only happens for an unselected file. Arrays and empty strings/numbers are unchanged, and required fields still fail validation.

Doesn't touch the separate type-level point in the issue (`file?` in `RemoteFormInput`).

Fixes #15886.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
