### PR TITLE
fix: allow `$app/environment` with a warning when `explicitEnvironmentVariables` is enabled

### DIFF
--- a/.changeset/late-camels-do.md
+++ b/.changeset/late-camels-do.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow `$app/environment` with a warning when `explicitEnvironmentVariables` is enabled

--- a/packages/kit/src/runtime/app/environment/index.js
+++ b/packages/kit/src/runtime/app/environment/index.js
@@ -1,7 +1,8 @@
+import { dev } from '../env/index.js';
 export * from '../env/index.js';
 
-if (__SVELTEKIT_EXPERIMENTAL_EXPLICIT_ENVIRONMENT_VARIABLES__) {
-	throw new Error(
-		'Cannot import `$app/environment` when `experimental.explicitEnvironmentVariables` is enabled. Use `$app/env` instead.'
+if (dev && __SVELTEKIT_EXPERIMENTAL_EXPLICIT_ENVIRONMENT_VARIABLES__) {
+	console.warn(
+		'Use `$app/env` instead of `$app.environment when `experimental.explicitEnvironmentVariables` is enabled'
 	);
 }

--- a/packages/kit/src/runtime/app/environment/index.js
+++ b/packages/kit/src/runtime/app/environment/index.js
@@ -3,6 +3,6 @@ export * from '../env/index.js';
 
 if (dev && __SVELTEKIT_EXPERIMENTAL_EXPLICIT_ENVIRONMENT_VARIABLES__) {
 	console.warn(
-		'Use `$app/env` instead of `$app.environment when `experimental.explicitEnvironmentVariables` is enabled'
+		'Use `$app/env` instead of `$app/environment` when `experimental.explicitEnvironmentVariables` is enabled'
 	);
 }


### PR DESCRIPTION
If you're using a library that uses `$app/environment`, enabling `explicitEnvironmentVariables` will blow everything up. This fixes it

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
