### PR TITLE
fix: pass all unknown options from the sveltekit Vite plugin through to vite-plugin-svelte

### DIFF
--- a/.changeset/tame-spoons-jump.md
+++ b/.changeset/tame-spoons-jump.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: pass all unknown options from the `sveltekit` Vite plugin through to `vite-plugin-svelte`

--- a/documentation/docs/98-reference/50-configuration.md
+++ b/documentation/docs/98-reference/50-configuration.md
@@ -61,6 +61,8 @@ export default defineConfig({
 
 > [!NOTE] The `kit` namespace is at the same level as the other top level entries; this is the only difference to the `svelte.config.js` layout.
 
+Any options that don't belong to SvelteKit are passed through to [`vite-plugin-svelte`](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/config.md), so you can set options like `inspector` here too. The `experimental` namespace is shared — SvelteKit reads its own flags and forwards the rest.
+
 If the config is defined via the plugin, the `svelte.config.js` file is ignored.
 
 ## Config

--- a/packages/kit/src/core/config/fixtures/vite-inline/vite.config.js
+++ b/packages/kit/src/core/config/fixtures/vite-inline/vite.config.js
@@ -6,7 +6,10 @@ export default defineConfig({
 		sveltekit({
 			paths: {
 				base: '/from-vite'
-			}
+			},
+			// a vite-plugin-svelte option that SvelteKit doesn't use itself —
+			// it should be passed through rather than treated as a Kit option
+			inspector: true
 		})
 	]
 });

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -1,13 +1,71 @@
-/** @import { Config } from '@sveltejs/kit' */
+/** @import { Config, KitConfig } from '@sveltejs/kit' */
+/** @import { Options, SvelteConfig } from '@sveltejs/vite-plugin-svelte' */
 /** @import { ValidatedConfig } from 'types' */
 /** @import { ResolvedConfig } from 'vite' */
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import * as url from 'node:url';
-import options from './options.js';
+import options, { kit_options, kit_experimental_options } from './options.js';
 import { resolve_entry } from '../../utils/filesystem.js';
 import { import_peer } from '../../utils/import.js';
