### PR TITLE
feat: send periodic keep-alive SSE comments from query.live

### DIFF
--- a/.changeset/live-query-keep-alive.md
+++ b/.changeset/live-query-keep-alive.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+feat: send periodic `keep-alive` SSE comments from `query.live` to prevent idle-timeout errors

--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -14,6 +14,13 @@ import { DEV } from 'esm-env';
 import { record_span } from '../telemetry/record_span.js';
 import { deserialize_binary_form } from '../form-utils.js';
 
+/**
+ * How long (in milliseconds) to wait after the last message was sent before
+ * sending a `: keep-alive` SSE comment, to prevent proxies/load balancers with
+ * an idle timeout from closing an otherwise-quiet `query.live` connection.
+ */
+const KEEP_ALIVE_INTERVAL = 30_000;
+
 /** @type {typeof handle_remote_call_internal} */
 export async function handle_remote_call(event, state, options, manifest, id) {
 	return record_span({
@@ -79,15 +86,35 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 
 				const encoder = new TextEncoder();
 
+				let closed = false;
+
+				/** @type {ReturnType<typeof setTimeout> | undefined} */
+				let keep_alive;
+
+				/**
+				 * (Re)schedule the keep-alive comment. Called whenever a message is sent, so
+				 * that a keep-alive is only emitted once `KEEP_ALIVE_INTERVAL` has elapsed
+				 * without any other activity.
+				 * @param {ReadableStreamDefaultController} controller
+				 */
+				function schedule_keep_alive(controller) {
+					clearTimeout(keep_alive);
+					keep_alive = setTimeout(() => {
+						if (closed || event.request.signal.aborted) return;
+						// SSE comments (lines starting with `:`) are ignored by the client
+						controller.enqueue(encoder.encode(': keep-alive\n\n'));
+						schedule_keep_alive(controller);
+					}, KEEP_ALIVE_INTERVAL);
+				}
+
 				/**
 				 * @param {ReadableStreamDefaultController} controller
 				 * @param {any} payload
 				 */
 				function send(controller, payload) {
 					controller.enqueue(encoder.encode('data: ' + JSON.stringify(payload) + '\n\n'));
+					schedule_keep_alive(controller);
 				}
-
-				let closed = false;
 
 				/** @type {string | undefined} */
 				let result = undefined;
@@ -95,6 +122,7 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 				async function cancel() {
 					if (closed) return;
 					closed = true;
+					clearTimeout(keep_alive);
 					await generator.return(undefined);
 				}
 
@@ -102,6 +130,9 @@ async function handle_remote_call_internal(event, state, options, manifest, id) 
 
 				return new Response(
 					new ReadableStream({
+						start(controller) {
+							schedule_keep_alive(controller);
+						},
 						async pull(controller) {
 							if (event.request.signal.aborted) {
 								await cancel();


### PR DESCRIPTION
Closes #16040 

Send a little `keep-alive` comment every 30 seconds of inactivity to prevent proxies killing the response for inactivity. No configuration for now; if there's a realistic usecase for it we can add it later.