### PR TITLE
fix: preserve status code when remote function transport requests fail

### DIFF
--- a/.changeset/remote-transport-status-preserve.md
+++ b/.changeset/remote-transport-status-preserve.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: preserve the HTTP status and error body when a remote function request fails in transport (e.g. a 401/403 from a `handle` hook), instead of reporting a generic 500

--- a/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
@@ -114,7 +114,13 @@ export async function remote_request(url, init) {
 	const response = await fetch(url, init);
 
 	if (!response.ok) {
-		throw new HttpError(500, 'Failed to execute remote function');
+		const result = await response.json().catch(() => ({
+			type: 'error',
+			status: response.status,
+			error: response.statusText
+		}));
+
+		throw new HttpError(result.status ?? response.status ?? 500, result.error);
 	}
 
 	const result = /** @type {RemoteFunctionResponse} */ (await response.json());

--- a/packages/kit/src/runtime/client/remote-functions/shared.transport.spec.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.transport.spec.js
@@ -1,5 +1,4 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
-import * as devalue from 'devalue';
 
 // Mock `client.js` — the real module pulls in the SvelteKit router/hydration
 // machinery and resolves `$app/paths` to a server-side virtual module that only

--- a/packages/kit/src/runtime/client/remote-functions/shared.transport.spec.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.transport.spec.js
@@ -1,0 +1,73 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import * as devalue from 'devalue';
+
+// Mock `client.js` — the real module pulls in the SvelteKit router/hydration
+// machinery and resolves `$app/paths` to a server-side virtual module that only
+// exists during a real SvelteKit build. We only need stubs for the names that
+// `shared.svelte.js` imports.
+vi.mock(new URL('../client.js', import.meta.url).pathname, () => ({
+	app: { hooks: { transport: {} }, decoders: {} },
+	query_map: new Map(),
+	query_responses: {},
+	live_query_map: new Map(),
+	goto: () => {}
+}));
+
+// Mock `state.svelte.js` — imports `navigating` and `page` which are reactive
+// Svelte state only available in a full SvelteKit runtime.
+vi.mock(new URL('../state.svelte.js', import.meta.url).pathname, () => ({
+	navigating: { current: null },
+	page: { url: new URL('http://localhost/') }
+}));
+
+const { remote_request } = await import('./shared.svelte.js');
+const { HttpError } = await import('@sveltejs/kit/internal');
+
+describe('remote_request transport error handling', () => {
+	beforeEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	test('non-OK response with JSON error body preserves status and error body', async () => {
+		vi.stubGlobal('fetch', async () => ({
+			ok: false,
+			status: 401,
+			statusText: 'Unauthorized',
+			json: async () => ({ type: 'error', status: 401, error: { message: 'unauthorized' } })
+		}));
+
+		await expect(remote_request('/x')).rejects.toSatisfy((e) => {
+			return e instanceof HttpError && e.status === 401 && e.body?.message === 'unauthorized';
+		});
+	});
+
+	test('non-OK response with non-JSON body falls back to response.status and statusText', async () => {
+		vi.stubGlobal('fetch', async () => ({
+			ok: false,
+			status: 503,
+			statusText: 'Service Unavailable',
+			json: async () => {
+				throw new SyntaxError('Unexpected token');
+			}
+		}));
+
+		await expect(remote_request('/x')).rejects.toSatisfy((e) => {
+			return e instanceof HttpError && e.status === 503;
+		});
+	});
+
+	test('OK response with valid result payload does not throw an HttpError with status 500', async () => {
+		// Build a minimal valid RemoteFunctionResponse with type 'result' and no data.
+		const body = JSON.stringify({ type: 'result', data: null });
+
+		vi.stubGlobal('fetch', async () => ({
+			ok: true,
+			status: 200,
+			statusText: 'OK',
+			json: async () => JSON.parse(body)
+		}));
+
+		// Should resolve without throwing.
+		await expect(remote_request('/x')).resolves.toBeDefined();
+	});
+});

--- a/packages/kit/src/runtime/client/remote-functions/shared.transport.spec.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.transport.spec.js
@@ -28,12 +28,15 @@ describe('remote_request transport error handling', () => {
 	});
 
 	test('non-OK response with JSON error body preserves status and error body', async () => {
-		vi.stubGlobal('fetch', async () => ({
-			ok: false,
-			status: 401,
-			statusText: 'Unauthorized',
-			json: async () => ({ type: 'error', status: 401, error: { message: 'unauthorized' } })
-		}));
+		vi.stubGlobal('fetch', () =>
+			Promise.resolve({
+				ok: false,
+				status: 401,
+				statusText: 'Unauthorized',
+				json: () =>
+					Promise.resolve({ type: 'error', status: 401, error: { message: 'unauthorized' } })
+			})
+		);
 
 		await expect(remote_request('/x')).rejects.toSatisfy((e) => {
 			return e instanceof HttpError && e.status === 401 && e.body?.message === 'unauthorized';
@@ -41,14 +44,14 @@ describe('remote_request transport error handling', () => {
 	});
 
 	test('non-OK response with non-JSON body falls back to response.status and statusText', async () => {
-		vi.stubGlobal('fetch', async () => ({
-			ok: false,
-			status: 503,
-			statusText: 'Service Unavailable',
-			json: async () => {
-				throw new SyntaxError('Unexpected token');
-			}
-		}));
+		vi.stubGlobal('fetch', () =>
+			Promise.resolve({
+				ok: false,
+				status: 503,
+				statusText: 'Service Unavailable',
+				json: () => Promise.reject(new SyntaxError('Unexpected token'))
+			})
+		);
 
 		await expect(remote_request('/x')).rejects.toSatisfy((e) => {
 			return e instanceof HttpError && e.status === 503;
@@ -59,12 +62,14 @@ describe('remote_request transport error handling', () => {
 		// Build a minimal valid RemoteFunctionResponse with type 'result' and no data.
 		const body = JSON.stringify({ type: 'result', data: null });
 
-		vi.stubGlobal('fetch', async () => ({
-			ok: true,
-			status: 200,
-			statusText: 'OK',
-			json: async () => JSON.parse(body)
-		}));
+		vi.stubGlobal('fetch', () =>
+			Promise.resolve({
+				ok: true,
+				status: 200,
+				statusText: 'OK',
+				json: () => Promise.resolve(JSON.parse(body))
+			})
+		);
 
 		// Should resolve without throwing.
 		await expect(remote_request('/x')).resolves.toBeDefined();

--- a/packages/kit/test/apps/async/src/hooks.server.js
+++ b/packages/kit/test/apps/async/src/hooks.server.js
@@ -3,6 +3,13 @@ import { do_something } from './routes/remote/server-action/action.remote';
 
 /** @type {import('@sveltejs/kit').Handle} */
 export async function handle({ event, resolve }) {
+	if (event.isRemoteRequest && event.cookies.get('deny-remote') === '1') {
+		return new Response(JSON.stringify({ message: 'denied by hook' }), {
+			status: 403,
+			headers: { 'content-type': 'application/json' }
+		});
+	}
+
 	if (event.url.pathname === '/remote/hook-command') {
 		try {
 			const result = await do_something('from-hook');

--- a/packages/kit/test/apps/async/src/routes/remote/transport-status/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/transport-status/+page.svelte
@@ -1,0 +1,26 @@
+<script>
+	import { get_data } from './data.remote.js';
+
+	const result = get_data();
+</script>
+
+<button
+	id="deny-btn"
+	onclick={() => {
+		document.cookie = 'deny-remote=1; path=/';
+		result.refresh();
+	}}>Deny and refresh</button
+>
+
+<button
+	id="clear-btn"
+	onclick={() => {
+		document.cookie = 'deny-remote=0; path=/; max-age=0';
+	}}>Clear cookie</button
+>
+
+{#if result.error}
+	<p id="status">{result.error.status}</p>
+{:else if result.current !== undefined}
+	<p id="value">{result.current}</p>
+{/if}

--- a/packages/kit/test/apps/async/src/routes/remote/transport-status/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/transport-status/data.remote.js
@@ -1,0 +1,3 @@
+import { query } from '$app/server';
+
+export const get_data = query(() => 'ok');

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -840,6 +840,27 @@ test.describe('remote function mutations', () => {
 		await expect(page.locator('h1')).toHaveText('hello from remote function!');
 	});
 
+	test('denied by hook: transport 403 surfaces as error.status 403 on query resource', async ({
+		page
+	}) => {
+		await page.goto('/remote/transport-status');
+
+		// initial load should succeed and show the value
+		await expect(page.locator('#value')).toHaveText('ok');
+
+		// set the cookie and trigger a refresh; the handle hook blocks remote requests
+		await page.click('#deny-btn');
+
+		// the query resource should report the 403 status from the hook
+		await expect(page.locator('#status')).toHaveText('403');
+
+		// clean up the cookie so other tests aren't affected
+		await page.click('#clear-btn');
+		await page.evaluate(() => {
+			document.cookie = 'deny-remote=; path=/; max-age=0';
+		});
+	});
+
 	test('form.for() with enhance does not duplicate requests', async ({ page }) => {
 		await page.goto('/remote/form/for-duplicate');
 


### PR DESCRIPTION
We had better error handling in the SSE handling for live queries, so I ported it over to regular queries as well. Previously, if an error occurred outside of the remote functions handling, we'd lose all of that error's metadata.