+
+/**
+ * Splits the config passed to the `sveltekit` Vite plugin into the options that
+ * SvelteKit processes itself and the options that are forwarded to
+ * `vite-plugin-svelte`. SvelteKit makes no assumptions about which options
+ * `vite-plugin-svelte` accepts — it plucks out its own options and passes
+ * everything else along (`vite-plugin-svelte` does its own validation).
+ * @param {KitConfig & Omit<Options, 'onwarn'> & Pick<SvelteConfig, 'vitePlugin'>} config
+ * @returns {{ svelte_config: Config, vite_plugin_svelte_config: Record<string, any> }}
+ */
+export function split_config(config) {
+	const { extensions, compilerOptions, vitePlugin, preprocess, ...rest } = config;
+
+	/** @type {KitConfig} */
+	const kit = {};
+
+	/** @type {Record<string, any>} */
+	const vite_plugin_svelte_config = {};
+
+	for (const key in rest) {
+		if (key === 'experimental') {
+			// `experimental` is a namespace that both SvelteKit and vite-plugin-svelte
+			// use, so pluck out the flags SvelteKit recognises and pass the rest along
+			const experimental = /** @type {Record<string, any>} */ (rest[key]) ?? {};
+
+			/** @type {Record<string, any>} */
+			const kit_experimental = {};
+			/** @type {Record<string, any>} */
+			const vps_experimental = {};
+
+			for (const flag in experimental) {
+				if (kit_experimental_options.includes(flag)) {
+					kit_experimental[flag] = experimental[flag];
+				} else {
+					vps_experimental[flag] = experimental[flag];
+				}
+			}
+
+			if (Object.keys(kit_experimental).length > 0) {
+				kit.experimental = kit_experimental;
+			}
+			if (Object.keys(vps_experimental).length > 0) {
+				vite_plugin_svelte_config.experimental = vps_experimental;
+			}
+		} else if (kit_options.includes(key)) {
+			// @ts-expect-error - we've verified this is one of SvelteKit's own options
+			kit[key] = rest[key];
+		} else {
+			vite_plugin_svelte_config[key] = /** @type {Record<string, any>} */ (rest)[key];
+		}
+	}
+
+	return {
+		svelte_config: { extensions, compilerOptions, vitePlugin, preprocess, kit },
+		vite_plugin_svelte_config
+	};
+}
 
 /**
  * Loads the template (src/app.html by default) and validates that it has the

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -6,7 +6,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import * as url from 'node:url';
-import options, { kit_options, kit_experimental_options } from './options.js';
+import { options, kit_options, kit_experimental_options } from './options.js';
 import { resolve_entry } from '../../utils/filesystem.js';
 import { import_peer } from '../../utils/import.js';
 

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -1,7 +1,7 @@
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { assert, expect, test } from 'vitest';
-import { validate_config, load_config } from './index.js';
+import { validate_config, load_config, split_config } from './index.js';
 import process from 'node:process';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -531,4 +531,72 @@ test('uses src prefix for other kit.files options', async () => {
 	defaults.kit.version.name = config.kit.version.name;
 
 	expect(config.kit.files.lib).toEqual(join(cwd, 'source/lib'));
+});
+
+test('split_config keeps SvelteKit options under the `kit` namespace', () => {
+	const adapter = { name: 'test', adapt: () => {} };
+	const { svelte_config, vite_plugin_svelte_config } = split_config({
+		adapter,
+		paths: { base: '/base' },
+		router: { type: 'hash' }
+	});
+
+	expect(svelte_config.kit).toEqual({
+		adapter,
+		paths: { base: '/base' },
+		router: { type: 'hash' }
+	});
+	expect(vite_plugin_svelte_config).toEqual({});
+});
+
+test('split_config forwards unknown (vite-plugin-svelte) options', () => {
+	const dynamicCompileOptions = () => {};
+	const { svelte_config, vite_plugin_svelte_config } = split_config({
+		paths: { base: '/base' },
+		inspector: true,
+		dynamicCompileOptions
+	});
+
+	expect(svelte_config.kit).toEqual({ paths: { base: '/base' } });
+	expect(vite_plugin_svelte_config).toEqual({ inspector: true, dynamicCompileOptions });
+});
+
+test('split_config keeps Svelte-level options out of the `kit` namespace', () => {
+	const preprocess = { markup: () => ({ code: '' }) };
+	const { svelte_config, vite_plugin_svelte_config } = split_config({
+		extensions: ['.svelte', '.svx'],
+		compilerOptions: { runes: true },
+		preprocess,
+		vitePlugin: { inspector: true }
+	});
+
+	expect(svelte_config.extensions).toEqual(['.svelte', '.svx']);
+	expect(svelte_config.compilerOptions).toEqual({ runes: true });
+	expect(svelte_config.preprocess).toBe(preprocess);
+	expect(svelte_config.vitePlugin).toEqual({ inspector: true });
+	expect(svelte_config.kit).toEqual({});
+	expect(vite_plugin_svelte_config).toEqual({});
+});
+
+test('split_config splits the shadowed `experimental` namespace', () => {
+	const { svelte_config, vite_plugin_svelte_config } = split_config({
+		experimental: /** @type {any} */ ({
+			remoteFunctions: true,
+			sendWarningsToBrowser: true
+		})
+	});
+
+	expect(svelte_config.kit?.experimental).toEqual({ remoteFunctions: true });
+	expect(vite_plugin_svelte_config).toEqual({ experimental: { sendWarningsToBrowser: true } });
+});
+
+test('split_config only sets `kit.experimental` when SvelteKit flags are present', () => {
+	const { svelte_config, vite_plugin_svelte_config } = split_config({
+		experimental: /** @type {any} */ ({
+			sendWarningsToBrowser: true
+		})
+	});
+
+	expect(svelte_config.kit).toEqual({});
+	expect(vite_plugin_svelte_config).toEqual({ experimental: { sendWarningsToBrowser: true } });
 });

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -45,7 +45,7 @@ const directives = object({
 });
 
 /** @type {Validator} */
