### PR TITLE
fix: avoid colliding with user-typed `platform.env`

### DIFF
--- a/.changeset/tall-forks-brush.md
+++ b/.changeset/tall-forks-brush.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': patch
+---
+
+fix: avoid type collision with user defined `App.Platform` `env` property

--- a/packages/adapter-cloudflare/ambient.d.ts
+++ b/packages/adapter-cloudflare/ambient.d.ts
@@ -7,7 +7,8 @@ import {
 declare global {
 	namespace App {
 		export interface Platform {
-			env: unknown;
+			// we should not type `env` here because it will override any type set by
+			// the user in `src/app.d.ts`
 			ctx: ExecutionContext;
 			/** @deprecated Use `ctx` instead */
 			context: ExecutionContext;

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -183,7 +183,7 @@ export default function (options = {}) {
 			// If we would await it here, it would hang indefinitely because the platform proxy only resolves once a request happens
 			const get_emulated = async () => {
 				const proxy = await getPlatformProxy(options.platformProxy);
-				const platform = /** @type {App.Platform} */ ({
+				const platform = ({
 					env: proxy.env,
 					ctx: proxy.ctx,
 					context: proxy.ctx, // deprecated in favor of ctx
@@ -203,7 +203,6 @@ export default function (options = {}) {
 				return { platform, prerender_platform };
 			};
 
-			/** @type {{ platform: App.Platform, prerender_platform: App.Platform }} */
 			let emulated;
 
 			return {

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -183,13 +183,13 @@ export default function (options = {}) {
 			// If we would await it here, it would hang indefinitely because the platform proxy only resolves once a request happens
 			const get_emulated = async () => {
 				const proxy = await getPlatformProxy(options.platformProxy);
-				const platform = ({
+				const platform = {
 					env: proxy.env,
 					ctx: proxy.ctx,
 					context: proxy.ctx, // deprecated in favor of ctx
 					caches: proxy.caches,
 					cf: proxy.cf
-				});
+				};
 				/** @type {Record<string, any>} */
 				const env = {};
 				const prerender_platform = /** @type {App.Platform} */ (/** @type {unknown} */ ({ env }));


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/16036

Ever since we moved the svelte config to the Vite config file, the user's adapter `ambient.d.ts` actually gets applied (good thing!). Unfortunately, our adapter's type of `platform.env` is preventing the user from declaring it themselves. This PR fixes that.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
