### PR TITLE
chore: more queries-in-queries fixes

### DIFF
--- a/packages/kit/src/runtime/app/server/remote/form.js
+++ b/packages/kit/src/runtime/app/server/remote/form.js
@@ -11,7 +11,7 @@ import {
 	normalize_issue,
 	flatten_issues
 } from '../../../form-utils.js';
-import { get_cache, run_remote_function } from './shared.js';
+import { get_cache, get_implicit_lookup, run_remote_function } from './shared.js';
 import { ValidationError } from '@sveltejs/kit/internal';
 
 /**
@@ -158,7 +158,12 @@ export function form(validate_or_fn, maybe_fn) {
 				// We don't need to care about args or deduplicating calls, because uneval results are only relevant in full page reloads
 				// where only one form submission is active at the same time
 				if (!event.isRemoteRequest) {
-					get_cache(__, state)[''] ??= output;
+					const cache = get_cache(__, state);
+					cache[''] ??= output;
+
+					// register under the client-side action id so the output is serialized
+					// into the page, allowing the hydrated client to restore `result`/`issues`/`input`
+					get_implicit_lookup(__, state)[__.action_id ?? __.id] = () => cache[''];
 				}
 
 				return output;
@@ -263,6 +268,7 @@ export function form(validate_or_fn, maybe_fn) {
 					if (!instance) {
 						instance = create_instance(key);
 						instance.__.id = `${__.id}/${encodeURIComponent(JSON.stringify(key))}`;
+						instance.__.action_id = `${__.id}/${JSON.stringify(key)}`;
 						instance.__.name = __.name;
 
 						state.remote.forms.set(cache_key, instance);

--- a/packages/kit/src/runtime/app/server/remote/form.js
+++ b/packages/kit/src/runtime/app/server/remote/form.js
@@ -174,11 +174,13 @@ export function form(validate_or_fn, maybe_fn) {
 
 		Object.defineProperty(instance, 'fields', {
 			get() {
+				// the form instance is created once per module and shared across requests,
+				// so the current request's state has to be resolved at access time
 				return create_field_proxy(
 					{},
-					() => get_cache(__)?.['']?.input ?? {},
+					() => get_cache(__, get_request_store().state)?.['']?.input ?? {},
 					(path, value) => {
-						const cache = get_cache(__);
+						const cache = get_cache(__, get_request_store().state);
 						const entry = cache[''];
 
 						if (entry?.submission) {
@@ -195,7 +197,7 @@ export function form(validate_or_fn, maybe_fn) {
 						deep_set(input, path.map(String), value);
 						(cache[''] ??= {}).input = input;
 					},
-					() => flatten_issues(get_cache(__)?.['']?.issues ?? [])
+					() => flatten_issues(get_cache(__, get_request_store().state)?.['']?.issues ?? [])
 				);
 			}
 		});
@@ -217,7 +219,7 @@ export function form(validate_or_fn, maybe_fn) {
 		Object.defineProperty(instance, 'result', {
 			get() {
 				try {
-					return get_cache(__)?.['']?.result;
+					return get_cache(__, get_request_store().state)?.['']?.result;
 				} catch {
 					return undefined;
 				}

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -401,7 +401,7 @@ function batch(validate_or_fn, maybe_fn) {
  * @param {string} payload
  * @param {() => Promise<any>} fn
  */
