### PR TITLE
fix: avoid loading universal nodes during build analysis when using a hash router

### DIFF
--- a/.changeset/rude-eggs-fold.md
+++ b/.changeset/rude-eggs-fold.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: avoid loading universal nodes during build analysis when the app uses a hash router

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -148,7 +148,9 @@ export function build_server_nodes(
 
 		if (node.universal) {
 			if (
-				(kit.router.type === 'hash' && node.page_options?.ssr === undefined) ||
+				(kit.router.type === 'hash' &&
+					node.page_options !== null &&
+					node.page_options.ssr === undefined) ||
 				(node.page_options && node.page_options.ssr === false)
 			) {
 				exports.push(`export const universal = ${s(node.page_options, null, 2)};`);

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -147,7 +147,10 @@ export function build_server_nodes(
 		}
 
 		if (node.universal) {
-			if (!!node.page_options && node.page_options.ssr === false) {
+			if (
+				(kit.router.type === 'hash' && node.page_options?.ssr === undefined) ||
+				(node.page_options && node.page_options.ssr === false)
+			) {
 				exports.push(`export const universal = ${s(node.page_options, null, 2)};`);
 			} else {
 				imports.push(

--- a/packages/kit/src/exports/vite/build/build_server.js
+++ b/packages/kit/src/exports/vite/build/build_server.js
@@ -150,7 +150,7 @@ export function build_server_nodes(
 			if (
 				(kit.router.type === 'hash' &&
 					node.page_options !== null &&
-					node.page_options.ssr === undefined) ||
+					node.page_options?.ssr === undefined) ||
 				(node.page_options && node.page_options.ssr === false)
 			) {
 				exports.push(`export const universal = ${s(node.page_options, null, 2)};`);

--- a/packages/kit/test/apps/hash-based-routing/src/routes/client-only/+page.ts
+++ b/packages/kit/test/apps/hash-based-routing/src/routes/client-only/+page.ts
@@ -1,0 +1,3 @@
+// Referencing the browser-only API in the universal node helps us test if the
+// app can be built without errors although SSR is not explicitly set to false
+indexedDB.open('toDoList');


### PR DESCRIPTION
fixes https://github.com/sveltejs/kit/issues/16033

We previously only avoided loading universal nodes if SSR was explicitly turned off. However, this doesn't work for hash router apps because we throw an error if the user sets any page options. This PR fixes that by avoiding universal node imports if the hash router is configured for the app (not just when SSR is explicitly false). It also does so in a way that we still throw the validation error if the user sets any page options.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
