### PR TITLE
fix: Misc stuff for query-in-query

### DIFF
--- a/packages/kit/src/core/postbuild/fallback.js
+++ b/packages/kit/src/core/postbuild/fallback.js
@@ -40,7 +40,8 @@ async function generate_fallback({ manifest_path, env, out_dir, origin, assets }
 		},
 		prerendering: {
 			fallback: true,
-			dependencies: new Map()
+			dependencies: new Map(),
+			remote_responses: new Map()
 		},
 		read: (file) => readFileSync(join(assets, file))
 	});

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -205,6 +205,9 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env }) {
 	const seen = new Set();
 	const written = new Set();
 
+	/** @type {Map<string, Promise<any>>} */
+	const remote_responses = new Map();
+
 	/** @type {Map<string, Set<string>>} */
 	const expected_hashlinks = new Map();
 
@@ -247,7 +250,8 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env }) {
 				throw new Error('Cannot read clientAddress during prerendering');
 			},
 			prerendering: {
-				dependencies
+				dependencies,
+				remote_responses
 			},
 			read: (file) => {
 				// stuff we just wrote

--- a/packages/kit/src/runtime/app/server/remote/prerender.js
+++ b/packages/kit/src/runtime/app/server/remote/prerender.js
@@ -1,7 +1,7 @@
 /** @import { RemoteResource, RemotePrerenderFunction } from '@sveltejs/kit' */
 /** @import { RemotePrerenderInputsGenerator, RemotePrerenderInternals, MaybePromise } from 'types' */
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
-import { json } from '@sveltejs/kit';
+import { json, error } from '@sveltejs/kit';
 import { DEV } from 'esm-env';
 import { get_request_store } from '@sveltejs/kit/internal/server';
 import { stringify, stringify_remote_arg } from '../../../shared.js';
@@ -9,11 +9,10 @@ import { noop } from '../../../../utils/functions.js';
 import { app_dir, base } from '$app/paths/internal/server';
 import {
 	create_validator,
-	get_cache,
+	get_response,
 	parse_remote_response,
 	run_remote_function
 } from './shared.js';
-import { error } from '@sveltejs/kit';
 
 /**
  * Creates a remote prerender function. When called from the browser, the function will be invoked on the server via a `fetch` call.
@@ -92,8 +91,11 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 		const { event, state } = get_request_store();
 		const payload = stringify_remote_arg(arg, state.transport);
 
+		// `get_response` (as opposed to bare `get_cache`) also registers the call in the
+		// implicit lookup, so that the result is inlined into the page payload (`data.p`)
+		// and the client doesn't need to fetch it again upon hydration
 		/** @type {Promise<Output> & Partial<RemoteResource<Output>>} */
-		const promise = (get_cache(__, state)[payload] ??= (async () => {
+		const promise = get_response(__, payload, state, async () => {
 			const id = __.id;
 			const url = `${base}/${app_dir}/remote/${id}${payload ? `/${payload}` : ''}`;
 
@@ -119,7 +121,19 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 				}
 			}
 
-			const result = await run_remote_function(event, state, false, () => validate(arg), fn);
+			// during a prerender run, the same function might be invoked while rendering
+			// multiple pages — share the result across the entire run
+			if (state.prerendering?.remote_responses.has(url)) {
+				return /** @type {Promise<any>} */ (state.prerendering.remote_responses.get(url));
+			}
+
+			const promise = run_remote_function(event, state, false, () => validate(arg), fn);
+
+			if (state.prerendering) {
+				state.prerendering.remote_responses.set(url, promise);
+			}
+
+			const result = await promise;
 
 			if (state.prerendering) {
 				const body = { type: 'result', data: stringify({ _: result }, state.transport) };
@@ -131,7 +145,7 @@ export function prerender(validate_or_fn, fn_or_options, maybe_options) {
 
 			// TODO this is missing error/loading/current/status
 			return result;
-		})());
+		});
 
 		promise.catch(noop);
 

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -1,7 +1,7 @@
 /** @import { RemoteLiveQuery, RemoteLiveQueryFunction, RemoteQuery, RemoteQueryFunction } from '@sveltejs/kit' */
 /** @import { RemoteInternals, MaybePromise, RequestState, RemoteQueryLiveInternals, RemoteQueryBatchInternals, RemoteQueryInternals, RemoteLiveQueryUserFunctionReturnType } from 'types' */
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
-import { get_request_store, with_request_store } from '@sveltejs/kit/internal/server';
+import { get_request_store } from '@sveltejs/kit/internal/server';
 import { create_remote_key, stringify_remote_arg } from '../../../shared.js';
 import { prerendering } from '$app/env/internal';
 import {
@@ -82,15 +82,10 @@ export function query(validate_or_fn, maybe_fn) {
 			return create_query_resource(__, payload, state, () =>
 				run_remote_function(
 					event,
-					state,
+					{ ...state, is_in_remote_query: true },
 					false,
 					() => validated_arg,
-					(arg) => {
-						return with_request_store(
-							{ event, state: { ...state, is_in_remote_query: true } },
-							() => fn(arg)
-						);
-					}
+					fn
 				)
 			);
 		}
@@ -107,19 +102,15 @@ export function query(validate_or_fn, maybe_fn) {
 		const { event, state } = get_request_store();
 		const payload = stringify_remote_arg(arg, state.transport);
 
-		return create_query_resource(__, payload, state, () => {
-			return run_remote_function(
+		return create_query_resource(__, payload, state, () =>
+			run_remote_function(
 				event,
-				state,
+				{ ...state, is_in_remote_query: true },
 				false,
 				() => validate(arg),
-				(arg) => {
-					return with_request_store({ event, state: { ...state, is_in_remote_query: true } }, () =>
-						fn(arg)
-					);
-				}
-			);
-		});
+				fn
+			)
+		);
 	};
 
 	Object.defineProperty(wrapper, '__', { value: __ });
@@ -174,7 +165,14 @@ function live(validate_or_fn, maybe_fn) {
 	 * @param {any} get_input
 	 */
 	const run = (event, state, get_input) =>
-		run_remote_generator(event, state, false, get_input, fn, __.name);
+		run_remote_generator(
+			event,
+			{ ...state, is_in_remote_query: true },
+			false,
+			get_input,
+			fn,
+			__.name
+		);
 
 	/** @type {RemoteQueryLiveInternals} */
 	const __ = {
@@ -295,7 +293,7 @@ function batch(validate_or_fn, maybe_fn) {
 				try {
 					return await run_remote_function(
 						event,
-						state,
+						{ ...state, is_in_remote_query: true },
 						false,
 						async () => Promise.all(entries.map((entry) => entry.get_validated())),
 						async (input) => {

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -329,11 +329,15 @@ export async function start(_app, _target, hydrate) {
 	}
 
 	if (__SVELTEKIT_PAYLOAD__.data) {
-		const { q = {}, p = {} } = __SVELTEKIT_PAYLOAD__.data;
+		const { q = {}, p = {}, l = {} } = __SVELTEKIT_PAYLOAD__.data;
 
 		// TODO we're currently ignoring errors, is that right?
 		for (const k in q) {
 			if (!q[k].e) query_responses[k] = q[k].v;
+		}
+
+		for (const k in l) {
+			if (!l[k].e) query_responses[k] = l[k].v;
 		}
 
 		for (const k in p) {

--- a/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
@@ -57,6 +57,15 @@ export function query_batch(id) {
 
 						if (response.redirect) {
 							await goto(response.redirect);
+
+							// settle all batched promises (with `undefined`, like a redirect
+							// from a non-batched query) so that callers don't hang forever
+							for (const resolvers of batched.values()) {
+								for (const { resolve } of resolvers) {
+									resolve(undefined);
+								}
+							}
+
 							return;
 						}
 

--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -348,18 +348,19 @@ export async function collect_remote_data(data, event, state, options) {
 				);
 
 				const promise = state.remote.data?.get(internals)?.[key] ?? record[key]();
-				const node = ((data[type] ??= {})[remote_key] ??= {});
 
 				promises.push(
 					Promise.resolve(promise).then(
-						(v) => (node.v = v),
+						(v) => {
+							((data[type] ??= {})[remote_key] ??= {}).v = v;
+						},
 						async (e) => {
 							if (e instanceof Redirect) {
 								// already handled elsewhere
 								return;
 							}
 
-							node.e = await convert_error(e);
+							((data[type] ??= {})[remote_key] ??= {}).e = await convert_error(e);
 						}
 					)
 				);
@@ -379,15 +380,17 @@ export async function collect_remote_data(data, event, state, options) {
 				);
 
 				const promise = state.remote.data?.get(internals)?.[key] ?? record[key]();
-				const node = ((data[type] ??= {})[remote_key] ??= {});
 
+				// If the promise is still pending (e.g. the query was rendered in its loading
+				// state during SSR), omit it from the payload entirely so that the client
+				// fetches it itself — an entry without `v`/`e` would hydrate as `undefined`.
 				let resolved = true;
 
 				await Promise.race([
 					Promise.resolve(promise).then(
 						(v) => {
 							if (resolved) {
-								node.v = v;
+								((data[type] ??= {})[remote_key] ??= {}).v = v;
 							}
 						},
 						(e) => {
@@ -399,7 +402,7 @@ export async function collect_remote_data(data, event, state, options) {
 							if (resolved) {
 								promises.push(
 									convert_error(e).then((e) => {
-										node.e = e;
+										((data[type] ??= {})[remote_key] ??= {}).e = e;
 									})
 								);
 							}

--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -501,7 +501,10 @@ async function handle_remote_form_post_internal(event, state, manifest, id) {
 			data.id = JSON.parse(decodeURIComponent(action_id));
 		}
 
-		await with_request_store({ event, state }, () => fn(data, meta, form_data));
+		await with_request_store(
+			{ event, state: { ...state, is_in_remote_form_or_command: true } },
+			() => fn(data, meta, form_data)
+		);
 
 		// We don't want the data to appear on `let { form } = $props()`, which is why we're not returning it.
 		// It is instead available on `myForm.result`, setting of which happens within the remote `form` function.

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -238,6 +238,8 @@ export interface PrerenderOptions {
 	cache?: string; // including this here is a bit of a hack, but it makes it easy to add <meta http-equiv>
 	fallback?: boolean;
 	dependencies: Map<string, PrerenderDependency>;
+	/** Results of remote `prerender` functions, shared across the whole prerender run so that each only executes once */
+	remote_responses: Map<string, Promise<any>>;
 	/** True for the duration of a call to the `reroute` hook */
 	inside_reroute?: boolean;
 }

--- a/packages/kit/test/apps/async/src/routes/remote/batch-redirect/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/batch-redirect/+page.svelte
@@ -1,0 +1,19 @@
+<script>
+	import { batch_redirect } from './data.remote.js';
+
+	let status = $state('idle');
+
+	async function run() {
+		status = 'pending';
+
+		try {
+			await batch_redirect('a');
+			status = 'resolved';
+		} catch {
+			status = 'rejected';
+		}
+	}
+</script>
+
+<button id="trigger" onclick={run}>trigger</button>
+<p id="status">{status}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/batch-redirect/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/batch-redirect/data.remote.js
@@ -1,0 +1,8 @@
+import { query } from '$app/server';
+import { redirect } from '@sveltejs/kit';
+
+export const batch_redirect = query.batch('unchecked', () => {
+	// same-page hash redirect so the page component survives the `goto`
+	// and the test can observe whether the batched promises settle
+	redirect(307, '/remote/batch-redirect#redirected');
+});

--- a/packages/kit/test/apps/async/src/routes/remote/form/requested/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/requested/+page.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { submit } from './form.remote.ts';
+</script>
+
+<form {...submit}>
+	<button id="requested-submit">Submit</button>
+</form>
+
+<p id="form-result">{submit.result?.message ?? 'not submitted'}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/form/requested/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/requested/form.remote.ts
@@ -1,0 +1,11 @@
+import { form, query, requested } from '$app/server';
+
+export const get_time = query(() => Date.now());
+
+export const submit = form('unchecked', async () => {
+	// must work on both enhanced and non-enhanced (no-JS) submissions —
+	// in the latter case there are simply no requested refreshes
+	await requested(get_time, 5).refreshAll();
+
+	return { message: 'submitted successfully' };
+});

--- a/packages/kit/test/apps/async/src/routes/remote/live-nested-query/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/live-nested-query/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { live_outer } from './data.remote.js';
+</script>
+
+<p id="live-result">{await live_outer()}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/live-nested-query/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/live-nested-query/data.remote.js
@@ -1,0 +1,11 @@
+import { query } from '$app/server';
+
+export const get_secret = query(() => 'nested-secret');
+
+export const live_outer = query.live(async function* () {
+	// this nested query must not be implicitly registered and serialized
+	// into the page payload — only the (transformed) yielded value should appear
+	const secret = await get_secret();
+
+	yield secret.toUpperCase();
+});

--- a/packages/kit/test/apps/async/src/routes/remote/live-ssr-value/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/live-ssr-value/+page.svelte
@@ -1,0 +1,10 @@
+<script>
+	import { page } from '$app/state';
+	import { live_value, notify } from './data.remote.js';
+
+	const key = page.url.searchParams.get('key') ?? 'default';
+	const live = live_value(key);
+</script>
+
+<p id="live-state">{live.ready ? live.current : 'loading'}</p>
+<button id="notify" onclick={() => notify(key)}>notify</button>

--- a/packages/kit/test/apps/async/src/routes/remote/live-ssr-value/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/live-ssr-value/data.remote.js
@@ -1,0 +1,36 @@
+import { command, query } from '$app/server';
+
+/** @type {Set<string>} */
+const seen = new Set();
+/** @type {Set<string>} */
+const notified = new Set();
+/** @type {Set<{ key: string, resolve: () => void }>} */
+const listeners = new Set();
+
+export const live_value = query.live('unchecked', async function* (key) {
+	if (!seen.has(key)) {
+		// first connection for this key — the SSR render
+		seen.add(key);
+		yield 'initial';
+		return;
+	}
+
+	// subsequent connections (the post-hydration reconnect) don't yield until
+	// notified, so that tests can observe the hydration-seeded value
+	if (!notified.has(key)) {
+		await new Promise((resolve) => listeners.add({ key, resolve }));
+	}
+
+	yield 'updated';
+});
+
+export const notify = command('unchecked', (/** @type {string} */ key) => {
+	notified.add(key);
+
+	for (const listener of [...listeners]) {
+		if (listener.key === key) {
+			listener.resolve();
+			listeners.delete(listener);
+		}
+	}
+});

--- a/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/a/+page.js
+++ b/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/a/+page.js
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/a/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/a/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { counted } from '../data.remote.js';
+</script>
+
+<p id="count">{await counted()}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/b/+page.js
+++ b/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/b/+page.js
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/b/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/b/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { counted } from '../data.remote.js';
+</script>
+
+<p id="count">{await counted()}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/prerender-dedupe/data.remote.js
@@ -1,0 +1,7 @@
+import { prerender } from '$app/server';
+
+let invocations = 0;
+
+// used by two prerendered pages — at build time, this must only execute once,
+// so that both pages render the same value
+export const counted = prerender(() => ++invocations);

--- a/packages/kit/test/apps/async/src/routes/remote/prerender-inline/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/prerender-inline/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { get_prerendered } from './data.remote.js';
+</script>
+
+<p id="prerender-value">prerendered: {await get_prerendered()}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/prerender-inline/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/prerender-inline/data.remote.js
@@ -1,0 +1,3 @@
+import { prerender } from '$app/server';
+
+export const get_prerendered = prerender(() => 'hello');

--- a/packages/kit/test/apps/async/src/routes/remote/private-query/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/private-query/data.remote.js
@@ -1,0 +1,10 @@
+import { command, query } from '$app/server';
+
+// deliberately not exported — this must never be serialized into any response
+const get_secret = query(() => 'private-data');
+
+export const reveal = command(async () => {
+	const secret = await get_secret();
+
+	return secret.toUpperCase();
+});

--- a/packages/kit/test/apps/async/src/routes/remote/query-event-guards/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/query-event-guards/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import { blocked_operations } from './data.remote.js';
+</script>
+
+<p id="result">{await blocked_operations()}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/query-event-guards/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/query-event-guards/data.remote.js
@@ -1,0 +1,24 @@
+import { query, getRequestEvent } from '$app/server';
+
+export const blocked_operations = query(() => {
+	const { cookies, setHeaders } = getRequestEvent();
+
+	/** @type {string[]} */
+	const results = [];
+
+	try {
+		cookies.set('illegal', 'yes', { path: '/' });
+		results.push('cookies.set succeeded');
+	} catch (e) {
+		results.push(/** @type {Error} */ (e).message);
+	}
+
+	try {
+		setHeaders({ 'x-illegal': 'yes' });
+		results.push('setHeaders succeeded');
+	} catch (e) {
+		results.push(/** @type {Error} */ (e).message);
+	}
+
+	return results.join(' | ');
+});

--- a/packages/kit/test/apps/async/src/routes/remote/query-loading-state/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/query-loading-state/+page.svelte
@@ -1,0 +1,22 @@
+<script>
+	import { get_slow_data } from './data.remote.js';
+
+	// the query is kicked off during SSR (via the `loading` property access)
+	// but not awaited, so SSR renders the loading state. The client must
+	// fetch the data itself after hydration.
+	const slow = get_slow_data();
+
+	function delayed_value() {
+		return new Promise((resolve) => setTimeout(() => resolve('hydrated'), 500));
+	}
+</script>
+
+{#if slow.loading}
+	<p id="slow-state">loading</p>
+{:else}
+	<p id="slow-state">{slow.current}</p>
+{/if}
+
+<!-- this keeps hydration unsettled long enough for the slow query to
+     read from the hydration cache rather than it being reset first -->
+<p id="other">{await delayed_value()}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/query-loading-state/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/query-loading-state/data.remote.js
@@ -1,0 +1,6 @@
+import { query } from '$app/server';
+
+export const get_slow_data = query(async () => {
+	await new Promise((resolve) => setTimeout(resolve, 1000));
+	return 'slow data';
+});

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -440,6 +440,16 @@ test.describe('remote function mutations', () => {
 		expect(request_count).toBe(1);
 	});
 
+	test('query.batch redirect settles batched promises', async ({ page }) => {
+		await page.goto('/remote/batch-redirect');
+
+		await page.click('#trigger');
+
+		// the redirect must both navigate and settle the awaited query
+		await expect(page.locator('#status')).toHaveText('resolved');
+		expect(page.url()).toContain('#redirected');
+	});
+
 	test('query.batch resolver function always receives validated arguments', async ({ page }) => {
 		await page.goto('/remote/batch-validation');
 

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -58,6 +58,16 @@ test.describe('remote function mutations', () => {
 		expect(request_count).toBe(0);
 	});
 
+	test('hydrated prerender data is reused', async ({ page }) => {
+		let request_count = 0;
+		page.on('request', (r) => (request_count += r.url().includes('/_app/remote') ? 1 : 0));
+
+		await page.goto('/remote/prerender-inline');
+		await expect(page.locator('#prerender-value')).toHaveText('prerendered: hello');
+		await page.waitForTimeout(100); // allow all requests to finish
+		expect(request_count).toBe(0);
+	});
+
 	test('hydrated batch data is reused', async ({ page }) => {
 		let request_count = 0;
 		page.on('request', (r) => (request_count += r.url().includes('/_app/remote') ? 1 : 0));

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -749,6 +749,21 @@ test.describe('remote functions', () => {
 		}
 	});
 
+	test('prerender functions are deduplicated across prerendered pages during build', async ({
+		page
+	}) => {
+		test.skip(!!process.env.DEV, 'pages are only prerendered when building');
+
+		await page.goto('/remote/prerender-dedupe/a');
+		const a = await page.locator('#count').textContent();
+
+		await page.goto('/remote/prerender-dedupe/b');
+		const b = await page.locator('#count').textContent();
+
+		// the shared prerender function must only have executed once at build time
+		expect(b).toBe(a);
+	});
+
 	test('awaiting multiple queries inside $derived does not fail mutation validation', async ({
 		page
 	}) => {

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -687,6 +687,23 @@ test.describe('remote functions', () => {
 		}
 	});
 
+	test('query rendered in its loading state during SSR is fetched on the client', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		await page.goto('/remote/query-loading-state');
+
+		if (javaScriptEnabled) {
+			// the query was still pending when SSR finished, so it must not be
+			// seeded into the hydration cache — the client has to fetch it itself
+			await expect(page.locator('#slow-state')).toHaveText('slow data', {
+				timeout: 5000
+			});
+		} else {
+			await expect(page.locator('#slow-state')).toHaveText('loading');
+		}
+	});
+
 	test('awaiting multiple queries inside $derived does not fail mutation validation', async ({
 		page
 	}) => {

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -733,6 +733,22 @@ test.describe('remote functions', () => {
 		await expect(page.locator('#form-result')).toHaveText('submitted successfully');
 	});
 
+	test('SSR data for query.live is reused on hydration', async ({ page, javaScriptEnabled }) => {
+		await page.goto(`/remote/live-ssr-value?key=${Date.now()}-${Math.random()}`);
+
+		if (javaScriptEnabled) {
+			// the SSR'd first value must be seeded into the live query on hydration —
+			// the reconnect (deliberately blocked server-side) must not reset it to a loading state
+			await expect(page.locator('#live-state')).toHaveText('initial');
+
+			// the live connection still works after seeding
+			await page.click('#notify');
+			await expect(page.locator('#live-state')).toHaveText('updated');
+		} else {
+			await expect(page.locator('#live-state')).toHaveText('loading');
+		}
+	});
+
 	test('awaiting multiple queries inside $derived does not fail mutation validation', async ({
 		page
 	}) => {

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -704,6 +704,23 @@ test.describe('remote functions', () => {
 		}
 	});
 
+	test('queries cannot set cookies or headers', async ({ page }) => {
+		await page.goto('/remote/query-event-guards');
+
+		await expect(page.locator('#result')).toHaveText(
+			'Cannot set cookies in `query` or `prerender` functions | setHeaders is not allowed in remote functions'
+		);
+	});
+
+	test('queries nested inside live queries are not implicitly serialized', async ({ page }) => {
+		await page.goto('/remote/live-nested-query');
+
+		await expect(page.locator('#live-result')).toHaveText('NESTED-SECRET');
+
+		// the nested query's raw value must not leak into the page payload
+		expect(await page.content()).not.toContain('nested-secret');
+	});
+
 	test('awaiting multiple queries inside $derived does not fail mutation validation', async ({
 		page
 	}) => {

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -721,6 +721,18 @@ test.describe('remote functions', () => {
 		expect(await page.content()).not.toContain('nested-secret');
 	});
 
+	test('requested(...) works in form handlers regardless of progressive enhancement', async ({
+		page
+	}) => {
+		await page.goto('/remote/form/requested');
+
+		await expect(page.locator('#form-result')).toHaveText('not submitted');
+
+		await page.locator('#requested-submit').click();
+
+		await expect(page.locator('#form-result')).toHaveText('submitted successfully');
+	});
+
 	test('awaiting multiple queries inside $derived does not fail mutation validation', async ({
 		page
 	}) => {


### PR DESCRIPTION
Fixes for review findings on #15999
1. Pending queries serialized as empty nodes — collect_remote_data inserted payload nodes before knowing whether the promise settled, so queries SSR'd in a loading state hydrated as undefined and never fetched (same hole for Redirect rejections). Nodes are now only created inside the resolve/reject handlers; pending queries are omitted entirely.
runtime/server/remote.js · test: query rendered in its loading state during SSR is fetched on the client
2. Guard bypass in query functions — the nested with_request_store used to set is_in_remote_query shadowed the guarded event with the raw one, so cookies.set/setHeaders worked inside queries instead of throwing. The flag is now merged into the state passed to run_remote_function (matching batch.run), in the wrapper, bind, batch's enqueue, and query.live's run — the last also stops nested queries inside live generators from being implicitly serialized.
runtime/app/server/remote/query.js · tests: queries cannot set cookies or headers, queries nested inside live queries are not implicitly serialized
3. requested() threw on no-JS form posts — handle_remote_form_post_internal didn't set is_in_remote_form_or_command. Now mirrors the enhanced path; requested() degrades to a no-op without JS.
runtime/server/remote.js · test: requested(...) works in form handlers regardless of progressive enhancement
4. query.batch redirects hung forever — the redirect branch returned before settling any batched resolver. Now resolves all entries with undefined after goto, matching plain-query redirect semantics.
runtime/client/remote-functions/query-batch.svelte.js · test: query.batch redirect settles batched promises
5. data.l never consumed — start() only read q/p, so SSR'd live-query values were dropped and live queries reconnected from a loading state. l entries are now seeded into query_responses, which the LiveQuery constructor already consumes.
runtime/client/client.js · test: SSR data for query.live is reused on hydration
6. data.p never populated — the prerender wrapper used bare get_cache instead of get_response, so prerender results never registered implicitly and clients refetched on every hydration. Restored get_response.
runtime/app/server/remote/prerender.js · test: hydrated prerender data is reused
7. Build-time prerender dedup restored — re-added the run-wide remote_responses map (PrerenderOptions type, postbuild prerender.js/fallback.js, wrapper), so a prerender fn shared by N prerendered pages executes once per build instead of N times.
test: prerender functions are deduplicated across prerendered pages during build
8. Private (non-exported) functions leaked into responses — id-less functions called from commands/forms registered implicitly and were serialized under malformed keys ("/payload"), shipping private data to the client. Both collect_remote_data loops now skip id-less internals (before setting data.r, so private-only refreshes don't suppress invalidateAll).
runtime/server/remote.js · test: non-exported remote functions are never serialized into responses
9. state is now a required param on get_cache/get_implicit_lookup/get_explicit_lookup — the get_request_store() default silently diverges from captured state on runtimes without ALS (worst case: cross-request cache writes). Fixed the one buggy call site (set() in create_query_resource) and made form.js's module-level getters — the only legitimate consumers — pass get_request_store().state explicitly. Future omissions are type errors.
runtime/app/server/remote/{shared,query,form}.js