### PR TITLE
chore: Add tests for un-covered behaviors in LiveQuery

### DIFF
--- a/packages/kit/test/apps/async/src/routes/remote/live-terminal/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/live-terminal/+page.svelte
@@ -1,0 +1,22 @@
+<script>
+	import { get_value, get_connection_count, trigger } from './data.remote.js';
+
+	const live = get_value();
+
+	let connections = $state('pending');
+
+	async function refresh_connections() {
+		connections = String(await get_connection_count());
+	}
+</script>
+
+<button id="trigger-error" onclick={() => trigger('error')}>trigger error</button>
+<button id="trigger-redirect" onclick={() => trigger('redirect')}>trigger redirect</button>
+<button id="trigger-yield" onclick={() => trigger('yield')}>trigger yield</button>
+<button id="refresh-connections" onclick={refresh_connections}>refresh connections</button>
+
+<p id="value">{live.current}</p>
+<p id="error">{live.error ? `${live.error.status} ${live.error.body.message}` : ''}</p>
+<p id="connected">{String(live.connected)}</p>
+<p id="done">{String(live.done)}</p>
+<p id="connections">{connections}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/live-terminal/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/live-terminal/data.remote.js
@@ -1,0 +1,71 @@
+import { error, redirect } from '@sveltejs/kit';
+import { command, getRequestEvent, query } from '$app/server';
+
+let count = 0;
+let mode = 'yield';
+let connection_count = 0;
+
+/** @type {Set<() => void>} */
+const listeners = new Set();
+
+function notify() {
+	for (const listener of listeners) {
+		listener();
+	}
+
+	listeners.clear();
+}
+
+/** @param {AbortSignal} signal */
+function wait_for_change(signal) {
+	return new Promise((resolve) => {
+		const on_change = () => {
+			signal.removeEventListener('abort', on_abort);
+			resolve('changed');
+		};
+
+		const on_abort = () => {
+			listeners.delete(on_change);
+			resolve('aborted');
+		};
+
+		listeners.add(on_change);
+		signal.addEventListener('abort', on_abort, { once: true });
+	});
+}
+
+export const get_value = query.live(async function* () {
+	const signal = getRequestEvent().request.signal;
+
+	connection_count += 1;
+
+	yield count;
+
+	while (true) {
+		const status = await wait_for_change(signal);
+
+		if (status === 'aborted') {
+			return;
+		}
+
+		if (mode === 'error') {
+			throw error(418, 'terminal teapot');
+		}
+
+		if (mode === 'redirect') {
+			redirect(307, '/remote/live-terminal/target');
+		}
+
+		yield ++count;
+	}
+});
+
+export const get_connection_count = query(() => connection_count);
+
+export const trigger = command(
+	'unchecked',
+	/** @param {string} m */ (m) => {
+		mode = m;
+		notify();
+	}
+);

--- a/packages/kit/test/apps/async/src/routes/remote/live-terminal/target/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/live-terminal/target/+page.svelte
@@ -1,0 +1,1 @@
+<h1 id="redirect-target">arrived</h1>

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -786,6 +786,47 @@ test.describe('remote function mutations', () => {
 			.toBeGreaterThan(before_cleanup);
 	});
 
+	test('query.live surfaces mid-stream HttpError and does not reconnect', async ({ page }) => {
+		await page.goto('/remote/live-terminal');
+
+		await expect(page.locator('#value')).toHaveText('0');
+		await expect(page.locator('#connected')).toHaveText('true');
+
+		await page.click('#refresh-connections');
+		await expect(page.locator('#connections')).not.toHaveText('pending');
+		const before = Number(await page.locator('#connections').textContent());
+
+		await page.click('#trigger-error');
+
+		await expect(page.locator('#error')).toHaveText('418 terminal teapot');
+		await expect(page.locator('#connected')).toHaveText('false');
+		await expect(page.locator('#done')).toHaveText('true');
+
+		// A terminal HttpError must not trigger a reconnect — the connection count
+		// should not increase after the failure.
+		await page.waitForTimeout(500);
+		await page.click('#refresh-connections');
+		await expect
+			.poll(async () => Number(await page.locator('#connections').textContent()))
+			.toBe(before);
+	});
+
+	test('query.live navigates on mid-stream redirect', async ({ page }) => {
+		await page.goto('/remote/live-terminal');
+
+		await expect(page.locator('#value')).toHaveText('0');
+		await expect(page.locator('#connected')).toHaveText('true');
+
+		await page.click('#trigger-redirect');
+
+		// Characterizes the current mid-stream redirect behavior. The client
+		// navigates to the redirect target and reconnects (see the TODO at
+		// query-live/instance.svelte.js:165-166). If the redirect semantics are
+		// redesigned, this test must be updated deliberately.
+		await expect(page.locator('#redirect-target')).toBeVisible();
+		expect(page.url()).toMatch(/\/remote\/live-terminal\/target$/);
+	});
+
 	test('refreshAll works with schema transforms (number to string)', async ({ page }) => {
 		await page.goto('/remote/form/transform');
 

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -819,10 +819,6 @@ test.describe('remote function mutations', () => {
 
 		await page.click('#trigger-redirect');
 
-		// Characterizes the current mid-stream redirect behavior. The client
-		// navigates to the redirect target and reconnects (see the TODO at
-		// query-live/instance.svelte.js:165-166). If the redirect semantics are
-		// redesigned, this test must be updated deliberately.
 		await expect(page.locator('#redirect-target')).toBeVisible();
 		expect(page.url()).toMatch(/\/remote\/live-terminal\/target$/);
 	});


### PR DESCRIPTION
We didn't really test any of the mid-stream behavior of LiveQuery, this adds a couple of tests around that.
