### PR TITLE
fix: ensure pnpm global virtual store works

### DIFF
--- a/.changeset/shaggy-bees-play.md
+++ b/.changeset/shaggy-bees-play.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correctly serve client entry during development when using the pnpm global virtual store

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -293,8 +293,11 @@ async function kit({ svelte_config }) {
 				const allow = new Set([
 					kit.files.lib,
 					kit.files.routes,
+					kit.files.src,
 					kit.outDir,
-					path.resolve('src'), // TODO this isn't correct if user changed all his files to sth else than src (like in test/options)
+					// ensures that the client entry is served even if it's located outside
+					// the local node_modules, such as the pnpm global virtual store
+					runtime_directory,
 					path.resolve('node_modules'),
 					path.resolve(vite.searchForWorkspaceRoot(cwd), 'node_modules')
 				]);


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/14162

This PR modifies the Vite server filesystem allow list to always include our runtime directory. This ensures the client entry gets served correctly during development even when it's located in the global virtual store.

I also included a quick fix where we hardcoded allowing the "src" directory rather than `kit.files.src` (there was a TODO for that).

No tests included but tested in a local app. Unless we want to add https://pnpm.io/settings#enableglobalvirtualstore to our pnpm workspace file

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
