### PR TITLE
fix: use forward slashes in generated `env.d.ts` import path on Windows

### DIFF
--- a/.changeset/fix-env-dts-windows-path.md
+++ b/.changeset/fix-env-dts-windows-path.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: use forward slashes in the generated `env.d.ts` import path on Windows

--- a/packages/kit/src/core/sync/write_env.js
+++ b/packages/kit/src/core/sync/write_env.js
@@ -1,6 +1,7 @@
 /** @import { EnvVarConfig } from '@sveltejs/kit' */
 import path from 'node:path';
 import { create_explicit_env_types } from '../env.js';
+import { posixify } from '../../utils/filesystem.js';
 import { write_if_changed } from './utils.js';
 
 const DOCS = '// See https://svelte.dev/docs/kit/environment-variables for more information';
@@ -18,7 +19,7 @@ export function write_env(kit, entry, env_config) {
 	const out = path.join(kit.outDir, 'env.d.ts');
 
 	if (entry && env_config) {
-		const relative = path.relative(kit.outDir, entry);
+		const relative = posixify(path.relative(kit.outDir, entry));
 		content.push(
 			`// This file is generated from ${relative}.\n${DOCS}`,
 			create_explicit_env_types(env_config, relative, 'private'),


### PR DESCRIPTION
Fixes #15959.

`write_env` builds the path with `path.relative`, which returns backslashes on Windows. That value goes into an `import('...')` type in the generated `env.d.ts`, so the backslashes break module resolution and every explicit env var falls back to `any`. Wrapping it in `posixify` fixes it, the same way `write_tsconfig` already handles its relative paths.

The broken import degrades the types to `any` rather than erroring, which is probably why it slipped through Windows CI even though `options-2` generates this file with `explicitEnvironmentVariables` enabled.

### Changesets
- [x] patch changeset added
