### PR TITLE
chore: better internal types for page options

### DIFF
--- a/packages/kit/src/exports/vite/static_analysis/index.js
+++ b/packages/kit/src/exports/vite/static_analysis/index.js
@@ -1,8 +1,9 @@
+/** @import { PageOptions } from './types.js' */
 import { tsPlugin } from '@sveltejs/acorn-typescript';
 import { Parser } from 'acorn';
 import { read } from '../../../utils/filesystem.js';
 
-const valid_page_options_array = /** @type {const} */ ([
+export const valid_page_options_array = /** @type {const} */ ([
 	'ssr',
 	'prerender',
 	'csr',
@@ -14,9 +15,6 @@ const valid_page_options_array = /** @type {const} */ ([
 
 /** @type {Set<string>} */
 const valid_page_options = new Set(valid_page_options_array);
-
-/** @typedef {typeof valid_page_options_array[number]} ValidPageOption */
-/** @typedef {Partial<Record<ValidPageOption, any>>} PageOptions */
 
 const skip_parsing_regex = new RegExp(
 	`${Array.from(valid_page_options).join('|')}|(?:export[\\s\\n]+\\*[\\s\\n]+from)`

--- a/packages/kit/src/exports/vite/static_analysis/types.d.ts
+++ b/packages/kit/src/exports/vite/static_analysis/types.d.ts
@@ -1,0 +1,14 @@
+import type { PrerenderOption, TrailingSlash } from 'types';
+import type { valid_page_options_array } from './index.js';
+
+type ValidPageOption = (typeof valid_page_options_array)[number];
+
+export type PageOptions = Partial<{
+	[K in ValidPageOption]: K extends 'ssr' | 'csr'
+		? boolean
+		: K extends 'prerender'
+			? PrerenderOption
+			: K extends 'trailingSlash'
+				? TrailingSlash
+				: any;
+}>;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -34,7 +34,7 @@ import {
 	TrailingSlash
 } from './private.js';
 import { Span } from '@opentelemetry/api';
-import type { PageOptions } from '../exports/vite/static_analysis/index.js';
+import { PageOptions } from '../exports/vite/static_analysis/types.js';
 import { SharedIterator } from '../utils/shared-iterator.js';
 
 export interface ServerModule {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2948,8 +2948,16 @@ declare module '@sveltejs/kit' {
 	export type LessThan<TNumber extends number, TArray extends any[] = []> = TNumber extends TArray["length"] ? TArray[number] : LessThan<TNumber, [...TArray, TArray["length"]]>;
 	export type NumericRange<TStart extends number, TEnd extends number> = Exclude<TEnd | LessThan<TEnd>, LessThan<TStart>>;
 	type ValidPageOption = (typeof valid_page_options_array)[number];
-	type PageOptions = Partial<Record<ValidPageOption, any>>;
-	const valid_page_options_array: readonly ["ssr", "prerender", "csr", "trailingSlash", "config", "entries", "load"];
+
+	type PageOptions = Partial<{
+		[K in ValidPageOption]: K extends 'ssr' | 'csr'
+			? boolean
+			: K extends 'prerender'
+				? PrerenderOption
+				: K extends 'trailingSlash'
+					? TrailingSlash
+					: any;
+	}>;
 	export const VERSION: string;
 	class HttpError_1 {
 		
@@ -2966,6 +2974,7 @@ declare module '@sveltejs/kit' {
 		status: 300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308;
 		location: string;
 	}
+	const valid_page_options_array: readonly ["ssr", "prerender", "csr", "trailingSlash", "config", "entries", "load"];
 
 	export {};
 }


### PR DESCRIPTION
Updates the types to give us specific valid values rather than `any`