### PR TITLE
chore: await web-first assertions in basics client tests

### DIFF
--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1068,7 +1068,7 @@ test.describe('data-sveltekit attributes', () => {
 			// it's chrome-error://chromewebdata/ on ubuntu but not on windows
 			offline_url = /chrome-error:\/\/chromewebdata\/|\/data-sveltekit\/preload-data\/offline/;
 		}
-		expect(page).toHaveURL(offline_url);
+		await expect(page).toHaveURL(offline_url);
 	});
 
 	test('data-sveltekit-preload-data error does not block user navigation', async ({
@@ -1086,7 +1086,7 @@ test.describe('data-sveltekit attributes', () => {
 			page.waitForLoadState('networkidle') // wait for preloading to finish
 		]);
 
-		expect(page).toHaveURL('/data-sveltekit/preload-data/offline');
+		await expect(page).toHaveURL('/data-sveltekit/preload-data/offline');
 
 		await page.locator('#one').dispatchEvent('click');
 		await page.waitForTimeout(100); // wait for navigation to start
@@ -1097,7 +1097,7 @@ test.describe('data-sveltekit attributes', () => {
 			// it's chrome-error://chromewebdata/ on ubuntu but not on windows
 			offline_url = /chrome-error:\/\/chromewebdata\/|\/data-sveltekit\/preload-data\/offline/;
 		}
-		expect(page).toHaveURL(offline_url);
+		await expect(page).toHaveURL(offline_url);
 	});
 
 	test('data-sveltekit-preload does not abort ongoing navigation', async ({ page }) => {
@@ -1111,7 +1111,7 @@ test.describe('data-sveltekit attributes', () => {
 			page.waitForLoadState('networkidle') // wait for preloading to finish
 		]);
 
-		expect(page).toHaveURL('/data-sveltekit/preload-data/offline/slow-navigation');
+		await expect(page).toHaveURL('/data-sveltekit/preload-data/offline/slow-navigation');
 	});
 
 	test('data-sveltekit-preload does not abort ongoing navigation #2', async ({ page }) => {
@@ -1125,7 +1125,7 @@ test.describe('data-sveltekit attributes', () => {
 			page.waitForLoadState('networkidle') // wait for preloading to finish
 		]);
 
-		expect(page).toHaveURL('/data-sveltekit/preload-data/offline/slow-navigation');
+		await expect(page).toHaveURL('/data-sveltekit/preload-data/offline/slow-navigation');
 		await expect(page.getByText('slow navigation', { exact: true })).toBeVisible();
 	});
 
@@ -1331,7 +1331,7 @@ test.describe('env', () => {
 	}) => {
 		await page.goto('/prerendering/env/prerendered');
 		await clicknav('[href="/prerendering/env/dynamic"]');
-		expect(await page.locator('h2')).toHaveText('prerendering: false');
+		await expect(page.locator('h2')).toHaveText('prerendering: false');
 	});
 });
 


### PR DESCRIPTION
Several Playwright assertions in `packages/kit/test/apps/basics/test/client.test.js` use web-first matchers without awaiting them, so the returned promise floats and the assertion never actually runs. The affected tests pass regardless of the real page URL or text content, which means they provide no coverage today.

Affected assertions:

- `expect(page).toHaveURL(...)` in "data-sveltekit-preload-data network failure does not trigger navigation" (sole assertion of the test).
- two `expect(page).toHaveURL(...)` calls in "data-sveltekit-preload-data error does not block user navigation" (the only assertions of the test).
- `expect(page).toHaveURL(...)` in "data-sveltekit-preload does not abort ongoing navigation" (sole assertion).
- `expect(page).toHaveURL(...)` in "data-sveltekit-preload does not abort ongoing navigation #2".
- `expect(await page.locator('h2')).toHaveText(...)` in "uses correct dynamic env when navigating from prerendered page". Here the await is on the locator (a no-op) rather than on the assertion, so the matcher still floats. Sole assertion of the test.

The fix adds the missing await (and moves it outside `expect()` for the h2 case) so each matcher runs and can fail. No test titles, selectors, or expected values are changed; this only makes the existing assertions effective.

### Tests

- [ ] I was not able to run the full Playwright e2e suite locally (the demo apps require a build/dev server in my environment). The change is a mechanical addition of missing `await`s to existing assertions, with no behavior, selector, or expected-value change.

### Changesets

- [x] No changeset: this is a test-only change under `packages/kit/test/` with no published-package changelog impact.

### Edits

- [x] Allow edits from maintainers is enabled.

---

Found while reviewing the test suite with [e2e-skills/e2e-reviewer](https://github.com/voidmatcha/e2e-skills#skill-2-e2e-reviewer--quality-review).
