### PR TITLE
fix: re-ensure `__SVELTEKIT_PAYLOAD__.data` access is safe

### DIFF
--- a/.changeset/slimy-pants-build.md
+++ b/.changeset/slimy-pants-build.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: re-ensure `__SVELTEKIT_PAYLOAD__.data` access is safe

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -330,7 +330,7 @@ export async function start(_app, _target, hydrate) {
 		);
 	}
 
-	if (__SVELTEKIT_PAYLOAD__.data) {
+	if (__SVELTEKIT_PAYLOAD__?.data) {
 		const { q = {}, p = {}, l = {}, f = {} } = __SVELTEKIT_PAYLOAD__.data;
 
 		// store the whole nodes — error records seed the corresponding


### PR DESCRIPTION
Basically identical to #14491, the recent changes in #15991 made the access unsafe again.

I don't know why this situation appears, that the payload is undefined, but it does appear in our project, and simply adding the guard makes everything work again :D
And apparently, other people had the same issue in the past

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