-const options = object(
+export const options = object(
 	{
 		extensions: validate(['.svelte'], (input, keypath) => {
 			if (!Array.isArray(input) || !input.every((page) => typeof page === 'string')) {
@@ -513,5 +513,3 @@ function assert_trusted_types_supported(keypath) {
 		);
 	}
 }
-
-export default options;

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -326,6 +326,17 @@ const options = object(
 	true
 );
 
+// Derive the names of SvelteKit's own config options from the schema, so they
+// stay in sync automatically. These are used to separate Kit's options from
+// `vite-plugin-svelte`'s options when config is passed via the Vite plugin.
+const defaults = /** @type {Record<string, any>} */ (options({}, 'config'));
+
+/** The names of the options that live under the `kit` namespace */
+export const kit_options = Object.keys(defaults.kit);
+
+/** The names of the options that live under the `kit.experimental` namespace */
+export const kit_experimental_options = Object.keys(defaults.kit.experimental);
+
 /**
  * @param {Validator} fn
  * @param {(keypath: string) => string} get_message

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -22,7 +22,7 @@ import {
 import * as sync from '../../core/sync/sync.js';
 import { create_assets } from '../../core/sync/create_manifest_data/index.js';
 import { runtime_directory, logger } from '../../core/utils.js';
-import { load_svelte_config, process_config } from '../../core/config/index.js';
+import { load_svelte_config, process_config, split_config } from '../../core/config/index.js';
 import { generate_manifest } from '../../core/generate_manifest/index.js';
 import { build_server_nodes } from './build/build_server.js';
 import { build_service_worker } from './build/build_service_worker.js';
@@ -143,19 +143,27 @@ const warning_preprocessor = {
 /**
  * Returns the SvelteKit Vite plugins.
  * Since version 2.62.0 you can pass [configuration](configuration) directly, in which case `svelte.config.js` is ignored.
- * @param {KitConfig & Omit<SvelteConfig, 'onwarn'>} [config]
+ * Any options that don't belong to SvelteKit are passed through to `vite-plugin-svelte`.
+ * @param {KitConfig & Omit<Options, 'onwarn'> & Pick<SvelteConfig, 'vitePlugin'>} [config]
  * @returns {Promise<Plugin[]>}
  */
 export async function sveltekit(config) {
 	/** @type {ValidatedConfig} */
 	let svelte_config;
 
+	// any options passed to the plugin that SvelteKit doesn't use itself are
+	// forwarded to vite-plugin-svelte, which does its own validation
+	/** @type {Record<string, any>} */
+	let vite_plugin_svelte_config = {};
+
 	if (config !== undefined) {
-		const { extensions, compilerOptions, vitePlugin, preprocess, ...kit } = config;
-		svelte_config = process_config(
-			{ extensions, compilerOptions, vitePlugin, preprocess, kit },
-			{ cwd, source: 'SvelteKit options from Vite config' }
-		);
+		const split = split_config(config);
+		vite_plugin_svelte_config = split.vite_plugin_svelte_config;
+
+		svelte_config = process_config(split.svelte_config, {
+			cwd,
+			source: 'SvelteKit options from Vite config'
+		});
 
 		const config_file = ['svelte.config.js', 'svelte.config.ts'].find((file) =>
 			fs.existsSync(file)
@@ -180,6 +188,9 @@ export async function sveltekit(config) {
 
 	/** @type {Options} */
 	const vite_plugin_svelte_options = {
+		// pass through any options that SvelteKit doesn't use itself first, so
+		// that the options SvelteKit manages below always take precedence
+		...vite_plugin_svelte_config,
 		configFile: false,
 		extensions: svelte_config.extensions,
 		preprocess,

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3091,13 +3091,14 @@ declare module '@sveltejs/kit/node/polyfills' {
 
 declare module '@sveltejs/kit/vite' {
 	import type { KitConfig } from '@sveltejs/kit';
-	import type { SvelteConfig } from '@sveltejs/vite-plugin-svelte';
+	import type { Options, SvelteConfig } from '@sveltejs/vite-plugin-svelte';
 	import type { Plugin } from 'vite';
 	/**
 	 * Returns the SvelteKit Vite plugins.
 	 * Since version 2.62.0 you can pass [configuration](configuration) directly, in which case `svelte.config.js` is ignored.
+	 * Any options that don't belong to SvelteKit are passed through to `vite-plugin-svelte`.
 	 * */
-	export function sveltekit(config?: KitConfig & Omit<SvelteConfig, "onwarn">): Promise<Plugin[]>;
+	export function sveltekit(config?: KitConfig & Omit<Options, "onwarn"> & Pick<SvelteConfig, "vitePlugin">): Promise<Plugin[]>;
 
 	export {};
 }


### PR DESCRIPTION
Closes #16009

Previously `sveltekit(...)` only forwarded a subset of options to `vite-plugin-svelte` and treated everything else as Kit options, so options like `inspector` were rejected as unexpected Kit options instead of being passed through.

### Changes

- New internal `split_config()` helper that **plucks out SvelteKit's own options and passes everything else through to `vite-plugin-svelte`** (which does its own validation), making no assumptions about what VPS accepts.
- Resolves the shared `experimental` namespace: SvelteKit reads the flags it recognises and forwards the rest to VPS.
- The lists of Kit option keys are **derived from the validation schema** (`options.js` now exports `kit_options` / `kit_experimental_options`) so they stay in sync automatically.
- Types now use `Options` from `vite-plugin-svelte` instead of `SvelteConfig` (kept `Pick<SvelteConfig, 'vitePlugin'>` for back-compat).
- Docs + changeset + unit tests (passthrough, experimental splitting, fixture regression with `inspector: true`).

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changesets that add features with `feat:` and bugfixes with `fix:`.