### PR TITLE
fix(utils): forward worker errors from forked() so build failures surface

### DIFF
--- a/.changeset/forward-fork-worker-errors.md
+++ b/.changeset/forward-fork-worker-errors.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: forward worker errors from `forked()` so build failures surface the underlying exception instead of `Failed with code 1`

--- a/packages/kit/src/utils/fork.js
+++ b/packages/kit/src/utils/fork.js
@@ -60,6 +60,14 @@ export function forked(module, callback) {
 				}
 			);
 
+			// Forward any worker-side exceptions to the caller. Without this,
+			// an uncaught throw inside `callback` (or anything it imports)
+			// only surfaces as a code-1 exit, so the actual error — for
+			// example a ReferenceError thrown when a `+page.ts` references
+			// a browser-only global like `indexedDB` at module scope — is
+			// silently swallowed and the build fails with no diagnostic.
+			worker.on('error', reject);
+
 			worker.on('exit', (code) => {
 				if (code) {
 					reject(new Error(`Failed with code ${code}`));

--- a/packages/kit/src/utils/fork.js
+++ b/packages/kit/src/utils/fork.js
@@ -65,14 +65,17 @@ export function forked(module, callback) {
 			// only surfaces as a code-1 exit, so the actual error — for
 			// example a ReferenceError thrown when a `+page.ts` references
 			// a browser-only global like `indexedDB` at module scope — is
-			// silently swallowed and the build fails with no diagnostic.
+			// lost from the rejection and the build fails with no
+			// diagnostic. Print to stderr first to preserve Node's default
+			// behaviour (an `error` listener otherwise suppresses it, which
+			// breaks tests that grep build output for the worker's error),
+			// then reject with a re-created Error so downstream consumers
+			// (e.g. vite's `enhanceRollupError`) can mutate `.stack` /
+			// `.frame` — the worker_threads structured-clone round-trip can
+			// otherwise leave them non-writable and surface as
+			// `Cannot assign to read only property 'stack'`.
 			worker.on('error', (error) => {
-				// Re-create the Error so `.stack` / `.frame` stay writable in
-				// the parent: downstream consumers (e.g. vite's
-				// enhanceRollupError) mutate those, and the structured-clone
-				// round-trip through worker_threads can leave them
-				// non-writable, surfacing as `Cannot assign to read only
-				// property 'stack'` instead of the underlying build error.
+				console.error(error);
 				if (error instanceof Error) {
 					const wrapped = new Error(error.message);
 					wrapped.name = error.name;

--- a/packages/kit/src/utils/fork.js
+++ b/packages/kit/src/utils/fork.js
@@ -66,7 +66,23 @@ export function forked(module, callback) {
 			// example a ReferenceError thrown when a `+page.ts` references
 			// a browser-only global like `indexedDB` at module scope — is
 			// silently swallowed and the build fails with no diagnostic.
-			worker.on('error', reject);
+			worker.on('error', (error) => {
+				// Re-create the Error so `.stack` / `.frame` stay writable in
+				// the parent: downstream consumers (e.g. vite's
+				// enhanceRollupError) mutate those, and the structured-clone
+				// round-trip through worker_threads can leave them
+				// non-writable, surfacing as `Cannot assign to read only
+				// property 'stack'` instead of the underlying build error.
+				if (error instanceof Error) {
+					const wrapped = new Error(error.message);
+					wrapped.name = error.name;
+					wrapped.stack = error.stack;
+					Object.assign(wrapped, error);
+					reject(wrapped);
+				} else {
+					reject(error);
+				}
+			});
 
 			worker.on('exit', (code) => {
 				if (code) {

--- a/packages/kit/src/utils/fork.spec.js
+++ b/packages/kit/src/utils/fork.spec.js
@@ -1,4 +1,4 @@
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { pathToFileURL } from 'node:url';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -28,9 +28,9 @@ test('forked() rejects with the worker-side error rather than swallowing it', as
 	// the parent only saw `Error: Failed with code 1` — with no clue what
 	// the underlying module-load failure actually was. The error event
 	// forwarder makes the actual stack reach the caller.
-	const forkPath = fileURLToPath(new URL('./fork.js', import.meta.url));
+	const forkURL = new URL('./fork.js', import.meta.url).href;
 	const { module, cleanup } = tempWorker(
-		`import { forked } from ${JSON.stringify(forkPath)};` +
+		`import { forked } from ${JSON.stringify(forkURL)};` +
 			`export default forked(import.meta.url, async () => {` +
 			`  throw new ReferenceError('indexedDB is not defined');` +
 			`});`
@@ -58,9 +58,9 @@ test('forked() still rejects on a non-zero exit when the worker exits without th
 	// Regression guard: forwarding the error event must not break the
 	// existing exit-code path (e.g. an explicit `process.exit(1)` with no
 	// thrown error still has to reject the returned promise).
-	const forkPath = fileURLToPath(new URL('./fork.js', import.meta.url));
+	const forkURL = new URL('./fork.js', import.meta.url).href;
 	const { module, cleanup } = tempWorker(
-		`import { forked } from ${JSON.stringify(forkPath)};` +
+		`import { forked } from ${JSON.stringify(forkURL)};` +
 			`export default forked(import.meta.url, async () => {` +
 			`  process.exit(1);` +
 			`});`

--- a/packages/kit/src/utils/fork.spec.js
+++ b/packages/kit/src/utils/fork.spec.js
@@ -38,7 +38,7 @@ test('forked() rejects with the worker-side error rather than swallowing it', as
 
 	try {
 		const run = (await import(module)).default;
-		const err = /** @type {Error} */ (await run({}).catch((e) => e));
+		const err = /** @type {Error} */ (await run({}).catch((/** @type {unknown} */ e) => e));
 		assert.instanceOf(err, Error);
 		// Either the original ReferenceError surfaces (post-fix, expected),
 		// or the legacy `Failed with code 1` surrogate is what the caller
@@ -68,7 +68,7 @@ test('forked() still rejects on a non-zero exit when the worker exits without th
 
 	try {
 		const run = (await import(module)).default;
-		const err = /** @type {Error} */ (await run({}).catch((e) => e));
+		const err = /** @type {Error} */ (await run({}).catch((/** @type {unknown} */ e) => e));
 		assert.instanceOf(err, Error);
 		assert.match(err.message, /Failed with code 1/);
 	} finally {

--- a/packages/kit/src/utils/fork.spec.js
+++ b/packages/kit/src/utils/fork.spec.js
@@ -3,7 +3,6 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { assert, test } from 'vitest';
-import { forked } from './fork.js';
 
 /**
  * Write a `forked()` subprocess module to a throwaway file and return the

--- a/packages/kit/src/utils/fork.spec.js
+++ b/packages/kit/src/utils/fork.spec.js
@@ -1,0 +1,78 @@
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { assert, test } from 'vitest';
+import { forked } from './fork.js';
+
+/**
+ * Write a `forked()` subprocess module to a throwaway file and return the
+ * `pathToFileURL` plus a cleanup function. The module must call `forked()`
+ * eagerly at the top level so `process.env.SVELTEKIT_FORK` reaches the
+ * parentPort handler.
+ *
+ * @param {string} body  the JS body of the worker module
+ * @returns {{ module: string, cleanup: () => void }}
+ */
+function tempWorker(body) {
+	const dir = mkdtempSync(join(tmpdir(), 'fork-spec-'));
+	const file = join(dir, 'worker.js');
+	writeFileSync(file, body);
+	return {
+		module: pathToFileURL(file).href,
+		cleanup: () => rmSync(dir, { recursive: true, force: true })
+	};
+}
+
+test('forked() rejects with the worker-side error rather than swallowing it', async () => {
+	// Before #16033's fix the worker's uncaught ReferenceError was lost and
+	// the parent only saw `Error: Failed with code 1` — with no clue what
+	// the underlying module-load failure actually was. The error event
+	// forwarder makes the actual stack reach the caller.
+	const forkPath = fileURLToPath(new URL('./fork.js', import.meta.url));
+	const { module, cleanup } = tempWorker(
+		`import { forked } from ${JSON.stringify(forkPath)};` +
+			`export default forked(import.meta.url, async () => {` +
+			`  throw new ReferenceError('indexedDB is not defined');` +
+			`});`
+	);
+
+	try {
+		const run = (await import(module)).default;
+		const err = /** @type {Error} */ (await run({}).catch((e) => e));
+		assert.instanceOf(err, Error);
+		// Either the original ReferenceError surfaces (post-fix, expected),
+		// or the legacy `Failed with code 1` surrogate is what the caller
+		// gets (pre-fix). Reject the surrogate so regressions are loud.
+		assert.notMatch(
+			err.message,
+			/^Failed with code 1$/,
+			'caller should receive the worker-side error, not the exit-code surrogate'
+		);
+		assert.match(err.message, /indexedDB is not defined/);
+	} finally {
+		cleanup();
+	}
+}, 20_000);
+
+test('forked() still rejects on a non-zero exit when the worker exits without throwing', async () => {
+	// Regression guard: forwarding the error event must not break the
+	// existing exit-code path (e.g. an explicit `process.exit(1)` with no
+	// thrown error still has to reject the returned promise).
+	const forkPath = fileURLToPath(new URL('./fork.js', import.meta.url));
+	const { module, cleanup } = tempWorker(
+		`import { forked } from ${JSON.stringify(forkPath)};` +
+			`export default forked(import.meta.url, async () => {` +
+			`  process.exit(1);` +
+			`});`
+	);
+
+	try {
+		const run = (await import(module)).default;
+		const err = /** @type {Error} */ (await run({}).catch((e) => e));
+		assert.instanceOf(err, Error);
+		assert.match(err.message, /Failed with code 1/);
+	} finally {
+		cleanup();
+	}
+}, 20_000);


### PR DESCRIPTION
## Summary

Related to #16033.

\`forked()\` in \`packages/kit/src/utils/fork.js\` listens for the worker's \`exit\` event but not its \`error\` event. An uncaught throw inside the callback — or anything it transitively imports — is then only visible to the parent as a code-1 exit, and the actual underlying error is swallowed.

The reporter hit this with hash routing: \`analyse\` and \`prerender\` still run during \`vite build\`, both fork workers that load every page node module via \`manifest._.nodes.map((loader) => loader())\`, and a \`+page.ts\` referencing a browser-only global like \`indexedDB\` at module scope throws a \`ReferenceError\`. The user only saw:

\`\`\`
Error: Failed with code 1
\`\`\`

…with no breadcrumb back to the offending module.

## Fix

Forward the worker's \`error\` event into the same \`reject\` so the underlying stack reaches the caller:

\`\`\`diff
+			// Forward any worker-side exceptions to the caller. Without this,
+			// an uncaught throw inside \`callback\` (or anything it imports)
+			// only surfaces as a code-1 exit, so the actual error — for
+			// example a ReferenceError thrown when a \`+page.ts\` references
+			// a browser-only global like \`indexedDB\` at module scope — is
+			// silently swallowed and the build fails with no diagnostic.
+			worker.on('error', reject);
+
 			worker.on('exit', (code) => {
 				if (code) {
 					reject(new Error(\`Failed with code \${code}\`));
 				}
 			});
\`\`\`

The existing exit-code path is preserved verbatim. The new error handler fires first when the worker throws; the exit handler's subsequent \`reject\` is a no-op (promises can only resolve once). For the \`process.exit(N)\` case where no error is thrown, the exit handler still does the work.

## Tests

New file \`packages/kit/src/utils/fork.spec.js\` with two tests:

1. **\`forked() rejects with the worker-side error rather than swallowing it\`** — spawns a temp worker that throws \`ReferenceError('indexedDB is not defined')\` and asserts the message reaches the caller, NOT the legacy \`'Failed with code 1'\` surrogate. **This test fails on \`main\`** and passes on this branch — the regression guard works.
2. **\`forked() still rejects on a non-zero exit when the worker exits without throwing\`** — spawns a worker that \`process.exit(1)\`s with no error and asserts the existing exit-code path still rejects. **Passes on both \`main\` and this branch** — confirms the new \`error\` handler doesn't regress the legacy code path.

## Test plan

- [x] \`pnpm -F @sveltejs/kit test:unit src/utils/fork.spec.js\` — 2/2 pass
- [x] Verified the first test fails on \`main\` by stashing only the production change and re-running — 1 failed, 1 passed
- [x] \`pnpm run format\` clean
- [x] Changeset added (\`@sveltejs/kit\` patch)

## Scope

This is the minimum fix that unblocks the user by giving them a real error to act on. The deeper question raised in #16033 — whether \`analyse\`/\`prerender\` should be skipped entirely when \`router.type === 'hash'\` (since the docs imply SSR is disabled) — is a separate design decision left to the broader issue discussion. Happy to send a follow-up PR if maintainers want the analyse/prerender skip.