-function refresh(event, state, internals, payload, fn) {
+export function refresh(event, state, internals, payload, fn) {
 	if (!internals.id) {
 		// unless this is a non-exported (i.e. private) query...
 		return;
@@ -451,7 +451,11 @@ function create_query_resource(__, payload, event, state, fn) {
 		// accessing data properties needs to kick off the work
 		// so that it gets seeded in the hydration cache
 		// and becomes available on the client
-		void (__.id && state.is_in_render && get_promise());
+		if (__.id && state.is_in_render) {
+			// swallow rejections so they don't crash the server — the error is
+			// serialized into the response and surfaced on the client instead
+			get_promise().catch(noop);
+		}
 	};
 
 	return {
@@ -538,7 +542,11 @@ function create_live_query_resource(__, payload, event, state, get_generator) {
 	};
 
 	const populate_hydratable = () => {
-		void (__.id && state.is_in_render && get_promise());
+		if (__.id && state.is_in_render) {
+			// swallow rejections so they don't crash the server — the error is
+			// serialized into the response and surfaced on the client instead
+			get_promise().catch(noop);
+		}
 	};
 
 	return {

--- a/packages/kit/src/runtime/app/server/remote/requested.js
+++ b/packages/kit/src/runtime/app/server/remote/requested.js
@@ -1,9 +1,11 @@
 /** @import { RemoteLiveQuery, RemoteLiveQueryFunction, RemoteQuery, RemoteQueryFunction, RequestedResult, QueryRequestedResult, LiveQueryRequestedResult } from '@sveltejs/kit' */
 /** @import { MaybePromise, RemoteAnyQueryInternals } from 'types' */
+import { HttpError } from '@sveltejs/kit/internal';
 import { get_request_store } from '@sveltejs/kit/internal/server';
 import { parse_remote_arg } from '../../../shared.js';
 import { noop } from '../../../../utils/functions.js';
 import { get_cache } from './shared.js';
+import { refresh } from './query.js';
 
 /**
  * In the context of a remote `command` or `form` request, returns an iterable
@@ -96,7 +98,7 @@ import { get_cache } from './shared.js';
  * @returns {RequestedResult<Validated, Output>}
  */
 export function requested(query, limit) {
-	const { state } = get_request_store();
+	const { event, state } = get_request_store();
 	const internals = /** @type {RemoteAnyQueryInternals | undefined} */ (
 		/** @type {any} */ (query).__
 	);
@@ -129,6 +131,9 @@ export function requested(query, limit) {
 	const [selected, skipped] = split_limit(payloads, limit);
 
 	/**
+	 * Registers the failure exactly like `.set()` registers a value: the error record
+	 * is serialized to the client (putting the query there into a failed state), and
+	 * subsequent server-side calls of the query with the same argument reject with it.
 	 * @param {string} payload
 	 * @param {unknown} error
 	 */
@@ -137,12 +142,14 @@ export function requested(query, limit) {
 		promise.catch(noop);
 
 		get_cache(__, state)[payload] = promise;
+		refresh(event, state, __, payload, () => promise);
 	};
 
 	for (const payload of skipped) {
 		record_failure(
 			payload,
-			new Error(
+			new HttpError(
+				400,
 				`Requested refresh was rejected because it exceeded requested(${__.name}, ${limit}) limit`
 			)
 		);

--- a/packages/kit/src/runtime/app/server/remote/shared.js
+++ b/packages/kit/src/runtime/app/server/remote/shared.js
@@ -225,10 +225,15 @@ function to_iterator(source, name) {
 }
 
 /**
+ * Note that `state` is deliberately not optional: resources that capture the request
+ * state at creation must pass it explicitly, because reading it from the request store
+ * at call time is only equivalent on runtimes with `AsyncLocalStorage` support.
+ * Callers without a captured state (such as the module-level `form` instance getters)
+ * should pass `get_request_store().state` themselves.
  * @param {RemoteInternals} internals
  * @param {RequestState} state
  */
-export function get_cache(internals, state = get_request_store().state) {
+export function get_cache(internals, state) {
 	let cache = state.remote.data?.get(internals);
 
 	if (cache === undefined) {
@@ -243,7 +248,7 @@ export function get_cache(internals, state = get_request_store().state) {
  * @param {RemoteInternals} internals
  * @param {RequestState} state
  */
-export function get_implicit_lookup(internals, state = get_request_store().state) {
+export function get_implicit_lookup(internals, state) {
 	let cache = state.remote.implicit?.get(internals);
 
 	if (cache === undefined) {

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1,4 +1,4 @@
-/** @import { ServerNodesResponse, ServerRedirectNode } from 'types' */
+/** @import { RemoteFunctionDataNode, ServerNodesResponse, ServerRedirectNode } from 'types' */
 /** @import { CacheEntry } from './remote-functions/cache.svelte.js' */
 /** @import { Query } from './remote-functions/query/instance.svelte.js' */
 /** @import { LiveQuery } from './remote-functions/query-live/instance.svelte.js' */
@@ -202,16 +202,18 @@ let target;
 export let app;
 
 /**
- * Data that was serialized during SSR for queries/forms/commands.
- * This is cleared before client-side loads run.
- * @type {Record<string, any>}
+ * Data that was serialized during SSR for queries/forms/commands, stored as
+ * `{ v }` (value) or `{ e }` (error) nodes so that failed states survive hydration.
+ * Entries are deleted as they are consumed (when the corresponding resource is created).
+ * @type {Record<string, RemoteFunctionDataNode>}
  */
-export let query_responses = {};
+export const query_responses = {};
 
 /**
- * Data that was serialized during SSR for prerender functions.
+ * Data that was serialized during SSR for prerender functions, stored as
+ * `{ v }` (value) or `{ e }` (error) nodes.
  * This persists across client-side navigations.
- * @type {Record<string, any>}
+ * @type {Record<string, RemoteFunctionDataNode>}
  */
 export const prerender_responses = {};
 
@@ -331,22 +333,12 @@ export async function start(_app, _target, hydrate) {
 	if (__SVELTEKIT_PAYLOAD__.data) {
 		const { q = {}, p = {}, l = {}, f = {} } = __SVELTEKIT_PAYLOAD__.data;
 
-		// TODO we're currently ignoring errors, is that right?
-		for (const k in q) {
-			if (!q[k].e) query_responses[k] = q[k].v;
-		}
-
-		for (const k in l) {
-			if (!l[k].e) query_responses[k] = l[k].v;
-		}
-
-		for (const k in f) {
-			if (!f[k].e) query_responses[k] = f[k].v;
-		}
-
-		for (const k in p) {
-			if (!p[k].e) prerender_responses[k] = p[k].v;
-		}
+		// store the whole nodes — error records seed the corresponding
+		// resources in a failed state when they are created during hydration
+		for (const k in q) query_responses[k] = q[k];
+		for (const k in l) query_responses[k] = l[k];
+		for (const k in f) query_responses[k] = f[k];
+		for (const k in p) prerender_responses[k] = p[k];
 	}
 
 	// detect basic auth credentials in the current URL
@@ -716,10 +708,6 @@ async function initialize(result, target, hydrate) {
 					return error;
 				}
 			: undefined
-	});
-
-	void svelte.settled?.().then(() => {
-		query_responses = {};
 	});
 
 	// Wait for a microtask in case svelte experimental async is enabled,

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -329,7 +329,7 @@ export async function start(_app, _target, hydrate) {
 	}
 
 	if (__SVELTEKIT_PAYLOAD__.data) {
-		const { q = {}, p = {}, l = {} } = __SVELTEKIT_PAYLOAD__.data;
+		const { q = {}, p = {}, l = {}, f = {} } = __SVELTEKIT_PAYLOAD__.data;
 
 		// TODO we're currently ignoring errors, is that right?
 		for (const k in q) {
@@ -338,6 +338,10 @@ export async function start(_app, _target, hydrate) {
 
 		for (const k in l) {
 			if (!l[k].e) query_responses[k] = l[k].v;
+		}
+
+		for (const k in f) {
+			if (!f[k].e) query_responses[k] = f[k].v;
 		}
 
 		for (const k in p) {

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -60,9 +60,10 @@ export function form(id) {
 		const action = '?/remote=' + encodeURIComponent(action_id);
 
 		// the output of a non-enhanced submission that resulted in this page —
-		// consume it so the form's state survives hydration
+		// consume it so the form's state survives hydration (form outputs are
+		// always value nodes; the server never serializes them as errors)
 		/** @type {{ input?: Record<string, any>, issues?: InternalRemoteFormIssue[], result?: any } | undefined} */
-		const initial = query_responses[action_id];
+		const initial = query_responses[action_id]?.v;
 		delete query_responses[action_id];
 
 		/**

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -59,18 +59,24 @@ export function form(id) {
 		const action_id = id + (key != undefined ? `/${JSON.stringify(key)}` : '');
 		const action = '?/remote=' + encodeURIComponent(action_id);
 
+		// the output of a non-enhanced submission that resulted in this page —
+		// consume it so the form's state survives hydration
+		/** @type {{ input?: Record<string, any>, issues?: InternalRemoteFormIssue[], result?: any } | undefined} */
+		const initial = query_responses[action_id];
+		delete query_responses[action_id];
+
 		/**
 		 * @type {Record<string, string | string[] | File | File[]>}
 		 */
-		let input = $state({});
+		let input = $state(initial?.input ?? {});
 
 		/** @type {InternalRemoteFormIssue[]} */
-		let raw_issues = $state.raw([]);
+		let raw_issues = $state.raw(initial?.issues ?? []);
 
 		const issues = $derived(flatten_issues(raw_issues));
 
 		/** @type {any} */
-		let result = $state.raw(query_responses[action_id]);
+		let result = $state.raw(initial?.result);
 
 		/** @type {number} */
 		let pending_count = $state(0);
@@ -197,12 +203,16 @@ export function form(id) {
 
 					({ issues: raw_issues = [], result } = response._ ?? {});
 
+					// if the developer took control of updates via `.updates(...)` (even with
+					// no arguments), or the server performed explicit refreshes, don't invalidateAll
+					const should_invalidate = refreshes === null && !response.r;
+
 					if (response.redirect) {
 						// Use internal version to allow redirects to external URLs
 						void _goto(
 							response.redirect,
 							{
-								invalidateAll: !response.r
+								invalidateAll: should_invalidate
 							},
 							0
 						);
@@ -212,7 +222,7 @@ export function form(id) {
 					const succeeded = raw_issues.length === 0;
 
 					if (succeeded) {
-						if (!response.r) {
+						if (should_invalidate) {
 							void invalidateAll();
 						}
 					} else {

--- a/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
@@ -3,7 +3,7 @@ import { app_dir, base } from '$app/paths/internal/client';
 import { version } from '$app/env';
 import * as devalue from 'devalue';
 import { app, goto, prerender_responses } from '../client.js';
-import { get_remote_request_headers, remote_request } from './shared.svelte.js';
+import { get_remote_request_headers, remote_request, unwrap_node } from './shared.svelte.js';
 import { create_remote_key, stringify_remote_arg } from '../../shared.js';
 
 // Initialize Cache API for prerender functions
@@ -67,7 +67,7 @@ export function prerender(id) {
 				const url = `${base}/${app_dir}/remote/${id}${payload ? `/${payload}` : ''}`;
 
 				if (Object.hasOwn(prerender_responses, cache_key)) {
-					const data = prerender_responses[cache_key];
+					const data = unwrap_node(prerender_responses[cache_key]);
 
 					if (prerender_cache) {
 						void put(url, devalue.stringify(data, app.encoders));

--- a/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
@@ -1,6 +1,6 @@
 /** @import { RemoteQueryFunction } from '@sveltejs/kit' */
 import { app_dir, base } from '$app/paths/internal/client';
-import { goto, query_responses } from '../client.js';
+import { goto } from '../client.js';
 import { get_remote_request_headers, QUERY_FUNCTION_ID, remote_request } from './shared.svelte.js';
 import { QueryProxy } from './query/proxy.js';
 import { HttpError } from '@sveltejs/kit/internal';
@@ -15,13 +15,7 @@ export function query_batch(id) {
 
 	/** @type {RemoteQueryFunction<any, any>} */
 	const wrapper = (arg) => {
-		return new QueryProxy(id, arg, async (key, payload) => {
-			if (Object.hasOwn(query_responses, key)) {
-				const value = query_responses[key];
-				delete query_responses[key];
-				return value;
-			}
-
+		return new QueryProxy(id, arg, async (payload) => {
 			return await new Promise((resolve, reject) => {
 				// create_remote_function caches identical calls, but in case a refresh to the same query is called multiple times this function
 				// is invoked multiple times with the same payload, so we need to deduplicate here

--- a/packages/kit/src/runtime/client/remote-functions/query-live/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/instance.svelte.js
@@ -86,9 +86,24 @@ export class LiveQuery {
 		this.#reject_first = reject;
 
 		if (Object.hasOwn(query_responses, key)) {
-			const value = query_responses[key];
+			const node = query_responses[key];
 			delete query_responses[key];
-			this.set(value);
+
+			if (node.e) {
+				// the query failed during SSR — seed the failed state (mirroring `fail()`,
+				// minus its terminal `#done`), so the main loop still connects as usual
+				// and the query can recover
+				const error = new HttpError(node.e[0] ?? 500, node.e[1]);
+				this.#loading = false;
+				this.#error = error;
+
+				promise.catch(noop);
+				this.#reject_first?.(error);
+				this.#resolve_first = null;
+				this.#reject_first = null;
+			} else {
+				this.set(node.v);
+			}
 		}
 	}
 

--- a/packages/kit/src/runtime/client/remote-functions/query/index.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/index.js
@@ -1,6 +1,6 @@
 /** @import { RemoteQueryFunction } from '@sveltejs/kit' */
 import { app_dir, base } from '$app/paths/internal/client';
-import { goto, query_map, query_responses } from '../../client.js';
+import { goto, query_map } from '../../client.js';
 import { get_remote_request_headers, QUERY_FUNCTION_ID, remote_request } from '../shared.svelte.js';
 import { DEV } from 'esm-env';
 import { QueryProxy } from './proxy.js';
@@ -23,13 +23,7 @@ export function query(id) {
 
 	/** @type {RemoteQueryFunction<any, any>} */
 	const wrapper = (arg) => {
-		return new QueryProxy(id, arg, async (key, payload) => {
-			if (Object.hasOwn(query_responses, key)) {
-				const value = query_responses[key];
-				delete query_responses[key];
-				return value;
-			}
-
+		return new QueryProxy(id, arg, async (payload) => {
 			const url = `${base}/${app_dir}/remote/${id}${payload ? `?payload=${payload}` : ''}`;
 
 			const result = await remote_request(url, { headers: get_remote_request_headers() });

--- a/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
@@ -1,4 +1,5 @@
 import { query_responses } from '../../client.js';
+import { HttpError } from '@sveltejs/kit/internal';
 import { QUERY_OVERRIDE_KEY } from '../shared.svelte.js';
 import { noop } from '../../../../utils/functions.js';
 import { with_resolvers } from '../../../../utils/promise.js';
@@ -64,6 +65,17 @@ export class Query {
 	constructor(key, fn) {
 		this.#key = key;
 		this.#fn = fn;
+
+		if (Object.hasOwn(query_responses, key)) {
+			const node = query_responses[key];
+			delete query_responses[key];
+
+			if (node.e) {
+				this.fail(new HttpError(node.e[0] ?? 500, node.e[1]));
+			} else {
+				this.set(/** @type {T} */ (node.v));
+			}
+		}
 	}
 
 	#get_promise() {
@@ -199,6 +211,10 @@ export class Query {
 	 * @param {T} value
 	 */
 	set(value) {
+		// normally consumed in the constructor, but make sure a leftover
+		// SSR record can never shadow the newly-set value
+		delete query_responses[this.#key];
+
 		this.#clear_pending();
 		this.#ready = true;
 		this.#loading = false;
@@ -211,6 +227,10 @@ export class Query {
 	 * @param {unknown} error
 	 */
 	fail(error) {
+		// normally consumed in the constructor, but make sure a leftover
+		// SSR record can never shadow the newly-set error
+		delete query_responses[this.#key];
+
 		this.#clear_pending();
 		this.#loading = false;
 		this.#error = error;

--- a/packages/kit/src/runtime/client/remote-functions/query/proxy.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/proxy.js
@@ -25,7 +25,7 @@ export class QueryProxy {
 	/**
 	 * @param {string} id
 	 * @param {any} arg
-	 * @param {(key: string, payload: string) => Promise<T>} fn
+	 * @param {(payload: string) => Promise<T>} fn
 	 */
 	constructor(id, arg, fn) {
 		this.#id = id;
@@ -41,7 +41,7 @@ export class QueryProxy {
 			this.#payload,
 			// IMPORTANT: This cannot close over `this` or it becomes impossible to
 			// garbage collect the QueryProxy and thus impossible to evict cache entries.
-			() => new Query(key, () => fn(key, payload))
+			() => new Query(key, () => fn(payload))
 		);
 
 		cache.ref(this, entry, this.#id, this.#payload);
@@ -98,7 +98,7 @@ export class QueryProxy {
 			this.#payload,
 			// IMPORTANT: This cannot close over `this` or it becomes impossible to
 			// garbage collect the QueryProxy and thus impossible to evict cache entries.
-			() => new Query(key_ref, () => fn_ref(key_ref, payload_ref))
+			() => new Query(key_ref, () => fn_ref(payload_ref))
 		);
 
 		const deref = cache.manual_ref(entry, this.#id, this.#payload);

--- a/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
@@ -141,7 +141,10 @@ export async function remote_request(url, init) {
 				entry.resource.set(result.v);
 			}
 		} else if (!result.e) {
-			query_responses[key] = result.v;
+			// `query_responses` stores `{ v }`/`{ e }` nodes, not raw values.
+			// Errors are deliberately dropped here: they are responses to a specific
+			// refresh, not durable state a future resource should initialize with
+			query_responses[key] = result;
 		}
 	}
 

--- a/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
@@ -1,4 +1,4 @@
-/** @import { RemoteFunctionResponse, RemoteFunctionData } from 'types' */
+/** @import { RemoteFunctionResponse, RemoteFunctionData, RemoteFunctionDataNode } from 'types' */
 /** @import { RemoteQueryUpdate } from '@sveltejs/kit' */
 /** @import { CacheEntry } from './cache.svelte.js' */
 import * as devalue from 'devalue';
@@ -78,6 +78,20 @@ export function pin_while_resolving(cache_map, cache, id, payload, then) {
 /**
  * @returns {{ 'x-sveltekit-pathname': string, 'x-sveltekit-search': string }}
  */
+/**
+ * Unwraps a `RemoteFunctionDataNode` that was serialized during SSR,
+ * rethrowing serialized errors so the consuming resource ends up
+ * in the same failed state it had on the server
+ * @param {RemoteFunctionDataNode} node
+ */
+export function unwrap_node(node) {
+	if (node.e) {
+		throw new HttpError(node.e[0] ?? 500, node.e[1]);
+	}
+
+	return node.v;
+}
+
 export function get_remote_request_headers() {
 	// This will be the correct value of the current or soon-current url,
 	// even in forks because it's state-based - therefore not using window.location.

--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -463,7 +463,10 @@ export async function handle_remote_form_post(event, state, manifest, id) {
  * @returns {Promise<ActionResult>}
  */
 async function handle_remote_form_post_internal(event, state, manifest, id) {
-	const [hash, name, action_id] = id.split('/');
+	// `hash` and `name` can never contain a `/`, but the JSON-stringified key of a
+	// keyed (`form.for(key)`) instance can — rejoin the remaining segments
+	const [hash, name, ...rest] = id.split('/');
+	const action_id = rest.join('/');
 	const remotes = manifest._.remotes;
 	const module = await remotes[hash]?.();
 

--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -370,9 +370,10 @@ export async function collect_remote_data(data, event, state, options) {
 			if (!internals.id) continue;
 
 			for (const key in record) {
-				const remote_key = create_remote_key(internals.id, key);
+				// form outputs are registered under the client-side action id directly
+				const remote_key = internals.type === 'form' ? key : create_remote_key(internals.id, key);
 
-				const type = /** @type {'p' | 'q' | 'l'} */ (
+				const type = /** @type {'p' | 'q' | 'l' | 'f'} */ (
 					internals.type === 'query_live' ? 'l' : internals.type[0]
 				);
 

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -322,6 +322,8 @@ export type RemoteFunctionData = {
 	q?: Record<string, RemoteFunctionDataNode>;
 	/** `query.live` data that was accessed during the request */
 	l?: Record<string, RemoteFunctionDataNode>;
+	/** `form` outputs (result/issues/input) from a non-enhanced submission, keyed by the client-side action id */
+	f?: Record<string, RemoteFunctionDataNode>;
 	/** Whether there were any refreshes/reconnects during the request */
 	r?: true;
 	/** The redirect location, if any */
@@ -667,6 +669,11 @@ export interface RemoteCommandInternals extends BaseRemoteInternals {
 
 export interface RemoteFormInternals extends BaseRemoteInternals {
 	type: 'form';
+	/**
+	 * For keyed (`form.for(key)`) instances: the id as the client computes it
+	 * (the key is JSON-stringified but not URI-encoded, unlike `id`)
+	 */
+	action_id?: string;
 	fn(body: Record<string, any>, meta: BinaryFormMeta, form_data: FormData | null): Promise<any>;
 }
 

--- a/packages/kit/test/apps/async/src/routes/remote/error-hydration/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/error-hydration/+page.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { failing } from './data.remote';
+
+	const q = failing();
+</script>
+
+<div id="q-error">{q.error ? `${q.error.status}: ${q.error.body?.message}` : 'none'}</div>

--- a/packages/kit/test/apps/async/src/routes/remote/error-hydration/batch/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/error-hydration/batch/+page.svelte
@@ -1,0 +1,20 @@
+<script>
+	import { failing_batch } from '../data.remote';
+
+	const q = failing_batch('x');
+</script>
+
+<!--
+	batch execution is deferred to a macrotask, so the query has to be awaited
+	for it to settle during SSR and have its error record serialized. The failed
+	boundary doesn't re-run on hydration, so the seeded error is observed via
+	the reactive getter below.
+-->
+<svelte:boundary>
+	<div id="batch-value">{await q}</div>
+	{#snippet failed()}
+		<div id="batch-boundary-error">failed</div>
+	{/snippet}
+</svelte:boundary>
+
+<div id="batch-error">{q.error ? `${q.error.status}: ${q.error.body?.message}` : 'none'}</div>

--- a/packages/kit/test/apps/async/src/routes/remote/error-hydration/data.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/error-hydration/data.remote.ts
@@ -1,0 +1,13 @@
+import { query } from '$app/server';
+import { error } from '@sveltejs/kit';
+import * as v from 'valibot';
+
+export const failing = query(() => {
+	error(418, 'teapot');
+});
+
+export const failing_batch = query.batch(v.string(), () => {
+	return () => {
+		error(418, 'batch teapot');
+	};
+});

--- a/packages/kit/test/apps/async/src/routes/remote/form/native-result/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/native-result/+page.svelte
@@ -5,6 +5,9 @@
 	// a key with a space forces the encoded (server) and raw (client) id conventions to diverge
 	const keyed = echo.for('a b');
 
+	// a key with a slash must not break the `?/remote=` id parsing on the server
+	const keyed_slash = echo.for('a/b');
+
 	let hydrated = $state(false);
 
 	onMount(() => {
@@ -16,6 +19,7 @@
 <div id="result">{echo.result ?? 'none'}</div>
 <div id="issue">{echo.fields.message.issues()?.[0]?.message ?? 'no issues'}</div>
 <div id="keyed-result">{keyed.result ?? 'none'}</div>
+<div id="keyed-slash-result">{keyed_slash.result ?? 'none'}</div>
 
 <!-- deliberately not enhanced: action/method only, so submission is a native full-page POST -->
 <form id="plain" action={echo.action} method="POST">
@@ -25,5 +29,10 @@
 
 <form id="keyed" action={keyed.action} method="POST">
 	<input {...keyed.fields.message.as('text')} />
+	<button type="submit">Submit</button>
+</form>
+
+<form id="keyed-slash" action={keyed_slash.action} method="POST">
+	<input {...keyed_slash.fields.message.as('text')} />
 	<button type="submit">Submit</button>
 </form>

--- a/packages/kit/test/apps/async/src/routes/remote/form/native-result/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/native-result/+page.svelte
@@ -1,0 +1,29 @@
+<script>
+	import { onMount } from 'svelte';
+	import { echo } from './form.remote';
+
+	// a key with a space forces the encoded (server) and raw (client) id conventions to diverge
+	const keyed = echo.for('a b');
+
+	let hydrated = $state(false);
+
+	onMount(() => {
+		hydrated = true;
+	});
+</script>
+
+<div id="hydrated">{hydrated}</div>
+<div id="result">{echo.result ?? 'none'}</div>
+<div id="issue">{echo.fields.message.issues()?.[0]?.message ?? 'no issues'}</div>
+<div id="keyed-result">{keyed.result ?? 'none'}</div>
+
+<!-- deliberately not enhanced: action/method only, so submission is a native full-page POST -->
+<form id="plain" action={echo.action} method="POST">
+	<input {...echo.fields.message.as('text')} />
+	<button type="submit">Submit</button>
+</form>
+
+<form id="keyed" action={keyed.action} method="POST">
+	<input {...keyed.fields.message.as('text')} />
+	<button type="submit">Submit</button>
+</form>

--- a/packages/kit/test/apps/async/src/routes/remote/form/native-result/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/native-result/form.remote.ts
@@ -1,0 +1,9 @@
+import { form } from '$app/server';
+import * as v from 'valibot';
+
+export const echo = form(
+	v.object({ message: v.pipe(v.string(), v.minLength(3, 'too short')) }),
+	({ message }) => {
+		return `echo: ${message}`;
+	}
+);

--- a/packages/kit/test/apps/async/src/routes/remote/form/updates-no-invalidate/[key]/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/updates-no-invalidate/[key]/+page.svelte
@@ -1,0 +1,17 @@
+<script>
+	import { get_count, increment } from './form.remote';
+
+	const { params } = $props();
+</script>
+
+<div id="count">Count: {await get_count(params.key)}</div>
+<div id="result">Result: {increment.result ?? 'none'}</div>
+
+<form
+	{...increment.enhance(async ({ submit }) => {
+		await submit().updates();
+	})}
+>
+	<input {...increment.fields.key.as('hidden', params.key)} />
+	<button type="submit">Submit</button>
+</form>

--- a/packages/kit/test/apps/async/src/routes/remote/form/updates-no-invalidate/[key]/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/updates-no-invalidate/[key]/form.remote.ts
@@ -1,0 +1,15 @@
+import { form, query } from '$app/server';
+import * as v from 'valibot';
+
+const counts = new Map<string, number>();
+
+export const get_count = query(v.string(), (key) => {
+	return counts.get(key) ?? 0;
+});
+
+// deliberately refreshes nothing — the client's `.updates()` call alone
+// should suppress `invalidateAll`
+export const increment = form(v.object({ key: v.string() }), ({ key }) => {
+	counts.set(key, (counts.get(key) ?? 0) + 1);
+	return 'done';
+});

--- a/packages/kit/test/apps/async/src/routes/remote/live-error-seed/[key]/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/live-error-seed/[key]/+page.svelte
@@ -1,0 +1,8 @@
+<script>
+	import { live_fail } from './data.remote';
+
+	const { params } = $props();
+	const q = $derived(live_fail(params.key));
+</script>
+
+<div id="live-error">{q.error ? `${q.error.status}: ${q.error.body.message}` : 'none'}</div>

--- a/packages/kit/test/apps/async/src/routes/remote/live-error-seed/[key]/data.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/live-error-seed/[key]/data.remote.ts
@@ -1,0 +1,17 @@
+import { query } from '$app/server';
+import { error } from '@sveltejs/kit';
+import * as v from 'valibot';
+
+const seen = new Set<string>();
+
+export const live_fail = query.live(v.string(), async function* (key) {
+	if (!seen.has(key)) {
+		// first connection (the SSR render) fails...
+		seen.add(key);
+		error(418, 'live teapot');
+	}
+
+	// ...subsequent connections block forever, so the only way the client
+	// can show the error is by consuming the seeded SSR error record
+	yield await new Promise<string>(() => {});
+});

--- a/packages/kit/test/apps/async/src/routes/remote/live-ssr-value/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/live-ssr-value/data.remote.js
@@ -4,7 +4,7 @@ import { command, query } from '$app/server';
 const seen = new Set();
 /** @type {Set<string>} */
 const notified = new Set();
-/** @type {Set<{ key: string, resolve: () => void }>} */
+/** @type {Set<{ key: string, resolve: (value?: any) => void }>} */
 const listeners = new Set();
 
 export const live_value = query.live('unchecked', async function* (key) {

--- a/packages/kit/test/apps/async/src/routes/remote/private-query/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/private-query/+page.svelte
@@ -1,5 +1,8 @@
 <script>
 	import { reveal } from './data.remote.js';
+
+	let result = $state('none');
 </script>
 
-<button onclick={async () => console.log(await reveal())}>reveal</button>
+<button id="reveal" onclick={async () => (result = await reveal())}>reveal</button>
+<p id="result">{result}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/query-command.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/query-command.remote.js
@@ -1,4 +1,4 @@
-import { command, query, requested } from '$app/server';
+import { command, getRequestEvent, query, requested } from '$app/server';
 
 export const echo = query('unchecked', (value) => value);
 export const add = query('unchecked', ({ a, b }) => a + b);
@@ -9,9 +9,12 @@ let count = 0;
  */
 const deferreds = [];
 
-let get_count_called = false;
+// tracked per request event, so that parallel requests from other tests
+// (e.g. SSR of this route in another playwright worker) don't interfere
+const get_count_callers = new WeakSet();
+
 export const get_count = query(() => {
-	get_count_called = true;
+	get_count_callers.add(getRequestEvent());
 	return count;
 });
 
@@ -88,11 +91,11 @@ export const set_count_server_refresh_after_read = command('unchecked', async (c
 });
 
 export const set_count_server_set = command('unchecked', async (c) => {
-	get_count_called = false;
+	const event = getRequestEvent();
 	count = c;
 	get_count().set(c);
 	await new Promise((resolve) => setTimeout(resolve, 100));
-	if (get_count_called) {
+	if (get_count_callers.has(event)) {
 		throw new Error('get_count should not have been called');
 	}
 	return c;

--- a/packages/kit/test/apps/async/src/routes/remote/requested-limit/[key]/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/requested-limit/[key]/+page.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { bump, get_count } from './data.remote';
+
+	const { params } = $props();
+	const q = $derived(get_count(params.key));
+</script>
+
+<div id="value">{q.current ?? 'unset'}</div>
+<div id="error">{q.error ? `${q.error.status}: ${q.error.body.message}` : 'none'}</div>
+
+<button onclick={() => bump(params.key).updates(q)}>bump</button>

--- a/packages/kit/test/apps/async/src/routes/remote/requested-limit/[key]/data.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/requested-limit/[key]/data.remote.ts
@@ -1,0 +1,14 @@
+import { command, query, requested } from '$app/server';
+import * as v from 'valibot';
+
+const counts = new Map<string, number>();
+
+export const get_count = query(v.string(), (key) => counts.get(key) ?? 0);
+
+export const bump = command(v.string(), (key) => {
+	counts.set(key, (counts.get(key) ?? 0) + 1);
+
+	// limit 0: every requested refresh is over the limit and must be
+	// rejected with an error record that reaches the client
+	requested(get_count, 0);
+});

--- a/packages/kit/test/apps/async/src/routes/remote/sidechannel-store/[key]/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/sidechannel-store/[key]/+page.svelte
@@ -1,0 +1,14 @@
+<script>
+	import { get_value, update } from './data.remote';
+
+	const { params } = $props();
+
+	let show = $state(false);
+</script>
+
+<button id="update" onclick={() => update(params.key)}>update</button>
+<button id="show" onclick={() => (show = true)}>show</button>
+
+{#if show}
+	<div id="value">{await get_value(params.key)}</div>
+{/if}

--- a/packages/kit/test/apps/async/src/routes/remote/sidechannel-store/[key]/data.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/sidechannel-store/[key]/data.remote.ts
@@ -1,0 +1,14 @@
+import { command, query } from '$app/server';
+import * as v from 'valibot';
+
+const store = new Map<string, string>();
+
+export const get_value = query(v.string(), (key) => store.get(key) ?? 'initial');
+
+export const update = command(v.string(), (key) => {
+	store.set(key, 'updated');
+
+	// server-initiated single-flight update for a query that has
+	// no active resource on the client
+	void get_value(key).set('updated');
+});

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -847,6 +847,61 @@ test.describe('remote function mutations', () => {
 		// Should have refreshed
 		await expect(count).toHaveText('Count: 1');
 	});
+
+	test('form result from a native (non-enhanced) submission survives hydration', async ({
+		page
+	}) => {
+		await page.goto('/remote/form/native-result');
+		await page.locator('#plain input[name="message"]').fill('hello');
+		await page.click('#plain button');
+
+		// wait for the page resulting from the full-page POST to hydrate
+		await expect(page.locator('#hydrated')).toHaveText('true');
+		await expect(page.locator('#result')).toHaveText('echo: hello');
+	});
+
+	test('form issues and input from a native (non-enhanced) submission survive hydration', async ({
+		page
+	}) => {
+		await page.goto('/remote/form/native-result');
+		await page.locator('#plain input[name="message"]').fill('ab');
+		await page.click('#plain button');
+
+		// wait for the page resulting from the full-page POST to hydrate
+		await expect(page.locator('#hydrated')).toHaveText('true');
+		await expect(page.locator('#issue')).toHaveText('too short');
+		await expect(page.locator('#plain input[name="message"]')).toHaveValue('ab');
+	});
+
+	test('keyed form result from a native (non-enhanced) submission survives hydration', async ({
+		page
+	}) => {
+		await page.goto('/remote/form/native-result');
+		await page.locator('#keyed input[name="message"]').fill('hello');
+		await page.click('#keyed button');
+
+		// wait for the page resulting from the full-page POST to hydrate
+		await expect(page.locator('#hydrated')).toHaveText('true');
+		await expect(page.locator('#keyed-result')).toHaveText('echo: hello');
+		// the result must not leak to the unkeyed instance
+		await expect(page.locator('#result')).toHaveText('none');
+	});
+
+	test('form submission with .updates() does not trigger invalidateAll', async ({ page }) => {
+		await page.goto(`/remote/form/updates-no-invalidate/${Date.now()}${Math.random()}`);
+
+		const count = page.locator('#count');
+		await expect(count).toHaveText('Count: 0');
+
+		await page.click('button');
+		await expect(page.locator('#result')).toHaveText('Result: done');
+
+		await page.waitForTimeout(100); // allow all requests to finish (in case there are query refreshes which shouldn't happen)
+
+		// the developer took control of updates via `.updates()`, so the query
+		// must not have been refreshed by an implicit invalidateAll
+		await expect(count).toHaveText('Count: 0');
+	});
 });
 
 test.describe('client error boundaries', () => {

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -79,6 +79,48 @@ test.describe('remote function mutations', () => {
 		expect(request_count).toBe(0);
 	});
 
+	test('hydrated query errors are reused', async ({ page }) => {
+		let request_count = 0;
+		page.on('request', (r) => (request_count += r.url().includes('/_app/remote') ? 1 : 0));
+
+		await page.goto('/remote/error-hydration');
+		await expect(page.locator('#q-error')).toHaveText('418: teapot');
+		await page.waitForTimeout(100); // allow all requests to finish (there shouldn't be any)
+		expect(request_count).toBe(0);
+	});
+
+	test('hydrated batch query errors are reused', async ({ page }) => {
+		let request_count = 0;
+		page.on('request', (r) => (request_count += r.url().includes('/_app/remote') ? 1 : 0));
+
+		await page.goto('/remote/error-hydration/batch');
+		await expect(page.locator('#batch-error')).toHaveText('418: batch teapot');
+		await page.waitForTimeout(100); // allow all requests to finish (there shouldn't be any)
+		expect(request_count).toBe(0);
+	});
+
+	test('hydrated query.live errors are reused', async ({ page }) => {
+		await page.goto(`/remote/live-error-seed/${Date.now()}${Math.random()}`);
+
+		// the SSR HTML shows no error (server-side getters are static), but the
+		// hydrated client must seed the failed state from the payload — the
+		// reconnection attempt never settles, so this is the only way the error can appear
+		await expect(page.locator('#live-error')).toHaveText('418: live teapot');
+	});
+
+	test('over-limit requested() refreshes fail the client query', async ({ page }) => {
+		await page.goto(`/remote/requested-limit/${Date.now()}${Math.random()}`);
+
+		await expect(page.locator('#value')).toHaveText('0');
+		await expect(page.locator('#error')).toHaveText('none');
+
+		await page.click('button');
+
+		await expect(page.locator('#error')).toHaveText(
+			'400: Requested refresh was rejected because it exceeded requested(get_count, 0) limit'
+		);
+	});
+
 	test('command returns correct sum but does not refresh data by default', async ({ page }) => {
 		await page.goto('/remote');
 		await expect(page.locator('#count-result')).toHaveText('0 / 0 (false)');

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -887,6 +887,18 @@ test.describe('remote function mutations', () => {
 		await expect(page.locator('#result')).toHaveText('none');
 	});
 
+	test('form keys containing slashes work with native (non-enhanced) submissions', async ({
+		page
+	}) => {
+		await page.goto('/remote/form/native-result');
+		await page.locator('#keyed-slash input[name="message"]').fill('hello');
+		await page.click('#keyed-slash button');
+
+		// wait for the page resulting from the full-page POST to hydrate
+		await expect(page.locator('#hydrated')).toHaveText('true');
+		await expect(page.locator('#keyed-slash-result')).toHaveText('echo: hello');
+	});
+
 	test('form submission with .updates() does not trigger invalidateAll', async ({ page }) => {
 		await page.goto(`/remote/form/updates-no-invalidate/${Date.now()}${Math.random()}`);
 

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -460,6 +460,24 @@ test.describe('remote function mutations', () => {
 		expect(page.url()).toContain('#redirected');
 	});
 
+	test('non-exported remote functions are never serialized into responses', async ({ page }) => {
+		await page.goto('/remote/private-query');
+
+		const [response] = await Promise.all([
+			page.waitForResponse((r) => r.url().includes('/_app/remote')),
+			page.click('#reveal')
+		]);
+
+		const body = await response.text();
+
+		// the command's own (transformed) result is present...
+		expect(body).toContain('PRIVATE-DATA');
+		// ...but the private query's raw value must not leak
+		expect(body).not.toContain('private-data');
+
+		await expect(page.locator('#result')).toHaveText('PRIVATE-DATA');
+	});
+
 	test('query.batch resolver function always receives validated arguments', async ({ page }) => {
 		await page.goto('/remote/batch-validation');
 

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -108,6 +108,23 @@ test.describe('remote function mutations', () => {
 		await expect(page.locator('#live-error')).toHaveText('418: live teapot');
 	});
 
+	test('server-initiated updates for inactive queries are reused when the resource is created', async ({
+		page
+	}) => {
+		await page.goto(`/remote/sidechannel-store/${Date.now()}${Math.random()}`);
+
+		await page.click('#update');
+		await page.waitForTimeout(100); // allow the command roundtrip to finish
+
+		let request_count = 0;
+		page.on('request', (r) => (request_count += r.url().includes('/_app/remote') ? 1 : 0));
+
+		await page.click('#show');
+		await expect(page.locator('#value')).toHaveText('updated');
+		await page.waitForTimeout(100); // allow all requests to finish (there shouldn't be any)
+		expect(request_count).toBe(0);
+	});
+
 	test('over-limit requested() refreshes fail the client query', async ({ page }) => {
 		await page.goto(`/remote/requested-limit/${Date.now()}${Math.random()}`);
 


### PR DESCRIPTION
Fixes
- Standardized query failure serialization — `record_failure` now mirrors `query.set()` exactly (data-cache write + `refresh()` helper), so `requested()` failures serialize like any other refreshed result. Over-limit `requested()` calls produce an `HttpError(400)`
- Query errors survive hydration — `query_responses`/`prerender_responses` store whole `{ v, e }` nodes; `Query`/`LiveQuery` constructors consume the seed, so SSR-failed queries (incl. batch and .live) rehydrate with their error instead of refetching. `LiveQuery` error seeds are non-terminal so the stream still connects.
- Fixed side-channel storage for inactive resources — server-initiated .set()/.refresh() results for queries with no live client resource are now stored as nodes, so a later-created resource initializes with the refreshed value instead of undefined (and without an extra request).
- Fixed `.updates()` suppressing `invalidateAll` — calling `.updates()` with an empty list no longer falls back to `invalidateAll`.
- Fixed no-JS form result hydration — native (non-enhanced) submissions now rehydrate result/issues/input via a new data.f channel keyed by the client-side action id (previously broken on main due to key/shape mismatches).
- Fixed form keys containing / — handle_remote_form_post_internal no longer mis-splits ids whose key contains slashes.
- Fixed server crash on SSR'd failing queries — populate_hydratable discarded promise rejections, crashing node with an unhandled rejection for getter-only failing queries.
- Fixed test flake — set_count_server_set's race detection used a module-global flag shared across playwright workers; now scoped per RequestEvent, so the build suite passes fully parallel.