### PR TITLE
docs: fix preview docs deployments

### DIFF
--- a/documentation/docs/20-core-concepts/70-environment-variables.md
+++ b/documentation/docs/20-core-concepts/70-environment-variables.md
@@ -2,8 +2,6 @@
 title: Environment variables
 ---
 
-<!-- TODO this is out of date -->
-
 Environment variables are values your app needs that exist separately from the app's source code. They allow you to use sensitive information like API keys and database credentials without storing them in version control.
 
 During development, and at build time, variables defined in a `.env` or `.env.local` file will be added to the environment:
@@ -13,40 +11,17 @@ During development, and at build time, variables defined in a `.env` or `.env.lo
 API_KEY=19f401ba-e8b0-48c4-8c77-b0ebb26d97fe
 ```
 
-By default, every environment variable is implicitly available inside your app via the following modules:
-
-- [`$env/static/private`]($env-static-private)
-- [`$env/static/public`]($env-static-public)
-- [`$env/dynamic/private`]($env-dynamic-private)
-- [`$env/dynamic/public`]($env-dynamic-public)
-
-## Explicit environment variables
-
-As of SvelteKit 2.62, you can opt into _explicit_ environment variables, in which case you instead import environment variables from these modules:
+After following the setup below, they can be imported via the following modules:
 
 - [`$app/env/private`]($app-env-private)
 - [`$app/env/public`]($app-env-public)
 
-Additionally, the [`$app/environment`]($app-environment) module is renamed to [`$app/env`]($app-env).
-
-> [!NOTE] Explicit environment variables will become the default in SvelteKit 3. The `$env/*` modules, along with `$app/environment`, will be removed.
+> [!LEGACY]
+> The `$env/*` modules, along with `$app/environment` were removed in SvelteKit 3 in favour of explicit environment variables that were added in SvelteKit 2.62 as an experimental option.
 
 ### Setup
 
-To opt in, update your configuration...
-
-```js
-/// file: svelte.config.js
-export default {
-	kit: {
-		experimental: {
-			+++explicitEnvironmentVariables: true+++
-		}
-	}
-};
-```
-
-...and add a `src/env.ts` (or `src/env.js`) file that exports a `variables` object:
+Add a `src/env.ts` (or `src/env.js`) file that exports a `variables` object:
 
 ```ts
 /// file: src/env.ts

--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -100,6 +100,12 @@ Vercel supports [Incremental Static Regeneration](https://vercel.com/docs/increm
 To add ISR to a route, include the `isr` property in your `config` object:
 
 ```js
+// @filename: env.d.ts
+declare module '$app/env/private' {
+	export const BYPASS_TOKEN: string;
+}
+// ---cut---
+// @filename: +page.server.js
 import { BYPASS_TOKEN } from '$app/env/private';
 
 /** @type {import('@sveltejs/adapter-vercel').Config} */

--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -104,8 +104,8 @@ To add ISR to a route, include the `isr` property in your `config` object:
 declare module '$app/env/private' {
 	export const BYPASS_TOKEN: string;
 }
-// ---cut---
 // @filename: +page.server.js
+// ---cut---
 import { BYPASS_TOKEN } from '$app/env/private';
 
 /** @type {import('@sveltejs/adapter-vercel').Config} */

