### PR TITLE
fix: Restore `serialize`

### DIFF
--- a/packages/kit/src/runtime/app/server/remote/form.js
+++ b/packages/kit/src/runtime/app/server/remote/form.js
@@ -161,7 +161,7 @@ export function form(validate_or_fn, maybe_fn) {
 				// We don't need to care about args or deduplicating calls, because uneval results are only relevant in full page reloads
 				// where only one form submission is active at the same time
 				if (!event.isRemoteRequest) {
-					get_cache(__, state)[''] ??= output;
+					get_cache(__, state)[''] ??= { serialize: true, data: output };
 				}
 
 				return output;
@@ -179,26 +179,26 @@ export function form(validate_or_fn, maybe_fn) {
 			get() {
 				return create_field_proxy(
 					{},
-					() => get_cache(__)?.['']?.input ?? {},
+					() => get_cache(__)?.['']?.data?.input ?? {},
 					(path, value) => {
 						const cache = get_cache(__);
 						const entry = cache[''];
 
-						if (entry?.submission) {
+						if (entry?.data?.submission) {
 							// don't override a submission
 							return;
 						}
 
 						if (path.length === 0) {
-							(cache[''] ??= {}).input = value;
+							(cache[''] ??= { serialize: true, data: {} }).data.input = value;
 							return;
 						}
 
-						const input = entry?.input ?? {};
+						const input = entry?.data?.input ?? {};
 						deep_set(input, path.map(String), value);
-						(cache[''] ??= {}).input = input;
+						(cache[''] ??= { serialize: true, data: {} }).data.input = input;
 					},
-					() => flatten_issues(get_cache(__)?.['']?.issues ?? [])
+					() => flatten_issues(get_cache(__)?.['']?.data?.issues ?? [])
 				);
 			}
 		});
@@ -220,7 +220,7 @@ export function form(validate_or_fn, maybe_fn) {
 		Object.defineProperty(instance, 'result', {
 			get() {
 				try {
-					return get_cache(__)?.['']?.result;
+					return get_cache(__)?.['']?.data?.result;
 				} catch {
 					return undefined;
 				}

--- a/packages/kit/src/runtime/app/server/remote/prerender.js
+++ b/packages/kit/src/runtime/app/server/remote/prerender.js
@@ -103,8 +103,9 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 
 						// TODO adapters can provide prerendered data more efficiently than
 						// fetching from the public internet
-						const promise = (cache[payload] ??= fetch(new URL(url, event.url.origin).href).then(
-							async (response) => {
+						const promise = (cache[payload] ??= {
+							serialize: true,
+							data: fetch(new URL(url, event.url.origin).href).then(async (response) => {
 								if (!response.ok) {
 									throw new Error('Prerendered response not found');
 								}
@@ -116,8 +117,8 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 								}
 
 								return prerendered.result;
-							}
-						));
+							})
+						}).data;
 
 						return parse_remote_response(await promise, state.transport);
 					});

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -645,7 +645,7 @@ function get_refresh_context(__, action, payload) {
 }
 
 /**
- * @param {{ __: RemoteInternals; refreshes: Map<string, Promise<any>>; cache: Record<string, any>; refreshes_key: string; payload: string }} context
+ * @param {{ __: RemoteInternals; refreshes: Map<string, Promise<any>>; cache: Record<string, { serialize: boolean; data: any }>; refreshes_key: string; payload: string }} context
  * @param {any} value
  * @param {boolean} [is_immediate_refresh=false]
  * @returns {Promise<void>}
@@ -658,7 +658,7 @@ function update_refresh_value(
 	const promise = Promise.resolve(value);
 
 	if (!is_immediate_refresh) {
-		cache[payload] = promise;
+		cache[payload] = { serialize: true, data: promise };
 	}
 
 	if (__.id) {

--- a/packages/kit/src/runtime/app/server/remote/shared.js
+++ b/packages/kit/src/runtime/app/server/remote/shared.js
@@ -80,7 +80,7 @@ export async function get_response(internals, payload, state, get_result) {
 
 	// TODO: Add some sort of "&& not nested in remote function context" check here,
 	// as this would mean we don't need to serialize this entry (it's opaque to the client)
-	entry.serialize ||= !!state.is_in_universal_load;
+	entry.serialize ||= state.is_in_universal_load || state.is_in_render;
 
 	return entry.data;
 }

--- a/packages/kit/src/runtime/app/server/remote/shared.js
+++ b/packages/kit/src/runtime/app/server/remote/shared.js
@@ -73,7 +73,16 @@ export async function get_response(internals, payload, state, get_result) {
 	await 0;
 
 	const cache = get_cache(internals, state);
-	return (cache[payload] ??= get_result());
+	const entry = (cache[payload] ??= {
+		serialize: false,
+		data: get_result()
+	});
+
+	// TODO: Add some sort of "&& not nested in remote function context" check here,
+	// as this would mean we don't need to serialize this entry (it's opaque to the client)
+	entry.serialize ||= !!state.is_in_universal_load;
+
+	return entry.data;
 }
 
 /**

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -24,7 +24,6 @@ import {
 import { create_remote_key } from '../../shared.js';
 import { get_status } from '../../../utils/error.js';
 import * as env from '__sveltekit/env';
-import { noop } from '../../../utils/functions.js';
 
 // TODO rename this function/module
 
@@ -535,7 +534,7 @@ export async function render_response({
 				if (!internals.id) continue;
 
 				for (const key in cache) {
-					const value = cache[key];
+					const entry = cache[key];
 
 					const remote_key = create_remote_key(internals.id, key);
 
@@ -547,16 +546,24 @@ export async function render_response({
 					) {
 						// This entry was refreshed/set by a command or form action.
 						// Always await it so the mutation result is serialized.
-						store[remote_key] = await value;
+						store[remote_key] = await entry.data;
 					} else {
-						let resolved = true;
-
 						// Don't block the response on pending remote data - if a query
 						// hasn't settled yet, it wasn't awaited in the template (or is behind a pending boundary).
-						await Promise.race([
-							Promise.resolve(value).then((v) => resolved && (store[remote_key] = v), noop),
-							Promise.resolve().then(() => (resolved = false))
+						const result = await Promise.race([
+							Promise.resolve(entry.data).then(
+								(v) => /** @type {const} */ ({ settled: true, value: v }),
+								(e) => /** @type {const} */ ({ settled: true, error: e })
+							),
+							new Promise((resolve) => {
+								queueMicrotask(() => resolve(/** @type {const} */ ({ settled: false })));
+							})
 						]);
+
+						if (result.settled) {
+							if ('error' in result && entry.serialize) throw result.error;
+							store[remote_key] = result.value;
+						}
 					}
 				}
 			}

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -713,7 +713,10 @@ export interface RequestState {
 		record_span: RecordSpan;
 	};
 	readonly remote: {
-		data: null | Map<RemoteInternals, Record<string, MaybePromise<any>>>;
+		data: null | Map<
+			RemoteInternals,
+			Record<string, { serialize: boolean; data: MaybePromise<any> }>
+		>;
 		/** Instances created via `myForm.for(...)` */
 		forms: null | Map<string, any>;
 		/** A map of remote function key to corresponding single-flight-mutation promise */


### PR DESCRIPTION
This behavior is still needed to prevent remote functions from being unnecessarily serialized when they're used in a server-only context that would be opaque to the client. The behavior is slightly changed from `main`, and anything inside universal load _or_ render is now marked as serializable. A future pull request will update this to exclude functions that are only called from within other functions. 