### PR TITLE
feat: Add `isValid` to Remote Form

### DIFF
--- a/.changeset/open-guests-appear.md
+++ b/.changeset/open-guests-appear.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: Add `isValid` to remote form and remote form fields

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1997,6 +1997,8 @@ type RemoteFormFieldMethods<T> = {
 	set(input: DeepPartial<T>): DeepPartial<T>;
 	/** Validation issues, if any */
 	issues(): RemoteFormIssue[] | undefined;
+	/** The validity of the field. Defaults to `true` if this field has not been validated */
+	isValid(): boolean;
 };
 
 // These two types use "T extends unknown ? .. : .." to distribute over unions.
@@ -2210,6 +2212,8 @@ export type RemoteForm<Input extends RemoteFormInput | void, Output> = {
 	get result(): Output | undefined;
 	/** The number of pending submissions */
 	get pending(): number;
+	/** The overall validity of the form. Defaults to `true` if `validate` has not been called */
+	get isValid(): boolean;
 	/** Access form fields using object notation */
 	fields: RemoteFormFieldsRoot<Input>;
 };

--- a/packages/kit/src/runtime/app/server/remote/form.js
+++ b/packages/kit/src/runtime/app/server/remote/form.js
@@ -236,6 +236,10 @@ export function form(validate_or_fn, maybe_fn) {
 			get: () => 0
 		});
 
+		Object.defineProperty(instance, 'isValid', {
+			get: () => (get_cache(__, get_request_store().state)?.['']?.issues ?? []).length === 0
+		});
+
 		Object.defineProperty(instance, 'preflight', {
 			// preflight is a noop on the server
 			value: () => instance

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -76,6 +76,8 @@ export function form(id) {
 
 		const issues = $derived(flatten_issues(raw_issues));
 
+		const isFormValid = $derived(raw_issues.length === 0);
+
 		/** @type {any} */
 		let result = $state.raw(initial?.result);
 
@@ -688,6 +690,9 @@ export function form(id) {
 					enhance_callback = callback;
 					return instance;
 				}
+			},
+			isValid: {
+				get: () => isFormValid
 			}
 		});
 

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -669,6 +669,14 @@ export function create_field_proxy(target, get_input, set_input, get_issues, pat
 				return create_field_proxy(issues_func, get_input, set_input, get_issues, [...path, prop]);
 			}
 
