### PR TITLE
chore: remove unnecessary condition

### DIFF
--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -220,7 +220,7 @@ export function create_builder({
 
 				payload = devalue.uneval(values);
 
-				if (config.kit.experimental.explicitEnvironmentVariables && build_data.service_worker) {
+				if (build_data.service_worker) {
 					write(`${dest}/env.script.js`, `globalThis.__sveltekit_sw={env:${payload}}`);
 				}
 			} else {


### PR DESCRIPTION
quick follow-up to #16024 — the flag is guaranteed to be `true` at this point