### PR TITLE
fix: sort directory entries when building the route manifest

### DIFF
--- a/.changeset/sort-manifest-readdir.md
+++ b/.changeset/sort-manifest-readdir.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: sort directory entries when building the route manifest so node indices are deterministic across runtimes (e.g. Bun and Node)

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -221,10 +221,17 @@ function create_routes_and_nodes(cwd, config, fallback) {
 
 			// We can't use withFileTypes because of a NodeJs bug which returns wrong results
 			// with isDirectory() in case of symlinks: https://github.com/nodejs/node/issues/30646
-			const files = fs.readdirSync(dir).map((name) => ({
-				is_dir: fs.statSync(path.join(dir, name)).isDirectory(),
-				name
-			}));
+			// We sort the entries because `readdirSync` order is not guaranteed and differs
+			// between runtimes (e.g. Node returns entries alphabetically, Bun in directory
+			// order). Node indices are assigned from this traversal order, so without sorting
+			// the SSR and client manifests can disagree, causing hydration mismatches.
+			const files = fs
+				.readdirSync(dir)
+				.sort()
+				.map((name) => ({
+					is_dir: fs.statSync(path.join(dir, name)).isDirectory(),
+					name
+				}));
 
 			// process files first
 			for (const file of files) {

--- a/packages/kit/src/core/sync/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.spec.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { assert, expect, test } from 'vitest';
+import { assert, expect, test, vi } from 'vitest';
 import create_manifest_data from './index.js';
 import { sort_routes } from './sort.js';
 import { validate_config } from '../../config/index.js';
@@ -107,6 +107,31 @@ test('creates routes', () => {
 			page: { layouts: [0], errors: [1], leaf: 5 }
 		}
 	]);
+});
+
+test('assigns deterministic node indices regardless of readdirSync order', () => {
+	// `readdirSync` order is not guaranteed and differs between runtimes (e.g. Node
+	// returns entries alphabetically, Bun in directory order). Node indices are assigned
+	// from the traversal order, so an unsorted result could make the SSR and client
+	// manifests disagree. Simulate a runtime that returns entries in reverse order and
+	// assert the output matches the normal (sorted) run.
+	const expected = create('samples/basic');
+
+	const actual_readdir = fs.readdirSync;
+	const spy = vi.spyOn(fs, 'readdirSync').mockImplementation((...args) => {
+		const result = /** @type {string[]} */ (
+			/** @type {unknown} */ (actual_readdir(.../** @type {[any, any]} */ (args)))
+		);
+		return /** @type {any} */ ([...result].sort().reverse());
+	});
+
+	try {
+		const actual = create('samples/basic');
+		expect(actual.nodes.map(simplify_node)).toEqual(expected.nodes.map(simplify_node));
+		expect(actual.routes.map(simplify_route)).toEqual(expected.routes.map(simplify_route));
+	} finally {
+		spy.mockRestore();
+	}
 });
 
 const symlink_survived_git = fs


### PR DESCRIPTION
Closes #15313.

`create_manifest_data` assigns node indices based on the order `fs.readdirSync()` returns directory entries. That order isn't guaranteed and differs between runtimes (Node returns entries alphabetically, Bun in directory order). When the SSR manifest is generated by one runtime and the client manifest by another, the emitted `node_ids` point at the wrong components, causing hydration mismatches and `HierarchyRequestError`.

This sorts entries during traversal, matching Node's existing alphabetical behavior so it's a no-op for Node and normalizes other runtimes. The sort is build/sync-time only and negligible next to the per-entry `statSync` calls.
