### PR TITLE
chore: cache Deno installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,8 +267,8 @@ jobs:
       # required for testing netlify edge functions
       - uses: denoland/setup-deno@v2
         with:
-          cache-hash: ${{ runner.os }}-${{ runner.arch }}
           deno-version: ^2.2.4
+          cache: true
       - run: pnpm install --frozen-lockfile
       - name: setup overrides for matrix.node
         if: matrix.node-version == 18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,7 @@ jobs:
       # required for testing netlify edge functions
       - uses: denoland/setup-deno@v2
         with:
+          cache-hash: ${{ runner.os }}-${{ runner.arch }}
           deno-version: ^2.2.4
       - run: pnpm install --frozen-lockfile
       - name: setup overrides for matrix.node


### PR DESCRIPTION
The Deno server is prone to frequent 5xx errors (such as [this](https://github.com/sveltejs/kit/actions/runs/27120214619/job/80035410621?pr=15936#step:5:12)) so it'd be good if we cached the installation to avoid these and speed up the CI a bit for `test-others`. I don't think it caches by default like the setup-node action does
Reference: https://github.com/denoland/setup-deno#caching-dependencies-downloaded-by-deno-automatically