### PR TITLE
fix: declare typescript as an optional peer dependency of `@sveltejs/package`

### DIFF
--- a/.changeset/wise-pumas-deny.md
+++ b/.changeset/wise-pumas-deny.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/package': patch
+---
+
+fix: declare typescript as an optional peer dependency so svelte-package works under strict node-linkers

--- a/packages/package/package.json
+++ b/packages/package/package.json
@@ -38,7 +38,13 @@
 		"vitest": "catalog:"
 	},
 	"peerDependencies": {
-		"svelte": "^3.44.0 || ^4.0.0 || ^5.0.0-next.1"
+		"svelte": "^3.44.0 || ^4.0.0 || ^5.0.0-next.1",
+		"typescript": "^6.0.0"
+	},
+	"peerDependenciesMeta": {
+		"typescript": {
+			"optional": true
+		}
 	},
 	"bin": {
 		"svelte-package": "svelte-package.js"


### PR DESCRIPTION
Closes #16067.

`@sveltejs/package` (`svelte-package`) `import()`s `typescript` at runtime to transpile `.ts` files and emit `.d.ts` declarations, but never declares it. This works when `typescript` happens to be hoisted reachable from the package, but breaks under strict, non-hoisting node-linkers (pnpm `enableGlobalVirtualStore`, Yarn PnP / `node-linker=pnp`) — even when the consuming project depends on `typescript`.

I went with v6 for the peer dep since that's what we require for kit starting with v3.