### PR TITLE
fix: don't cache missing immutable asset 404s

### DIFF
--- a/.changeset/weak-files-enter.md
+++ b/.changeset/weak-files-enter.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/kit': patch
+'@sveltejs/adapter-vercel': patch
 ---
 
 fix: prevent missing immutable assets from being cached as 404s for a year

--- a/.changeset/weak-files-enter.md
+++ b/.changeset/weak-files-enter.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prevent missing immutable assets from being cached as 404s for a year

--- a/packages/adapter-vercel/index.js
+++ b/packages/adapter-vercel/index.js
@@ -683,10 +683,14 @@ function static_vercel_config(builder, config, dir) {
 	// Prevent incorrect caching: if a request to /_app/immutable/* doesn't match
 	// a static file, return 404 instead of falling through to dynamic routes.
 	// Otherwise, we could accidentally immutably cache dynamic content served
-	// by the fallback function.
+	// by the fallback function. `no-store` stops the earlier immutable header
+	// from sticking to this 404, so a missing asset isn't cached for a year.
 	routes.push({
 		src: `/${builder.getAppPath()}/immutable/.+`,
 		status: 404,
+		headers: {
+			'cache-control': 'no-store'
+		},
 		continue: false
 	});
 


### PR DESCRIPTION
closes #16071<!-- Add the related issue number here. Repeat this line for each additional issue it closes -->

<!-- Explain the goal of the PR, why it is needed, and what has been changed to achieve that goal -->

The 404 route added in `c67da8a` (for `/_app/immutable/*` requests that don't match a static file) correctly stops missing assets from falling through to the dynamic fallback. However, an earlier route in `static_vercel_config` applies `cache-control: public, immutable, max-age=31536000` to all `/_app/immutable/*` requests with `continue: true`, and the 404 route doesn't override it. As a result the 404 inherits the immutable, one-year header.

The effect is that a browser (or CDN) stores the "not found" for a year and replays it from disk. For clients holding stale HTML after a deploy — the exact version-skew scenario — this turns a transient, self-healing miss into a permanent failure: the request can never re-resolve even after the asset exists again, and a CSS/JS request gets a `text/plain` 404 body (causing MIME errors).

This adds cache-control: no-store to the 404 route so missing-asset responses are never stored and self-heal on the next request.

Repro (against any deployed `adapter-vercel` ≥ 6.3.2 site):

```shell
curl -sS -D - -o /dev/null 'https://<site>/_app/immutable/chunks/DOES-NOT-EXIST.js'
# HTTP/2 404
# cache-control: public, immutable, max-age=31536000   <-- inherited, the bug
```

After this change the same request returns `cache-control: no-store`.

I've been running this exact override as a local pnpm patch in production and verified on a preview deploy that the 404 now returns `cache-control: no-store` with no immutable header.

Note on the header value: I used no-store since a missing asset is a "don't keep this" response (matching the `no-store` convention used in kit's data layer). Happy to switch to `public, max-age=0, must-revalidate` if preferred to mirror the successful-page-render default in `respond.js` — functionally equivalent here since there's no validator.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
