### PR TITLE
fix: bundle entrypoints alongside app code

### DIFF
--- a/.changeset/major-lizards-wash.md
+++ b/.changeset/major-lizards-wash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+fix: bundle entrypoints alongside app code

--- a/packages/adapter-node/index.d.ts
+++ b/packages/adapter-node/index.d.ts
@@ -1,11 +1,6 @@
 import { Adapter } from '@sveltejs/kit';
 import './ambient.js';
 
-declare global {
-	const ENV_PREFIX: string;
-	const PRECOMPRESS: boolean;
-}
-
 interface AdapterOptions {
 	out?: string;
 	precompress?: boolean;

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -50,15 +50,6 @@ export default function (opts = {}) {
 			builder.copy(files, `${tmp}/entries`);
 			builder.writeServer(`${tmp}/app`);
 
-			writeFileSync(
-				`${tmp}/app/manifest.js`,
-				[
-					`export const manifest = ${builder.generateManifest({ relativePath: './' })};`,
-					`export const prerendered = new Set(${JSON.stringify(builder.prerendered.paths)});`,
-					`export const base = ${JSON.stringify(builder.config.kit.paths.base)};`
-				].join('\n\n')
-			);
-
 			const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
 
 			/** @type {Record<string, string>} */
@@ -66,23 +57,14 @@ export default function (opts = {}) {
 				index: `${tmp}/entries/index.js`,
 				env: `${tmp}/entries/env.js`,
 				handler: `${tmp}/entries/handler.js`,
-				shims: `${tmp}/entries/shims.js`,
-				['server/index']: `${tmp}/app/index.js`,
-				['server/manifest']: `${tmp}/app/manifest.js`
+				shims: `${tmp}/entries/shims.js`
 			};
 
 			if (builder.hasServerInstrumentationFile?.()) {
-				input['server/instrumentation.server'] = `${tmp}/instrumentation.server.js`;
+				input['instrumentation.server'] = `${tmp}/instrumentation.server.js`;
 			}
 
-			/** @type {Record<string, string>} */
-			const entries = {
-				ENV: './env.js',
-				HANDLER: './handler.js',
-				MANIFEST: './server/manifest.js',
-				SERVER: './server/index.js',
-				SHIMS: './shims.js'
-			};
+			const server = builder.getServerDirectory();
 
 			// we bundle the Vite output so that deployments only need
 			// their production dependencies. Anything in devDependencies
@@ -97,10 +79,15 @@ export default function (opts = {}) {
 					{
 						name: 'adapter-node:alias',
 						resolveId(id) {
-							if (Object.hasOwn(entries, id)) {
+							if (id === 'SERVER') {
 								return {
-									id: entries[id],
-									external: true
+									id: `${server}/index.js`
+								};
+							}
+
+							if (id === 'MANIFEST') {
+								return {
+									id: `${server}/manifest.js`
 								};
 							}
 						}
@@ -112,8 +99,10 @@ export default function (opts = {}) {
 					// @ts-expect-error typescript is just... wrong here?
 					replace({
 						values: {
+							BASE: JSON.stringify(builder.config.kit.paths.base),
 							ENV_PREFIX: JSON.stringify(envPrefix),
-							PRECOMPRESS: JSON.stringify(precompress)
+							PRECOMPRESS: JSON.stringify(precompress),
+							PRERENDERED: `new Set(${JSON.stringify(builder.prerendered.paths)})`
 						},
 						preventAssignment: true
 					}),
@@ -134,7 +123,7 @@ export default function (opts = {}) {
 			if (builder.hasServerInstrumentationFile?.()) {
 				builder.instrument?.({
 					entrypoint: `${out}/index.js`,
-					instrumentation: `${out}/server/instrumentation.server.js`,
+					instrumentation: `${out}/instrumentation.server.js`,
 					module: {
 						exports: ['path', 'host', 'port', 'server']
 					}

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -4,6 +4,7 @@ import { rollup } from 'rollup';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
+import replace from '@rollup/plugin-replace';
 
 /**
  * @template T
@@ -46,10 +47,11 @@ export default function (opts = {}) {
 
 			builder.log.minor('Building server');
 
-			builder.writeServer(tmp);
+			builder.copy(files, `${tmp}/entries`);
+			builder.writeServer(`${tmp}/app`);
 
 			writeFileSync(
-				`${tmp}/manifest.js`,
+				`${tmp}/app/manifest.js`,
 				[
 					`export const manifest = ${builder.generateManifest({ relativePath: './' })};`,
 					`export const prerendered = new Set(${JSON.stringify(builder.prerendered.paths)});`,
@@ -61,13 +63,26 @@ export default function (opts = {}) {
 
 			/** @type {Record<string, string>} */
 			const input = {
-				index: `${tmp}/index.js`,
-				manifest: `${tmp}/manifest.js`
+				index: `${tmp}/entries/index.js`,
+				env: `${tmp}/entries/env.js`,
+				handler: `${tmp}/entries/handler.js`,
+				shims: `${tmp}/entries/shims.js`,
+				['server/index']: `${tmp}/app/index.js`,
+				['server/manifest']: `${tmp}/app/manifest.js`
 			};
 
 			if (builder.hasServerInstrumentationFile?.()) {
-				input['instrumentation.server'] = `${tmp}/instrumentation.server.js`;
+				input['server/instrumentation.server'] = `${tmp}/instrumentation.server.js`;
 			}
+
+			/** @type {Record<string, string>} */
+			const entries = {
+				ENV: './env.js',
+				HANDLER: './handler.js',
+				MANIFEST: './server/manifest.js',
+				SERVER: './server/index.js',
+				SHIMS: './shims.js'
+			};
 
 			// we bundle the Vite output so that deployments only need
 			// their production dependencies. Anything in devDependencies
@@ -79,9 +94,28 @@ export default function (opts = {}) {
 					...Object.keys(pkg.dependencies || {}).map((d) => new RegExp(`^${d}(\\/.*)?$`))
 				],
 				plugins: [
+					{
+						name: 'adapter-node:alias',
+						resolveId(id) {
+							if (Object.hasOwn(entries, id)) {
+								return {
+									id: entries[id],
+									external: true
+								};
+							}
+						}
+					},
 					nodeResolve({
 						preferBuiltins: true,
 						exportConditions: ['node']
+					}),
+					// @ts-expect-error typescript is just... wrong here?
+					replace({
+						values: {
+							ENV_PREFIX: JSON.stringify(envPrefix),
+							PRECOMPRESS: JSON.stringify(precompress)
+						},
+						preventAssignment: true
 					}),
 					// @ts-ignore https://github.com/rollup/plugins/issues/1329
 					commonjs({ strictRequires: true }),
@@ -91,22 +125,10 @@ export default function (opts = {}) {
 			});
 
 			await bundle.write({
-				dir: `${out}/server`,
+				dir: out,
 				format: 'esm',
 				sourcemap: true,
-				chunkFileNames: 'chunks/[name]-[hash].js'
-			});
-
-			builder.copy(files, out, {
-				replace: {
-					ENV: './env.js',
-					HANDLER: './handler.js',
-					MANIFEST: './server/manifest.js',
-					SERVER: './server/index.js',
-					SHIMS: './shims.js',
-					ENV_PREFIX: JSON.stringify(envPrefix),
-					PRECOMPRESS: JSON.stringify(precompress)
-				}
+				chunkFileNames: 'server/chunks/[name]-[hash].js'
 			});
 
 			if (builder.hasServerInstrumentationFile?.()) {

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -51,6 +51,9 @@ export default function (opts = {}) {
 			// so that node modules are correctly resolved
 			builder.copy(files, `${tmp}/entries`);
 
+			const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+			const server = builder.getServerDirectory();
+
 			/** @type {Record<string, string>} */
 			const input = {
 				index: `${tmp}/entries/index.js`,
@@ -60,11 +63,8 @@ export default function (opts = {}) {
 			};
 
 			if (builder.hasServerInstrumentationFile?.()) {
-				input['instrumentation.server'] = `${tmp}/instrumentation.server.js`;
+				input['instrumentation.server'] = `${server}/instrumentation.server.js`;
 			}
-
-			const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
-			const server = builder.getServerDirectory();
 
 			// we bundle the Vite output so that deployments only need
 			// their production dependencies. Anything in devDependencies

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { rollup } from 'rollup';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
@@ -47,10 +47,9 @@ export default function (opts = {}) {
 
 			builder.log.minor('Building server');
 
+			// Copy the entrypoints into `.svelte-kit/adapter-node/entries`,
+			// so that node modules are correctly resolved
 			builder.copy(files, `${tmp}/entries`);
-			builder.writeServer(`${tmp}/app`);
-
-			const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
 
 			/** @type {Record<string, string>} */
 			const input = {
@@ -64,6 +63,7 @@ export default function (opts = {}) {
 				input['instrumentation.server'] = `${tmp}/instrumentation.server.js`;
 			}
 
+			const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
 			const server = builder.getServerDirectory();
 
 			// we bundle the Vite output so that deployments only need
@@ -79,24 +79,15 @@ export default function (opts = {}) {
 					{
 						name: 'adapter-node:alias',
 						resolveId(id) {
-							if (id === 'SERVER') {
-								return {
-									id: `${server}/index.js`
-								};
-							}
-
-							if (id === 'MANIFEST') {
-								return {
-									id: `${server}/manifest.js`
-								};
-							}
+							if (id === 'SERVER') return `${server}/index.js`;
+							if (id === 'MANIFEST') return `${server}/manifest.js`;
 						}
 					},
 					nodeResolve({
 						preferBuiltins: true,
 						exportConditions: ['node']
 					}),
-					// @ts-expect-error typescript is just... wrong here?
+					// @ts-expect-error https://github.com/rollup/plugins/issues/1329
 					replace({
 						values: {
 							BASE: JSON.stringify(builder.config.kit.paths.base),
@@ -106,9 +97,9 @@ export default function (opts = {}) {
 						},
 						preventAssignment: true
 					}),
-					// @ts-ignore https://github.com/rollup/plugins/issues/1329
+					// @ts-expect-error https://github.com/rollup/plugins/issues/1329
 					commonjs({ strictRequires: true }),
-					// @ts-ignore https://github.com/rollup/plugins/issues/1329
+					// @ts-expect-error https://github.com/rollup/plugins/issues/1329
 					json()
 				]
 			});

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -89,6 +89,10 @@ export default function (opts = {}) {
 					}),
 					// @ts-expect-error https://github.com/rollup/plugins/issues/1329
 					replace({
+						// only replace tokens in the adapter's own entrypoints, so that
+						// identifiers like `BASE` in the user's app code or bundled
+						// dependencies aren't accidentally replaced
+						include: [`${tmp}/entries/**`],
 						values: {
 							BASE: JSON.stringify(builder.config.kit.paths.base),
 							ENV_PREFIX: JSON.stringify(envPrefix),

--- a/packages/adapter-node/internal.d.ts
+++ b/packages/adapter-node/internal.d.ts
@@ -7,9 +7,7 @@ declare module 'SERVER' {
 	export { Server } from '@sveltejs/kit';
 }
 
-declare global {
-	const ENV_PREFIX: string;
-	const PRECOMPRESS: boolean;
-}
-
-export {};
+declare const BASE: string;
+declare const ENV_PREFIX: string;
+declare const PRECOMPRESS: boolean;
+declare const PRERENDERED: Set<string>;

--- a/packages/adapter-node/internal.d.ts
+++ b/packages/adapter-node/internal.d.ts
@@ -1,22 +1,15 @@
-declare module 'ENV' {
-	export function env(key: string, fallback?: any): string;
-	export function timeout_env(key: string, fallback?: any): number | undefined;
-}
-
-declare module 'HANDLER' {
-	export const handler: import('polka').Middleware;
-}
-
 declare module 'MANIFEST' {
 	import { SSRManifest } from '@sveltejs/kit';
-
-	export const base: string;
 	export const manifest: SSRManifest;
-	export const prerendered: Set<string>;
 }
 
 declare module 'SERVER' {
 	export { Server } from '@sveltejs/kit';
 }
 
-declare module 'SHIMS' {}
+declare global {
+	const ENV_PREFIX: string;
+	const PRECOMPRESS: boolean;
+}
+
+export {};

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -54,6 +54,7 @@
 		"@rollup/plugin-commonjs": "^29.0.0",
 		"@rollup/plugin-json": "^6.1.0",
 		"@rollup/plugin-node-resolve": "^16.0.0",
+		"@rollup/plugin-replace": "^6.0.3",
 		"rollup": "^4.59.0"
 	},
 	"peerDependencies": {

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -35,60 +35,27 @@ function prefixBuiltinModules() {
 	};
 }
 
-// TODO could this be a single build with multiple entries?
 export default [
 	{
-		input: 'src/index.js',
+		input: {
+			index: 'src/index.js',
+			env: 'src/env.js',
+			handler: 'src/handler.js',
+			shims: 'src/shims.js'
+		},
 		output: {
-			file: 'files/index.js',
-			format: 'esm'
+			dir: 'files',
+			format: 'esm',
+			hoistTransitiveImports: false,
+			chunkFileNames: 'chunks/[hash].js'
 		},
 		plugins: [
-			clearOutput('files/index.js'),
+			clearOutput('files'),
 			nodeResolve({ preferBuiltins: true }),
 			commonjs(),
 			json(),
 			prefixBuiltinModules()
 		],
-		external: ['ENV', 'HANDLER']
-	},
-	{
-		input: 'src/env.js',
-		output: {
-			file: 'files/env.js',
-			format: 'esm'
-		},
-		plugins: [
-			clearOutput('files/env.js'),
-			nodeResolve(),
-			commonjs(),
-			json(),
-			prefixBuiltinModules()
-		],
-		external: ['HANDLER']
-	},
-	{
-		input: 'src/handler.js',
-		output: {
-			file: 'files/handler.js',
-			format: 'esm',
-			inlineDynamicImports: true
-		},
-		plugins: [
-			clearOutput('files/handler.js'),
-			nodeResolve(),
-			commonjs(),
-			json(),
-			prefixBuiltinModules()
-		],
-		external: ['ENV', 'MANIFEST', 'SERVER', 'SHIMS', '@sveltejs/kit/node']
-	},
-	{
-		input: 'src/shims.js',
-		output: {
-			file: 'files/shims.js',
-			format: 'esm'
-		},
-		plugins: [clearOutput('files/shims.js'), nodeResolve(), commonjs(), prefixBuiltinModules()]
+		external: ['MANIFEST', 'SERVER', '@sveltejs/kit/node', '@sveltejs/kit/node/polyfills']
 	}
 ];

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -35,27 +35,25 @@ function prefixBuiltinModules() {
 	};
 }
 
-export default [
-	{
-		input: {
-			index: 'src/index.js',
-			env: 'src/env.js',
-			handler: 'src/handler.js',
-			shims: 'src/shims.js'
-		},
-		output: {
-			dir: 'files',
-			format: 'esm',
-			hoistTransitiveImports: false,
-			chunkFileNames: 'chunks/[hash].js'
-		},
-		plugins: [
-			clearOutput('files'),
-			nodeResolve({ preferBuiltins: true }),
-			commonjs(),
-			json(),
-			prefixBuiltinModules()
-		],
-		external: ['MANIFEST', 'SERVER', '@sveltejs/kit/node', '@sveltejs/kit/node/polyfills']
-	}
-];
+export default {
+	input: {
+		index: 'src/index.js',
+		env: 'src/env.js',
+		handler: 'src/handler.js',
+		shims: 'src/shims.js'
+	},
+	output: {
+		dir: 'files',
+		format: 'esm',
+		hoistTransitiveImports: false,
+		chunkFileNames: 'chunks/[hash].js'
+	},
+	plugins: [
+		clearOutput('files'),
+		nodeResolve({ preferBuiltins: true }),
+		commonjs(),
+		json(),
+		prefixBuiltinModules()
+	],
+	external: ['MANIFEST', 'SERVER', '@sveltejs/kit/node', '@sveltejs/kit/node/polyfills']
+};

--- a/packages/adapter-node/rollup.config.js
+++ b/packages/adapter-node/rollup.config.js
@@ -35,6 +35,7 @@ function prefixBuiltinModules() {
 	};
 }
 
+// TODO could this be a single build with multiple entries?
 export default [
 	{
 		input: 'src/index.js',
@@ -80,7 +81,7 @@ export default [
 			json(),
 			prefixBuiltinModules()
 		],
-		external: ['ENV', 'MANIFEST', 'SERVER', 'SHIMS']
+		external: ['ENV', 'MANIFEST', 'SERVER', 'SHIMS', '@sveltejs/kit/node']
 	},
 	{
 		input: 'src/shims.js',

--- a/packages/adapter-node/src/env.js
+++ b/packages/adapter-node/src/env.js
@@ -35,7 +35,7 @@ if (ENV_PREFIX) {
 
 /**
  * @param {string} name
- * @param {any} fallback
+ * @param {any} [fallback]
  */
 export function env(name, fallback) {
 	const prefix = expected_unprefixed.has(name) ? '' : ENV_PREFIX;

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -1,4 +1,4 @@
-import 'SHIMS';
+import './shims.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
@@ -7,12 +7,16 @@ import { fileURLToPath } from 'node:url';
 import { parse as polka_url_parser } from '@polka/url';
 import { getRequest, setResponse, createReadableStream } from '@sveltejs/kit/node';
 import { Server } from 'SERVER';
-import { manifest, prerendered, base } from 'MANIFEST';
-import { env } from 'ENV';
+import { manifest } from 'MANIFEST';
+import { env } from './env.js';
 import { parse_as_bytes, parse_origin } from '../utils.js';
 
+/* global BASE */
 /* global ENV_PREFIX */
 /* global PRECOMPRESS */
+/* global PRERENDERED */
+
+const prerendered = PRERENDERED;
 
 const server = new Server(manifest);
 
@@ -35,7 +39,7 @@ if (isNaN(body_size_limit)) {
 
 const dir = path.dirname(fileURLToPath(import.meta.url));
 
-const asset_dir = `${dir}/client${base}`;
+const asset_dir = `${dir}/client${BASE}`;
 
 await server.init({
 	env: /** @type {Record<string, string>} */ (process.env),

--- a/packages/adapter-node/src/index.js
+++ b/packages/adapter-node/src/index.js
@@ -1,7 +1,7 @@
 import http from 'node:http';
 import process from 'node:process';
-import { handler } from 'HANDLER';
-import { env, timeout_env } from 'ENV';
+import { handler } from './handler.js';
+import { env, timeout_env } from './env.js';
 import polka from 'polka';
 import { format_listening_address } from '../utils.js';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,6 +340,9 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: ^16.0.0
         version: 16.0.0(rollup@4.59.0)
+      '@rollup/plugin-replace':
+        specifier: ^6.0.3
+        version: 6.0.3(rollup@4.59.0)
       rollup:
         specifier: ^4.59.0
         version: 4.59.0
@@ -3227,6 +3230,15 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.78.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-replace@6.0.3':
+    resolution: {integrity: sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -7890,6 +7902,13 @@ snapshots:
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.8
+    optionalDependencies:
+      rollup: 4.59.0
+
+  '@rollup/plugin-replace@6.0.3(rollup@4.59.0)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.3(rollup@4.59.0)
+      magic-string: 0.30.21
     optionalDependencies:
       rollup: 4.59.0
 


### PR DESCRIPTION
closes #15755. By bundling the adapter entry points and the already-Vite-bundled app code together, we prevent multiple copies of things like `SvelteKitError`

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
