### PR TITLE
chore: make `set_env` synchronous

### DIFF
--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -167,8 +167,11 @@ export function create_dynamic_module(type, dev_values, disabled) {
  */
 export function create_sveltekit_env(variables, env, entry) {
 	const imports = entry
-		? [`import { validate, handle_issues } from '@sveltejs/kit/internal/env';`]
-		: [`const handle_issues = () => {};`];
+		? [
+				`import { variables } from ${JSON.stringify(entry)};`,
+				`import { validate, handle_issues } from '@sveltejs/kit/internal/env';`
+			]
+		: [`const variables = {};`, `const handle_issues = () => {};`];
 
 	const declarations = [];
 	const setters = [];
@@ -202,16 +205,14 @@ export function create_sveltekit_env(variables, env, entry) {
 		GENERATED_COMMENT,
 		imports.join('\n'),
 		`const issues = {};`,
+		'export { variables }',
 		'export const dynamic_private_env = {};',
 		'export const explicit_public_env = {};',
 		'export const rendered_env = {};',
 		...declarations,
 		`handle_issues(issues);`,
-		// avoid `variables` from being imported before `set_building` is called
-		// because that causes expressions with `building` to resolve incorrectly
 		dedent`
-			export async function set_env(env) {
-				${entry ? `const { variables } = (await import(${JSON.stringify(entry)}));` : ''}
+			export function set_env(env) {
 				const issues = {};
 				${setters.join('\n')}
 				handle_issues(issues);

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -61,7 +61,7 @@ async function analyse({
 	internal.set_manifest(manifest);
 	internal.set_read_implementation((file) => createReadableStream(`${server_root}/server/${file}`));
 
-	/** @type {import('types').ServerInternalModule} */
+	/** @type {import('__sveltekit/env')} */
 	const { set_env } = await import(pathToFileURL(`${server_root}/server/env.js`).href);
 	set_env(env);
 

--- a/packages/kit/src/core/postbuild/analyse.js
+++ b/packages/kit/src/core/postbuild/analyse.js
@@ -58,9 +58,12 @@ async function analyse({
 	const public_env = filter_env(env, public_prefix, private_prefix);
 	internal.set_private_env(private_env);
 	internal.set_public_env(public_env);
-	await internal.set_env(env);
 	internal.set_manifest(manifest);
 	internal.set_read_implementation((file) => createReadableStream(`${server_root}/server/${file}`));
+
+	/** @type {import('types').ServerInternalModule} */
+	const { set_env } = await import(pathToFileURL(`${server_root}/server/env.js`).href);
+	set_env(env);
 
 	/** @type {import('types').ServerMetadata} */
 	const metadata = {

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -43,13 +43,17 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env }) {
 	/** @type {import('types').ServerInternalModule} */
 	const internal = await import(pathToFileURL(`${out}/server/internal.js`).href);
 
-	/** @type {import('types').ServerModule} */
-	const { Server } = await import(pathToFileURL(`${out}/server/index.js`).href);
-
 	// configure `import { building } from '$app/environment'` and `$app/env` —
 	// essential we do this before analysing the code
 	internal.set_building();
 	internal.set_prerendering();
+
+	/** @type {import('__sveltekit/env')} */
+	const { set_env } = await import(pathToFileURL(`${out}/server/env.js`).href);
+	set_env(env);
+
+	/** @type {import('types').ServerModule} */
+	const { Server } = await import(pathToFileURL(`${out}/server/index.js`).href);
 
 	/**
 	 * @template {{message: string}} T
@@ -505,7 +509,6 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env }) {
 	const public_env = filter_env(env, public_prefix, private_prefix);
 	internal.set_private_env(private_env);
 	internal.set_public_env(public_env);
-	await internal.set_env(env);
 	internal.set_manifest(manifest);
 	internal.set_read_implementation((file) => createReadableStream(`${out}/server/${file}`));
 

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -33,7 +33,6 @@ import root from '../root.${isSvelte5Plus() ? 'js' : 'svelte'}';
 import { set_building, set_prerendering } from '$app/env/internal';
 import { set_assets } from '$app/paths/internal/server';
 import { set_manifest, set_read_implementation } from '__sveltekit/server';
-import { set_env } from '__sveltekit/env';
 import { set_private_env, set_public_env } from '${runtime_directory}/shared-server.js';
 
 export const options = {
@@ -93,7 +92,7 @@ export async function get_hooks() {
 	};
 }
 
-export { set_assets, set_building, set_env, set_manifest, set_prerendering, set_private_env, set_public_env, set_read_implementation };
+export { set_assets, set_building, set_manifest, set_prerendering, set_private_env, set_public_env, set_read_implementation };
 `;
 
 // TODO need to re-run this whenever src/app.html or src/error.html are

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -961,6 +961,7 @@ async function kit({ svelte_config }) {
 					if (ssr) {
 						input.index = `${runtime_directory}/server/index.js`;
 						input.internal = `${out_dir}/generated/server/internal.js`;
+						input.env = `__sveltekit/env`;
 						input['remote-entry'] = `${runtime_directory}/app/server/remote/index.js`;
 
 						// add entry points for every endpoint...

--- a/packages/kit/src/runtime/server/index.js
+++ b/packages/kit/src/runtime/server/index.js
@@ -63,7 +63,7 @@ export class Server {
 
 		set_private_env(filter_env(env, env_private_prefix, env_public_prefix));
 		set_public_env(filter_env(env, env_public_prefix, env_private_prefix));
-		await set_env(env);
+		set_env(env);
 
 		if (read) {
 			// Wrap the read function to handle MaybePromise<ReadableStream>

--- a/packages/kit/src/types/ambient-private.d.ts
+++ b/packages/kit/src/types/ambient-private.d.ts
@@ -23,7 +23,7 @@ declare module '__sveltekit/env' {
 	// exported environment variables are defined in env.d.ts
 
 	/** Populate exported environment variables */
-	export function set_env(environment: Record<string, string>): Promise<void>;
+	export function set_env(environment: Record<string, string>): void;
 
 	/** public env vars */
 	export const explicit_public_env: Record<string, any>;

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -44,7 +44,6 @@ export interface ServerModule {
 export interface ServerInternalModule {
 	set_assets(path: string): void;
 	set_building(): void;
-	set_env(environment: Record<string, string>): Promise<void>;
 	set_manifest(manifest: SSRManifest): void;
 	set_prerendering(): void;
 	set_private_env(environment: Record<string, string>): void;


### PR DESCRIPTION
Didn't get a chance to review #16058, but I think we should extract the env stuff out into a separate module, so that we don't need the dynamic import in `set_env` — not really an issue during build, but adds unnecessary microtasks on every `server.init(...)` at runtime