### PR TITLE
fix: dedupe remote data

### DIFF
--- a/.changeset/sad-frogs-wink.md
+++ b/.changeset/sad-frogs-wink.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: dedupe remote data

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -204,6 +204,8 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env }) {
 
 	const seen = new Set();
 	const written = new Set();
+
+	/** @type {Map<string, Promise<any>>} */
 	const remote_responses = new Map();
 
 	/** @type {Map<string, Set<string>>} */

--- a/packages/kit/src/runtime/app/server/remote/command.js
+++ b/packages/kit/src/runtime/app/server/remote/command.js
@@ -77,9 +77,6 @@ export function command(validate_or_fn, maybe_fn) {
 			);
 		}
 
-		state.remote.refreshes ??= new Map();
-		state.remote.reconnects ??= new Map();
-
 		const promise = Promise.resolve(
 			run_remote_function(event, state, true, () => validate(arg), fn)
 		);

--- a/packages/kit/src/runtime/app/server/remote/form.js
+++ b/packages/kit/src/runtime/app/server/remote/form.js
@@ -161,7 +161,7 @@ export function form(validate_or_fn, maybe_fn) {
 				// We don't need to care about args or deduplicating calls, because uneval results are only relevant in full page reloads
 				// where only one form submission is active at the same time
 				if (!event.isRemoteRequest) {
-					get_cache(__, state)[''] ??= { serialize: true, data: output };
+					get_cache(__, state)[''] ??= output;
 				}
 
 				return output;
@@ -179,26 +179,26 @@ export function form(validate_or_fn, maybe_fn) {
 			get() {
 				return create_field_proxy(
 					{},
-					() => get_cache(__)?.['']?.data?.input ?? {},
+					() => get_cache(__)?.['']?.input ?? {},
 					(path, value) => {
 						const cache = get_cache(__);
 						const entry = cache[''];
 
-						if (entry?.data?.submission) {
+						if (entry?.submission) {
 							// don't override a submission
 							return;
 						}
 
 						if (path.length === 0) {
-							(cache[''] ??= { serialize: true, data: {} }).data.input = value;
+							(cache[''] ??= {}).input = value;
 							return;
 						}
 
-						const input = entry?.data?.input ?? {};
+						const input = entry?.input ?? {};
 						deep_set(input, path.map(String), value);
-						(cache[''] ??= { serialize: true, data: {} }).data.input = input;
+						(cache[''] ??= {}).input = input;
 					},
-					() => flatten_issues(get_cache(__)?.['']?.data?.issues ?? [])
+					() => flatten_issues(get_cache(__)?.['']?.issues ?? [])
 				);
 			}
 		});
@@ -220,7 +220,7 @@ export function form(validate_or_fn, maybe_fn) {
 		Object.defineProperty(instance, 'result', {
 			get() {
 				try {
-					return get_cache(__)?.['']?.data?.result;
+					return get_cache(__)?.['']?.result;
 				} catch {
 					return undefined;
 				}

--- a/packages/kit/src/runtime/app/server/remote/form.js
+++ b/packages/kit/src/runtime/app/server/remote/form.js
@@ -11,7 +11,7 @@ import {
 	normalize_issue,
 	flatten_issues
 } from '../../../form-utils.js';
-import { get_cache, run_remote_function } from './shared.js';
+import { get_cache, get_implicit_lookup, run_remote_function } from './shared.js';
 import { ValidationError } from '@sveltejs/kit/internal';
 
 /**
@@ -136,9 +136,6 @@ export function form(validate_or_fn, maybe_fn) {
 						data = validated.value;
 					}
 
-					state.remote.refreshes ??= new Map();
-					state.remote.reconnects ??= new Map();
-
 					const issue = create_issues();
 
 					try {
@@ -161,7 +158,12 @@ export function form(validate_or_fn, maybe_fn) {
 				// We don't need to care about args or deduplicating calls, because uneval results are only relevant in full page reloads
 				// where only one form submission is active at the same time
 				if (!event.isRemoteRequest) {
-					get_cache(__, state)[''] ??= output;
+					const cache = get_cache(__, state);
+					cache[''] ??= output;
+
+					// register under the client-side action id so the output is serialized
+					// into the page, allowing the hydrated client to restore `result`/`issues`/`input`
+					get_implicit_lookup(__, state)[__.action_id ?? __.id] = () => cache[''];
 				}
 
 				return output;
@@ -177,11 +179,13 @@ export function form(validate_or_fn, maybe_fn) {
 
 		Object.defineProperty(instance, 'fields', {
 			get() {
+				// the form instance is created once per module and shared across requests,
+				// so the current request's state has to be resolved at access time
 				return create_field_proxy(
 					{},
-					() => get_cache(__)?.['']?.input ?? {},
+					() => get_cache(__, get_request_store().state)?.['']?.input ?? {},
 					(path, value) => {
-						const cache = get_cache(__);
+						const cache = get_cache(__, get_request_store().state);
 						const entry = cache[''];
 
 						if (entry?.submission) {
@@ -198,7 +202,7 @@ export function form(validate_or_fn, maybe_fn) {
 						deep_set(input, path.map(String), value);
 						(cache[''] ??= {}).input = input;
 					},
-					() => flatten_issues(get_cache(__)?.['']?.issues ?? [])
+					() => flatten_issues(get_cache(__, get_request_store().state)?.['']?.issues ?? [])
 				);
 			}
 		});
@@ -220,7 +224,7 @@ export function form(validate_or_fn, maybe_fn) {
 		Object.defineProperty(instance, 'result', {
 			get() {
 				try {
-					return get_cache(__)?.['']?.result;
+					return get_cache(__, get_request_store().state)?.['']?.result;
 				} catch {
 					return undefined;
 				}
@@ -264,6 +268,7 @@ export function form(validate_or_fn, maybe_fn) {
 					if (!instance) {
 						instance = create_instance(key);
 						instance.__.id = `${__.id}/${encodeURIComponent(JSON.stringify(key))}`;
+						instance.__.action_id = `${__.id}/${JSON.stringify(key)}`;
 						instance.__.name = __.name;
 
 						state.remote.forms.set(cache_key, instance);

--- a/packages/kit/src/runtime/app/server/remote/prerender.js
+++ b/packages/kit/src/runtime/app/server/remote/prerender.js
@@ -103,9 +103,8 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 
 						// TODO adapters can provide prerendered data more efficiently than
 						// fetching from the public internet
-						const promise = (cache[payload] ??= {
-							serialize: true,
-							data: fetch(new URL(url, event.url.origin).href).then(async (response) => {
+						const promise = (cache[payload] ??= fetch(new URL(url, event.url.origin).href).then(
+							async (response) => {
 								if (!response.ok) {
 									throw new Error('Prerendered response not found');
 								}
@@ -117,8 +116,8 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 								}
 
 								return prerendered.result;
-							})
-						}).data;
+							}
+						));
 
 						return parse_remote_response(await promise, state.transport);
 					});

--- a/packages/kit/src/runtime/app/server/remote/prerender.js
+++ b/packages/kit/src/runtime/app/server/remote/prerender.js
@@ -1,7 +1,7 @@
 /** @import { RemoteResource, RemotePrerenderFunction } from '@sveltejs/kit' */
 /** @import { RemotePrerenderInputsGenerator, RemotePrerenderInternals, MaybePromise } from 'types' */
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
-import { error, json } from '@sveltejs/kit';
+import { json, error } from '@sveltejs/kit';
 import { DEV } from 'esm-env';
 import { get_request_store } from '@sveltejs/kit/internal/server';
 import { stringify, stringify_remote_arg } from '../../../shared.js';
@@ -9,7 +9,6 @@ import { noop } from '../../../../utils/functions.js';
 import { app_dir, base } from '$app/paths/internal/server';
 import {
 	create_validator,
-	get_cache,
 	get_response,
 	parse_remote_response,
 	run_remote_function
@@ -89,50 +88,46 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 
 	/** @type {RemotePrerenderFunction<Input, Output> & { __: RemotePrerenderInternals }} */
 	const wrapper = (arg) => {
+		const { event, state } = get_request_store();
+		const payload = stringify_remote_arg(arg, state.transport);
+
+		// `get_response` (as opposed to bare `get_cache`) also registers the call in the
+		// implicit lookup, so that the result is inlined into the page payload (`data.p`)
+		// and the client doesn't need to fetch it again upon hydration
 		/** @type {Promise<Output> & Partial<RemoteResource<Output>>} */
-		const promise = (async () => {
-			const { event, state } = get_request_store();
-			const payload = stringify_remote_arg(arg, state.transport);
+		const promise = get_response(__, payload, state, async () => {
 			const id = __.id;
 			const url = `${base}/${app_dir}/remote/${id}${payload ? `/${payload}` : ''}`;
 
 			if (!state.prerendering && !DEV && !event.isRemoteRequest) {
 				try {
-					return await get_response(__, payload, state, async () => {
-						const cache = get_cache(__, state);
+					// TODO adapters can provide prerendered data more efficiently than
+					// fetching from the public internet
+					const response = await fetch(new URL(url, event.url.origin).href);
 
-						// TODO adapters can provide prerendered data more efficiently than
-						// fetching from the public internet
-						const promise = (cache[payload] ??= fetch(new URL(url, event.url.origin).href).then(
-							async (response) => {
-								if (!response.ok) {
-									throw new Error('Prerendered response not found');
-								}
+					if (!response.ok) {
+						throw new Error('Prerendered response not found');
+					}
 
-								const prerendered = await response.json();
+					const prerendered = /** @type {RemoteFunctionResponse} */ await response.json();
 
-								if (prerendered.type === 'error') {
-									error(prerendered.status, prerendered.error);
-								}
+					if (prerendered.type === 'error') {
+						error(prerendered.status, prerendered.error);
+					}
 
-								return prerendered.result;
-							}
-						));
-
-						return parse_remote_response(await promise, state.transport);
-					});
+					return parse_remote_response(prerendered.data, state.transport)._;
 				} catch {
 					// not available prerendered, fallback to normal function
 				}
 			}
 
+			// during a prerender run, the same function might be invoked while rendering
+			// multiple pages — share the result across the entire run
 			if (state.prerendering?.remote_responses.has(url)) {
 				return /** @type {Promise<any>} */ (state.prerendering.remote_responses.get(url));
 			}
 
-			const promise = get_response(__, payload, state, () =>
-				run_remote_function(event, state, false, () => validate(arg), fn)
-			);
+			const promise = run_remote_function(event, state, false, () => validate(arg), fn);
 
 			if (state.prerendering) {
 				state.prerendering.remote_responses.set(url, promise);
@@ -141,7 +136,7 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 			const result = await promise;
 
 			if (state.prerendering) {
-				const body = { type: 'result', result: stringify(result, state.transport) };
+				const body = { type: 'result', data: stringify({ _: result }, state.transport) };
 				state.prerendering.dependencies.set(url, {
 					body: JSON.stringify(body),
 					response: json(body)
@@ -150,7 +145,7 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 
 			// TODO this is missing error/loading/current/status
 			return result;
-		})();
+		});
 
 		promise.catch(noop);
 

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -1,8 +1,8 @@
-/** @import { RemoteLiveQuery, RemoteLiveQueryFunction, RemoteQuery, RemoteQueryFunction } from '@sveltejs/kit' */
+/** @import { RemoteLiveQuery, RemoteLiveQueryFunction, RemoteQuery, RemoteQueryFunction, RequestEvent } from '@sveltejs/kit' */
 /** @import { RemoteInternals, MaybePromise, RequestState, RemoteQueryLiveInternals, RemoteQueryBatchInternals, RemoteQueryInternals, RemoteLiveQueryUserFunctionReturnType } from 'types' */
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 import { get_request_store } from '@sveltejs/kit/internal/server';
-import { create_remote_key, stringify, stringify_remote_arg } from '../../../shared.js';
+import { create_remote_key, stringify_remote_arg } from '../../../shared.js';
 import { prerendering } from '$app/env/internal';
 import {
 	create_validator,
@@ -11,10 +11,10 @@ import {
 	run_remote_function,
 	run_remote_generator
 } from './shared.js';
-import { handle_error_and_jsonify } from '../../../server/utils.js';
-import { HttpError, SvelteKitError } from '@sveltejs/kit/internal';
 import { noop } from '../../../../utils/functions.js';
 import { SharedIterator } from '../../../../utils/shared-iterator.js';
+import { handle_error_and_jsonify } from '../../../server/utils.js';
+import { HttpError, SvelteKitError } from '@sveltejs/kit/internal';
 
 /**
  * Creates a remote query. When called from the browser, the function will be invoked on the server via a `fetch` call.
@@ -78,8 +78,14 @@ export function query(validate_or_fn, maybe_fn) {
 		bind(payload, validated_arg) {
 			const { event, state } = get_request_store();
 
-			return create_query_resource(__, payload, state, () =>
-				run_remote_function(event, state, false, () => validated_arg, fn)
+			return create_query_resource(__, payload, event, state, () =>
+				run_remote_function(
+					event,
+					{ ...state, is_in_remote_query: true },
+					false,
+					() => validated_arg,
+					fn
+				)
 			);
 		}
 	};
@@ -95,8 +101,14 @@ export function query(validate_or_fn, maybe_fn) {
 		const { event, state } = get_request_store();
 		const payload = stringify_remote_arg(arg, state.transport);
 
-		return create_query_resource(__, payload, state, () =>
-			run_remote_function(event, state, false, () => validate(arg), fn)
+		return create_query_resource(__, payload, event, state, () =>
+			run_remote_function(
+				event,
+				{ ...state, is_in_remote_query: true },
+				false,
+				() => validate(arg),
+				fn
+			)
 		);
 	};
 
@@ -152,7 +164,14 @@ function live(validate_or_fn, maybe_fn) {
 	 * @param {any} get_input
 	 */
 	const run = (event, state, get_input) =>
-		run_remote_generator(event, state, false, get_input, fn, __.name);
+		run_remote_generator(
+			event,
+			{ ...state, is_in_remote_query: true },
+			false,
+			get_input,
+			fn,
+			__.name
+		);
 
 	/** @type {RemoteQueryLiveInternals} */
 	const __ = {
@@ -164,7 +183,7 @@ function live(validate_or_fn, maybe_fn) {
 		bind(payload, validated_arg) {
 			const { event, state } = get_request_store();
 
-			return create_live_query_resource(__, payload, state, event.request.signal, () =>
+			return create_live_query_resource(__, payload, event, state, () =>
 				run(event, state, () => validated_arg)
 			);
 		}
@@ -181,7 +200,7 @@ function live(validate_or_fn, maybe_fn) {
 		const { event, state } = get_request_store();
 		const payload = stringify_remote_arg(arg, state.transport);
 
-		return create_live_query_resource(__, payload, state, event.request.signal, () =>
+		return create_live_query_resource(__, payload, event, state, () =>
 			run(event, state, () => validate(arg))
 		);
 	};
@@ -273,7 +292,7 @@ function batch(validate_or_fn, maybe_fn) {
 				try {
 					return await run_remote_function(
 						event,
-						state,
+						{ ...state, is_in_remote_query: true },
 						false,
 						async () => Promise.all(entries.map((entry) => entry.get_validated())),
 						async (input) => {
@@ -316,7 +335,7 @@ function batch(validate_or_fn, maybe_fn) {
 
 			return run_remote_function(
 				event,
-				state,
+				{ ...state, is_in_remote_query: true },
 				false,
 				async () => Promise.all(args.map(validate)),
 				async (/** @type {any[]} */ input) => {
@@ -326,7 +345,7 @@ function batch(validate_or_fn, maybe_fn) {
 						input.map(async (arg, i) => {
 							try {
 								const data = get_result(arg, i);
-								return { type: 'result', data: stringify(data, state.transport) };
+								return { type: 'result', data };
 							} catch (error) {
 								return {
 									type: 'error',
@@ -343,9 +362,11 @@ function batch(validate_or_fn, maybe_fn) {
 			);
 		},
 		bind(payload, validated_arg) {
-			const { state } = get_request_store();
+			const { event, state } = get_request_store();
 
-			return create_query_resource(__, payload, state, () => enqueue(payload, () => validated_arg));
+			return create_query_resource(__, payload, event, state, () =>
+				enqueue(payload, () => validated_arg)
+			);
 		}
 	};
 
@@ -357,10 +378,10 @@ function batch(validate_or_fn, maybe_fn) {
 			);
 		}
 
-		const { state } = get_request_store();
+		const { event, state } = get_request_store();
 		const payload = stringify_remote_arg(arg, state.transport);
 
-		return create_query_resource(__, payload, state, () =>
+		return create_query_resource(__, payload, event, state, () =>
 			// Collect all the calls to the same query in the same macrotask,
 			// then execute them as one backend request.
 			enqueue(payload, () => validate(arg))
@@ -373,13 +394,52 @@ function batch(validate_or_fn, maybe_fn) {
 }
 
 /**
+ * Include this value in the returned payload...
+ * @param {RequestEvent} event
+ * @param {RequestState} state
+ * @param {RemoteInternals} internals
+ * @param {string} payload
+ * @param {() => Promise<any>} fn
+ */
+export function refresh(event, state, internals, payload, fn) {
+	if (!internals.id) {
+		// unless this is a non-exported (i.e. private) query...
+		return;
+	}
+
+	if (!event.isRemoteRequest) {
+		// or this is a no-JS form submission
+		return;
+	}
+
+	const key = create_remote_key(internals.id, payload);
+
+	// `fn()` is invoked eagerly here, which starts running the query immediately.
+	// The resulting promise is normally awaited (and its rejection handled) in
+	// `collect_remote_data`, but some code paths (e.g. a command throwing a
+	// non-redirect error) never reach that point. Attach a no-op `catch` to the
+	// promise so a rejection is always considered handled and can never become an
+	// unhandled promise rejection (which crashes the process on modern Node).
+	// We still store the original promise so `collect_remote_data` can serialize
+	// either its value or its error as before.
+	const promise = fn();
+	promise.catch(() => {});
+
+	(state.remote.explicit ??= new Map()).set(key, {
+		internals,
+		promise
+	});
+}
+
+/**
  * @param {RemoteInternals} __
  * @param {string} payload — the stringified raw argument (i.e. the cache key the client will use)
+ * @param {RequestEvent} event
  * @param {RequestState} state
  * @param {() => Promise<any>} fn
  * @returns {RemoteQuery<any>}
  */
-function create_query_resource(__, payload, state, fn) {
+function create_query_resource(__, payload, event, state, fn) {
 	/** @type {Promise<any> | null} */
 	let promise = null;
 
@@ -391,7 +451,11 @@ function create_query_resource(__, payload, state, fn) {
 		// accessing data properties needs to kick off the work
 		// so that it gets seeded in the hydration cache
 		// and becomes available on the client
-		void (__.id && state.is_in_render && get_promise());
+		if (__.id && state.is_in_render) {
+			// swallow rejections so they don't crash the server — the error is
+			// serialized into the response and surfaced on the client instead
+			get_promise().catch(noop);
+		}
 	};
 
 	return {
@@ -420,20 +484,19 @@ function create_query_resource(__, payload, state, fn) {
 			return false;
 		},
 		refresh() {
-			const { event } = get_request_store();
-			if (!event.isRemoteRequest) {
-				// If the form submission is not a remote request, refreshing the data is
-				// useless, because it can't be returned to the client.
-				return Promise.resolve();
-			}
-			const refresh_context = get_refresh_context(__, 'refresh', payload);
-			const is_immediate_refresh = !refresh_context.cache[refresh_context.payload];
-			const value = is_immediate_refresh ? get_promise() : fn();
-			return update_refresh_value(refresh_context, value, is_immediate_refresh);
+			promise = null;
+			delete get_cache(__, state)[payload];
+
+			refresh(event, state, __, payload, get_promise);
+
+			return Promise.resolve();
 		},
 		/** @param {any} value */
 		set(value) {
-			return update_refresh_value(get_refresh_context(__, 'set', payload), value);
+			const p = (promise = Promise.resolve(value));
+			get_cache(__, state)[payload] = p;
+
+			refresh(event, state, __, payload, () => p);
 		},
 		// TODO 3.0 remove this
 		// @ts-expect-error This method no longer exists
@@ -458,12 +521,12 @@ function create_query_resource(__, payload, state, fn) {
 /**
  * @param {RemoteQueryLiveInternals} __
  * @param {string} payload — the stringified raw argument (i.e. the cache key the client will use)
+ * @param {RequestEvent} event
  * @param {RequestState} state
- * @param {AbortSignal} signal — the request signal; aborts in-flight iteration when the client disconnects
  * @param {() => AsyncGenerator<any, void, void>} get_generator
  * @returns {RemoteLiveQuery<any>}
  */
-function create_live_query_resource(__, payload, state, signal, get_generator) {
+function create_live_query_resource(__, payload, event, state, get_generator) {
 	/** @type {Promise<any> | null} */
 	let promise = null;
 
@@ -479,7 +542,11 @@ function create_live_query_resource(__, payload, state, signal, get_generator) {
 	};
 
 	const populate_hydratable = () => {
-		void (__.id && state.is_in_render && get_promise());
+		if (__.id && state.is_in_render) {
+			// swallow rejections so they don't crash the server — the error is
+			// serialized into the response and surfaced on the client instead
+			get_promise().catch(noop);
+		}
 	};
 
 	return {
@@ -516,15 +583,11 @@ function create_live_query_resource(__, payload, state, signal, get_generator) {
 			return false;
 		},
 		reconnect() {
-			const reconnects = state.remote.reconnects;
+			promise = null;
+			delete get_cache(__, state)[payload];
 
-			if (!reconnects) {
-				throw new Error(
-					`Cannot call reconnect on query.live '${__.name}' because it is not executed in the context of a command/form remote function`
-				);
-			}
+			refresh(event, state, __, payload, get_promise);
 
-			reconnects.set(create_remote_key(__.id, payload), get_promise());
 			return Promise.resolve();
 		},
 		/** @ts-expect-error This method no longer exists */
@@ -542,7 +605,7 @@ function create_live_query_resource(__, payload, state, signal, get_generator) {
 			const cache = (state.remote.live_iterators ??= new Map());
 			let cached = cache.get(key);
 			if (!cached) {
-				cached = create_shared_live_iterator(signal, get_generator);
+				cached = create_shared_live_iterator(event.request.signal, get_generator);
 				cache.set(key, cached);
 			}
 			return cached.subscribe();
@@ -620,55 +683,3 @@ function create_shared_live_iterator(signal, get_generator) {
 // Add batch as a property to the query function
 Object.defineProperty(query, 'batch', { value: batch, enumerable: true });
 Object.defineProperty(query, 'live', { value: live, enumerable: true });
-
-/**
- * @param {RemoteInternals} __
- * @param {'set' | 'refresh'} action
- * @param {string} payload — the stringified raw argument (i.e. the cache key the client will use)
- * @returns {{ __: RemoteInternals; state: any; refreshes: Map<string, Promise<any>>; cache: Record<string, { serialize: boolean; data: any }>; refreshes_key: string; payload: string }}
- */
-function get_refresh_context(__, action, payload) {
-	const { state } = get_request_store();
-	const { refreshes } = state.remote;
-
-	if (!refreshes) {
-		const name = __.type === 'query_batch' ? `query.batch '${__.name}'` : `query '${__.name}'`;
-		throw new Error(
-			`Cannot call ${action} on ${name} because it is not executed in the context of a command/form remote function`
-		);
-	}
-
-	const cache = get_cache(__, state);
-	const refreshes_key = create_remote_key(__.id, payload);
-
-	return { __, state, refreshes, refreshes_key, cache, payload };
-}
-
-/**
- * @param {{ __: RemoteInternals; refreshes: Map<string, Promise<any>>; cache: Record<string, any>; refreshes_key: string; payload: string }} context
- * @param {any} value
- * @param {boolean} [is_immediate_refresh=false]
- * @returns {Promise<void>}
- */
-function update_refresh_value(
-	{ __, refreshes, refreshes_key, cache, payload },
-	value,
-	is_immediate_refresh = false
-) {
-	const promise = Promise.resolve(value);
-
-	if (!is_immediate_refresh) {
-		cache[payload] = promise;
-	}
-
-	if (__.id) {
-		refreshes.set(refreshes_key, promise);
-	}
-
-	promise.catch(noop);
-
-	// we return an immediately-resolving promise so that the `refresh()` signature is consistent,
-	// but it doesn't delay anything if awaited inside a command. this way, people aren't
-	// penalised if they do `await q1.refresh(); await q2.refresh()`
-	return Promise.resolve();
-}

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -645,7 +645,7 @@ function get_refresh_context(__, action, payload) {
 }
 
 /**
- * @param {{ __: RemoteInternals; refreshes: Map<string, Promise<any>>; cache: Record<string, { serialize: boolean; data: any }>; refreshes_key: string; payload: string }} context
+ * @param {{ __: RemoteInternals; refreshes: Map<string, Promise<any>>; cache: Record<string, any>; refreshes_key: string; payload: string }} context
  * @param {any} value
  * @param {boolean} [is_immediate_refresh=false]
  * @returns {Promise<void>}
@@ -658,7 +658,7 @@ function update_refresh_value(
 	const promise = Promise.resolve(value);
 
 	if (!is_immediate_refresh) {
-		cache[payload] = { serialize: true, data: promise };
+		cache[payload] = promise;
 	}
 
 	if (__.id) {

--- a/packages/kit/src/runtime/app/server/remote/requested.js
+++ b/packages/kit/src/runtime/app/server/remote/requested.js
@@ -1,8 +1,11 @@
 /** @import { RemoteLiveQuery, RemoteLiveQueryFunction, RemoteQuery, RemoteQueryFunction, RequestedResult, QueryRequestedResult, LiveQueryRequestedResult } from '@sveltejs/kit' */
 /** @import { MaybePromise, RemoteAnyQueryInternals } from 'types' */
+import { HttpError } from '@sveltejs/kit/internal';
 import { get_request_store } from '@sveltejs/kit/internal/server';
-import { create_remote_key, parse_remote_arg } from '../../../shared.js';
+import { parse_remote_arg } from '../../../shared.js';
 import { noop } from '../../../../utils/functions.js';
+import { get_cache } from './shared.js';
+import { refresh } from './query.js';
 
 /**
  * In the context of a remote `command` or `form` request, returns an iterable
@@ -95,7 +98,7 @@ import { noop } from '../../../../utils/functions.js';
  * @returns {RequestedResult<Validated, Output>}
  */
 export function requested(query, limit) {
-	const { state } = get_request_store();
+	const { event, state } = get_request_store();
 	const internals = /** @type {RemoteAnyQueryInternals | undefined} */ (
 		/** @type {any} */ (query).__
 	);
@@ -115,15 +118,12 @@ export function requested(query, limit) {
 
 	const requested = state.remote.requested;
 	const payloads = requested?.get(__.id) ?? [];
+
 	// note: don't initialize these maps here -- they will be initialized by the
 	// command/form wrapper when we enter them, and if we initialize them here
 	// we will enable requested(...) in contexts where it shouldn't be allowed,
 	// such as load functions or other server functions
-	const refreshes = state.remote.refreshes;
-	const reconnects = state.remote.reconnects;
-	const store = __.type === 'query_live' ? reconnects : refreshes;
-
-	if (!store) {
+	if (!state.is_in_remote_form_or_command) {
 		throw new Error(
 			'requested(...) can only be called in the context of a command/form remote function'
 		);
@@ -131,6 +131,9 @@ export function requested(query, limit) {
 	const [selected, skipped] = split_limit(payloads, limit);
 
 	/**
+	 * Registers the failure exactly like `.set()` registers a value: the error record
+	 * is serialized to the client (putting the query there into a failed state), and
+	 * subsequent server-side calls of the query with the same argument reject with it.
 	 * @param {string} payload
 	 * @param {unknown} error
 	 */
@@ -138,14 +141,15 @@ export function requested(query, limit) {
 		const promise = Promise.reject(error);
 		promise.catch(noop);
 
-		const key = create_remote_key(__.id, payload);
-		store.set(key, promise);
+		get_cache(__, state)[payload] = promise;
+		refresh(event, state, __, payload, () => promise);
 	};
 
 	for (const payload of skipped) {
 		record_failure(
 			payload,
-			new Error(
+			new HttpError(
+				400,
 				`Requested refresh was rejected because it exceeded requested(${__.name}, ${limit}) limit`
 			)
 		);

--- a/packages/kit/src/runtime/app/server/remote/shared.js
+++ b/packages/kit/src/runtime/app/server/remote/shared.js
@@ -73,6 +73,12 @@ export async function get_response(internals, payload, state, get_result) {
 	await 0;
 
 	const cache = get_cache(internals, state);
+
+	if (!state.is_in_remote_query) {
+		// if this is a top-level (not nested) `await myQuery()`, include it in the serialized response
+		get_implicit_lookup(internals, state)[payload] = get_result;
+	}
+
 	return (cache[payload] ??= get_result());
 }
 
@@ -219,15 +225,35 @@ function to_iterator(source, name) {
 }
 
 /**
+ * Note that `state` is deliberately not optional: resources that capture the request
+ * state at creation must pass it explicitly, because reading it from the request store
+ * at call time is only equivalent on runtimes with `AsyncLocalStorage` support.
+ * Callers without a captured state (such as the module-level `form` instance getters)
+ * should pass `get_request_store().state` themselves.
  * @param {RemoteInternals} internals
  * @param {RequestState} state
  */
-export function get_cache(internals, state = get_request_store().state) {
+export function get_cache(internals, state) {
 	let cache = state.remote.data?.get(internals);
 
 	if (cache === undefined) {
 		cache = {};
 		(state.remote.data ??= new Map()).set(internals, cache);
+	}
+
+	return cache;
+}
+
+/**
+ * @param {RemoteInternals} internals
+ * @param {RequestState} state
+ */
+export function get_implicit_lookup(internals, state) {
+	let cache = state.remote.implicit?.get(internals);
+
+	if (cache === undefined) {
+		cache = {};
+		(state.remote.implicit ??= new Map()).set(internals, cache);
 	}
 
 	return cache;

--- a/packages/kit/src/runtime/app/server/remote/shared.js
+++ b/packages/kit/src/runtime/app/server/remote/shared.js
@@ -73,14 +73,7 @@ export async function get_response(internals, payload, state, get_result) {
 	await 0;
 
 	const cache = get_cache(internals, state);
-	const entry = (cache[payload] ??= {
-		serialize: false,
-		data: get_result()
-	});
-
-	entry.serialize ||= !!state.is_in_universal_load;
-
-	return entry.data;
+	return (cache[payload] ??= get_result());
 }
 
 /**

--- a/packages/kit/src/runtime/app/server/remote/shared.js
+++ b/packages/kit/src/runtime/app/server/remote/shared.js
@@ -3,8 +3,6 @@
 import { parse } from 'devalue';
 import { error } from '@sveltejs/kit';
 import { with_request_store, get_request_store } from '@sveltejs/kit/internal/server';
-import { noop } from '../../../../utils/functions.js';
-import { create_remote_key, stringify, unfriendly_hydratable } from '../../../shared.js';
 
 /**
  * @param {any} validate_or_fn
@@ -81,16 +79,6 @@ export async function get_response(internals, payload, state, get_result) {
 	});
 
 	entry.serialize ||= !!state.is_in_universal_load;
-
-	if (state.is_in_render && internals.id) {
-		const remote_key = create_remote_key(internals.id, payload);
-
-		Promise.resolve(entry.data)
-			.then((value) => {
-				void unfriendly_hydratable(remote_key, () => stringify(value, state.transport));
-			})
-			.catch(noop);
-	}
 
 	return entry.data;
 }

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1,4 +1,4 @@
-/** @import { ServerNodesResponse, ServerRedirectNode } from 'types' */
+/** @import { RemoteFunctionDataNode, ServerNodesResponse, ServerRedirectNode } from 'types' */
 /** @import { CacheEntry } from './remote-functions/cache.svelte.js' */
 /** @import { Query } from './remote-functions/query/instance.svelte.js' */
 /** @import { LiveQuery } from './remote-functions/query-live/instance.svelte.js' */
@@ -202,18 +202,20 @@ let target;
 export let app;
 
 /**
- * Data that was serialized during SSR for queries/forms/commands.
- * This is cleared before client-side loads run.
- * @type {Record<string, any>}
+ * Data that was serialized during SSR for queries/forms/commands, stored as
+ * `{ v }` (value) or `{ e }` (error) nodes so that failed states survive hydration.
+ * Entries are deleted as they are consumed (when the corresponding resource is created).
+ * @type {Record<string, RemoteFunctionDataNode>}
  */
-export let query_responses = {};
+export const query_responses = {};
 
 /**
- * Data that was serialized during SSR for prerender functions.
+ * Data that was serialized during SSR for prerender functions, stored as
+ * `{ v }` (value) or `{ e }` (error) nodes.
  * This persists across client-side navigations.
- * @type {Record<string, any>}
+ * @type {Record<string, RemoteFunctionDataNode>}
  */
-export let prerender_responses = {};
+export const prerender_responses = {};
 
 /** @type {Array<((url: URL) => boolean)>} */
 const invalidated = [];
@@ -328,9 +330,15 @@ export async function start(_app, _target, hydrate) {
 		);
 	}
 
-	if (__SVELTEKIT_PAYLOAD__) {
-		query_responses = __SVELTEKIT_PAYLOAD__.query ?? {};
-		prerender_responses = __SVELTEKIT_PAYLOAD__.prerender ?? {};
+	if (__SVELTEKIT_PAYLOAD__.data) {
+		const { q = {}, p = {}, l = {}, f = {} } = __SVELTEKIT_PAYLOAD__.data;
+
+		// store the whole nodes — error records seed the corresponding
+		// resources in a failed state when they are created during hydration
+		for (const k in q) query_responses[k] = q[k];
+		for (const k in l) query_responses[k] = l[k];
+		for (const k in f) query_responses[k] = f[k];
+		for (const k in p) prerender_responses[k] = p[k];
 	}
 
 	// detect basic auth credentials in the current URL
@@ -700,10 +708,6 @@ async function initialize(result, target, hydrate) {
 					return error;
 				}
 			: undefined
-	});
-
-	void svelte.settled?.().then(() => {
-		query_responses = {};
 	});
 
 	// Wait for a microtask in case svelte experimental async is enabled,

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -702,6 +702,10 @@ async function initialize(result, target, hydrate) {
 			: undefined
 	});
 
+	void svelte.settled?.().then(() => {
+		query_responses = {};
+	});
+
 	// Wait for a microtask in case svelte experimental async is enabled,
 	// which causes component script blocks to run asynchronously
 	void (await Promise.resolve());
@@ -3028,8 +3032,6 @@ async function _hydrate(
 
 		target.textContent = '';
 		hydrate = false;
-	} finally {
-		query_responses = {};
 	}
 
 	if (result.props.page) {

--- a/packages/kit/src/runtime/client/remote-functions/command.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/command.svelte.js
@@ -1,16 +1,8 @@
 /** @import { RemoteCommand, RemoteQueryUpdate } from '@sveltejs/kit' */
-/** @import { RemoteFunctionResponse } from 'types' */
 import { app_dir, base } from '$app/paths/internal/client';
-import * as devalue from 'devalue';
-import { HttpError } from '@sveltejs/kit/internal';
 import { app } from '../client.js';
 import { stringify_command_arg } from '../../shared.js';
-import {
-	get_remote_request_headers,
-	apply_refreshes,
-	categorize_updates,
-	apply_reconnections
-} from './shared.svelte.js';
+import { get_remote_request_headers, categorize_updates, remote_request } from './shared.svelte.js';
 
 /**
  * Client-version of the `command` function from `$app/server`.
@@ -53,7 +45,7 @@ export function command(id) {
 					throw updates_error;
 				}
 
-				const response = await fetch(`${base}/${app_dir}/remote/${id}`, {
+				const response = await remote_request(`${base}/${app_dir}/remote/${id}`, {
 					method: 'POST',
 					body: JSON.stringify({
 						payload: await stringify_command_arg(arg, app.hooks.transport),
@@ -62,30 +54,13 @@ export function command(id) {
 					headers
 				});
 
-				if (!response.ok) {
-					// We only end up here in case of a network error or if the server has an internal error
-					// (which shouldn't happen because we handle errors on the server and always send a 200 response)
-					throw new Error('Failed to execute remote function');
-				}
-
-				const result = /** @type {RemoteFunctionResponse} */ (await response.json());
-				if (result.type === 'redirect') {
+				if (response.redirect) {
 					throw new Error(
 						'Redirects are not allowed in commands. Return a result instead and use goto on the client'
 					);
-				} else if (result.type === 'error') {
-					throw new HttpError(result.status ?? 500, result.error);
-				} else {
-					if (result.refreshes) {
-						apply_refreshes(result.refreshes);
-					}
-
-					if (result.reconnects) {
-						apply_reconnections(result.reconnects);
-					}
-
-					return devalue.parse(result.result, app.decoders);
 				}
+
+				return response._;
 			} finally {
 				overrides?.forEach((fn) => fn());
 

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -1,13 +1,12 @@
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 /** @import { RemoteFormInput, RemoteForm, RemoteQueryUpdate } from '@sveltejs/kit' */
-/** @import { InternalRemoteFormIssue, RemoteFunctionResponse } from 'types' */
+/** @import { InternalRemoteFormIssue } from 'types' */
 import { app_dir, base } from '$app/paths/internal/client';
-import * as devalue from 'devalue';
 import { DEV } from 'esm-env';
 import { HttpError } from '@sveltejs/kit/internal';
-import { app, query_responses, _goto, set_nearest_error_page, invalidateAll } from '../client.js';
+import { query_responses, _goto, set_nearest_error_page, invalidateAll } from '../client.js';
 import { tick } from 'svelte';
-import { apply_refreshes, categorize_updates, apply_reconnections } from './shared.svelte.js';
+import { categorize_updates, remote_request } from './shared.svelte.js';
 import { createAttachmentKey } from 'svelte/attachments';
 import {
 	convert_formdata,
@@ -60,18 +59,25 @@ export function form(id) {
 		const action_id = id + (key != undefined ? `/${JSON.stringify(key)}` : '');
 		const action = '?/remote=' + encodeURIComponent(action_id);
 
+		// the output of a non-enhanced submission that resulted in this page —
+		// consume it so the form's state survives hydration (form outputs are
+		// always value nodes; the server never serializes them as errors)
+		/** @type {{ input?: Record<string, any>, issues?: InternalRemoteFormIssue[], result?: any } | undefined} */
+		const initial = query_responses[action_id]?.v;
+		delete query_responses[action_id];
+
 		/**
 		 * @type {Record<string, string | string[] | File | File[]>}
 		 */
-		let input = $state({});
+		let input = $state(initial?.input ?? {});
 
 		/** @type {InternalRemoteFormIssue[]} */
-		let raw_issues = $state.raw([]);
+		let raw_issues = $state.raw(initial?.issues ?? []);
 
 		const issues = $derived(flatten_issues(raw_issues));
 
 		/** @type {any} */
-		let result = $state.raw(query_responses[action_id]);
+		let result = $state.raw(initial?.result);
 
 		/** @type {number} */
 		let pending_count = $state(0);
@@ -182,77 +188,54 @@ export function form(id) {
 						remote_refreshes: Array.from(refreshes ?? [])
 					});
 
-					const response = await fetch(`${base}/${app_dir}/remote/${action_id_without_key}`, {
-						method: 'POST',
-						headers: {
-							'Content-Type': BINARY_FORM_CONTENT_TYPE,
-							// Forms cannot be called during rendering, so it's save to use location here
-							'x-sveltekit-pathname': location.pathname,
-							'x-sveltekit-search': location.search
-						},
-						body: blob
-					});
-
-					if (!response.ok) {
-						// We only end up here in case of a network error or if the server has an internal error
-						// (which shouldn't happen because we handle errors on the server and always send a 200 response)
-						throw new Error('Failed to execute remote function');
-					}
-
-					const form_result = /** @type { RemoteFunctionResponse} */ (await response.json());
-
-					// reset issues in case it's a redirect or error (but issues passed in that case)
-					raw_issues = [];
-					result = undefined;
-
-					if (form_result.type === 'result') {
-						({ issues: raw_issues = [], result } = devalue.parse(form_result.result, app.decoders));
-						const succeeded = raw_issues.length === 0;
-
-						if (succeeded) {
-							if (refreshes === null && !form_result.refreshes && !form_result.reconnects) {
-								void invalidateAll();
-							} else {
-								if (form_result.refreshes) {
-									apply_refreshes(form_result.refreshes);
-								}
-								if (form_result.reconnects) {
-									apply_reconnections(form_result.reconnects);
-								}
-							}
-						} else {
-							if (DEV) {
-								warn_on_missing_issue_reads();
-							}
+					const response = await remote_request(
+						`${base}/${app_dir}/remote/${action_id_without_key}`,
+						{
+							method: 'POST',
+							headers: {
+								'Content-Type': BINARY_FORM_CONTENT_TYPE,
+								// Forms cannot be called during rendering, so it's save to use location here
+								'x-sveltekit-pathname': location.pathname,
+								'x-sveltekit-search': location.search
+							},
+							body: blob
 						}
+					);
 
-						return succeeded;
-					} else if (form_result.type === 'redirect') {
-						const stringified_refreshes = form_result.refreshes ?? '';
-						const stringified_reconnects = form_result.reconnects ?? '';
-						if (stringified_refreshes) {
-							apply_refreshes(stringified_refreshes);
-						}
+					({ issues: raw_issues = [], result } = response._ ?? {});
 
-						if (stringified_reconnects) {
-							apply_reconnections(stringified_reconnects);
-						}
+					// if the developer took control of updates via `.updates(...)` (even with
+					// no arguments), or the server performed explicit refreshes, don't invalidateAll
+					const should_invalidate = refreshes === null && !response.r;
 
+					if (response.redirect) {
 						// Use internal version to allow redirects to external URLs
 						void _goto(
-							form_result.location,
+							response.redirect,
 							{
-								invalidateAll:
-									refreshes === null && !stringified_refreshes && !stringified_reconnects
+								invalidateAll: should_invalidate
 							},
 							0
 						);
 						return true;
-					} else {
-						throw new HttpError(form_result.status ?? 500, form_result.error);
 					}
+
+					const succeeded = raw_issues.length === 0;
+
+					if (succeeded) {
+						if (should_invalidate) {
+							void invalidateAll();
+						}
+					} else {
+						if (DEV) {
+							warn_on_missing_issue_reads();
+						}
+					}
+
+					return succeeded;
 				} catch (e) {
 					result = undefined;
+					raw_issues = [];
 					throw e;
 				} finally {
 					overrides?.forEach((fn) => fn());
@@ -661,30 +644,27 @@ export function form(id) {
 					if (validated?.issues) {
 						array = validated.issues.map((issue) => normalize_issue(issue, false));
 					} else if (!preflightOnly) {
-						const response = await fetch(`${base}/${app_dir}/remote/${action_id_without_key}`, {
-							method: 'POST',
-							headers: {
-								'Content-Type': BINARY_FORM_CONTENT_TYPE,
-								// Validation should not be and will not be called during rendering, so it's save to use location here
-								'x-sveltekit-pathname': location.pathname,
-								'x-sveltekit-search': location.search
-							},
-							body: serialize_binary_form(data, {
-								validate_only: true
-							}).blob
-						});
-
-						const result = await response.json();
+						const result = await remote_request(
+							`${base}/${app_dir}/remote/${action_id_without_key}`,
+							{
+								method: 'POST',
+								headers: {
+									'Content-Type': BINARY_FORM_CONTENT_TYPE,
+									// Validation should not be and will not be called during rendering, so it's save to use location here
+									'x-sveltekit-pathname': location.pathname,
+									'x-sveltekit-search': location.search
+								},
+								body: serialize_binary_form(data, {
+									validate_only: true
+								}).blob
+							}
+						);
 
 						if (validate_id !== id) {
 							return;
 						}
 
-						if (result.type === 'result') {
-							array = /** @type {InternalRemoteFormIssue[]} */ (
-								devalue.parse(result.result, app.decoders)
-							);
-						}
+						array = /** @type {InternalRemoteFormIssue[]} */ (result._);
 					}
 
 					if (!includeUntouched && !submitted) {

--- a/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
@@ -2,8 +2,8 @@
 import { app_dir, base } from '$app/paths/internal/client';
 import { version } from '$app/env';
 import * as devalue from 'devalue';
-import { app, prerender_responses } from '../client.js';
-import { get_remote_request_headers, remote_request } from './shared.svelte.js';
+import { app, goto, prerender_responses } from '../client.js';
+import { get_remote_request_headers, remote_request, unwrap_node } from './shared.svelte.js';
 import { create_remote_key, stringify_remote_arg } from '../../shared.js';
 
 // Initialize Cache API for prerender functions
@@ -67,7 +67,7 @@ export function prerender(id) {
 				const url = `${base}/${app_dir}/remote/${id}${payload ? `/${payload}` : ''}`;
 
 				if (Object.hasOwn(prerender_responses, cache_key)) {
-					const data = prerender_responses[cache_key];
+					const data = unwrap_node(prerender_responses[cache_key]);
 
 					if (prerender_cache) {
 						void put(url, devalue.stringify(data, app.encoders));
@@ -77,6 +77,7 @@ export function prerender(id) {
 				}
 
 				// Do this here, after await Svelte' reactivity context is gone.
+				// TODO we really don't want to be sending these specific headers here?
 				const headers = get_remote_request_headers();
 
 				// Check the Cache API first
@@ -93,14 +94,21 @@ export function prerender(id) {
 					}
 				}
 
-				const encoded = await remote_request(url, headers);
+				const result = await remote_request(url, { headers });
+
+				if (result.redirect) {
+					void goto(result.redirect);
+					return;
+				}
+
+				const data = result._;
 
 				// For successful prerender requests, save to cache
 				if (prerender_cache) {
-					void put(url, encoded);
+					void put(url, devalue.stringify(data, app.encoders));
 				}
 
-				return devalue.parse(encoded, app.decoders);
+				return data;
 			});
 
 			prerender_resources.set(cache_key, new WeakRef(resource));

--- a/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
@@ -1,12 +1,11 @@
 /** @import { RemoteQueryFunction } from '@sveltejs/kit' */
 /** @import { RemoteFunctionResponse } from 'types' */
 import { app_dir, base } from '$app/paths/internal/client';
-import { app, goto } from '../client.js';
+import { app, goto, query_responses } from '../client.js';
 import { get_remote_request_headers, QUERY_FUNCTION_ID } from './shared.svelte.js';
 import { QueryProxy } from './query/proxy.js';
 import * as devalue from 'devalue';
 import { HttpError, Redirect } from '@sveltejs/kit/internal';
-import { unfriendly_hydratable } from '../../shared.js';
 
 /**
  * @param {string} id
@@ -19,80 +18,84 @@ export function query_batch(id) {
 	/** @type {RemoteQueryFunction<any, any>} */
 	const wrapper = (arg) => {
 		return new QueryProxy(id, arg, async (key, payload) => {
-			const serialized = await unfriendly_hydratable(key, () => {
-				return new Promise((resolve, reject) => {
-					// create_remote_function caches identical calls, but in case a refresh to the same query is called multiple times this function
-					// is invoked multiple times with the same payload, so we need to deduplicate here
-					const entry = batching.get(payload) ?? [];
-					entry.push({ resolve, reject });
-					batching.set(payload, entry);
+			if (query_responses[key]) {
+				const value = query_responses[key];
+				delete query_responses[key];
+				return value;
+			}
 
-					if (batching.size > 1) return;
+			const serialized = await new Promise((resolve, reject) => {
+				// create_remote_function caches identical calls, but in case a refresh to the same query is called multiple times this function
+				// is invoked multiple times with the same payload, so we need to deduplicate here
+				const entry = batching.get(payload) ?? [];
+				entry.push({ resolve, reject });
+				batching.set(payload, entry);
 
-					// Do this here, after await Svelte' reactivity context is gone.
-					// TODO is it possible to have batches of the same key
-					// but in different forks/async contexts and in the same macrotask?
-					// If so this would potentially be buggy
-					const headers = {
-						'Content-Type': 'application/json',
-						...get_remote_request_headers()
-					};
+				if (batching.size > 1) return;
 
-					// Wait for the next macrotask - don't use microtask as Svelte runtime uses these to collect changes and flush them,
-					// and flushes could reveal more queries that should be batched.
-					setTimeout(async () => {
-						const batched = batching;
-						batching = new Map();
+				// Do this here, after await Svelte' reactivity context is gone.
+				// TODO is it possible to have batches of the same key
+				// but in different forks/async contexts and in the same macrotask?
+				// If so this would potentially be buggy
+				const headers = {
+					'Content-Type': 'application/json',
+					...get_remote_request_headers()
+				};
 
-						try {
-							const response = await fetch(`${base}/${app_dir}/remote/${id}`, {
-								method: 'POST',
-								body: JSON.stringify({
-									payloads: Array.from(batched.keys())
-								}),
-								headers
-							});
+				// Wait for the next macrotask - don't use microtask as Svelte runtime uses these to collect changes and flush them,
+				// and flushes could reveal more queries that should be batched.
+				setTimeout(async () => {
+					const batched = batching;
+					batching = new Map();
 
-							if (!response.ok) {
-								throw new Error('Failed to execute batch query');
-							}
+					try {
+						const response = await fetch(`${base}/${app_dir}/remote/${id}`, {
+							method: 'POST',
+							body: JSON.stringify({
+								payloads: Array.from(batched.keys())
+							}),
+							headers
+						});
 
-							const result = /** @type {RemoteFunctionResponse} */ (await response.json());
-							if (result.type === 'error') {
-								throw new HttpError(result.status ?? 500, result.error);
-							}
+						if (!response.ok) {
+							throw new Error('Failed to execute batch query');
+						}
 
-							if (result.type === 'redirect') {
-								await goto(result.location);
-								throw new Redirect(307, result.location);
-							}
+						const result = /** @type {RemoteFunctionResponse} */ (await response.json());
+						if (result.type === 'error') {
+							throw new HttpError(result.status ?? 500, result.error);
+						}
 
-							const results = devalue.parse(result.result, app.decoders);
+						if (result.type === 'redirect') {
+							await goto(result.location);
+							throw new Redirect(307, result.location);
+						}
 
-							// Resolve individual queries
-							// Maps guarantee insertion order so we can do it like this
-							let i = 0;
+						const results = devalue.parse(result.result, app.decoders);
 
-							for (const resolvers of batched.values()) {
-								for (const { resolve, reject } of resolvers) {
-									if (results[i].type === 'error') {
-										reject(new HttpError(results[i].status, results[i].error));
-									} else {
-										resolve(results[i].data);
-									}
+						// Resolve individual queries
+						// Maps guarantee insertion order so we can do it like this
+						let i = 0;
+
+						for (const resolvers of batched.values()) {
+							for (const { resolve, reject } of resolvers) {
+								if (results[i].type === 'error') {
+									reject(new HttpError(results[i].status, results[i].error));
+								} else {
+									resolve(results[i].data);
 								}
-								i++;
 							}
-						} catch (error) {
-							// Reject all queries in the batch
-							for (const resolver of batched.values()) {
-								for (const { reject } of resolver) {
-									reject(error);
-								}
+							i++;
+						}
+					} catch (error) {
+						// Reject all queries in the batch
+						for (const resolver of batched.values()) {
+							for (const { reject } of resolver) {
+								reject(error);
 							}
 						}
-					}, 0);
-				});
+					}
+				}, 0);
 			});
 
 			return devalue.parse(serialized, app.decoders);

--- a/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
@@ -1,11 +1,9 @@
 /** @import { RemoteQueryFunction } from '@sveltejs/kit' */
-/** @import { RemoteFunctionResponse } from 'types' */
 import { app_dir, base } from '$app/paths/internal/client';
-import { app, goto, query_responses } from '../client.js';
-import { get_remote_request_headers, QUERY_FUNCTION_ID } from './shared.svelte.js';
+import { goto } from '../client.js';
+import { get_remote_request_headers, QUERY_FUNCTION_ID, remote_request } from './shared.svelte.js';
 import { QueryProxy } from './query/proxy.js';
-import * as devalue from 'devalue';
-import { HttpError, Redirect } from '@sveltejs/kit/internal';
+import { HttpError } from '@sveltejs/kit/internal';
 
 /**
  * @param {string} id
@@ -17,14 +15,8 @@ export function query_batch(id) {
 
 	/** @type {RemoteQueryFunction<any, any>} */
 	const wrapper = (arg) => {
-		return new QueryProxy(id, arg, async (key, payload) => {
-			if (Object.hasOwn(query_responses, key)) {
-				const value = query_responses[key];
-				delete query_responses[key];
-				return value;
-			}
-
-			const serialized = await new Promise((resolve, reject) => {
+		return new QueryProxy(id, arg, async (payload) => {
+			return await new Promise((resolve, reject) => {
 				// create_remote_function caches identical calls, but in case a refresh to the same query is called multiple times this function
 				// is invoked multiple times with the same payload, so we need to deduplicate here
 				const entry = batching.get(payload) ?? [];
@@ -49,7 +41,7 @@ export function query_batch(id) {
 					batching = new Map();
 
 					try {
-						const response = await fetch(`${base}/${app_dir}/remote/${id}`, {
+						const response = await remote_request(`${base}/${app_dir}/remote/${id}`, {
 							method: 'POST',
 							body: JSON.stringify({
 								payloads: Array.from(batched.keys())
@@ -57,48 +49,44 @@ export function query_batch(id) {
 							headers
 						});
 
-						if (!response.ok) {
-							throw new Error('Failed to execute batch query');
+						if (response.redirect) {
+							await goto(response.redirect);
+
+							// settle all batched promises (with `undefined`, like a redirect
+							// from a non-batched query) so that callers don't hang forever
+							for (const resolvers of batched.values()) {
+								for (const { resolve } of resolvers) {
+									resolve(undefined);
+								}
+							}
+
+							return;
 						}
 
-						const result = /** @type {RemoteFunctionResponse} */ (await response.json());
-						if (result.type === 'error') {
-							throw new HttpError(result.status ?? 500, result.error);
-						}
-
-						if (result.type === 'redirect') {
-							await goto(result.location);
-							throw new Redirect(307, result.location);
-						}
-
-						const results = devalue.parse(result.result, app.decoders);
-
-						// Resolve individual queries
-						// Maps guarantee insertion order so we can do it like this
+						const results = response._;
 						let i = 0;
 
 						for (const resolvers of batched.values()) {
+							const result = results[i];
+
 							for (const { resolve, reject } of resolvers) {
-								if (results[i].type === 'error') {
-									reject(new HttpError(results[i].status, results[i].error));
+								if (result.type === 'error') {
+									reject(new HttpError(result.status, result.error));
 								} else {
-									resolve(results[i].data);
+									resolve(result.data);
 								}
 							}
 							i++;
 						}
-					} catch (error) {
-						// Reject all queries in the batch
-						for (const resolver of batched.values()) {
-							for (const { reject } of resolver) {
-								reject(error);
+					} catch (e) {
+						for (const resolvers of batched.values()) {
+							for (const { reject } of resolvers) {
+								reject(e);
 							}
 						}
 					}
 				}, 0);
 			});
-
-			return devalue.parse(serialized, app.decoders);
 		});
 	};
 

--- a/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
@@ -18,7 +18,7 @@ export function query_batch(id) {
 	/** @type {RemoteQueryFunction<any, any>} */
 	const wrapper = (arg) => {
 		return new QueryProxy(id, arg, async (key, payload) => {
-			if (query_responses[key]) {
+			if (Object.hasOwn(query_responses, key)) {
 				const value = query_responses[key];
 				delete query_responses[key];
 				return value;

--- a/packages/kit/src/runtime/client/remote-functions/query-live/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/instance.svelte.js
@@ -86,9 +86,24 @@ export class LiveQuery {
 		this.#reject_first = reject;
 
 		if (Object.hasOwn(query_responses, key)) {
-			const value = query_responses[key];
+			const node = query_responses[key];
 			delete query_responses[key];
-			this.set(value);
+
+			if (node.e) {
+				// the query failed during SSR — seed the failed state (mirroring `fail()`,
+				// minus its terminal `#done`), so the main loop still connects as usual
+				// and the query can recover
+				const error = new HttpError(node.e[0] ?? 500, node.e[1]);
+				this.#loading = false;
+				this.#error = error;
+
+				promise.catch(noop);
+				this.#reject_first?.(error);
+				this.#resolve_first = null;
+				this.#reject_first = null;
+			} else {
+				this.set(node.v);
+			}
 		}
 	}
 

--- a/packages/kit/src/runtime/client/remote-functions/query-live/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/instance.svelte.js
@@ -1,6 +1,5 @@
 /** @import { PromiseWithResolvers } from '../../../../utils/promise.js' */
-import { app, query_responses } from '../../client.js';
-import * as devalue from 'devalue';
+import { query_responses } from '../../client.js';
 import { HttpError, Redirect } from '@sveltejs/kit/internal';
 import { noop, once } from '../../../../utils/functions.js';
 import { with_resolvers } from '../../../../utils/promise.js';
@@ -86,8 +85,8 @@ export class LiveQuery {
 		this.#resolve_first = resolve;
 		this.#reject_first = reject;
 
-		const value = query_responses[key];
-		if (value !== undefined) {
+		if (Object.hasOwn(query_responses, key)) {
+			const value = query_responses[key];
 			delete query_responses[key];
 			this.set(value);
 		}

--- a/packages/kit/src/runtime/client/remote-functions/query-live/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/instance.svelte.js
@@ -1,12 +1,11 @@
 /** @import { PromiseWithResolvers } from '../../../../utils/promise.js' */
-import { app } from '../../client.js';
+import { app, query_responses } from '../../client.js';
 import * as devalue from 'devalue';
 import { HttpError, Redirect } from '@sveltejs/kit/internal';
 import { noop, once } from '../../../../utils/functions.js';
 import { with_resolvers } from '../../../../utils/promise.js';
 import { SharedIterator } from '../../../../utils/shared-iterator.js';
 import { tick } from 'svelte';
-import { unfriendly_hydratable } from '../../../shared.js';
 import { create_live_iterator } from './iterator.js';
 
 /**
@@ -87,9 +86,10 @@ export class LiveQuery {
 		this.#resolve_first = resolve;
 		this.#reject_first = reject;
 
-		const serialized = unfriendly_hydratable(key, () => undefined);
-		if (serialized !== undefined) {
-			this.set(devalue.parse(serialized, app.decoders));
+		const value = query_responses[key];
+		if (value !== undefined) {
+			delete query_responses[key];
+			this.set(value);
 		}
 	}
 

--- a/packages/kit/src/runtime/client/remote-functions/query/index.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/index.js
@@ -4,7 +4,6 @@ import { app, query_map, query_responses } from '../../client.js';
 import { get_remote_request_headers, QUERY_FUNCTION_ID, remote_request } from '../shared.svelte.js';
 import * as devalue from 'devalue';
 import { DEV } from 'esm-env';
-import { unfriendly_hydratable } from '../../../shared.js';
 import { QueryProxy } from './proxy.js';
 
 /**
@@ -34,9 +33,7 @@ export function query(id) {
 
 			const url = `${base}/${app_dir}/remote/${id}${payload ? `?payload=${payload}` : ''}`;
 
-			const serialized = await unfriendly_hydratable(key, () =>
-				remote_request(url, get_remote_request_headers())
-			);
+			const serialized = await remote_request(url, get_remote_request_headers());
 
 			return devalue.parse(serialized, app.decoders);
 		});

--- a/packages/kit/src/runtime/client/remote-functions/query/index.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/index.js
@@ -1,8 +1,7 @@
 /** @import { RemoteQueryFunction } from '@sveltejs/kit' */
 import { app_dir, base } from '$app/paths/internal/client';
-import { app, query_map, query_responses } from '../../client.js';
+import { goto, query_map } from '../../client.js';
 import { get_remote_request_headers, QUERY_FUNCTION_ID, remote_request } from '../shared.svelte.js';
-import * as devalue from 'devalue';
 import { DEV } from 'esm-env';
 import { QueryProxy } from './proxy.js';
 
@@ -24,18 +23,14 @@ export function query(id) {
 
 	/** @type {RemoteQueryFunction<any, any>} */
 	const wrapper = (arg) => {
-		return new QueryProxy(id, arg, async (key, payload) => {
-			if (Object.hasOwn(query_responses, key)) {
-				const value = query_responses[key];
-				delete query_responses[key];
-				return value;
-			}
-
+		return new QueryProxy(id, arg, async (payload) => {
 			const url = `${base}/${app_dir}/remote/${id}${payload ? `?payload=${payload}` : ''}`;
 
-			const serialized = await remote_request(url, get_remote_request_headers());
+			const result = await remote_request(url, { headers: get_remote_request_headers() });
 
-			return devalue.parse(serialized, app.decoders);
+			if (result.redirect) {
+				await goto(result.redirect);
+			}
 		});
 	};
 

--- a/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
@@ -1,4 +1,5 @@
 import { query_responses } from '../../client.js';
+import { HttpError } from '@sveltejs/kit/internal';
 import { QUERY_OVERRIDE_KEY } from '../shared.svelte.js';
 import { noop } from '../../../../utils/functions.js';
 import { with_resolvers } from '../../../../utils/promise.js';
@@ -64,6 +65,17 @@ export class Query {
 	constructor(key, fn) {
 		this.#key = key;
 		this.#fn = fn;
+
+		if (Object.hasOwn(query_responses, key)) {
+			const node = query_responses[key];
+			delete query_responses[key];
+
+			if (node.e) {
+				this.fail(new HttpError(node.e[0] ?? 500, node.e[1]));
+			} else {
+				this.set(/** @type {T} */ (node.v));
+			}
+		}
 	}
 
 	#get_promise() {
@@ -199,6 +211,10 @@ export class Query {
 	 * @param {T} value
 	 */
 	set(value) {
+		// normally consumed in the constructor, but make sure a leftover
+		// SSR record can never shadow the newly-set value
+		delete query_responses[this.#key];
+
 		this.#clear_pending();
 		this.#ready = true;
 		this.#loading = false;
@@ -211,6 +227,10 @@ export class Query {
 	 * @param {unknown} error
 	 */
 	fail(error) {
+		// normally consumed in the constructor, but make sure a leftover
+		// SSR record can never shadow the newly-set error
+		delete query_responses[this.#key];
+
 		this.#clear_pending();
 		this.#loading = false;
 		this.#error = error;

--- a/packages/kit/src/runtime/client/remote-functions/query/proxy.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/proxy.js
@@ -25,7 +25,7 @@ export class QueryProxy {
 	/**
 	 * @param {string} id
 	 * @param {any} arg
-	 * @param {(key: string, payload: string) => Promise<T>} fn
+	 * @param {(payload: string) => Promise<T>} fn
 	 */
 	constructor(id, arg, fn) {
 		this.#id = id;
@@ -41,7 +41,7 @@ export class QueryProxy {
 			this.#payload,
 			// IMPORTANT: This cannot close over `this` or it becomes impossible to
 			// garbage collect the QueryProxy and thus impossible to evict cache entries.
-			() => new Query(key, () => fn(key, payload))
+			() => new Query(key, () => fn(payload))
 		);
 
 		cache.ref(this, entry, this.#id, this.#payload);
@@ -98,7 +98,7 @@ export class QueryProxy {
 			this.#payload,
 			// IMPORTANT: This cannot close over `this` or it becomes impossible to
 			// garbage collect the QueryProxy and thus impossible to evict cache entries.
-			() => new Query(key_ref, () => fn_ref(key_ref, payload_ref))
+			() => new Query(key_ref, () => fn_ref(payload_ref))
 		);
 
 		const deref = cache.manual_ref(entry, this.#id, this.#payload);

--- a/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
@@ -1,7 +1,8 @@
-/** @import { RemoteFunctionResponse, RemoteSingleflightMap, RemoteSingleflightEntry } from 'types' */
+/** @import { RemoteFunctionResponse, RemoteFunctionData, RemoteFunctionDataNode } from 'types' */
 /** @import { RemoteQueryUpdate } from '@sveltejs/kit' */
+/** @import { CacheEntry } from './cache.svelte.js' */
 import * as devalue from 'devalue';
-import { app, goto, live_query_map, query_map } from '../client.js';
+import { app, goto, live_query_map, query_map, query_responses } from '../client.js';
 import { HttpError, Redirect } from '@sveltejs/kit/internal';
 import { untrack } from 'svelte';
 import { create_remote_key, split_remote_key } from '../../shared.js';
@@ -77,6 +78,20 @@ export function pin_while_resolving(cache_map, cache, id, payload, then) {
 /**
  * @returns {{ 'x-sveltekit-pathname': string, 'x-sveltekit-search': string }}
  */
+/**
+ * Unwraps a `RemoteFunctionDataNode` that was serialized during SSR,
+ * rethrowing serialized errors so the consuming resource ends up
+ * in the same failed state it had on the server
+ * @param {RemoteFunctionDataNode} node
+ */
+export function unwrap_node(node) {
+	if (node.e) {
+		throw new HttpError(node.e[0] ?? 500, node.e[1]);
+	}
+
+	return node.v;
+}
+
 export function get_remote_request_headers() {
 	// This will be the correct value of the current or soon-current url,
 	// even in forks because it's state-based - therefore not using window.location.
@@ -93,15 +108,10 @@ export function get_remote_request_headers() {
 
 /**
  * @param {string} url
- * @param {HeadersInit} headers
+ * @param {RequestInit} [init]
  */
-export async function remote_request(url, headers) {
-	const response = await fetch(url, {
-		headers: {
-			'Content-Type': 'application/json',
-			...headers
-		}
-	});
+export async function remote_request(url, init) {
+	const response = await fetch(url, init);
 
 	if (!response.ok) {
 		throw new HttpError(500, 'Failed to execute remote function');
@@ -109,9 +119,63 @@ export async function remote_request(url, headers) {
 
 	const result = /** @type {RemoteFunctionResponse} */ (await response.json());
 
-	const resolved = await handle_side_channel_response(result);
+	if (result.type === 'error') {
+		throw new HttpError(result.status ?? 500, result.error);
+	}
 
-	return resolved.result;
+	const data = /** @type {RemoteFunctionData} */ (
+		result.data ? devalue.parse(result.data, app.decoders) : {}
+	);
+
+	/**
+	 *
+	 * @param {string} key
+	 * @param {CacheEntry<any> | undefined} entry
+	 * @param {any} result
+	 */
+	function refresh(key, entry, result) {
+		if (entry?.resource) {
+			if (result.e) {
+				entry.resource.fail(new HttpError(result.e[0] ?? 500, result.e[1]));
+			} else {
+				entry.resource.set(result.v);
+			}
+		} else if (!result.e) {
+			// `query_responses` stores `{ v }`/`{ e }` nodes, not raw values.
+			// Errors are deliberately dropped here: they are responses to a specific
+			// refresh, not durable state a future resource should initialize with
+			query_responses[key] = result;
+		}
+	}
+
+	// update queries with refreshed data
+	if (data.q) {
+		for (const key in data.q) {
+			const parts = split_remote_key(key);
+			const entry = query_map.get(parts.id)?.get(parts.payload);
+
+			refresh(key, entry, data.q[key]);
+		}
+	}
+
+	// reconnect live queries
+	if (data.l) {
+		for (const key in data.l) {
+			const parts = split_remote_key(key);
+			const entry = live_query_map.get(parts.id)?.get(parts.payload);
+
+			refresh(key, entry, data.l[key]);
+
+			// `fail()` is terminal, so only reconnect on the success path —
+			// reconnecting after a hard failure would wipe the error state and
+			// restart the stream (see commit 63a3e83 regression).
+			if (!data.l[key].e) {
+				void entry?.resource.reconnect();
+			}
+		}
+	}
+
+	return data;
 }
 
 /**
@@ -206,50 +270,3 @@ export function categorize_updates(updates) {
 
 	return { overrides, refreshes };
 }
-
-/**
- * @template TResource
- * @param {string} stringified_singleflight
- * @param {Map<string, Map<string, { resource: TResource }>>} map
- * @param {(resource: TResource, value: RemoteSingleflightEntry) => void} callback
- */
-function apply_singleflight(stringified_singleflight, map, callback) {
-	const singleflight = /** @type {RemoteSingleflightMap} */ (
-		devalue.parse(stringified_singleflight, app.decoders)
-	);
-
-	for (const [key, value] of Object.entries(singleflight)) {
-		const parts = split_remote_key(key);
-		const entry = map.get(parts.id)?.get(parts.payload);
-		if (entry?.resource) {
-			callback(entry.resource, value);
-		}
-	}
-}
-
-/**
- * Apply refresh data from the server to the relevant queries
- *
- * @param {string} stringified_refreshes
- */
-export const apply_refreshes = (stringified_refreshes) => {
-	apply_singleflight(stringified_refreshes, query_map, (resource, value) => {
-		if (value.type === 'result') {
-			resource?.set(value.data);
-		} else {
-			resource?.fail(new HttpError(value.status ?? 500, value.error));
-		}
-	});
-};
-
-/** @param {string} stringified_reconnects */
-export const apply_reconnections = (stringified_reconnects) => {
-	apply_singleflight(stringified_reconnects, live_query_map, (resource, value) => {
-		if (value.type === 'result') {
-			resource?.set(value.data);
-			void resource?.reconnect();
-		} else {
-			resource?.fail(new HttpError(value.status ?? 500, value.error));
-		}
-	});
-};

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -21,10 +21,9 @@ import {
 	get_global_name,
 	handle_error_and_jsonify
 } from '../utils.js';
-import { create_remote_key } from '../../shared.js';
 import { get_status } from '../../../utils/error.js';
 import * as env from '__sveltekit/env';
-import { noop } from '../../../utils/functions.js';
+import { collect_remote_data } from '../remote.js';
 
 // TODO rename this function/module
 
@@ -517,77 +516,27 @@ export async function render_response({
 			args.push(`{\n${indent}\t${hydrate.join(`,\n${indent}\t`)}\n${indent}}`);
 		}
 
-		const { remote } = event_state;
+		const remote_data = await collect_remote_data({}, event, event_state, options);
 
-		let serialized_query_data = '';
-		let serialized_prerender_data = '';
-
-		if (remote.data) {
-			/** @type {Record<string, any>} */
-			const query = {};
-
-			/** @type {Record<string, any>} */
-			const prerender = {};
-
-			for (const [internals, cache] of remote.data) {
-				// remote functions without an `id` aren't exported, and thus
-				// cannot be called from the client
-				if (!internals.id) continue;
-
-				for (const key in cache) {
-					const value = cache[key];
-
-					const remote_key = create_remote_key(internals.id, key);
-
-					const store = internals.type === 'prerender' ? prerender : query;
-
-					if (
-						event_state.remote.refreshes?.has(remote_key) ||
-						event_state.remote.reconnects?.has(remote_key)
-					) {
-						// This entry was refreshed/set by a command or form action.
-						// Always await it so the mutation result is serialized.
-						store[remote_key] = await value;
-					} else {
-						let resolved = true;
-
-						// Don't block the response on pending remote data - if a query
-						// hasn't settled yet, it wasn't awaited in the template (or is behind a pending boundary).
-						await Promise.race([
-							Promise.resolve(value).then((v) => resolved && (store[remote_key] = v), noop),
-							Promise.resolve().then(() => (resolved = false))
-						]);
-					}
-				}
-			}
-
-			const replacer = create_replacer(options.hooks.transport);
-
-			if (Object.keys(query).length > 0) {
-				serialized_query_data = `${global}.query = ${devalue.uneval(query, replacer)};\n\n\t\t\t\t\t\t`;
-			}
-
-			if (Object.keys(prerender).length > 0) {
-				serialized_prerender_data = `${global}.prerender = ${devalue.uneval(prerender, replacer)};\n\n\t\t\t\t\t\t`;
-			}
-		}
-
-		const serialized_remote_data = `${serialized_query_data}${serialized_prerender_data}`;
+		const serialized_data =
+			Object.keys(remote_data).length > 0
+				? `${global}.data = ${devalue.uneval(remote_data, create_replacer(options.hooks.transport))};\n\n\t\t\t\t\t\t`
+				: '';
 
 		// `client.app` is a proxy for `bundleStrategy === 'split'`
 		const boot = client.inline
 			? `${client.inline.script}
 
-					${serialized_remote_data}${global}.app.start(${args.join(', ')});`
+					${serialized_data}${global}.app.start(${args.join(', ')});`
 			: client.app
 				? `Promise.all([
 						import(${s(prefixed(client.start))}),
 						import(${s(prefixed(client.app))})
 					]).then(([kit, app]) => {
-						${serialized_remote_data}kit.start(app, ${args.join(', ')});
+						${serialized_data}kit.start(app, ${args.join(', ')});
 					});`
 				: `import(${s(prefixed(client.start))}).then((app) => {
-						${serialized_remote_data}app.start(${args.join(', ')})
+						${serialized_data}app.start(${args.join(', ')})
 					});`;
 
 		if (load_env_eagerly) {

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -24,6 +24,7 @@ import {
 import { create_remote_key } from '../../shared.js';
 import { get_status } from '../../../utils/error.js';
 import * as env from '__sveltekit/env';
+import { noop } from '../../../utils/functions.js';
 
 // TODO rename this function/module
 
@@ -534,7 +535,7 @@ export async function render_response({
 				if (!internals.id) continue;
 
 				for (const key in cache) {
-					const entry = cache[key];
+					const value = cache[key];
 
 					const remote_key = create_remote_key(internals.id, key);
 
@@ -546,24 +547,16 @@ export async function render_response({
 					) {
 						// This entry was refreshed/set by a command or form action.
 						// Always await it so the mutation result is serialized.
-						store[remote_key] = await entry.data;
+						store[remote_key] = await value;
 					} else {
+						let resolved = true;
+
 						// Don't block the response on pending remote data - if a query
 						// hasn't settled yet, it wasn't awaited in the template (or is behind a pending boundary).
-						const result = await Promise.race([
-							Promise.resolve(entry.data).then(
-								(v) => /** @type {const} */ ({ settled: true, value: v }),
-								(e) => /** @type {const} */ ({ settled: true, error: e })
-							),
-							new Promise((resolve) => {
-								queueMicrotask(() => resolve(/** @type {const} */ ({ settled: false })));
-							})
+						await Promise.race([
+							Promise.resolve(value).then((v) => resolved && (store[remote_key] = v), noop),
+							Promise.resolve().then(() => (resolved = false))
 						]);
-
-						if (result.settled) {
-							if ('error' in result && entry.serialize) throw result.error;
-							store[remote_key] = result.value;
-						}
 					}
 				}
 			}

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -536,8 +536,6 @@ export async function render_response({
 				for (const key in cache) {
 					const entry = cache[key];
 
-					if (!entry.serialize) continue;
-
 					const remote_key = create_remote_key(internals.id, key);
 
 					const store = internals.type === 'prerender' ? prerender : query;
@@ -563,7 +561,7 @@ export async function render_response({
 						]);
 
 						if (result.settled) {
-							if ('error' in result) throw result.error;
+							if ('error' in result && entry.serialize) throw result.error;
 							store[remote_key] = result.value;
 						}
 					}

--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -1,12 +1,12 @@
 /** @import { ActionResult, RemoteForm, RequestEvent, SSRManifest } from '@sveltejs/kit' */
-/** @import { RemoteFormInternals, RemoteFunctionResponse, RemoteInternals, RequestState, SSROptions } from 'types' */
+/** @import { RemoteFormInternals, RemoteFunctionData, RemoteFunctionResponse, RemoteInternals, RequestState, SSROptions } from 'types' */
 
 import { json, error } from '@sveltejs/kit';
 import { HttpError, Redirect, SvelteKitError } from '@sveltejs/kit/internal';
 import { with_request_store, merge_tracing } from '@sveltejs/kit/internal/server';
 import { app_dir, base } from '$app/paths/internal/server';
 import { is_form_content_type } from '../../utils/http.js';
-import { parse_remote_arg, split_remote_key, stringify } from '../shared.js';
+import { create_remote_key, parse_remote_arg, split_remote_key, stringify } from '../shared.js';
 import { handle_error_and_jsonify } from './utils.js';
 import { normalize_error } from '../../utils/error.js';
 import { check_incorrect_fail_use } from './page/actions.js';
@@ -58,225 +58,233 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 	});
 
 	try {
-		if (internals.type === 'query_batch') {
-			if (event.request.method !== 'POST') {
-				throw new SvelteKitError(
-					405,
-					'Method Not Allowed',
-					`\`query.batch\` functions must be invoked via POST request, not ${event.request.method}`
-				);
-			}
+		/** @type {RemoteFunctionData} */
+		const data = {};
 
-			/** @type {{ payloads: string[] }} */
-			const { payloads } = await event.request.json();
-
-			const args = await Promise.all(
-				payloads.map((payload) => parse_remote_arg(payload, transport))
-			);
-
-			const results = await with_request_store({ event, state }, () =>
-				internals.run(args, options)
-			);
-
-			return json(
-				/** @type {RemoteFunctionResponse} */ ({
-					type: 'result',
-					result: stringify(results, transport)
-				})
-			);
-		}
-
-		if (internals.type === 'form') {
-			if (event.request.method !== 'POST') {
-				throw new SvelteKitError(
-					405,
-					'Method Not Allowed',
-					`\`form\` functions must be invoked via POST request, not ${event.request.method}`
-				);
-			}
-
-			if (!is_form_content_type(event.request)) {
-				throw new SvelteKitError(
-					415,
-					'Unsupported Media Type',
-					`\`form\` functions expect form-encoded data — received ${event.request.headers.get(
-						'content-type'
-					)}`
-				);
-			}
-
-			const { data, meta, form_data } = await deserialize_binary_form(event.request);
-			state.remote.requested = create_requested_map(meta.remote_refreshes);
-
-			// If this is a keyed form instance (created via form.for(key)), add the key to the form data (unless already set)
-			// Note that additional_args will only be set if the form is not enhanced, as enhanced forms transfer the key inside `data`.
-			if (additional_args && !('id' in data)) {
-				data.id = JSON.parse(decodeURIComponent(additional_args));
-			}
-
-			const fn = internals.fn;
-			const result = await with_request_store({ event, state }, () => fn(data, meta, form_data));
-
-			return json(
-				/** @type {RemoteFunctionResponse} */ ({
-					type: 'result',
-					result: stringify(result, transport),
-					refreshes: result.issues
-						? undefined
-						: await serialize_singleflight(state.remote.refreshes),
-					reconnects: result.issues
-						? undefined
-						: await serialize_singleflight(state.remote.reconnects)
-				})
-			);
-		}
-
-		if (internals.type === 'command') {
-			/** @type {{ payload: string, refreshes?: string[] }} */
-			const { payload, refreshes } = await event.request.json();
-			state.remote.requested = create_requested_map(refreshes);
-			const arg = parse_remote_arg(payload, transport);
-			const data = await with_request_store({ event, state }, () => fn(arg));
-
-			return json(
-				/** @type {RemoteFunctionResponse} */ ({
-					type: 'result',
-					result: stringify(data, transport),
-					refreshes: await serialize_singleflight(state.remote.refreshes),
-					reconnects: await serialize_singleflight(state.remote.reconnects)
-				})
-			);
-		}
-
-		if (internals.type === 'query_live') {
-			if (event.request.method !== 'GET') {
-				throw new SvelteKitError(
-					405,
-					'Method Not Allowed',
-					`\`query.live\` functions must be invoked via GET request, not ${event.request.method}`
-				);
-			}
-
-			const payload = /** @type {string} */ (
-				new URL(event.request.url).searchParams.get('payload')
-			);
-
-			const generator = internals.run(event, state, parse_remote_arg(payload, transport));
-
-			const encoder = new TextEncoder();
-
-			/**
-			 * @param {ReadableStreamDefaultController} controller
-			 * @param {any} payload
-			 */
-			function send(controller, payload) {
-				controller.enqueue(encoder.encode('data: ' + JSON.stringify(payload) + '\n\n'));
-			}
-
-			let closed = false;
-
-			/** @type {string | undefined} */
-			let result = undefined;
-
-			async function cancel() {
-				if (closed) return;
-				closed = true;
-				await generator.return(undefined);
-			}
-
-			event.request.signal.addEventListener('abort', cancel, { once: true });
-
-			return new Response(
-				new ReadableStream({
-					async pull(controller) {
-						if (event.request.signal.aborted) {
-							await cancel();
-							controller.close();
-							return;
-						}
-
-						try {
-							while (true) {
-								const { value, done } = await generator.next();
-
-								if (done) {
-									await cancel();
-									controller.close();
-									return;
-								}
-
-								// only send changed data
-								if (result !== (result = stringify(value, transport))) {
-									send(controller, {
-										type: 'result',
-										result
-									});
-
-									return;
-								}
-							}
-						} catch (error) {
-							if (!event.request.signal.aborted) {
-								if (error instanceof Redirect) {
-									send(controller, {
-										type: 'redirect',
-										location: error.location
-									});
-								} else {
-									const status =
-										error instanceof HttpError || error instanceof SvelteKitError
-											? error.status
-											: 500;
-
-									send(controller, {
-										type: 'error',
-										error: await handle_error_and_jsonify(event, state, options, error),
-										status
-									});
-								}
-							}
-
-							await cancel();
-							controller.close();
-						}
-					},
-					cancel
-				}),
-				{
-					headers: {
-						'cache-control': 'private, no-store',
-						'content-type': 'text/event-stream'
-					}
-				}
-			);
-		}
-
-		const payload =
-			internals.type === 'prerender'
-				? additional_args
-				: /** @type {string} */ (
-						// new URL(...) necessary because we're hiding the URL from the user in the event object
-						new URL(event.request.url).searchParams.get('payload')
+		switch (internals.type) {
+			case 'query_live': {
+				if (event.request.method !== 'GET') {
+					throw new SvelteKitError(
+						405,
+						'Method Not Allowed',
+						`\`query.live\` functions must be invoked via GET request, not ${event.request.method}`
 					);
+				}
 
-		const data = await with_request_store({ event, state }, () =>
-			fn(parse_remote_arg(payload, transport))
-		);
+				const payload = /** @type {string} */ (
+					new URL(event.request.url).searchParams.get('payload')
+				);
+
+				const generator = internals.run(event, state, parse_remote_arg(payload, transport));
+
+				const encoder = new TextEncoder();
+
+				/**
+				 * @param {ReadableStreamDefaultController} controller
+				 * @param {any} payload
+				 */
+				function send(controller, payload) {
+					controller.enqueue(encoder.encode('data: ' + JSON.stringify(payload) + '\n\n'));
+				}
+
+				let closed = false;
+
+				/** @type {string | undefined} */
+				let result = undefined;
+
+				async function cancel() {
+					if (closed) return;
+					closed = true;
+					await generator.return(undefined);
+				}
+
+				event.request.signal.addEventListener('abort', cancel, { once: true });
+
+				return new Response(
+					new ReadableStream({
+						async pull(controller) {
+							if (event.request.signal.aborted) {
+								await cancel();
+								controller.close();
+								return;
+							}
+
+							try {
+								while (true) {
+									const { value, done } = await generator.next();
+
+									if (done) {
+										await cancel();
+										controller.close();
+										return;
+									}
+
+									// only send changed data
+									if (result !== (result = stringify(value, transport))) {
+										send(controller, {
+											type: 'result',
+											result
+										});
+
+										return;
+									}
+								}
+							} catch (error) {
+								if (!event.request.signal.aborted) {
+									if (error instanceof Redirect) {
+										send(controller, {
+											type: 'redirect',
+											location: error.location
+										});
+									} else {
+										const status =
+											error instanceof HttpError || error instanceof SvelteKitError
+												? error.status
+												: 500;
+
+										send(controller, {
+											type: 'error',
+											error: await handle_error_and_jsonify(event, state, options, error),
+											status
+										});
+									}
+								}
+
+								await cancel();
+								controller.close();
+							}
+						},
+						cancel
+					}),
+					{
+						headers: {
+							'cache-control': 'private, no-store',
+							'content-type': 'text/event-stream'
+						}
+					}
+				);
+			}
+
+			case 'query_batch': {
+				if (event.request.method !== 'POST') {
+					throw new SvelteKitError(
+						405,
+						'Method Not Allowed',
+						`\`query.batch\` functions must be invoked via POST request, not ${event.request.method}`
+					);
+				}
+
+				/** @type {{ payloads: string[] }} */
+				const { payloads } = await event.request.json();
+
+				const args = await Promise.all(
+					payloads.map((payload) => parse_remote_arg(payload, transport))
+				);
+
+				data._ = await with_request_store({ event, state }, () => internals.run(args, options));
+
+				break;
+			}
+
+			case 'form': {
+				if (event.request.method !== 'POST') {
+					throw new SvelteKitError(
+						405,
+						'Method Not Allowed',
+						`\`form\` functions must be invoked via POST request, not ${event.request.method}`
+					);
+				}
+
+				if (!is_form_content_type(event.request)) {
+					throw new SvelteKitError(
+						415,
+						'Unsupported Media Type',
+						`\`form\` functions expect form-encoded data — received ${event.request.headers.get(
+							'content-type'
+						)}`
+					);
+				}
+
+				const { data: input, meta, form_data } = await deserialize_binary_form(event.request);
+				state.remote.requested = create_requested_map(meta.remote_refreshes);
+
+				// If this is a keyed form instance (created via form.for(key)), add the key to the form data (unless already set)
+				// Note that additional_args will only be set if the form is not enhanced, as enhanced forms transfer the key inside `data`.
+				if (additional_args && !('id' in input)) {
+					input.id = JSON.parse(decodeURIComponent(additional_args));
+				}
+
+				const fn = internals.fn;
+				data._ = await with_request_store(
+					{ event, state: { ...state, is_in_remote_form_or_command: true } },
+					() => fn(input, meta, form_data)
+				);
+
+				if (data._.issues) {
+					// special case — don't serialize refreshes/reconnects
+					return json(
+						/** @type {RemoteFunctionResponse} */ ({
+							type: 'result',
+							data: stringify(data, transport)
+						})
+					);
+				}
+
+				break;
+			}
+
+			case 'command': {
+				/** @type {{ payload: string, refreshes?: string[] }} */
+				const { payload, refreshes } = await event.request.json();
+				state.remote.requested = create_requested_map(refreshes);
+				const arg = parse_remote_arg(payload, transport);
+
+				data._ = await with_request_store(
+					{ event, state: { ...state, is_in_remote_form_or_command: true } },
+					() => fn(arg)
+				);
+
+				break;
+			}
+
+			case 'prerender': {
+				data._ = await with_request_store({ event, state }, () =>
+					fn(parse_remote_arg(additional_args, transport))
+				);
+
+				break;
+			}
+
+			case 'query': {
+				const payload = /** @type {string} */ (
+					// new URL(...) necessary because we're hiding the URL from the user in the event object
+					new URL(event.request.url).searchParams.get('payload')
+				);
+
+				data._ = await with_request_store({ event, state }, () =>
+					fn(parse_remote_arg(payload, transport))
+				);
+
+				break;
+			}
+		}
+
+		await collect_remote_data(data, event, state, options);
 
 		return json(
 			/** @type {RemoteFunctionResponse} */ ({
 				type: 'result',
-				result: stringify(data, transport)
+				data: stringify(data, transport)
 			})
 		);
 	} catch (error) {
 		if (error instanceof Redirect) {
+			const data = await collect_remote_data({ redirect: error.location }, event, state, options);
+
 			return json(
 				/** @type {RemoteFunctionResponse} */ ({
-					type: 'redirect',
-					location: error.location,
-					refreshes: await serialize_singleflight(state.remote.refreshes),
-					reconnects: await serialize_singleflight(state.remote.reconnects)
+					type: 'result',
+					data: stringify(data, transport)
 				})
 			);
 		}
@@ -300,35 +308,113 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 			}
 		);
 	}
+}
 
-	/** @param {Map<string, Promise<any>> | null} map */
-	async function serialize_singleflight(map) {
-		if (!map || map.size === 0) {
-			return undefined;
-		}
+/**
+ * Collects all the query/prerender data that was retrieved
+ * during the request and adds it to `data`
+ * @param {RemoteFunctionData} data
+ * @param {RequestEvent} event
+ * @param {RequestState} state
+ * @param {SSROptions} options
+ */
+export async function collect_remote_data(data, event, state, options) {
+	/**
+	 *
+	 * @param {unknown} error
+	 * @returns {Promise<[status: number, error: App.Error]>}
+	 */
+	async function convert_error(error) {
+		const status =
+			error instanceof HttpError || error instanceof SvelteKitError ? error.status : 500;
 
-		const results = await Promise.all(
-			Array.from(map, async ([key, promise]) => {
-				try {
-					return [key, { type: 'result', data: await promise }];
-				} catch (error) {
-					const status =
-						error instanceof HttpError || error instanceof SvelteKitError ? error.status : 500;
-
-					return [
-						key,
-						{
-							type: 'error',
-							status,
-							error: await handle_error_and_jsonify(event, state, options, error)
-						}
-					];
-				}
-			})
-		);
-
-		return stringify(Object.fromEntries(results), transport);
+		return [status, await handle_error_and_jsonify(event, state, options, error)];
 	}
+
+	/** @type {Promise<any>[]} */
+	const promises = [];
+
+	if (state.remote.explicit) {
+		for (const [remote_key, { internals, promise }] of state.remote.explicit) {
+			// there were explicit refreshes/reconnects (via `refresh()`/`set()`/`reconnect()`),
+			// so the client should apply these single-flight updates instead of calling `invalidateAll()`
+			data.r = true;
+
+			const type = /** @type {'p' | 'q' | 'l'} */ (
+				internals.type === 'query_live' ? 'l' : internals.type[0]
+			);
+
+			await promise.then(
+				(v) => {
+					((data[type] ??= {})[remote_key] ??= {}).v = v;
+				},
+				async (e) => {
+					if (e instanceof Redirect) {
+						// already handled elsewhere
+						return;
+					}
+
+					((data[type] ??= {})[remote_key] ??= {}).e = await convert_error(e);
+				}
+			);
+		}
+	}
+
+	await Promise.all(promises);
+
+	if (state.remote.implicit) {
+		for (const [internals, record] of state.remote.implicit) {
+			// Private (non-exported) remote functions have no `id` and must never be
+			// serialized into the response — otherwise their (potentially private) result
+			// would be shipped to the client under a malformed `undefined/...` key.
+			if (!internals.id) continue;
+
+			for (const key in record) {
+				// form outputs are registered under the client-side action id directly
+				const remote_key = internals.type === 'form' ? key : create_remote_key(internals.id, key);
+
+				const type = /** @type {'p' | 'q' | 'l' | 'f'} */ (
+					internals.type === 'query_live' ? 'l' : internals.type[0]
+				);
+
+				const promise = state.remote.data?.get(internals)?.[key] ?? record[key]();
+
+				// If the promise is still pending (e.g. the query was rendered in its loading
+				// state during SSR), omit it from the payload entirely so that the client
+				// fetches it itself — an entry without `v`/`e` would hydrate as `undefined`.
+				let resolved = true;
+
+				await Promise.race([
+					Promise.resolve(promise).then(
+						(v) => {
+							if (resolved) {
+								((data[type] ??= {})[remote_key] ??= {}).v = v;
+							}
+						},
+						(e) => {
+							if (e instanceof Redirect) {
+								// already handled elsewhere
+								return;
+							}
+
+							if (resolved) {
+								promises.push(
+									convert_error(e).then((e) => {
+										((data[type] ??= {})[remote_key] ??= {}).e = e;
+									})
+								);
+							}
+						}
+					),
+					Promise.resolve().then(() => (resolved = false))
+				]);
+			}
+		}
+	}
+
+	await Promise.all(promises);
+
+	return data;
 }
 
 /**
@@ -377,7 +463,10 @@ export async function handle_remote_form_post(event, state, manifest, id) {
  * @returns {Promise<ActionResult>}
  */
 async function handle_remote_form_post_internal(event, state, manifest, id) {
-	const [hash, name, action_id] = id.split('/');
+	// `hash` and `name` can never contain a `/`, but the JSON-stringified key of a
+	// keyed (`form.for(key)`) instance can — rejoin the remaining segments
+	const [hash, name, ...rest] = id.split('/');
+	const action_id = rest.join('/');
 	const remotes = manifest._.remotes;
 	const module = await remotes[hash]?.();
 
@@ -413,7 +502,10 @@ async function handle_remote_form_post_internal(event, state, manifest, id) {
 			data.id = JSON.parse(decodeURIComponent(action_id));
 		}
 
-		await with_request_store({ event, state }, () => fn(data, meta, form_data));
+		await with_request_store(
+			{ event, state: { ...state, is_in_remote_form_or_command: true } },
+			() => fn(data, meta, form_data)
+		);
 
 		// We don't want the data to appear on `let { form } = $props()`, which is why we're not returning it.
 		// It is instead available on `myForm.result`, setting of which happens within the remote `form` function.

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -147,14 +147,16 @@ export async function internal_respond(request, options, manifest, state) {
 		},
 		remote: {
 			data: null,
+			explicit: null,
+			implicit: null,
 			forms: null,
-			refreshes: null,
 			requested: null,
-			reconnects: null,
 			batches: null,
 			live_iterators: null
 		},
 		is_in_remote_function: false,
+		is_in_remote_form_or_command: false,
+		is_in_remote_query: false,
 		is_in_render: false,
 		is_in_universal_load: false
 	};

--- a/packages/kit/src/runtime/shared.js
+++ b/packages/kit/src/runtime/shared.js
@@ -1,7 +1,6 @@
 /** @import { Transport } from '@sveltejs/kit' */
 import * as devalue from 'devalue';
 import { base64_decode, base64_encode, text_encoder } from './utils.js';
-import * as svelte from 'svelte';
 
 /**
  * @param {string} route_id

--- a/packages/kit/src/runtime/shared.js
+++ b/packages/kit/src/runtime/shared.js
@@ -375,17 +375,3 @@ export function split_remote_key(key) {
 		payload: key.slice(i + 1)
 	};
 }
-
-/**
- * @template T
- * @param {string} key
- * @param {() => T} fn
- * @returns {T}
- * @deprecated TODO remove in SvelteKit 3.0
- */
-export function unfriendly_hydratable(key, fn) {
-	if (!svelte.hydratable) {
-		throw new Error('Remote functions require Svelte 5.44.0 or later');
-	}
-	return svelte.hydratable(key, fn);
-}

--- a/packages/kit/src/types/global-private.d.ts
+++ b/packages/kit/src/types/global-private.d.ts
@@ -1,3 +1,5 @@
+import { RemoteFunctionData } from 'types';
+
 declare global {
 	const __SVELTEKIT_ADAPTER_NAME__: string;
 	const __SVELTEKIT_APP_DIR__: string;
@@ -40,9 +42,7 @@ declare global {
 		/** Public environment variables */
 		env?: Record<string, string>;
 		/** Serialized data from query/form/command functions */
-		query?: Record<string, any>;
-		/** Serialized data from prerender functions */
-		prerender?: Record<string, any>;
+		data?: RemoteFunctionData;
 		/** Create a placeholder promise */
 		defer?: (id: number) => Promise<any>;
 		/** Resolve a placeholder promise */

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -713,10 +713,7 @@ export interface RequestState {
 		record_span: RecordSpan;
 	};
 	readonly remote: {
-		data: null | Map<
-			RemoteInternals,
-			Record<string, { serialize: boolean; data: MaybePromise<any> }>
-		>;
+		data: null | Map<RemoteInternals, Record<string, MaybePromise<any>>>;
 		/** Instances created via `myForm.for(...)` */
 		forms: null | Map<string, any>;
 		/** A map of remote function key to corresponding single-flight-mutation promise */

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -238,10 +238,7 @@ export interface PrerenderOptions {
 	cache?: string; // including this here is a bit of a hack, but it makes it easy to add <meta http-equiv>
 	fallback?: boolean;
 	dependencies: Map<string, PrerenderDependency>;
-	/**
-	 * For each key the (possibly still pending) result of a prerendered remote function.
-	 * Used to deduplicate requests to the same remote function with the same arguments.
-	 */
+	/** Results of remote `prerender` functions, shared across the whole prerender run so that each only executes once */
 	remote_responses: Map<string, Promise<any>>;
 	/** True for the duration of a call to the `reroute` hook */
 	inside_reroute?: boolean;
@@ -309,37 +306,41 @@ export type ServerNodesResponse = {
 	nodes: Array<ServerDataNode | ServerDataSkippedNode | ServerErrorNode | null>;
 };
 
+export type RemoteFunctionDataNode = {
+	/** value */
+	v?: any;
+	/** error */
+	e?: [status: number, error: any];
+};
+
+export type RemoteFunctionData = {
+	/** The result of a command/form invocation */
+	_?: any;
+	/** `prerender` data that was accessed during the request */
+	p?: Record<string, RemoteFunctionDataNode>;
+	/** `query` or `query.batch` data that was accessed during the request */
+	q?: Record<string, RemoteFunctionDataNode>;
+	/** `query.live` data that was accessed during the request */
+	l?: Record<string, RemoteFunctionDataNode>;
+	/** `form` outputs (result/issues/input) from a non-enhanced submission, keyed by the client-side action id */
+	f?: Record<string, RemoteFunctionDataNode>;
+	/** Whether there were any refreshes/reconnects during the request */
+	r?: true;
+	/** The redirect location, if any */
+	redirect?: string;
+};
+
 export type RemoteFunctionResponse =
 	| (ServerRedirectNode & {
-			/** devalue'd Record<string, any> */
-			refreshes?: string;
-			/** devalue'd Record<string, any> */
-			reconnects?: string;
+			/** stringified RemoteFunctionData */
+			data: string;
 	  })
 	| ServerErrorNode
 	| {
 			type: 'result';
-			result: string;
-			/** devalue'd Record<string, any> */
-			refreshes: string | undefined;
-			/** devalue'd Record<string, any> */
-			reconnects: string | undefined;
+			/** stringified RemoteFunctionData */
+			data: string;
 	  };
-
-export type RemoteSingleflightResult = {
-	type: 'result';
-	data: any;
-};
-
-export type RemoteSingleflightError = {
-	type: 'error';
-	status?: number;
-	error: App.Error;
-};
-
-export type RemoteSingleflightEntry = RemoteSingleflightResult | RemoteSingleflightError;
-
-export type RemoteSingleflightMap = Record<string, RemoteSingleflightEntry>;
 
 export type RemoteLiveQueryUserFunctionReturnType<Output> = MaybePromise<
 	| AsyncGenerator<Output>
@@ -668,6 +669,11 @@ export interface RemoteCommandInternals extends BaseRemoteInternals {
 
 export interface RemoteFormInternals extends BaseRemoteInternals {
 	type: 'form';
+	/**
+	 * For keyed (`form.for(key)`) instances: the id as the client computes it
+	 * (the key is JSON-stringified but not URI-encoded, unlike `id`)
+	 */
+	action_id?: string;
 	fn(body: Record<string, any>, meta: BinaryFormMeta, form_data: FormData | null): Promise<any>;
 }
 
@@ -713,12 +719,26 @@ export interface RequestState {
 		record_span: RecordSpan;
 	};
 	readonly remote: {
+		/** Resolved query/prerender data, populated by `await myQuery()` or `myQuery.set(...)` */
 		data: null | Map<RemoteInternals, Record<string, MaybePromise<any>>>;
+		/**
+		 * Data that is implicitly included because it was awaited during render.
+		 * This is serialized during SSR if the promise already resolved
+		 */
+		implicit: null | Map<RemoteInternals, Record<string, () => MaybePromise<any>>>;
+		/**
+		 * Data that is explicitly included because of a `set(...)` or `refresh()`.
+		 * This is always awaited
+		 */
+		explicit: null | Map<
+			string,
+			{
+				internals: RemoteInternals;
+				promise: Promise<any>;
+			}
+		>;
 		/** Instances created via `myForm.for(...)` */
 		forms: null | Map<string, any>;
-		/** A map of remote function key to corresponding single-flight-mutation promise */
-		refreshes: null | Map<string, Promise<any>>;
-		reconnects: null | Map<string, Promise<void>>;
 		/** A map of remote function ID to payloads requested for refreshing by the client */
 		requested: null | Map<string, string[]>;
 		/** A map of query.batch ID to payloads requested for that batch within the same macrotask */
@@ -741,6 +761,8 @@ export interface RequestState {
 		live_iterators: null | Map<string, SharedIterator<any>>;
 	};
 	readonly is_in_remote_function: boolean;
+	readonly is_in_remote_form_or_command: boolean;
+	readonly is_in_remote_query: boolean;
 	readonly is_in_render: boolean;
 	readonly is_in_universal_load: boolean;
 }

--- a/packages/kit/test/apps/async/src/routes/remote/batch-redirect/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/batch-redirect/+page.svelte
@@ -1,0 +1,19 @@
+<script>
+	import { batch_redirect } from './data.remote.js';
+
+	let status = $state('idle');
+
+	async function run() {
+		status = 'pending';
+
+		try {
+			await batch_redirect('a');
+			status = 'resolved';
+		} catch {
+			status = 'rejected';
+		}
+	}
+</script>
+
+<button id="trigger" onclick={run}>trigger</button>
+<p id="status">{status}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/batch-redirect/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/batch-redirect/data.remote.js
@@ -1,0 +1,8 @@
+import { query } from '$app/server';
+import { redirect } from '@sveltejs/kit';
+
+export const batch_redirect = query.batch('unchecked', () => {
+	// same-page hash redirect so the page component survives the `goto`
+	// and the test can observe whether the batched promises settle
+	redirect(307, '/remote/batch-redirect#redirected');
+});

--- a/packages/kit/test/apps/async/src/routes/remote/error-hydration/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/error-hydration/+page.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { failing } from './data.remote';
+
+	const q = failing();
+</script>
+
+<div id="q-error">{q.error ? `${q.error.status}: ${q.error.body?.message}` : 'none'}</div>

--- a/packages/kit/test/apps/async/src/routes/remote/error-hydration/batch/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/error-hydration/batch/+page.svelte
@@ -1,0 +1,20 @@
+<script>
+	import { failing_batch } from '../data.remote';
+
+	const q = failing_batch('x');
+</script>
+
+<!--
+	batch execution is deferred to a macrotask, so the query has to be awaited
+	for it to settle during SSR and have its error record serialized. The failed
+	boundary doesn't re-run on hydration, so the seeded error is observed via
+	the reactive getter below.
+-->
+<svelte:boundary>
+	<div id="batch-value">{await q}</div>
+	{#snippet failed()}
+		<div id="batch-boundary-error">failed</div>
+	{/snippet}
+</svelte:boundary>
+
+<div id="batch-error">{q.error ? `${q.error.status}: ${q.error.body?.message}` : 'none'}</div>

--- a/packages/kit/test/apps/async/src/routes/remote/error-hydration/data.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/error-hydration/data.remote.ts
@@ -1,0 +1,13 @@
+import { query } from '$app/server';
+import { error } from '@sveltejs/kit';
+import * as v from 'valibot';
+
+export const failing = query(() => {
+	error(418, 'teapot');
+});
+
+export const failing_batch = query.batch(v.string(), () => {
+	return () => {
+		error(418, 'batch teapot');
+	};
+});

--- a/packages/kit/test/apps/async/src/routes/remote/form/native-result/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/native-result/+page.svelte
@@ -1,0 +1,38 @@
+<script>
+	import { onMount } from 'svelte';
+	import { echo } from './form.remote';
+
+	// a key with a space forces the encoded (server) and raw (client) id conventions to diverge
+	const keyed = echo.for('a b');
+
+	// a key with a slash must not break the `?/remote=` id parsing on the server
+	const keyed_slash = echo.for('a/b');
+
+	let hydrated = $state(false);
+
+	onMount(() => {
+		hydrated = true;
+	});
+</script>
+
+<div id="hydrated">{hydrated}</div>
+<div id="result">{echo.result ?? 'none'}</div>
+<div id="issue">{echo.fields.message.issues()?.[0]?.message ?? 'no issues'}</div>
+<div id="keyed-result">{keyed.result ?? 'none'}</div>
+<div id="keyed-slash-result">{keyed_slash.result ?? 'none'}</div>
+
+<!-- deliberately not enhanced: action/method only, so submission is a native full-page POST -->
+<form id="plain" action={echo.action} method="POST">
+	<input {...echo.fields.message.as('text')} />
+	<button type="submit">Submit</button>
+</form>
+
+<form id="keyed" action={keyed.action} method="POST">
+	<input {...keyed.fields.message.as('text')} />
+	<button type="submit">Submit</button>
+</form>
+
+<form id="keyed-slash" action={keyed_slash.action} method="POST">
+	<input {...keyed_slash.fields.message.as('text')} />
+	<button type="submit">Submit</button>
+</form>

--- a/packages/kit/test/apps/async/src/routes/remote/form/native-result/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/native-result/form.remote.ts
@@ -1,0 +1,9 @@
+import { form } from '$app/server';
+import * as v from 'valibot';
+
+export const echo = form(
+	v.object({ message: v.pipe(v.string(), v.minLength(3, 'too short')) }),
+	({ message }) => {
+		return `echo: ${message}`;
+	}
+);

--- a/packages/kit/test/apps/async/src/routes/remote/form/requested/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/requested/+page.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { submit } from './form.remote.ts';
+</script>
+
+<form {...submit}>
+	<button id="requested-submit">Submit</button>
+</form>
+
+<p id="form-result">{submit.result?.message ?? 'not submitted'}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/form/requested/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/requested/form.remote.ts
@@ -1,0 +1,11 @@
+import { form, query, requested } from '$app/server';
+
+export const get_time = query(() => Date.now());
+
+export const submit = form('unchecked', async () => {
+	// must work on both enhanced and non-enhanced (no-JS) submissions —
+	// in the latter case there are simply no requested refreshes
+	await requested(get_time, 5).refreshAll();
+
+	return { message: 'submitted successfully' };
+});

--- a/packages/kit/test/apps/async/src/routes/remote/form/updates-no-invalidate/[key]/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/updates-no-invalidate/[key]/+page.svelte
@@ -1,0 +1,17 @@
+<script>
+	import { get_count, increment } from './form.remote';
+
+	const { params } = $props();
+</script>
+
+<div id="count">Count: {await get_count(params.key)}</div>
+<div id="result">Result: {increment.result ?? 'none'}</div>
+
+<form
+	{...increment.enhance(async ({ submit }) => {
+		await submit().updates();
+	})}
+>
+	<input {...increment.fields.key.as('hidden', params.key)} />
+	<button type="submit">Submit</button>
+</form>

--- a/packages/kit/test/apps/async/src/routes/remote/form/updates-no-invalidate/[key]/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/updates-no-invalidate/[key]/form.remote.ts
@@ -1,0 +1,15 @@
+import { form, query } from '$app/server';
+import * as v from 'valibot';
+
+const counts = new Map<string, number>();
+
+export const get_count = query(v.string(), (key) => {
+	return counts.get(key) ?? 0;
+});
+
+// deliberately refreshes nothing — the client's `.updates()` call alone
+// should suppress `invalidateAll`
+export const increment = form(v.object({ key: v.string() }), ({ key }) => {
+	counts.set(key, (counts.get(key) ?? 0) + 1);
+	return 'done';
+});

--- a/packages/kit/test/apps/async/src/routes/remote/live-error-seed/[key]/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/live-error-seed/[key]/+page.svelte
@@ -1,0 +1,8 @@
+<script>
+	import { live_fail } from './data.remote';
+
+	const { params } = $props();
+	const q = $derived(live_fail(params.key));
+</script>
+
+<div id="live-error">{q.error ? `${q.error.status}: ${q.error.body.message}` : 'none'}</div>

--- a/packages/kit/test/apps/async/src/routes/remote/live-error-seed/[key]/data.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/live-error-seed/[key]/data.remote.ts
@@ -1,0 +1,17 @@
+import { query } from '$app/server';
+import { error } from '@sveltejs/kit';
+import * as v from 'valibot';
+
+const seen = new Set<string>();
+
+export const live_fail = query.live(v.string(), async function* (key) {
+	if (!seen.has(key)) {
+		// first connection (the SSR render) fails...
+		seen.add(key);
+		error(418, 'live teapot');
+	}
+
+	// ...subsequent connections block forever, so the only way the client
+	// can show the error is by consuming the seeded SSR error record
+	yield await new Promise<string>(() => {});
+});

--- a/packages/kit/test/apps/async/src/routes/remote/live-nested-query/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/live-nested-query/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { live_outer } from './data.remote.js';
+</script>
+
+<p id="live-result">{await live_outer()}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/live-nested-query/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/live-nested-query/data.remote.js
@@ -1,0 +1,11 @@
+import { query } from '$app/server';
+
+export const get_secret = query(() => 'nested-secret');
+
+export const live_outer = query.live(async function* () {
+	// this nested query must not be implicitly registered and serialized
+	// into the page payload — only the (transformed) yielded value should appear
+	const secret = await get_secret();
+
+	yield secret.toUpperCase();
+});

--- a/packages/kit/test/apps/async/src/routes/remote/live-ssr-value/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/live-ssr-value/+page.svelte
@@ -1,0 +1,10 @@
+<script>
+	import { page } from '$app/state';
+	import { live_value, notify } from './data.remote.js';
+
+	const key = page.url.searchParams.get('key') ?? 'default';
+	const live = live_value(key);
+</script>
+
+<p id="live-state">{live.ready ? live.current : 'loading'}</p>
+<button id="notify" onclick={() => notify(key)}>notify</button>

--- a/packages/kit/test/apps/async/src/routes/remote/live-ssr-value/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/live-ssr-value/data.remote.js
@@ -1,0 +1,36 @@
+import { command, query } from '$app/server';
+
+/** @type {Set<string>} */
+const seen = new Set();
+/** @type {Set<string>} */
+const notified = new Set();
+/** @type {Set<{ key: string, resolve: (value?: any) => void }>} */
+const listeners = new Set();
+
+export const live_value = query.live('unchecked', async function* (key) {
+	if (!seen.has(key)) {
+		// first connection for this key — the SSR render
+		seen.add(key);
+		yield 'initial';
+		return;
+	}
+
+	// subsequent connections (the post-hydration reconnect) don't yield until
+	// notified, so that tests can observe the hydration-seeded value
+	if (!notified.has(key)) {
+		await new Promise((resolve) => listeners.add({ key, resolve }));
+	}
+
+	yield 'updated';
+});
+
+export const notify = command('unchecked', (/** @type {string} */ key) => {
+	notified.add(key);
+
+	for (const listener of [...listeners]) {
+		if (listener.key === key) {
+			listener.resolve();
+			listeners.delete(listener);
+		}
+	}
+});

--- a/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/a/+page.js
+++ b/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/a/+page.js
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/a/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/a/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { counted } from '../data.remote.js';
+</script>
+
+<p id="count">{await counted()}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/b/+page.js
+++ b/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/b/+page.js
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/b/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/b/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { counted } from '../data.remote.js';
+</script>
+
+<p id="count">{await counted()}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/data.remote.js
@@ -1,0 +1,7 @@
+import { prerender } from '$app/server';
+
+let invocations = 0;
+
+// used by two prerendered pages — at build time, this must only execute once,
+// so that both pages render the same value
+export const counted = prerender(() => ++invocations);

--- a/packages/kit/test/apps/async/src/routes/remote/prerender-inline/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/prerender-inline/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { get_prerendered } from './data.remote.js';
+</script>
+
+<p id="prerender-value">prerendered: {await get_prerendered()}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/prerender-inline/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/prerender-inline/data.remote.js
@@ -1,0 +1,3 @@
+import { prerender } from '$app/server';
+
+export const get_prerendered = prerender(() => 'hello');

--- a/packages/kit/test/apps/async/src/routes/remote/private-query/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/private-query/+page.svelte
@@ -1,0 +1,8 @@
+<script>
+	import { reveal } from './data.remote.js';
+
+	let result = $state('none');
+</script>
+
+<button id="reveal" onclick={async () => (result = await reveal())}>reveal</button>
+<p id="result">{result}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/private-query/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/private-query/data.remote.js
@@ -1,0 +1,10 @@
+import { query } from '$app/server';
+
+// deliberately not exported — this must never be serialized into any response
+const get_secret = query(() => 'private-data');
+
+export const reveal = query(async () => {
+	const secret = await get_secret();
+
+	return secret.toUpperCase();
+});

--- a/packages/kit/test/apps/async/src/routes/remote/query-command.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/query-command.remote.js
@@ -1,4 +1,4 @@
-import { command, query, requested } from '$app/server';
+import { command, getRequestEvent, query, requested } from '$app/server';
 
 export const echo = query('unchecked', (value) => value);
 export const add = query('unchecked', ({ a, b }) => a + b);
@@ -9,9 +9,12 @@ let count = 0;
  */
 const deferreds = [];
 
-let get_count_called = false;
+// tracked per request event, so that parallel requests from other tests
+// (e.g. SSR of this route in another playwright worker) don't interfere
+const get_count_callers = new WeakSet();
+
 export const get_count = query(() => {
-	get_count_called = true;
+	get_count_callers.add(getRequestEvent());
 	return count;
 });
 
@@ -88,11 +91,11 @@ export const set_count_server_refresh_after_read = command('unchecked', async (c
 });
 
 export const set_count_server_set = command('unchecked', async (c) => {
-	get_count_called = false;
+	const event = getRequestEvent();
 	count = c;
 	get_count().set(c);
 	await new Promise((resolve) => setTimeout(resolve, 100));
-	if (get_count_called) {
+	if (get_count_callers.has(event)) {
 		throw new Error('get_count should not have been called');
 	}
 	return c;

--- a/packages/kit/test/apps/async/src/routes/remote/query-event-guards/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/query-event-guards/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { blocked_operations } from './data.remote.js';
+</script>
+
+<p id="result">{await blocked_operations()}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/query-event-guards/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/query-event-guards/data.remote.js
@@ -1,0 +1,24 @@
+import { query, getRequestEvent } from '$app/server';
+
+export const blocked_operations = query(() => {
+	const { cookies, setHeaders } = getRequestEvent();
+
+	/** @type {string[]} */
+	const results = [];
+
+	try {
+		cookies.set('illegal', 'yes', { path: '/' });
+		results.push('cookies.set succeeded');
+	} catch (e) {
+		results.push(/** @type {Error} */ (e).message);
+	}
+
+	try {
+		setHeaders({ 'x-illegal': 'yes' });
+		results.push('setHeaders succeeded');
+	} catch (e) {
+		results.push(/** @type {Error} */ (e).message);
+	}
+
+	return results.join(' | ');
+});

--- a/packages/kit/test/apps/async/src/routes/remote/query-loading-state/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/query-loading-state/+page.svelte
@@ -1,0 +1,22 @@
+<script>
+	import { get_slow_data } from './data.remote.js';
+
+	// the query is kicked off during SSR (via the `loading` property access)
+	// but not awaited, so SSR renders the loading state. The client must
+	// fetch the data itself after hydration.
+	const slow = get_slow_data();
+
+	function delayed_value() {
+		return new Promise((resolve) => setTimeout(() => resolve('hydrated'), 500));
+	}
+</script>
+
+{#if slow.loading}
+	<p id="slow-state">loading</p>
+{:else}
+	<p id="slow-state">{slow.current}</p>
+{/if}
+
+<!-- this keeps hydration unsettled long enough for the slow query to
+     read from the hydration cache rather than it being reset first -->
+<p id="other">{await delayed_value()}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/query-loading-state/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/query-loading-state/data.remote.js
@@ -1,0 +1,6 @@
+import { query } from '$app/server';
+
+export const get_slow_data = query(async () => {
+	await new Promise((resolve) => setTimeout(resolve, 1000));
+	return 'slow data';
+});

--- a/packages/kit/test/apps/async/src/routes/remote/requested-limit/[key]/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/requested-limit/[key]/+page.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { bump, get_count } from './data.remote';
+
+	const { params } = $props();
+	const q = $derived(get_count(params.key));
+</script>
+
+<div id="value">{q.current ?? 'unset'}</div>
+<div id="error">{q.error ? `${q.error.status}: ${q.error.body.message}` : 'none'}</div>
+
+<button onclick={() => bump(params.key).updates(q)}>bump</button>

--- a/packages/kit/test/apps/async/src/routes/remote/requested-limit/[key]/data.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/requested-limit/[key]/data.remote.ts
@@ -1,0 +1,14 @@
+import { command, query, requested } from '$app/server';
+import * as v from 'valibot';
+
+const counts = new Map<string, number>();
+
+export const get_count = query(v.string(), (key) => counts.get(key) ?? 0);
+
+export const bump = command(v.string(), (key) => {
+	counts.set(key, (counts.get(key) ?? 0) + 1);
+
+	// limit 0: every requested refresh is over the limit and must be
+	// rejected with an error record that reaches the client
+	requested(get_count, 0);
+});

--- a/packages/kit/test/apps/async/src/routes/remote/sidechannel-store/[key]/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/sidechannel-store/[key]/+page.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { get_value, update } from './data.remote';
+
+	const { params } = $props();
+
+	let show = $state(false);
+</script>
+
+<button id="update" onclick={() => update(params.key)}>update</button>
+<button id="show" onclick={() => (show = true)}>show</button>
+
+{#if show}
+	<div id="value">{await get_value(params.key)}</div>
+{/if}

--- a/packages/kit/test/apps/async/src/routes/remote/sidechannel-store/[key]/data.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/sidechannel-store/[key]/data.remote.ts
@@ -1,0 +1,14 @@
+import { command, query } from '$app/server';
+import * as v from 'valibot';
+
+const store = new Map<string, string>();
+
+export const get_value = query(v.string(), (key) => store.get(key) ?? 'initial');
+
+export const update = command(v.string(), (key) => {
+	store.set(key, 'updated');
+
+	// server-initiated single-flight update for a query that has
+	// no active resource on the client
+	void get_value(key).set('updated');
+});

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -58,6 +58,16 @@ test.describe('remote function mutations', () => {
 		expect(request_count).toBe(0);
 	});
 
+	test('hydrated prerender data is reused', async ({ page }) => {
+		let request_count = 0;
+		page.on('request', (r) => (request_count += r.url().includes('/_app/remote') ? 1 : 0));
+
+		await page.goto('/remote/prerender-inline');
+		await expect(page.locator('#prerender-value')).toHaveText('prerendered: hello');
+		await page.waitForTimeout(100); // allow all requests to finish
+		expect(request_count).toBe(0);
+	});
+
 	test('hydrated batch data is reused', async ({ page }) => {
 		let request_count = 0;
 		page.on('request', (r) => (request_count += r.url().includes('/_app/remote') ? 1 : 0));
@@ -67,6 +77,65 @@ test.describe('remote function mutations', () => {
 		await expect(page.locator('#ssr-batch-result-2')).toHaveText('Walk the dog');
 		await expect(page.locator('#ssr-batch-result-3')).toHaveText('Not found');
 		expect(request_count).toBe(0);
+	});
+
+	test('hydrated query errors are reused', async ({ page }) => {
+		let request_count = 0;
+		page.on('request', (r) => (request_count += r.url().includes('/_app/remote') ? 1 : 0));
+
+		await page.goto('/remote/error-hydration');
+		await expect(page.locator('#q-error')).toHaveText('418: teapot');
+		await page.waitForTimeout(100); // allow all requests to finish (there shouldn't be any)
+		expect(request_count).toBe(0);
+	});
+
+	test('hydrated batch query errors are reused', async ({ page }) => {
+		let request_count = 0;
+		page.on('request', (r) => (request_count += r.url().includes('/_app/remote') ? 1 : 0));
+
+		await page.goto('/remote/error-hydration/batch');
+		await expect(page.locator('#batch-error')).toHaveText('418: batch teapot');
+		await page.waitForTimeout(100); // allow all requests to finish (there shouldn't be any)
+		expect(request_count).toBe(0);
+	});
+
+	test('hydrated query.live errors are reused', async ({ page }) => {
+		await page.goto(`/remote/live-error-seed/${Date.now()}${Math.random()}`);
+
+		// the SSR HTML shows no error (server-side getters are static), but the
+		// hydrated client must seed the failed state from the payload — the
+		// reconnection attempt never settles, so this is the only way the error can appear
+		await expect(page.locator('#live-error')).toHaveText('418: live teapot');
+	});
+
+	test('server-initiated updates for inactive queries are reused when the resource is created', async ({
+		page
+	}) => {
+		await page.goto(`/remote/sidechannel-store/${Date.now()}${Math.random()}`);
+
+		await page.click('#update');
+		await page.waitForTimeout(100); // allow the command roundtrip to finish
+
+		let request_count = 0;
+		page.on('request', (r) => (request_count += r.url().includes('/_app/remote') ? 1 : 0));
+
+		await page.click('#show');
+		await expect(page.locator('#value')).toHaveText('updated');
+		await page.waitForTimeout(100); // allow all requests to finish (there shouldn't be any)
+		expect(request_count).toBe(0);
+	});
+
+	test('over-limit requested() refreshes fail the client query', async ({ page }) => {
+		await page.goto(`/remote/requested-limit/${Date.now()}${Math.random()}`);
+
+		await expect(page.locator('#value')).toHaveText('0');
+		await expect(page.locator('#error')).toHaveText('none');
+
+		await page.click('button');
+
+		await expect(page.locator('#error')).toHaveText(
+			'400: Requested refresh was rejected because it exceeded requested(get_count, 0) limit'
+		);
 	});
 
 	test('command returns correct sum but does not refresh data by default', async ({ page }) => {
@@ -440,6 +509,34 @@ test.describe('remote function mutations', () => {
 		expect(request_count).toBe(1);
 	});
 
+	test('query.batch redirect settles batched promises', async ({ page }) => {
+		await page.goto('/remote/batch-redirect');
+
+		await page.click('#trigger');
+
+		// the redirect must both navigate and settle the awaited query
+		await expect(page.locator('#status')).toHaveText('resolved');
+		expect(page.url()).toContain('#redirected');
+	});
+
+	test('non-exported remote functions are never serialized into responses', async ({ page }) => {
+		await page.goto('/remote/private-query');
+
+		const [response] = await Promise.all([
+			page.waitForResponse((r) => r.url().includes('/_app/remote')),
+			page.click('#reveal')
+		]);
+
+		const body = await response.text();
+
+		// the command's own (transformed) result is present...
+		expect(body).toContain('PRIVATE-DATA');
+		// ...but the private query's raw value must not leak
+		expect(body).not.toContain('private-data');
+
+		await expect(page.locator('#result')).toHaveText('PRIVATE-DATA');
+	});
+
 	test('query.batch resolver function always receives validated arguments', async ({ page }) => {
 		await page.goto('/remote/batch-validation');
 
@@ -808,6 +905,73 @@ test.describe('remote function mutations', () => {
 
 		// Should have refreshed
 		await expect(count).toHaveText('Count: 1');
+	});
+
+	test('form result from a native (non-enhanced) submission survives hydration', async ({
+		page
+	}) => {
+		await page.goto('/remote/form/native-result');
+		await page.locator('#plain input[name="message"]').fill('hello');
+		await page.click('#plain button');
+
+		// wait for the page resulting from the full-page POST to hydrate
+		await expect(page.locator('#hydrated')).toHaveText('true');
+		await expect(page.locator('#result')).toHaveText('echo: hello');
+	});
+
+	test('form issues and input from a native (non-enhanced) submission survive hydration', async ({
+		page
+	}) => {
+		await page.goto('/remote/form/native-result');
+		await page.locator('#plain input[name="message"]').fill('ab');
+		await page.click('#plain button');
+
+		// wait for the page resulting from the full-page POST to hydrate
+		await expect(page.locator('#hydrated')).toHaveText('true');
+		await expect(page.locator('#issue')).toHaveText('too short');
+		await expect(page.locator('#plain input[name="message"]')).toHaveValue('ab');
+	});
+
+	test('keyed form result from a native (non-enhanced) submission survives hydration', async ({
+		page
+	}) => {
+		await page.goto('/remote/form/native-result');
+		await page.locator('#keyed input[name="message"]').fill('hello');
+		await page.click('#keyed button');
+
+		// wait for the page resulting from the full-page POST to hydrate
+		await expect(page.locator('#hydrated')).toHaveText('true');
+		await expect(page.locator('#keyed-result')).toHaveText('echo: hello');
+		// the result must not leak to the unkeyed instance
+		await expect(page.locator('#result')).toHaveText('none');
+	});
+
+	test('form keys containing slashes work with native (non-enhanced) submissions', async ({
+		page
+	}) => {
+		await page.goto('/remote/form/native-result');
+		await page.locator('#keyed-slash input[name="message"]').fill('hello');
+		await page.click('#keyed-slash button');
+
+		// wait for the page resulting from the full-page POST to hydrate
+		await expect(page.locator('#hydrated')).toHaveText('true');
+		await expect(page.locator('#keyed-slash-result')).toHaveText('echo: hello');
+	});
+
+	test('form submission with .updates() does not trigger invalidateAll', async ({ page }) => {
+		await page.goto(`/remote/form/updates-no-invalidate/${Date.now()}${Math.random()}`);
+
+		const count = page.locator('#count');
+		await expect(count).toHaveText('Count: 0');
+
+		await page.click('button');
+		await expect(page.locator('#result')).toHaveText('Result: done');
+
+		await page.waitForTimeout(100); // allow all requests to finish (in case there are query refreshes which shouldn't happen)
+
+		// the developer took control of updates via `.updates()`, so the query
+		// must not have been refreshed by an implicit invalidateAll
+		await expect(count).toHaveText('Count: 0');
 	});
 });
 

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import http from 'node:http';
 import { expect } from '@playwright/test';
 import { test } from '../../../utils.js';
@@ -62,6 +63,28 @@ test.describe('remote functions', () => {
 		await page.goto('/remote/query-non-exported');
 
 		await expect(page.locator('h1')).toHaveText('3');
+	});
+
+	test('private (non-exported) query results are not leaked into command responses', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		test.skip(!javaScriptEnabled, 'requires JavaScript to invoke the command');
+
+		await page.goto('/remote/private-query');
+
+		const [response] = await Promise.all([
+			page.waitForResponse((response) => response.url().includes('/reveal')),
+			page.getByRole('button', { name: 'reveal' }).click()
+		]);
+
+		const body = await response.text();
+
+		// the command returns the uppercased secret...
+		expect(body).toContain('PRIVATE-DATA');
+
+		// ...but the raw private query result must never appear in the serialized payload
+		expect(body).not.toContain('private-data');
 	});
 
 	test('queries can access the route/url of the page they were called from', async ({
@@ -685,6 +708,83 @@ test.describe('remote functions', () => {
 				timeout: 5000
 			});
 		}
+	});
+
+	test('query rendered in its loading state during SSR is fetched on the client', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		await page.goto('/remote/query-loading-state');
+
+		if (javaScriptEnabled) {
+			// the query was still pending when SSR finished, so it must not be
+			// seeded into the hydration cache — the client has to fetch it itself
+			await expect(page.locator('#slow-state')).toHaveText('slow data', {
+				timeout: 5000
+			});
+		} else {
+			await expect(page.locator('#slow-state')).toHaveText('loading');
+		}
+	});
+
+	test('queries cannot set cookies or headers', async ({ page }) => {
+		await page.goto('/remote/query-event-guards');
+
+		await expect(page.locator('#result')).toHaveText(
+			'Cannot set cookies in `query` or `prerender` functions | setHeaders is not allowed in remote functions'
+		);
+	});
+
+	test('queries nested inside live queries are not implicitly serialized', async ({ page }) => {
+		await page.goto('/remote/live-nested-query');
+
+		await expect(page.locator('#live-result')).toHaveText('NESTED-SECRET');
+
+		// the nested query's raw value must not leak into the page payload
+		expect(await page.content()).not.toContain('nested-secret');
+	});
+
+	test('requested(...) works in form handlers regardless of progressive enhancement', async ({
+		page
+	}) => {
+		await page.goto('/remote/form/requested');
+
+		await expect(page.locator('#form-result')).toHaveText('not submitted');
+
+		await page.locator('#requested-submit').click();
+
+		await expect(page.locator('#form-result')).toHaveText('submitted successfully');
+	});
+
+	test('SSR data for query.live is reused on hydration', async ({ page, javaScriptEnabled }) => {
+		await page.goto(`/remote/live-ssr-value?key=${Date.now()}-${Math.random()}`);
+
+		if (javaScriptEnabled) {
+			// the SSR'd first value must be seeded into the live query on hydration —
+			// the reconnect (deliberately blocked server-side) must not reset it to a loading state
+			await expect(page.locator('#live-state')).toHaveText('initial');
+
+			// the live connection still works after seeding
+			await page.click('#notify');
+			await expect(page.locator('#live-state')).toHaveText('updated');
+		} else {
+			await expect(page.locator('#live-state')).toHaveText('loading');
+		}
+	});
+
+	test('prerender functions are deduplicated across prerendered pages during build', async ({
+		page
+	}) => {
+		test.skip(!!process.env.DEV, 'pages are only prerendered when building');
+
+		await page.goto('/remote/prerender-dedupe/a');
+		const a = await page.locator('#count').textContent();
+
+		await page.goto('/remote/prerender-dedupe/b');
+		const b = await page.locator('#count').textContent();
+
+		// the shared prerender function must only have executed once at build time
+		expect(b).toBe(a);
 	});
 
 	test('awaiting multiple queries inside $derived does not fail mutation validation', async ({

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2824,7 +2824,7 @@ declare module '@sveltejs/kit' {
 	 * @throws {HttpError} This error instructs SvelteKit to initiate HTTP error handling.
 	 * @throws {Error} If the provided status is invalid (not between 400 and 599).
 	 */
-	export function error(status: number, body: App.Error): never;
+	function error_1(status: number, body: App.Error): never;
 	/**
 	 * Throws an error with a HTTP status code and an optional message.
 	 * When called during request handling, this will cause SvelteKit to
@@ -2835,7 +2835,7 @@ declare module '@sveltejs/kit' {
 	 * @throws {HttpError} This error instructs SvelteKit to initiate HTTP error handling.
 	 * @throws {Error} If the provided status is invalid (not between 400 and 599).
 	 */
-	export function error(status: number, body?: {
+	function error_1(status: number, body?: {
 		message: string;
 	} extends App.Error ? App.Error | string | undefined : never): never;
 	/**
@@ -2976,7 +2976,7 @@ declare module '@sveltejs/kit' {
 	}
 	const valid_page_options_array: readonly ["ssr", "prerender", "csr", "trailingSlash", "config", "entries", "load"];
 
-	export {};
+	export { error_1 as error };
 }
 
 declare module '@sveltejs/kit/hooks' {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ catalogs:
       specifier: ^3.0.0
       version: 3.0.0
     svelte:
-      specifier: ^5.55.7
-      version: 5.55.7
+      specifier: ^5.56.3
+      version: 5.56.3
     svelte-check:
       specifier: ^4.4.6
       version: 4.4.6
@@ -133,7 +133,7 @@ importers:
         version: 1.60.0
       '@sveltejs/eslint-config':
         specifier: 'catalog:'
-        version: 10.0.0(@eslint/js@10.0.1(eslint@10.0.0(jiti@2.4.2)))(@stylistic/eslint-plugin@5.10.0(eslint@10.0.0(jiti@2.4.2)))(eslint-config-prettier@9.1.0(eslint@10.0.0(jiti@2.4.2)))(eslint-plugin-n@17.24.0(eslint@10.0.0(jiti@2.4.2))(typescript@6.0.2))(eslint-plugin-svelte@3.15.0(eslint@10.0.0(jiti@2.4.2))(svelte@5.55.7(@typescript-eslint/types@8.59.4))(ts-node@10.9.2(@types/node@18.19.130)(typescript@6.0.2)))(eslint@10.0.0(jiti@2.4.2))(typescript-eslint@8.58.0(eslint@10.0.0(jiti@2.4.2))(typescript@6.0.2))(typescript@6.0.2)
+        version: 10.0.0(@eslint/js@10.0.1(eslint@10.0.0(jiti@2.4.2)))(@stylistic/eslint-plugin@5.10.0(eslint@10.0.0(jiti@2.4.2)))(eslint-config-prettier@9.1.0(eslint@10.0.0(jiti@2.4.2)))(eslint-plugin-n@17.24.0(eslint@10.0.0(jiti@2.4.2))(typescript@6.0.2))(eslint-plugin-svelte@3.15.0(eslint@10.0.0(jiti@2.4.2))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(ts-node@10.9.2(@types/node@18.19.130)(typescript@6.0.2)))(eslint@10.0.0(jiti@2.4.2))(typescript-eslint@8.58.0(eslint@10.0.0(jiti@2.4.2))(typescript@6.0.2))(typescript@6.0.2)
       '@svitejs/changesets-changelog-github-compact':
         specifier: 'catalog:'
         version: 1.2.0
@@ -145,7 +145,7 @@ importers:
         version: 3.8.1
       prettier-plugin-svelte:
         specifier: 'catalog:'
-        version: 3.5.1(prettier@3.8.1)(svelte@5.55.7(@typescript-eslint/types@8.59.4))
+        version: 3.5.1(prettier@3.8.1)(svelte@5.56.3(@typescript-eslint/types@8.59.4))
 
   packages/adapter-auto:
     devDependencies:
@@ -200,13 +200,13 @@ importers:
         version: link:../../../../kit
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       server-side-dep:
         specifier: file:server-side-dep
         version: file:packages/adapter-cloudflare/test/apps/pages/server-side-dep
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       vite:
         specifier: 'catalog:'
         version: 6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3)
@@ -221,13 +221,13 @@ importers:
         version: link:../../../../kit
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       server-side-dep:
         specifier: file:server-side-dep
         version: file:packages/adapter-cloudflare/test/apps/workers/server-side-dep
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       vite:
         specifier: 'catalog:'
         version: 6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3)
@@ -291,10 +291,10 @@ importers:
         version: link:../../../../kit
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       vite:
         specifier: 'catalog:'
         version: 6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3)
@@ -306,10 +306,10 @@ importers:
         version: link:../../../../kit
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       vite:
         specifier: 'catalog:'
         version: 6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3)
@@ -321,10 +321,10 @@ importers:
         version: link:../../../../kit
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       vite:
         specifier: 'catalog:'
         version: 6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3)
@@ -382,7 +382,7 @@ importers:
         version: 3.0.2
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -397,13 +397,13 @@ importers:
         version: link:../../../../kit
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       sirv-cli:
         specifier: 'catalog:'
         version: 3.0.0
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       vite:
         specifier: 'catalog:'
         version: 6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3)
@@ -415,13 +415,13 @@ importers:
         version: link:../../../../kit
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       sirv-cli:
         specifier: 'catalog:'
         version: 3.0.0
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       vite:
         specifier: 'catalog:'
         version: 6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3)
@@ -455,10 +455,10 @@ importers:
         version: link:../../../../kit
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -479,7 +479,7 @@ importers:
     dependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.0.0 || ^7.0.0
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       magic-string:
         specifier: ^0.30.5
         version: 0.30.21
@@ -488,7 +488,7 @@ importers:
         version: 0.34.4
       svelte-parse-markup:
         specifier: ^0.1.5
-        version: 0.1.5(svelte@5.55.7(@typescript-eslint/types@8.59.4))
+        version: 0.1.5(svelte@5.56.3(@typescript-eslint/types@8.59.4))
       vite-imagetools:
         specifier: ^9.0.3
         version: 9.0.3(rollup@4.59.0)
@@ -507,7 +507,7 @@ importers:
         version: 4.59.0
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -528,10 +528,10 @@ importers:
         version: link:../../../../kit
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       vite:
         specifier: 'catalog:'
         version: 6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3)
@@ -583,7 +583,7 @@ importers:
         version: 1.60.0
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       '@types/connect':
         specifier: 'catalog:'
         version: 3.4.38
@@ -604,7 +604,7 @@ importers:
         version: 4.59.0
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
@@ -625,16 +625,16 @@ importers:
         version: link:../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       dropcss:
         specifier: 'catalog:'
         version: 1.0.16
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -649,13 +649,13 @@ importers:
         version: link:../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -682,16 +682,16 @@ importers:
         version: link:../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       '@vitest/browser-playwright':
         specifier: 'catalog:'
         version: 4.1.7(playwright@1.60.0)(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))(vitest@4.1.7)
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       test-redirect-importer:
         specifier: workspace:*
         version: link:../../../../test-redirect-importer
@@ -715,7 +715,7 @@ importers:
         version: link:../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       e2e-test-dep-error:
         specifier: file:./_test_dependencies/cjs-only
         version: e2e-test-dep-cjs-only@file:packages/kit/test/apps/dev-only/_test_dependencies/cjs-only
@@ -748,10 +748,10 @@ importers:
         version: e2e-test-dep-cjs-only@file:packages/kit/test/apps/dev-only/_test_dependencies/cjs-only
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -766,13 +766,13 @@ importers:
         version: link:../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -787,13 +787,13 @@ importers:
         version: link:../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -808,13 +808,13 @@ importers:
         version: link:../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -832,13 +832,13 @@ importers:
         version: link:../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -859,13 +859,13 @@ importers:
         version: link:../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -886,13 +886,13 @@ importers:
         version: link:../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -907,13 +907,13 @@ importers:
         version: link:../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -928,13 +928,13 @@ importers:
         version: link:../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -958,13 +958,13 @@ importers:
         version: link:../../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -982,13 +982,13 @@ importers:
         version: link:../../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1006,13 +1006,13 @@ importers:
         version: link:../../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1030,13 +1030,13 @@ importers:
         version: link:../../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1051,13 +1051,13 @@ importers:
         version: link:../../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1072,13 +1072,13 @@ importers:
         version: link:../../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1093,13 +1093,13 @@ importers:
         version: link:../../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1114,13 +1114,13 @@ importers:
         version: link:../../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1135,13 +1135,13 @@ importers:
         version: link:../../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1156,13 +1156,13 @@ importers:
         version: link:../../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1177,13 +1177,13 @@ importers:
         version: link:../../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1198,13 +1198,13 @@ importers:
         version: link:../../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1219,13 +1219,13 @@ importers:
         version: link:../../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1240,13 +1240,13 @@ importers:
         version: link:../../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1261,13 +1261,13 @@ importers:
         version: link:../../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1282,13 +1282,13 @@ importers:
         version: link:../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1306,13 +1306,13 @@ importers:
         version: link:../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1330,13 +1330,13 @@ importers:
         version: link:../../..
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1363,11 +1363,11 @@ importers:
         version: 7.8.0
       svelte2tsx:
         specifier: ~0.7.55
-        version: 0.7.55(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 0.7.55(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       '@types/node':
         specifier: 'catalog:'
         version: 18.19.130
@@ -1379,10 +1379,10 @@ importers:
         version: 3.8.1
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-preprocess:
         specifier: 'catalog:'
-        version: 6.0.5(postcss-load-config@3.1.4(postcss@8.5.15)(ts-node@10.9.2(@types/node@18.19.130)(typescript@6.0.2)))(postcss@8.5.15)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 6.0.5(postcss-load-config@3.1.4(postcss@8.5.15)(ts-node@10.9.2(@types/node@18.19.130)(typescript@6.0.2)))(postcss@8.5.15)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -1430,22 +1430,22 @@ importers:
         version: link:../../packages/package
       '@sveltejs/vite-plugin-svelte':
         specifier: 'catalog:'
-        version: 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       prettier:
         specifier: 'catalog:'
         version: 3.8.1
       prettier-plugin-svelte:
         specifier: 'catalog:'
-        version: 3.5.1(prettier@3.8.1)(svelte@5.55.7(@typescript-eslint/types@8.59.4))
+        version: 3.5.1(prettier@3.8.1)(svelte@5.56.3(@typescript-eslint/types@8.59.4))
       publint:
         specifier: 'catalog:'
         version: 0.3.0
       svelte:
         specifier: 'catalog:'
-        version: 5.55.7(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: 'catalog:'
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2)
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -3207,6 +3207,11 @@ packages:
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
 
+  '@sveltejs/acorn-typescript@1.0.10':
+    resolution: {integrity: sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
   '@sveltejs/acorn-typescript@1.0.9':
     resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
     peerDependencies:
@@ -4124,8 +4129,8 @@ packages:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
 
-  esrap@2.2.8:
-    resolution: {integrity: sha512-MPweq2EvEGj8jwOI7Hgycw/QIHzqA1EbAM8lG7p+FBfZbZq/hQ6h3AMsqnu/djzisH1KVWNzbb7LSgIVtMlPSg==}
+  esrap@2.2.11:
+    resolution: {integrity: sha512-gPdx+I+BjYEinNMQaBXFjbaJVyoPMU4ZODg5mE+M4DqVG9VusAVHHjcBX+zqyITlI0DIARwDMMzZwAWj36dRoQ==}
     peerDependencies:
       '@typescript-eslint/types': ^8.2.0
     peerDependenciesMeta:
@@ -5553,8 +5558,8 @@ packages:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0 || ^6.0.0
 
-  svelte@5.55.7:
-    resolution: {integrity: sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==}
+  svelte@5.56.3:
+    resolution: {integrity: sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==}
     engines: {node: '>=18'}
 
   svgo@4.0.1:
@@ -7724,36 +7729,40 @@ snapshots:
       estraverse: 5.3.0
       picomatch: 4.0.4
 
+  '@sveltejs/acorn-typescript@1.0.10(acorn@8.16.0)':
+    dependencies:
+      acorn: 8.16.0
+
   '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/eslint-config@10.0.0(@eslint/js@10.0.1(eslint@10.0.0(jiti@2.4.2)))(@stylistic/eslint-plugin@5.10.0(eslint@10.0.0(jiti@2.4.2)))(eslint-config-prettier@9.1.0(eslint@10.0.0(jiti@2.4.2)))(eslint-plugin-n@17.24.0(eslint@10.0.0(jiti@2.4.2))(typescript@6.0.2))(eslint-plugin-svelte@3.15.0(eslint@10.0.0(jiti@2.4.2))(svelte@5.55.7(@typescript-eslint/types@8.59.4))(ts-node@10.9.2(@types/node@18.19.130)(typescript@6.0.2)))(eslint@10.0.0(jiti@2.4.2))(typescript-eslint@8.58.0(eslint@10.0.0(jiti@2.4.2))(typescript@6.0.2))(typescript@6.0.2)':
+  '@sveltejs/eslint-config@10.0.0(@eslint/js@10.0.1(eslint@10.0.0(jiti@2.4.2)))(@stylistic/eslint-plugin@5.10.0(eslint@10.0.0(jiti@2.4.2)))(eslint-config-prettier@9.1.0(eslint@10.0.0(jiti@2.4.2)))(eslint-plugin-n@17.24.0(eslint@10.0.0(jiti@2.4.2))(typescript@6.0.2))(eslint-plugin-svelte@3.15.0(eslint@10.0.0(jiti@2.4.2))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(ts-node@10.9.2(@types/node@18.19.130)(typescript@6.0.2)))(eslint@10.0.0(jiti@2.4.2))(typescript-eslint@8.58.0(eslint@10.0.0(jiti@2.4.2))(typescript@6.0.2))(typescript@6.0.2)':
     dependencies:
       '@eslint/js': 10.0.1(eslint@10.0.0(jiti@2.4.2))
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.0.0(jiti@2.4.2))
       eslint: 10.0.0(jiti@2.4.2)
       eslint-config-prettier: 9.1.0(eslint@10.0.0(jiti@2.4.2))
       eslint-plugin-n: 17.24.0(eslint@10.0.0(jiti@2.4.2))(typescript@6.0.2)
-      eslint-plugin-svelte: 3.15.0(eslint@10.0.0(jiti@2.4.2))(svelte@5.55.7(@typescript-eslint/types@8.59.4))(ts-node@10.9.2(@types/node@18.19.130)(typescript@6.0.2))
+      eslint-plugin-svelte: 3.15.0(eslint@10.0.0(jiti@2.4.2))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(ts-node@10.9.2(@types/node@18.19.130)(typescript@6.0.2))
       globals: 17.4.0
       typescript: 6.0.2
       typescript-eslint: 8.58.0(eslint@10.0.0(jiti@2.4.2))(typescript@6.0.2)
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3)))(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       obug: 2.1.1
-      svelte: 5.55.7(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
       vite: 6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3)
 
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))':
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3)))(svelte@5.55.7(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
-      svelte: 5.55.7(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
       vite: 6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3)
       vitefu: 1.1.1(vite@6.4.2(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
 
@@ -8752,7 +8761,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  eslint-plugin-svelte@3.15.0(eslint@10.0.0(jiti@2.4.2))(svelte@5.55.7(@typescript-eslint/types@8.59.4))(ts-node@10.9.2(@types/node@18.19.130)(typescript@6.0.2)):
+  eslint-plugin-svelte@3.15.0(eslint@10.0.0(jiti@2.4.2))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(ts-node@10.9.2(@types/node@18.19.130)(typescript@6.0.2)):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.0(jiti@2.4.2))
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -8764,9 +8773,9 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.15)(ts-node@10.9.2(@types/node@18.19.130)(typescript@6.0.2))
       postcss-safe-parser: 7.0.1(postcss@8.5.15)
       semver: 7.8.0
-      svelte-eslint-parser: 1.6.1(svelte@5.55.7(@typescript-eslint/types@8.59.4))
+      svelte-eslint-parser: 1.6.1(svelte@5.56.3(@typescript-eslint/types@8.59.4))
     optionalDependencies:
-      svelte: 5.55.7(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
     transitivePeerDependencies:
       - ts-node
 
@@ -8845,7 +8854,7 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
-  esrap@2.2.8(@typescript-eslint/types@8.59.4):
+  esrap@2.2.11(@typescript-eslint/types@8.59.4):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
     optionalDependencies:
@@ -9846,10 +9855,10 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.5.1(prettier@3.8.1)(svelte@5.55.7(@typescript-eslint/types@8.59.4)):
+  prettier-plugin-svelte@3.5.1(prettier@3.8.1)(svelte@5.56.3(@typescript-eslint/types@8.59.4)):
     dependencies:
       prettier: 3.8.1
-      svelte: 5.55.7(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
 
   prettier@3.8.1: {}
 
@@ -10222,19 +10231,19 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.4.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2):
+  svelte-check@4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 4.0.3
       fdir: 6.5.0(picomatch@4.0.4)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.55.7(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
       typescript: 6.0.2
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@1.6.1(svelte@5.55.7(@typescript-eslint/types@8.59.4)):
+  svelte-eslint-parser@1.6.1(svelte@5.56.3(@typescript-eslint/types@8.59.4)):
     dependencies:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -10244,32 +10253,32 @@ snapshots:
       postcss-selector-parser: 7.1.1
       semver: 7.8.0
     optionalDependencies:
-      svelte: 5.55.7(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
 
-  svelte-parse-markup@0.1.5(svelte@5.55.7(@typescript-eslint/types@8.59.4)):
+  svelte-parse-markup@0.1.5(svelte@5.56.3(@typescript-eslint/types@8.59.4)):
     dependencies:
-      svelte: 5.55.7(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
 
-  svelte-preprocess@6.0.5(postcss-load-config@3.1.4(postcss@8.5.15)(ts-node@10.9.2(@types/node@18.19.130)(typescript@6.0.2)))(postcss@8.5.15)(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2):
+  svelte-preprocess@6.0.5(postcss-load-config@3.1.4(postcss@8.5.15)(ts-node@10.9.2(@types/node@18.19.130)(typescript@6.0.2)))(postcss@8.5.15)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2):
     dependencies:
-      svelte: 5.55.7(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
     optionalDependencies:
       postcss: 8.5.15
       postcss-load-config: 3.1.4(postcss@8.5.15)(ts-node@10.9.2(@types/node@18.19.130)(typescript@6.0.2))
       typescript: 6.0.2
 
-  svelte2tsx@0.7.55(svelte@5.55.7(@typescript-eslint/types@8.59.4))(typescript@6.0.2):
+  svelte2tsx@0.7.55(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.2):
     dependencies:
       dedent-js: 1.0.1
       scule: 1.3.0
-      svelte: 5.55.7(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
       typescript: 6.0.2
 
-  svelte@5.55.7(@typescript-eslint/types@8.59.4):
+  svelte@5.56.3(@typescript-eslint/types@8.59.4):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
       '@types/estree': 1.0.8
       '@types/trusted-types': 2.0.7
       acorn: 8.16.0
@@ -10278,7 +10287,7 @@ snapshots:
       clsx: 2.1.1
       devalue: 5.8.1
       esm-env: 1.2.2
-      esrap: 2.2.8(@typescript-eslint/types@8.59.4)
+      esrap: 2.2.11(@typescript-eslint/types@8.59.4)
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.21

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,7 +53,7 @@ catalog:
   prettier-plugin-svelte: ^3.5.1
   semver: ^7.5.4
   sirv-cli: ^3.0.0
-  svelte: ^5.55.7
+  svelte: ^5.56.3
   svelte-check: ^4.4.6
   svelte-preprocess: ^6.0.5
   typescript: ^6.0.2
@@ -83,3 +83,5 @@ catalogs:
 overrides:
 # ci script replaces all overrides with the vite-xxx or node-xx catalogs above.
 # if you want to introduce an override, make sure to add it to all of them too
+minimumReleaseAgeExclude:
+  - svelte


### PR DESCRIPTION
I thought that https://github.com/sveltejs/svelte/pull/18406 would be necessary to do this, but I was wrong — it actually seems easier and simpler to bypass `hydratable` altogether. Instead, we serialize all the remote data in one go, allowing devalue to do its thing and deduplicate everything. (I still think it's worth merging that PR.)

That way, if you have (for example) a `getUser(): Promise<User | null>` and a `requireUser(): Promise<User>` that calls `getUser` internally (and redirects if it returns `null`), the `User` object is only serialized once.

I can't remember exactly why we chose to use `hydratable` in the first place. Perhaps it was a lifecycle thing — we wanted to be careful about data being stale by the time it was read? In which case I think that has changed now that query lifecycle is determined by the garbage collector. Maybe @elliott-with-the-longest-name-on-github remembers.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
