### PR TITLE
fix: reset queries before navigating when `invalidateAll` is set

### DIFF
--- a/.changeset/long-yaks-care.md
+++ b/.changeset/long-yaks-care.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: reset queries before navigating when `invalidateAll` is set

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -554,7 +554,11 @@ export async function _goto(url, options, redirect_count, nav_token) {
 				force_invalidation = true;
 				query_keys = new Set();
 				for (const [id, entries] of query_map) {
-					for (const payload of entries.keys()) {
+					for (const [payload, entry] of entries) {
+						// don't refresh yet, as some queries will be unrendered,
+						// but clear caches so that newly rendered queries
+						// don't use stale data. TODO same for `live_query_map`
+						entry.resource?.reset();
 						query_keys.add(create_remote_key(id, payload));
 					}
 				}

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -586,7 +586,7 @@ export async function _goto(url, options, redirect_count, nav_token) {
 				for (const [id, entries] of query_map) {
 					for (const [payload, { resource }] of entries) {
 						if (query_keys?.has(create_remote_key(id, payload))) {
-							void resource.refresh();
+							void resource.start();
 						}
 					}
 				}

--- a/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
@@ -263,6 +263,15 @@ export class Query {
 		return release;
 	}
 
+	/**
+	 * Reset ahead of a navigation that invalidates all, to force newly
+	 * rendered queries to get fresh data
+	 */
+	reset() {
+		this.#promise = null;
+		delete query_responses[this.#key];
+	}
+
 	get [Symbol.toStringTag]() {
 		return 'Query';
 	}

--- a/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
@@ -83,7 +83,7 @@ export class Query {
 		return /** @type {Promise<T>} */ (this.#promise);
 	}
 
-	#start() {
+	start() {
 		// there is a really weird bug with untrack and writes and initializations
 		// every time you see this comment, try removing the `tick.then` here and see
 		// if all the tests still pass with the latest svelte version
@@ -144,12 +144,12 @@ export class Query {
 	get then() {
 		// TODO this should be unnecessary but due to the bug described
 		// in #start, we need to do this in some circumstances
-		this.#start();
+		this.start();
 		return this.#then;
 	}
 
 	get catch() {
-		this.#start();
+		this.start();
 		this.#then;
 		return (/** @type {any} */ reject) => {
 			return this.#then(undefined, reject);
@@ -157,7 +157,7 @@ export class Query {
 	}
 
 	get finally() {
-		this.#start();
+		this.start();
 		this.#then;
 		return (/** @type {any} */ fn) => {
 			return this.#then(
@@ -174,12 +174,12 @@ export class Query {
 	}
 
 	get current() {
-		this.#start();
+		this.start();
 		return this.#current;
 	}
 
 	get error() {
-		this.#start();
+		this.start();
 		return this.#error;
 	}
 
@@ -187,7 +187,7 @@ export class Query {
 	 * Returns true if the resource is loading or reloading.
 	 */
 	get loading() {
-		this.#start();
+		this.start();
 		return this.#loading;
 	}
 
@@ -195,7 +195,7 @@ export class Query {
 	 * Returns true once the resource has been loaded for the first time.
 	 */
 	get ready() {
-		this.#start();
+		this.start();
 		return this.#ready;
 	}
 


### PR DESCRIPTION
When navigating with `_goto(url, { invalidateAll: true })`, we don't refresh queries until _after_ the navigation has occurred. That's deliberate, because we wanted to avoid refreshing queries that were unrendered as part of the navigation (though @elliott-with-the-longest-name-on-github I wonder if this actually does anything with our new approach to caching — the queries in question likely won't have been GC'd by the time we refresh them).

The problem is that a newly rendered query might use cached and incorrect data. This fixes it by _resetting_ the query before the navigation, forcing it to go back to the server, and only running it after.

No test because I'm delivering a [workshop](https://master.dev/workshops/svelte-sveltekit-v2) in a few hours and need to finish writing it

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
