### PR TITLE
chore: add `dts-buddy` to minimum age exclude list

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ minimumReleaseAgeExclude:
   - prettier-plugin-svelte
   - svelte-check
   - esm-env
+	- dts-buddy
 blockExoticSubdeps: true
 linkWorkspacePackages: true
 shellEmulator: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ minimumReleaseAgeExclude:
   - prettier-plugin-svelte
   - svelte-check
   - esm-env
-	- dts-buddy
+  - dts-buddy
 blockExoticSubdeps: true
 linkWorkspacePackages: true
 shellEmulator: true


### PR DESCRIPTION
Avoids this error when running `pnpm dedupe`

```
ERR_PNPM_NO_MATURE_MATCHING_VERSION  Version 0.8.1 (released 38 hours ago) of dts-buddy does not meet the minimumReleaseAge constraint

This error happened while installing a direct dependency of /Users/teeming/git/sveltejs/kit/packages/kit

The latest release of dts-buddy is "0.8.1". Published at 6/15/2026

If you need the full list of all 52 published versions run "pnpm view dts-buddy versions".

If you want to install the matched version ignoring the time it was published, you can add the package name to the minimumReleaseAgeExclude setting. Read more about it: https://pnpm.io/settings#minimumreleaseageexclude
```
