### PR TITLE
fix: encode non-ASCII characters before redirecting

### DIFF
--- a/.changeset/many-mammals-drum.md
+++ b/.changeset/many-mammals-drum.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: encode non-ASCII characters passed to `redirect`

--- a/packages/kit/src/exports/index.spec.js
+++ b/packages/kit/src/exports/index.spec.js
@@ -74,10 +74,16 @@ describe('redirect', () => {
 		assert.equal(e.location, '/%E3%84%B1');
 	});
 
-	it('preserves already percent-encoded pathname characters', () => {
+	it('preserves already percent-encoded characters for relative locations', () => {
 		const e = assert.throws(() => redirect(307, '/%E3%84%B1'));
 		assert.ok(isRedirect(e));
 		assert.equal(e.location, '/%E3%84%B1');
+	});
+
+	it('preserves already percent-encoded characters for absolute locations', () => {
+		const e = assert.throws(() => redirect(307, 'http://%E3%84%B1.com/%E3%84%B1'));
+		assert.ok(isRedirect(e));
+		assert.equal(e.location, 'http://xn--ypd.com/%E3%84%B1');
 	});
 
 	it('preserves pathname relative locations', () => {

--- a/packages/kit/src/exports/index.spec.js
+++ b/packages/kit/src/exports/index.spec.js
@@ -54,17 +54,10 @@ describe('normalizeUrl', () => {
 
 describe('redirect', () => {
 	it('throws Redirect for valid locations', () => {
-		try {
-			redirect(307, '/valid-location');
-			assert.fail('Expected redirect to throw');
-		} catch (e) {
-			if (!isRedirect(e)) {
-				assert.fail('Expected a Redirect error');
-			}
-
-			assert.equal(e.status, 307);
-			assert.equal(e.location, '/valid-location');
-		}
+		const e = assert.throws(() => redirect(307, '/valid-location'));
+		assert.ok(isRedirect(e));
+		assert.equal(e.status, 307);
+		assert.equal(e.location, '/valid-location');
 	});
 
 	it('throws a descriptive error for invalid redirect locations', () => {

--- a/packages/kit/src/exports/index.spec.js
+++ b/packages/kit/src/exports/index.spec.js
@@ -67,14 +67,14 @@ describe('redirect', () => {
 		);
 	});
 
-	it('encodes non-ASCII characters in redirect location', () => {
+	it('encodes non-ASCII characters', () => {
 		const e = assert.throws(() => redirect(303, '/ㄱ'));
 		assert.ok(isRedirect(e));
 		assert.equal(e.status, 303);
 		assert.equal(e.location, '/%E3%84%B1');
 	});
 
-	it('preserves already percent-encoded redirect locations', () => {
+	it('preserves already percent-encoded characters', () => {
 		const e = assert.throws(() => redirect(307, '/%E3%84%B1'));
 		assert.ok(isRedirect(e));
 		assert.equal(e.location, '/%E3%84%B1');
@@ -84,5 +84,12 @@ describe('redirect', () => {
 		const e = assert.throws(() => redirect(303, '/path/한글?q=값#섹션'));
 		assert.ok(isRedirect(e));
 		assert.equal(e.location, '/path/%ED%95%9C%EA%B8%80?q=%EA%B0%92#%EC%84%B9%EC%85%98');
+	});
+
+	it('uses puny code for non-ASCII hosts', () => {
+		const e = assert.throws(() => redirect(303, 'https://내도메인.한국/'));
+		assert.ok(isRedirect(e));
+		assert.equal(e.status, 303);
+		assert.equal(e.location, 'https://xn--220b31d95hq8o.xn--3e0b707e/');
 	});
 });

--- a/packages/kit/src/exports/index.spec.js
+++ b/packages/kit/src/exports/index.spec.js
@@ -80,6 +80,20 @@ describe('redirect', () => {
 		assert.equal(e.location, '/%E3%84%B1');
 	});
 
+	it('preserves pathname relative locations', () => {
+		const e = assert.throws(() => redirect(303, '../'));
+		assert.ok(isRedirect(e));
+		assert.equal(e.status, 303);
+		assert.equal(e.location, '../');
+	});
+
+	it('preserves protocol relative locations', () => {
+		const e = assert.throws(() => redirect(303, '//example.com/a'));
+		assert.ok(isRedirect(e));
+		assert.equal(e.status, 303);
+		assert.equal(e.location, '//example.com/a');
+	});
+
 	it('encodes non-ASCII characters while preserving URL structure', () => {
 		const e = assert.throws(() => redirect(303, '/path/한글?q=값#섹션'));
 		assert.ok(isRedirect(e));

--- a/packages/kit/src/exports/index.spec.js
+++ b/packages/kit/src/exports/index.spec.js
@@ -73,4 +73,23 @@ describe('redirect', () => {
 			'Invalid redirect location "/invalid\\r\\nset-cookie: x=y": this string contains characters that cannot be used in HTTP headers'
 		);
 	});
+
+	it('encodes non-ASCII characters in redirect location', () => {
+		const e = assert.throws(() => redirect(303, '/ㄱ'));
+		assert.ok(isRedirect(e));
+		assert.equal(e.status, 303);
+		assert.equal(e.location, '/%E3%84%B1');
+	});
+
+	it('preserves already percent-encoded redirect locations', () => {
+		const e = assert.throws(() => redirect(307, '/%E3%84%B1'));
+		assert.ok(isRedirect(e));
+		assert.equal(e.location, '/%E3%84%B1');
+	});
+
+	it('encodes non-ASCII characters while preserving URL structure', () => {
+		const e = assert.throws(() => redirect(303, '/path/한글?q=값#섹션'));
+		assert.ok(isRedirect(e));
+		assert.equal(e.location, '/path/%ED%95%9C%EA%B8%80?q=%EA%B0%92#%EC%84%B9%EC%85%98');
+	});
 });

--- a/packages/kit/src/exports/index.spec.js
+++ b/packages/kit/src/exports/index.spec.js
@@ -74,7 +74,7 @@ describe('redirect', () => {
 		assert.equal(e.location, '/%E3%84%B1');
 	});
 
-	it('preserves already percent-encoded characters', () => {
+	it('preserves already percent-encoded pathname characters', () => {
 		const e = assert.throws(() => redirect(307, '/%E3%84%B1'));
 		assert.ok(isRedirect(e));
 		assert.equal(e.location, '/%E3%84%B1');

--- a/packages/kit/src/exports/index.spec.js
+++ b/packages/kit/src/exports/index.spec.js
@@ -86,7 +86,7 @@ describe('redirect', () => {
 		assert.equal(e.location, '/path/%ED%95%9C%EA%B8%80?q=%EA%B0%92#%EC%84%B9%EC%85%98');
 	});
 
-	it('uses puny code for non-ASCII hosts', () => {
+	it('uses punycode for non-ASCII hosts', () => {
 		const e = assert.throws(() => redirect(303, 'https://내도메인.한국/'));
 		assert.ok(isRedirect(e));
 		assert.equal(e.status, 303);

--- a/packages/kit/src/exports/internal/index.js
+++ b/packages/kit/src/exports/internal/index.js
@@ -1,5 +1,7 @@
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 
+import { encode_pathname } from '../../utils/url.js';
+
 export class HttpError {
 	/**
 	 * @param {number} status
@@ -28,8 +30,12 @@ export class Redirect {
 	 */
 	constructor(status, location) {
 		try {
-			// Encode non-ASCII characters so the location is valid in HTTP headers
-			location = location.replace(/[^\u0020-\u007E\t\n\r]+/g, (match) => encodeURIComponent(match));
+			// Encode non-ASCII characters so that the location is valid in HTTP headers
+			if (!location.match(/[\r\n]/)) {
+				location = location.startsWith('/')
+					? encode_pathname(location)
+					: new URL(location).toString();
+			}
 
 			new Headers({ location });
 		} catch {

--- a/packages/kit/src/exports/internal/index.js
+++ b/packages/kit/src/exports/internal/index.js
@@ -27,6 +27,9 @@ export class Redirect {
 	 * @param {string} location
 	 */
 	constructor(status, location) {
+		// Encode non-ASCII characters so the location is valid in HTTP headers
+		location = location.replace(/[^\u0020-\u007E\t\n\r]+/g, (match) => encodeURIComponent(match));
+
 		try {
 			new Headers({ location });
 		} catch {

--- a/packages/kit/src/exports/internal/index.js
+++ b/packages/kit/src/exports/internal/index.js
@@ -29,9 +29,7 @@ export class Redirect {
 	constructor(status, location) {
 		try {
 			// Encode non-ASCII characters so the location is valid in HTTP headers
-			location = location.replace(/[^\u0020-\u007E\t\n\r]+/g, (match) =>
-				encodeURIComponent(match)
-			);
+			location = location.replace(/[^\u0020-\u007E\t\n\r]+/g, (match) => encodeURIComponent(match));
 
 			new Headers({ location });
 		} catch {

--- a/packages/kit/src/exports/internal/index.js
+++ b/packages/kit/src/exports/internal/index.js
@@ -27,10 +27,12 @@ export class Redirect {
 	 * @param {string} location
 	 */
 	constructor(status, location) {
-		// Encode non-ASCII characters so the location is valid in HTTP headers
-		location = location.replace(/[^\u0020-\u007E\t\n\r]+/g, (match) => encodeURIComponent(match));
-
 		try {
+			// Encode non-ASCII characters so the location is valid in HTTP headers
+			location = location.replace(/[^\u0020-\u007E\t\n\r]+/g, (match) =>
+				encodeURIComponent(match)
+			);
+
 			new Headers({ location });
 		} catch {
 			throw new Error(

--- a/packages/kit/src/exports/internal/index.js
+++ b/packages/kit/src/exports/internal/index.js
@@ -1,7 +1,5 @@
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 
-import { encode_pathname } from '../../utils/url.js';
-
 export class HttpError {
 	/**
 	 * @param {number} status
@@ -23,6 +21,8 @@ export class HttpError {
 	}
 }
 
+const url_base_dummy = 'a://a';
+
 export class Redirect {
 	/**
 	 * @param {300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308} status
@@ -33,7 +33,7 @@ export class Redirect {
 			// Encode non-ASCII characters so that the location is valid in HTTP headers
 			if (!location.match(/[\r\n]/)) {
 				location = location.startsWith('/')
-					? encode_pathname(location)
+					? new URL(location, url_base_dummy).href.slice(url_base_dummy.length)
 					: new URL(location).toString();
 			}
 

--- a/packages/kit/src/exports/internal/index.js
+++ b/packages/kit/src/exports/internal/index.js
@@ -34,9 +34,10 @@ export class Redirect {
 		try {
 			// Encode non-ASCII characters so that the location is valid in HTTP headers
 			if (!location.match(/[\r\n]/)) {
+				// if there's a host, use `new URL` instead so that it uses punycode
 				location = location.match(/^[./]/)
 					? encode_pathname(location)
-					: new URL(location).toString(); // if there's a host, use `new URL` so that it uses punycode
+					: new URL(location).toString();
 			}
 
 			new Headers({ location });

--- a/packages/kit/src/exports/internal/index.js
+++ b/packages/kit/src/exports/internal/index.js
@@ -1,5 +1,7 @@
 /** @import { StandardSchemaV1 } from '@standard-schema/spec' */
 
+import { encode_pathname } from '../../utils/url.js';
+
 export class HttpError {
 	/**
 	 * @param {number} status
@@ -32,9 +34,9 @@ export class Redirect {
 		try {
 			// Encode non-ASCII characters so that the location is valid in HTTP headers
 			if (!location.match(/[\r\n]/)) {
-				location = location.startsWith('/')
-					? new URL(location, url_base_dummy).href.slice(url_base_dummy.length)
-					: new URL(location).toString();
+				location = location.match(/^[./]/)
+					? encode_pathname(location)
+					: new URL(location).toString(); // if there's a host, use `new URL` so that it uses punycode
 			}
 
 			new Headers({ location });

--- a/packages/kit/src/exports/internal/index.js
+++ b/packages/kit/src/exports/internal/index.js
@@ -23,8 +23,6 @@ export class HttpError {
 	}
 }
 
-const url_base_dummy = 'a://a';
-
 export class Redirect {
 	/**
 	 * @param {300 | 301 | 302 | 303 | 304 | 305 | 306 | 307 | 308} status

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -44,6 +44,14 @@ export function normalize_path(path, trailing_slash) {
 }
 
 /**
+ * Encode pathname excluding % to prevent further double encoding
+ * @param {string} pathname
+ */
+export function encode_pathname(pathname) {
+	return pathname.split('%').map(encodeURI).join('%');
+}
+
+/**
  * Decode pathname excluding %25 to prevent further double decoding of params
  * @param {string} pathname
  */

--- a/packages/kit/src/utils/url.js
+++ b/packages/kit/src/utils/url.js
@@ -44,14 +44,6 @@ export function normalize_path(path, trailing_slash) {
 }
 
 /**
- * Encode pathname excluding % to prevent further double encoding
- * @param {string} pathname
- */
-export function encode_pathname(pathname) {
-	return pathname.split('%').map(encodeURI).join('%');
-}
-
-/**
  * Decode pathname excluding %25 to prevent further double decoding of params
  * @param {string} pathname
  */


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/16054

This PR calls `encodeURIComponent` for non-ASCII characters before redirecting. Not sure if this is the best solution as I used Opus for this. Tests seem useful though.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