+			if (prop === 'isValid') {
+				const is_valid_func = () => {
+					return !((key === '' ? '$' : key) in get_issues());
+				};
+
+				return create_field_proxy(is_valid_func, get_input, set_input, get_issues, [...path, prop]);
+			}
+
 			if (prop === 'as') {
 				/**
 				 * @param {string} type

--- a/packages/kit/test/apps/async/src/routes/remote/form/is-valid/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/is-valid/+page.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { test_form } from './form.remote';
+</script>
+
+<p id="foo">foo: {test_form.fields?.foo?.isValid()}</p>
+<p id="nested-bar">nested.bar: {test_form.fields?.nested?.bar?.isValid()}</p>
+<p id="overall-fields">overall fields: {test_form.fields.isValid()}</p>
+<p id="overall-form">overall form: {test_form.isValid}</p>
+
+<form {...test_form} oninput={() => test_form.validate()}>
+	<input {...test_form.fields.foo.as('text')} />
+	<input {...test_form.fields.nested.bar.as('text')} />
+	<button type="submit">Submit</button>
+</form>

--- a/packages/kit/test/apps/async/src/routes/remote/form/is-valid/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/is-valid/form.remote.ts
@@ -1,0 +1,12 @@
+import { form } from '$app/server';
+import * as v from 'valibot';
+
+export const test_form = form(
+	v.object({
+		foo: v.pipe(v.string(), v.minLength(2)),
+		nested: v.object({
+			bar: v.pipe(v.string(), v.maxLength(2))
+		})
+	}),
+	async () => {}
+);

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -817,6 +817,53 @@ test.describe('remote functions', () => {
 		await expect(form2.locator('input[name="n:range_field"]')).toHaveValue('8');
 		await expect(form2.locator('input[name="b:checkbox_field"]')).not.toBeChecked();
 	});
+
+	test('form isValid defaults to true', async ({ page, javaScriptEnabled }) => {
+		if (!javaScriptEnabled) return;
+
+		await page.goto('/remote/form/is-valid');
+
+		const foo_status = page.locator('#foo');
+		const nested_bar_status = page.locator('#nested-bar');
+		const overall_fields_status = page.locator('#overall-fields');
+		const overall_form_status = page.locator('#overall-form');
+
+		expect(foo_status).toHaveText('foo: true');
+		expect(nested_bar_status).toHaveText('nested.bar: true');
+		expect(overall_fields_status).toHaveText('overall fields: true');
+		expect(overall_form_status).toHaveText('overall form: true');
+	});
+
+	test('form isValid set to a correct value', async ({ page, javaScriptEnabled }) => {
+		if (!javaScriptEnabled) return;
+
+		await page.goto('/remote/form/is-valid');
+
+		const foo_status = page.locator('#foo');
+		const nested_bar_status = page.locator('#nested-bar');
+		const overall_fields_status = page.locator('#overall-fields');
+		const overall_form_status = page.locator('#overall-form');
+
+		// Invalid, min length is 2
+		await page.fill('input[name="foo"]', 'c');
+		expect(foo_status).toHaveText('foo: false');
+		expect(nested_bar_status).toHaveText('nested.bar: true');
+		expect(overall_fields_status).toHaveText('overall fields: false');
+		expect(overall_form_status).toHaveText('overall form: false');
+
+		await page.fill('input[name="foo"]', 'cc');
+		expect(foo_status).toHaveText('foo: true');
+		expect(nested_bar_status).toHaveText('nested.bar: true');
+		expect(overall_fields_status).toHaveText('overall fields: true');
+		expect(overall_form_status).toHaveText('overall form: true');
+
+		// Invalid, max length is 2
+		await page.fill('input[name="nested.bar"]', 'ccc');
+		expect(foo_status).toHaveText('foo: true');
+		expect(nested_bar_status).toHaveText('nested.bar: false');
+		expect(overall_fields_status).toHaveText('overall fields: false');
+		expect(overall_form_status).toHaveText('overall form: false');
+	});
 });
 
 test.describe('server error boundaries', () => {

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -828,10 +828,10 @@ test.describe('remote functions', () => {
 		const overall_fields_status = page.locator('#overall-fields');
 		const overall_form_status = page.locator('#overall-form');
 
-		expect(foo_status).toHaveText('foo: true');
-		expect(nested_bar_status).toHaveText('nested.bar: true');
-		expect(overall_fields_status).toHaveText('overall fields: true');
-		expect(overall_form_status).toHaveText('overall form: true');
+		await expect(foo_status).toHaveText('foo: true');
+		await expect(nested_bar_status).toHaveText('nested.bar: true');
+		await expect(overall_fields_status).toHaveText('overall fields: true');
+		await expect(overall_form_status).toHaveText('overall form: true');
 	});
 
 	test('form isValid set to a correct value', async ({ page, javaScriptEnabled }) => {
@@ -846,23 +846,23 @@ test.describe('remote functions', () => {
 
 		// Invalid, min length is 2
 		await page.fill('input[name="foo"]', 'c');
-		expect(foo_status).toHaveText('foo: false');
-		expect(nested_bar_status).toHaveText('nested.bar: true');
-		expect(overall_fields_status).toHaveText('overall fields: false');
-		expect(overall_form_status).toHaveText('overall form: false');
+		await expect(foo_status).toHaveText('foo: false');
+		await expect(nested_bar_status).toHaveText('nested.bar: true');
+		await expect(overall_fields_status).toHaveText('overall fields: false');
+		await expect(overall_form_status).toHaveText('overall form: false');
 
 		await page.fill('input[name="foo"]', 'cc');
-		expect(foo_status).toHaveText('foo: true');
-		expect(nested_bar_status).toHaveText('nested.bar: true');
-		expect(overall_fields_status).toHaveText('overall fields: true');
-		expect(overall_form_status).toHaveText('overall form: true');
+		await expect(foo_status).toHaveText('foo: true');
+		await expect(nested_bar_status).toHaveText('nested.bar: true');
+		await expect(overall_fields_status).toHaveText('overall fields: true');
+		await expect(overall_form_status).toHaveText('overall form: true');
 
 		// Invalid, max length is 2
 		await page.fill('input[name="nested.bar"]', 'ccc');
-		expect(foo_status).toHaveText('foo: true');
-		expect(nested_bar_status).toHaveText('nested.bar: false');
-		expect(overall_fields_status).toHaveText('overall fields: false');
-		expect(overall_form_status).toHaveText('overall form: false');
+		await expect(foo_status).toHaveText('foo: true');
+		await expect(nested_bar_status).toHaveText('nested.bar: false');
+		await expect(overall_fields_status).toHaveText('overall fields: false');
+		await expect(overall_form_status).toHaveText('overall form: false');
 	});
 });
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1971,6 +1971,8 @@ declare module '@sveltejs/kit' {
 		set(input: DeepPartial<T>): DeepPartial<T>;
 		/** Validation issues, if any */
 		issues(): RemoteFormIssue[] | undefined;
+		/** The validity of the field. Defaults to `true` if this field has not been validated */
+		isValid(): boolean;
 	};
 
 	// These two types use "T extends unknown ? .. : .." to distribute over unions.
@@ -2184,6 +2186,8 @@ declare module '@sveltejs/kit' {
 		get result(): Output | undefined;
 		/** The number of pending submissions */
 		get pending(): number;
+		/** The overall validity of the form. Defaults to `true` if `validate` has not been called */
+		get isValid(): boolean;
 		/** Access form fields using object notation */
 		fields: RemoteFormFieldsRoot<Input>;
 	};


### PR DESCRIPTION
closes #16032
<!-- Explain the goal of the PR, why it is needed, and what has been changed to achieve that goal -->
## Goal
Adds a `isValid` property to remote form and fields. This makes it easier to dynamically react to the validity of the fields and the form with less boilerplate.

## Reason for this feature
It requires some boilerplate to check if a form is valid:
```js
const isValid = $derived(!form.fields.allIssues())
```
Or for a field
```js
const isValid = $derived(!form.fields.group.allIssues())
```
## Changes made
1. Added a `isValid` property in `RemoteForm`. Defaults to `true`. Refresh when `validate` is called.
2. Added a `isValid` property in the fields proxy (via `create_field_proxy`), enables users to check if a group of fields are valid easily.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
