### PR TITLE
feat: allow commands to receive `File` objects

### DIFF
--- a/.changeset/cold-sloths-ask.md
+++ b/.changeset/cold-sloths-ask.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: allow commands to receive `File` objects

--- a/packages/kit/src/runtime/client/remote-functions/command.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/command.svelte.js
@@ -4,7 +4,7 @@ import { app_dir, base } from '$app/paths/internal/client';
 import * as devalue from 'devalue';
 import { HttpError } from '@sveltejs/kit/internal';
 import { app } from '../client.js';
-import { stringify_remote_arg } from '../../shared.js';
+import { stringify_command_arg } from '../../shared.js';
 import {
 	get_remote_request_headers,
 	apply_refreshes,
@@ -56,7 +56,7 @@ export function command(id) {
 				const response = await fetch(`${base}/${app_dir}/remote/${id}`, {
 					method: 'POST',
 					body: JSON.stringify({
-						payload: stringify_remote_arg(arg, app.hooks.transport, false),
+						payload: await stringify_command_arg(arg, app.hooks.transport),
 						refreshes: Array.from(refreshes ?? [])
 					}),
 					headers

--- a/packages/kit/src/runtime/shared.js
+++ b/packages/kit/src/runtime/shared.js
@@ -97,6 +97,7 @@ function to_sorted(value, clones) {
 const remote_object = '__skrao';
 const remote_map = '__skram';
 const remote_set = '__skras';
+const remote_file = '__skraf';
 const remote_regex_guard = '__skrag';
 const remote_arg_marker = Symbol(remote_object);
 
@@ -230,6 +231,26 @@ function create_remote_arg_revivers(transport) {
 			}
 
 			return set;
+		},
+		/** @type {(value: any) => File} */
+		[remote_file]: (value) => {
+			if (!value || typeof value !== 'object') {
+				throw new Error('Invalid data for File reviver');
+			}
+
+			if (
+				typeof value.name !== 'string' ||
+				typeof value.type !== 'string' ||
+				typeof value.size !== 'number' ||
+				typeof value.lastModified !== 'number' ||
+				!(value.data instanceof ArrayBuffer)
+			) {
+				throw new Error('Invalid data for File reviver');
+			}
+
+			const { data, name, ...meta } = value;
+
+			return new File([data], name, meta);
 		}
 	};
 
@@ -250,16 +271,42 @@ function create_remote_arg_revivers(transport) {
  * it is both a valid URL and a valid file name (necessary for prerendering).
  * @param {any} value
  * @param {Transport} transport
- * @param {boolean} [sort]
  */
-export function stringify_remote_arg(value, transport, sort = true) {
+export function stringify_remote_arg(value, transport) {
 	if (value === undefined) return '';
 
 	// If people hit file/url size limits, we can look into using something like compress_and_encode_text from svelte.dev beyond a certain size
 	const json_string = devalue.stringify(
 		value,
-		create_remote_arg_reducers(transport, sort, new Map())
+		create_remote_arg_reducers(transport, true, new Map())
 	);
+
+	const bytes = text_encoder.encode(json_string);
+	return base64_encode(bytes).replaceAll('=', '').replaceAll('+', '-').replaceAll('/', '_');
+}
+
+/**
+ * Stringifies command arguments, including `File` objects.
+ * @param {any} value
+ * @param {Transport} transport
+ */
+export async function stringify_command_arg(value, transport) {
+	if (value === undefined) return '';
+
+	const reducers = create_remote_arg_reducers(transport, false, new Map());
+
+	/** @param {any} value */
+	reducers[remote_file] = (value) =>
+		value instanceof File &&
+		value.arrayBuffer().then((data) => ({
+			data,
+			lastModified: value.lastModified,
+			name: value.name,
+			size: value.size,
+			type: value.type
+		}));
+
+	const json_string = await devalue.stringifyAsync(value, reducers);
 
 	const bytes = text_encoder.encode(json_string);
 	return base64_encode(bytes).replaceAll('=', '').replaceAll('+', '-').replaceAll('/', '_');

--- a/packages/kit/src/runtime/shared.js
+++ b/packages/kit/src/runtime/shared.js
@@ -98,6 +98,7 @@ const remote_object = '__skrao';
 const remote_map = '__skram';
 const remote_set = '__skras';
 const remote_file = '__skraf';
+const remote_promise_guard = '__skrap';
 const remote_regex_guard = '__skrag';
 const remote_arg_marker = Symbol(remote_object);
 
@@ -109,13 +110,12 @@ const remote_arg_marker = Symbol(remote_object);
 function create_remote_arg_reducers(transport, sort, remote_arg_clones) {
 	/** @type {Record<string, (value: unknown) => unknown>} */
 	const remote_fns_reducers = {
-		[remote_regex_guard]:
-			/** @type {(value: unknown) => void} */
-			(value) => {
-				if (value instanceof RegExp) {
-					throw new Error('Regular expressions are not valid remote function arguments');
-				}
+		/** @param {unknown} value */
+		[remote_regex_guard]: (value) => {
+			if (value instanceof RegExp) {
+				throw new Error('Regular expressions are not valid remote function arguments');
 			}
+		}
 	};
 
 	if (sort) {
@@ -295,16 +295,36 @@ export async function stringify_command_arg(value, transport) {
 
 	const reducers = create_remote_arg_reducers(transport, false, new Map());
 
+	/** @type {Set<Promise<any>>} */
+	const allowed_promises = new Set();
+
 	/** @param {any} value */
-	reducers[remote_file] = (value) =>
-		value instanceof File &&
-		value.arrayBuffer().then((data) => ({
-			data,
-			lastModified: value.lastModified,
-			name: value.name,
-			size: value.size,
-			type: value.type
-		}));
+	reducers[remote_file] = (value) => {
+		if (value instanceof File) {
+			const promise = value.arrayBuffer().then((data) => ({
+				data,
+				lastModified: value.lastModified,
+				name: value.name,
+				size: value.size,
+				type: value.type
+			}));
+
+			allowed_promises.add(promise);
+
+			return promise;
+		}
+	};
+
+	// we don't want to allow arbitrary promises, because they won't
+	// show up as promises on the other side. this is something
+	// we could potentially change in future. stringifyAsync
+	// will await them, so we need to explicitly deny them
+	/** @param {unknown} value */
+	reducers[remote_promise_guard] = (value) => {
+		if (value instanceof Promise && !allowed_promises.has(value)) {
+			throw new Error('Promises are not valid remote function arguments');
+		}
+	};
 
 	const json_string = await devalue.stringifyAsync(value, reducers);
 

--- a/packages/kit/src/runtime/shared.js
+++ b/packages/kit/src/runtime/shared.js
@@ -274,13 +274,9 @@ export function stringify_remote_arg(value, transport) {
 	if (value === undefined) return '';
 
 	// If people hit file/url size limits, we can look into using something like compress_and_encode_text from svelte.dev beyond a certain size
-	const json_string = devalue.stringify(
-		value,
-		create_remote_arg_reducers(transport, true, new Map())
-	);
+	const json = devalue.stringify(value, create_remote_arg_reducers(transport, true, new Map()));
 
-	const bytes = text_encoder.encode(json_string);
-	return base64_encode(bytes).replaceAll('=', '').replaceAll('+', '-').replaceAll('/', '_');
+	return url_friendly_base64_encode(json);
 }
 
 /**
@@ -324,9 +320,18 @@ export async function stringify_command_arg(value, transport) {
 		}
 	};
 
-	const json_string = await devalue.stringifyAsync(value, reducers);
+	const json = await devalue.stringifyAsync(value, reducers);
 
-	const bytes = text_encoder.encode(json_string);
+	return url_friendly_base64_encode(json);
+}
+
+/**
+ * Base64-encodes `string` in such a way that the result is safe to use
+ * as both a URI component and a filename
+ * @param {string} string
+ */
+function url_friendly_base64_encode(string) {
+	const bytes = text_encoder.encode(string);
 	return base64_encode(bytes).replaceAll('=', '').replaceAll('+', '-').replaceAll('/', '_');
 }
 

--- a/packages/kit/src/runtime/shared.js
+++ b/packages/kit/src/runtime/shared.js
@@ -234,11 +234,9 @@ function create_remote_arg_revivers(transport) {
 		},
 		/** @type {(value: any) => File} */
 		[remote_file]: (value) => {
-			if (!value || typeof value !== 'object') {
-				throw new Error('Invalid data for File reviver');
-			}
-
 			if (
+				!value ||
+				typeof value !== 'object' ||
 				typeof value.name !== 'string' ||
 				typeof value.type !== 'string' ||
 				typeof value.size !== 'number' ||

--- a/packages/kit/src/runtime/shared.spec.js
+++ b/packages/kit/src/runtime/shared.spec.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { parse_remote_arg, stringify_remote_arg } from './shared.js';
+import { parse_remote_arg, stringify_command_arg, stringify_remote_arg } from './shared.js';
 
 class Thing {
 	/** @param {number} a @param {number} z */
@@ -143,13 +143,6 @@ describe('stringify_remote_arg', () => {
 		expect(a).toBe(b);
 	});
 
-	test('preserves input ordering when sort is false', () => {
-		const a = stringify_remote_arg({ limit: 10, offset: 20 }, {}, false);
-		const b = stringify_remote_arg({ offset: 20, limit: 10 }, {}, false);
-
-		expect(a).not.toBe(b);
-	});
-
 	test('produces the same key for transported values nested inside Maps and Sets', () => {
 		const a = stringify_remote_arg(
 			map([
@@ -237,6 +230,32 @@ describe('stringify_remote_arg', () => {
 		expect(parsed).toHaveLength(1_000_001);
 		expect(0 in parsed).toBe(false);
 		expect(Object.keys(parsed[1_000_000])).toEqual(['a', 'b']);
+	});
+});
+
+describe('stringify_command_arg', () => {
+	test('preserves input ordering', async () => {
+		const a = await stringify_command_arg({ limit: 10, offset: 20 }, {});
+		const b = await stringify_command_arg({ offset: 20, limit: 10 }, {});
+
+		expect(a).not.toBe(b);
+	});
+
+	test('serializes files', async () => {
+		const serialized = await stringify_command_arg(
+			{
+				myfile: new File(['hello'], 'hello.md', {
+					type: 'text/markdown',
+					lastModified: -1
+				})
+			},
+			{}
+		);
+
+		const parsed = parse_remote_arg(serialized, {});
+
+		expect(parsed.myfile).toBeInstanceOf(File);
+		expect(parsed.myfile.name).toBe('hello.md');
 	});
 });
 

--- a/packages/kit/src/runtime/shared.spec.js
+++ b/packages/kit/src/runtime/shared.spec.js
@@ -1,5 +1,12 @@
+import buffer from 'node:buffer';
 import { describe, expect, test } from 'vitest';
 import { parse_remote_arg, stringify_command_arg, stringify_remote_arg } from './shared.js';
+
+if (!globalThis.File) {
+	// TODO remove in SvelteKit 3 — we only need it for node 18
+	// @ts-expect-error
+	globalThis.File = /** @type {import('node:buffer') & { File?: File}} */ (buffer).File;
+}
 
 class Thing {
 	/** @param {number} a @param {number} z */


### PR DESCRIPTION
While it's generally better to use a `<form>` to deal with files, sometimes it imposes unreasonable constraints on a design. In these cases it would be nice to be able to pass `File` objects to a `command`.

A short while ago, devalue added a `stringifyAsync` method that makes this possible — we just need a custom reducer that returns a `Promise`. We could potentially use the same trick for other things in future, or even allow async custom transports, but for now this is deliberately narrowly scoped.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