--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -172,7 +172,7 @@ export function load() {
 <p>This staging environment was deployed from {data.deploymentGitBranch}.</p>
 ```
 
-Since all of these variables are unchanged between build time and run time when building on Vercel, we recommend configuring the variable with `state: true` — which will statically replace the variables, enabling optimisations like dead code elimination.
+Since all of these variables are unchanged between build time and run time when building on Vercel, we recommend configuring the variable with `static: true` — which will statically replace the variables, enabling optimisations like dead code elimination.
 
 ## Skew protection
 

--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -158,6 +158,12 @@ Vercel makes a set of [deployment-specific environment variables](https://vercel
 
 ```js
 /// file: +layout.server.js
+// @filename: env.d.ts
+declare module '$app/env/private' {
+	export const VERCEL_COMMIT_REF: string;
+}
+// @filename: +layout.server.js
+// ---cut---
 import { VERCEL_COMMIT_REF } from '$app/env/private';
 
 /** @type {import('./$types').LayoutServerLoad} */

--- a/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
+++ b/documentation/docs/25-build-and-deploy/90-adapter-vercel.md
@@ -100,7 +100,7 @@ Vercel supports [Incremental Static Regeneration](https://vercel.com/docs/increm
 To add ISR to a route, include the `isr` property in your `config` object:
 
 ```js
-import { BYPASS_TOKEN } from '$env/static/private';
+import { BYPASS_TOKEN } from '$app/env/private';
 
 /** @type {import('@sveltejs/adapter-vercel').Config} */
 export const config = {
@@ -148,11 +148,11 @@ A list of valid query parameters that contribute to the cache key. Other paramet
 
 ## Environment variables
 
-Vercel makes a set of [deployment-specific environment variables](https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables) available. Like other environment variables, these are accessible from `$env/static/private` and `$env/dynamic/private` (sometimes — more on that later), and inaccessible from their public counterparts. To access one of these variables from the client:
+Vercel makes a set of [deployment-specific environment variables](https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables) available. Like other environment variables, these are accessible from `$app/env/private` if explicitly defined in `src/env.ts`. To access one of these variables from the client:
 
 ```js
 /// file: +layout.server.js
-import { VERCEL_COMMIT_REF } from '$env/static/private';
+import { VERCEL_COMMIT_REF } from '$app/env/private';
 
 /** @type {import('./$types').LayoutServerLoad} */
 export function load() {
@@ -172,7 +172,7 @@ export function load() {
 <p>This staging environment was deployed from {data.deploymentGitBranch}.</p>
 ```
 
-Since all of these variables are unchanged between build time and run time when building on Vercel, we recommend using `$env/static/private` — which will statically replace the variables, enabling optimisations like dead code elimination — rather than `$env/dynamic/private`.
+Since all of these variables are unchanged between build time and run time when building on Vercel, we recommend configuring the variable with `state: true` — which will statically replace the variables, enabling optimisations like dead code elimination.
 
 ## Skew protection
 

--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -37,7 +37,7 @@ export async function handle({ event, resolve }) {
 
 If unimplemented, defaults to `({ event, resolve }) => resolve(event)`.
 
-During prerendering, SvelteKit crawls your pages for links and renders each route it finds. Rendering the route invokes the `handle` function (and all other route dependencies, like `load`). If you need to exclude some code from running during this phase, check that the app is not [`building`]($app-environment#building) beforehand.
+During prerendering, SvelteKit crawls your pages for links and renders each route it finds. Rendering the route invokes the `handle` function (and all other route dependencies, like `load`). If you need to exclude some code from running during this phase, check that the app is not [`building`]($app-env#building) beforehand.
 
 ### locals
 

--- a/documentation/docs/30-advanced/40-service-workers.md
+++ b/documentation/docs/30-advanced/40-service-workers.md
@@ -23,6 +23,7 @@ Inside the service worker you have access to the [`$service-worker` module]($ser
 The following example caches the built app and any files in `static` eagerly, and caches all other requests as they happen. This would make each page work offline once visited.
 
 ```js
+// @errors: 2688
 /// file: src/service-worker.js
 // Disables access to DOM typings like `HTMLElement` which are not available
 // inside a service worker and instantiates the correct globals

--- a/documentation/docs/30-advanced/40-service-workers.md
+++ b/documentation/docs/30-advanced/40-service-workers.md
@@ -33,8 +33,8 @@ The following example caches the built app and any files in `static` eagerly, an
 // Ensures that the `$service-worker` import has proper type definitions
 /// <reference types="@sveltejs/kit" />
 
-// Only necessary if you have an import from `$env/static/public`
-/// <reference types="../.svelte-kit/ambient.d.ts" />
+// Only necessary if you have an import from `$app/env/*`
+/// <reference types="../.svelte-kit/env.d.ts" />
 
 import { build, files, version } from '$service-worker';
 

--- a/documentation/docs/30-advanced/50-server-only-modules.md
+++ b/documentation/docs/30-advanced/50-server-only-modules.md
@@ -6,7 +6,7 @@ Like a good friend, SvelteKit keeps your secrets. When writing your backend and 
 
 ## Private environment variables
 
-The [`$env/static/private`]($env-static-private) and [`$env/dynamic/private`]($env-dynamic-private) modules can only be imported into modules that only run on the server, such as [`hooks.server.js`](hooks#Server-hooks) or [`+page.server.js`](routing#page-page.server.js).
+The [`$app/env/private`](environment-variables) module can only be imported into modules that only run on the server, such as [`hooks.server.js`](hooks#Server-hooks) or [`+page.server.js`](routing#page-page.server.js).
 
 ## Server-only utilities
 

--- a/documentation/docs/98-reference/20-$app-environment.md
+++ b/documentation/docs/98-reference/20-$app-environment.md
@@ -1,5 +1,0 @@
----
-title: $app/environment
----
-
-> MODULE: $app/environment

--- a/documentation/docs/98-reference/20-$app-environment.md
+++ b/documentation/docs/98-reference/20-$app-environment.md
@@ -1,0 +1,5 @@
+---
+title: $app/environment
+---
+
+This module was removed in SvelteKit 3 in favour of [$app/env]($app/env).

--- a/documentation/docs/98-reference/20-$app-environment.md
+++ b/documentation/docs/98-reference/20-$app-environment.md
@@ -2,4 +2,4 @@
 title: $app/environment
 ---
 
-This module was removed in SvelteKit 3 in favour of [$app/env]($app/env).
+This module was removed in SvelteKit 3 in favour of [$app/env]($app-env).

--- a/documentation/docs/98-reference/25-$env-dynamic-private.md
+++ b/documentation/docs/98-reference/25-$env-dynamic-private.md
@@ -1,5 +1,0 @@
----
-title: $env/dynamic/private
----
-
-> MODULE: $env/dynamic/private

--- a/documentation/docs/98-reference/25-$env-dynamic-private.md
+++ b/documentation/docs/98-reference/25-$env-dynamic-private.md
@@ -1,0 +1,5 @@
+---
+title: $env/dynamic/private
+---
+
+This module was removed in SvelteKit 3 in favour of [explicit environment variables](environment-variables).

--- a/documentation/docs/98-reference/25-$env-dynamic-public.md
+++ b/documentation/docs/98-reference/25-$env-dynamic-public.md
@@ -1,5 +1,0 @@
----
-title: $env/dynamic/public
----
-
-> MODULE: $env/dynamic/public

--- a/documentation/docs/98-reference/25-$env-dynamic-public.md
+++ b/documentation/docs/98-reference/25-$env-dynamic-public.md
@@ -1,0 +1,5 @@
+---
+title: $env/dynamic/public
+---
+
+This module was removed in SvelteKit 3 in favour of [explicit environment variables](environment-variables).

--- a/documentation/docs/98-reference/25-$env-static-private.md
+++ b/documentation/docs/98-reference/25-$env-static-private.md
@@ -1,5 +1,0 @@
----
-title: $env/static/private
----
-
-> MODULE: $env/static/private

--- a/documentation/docs/98-reference/25-$env-static-private.md
+++ b/documentation/docs/98-reference/25-$env-static-private.md
@@ -1,0 +1,5 @@
+---
+title: $env/static/private
+---
+
+This module was removed in SvelteKit 3 in favour of [explicit environment variables](environment-variables).

--- a/documentation/docs/98-reference/25-$env-static-public.md
+++ b/documentation/docs/98-reference/25-$env-static-public.md
@@ -1,5 +1,0 @@
----
-title: $env/static/public
----
-
-> MODULE: $env/static/public

--- a/documentation/docs/98-reference/25-$env-static-public.md
+++ b/documentation/docs/98-reference/25-$env-static-public.md
@@ -1,0 +1,5 @@
+---
+title: $env/static/public
+---
+
+This module was removed in SvelteKit 3 in favour of [explicit environment variables](environment-variables).


### PR DESCRIPTION
We need to update the explicit environment variables docs to solve the preview error deployment. It's looking for `$app/environment` types but they've been removed when we merged `main` in https://github.com/sveltejs/svelte.dev/actions/runs/27088756592/job/79948243995#step:10:25

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
