### PR TITLE
fix: allow `preloadCode` to be called during initial page load

### DIFF
--- a/.changeset/preload-code-initial-load.md
+++ b/.changeset/preload-code-initial-load.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow `preloadCode` to be called during initial page load

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2419,7 +2419,9 @@ export async function preloadCode(pathname) {
 		throw new Error('Cannot call preloadCode(...) on the server');
 	}
 
-	const url = new URL(pathname, current.url);
+	// `current.url` is null until the first navigation/hydration completes, so fall back
+	// to `location` to support calling `preloadCode` during initial page load (#13297)
+	const url = new URL(pathname, current.url ?? location.href);
 
 	if (DEV) {
 		if (!pathname.startsWith('/')) {

--- a/packages/kit/test/apps/basics/src/routes/preload-code-on-load/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/preload-code-on-load/+page.svelte
@@ -1,0 +1,1 @@
+<h1>preload code on load</h1>

--- a/packages/kit/test/apps/basics/src/routes/preload-code-on-load/+page.ts
+++ b/packages/kit/test/apps/basics/src/routes/preload-code-on-load/+page.ts
@@ -1,0 +1,10 @@
+import { browser } from '$app/environment';
+import { preloadCode } from '$app/navigation';
+
+export async function load() {
+	// #13297: calling `preloadCode` during initial load, before `current.url` is set,
+	// used to throw `Failed to construct 'URL': Invalid base URL`
+	if (browser) {
+		await preloadCode('/preload-code-on-load');
+	}
+}

--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -1244,3 +1244,20 @@ test.describe('Load', () => {
 		});
 	}
 });
+
+test.describe('preloadCode', () => {
+	test('can be called during initial load (#13297)', async ({ page }) => {
+		// the thrown error is caught by the load machinery and surfaces as a console
+		// error (not an uncaught pageerror), so capture console output to detect it
+		/** @type {string[]} */
+		const errors = [];
+		page.on('console', (msg) => {
+			if (msg.type() === 'error') errors.push(msg.text());
+		});
+
+		await page.goto('/preload-code-on-load');
+
+		await expect(page.locator('h1')).toHaveText('preload code on load');
+		expect(errors.filter((e) => e.includes('Invalid base URL'))).toEqual([]);
+	});
+});


### PR DESCRIPTION
First kit fix I ever wrote, it's been sitting on my machine because I wasn't confident enough to post it.

`preloadCode` throws when called during initial page load because `current.url` is null until hydration completes, so `new URL(pathname, current.url)` rejects the relative path. If the call happens in a `load` function, the throw takes the whole page down with a 500. Falling back to `location.href` covers that window. Same diagnosis I posted in the issue thread.

The new test calls `preloadCode` from a universal `load` during initial load. It fails on main and passes with this.

Fixes #13297

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests

- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets

- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
