### PR TITLE
feat: callable forms

### DIFF
--- a/.changeset/bumpy-parts-grin.md
+++ b/.changeset/bumpy-parts-grin.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: callable forms

--- a/.changeset/warm-pans-go.md
+++ b/.changeset/warm-pans-go.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+breaking: the `pending` property of a `form` object now contains the number of in-flight direct calls. The `submitting` property contains the number of in-flight form submissions, which is what `pending` previously referred to

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -2147,6 +2147,7 @@ export interface ValidationError {
  * The type of a remote `form` function. See [Remote functions](https://svelte.dev/docs/kit/remote-functions#form) for full documentation.
  */
 export type RemoteForm<Input extends RemoteFormInput | void, Output> = {
+	(data: Input): MaybePromise<Output>;
 	/** Attachment that sets up an event handler that intercepts the form submission on the client to prevent a full page reload */
 	[attachment: symbol]: (node: HTMLFormElement) => void;
 	method: 'POST';
@@ -2196,8 +2197,10 @@ export type RemoteForm<Input extends RemoteFormInput | void, Output> = {
 	}): Promise<void>;
 	/** The result of the form submission */
 	get result(): Output | undefined;
-	/** The number of pending submissions */
+	/** The number of direct calls that are currently in-flight */
 	get pending(): number;
+	/** The number of form submissions that are currently in-flight */
+	get submitting(): number;
 	/** Access form fields using object notation */
 	fields: RemoteFormFieldsRoot<Input>;
 };

--- a/packages/kit/src/runtime/app/server/remote/command.js
+++ b/packages/kit/src/runtime/app/server/remote/command.js
@@ -92,7 +92,7 @@ export function command(validate_or_fn, maybe_fn) {
 		return /** @type {ReturnType<RemoteCommand<Input, Output>>} */ (promise);
 	};
 
-	Object.defineProperty(wrapper, '__', { value: __ });
+	Object.defineProperty(wrapper, '__', { value: __, configurable: true });
 
 	// On the server, pending is always 0
 	Object.defineProperty(wrapper, 'pending', {

--- a/packages/kit/src/runtime/app/server/remote/form.js
+++ b/packages/kit/src/runtime/app/server/remote/form.js
@@ -13,6 +13,7 @@ import {
 } from '../../../form-utils.js';
 import { get_cache, run_remote_function } from './shared.js';
 import { ValidationError } from '@sveltejs/kit/internal';
+import { command } from './command.js';
 
 /**
  * Creates a form object that can be spread onto a `<form>` element.
@@ -74,7 +75,8 @@ export function form(validate_or_fn, maybe_fn) {
 	 */
 	function create_instance(key) {
 		/** @type {RemoteForm<Input, Output>} */
-		const instance = {};
+		// @ts-expect-error `command` is missing the properties we're about to add
+		const instance = command(validate_or_fn, maybe_fn);
 
 		instance.method = 'POST';
 
@@ -225,11 +227,6 @@ export function form(validate_or_fn, maybe_fn) {
 					return undefined;
 				}
 			}
-		});
-
-		// On the server, pending is always 0
-		Object.defineProperty(instance, 'pending', {
-			get: () => 0
 		});
 
 		Object.defineProperty(instance, 'preflight', {

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -21,6 +21,7 @@ import {
 	serialize_binary_form,
 	BINARY_FORM_CONTENT_TYPE
 } from '../../form-utils.js';
+import { command } from './command.svelte.js';
 
 /**
  * Merge client issues into server issues. Server issues are persisted unless
@@ -74,7 +75,7 @@ export function form(id) {
 		let result = $state.raw(query_responses[action_id]);
 
 		/** @type {number} */
-		let pending_count = $state(0);
+		let submitting_count = $state(0);
 
 		/** @type {StandardSchemaV1 | undefined} */
 		let preflight_schema = undefined;
@@ -361,7 +362,8 @@ export function form(id) {
 		}
 
 		/** @type {RemoteForm<T, U>} */
-		const instance = {};
+		// @ts-expect-error `command` is missing properties we're about to add
+		const instance = command(action_id);
 
 		instance.method = 'POST';
 		instance.action = action;
@@ -422,7 +424,7 @@ export function form(id) {
 				try {
 					// Increment pending count immediately so that `pending` reflects
 					// the in-progress state during async preflight validation
-					pending_count++;
+					submitting_count++;
 
 					const valid = await preflight(form_data);
 					if (!valid) return;
@@ -434,7 +436,7 @@ export function form(id) {
 					const status = e instanceof HttpError ? e.status : 500;
 					void set_nearest_error_page(error, status);
 				} finally {
-					pending_count--;
+					submitting_count--;
 				}
 			};
 
@@ -578,12 +580,12 @@ export function form(id) {
 					}
 
 					submitted = true;
-					pending_count++;
+					submitting_count++;
 
 					const submission = submit(form_data, true);
 
 					void submission.finally(() => {
-						pending_count--;
+						submitting_count--;
 					});
 
 					return submission;
@@ -621,8 +623,8 @@ export function form(id) {
 			result: {
 				get: () => result
 			},
-			pending: {
-				get: () => pending_count
+			submitting: {
+				get: () => submitting_count
 			},
 			preflight: {
 				/** @type {RemoteForm<T, U>['preflight']} */

--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -86,22 +86,12 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 			);
 		}
 
-		if (internals.type === 'form') {
+		if (internals.type === 'form' && is_form_content_type(event.request)) {
 			if (event.request.method !== 'POST') {
 				throw new SvelteKitError(
 					405,
 					'Method Not Allowed',
 					`\`form\` functions must be invoked via POST request, not ${event.request.method}`
-				);
-			}
-
-			if (!is_form_content_type(event.request)) {
-				throw new SvelteKitError(
-					415,
-					'Unsupported Media Type',
-					`\`form\` functions expect form-encoded data — received ${event.request.headers.get(
-						'content-type'
-					)}`
 				);
 			}
 
@@ -131,7 +121,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 			);
 		}
 
-		if (internals.type === 'command') {
+		if (internals.type === 'command' || internals.type === 'form') {
 			/** @type {{ payload: string, refreshes?: string[] }} */
 			const { payload, refreshes } = await event.request.json();
 			state.remote.requested = create_requested_map(refreshes);

--- a/packages/kit/test/apps/async/src/routes/remote/form/[test_name]/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/[test_name]/+page.svelte
@@ -33,7 +33,7 @@
 </form>
 
 <p>set_message.input.message: {set_message.fields.message.value()}</p>
-<p>set_message.pending: {set_message.pending}</p>
+<p>set_message.submitting: {set_message.submitting}</p>
 <p>set_message.result: {set_message.result}</p>
 
 <hr />
@@ -49,7 +49,7 @@
 </form>
 
 <p>scoped.input.message: {scoped.fields.message.value()}</p>
-<p>scoped.pending: {scoped.pending}</p>
+<p>scoped.submitting: {scoped.submitting}</p>
 <p>scoped.result: {scoped.result}</p>
 
 <hr />
@@ -77,7 +77,7 @@
 </form>
 
 <p>enhanced.input.message: {enhanced.fields.message.value()}</p>
-<p>enhanced.pending: {enhanced.pending}</p>
+<p>enhanced.submitting: {enhanced.submitting}</p>
 <p>enhanced.result: {enhanced.result}</p>
 <p>enhanced.submit_result: {submit_result}</p>
 <p>enhanced.element: {/** @type {any} */ (enhanced).element ? 'attached' : 'null'}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/form/preflight-pending/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/preflight-pending/+page.svelte
@@ -30,7 +30,7 @@
 	<input {...passing.fields.name.as('text')} value="test" />
 	<button>submit passing</button>
 </form>
-<p data-passing-pending>passing pending: {passing.pending}</p>
+<p data-passing-submitting>passing submitting: {passing.submitting}</p>
 <p data-passing-result>passing result: {passing.result}</p>
 
 <hr />
@@ -39,7 +39,7 @@
 	<input {...failing.fields.name.as('text')} value="test" />
 	<button>submit failing</button>
 </form>
-<p data-failing-pending>failing pending: {failing.pending}</p>
+<p data-failing-submitting>failing submitting: {failing.submitting}</p>
 {#each failing.fields.allIssues() as issue}
 	<p data-failing-issue>{issue.message}</p>
 {/each}

--- a/packages/kit/test/apps/async/src/routes/remote/form/skip-submit/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/skip-submit/+page.svelte
@@ -5,7 +5,7 @@
 
 	const pendings_arr: number[] = [];
 	const pendings = $derived.by(() => {
-		pendings_arr.push(set_message.pending);
+		pendings_arr.push(set_message.submitting);
 		return pendings_arr.join(', ');
 	});
 </script>

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -88,9 +88,13 @@ test.describe('remote functions', () => {
 		await page.getByText('set message').click();
 
 		if (javaScriptEnabled) {
-			await expect(page.getByText('set_message.pending:')).toHaveText('set_message.pending: 1');
+			await expect(page.getByText('set_message.submitting:')).toHaveText(
+				'set_message.submitting: 1'
+			);
 			await page.getByText('resolve deferreds').click();
-			await expect(page.getByText('set_message.pending:')).toHaveText('set_message.pending: 0');
+			await expect(page.getByText('set_message.submitting:')).toHaveText(
+				'set_message.submitting: 0'
+			);
 			await expect(page.getByText('message.current:')).toHaveText('message.current: hello');
 		}
 
@@ -240,9 +244,9 @@ test.describe('remote functions', () => {
 		await page.getByText('set scoped message').click();
 
 		if (javaScriptEnabled) {
-			await expect(page.getByText('scoped.pending:')).toHaveText('scoped.pending: 1');
+			await expect(page.getByText('scoped.submitting:')).toHaveText('scoped.submitting: 1');
 			await page.getByText('resolve deferreds').click();
-			await expect(page.getByText('scoped.pending:')).toHaveText('scoped.pending: 0');
+			await expect(page.getByText('scoped.submitting:')).toHaveText('scoped.submitting: 0');
 
 			await page.getByText('message.current: hello').waitFor();
 			await expect(page.getByText('await get_message():')).toHaveText('await get_message(): hello');
@@ -263,13 +267,13 @@ test.describe('remote functions', () => {
 		await page.locator('[data-enhanced] span').click();
 
 		if (javaScriptEnabled) {
-			await expect(page.getByText('enhanced.pending:')).toHaveText('enhanced.pending: 1');
+			await expect(page.getByText('enhanced.submitting:')).toHaveText('enhanced.submitting: 1');
 			await expect(page.getByText('enhanced.element:')).toHaveText('enhanced.element: attached');
 
 			await page.getByText('message.current: hello (override)').waitFor();
 
 			await page.getByText('resolve deferreds').click();
-			await expect(page.getByText('enhanced.pending:')).toHaveText('enhanced.pending: 0');
+			await expect(page.getByText('enhanced.submitting:')).toHaveText('enhanced.submitting: 0');
 			await expect(page.getByText('await get_message():')).toHaveText('await get_message(): hello');
 
 			// enhanced submission should not clear the input; the developer must do that at the appropriate time
@@ -324,7 +328,7 @@ test.describe('remote functions', () => {
 		await page.fill('[data-enhanced] input', 'hello');
 		await page.getByText('submit enhanced programmatically').click();
 
-		await expect(page.getByText('enhanced.pending:')).toHaveText('enhanced.pending: 1');
+		await expect(page.getByText('enhanced.submitting:')).toHaveText('enhanced.submitting: 1');
 
 		await page.getByText('resolve deferreds').click();
 		await expect(page.getByText('enhanced.imperative_submit_result:')).toHaveText(
@@ -377,29 +381,29 @@ test.describe('remote functions', () => {
 		await page.goto('/remote/form/preflight-pending');
 
 		// Test 1: async preflight that passes — pending should be true immediately
-		await expect(page.locator('[data-passing-pending]')).toHaveText('passing pending: 0');
+		await expect(page.locator('[data-passing-submitting]')).toHaveText('passing submitting: 0');
 
 		void page.click('[data-passing] button');
 
-		// pending should be true immediately (before async preflight finishes)
-		await expect(page.locator('[data-passing-pending]')).toHaveText('passing pending: 1');
+		// submitting should be true immediately (before async preflight finishes)
+		await expect(page.locator('[data-passing-submitting]')).toHaveText('passing submitting: 1');
 
-		// after submission completes, pending should return to 0
-		await expect(page.locator('[data-passing-pending]')).toHaveText('passing pending: 0', {
+		// after submission completes, submitting should return to 0
+		await expect(page.locator('[data-passing-submitting]')).toHaveText('passing submitting: 0', {
 			timeout: 5000
 		});
 		await expect(page.locator('[data-passing-result]')).toContainText('created:');
 
-		// Test 2: async preflight that fails — pending should be true during validation, then return to 0
-		await expect(page.locator('[data-failing-pending]')).toHaveText('failing pending: 0');
+		// Test 2: async preflight that fails — submitting should be true during validation, then return to 0
+		await expect(page.locator('[data-failing-submitting]')).toHaveText('failing submitting: 0');
 
 		void page.click('[data-failing] button');
 
-		// pending should be true immediately
-		await expect(page.locator('[data-failing-pending]')).toHaveText('failing pending: 1');
+		// submitting should be true immediately
+		await expect(page.locator('[data-failing-submitting]')).toHaveText('failing submitting: 1');
 
-		// after preflight fails, pending should return to 0 and issues should appear
-		await expect(page.locator('[data-failing-pending]')).toHaveText('failing pending: 0', {
+		// after preflight fails, submitting should return to 0 and issues should appear
+		await expect(page.locator('[data-failing-submitting]')).toHaveText('failing submitting: 0', {
 			timeout: 5000
 		});
 		await expect(page.locator('[data-failing-issue]')).toHaveText('async check failed');

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2121,6 +2121,7 @@ declare module '@sveltejs/kit' {
 	 * The type of a remote `form` function. See [Remote functions](https://svelte.dev/docs/kit/remote-functions#form) for full documentation.
 	 */
 	export type RemoteForm<Input extends RemoteFormInput | void, Output> = {
+		(data: Input): MaybePromise<Output>;
 		/** Attachment that sets up an event handler that intercepts the form submission on the client to prevent a full page reload */
 		[attachment: symbol]: (node: HTMLFormElement) => void;
 		method: 'POST';
@@ -2170,8 +2171,10 @@ declare module '@sveltejs/kit' {
 		}): Promise<void>;
 		/** The result of the form submission */
 		get result(): Output | undefined;
-		/** The number of pending submissions */
+		/** The number of direct calls that are currently in-flight */
 		get pending(): number;
+		/** The number of form submissions that are currently in-flight */
+		get submitting(): number;
 		/** Access form fields using object notation */
 		fields: RemoteFormFieldsRoot<Input>;
 	};


### PR DESCRIPTION
I found myself wanting to call a `form` directly, without actually using it on a `<form>`. In my case specifically it was for a recursive operation — I wanted the user to invoke `deleteFile` as a traditional `<form>`, but inside the handler I wanted to be able to call `deleteFile` as a function, which is currently impossible:

<img width="1438" height="634" alt="image" src="https://github.com/user-attachments/assets/bec87bb6-fde2-47de-b3be-b1671c241041" />

Obviously you can work around this by yoinking the logic out into a separate function, but it's not as nice — it's less self-contained, and you need to come up with two names instead of one. I gather I'm not the only person who has encountered cases like this.

The implementation is pleasingly simple — we just call `command` under the hood, remove the `is_form_content_type` check and it basically Just Works AFAICT? There is one change: `myform.pending` needs to become `myform.submitting` so that we can distinguish between form submissions (`myform.submitting`) and direct calls (`myform.pending`).

Note that the semantics of direct calls are exactly the same as for `command`:

- things like `myform.fields.foo.issues()` and `myform.result` do _not_ get populated — these only happen for form submissions
- form submissions invalidate everything on the page by default (we still need to come up with a sensible API for preventing this within the form handler...), whereas direct calls do not

Of course, the obvious follow-up question: if we can do this, is there any point in keeping `command` around? Two possible arguments:

- if you only use `command` in your app and not `form`, you will have a very slightly smaller JS bundle
- `command` can have any schema, whereas `form` always has to be a `v.object({...})` or the non-Valibot equivalent

I'm personally not sure those are compelling enough reasons, but this is a conversation to have as a follow-up.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
