### PR TITLE
fix: prevent unhandled rejections from reactively-consumed remote resources

### DIFF
--- a/.changeset/tame-pugs-grin.md
+++ b/.changeset/tame-pugs-grin.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prevent unhandled promise rejections when remote function failures are consumed via `current`/`error` instead of `await`

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -565,9 +565,10 @@ export function form(id) {
 
 					const submission = submit(form_data, true);
 
-					void submission.finally(() => {
+					const decrement = () => {
 						pending_count--;
-					});
+					};
+					void submission.then(decrement, decrement);
 
 					return submission;
 				}

--- a/packages/kit/src/runtime/client/remote-functions/instance.unhandled.svelte.spec.js
+++ b/packages/kit/src/runtime/client/remote-functions/instance.unhandled.svelte.spec.js
@@ -1,0 +1,85 @@
+import { describe, expect, test, vi } from 'vitest';
+import { tick } from 'svelte';
+
+// Mock `client.js` because the real one pulls in the SvelteKit
+// router/hydration machinery and resolves `$app/paths` to a server-side
+// virtual module that only exists during a real SvelteKit build. We only need
+// the cache `Map`s and a stub `app` for the instances' interactions.
+vi.mock(new URL('../client.js', import.meta.url).pathname, () => ({
+	app: { hooks: { transport: {} }, decoders: {}, encoders: {} },
+	query_map: new Map(),
+	query_responses: {},
+	live_query_map: new Map(),
+	prerender_responses: {},
+	goto: () => {}
+}));
+
+// `prerender.svelte.js` references the `__SVELTEKIT_DEV__` build-time constant at
+// module scope; it isn't provided by the unit-test config, so define it here.
+/** @type {any} */ (globalThis).__SVELTEKIT_DEV__ = false;
+
+const { Query } = await import('./query/instance.svelte.js');
+const { LiveQuery } = await import('./query-live/instance.svelte.js');
+const { prerender } = await import('./prerender.svelte.js');
+
+function track_unhandled() {
+	/** @type {unknown[]} */
+	const unhandled = [];
+	const listener = (/** @type {any} */ reason) => unhandled.push(reason);
+	process.on('unhandledRejection', listener);
+	return {
+		unhandled,
+		stop: () => process.off('unhandledRejection', listener)
+	};
+}
+
+async function flush() {
+	await tick();
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	await tick();
+	await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('reactive consumption never produces unhandled rejections', () => {
+	test('Query whose fn rejects', async () => {
+		const tracker = track_unhandled();
+		try {
+			const q = new Query('id/payload', () => Promise.reject(new Error('nope')));
+			void q.current; // reactive read triggers start()
+			await flush();
+			expect(q.error).toBeInstanceOf(Error);
+			expect(tracker.unhandled).toEqual([]);
+		} finally {
+			tracker.stop();
+		}
+	});
+
+	test('LiveQuery.fail without any consumers', async () => {
+		const tracker = track_unhandled();
+		try {
+			const instance = new LiveQuery('id', 'id/payload', 'payload');
+			instance.fail(new Error('nope'));
+			await flush();
+			expect(instance.error).toBeInstanceOf(Error);
+			expect(tracker.unhandled).toEqual([]);
+		} finally {
+			tracker.stop();
+		}
+	});
+
+	test('Prerender whose fetch rejects', async () => {
+		const tracker = track_unhandled();
+		const original_fetch = globalThis.fetch;
+		globalThis.fetch = () => Promise.reject(new Error('nope'));
+		try {
+			const resource = prerender('id')(undefined);
+			void resource.current; // reactive read, no awaiting
+			await flush();
+			expect(resource.error).toBeInstanceOf(Error);
+			expect(tracker.unhandled).toEqual([]);
+		} finally {
+			globalThis.fetch = original_fetch;
+			tracker.stop();
+		}
+	});
+});

--- a/packages/kit/src/runtime/client/remote-functions/instance.unhandled.svelte.spec.js
+++ b/packages/kit/src/runtime/client/remote-functions/instance.unhandled.svelte.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable n/prefer-global/process */
 import { describe, expect, test, vi } from 'vitest';
 import { tick } from 'svelte';
 

--- a/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
@@ -5,6 +5,7 @@ import * as devalue from 'devalue';
 import { app, goto, prerender_responses } from '../client.js';
 import { get_remote_request_headers, remote_request, unwrap_node } from './shared.svelte.js';
 import { create_remote_key, stringify_remote_arg } from '../../shared.js';
+import { noop } from '../../../utils/functions.js';
 
 // Initialize Cache API for prerender functions
 const CACHE_NAME = __SVELTEKIT_DEV__ ? `sveltekit:${Date.now()}` : `sveltekit:${version}`;
@@ -166,6 +167,10 @@ class Prerender {
 				throw error;
 			}
 		);
+
+		// rejections are surfaced via `.error` for reactive consumers — make sure the
+		// stored promise (consumed without `await`) never becomes an unhandled rejection
+		this.#promise.catch(noop);
 	}
 
 	/**

--- a/packages/kit/src/runtime/client/remote-functions/query-live/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/instance.svelte.js
@@ -383,6 +383,7 @@ export class LiveQuery {
 		void this.#interrupt?.();
 
 		if (this.#reject_first) {
+			this.#promise.catch(noop);
 			this.#reject_first(error);
 			this.#resolve_first = null;
 			this.#reject_first = null;

--- a/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
@@ -88,7 +88,9 @@ export class Query {
 		// every time you see this comment, try removing the `tick.then` here and see
 		// if all the tests still pass with the latest svelte version
 		// if they do, congrats, you can remove tick.then
-		void tick().then(() => this.#get_promise());
+		void tick()
+			.then(() => this.#get_promise())
+			.catch(noop);
 	}
 
 	#clear_pending() {
@@ -100,6 +102,11 @@ export class Query {
 		this.#loading = true;
 
 		const { promise, resolve, reject } = with_resolvers();
+
+		// the rejection is surfaced via `.error` / the `then` getter for awaiting
+		// consumers — a purely reactive consumer (`.current`) attaches no handler,
+		// so make sure the stored promise can never become an unhandled rejection
+		promise.catch(noop);
 
 		this.#latest.push(resolve);
 


### PR DESCRIPTION
Attaches catch handlers in a number of places that I'm pretty sure would cause unhandled rejections in some scenarios.
