### PR TITLE
fix: decode base64-serialized fetch bodies before caching them for client-side replay

### DIFF
--- a/.changeset/eighty-bytes-repeat.md
+++ b/.changeset/eighty-bytes-repeat.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: decode base64-serialized fetch bodies before caching them for client-side replay

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -94,14 +94,15 @@ export function initial_fetch(resource, opts) {
 		script.remove(); // In case multiple script tags match the same selector
 		let { body, ...init } = JSON.parse(script.textContent);
 
-		const ttl = script.getAttribute('data-ttl');
-		if (ttl) cache.set(selector, { body, init, ttl: 1000 * Number(ttl) });
 		const b64 = script.getAttribute('data-b64');
 		if (b64 !== null) {
 			// Can't use native_fetch('data:...;base64,${body}')
 			// csp can block the request
 			body = base64_decode(body);
 		}
+
+		const ttl = script.getAttribute('data-ttl');
+		if (ttl) cache.set(selector, { body, init, ttl: 1000 * Number(ttl) });
 
 		return Promise.resolve(new Response(body, init));
 	}

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-cache-control/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-cache-control/+page.svelte
@@ -1,3 +1,5 @@
 <a href="/load/fetch-cache-control/load-data">load-data</a>
 
 <a href="/load/fetch-cache-control/headers-diff">headers-diff</a>
+
+<a href="/load/fetch-cache-control/b64">b64</a>

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-cache-control/b64/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-cache-control/b64/+page.js
@@ -1,0 +1,8 @@
+/** @type {import("./$types").PageLoad} */
+export async function load({ fetch }) {
+	const res = await fetch('/load/fetch-cache-control/b64/data');
+
+	return {
+		data: await res.arrayBuffer()
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-cache-control/b64/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-cache-control/b64/+page.svelte
@@ -1,0 +1,9 @@
+<script>
+	export let data;
+
+	$: arr = [...new Uint8Array(data.data)];
+</script>
+
+<a href="/load/fetch-cache-control">fetch-cache-control</a>
+
+<span class="test-content">{JSON.stringify(arr)}</span>

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-cache-control/b64/data/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-cache-control/b64/data/+server.js
@@ -1,0 +1,8 @@
+/** @type {import('./$types').RequestHandler} */
+export const GET = () => {
+	return new Response(new Uint8Array([1, 2, 3, 4]), {
+		headers: {
+			'cache-control': 'public, max-age=7'
+		}
+	});
+};

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -219,6 +219,28 @@ test.describe('Load', () => {
 		expect(did_request_data).toBe(false);
 	});
 
+	test('cached base64-serialized response is decoded when replayed', async ({ page, clicknav }) => {
+		// 1. go to the page (first load, we expect the right data)
+		await page.goto('/load/fetch-cache-control/b64');
+		expect(await page.textContent('.test-content')).toBe('[1,2,3,4]');
+
+		// 2. change to another route (client side)
+		await clicknav('[href="/load/fetch-cache-control"]');
+
+		// 3. come back to the original page (client side)
+		let did_request_data = false;
+		page.on('request', (request) => {
+			if (request.url().endsWith('fetch-cache-control/b64/data')) {
+				did_request_data = true;
+			}
+		});
+		await clicknav('[href="/load/fetch-cache-control/b64"]');
+
+		// 4. data should still be the same (and cached)
+		expect(await page.textContent('.test-content')).toBe('[1,2,3,4]');
+		expect(did_request_data).toBe(false);
+	});
+
 	test('do not use cache if headers are different', async ({ page, clicknav }) => {
 		await page.goto('/load/fetch-cache-control/headers-diff');
 


### PR DESCRIPTION
When a universal `load` fetches a **binary** resource during SSR, the response is serialized into the page as `<script data-sveltekit-fetched data-b64 data-ttl="...">` (`data-ttl` derived from the response's `s-maxage`/`max-age`, `data-b64` marking a base64-encoded body).

During hydration, `initial_fetch` stores the entry in the client-side fetch cache **before** decoding the body:

```js
const ttl = script.getAttribute('data-ttl');
if (ttl) cache.set(selector, { body, init, ttl: 1000 * Number(ttl) }); // body is still a base64 string
const b64 = script.getAttribute('data-b64');
if (b64 !== null) {
	body = base64_decode(body);
}
```

So the cache holds the raw base64 string. When the user client-side navigates back to the page within the TTL window, `subsequent_fetch` replays `new Response(cached.body, cached.init)` and the load function receives base64 **text** instead of the original bytes — e.g. an endpoint returning `[1, 2, 3, 4]` is replayed as `[65, 81, 73, 68, 66, 65, 61, 61]` (the UTF-8 bytes of `"AQIDBA=="`). Anything that parses the body (protobuf, images, etc.) breaks, and only on cached client-side re-navigation, which makes it look like a flaky backend.

The fix moves the decode above the `cache.set` so the cache stores the decoded bytes; the hydration-time `Response` is unaffected (it was already constructed after decoding).

Includes a regression test mirroring the existing `fetch-cache-control` suite: a binary endpoint with `cache-control: public, max-age=7`, client-side navigation away and back, asserting the byte content and that no new request was made. It fails on `main` with the corrupted bytes above and passes with this change; the neighbouring cache and b64 serialization tests stay green.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
