### PR TITLE
fix: avoid adding the component to the server node if SSR is turned off

### DIFF
--- a/.changeset/ripe-nails-enjoy.md
+++ b/.changeset/ripe-nails-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: avoid server components from being bundled if SSR is turned off for a route

--- a/packages/adapter-netlify/test/apps/edge/src/routes/treeshake-server/+page.js
+++ b/packages/adapter-netlify/test/apps/edge/src/routes/treeshake-server/+page.js
@@ -1,0 +1,1 @@
+export const ssr = false;

--- a/packages/adapter-netlify/test/apps/edge/src/routes/treeshake-server/+page.svelte
+++ b/packages/adapter-netlify/test/apps/edge/src/routes/treeshake-server/+page.svelte
@@ -1,0 +1,1 @@
+<p>this should never appear in the server bundle</p>

--- a/packages/adapter-netlify/test/apps/edge/test/test.js
+++ b/packages/adapter-netlify/test/apps/edge/test/test.js
@@ -3,10 +3,22 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { expect, test } from '@playwright/test';
 
+// TODO: use import.meta.dirname in Kit 3
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 test('read from $app/server works', async ({ request }) => {
 	const content = fs.readFileSync(path.resolve(__dirname, '../src/routes/read/file.txt'), 'utf-8');
 	const response = await request.get('/read');
 	expect(await response.text()).toBe(content);
+});
+
+test('treeshakes component from the server bundle if SSR is turned off', async ({ page }) => {
+	await page.goto('/treeshake-server');
+	const component_text = 'this should never appear in the server bundle';
+	const server_bundle = fs.readFileSync(
+		path.resolve(__dirname, '../.netlify/edge-functions/render.js'),
+		'utf-8'
+	);
+	expect(server_bundle).not.toContain(component_text);
+	await expect(page.locator('p')).toHaveText(component_text);
 });

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -152,7 +152,7 @@ export function build_server_nodes(
 		/** @type {Set<string>} */
 		const eager_assets = new Set();
 
-		if (node.component && client_manifest) {
+		if (node.component && client_manifest && node.page_options?.ssr !== false) {
 			exports.push(
 				'let component_cache;',
 				`export const component = async () => component_cache ??= (await import('../${

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -152,7 +152,11 @@ export function build_server_nodes(
 		/** @type {Set<string>} */
 		const eager_assets = new Set();
 
-		if (node.component && client_manifest && node.page_options?.ssr !== false) {
+		const uses_server_component = node.child_pages
+			? node.child_pages.some((child) => child.page_options?.ssr !== false)
+			: node.page_options?.ssr !== false;
+
+		if (node.component && client_manifest && uses_server_component) {
 			exports.push(
 				'let component_cache;',
 				`export const component = async () => component_cache ??= (await import('../${


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/12578

This PR makes it so that component code is only imported in nodes that have SSR enabled. It should make bundle sizes smaller for bundled apps (vercel, netlify, cloudflare, node?) since the component code and its dependencies will no longer be bundled for nodes with SSR disabled.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
