### PR TITLE
fix: regression in loading assets for apps configured with absolute paths

### DIFF
--- a/.changeset/small-heads-wear.md
+++ b/.changeset/small-heads-wear.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: regression in loading assets for absolute path apps

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1046,8 +1046,15 @@ async function kit({ svelte_config }) {
 							.map(() => '..')
 							.join('/') + '/../';
 
+					const relative = kit.paths.relative !== false || !!kit.paths.assets;
+
 					new_config = {
-						base: './',
+						// Affects how Vite loads JS assets on the client.
+						// If the initial HTML we render uses an absolute path for assets,
+						// the additional chunks Vite loads must also use an absolute path.
+						// Otherwise, you end up with additional chunks being loaded relative
+						// to the current chunk rather than the root.
+						base: relative ? './' : base,
 						build: {
 							copyPublicDir: !ssr,
 							cssCodeSplit: svelte_config.kit.output.bundleStrategy !== 'inline',
@@ -1109,9 +1116,7 @@ async function kit({ svelte_config }) {
 									// E.g. Vite generates `new URL('/asset.png', import.meta).href` for a relative path vs just '/asset.png'.
 									// That's larger and takes longer to run and also causes an HTML diff between SSR and client
 									// causing us to do a more expensive hydration check.
-									return {
-										relative: kit.paths.relative !== false || !!kit.paths.assets
-									};
+									return { relative };
 								}
 
 								// _app/immutable/assets files

--- a/packages/kit/test/prerendering/paths-base/test/tests.spec.js
+++ b/packages/kit/test/prerendering/paths-base/test/tests.spec.js
@@ -34,3 +34,12 @@ test('prerenders /path-base/assets/emitted', () => {
 	const content = read('assets/emitted.html');
 	assert.ok(content.includes('<p>hello from message.csv'));
 });
+
+test('JS assets are loaded with an absolute path', () => {
+	const files = fs.readdirSync(`${build}/_app/immutable/entry`);
+	const app_file = files.find((file) => file.startsWith('app.'));
+	if (!app_file) throw new Error('app file not found');
+
+	const content = read(`_app/immutable/entry/${app_file}`);
+	assert.ok(!content.includes('./_app/immutable'));
+});


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/16013

This PR fixes the regression, adds a test for it, and a note about how Vite uses the `base` path setting even if `experimental.renderBuiltUrl` is configured. The `base` setting affects the JS chunk paths Vite stores in the `_app/immutable/entry/app.xxxx.js` file. Its base path is not affected by `renderBuiltUrl` apparently.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
