### PR TITLE
feat: support streaming for command `File` arguments

### DIFF
--- a/.changeset/curvy-pillows-shake.md
+++ b/.changeset/curvy-pillows-shake.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: support streaming for command `File` arguments

--- a/packages/kit/src/runtime/client/remote-functions/command.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/command.svelte.js
@@ -1,7 +1,8 @@
 /** @import { RemoteCommand, RemoteQueryUpdate } from '@sveltejs/kit' */
 import { app_dir, base } from '$app/paths/internal/client';
 import { app } from '../client.js';
-import { stringify_command_arg } from '../../shared.js';
+import { create_remote_arg_reducers } from '../../shared.js';
+import { BINARY_FORM_CONTENT_TYPE, serialize_binary_form } from '../../form-utils.js';
 import { get_remote_request_headers, categorize_updates, remote_request } from './shared.svelte.js';
 
 /**
@@ -31,7 +32,7 @@ export function command(id) {
 		// No one should call commands during rendering, but this is belt and braces.
 		// Do this here, after Svelte's reactivity context is gone.
 		const headers = {
-			'Content-Type': 'application/json',
+			'Content-Type': BINARY_FORM_CONTENT_TYPE,
 			...get_remote_request_headers()
 		};
 
@@ -45,12 +46,15 @@ export function command(id) {
 					throw updates_error;
 				}
 
+				const { blob } = serialize_binary_form(
+					arg,
+					{ remote_refreshes: Array.from(refreshes ?? []) },
+					create_remote_arg_reducers(app.hooks.transport, false, new Map())
+				);
+
 				const response = await remote_request(`${base}/${app_dir}/remote/${id}`, {
 					method: 'POST',
-					body: JSON.stringify({
-						payload: await stringify_command_arg(arg, app.hooks.transport),
-						refreshes: Array.from(refreshes ?? [])
-					}),
+					body: blob,
 					headers
 				});
 

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -78,8 +78,9 @@ const HEADER_BYTES = 1 + 4 + 2;
  * - file1, file2, ...
  * @param {Record<string, any>} data
  * @param {BinaryFormMeta} meta
+ * @param {Record<string, (value: any) => any>} [reducers]
  */
