### PR TITLE
fix: allow Vite to serve hoisted packages during development

### DIFF
--- a/.changeset/stale-monkeys-type.md
+++ b/.changeset/stale-monkeys-type.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: include hoisted packages in Vite's `server.fs.allow` list

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -56,8 +56,6 @@ import { should_ignore, has_children } from './static_analysis/utils.js';
 import { process_config } from '../../core/config/index.js';
 import { treeshake_prerendered_remotes } from './build/remote.js';
 
-const cwd = process.cwd();
-
 /** @type {string} */
 let root;
 
@@ -153,10 +151,12 @@ let vite_plugin_svelte;
  * @returns {Promise<Plugin[]>}
  */
 export async function sveltekit(config) {
+	const cwd = process.cwd();
+
 	const { extensions, compilerOptions, vitePlugin, preprocess, ...rest } = config ?? {};
 	const svelte_config = process_config(
 		{ extensions, compilerOptions, vitePlugin, preprocess, kit: rest },
-		{ cwd: process.cwd(), source: 'SvelteKit options from Vite config' }
+		{ cwd, source: 'SvelteKit options from Vite config' }
 	);
 
 	const config_file = ['svelte.config.js', 'svelte.config.ts'].find((file) => fs.existsSync(file));
@@ -356,7 +356,7 @@ function kit({ svelte_config, adapter }) {
 					// include the directory that contains the workspaces declaration
 					// which usually also contains hoisted packages
 					// see https://vite.dev/guide/api-javascript#searchforworkspaceroot
-					path.resolve(vite.searchForWorkspaceRoot(cwd), 'node_modules')
+					path.resolve(vite.searchForWorkspaceRoot(process.cwd()), 'node_modules')
 				]);
 
 				// We can only add directories to the allow list, so we find out
@@ -1666,7 +1666,7 @@ function kit({ svelte_config, adapter }) {
 				out,
 				remotes,
 				metadata,
-				cwd,
+				process.cwd(),
 				server_chunks,
 				vite_config.build.sourcemap
 			);

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -156,7 +156,7 @@ export async function sveltekit(config) {
 	const { extensions, compilerOptions, vitePlugin, preprocess, ...rest } = config ?? {};
 	const svelte_config = process_config(
 		{ extensions, compilerOptions, vitePlugin, preprocess, kit: rest },
-		{ cwd, source: 'SvelteKit options from Vite config' }
+		{ cwd: process.cwd(), source: 'SvelteKit options from Vite config' }
 	);
 
 	const config_file = ['svelte.config.js', 'svelte.config.ts'].find((file) => fs.existsSync(file));
@@ -192,7 +192,7 @@ export async function sveltekit(config) {
 
 /** @param {UserConfig | ResolvedConfig} vite_config */
 function resolve_root(vite_config) {
-	return posixify(vite_config.root ? path.resolve(vite_config.root) : cwd);
+	return posixify(vite_config.root ? path.resolve(vite_config.root) : process.cwd());
 }
 
 /**

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -56,6 +56,8 @@ import { should_ignore, has_children } from './static_analysis/utils.js';
 import { process_config } from '../../core/config/index.js';
 import { treeshake_prerendered_remotes } from './build/remote.js';
 
+const cwd = process.cwd();
+
 /** @type {string} */
 let root;
 
@@ -151,8 +153,6 @@ let vite_plugin_svelte;
  * @returns {Promise<Plugin[]>}
  */
 export async function sveltekit(config) {
-	const cwd = process.cwd();
-
 	const { extensions, compilerOptions, vitePlugin, preprocess, ...rest } = config ?? {};
 	const svelte_config = process_config(
 		{ extensions, compilerOptions, vitePlugin, preprocess, kit: rest },
@@ -192,7 +192,7 @@ export async function sveltekit(config) {
 
 /** @param {UserConfig | ResolvedConfig} vite_config */
 function resolve_root(vite_config) {
-	return posixify(vite_config.root ? path.resolve(vite_config.root) : process.cwd());
+	return posixify(vite_config.root ? path.resolve(vite_config.root) : cwd);
 }
 
 /**
@@ -353,7 +353,10 @@ function kit({ svelte_config, adapter }) {
 					kit.outDir,
 					path.resolve(root, kit.files.src),
 					path.resolve(root, 'node_modules'),
-					path.resolve(process.cwd(), 'node_modules')
+					// include the directory that contains the workspaces declaration
+					// which usually also contains hoisted packages
+					// see https://vite.dev/guide/api-javascript#searchforworkspaceroot
+					path.resolve(vite.searchForWorkspaceRoot(cwd), 'node_modules')
 				]);
 
 				// We can only add directories to the allow list, so we find out
@@ -1662,7 +1665,7 @@ function kit({ svelte_config, adapter }) {
 				out,
 				remotes,
 				metadata,
-				process.cwd(),
+				cwd,
 				server_chunks,
 				vite_config.build.sourcemap
 			);


### PR DESCRIPTION
fixes https://bsky.app/profile/peterreeves.bsky.social/post/3mnmomeazos2t

This PR fixes a regression when consolidating the workspace root path. The Vite function is important to find where the hoisted/symlinked packages are stored.

After merging this, we can probably remove https://github.com/sveltejs/svelte.dev/blob/0f7fe1eb930af4e2234c792bb09a290367e6c090/apps/svelte.dev/vite.config.ts#L97 too

EDIT: tests are failing on version-3 branch because of prerendered treeshaking having a bug

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