-export function serialize_binary_form(data, meta) {
+export function serialize_binary_form(data, meta, reducers = {}) {
 	/** @type {Array<BlobPart>} */
 	const blob_parts = [new Uint8Array([BINARY_FORM_VERSION])];
 
@@ -87,6 +88,7 @@ export function serialize_binary_form(data, meta) {
 	const files = [];
 
 	const encoded_header = devalue.stringify([data, meta], {
+		...reducers,
 		File: (file) => {
 			if (!(file instanceof File)) return;
 
@@ -135,9 +137,10 @@ export function serialize_binary_form(data, meta) {
 
 /**
  * @param {Request} request
+ * @param {Record<string, (value: any) => any>} [revivers]
  * @returns {Promise<{ data: Record<string, any>; meta: BinaryFormMeta; form_data: FormData | null }>}
  */
-export async function deserialize_binary_form(request) {
+export async function deserialize_binary_form(request, revivers = {}) {
 	if (request.headers.get('content-type') !== BINARY_FORM_CONTENT_TYPE) {
 		const form_data = await request.formData();
 		return { data: convert_formdata(form_data), meta: {}, form_data };
@@ -259,6 +262,7 @@ export async function deserialize_binary_form(request) {
 	/** @type {Array<{ offset: number, size: number }>} */
 	const file_spans = [];
 	const [data, meta] = devalue.parse(decoder.decode(data_buffer), {
+		...revivers,
 		File: ([name, type, size, last_modified, index]) => {
 			if (
 				typeof name !== 'string' ||

--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -6,7 +6,13 @@ import { HttpError, Redirect, SvelteKitError } from '@sveltejs/kit/internal';
 import { with_request_store, merge_tracing } from '@sveltejs/kit/internal/server';
 import { app_dir, base } from '$app/paths/internal/server';
 import { is_form_content_type } from '../../utils/http.js';
-import { create_remote_key, parse_remote_arg, split_remote_key, stringify } from '../shared.js';
+import {
+	create_remote_key,
+	create_remote_arg_revivers,
+	parse_remote_arg,
+	split_remote_key,
+	stringify
+} from '../shared.js';
 import { handle_error_and_jsonify } from './utils.js';
 import { normalize_error } from '../../utils/error.js';
 import { check_incorrect_fail_use } from './page/actions.js';
@@ -234,10 +240,9 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 			}
 
 			case 'command': {
-				/** @type {{ payload: string, refreshes?: string[] }} */
-				const { payload, refreshes } = await event.request.json();
-				state.remote.requested = create_requested_map(refreshes);
-				const arg = parse_remote_arg(payload, transport);
+				const revivers = create_remote_arg_revivers(transport);
+				const { data: arg, meta } = await deserialize_binary_form(event.request, revivers);
+				state.remote.requested = create_requested_map(meta.remote_refreshes);
 
 				data._ = await with_request_store(
 					{ event, state: { ...state, is_in_remote_form_or_command: true } },

--- a/packages/kit/src/runtime/shared.js
+++ b/packages/kit/src/runtime/shared.js
@@ -96,8 +96,6 @@ function to_sorted(value, clones) {
 const remote_object = '__skrao';
 const remote_map = '__skram';
 const remote_set = '__skras';
-const remote_file = '__skraf';
-const remote_promise_guard = '__skrap';
 const remote_regex_guard = '__skrag';
 const remote_arg_marker = Symbol(remote_object);
 
@@ -106,7 +104,7 @@ const remote_arg_marker = Symbol(remote_object);
  * @param {boolean} sort
  * @param {Map<any, any>} remote_arg_clones
  */
-function create_remote_arg_reducers(transport, sort, remote_arg_clones) {
+export function create_remote_arg_reducers(transport, sort, remote_arg_clones) {
 	/** @type {Record<string, (value: unknown) => unknown>} */
 	const remote_fns_reducers = {
 		/** @param {unknown} value */
@@ -187,7 +185,7 @@ function create_remote_arg_reducers(transport, sort, remote_arg_clones) {
 }
 
 /** @param {Transport} transport */
-function create_remote_arg_revivers(transport) {
+export function create_remote_arg_revivers(transport) {
 	const remote_fns_revivers = {
 		/** @type {(value: unknown) => unknown} */
 		[remote_object]: (value) => value,
@@ -230,24 +228,6 @@ function create_remote_arg_revivers(transport) {
 			}
 
 			return set;
-		},
-		/** @type {(value: any) => File} */
-		[remote_file]: (value) => {
-			if (
-				!value ||
-				typeof value !== 'object' ||
-				typeof value.name !== 'string' ||
-				typeof value.type !== 'string' ||
-				typeof value.size !== 'number' ||
-				typeof value.lastModified !== 'number' ||
-				!(value.data instanceof ArrayBuffer)
-			) {
-				throw new Error('Invalid data for File reviver');
-			}
-
-			const { data, name, ...meta } = value;
-
-			return new File([data], name, meta);
 		}
 	};
 
@@ -274,52 +254,6 @@ export function stringify_remote_arg(value, transport) {
 
 	// If people hit file/url size limits, we can look into using something like compress_and_encode_text from svelte.dev beyond a certain size
 	const json = devalue.stringify(value, create_remote_arg_reducers(transport, true, new Map()));
-
-	return url_friendly_base64_encode(json);
-}
-
-/**
- * Stringifies command arguments, including `File` objects.
- * @param {any} value
- * @param {Transport} transport
- */
-export async function stringify_command_arg(value, transport) {
-	if (value === undefined) return '';
-
-	const reducers = create_remote_arg_reducers(transport, false, new Map());
-
-	/** @type {Set<Promise<any>>} */
-	const allowed_promises = new Set();
-
-	/** @param {any} value */
-	reducers[remote_file] = (value) => {
-		if (value instanceof File) {
-			const promise = value.arrayBuffer().then((data) => ({
-				data,
-				lastModified: value.lastModified,
-				name: value.name,
-				size: value.size,
-				type: value.type
-			}));
-
-			allowed_promises.add(promise);
-
-			return promise;
-		}
-	};
-
-	// we don't want to allow arbitrary promises, because they won't
-	// show up as promises on the other side. this is something
-	// we could potentially change in future. stringifyAsync
-	// will await them, so we need to explicitly deny them
-	/** @param {unknown} value */
-	reducers[remote_promise_guard] = (value) => {
-		if (value instanceof Promise && !allowed_promises.has(value)) {
-			throw new Error('Promises are not valid remote function arguments');
-		}
-	};
-
-	const json = await devalue.stringifyAsync(value, reducers);
 
 	return url_friendly_base64_encode(json);
 }


### PR DESCRIPTION
Alternative to #15978 that also supports streaming of files with the lazy file implementation we already have.

But maybe this was already considered and rejected @Rich-Harris? The only negative impact I can think of is that its now a binary format and not human readable, but I already can't make sense of devalue's output personally.

TODO:
- Consider adding Blob support too!
- Add tests (especially: ensure that nested file support isn't accidentally removed from the binary format in the future, as that is the only difference between forms and commands at the moment)

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
