### PR TITLE
fix: add handleInvalidUrl prerender option for non-HTTP URL schemes

### DIFF
--- a/.changeset/fix-prerender-invalid-url-19c21cbf9730.md
+++ b/.changeset/fix-prerender-invalid-url-19c21cbf9730.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": minor
+---
+
+fix: add `handleInvalidUrl` prerender option for non-HTTP URL schemes

--- a/.changeset/fix-prerender-invalid-url-19c21cbf9730.md
+++ b/.changeset/fix-prerender-invalid-url-19c21cbf9730.md
@@ -2,4 +2,4 @@
 "@sveltejs/kit": minor
 ---
 
-fix: add `handleInvalidUrl` prerender option for non-HTTP URL schemes
+feat: add `prerender.handleInvalidUrl` option for invalid URLs discovered while crawling

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -281,6 +281,20 @@ export const options = object(
 					}
 				),
 
+				handleInvalidUrl: validate(
+					(/** @type {any} */ { message }) => {
+						throw new Error(
+							message +
+								'\nTo suppress or handle this error, implement `handleInvalidUrl` in https://svelte.dev/docs/kit/configuration#prerender'
+						);
+					},
+					(input, keypath) => {
+						if (typeof input === 'function') return input;
+						if (['fail', 'warn', 'ignore'].includes(input)) return input;
+						throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
+					}
+				),
+
 				origin: validate('http://sveltekit-prerender', (input, keypath) => {
 					assert_string(input, keypath);
 

--- a/packages/kit/src/core/postbuild/crawl.js
+++ b/packages/kit/src/core/postbuild/crawl.js
@@ -38,6 +38,18 @@ export function crawl(html, base) {
 	/** @type {string[]} */
 	const hrefs = [];
 
+	/** @type {string[]} */
+	const invalid = [];
+
+	/** @param {string} url */
+	const push_href = (url) => {
+		try {
+			hrefs.push(resolve(base, url));
+		} catch {
+			invalid.push(url);
+		}
+	};
+
 	let i = 0;
 	main: while (i < html.length) {
 		const char = html[i];
@@ -186,9 +198,13 @@ export function crawl(html, base) {
 
 				if (href) {
 					if (tag === 'BASE') {
-						base = resolve(base, href);
+						try {
+							base = resolve(base, href);
+						} catch {
+							invalid.push(href);
+						}
 					} else if (!rel || !/\bexternal\b/i.test(rel)) {
-						hrefs.push(resolve(base, href));
+						push_href(href);
 					}
 				}
 
@@ -201,7 +217,7 @@ export function crawl(html, base) {
 				}
 
 				if (src) {
-					hrefs.push(resolve(base, src));
+					push_href(src);
 				}
 
 				if (srcset) {
@@ -222,7 +238,7 @@ export function crawl(html, base) {
 					candidates.push(value);
 					for (const candidate of candidates) {
 						const src = candidate.split(WHITESPACE)[0];
-						if (src) hrefs.push(resolve(base, src));
+						if (src) push_href(src);
 					}
 				}
 
@@ -230,7 +246,7 @@ export function crawl(html, base) {
 					const attr = name ?? property;
 
 					if (attr && CRAWLABLE_META_NAME_ATTRS.has(attr)) {
-						hrefs.push(resolve(base, content));
+						push_href(content);
 					}
 				}
 			}
@@ -239,5 +255,5 @@ export function crawl(html, base) {
 		i += 1;
 	}
 
-	return { ids, hrefs };
+	return { ids, hrefs, invalid };
 }

--- a/packages/kit/src/core/postbuild/fixtures/base/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/base/output.json
@@ -8,5 +8,6 @@
 		"/base-path/wheee3",
 		"/base-path/wheee4"
 	],
-	"ids": []
+	"ids": [],
+	"invalid": []
 }

--- a/packages/kit/src/core/postbuild/fixtures/basic-href/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/basic-href/output.json
@@ -8,5 +8,6 @@
 		"/wheee3",
 		"/wheee4"
 	],
-	"ids": []
+	"ids": [],
+	"invalid": []
 }

--- a/packages/kit/src/core/postbuild/fixtures/basic-src/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/basic-src/output.json
@@ -1,4 +1,7 @@
 {
-	"hrefs": ["/potato.jpg"],
-	"ids": []
+	"hrefs": [
+		"/potato.jpg"
+	],
+	"ids": [],
+	"invalid": []
 }

--- a/packages/kit/src/core/postbuild/fixtures/basic-srcset/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/basic-srcset/output.json
@@ -10,5 +10,6 @@
 		"/issue-9369_newline-after-comma-is-bad.png",
 		"/issue-9369_800px.png"
 	],
-	"ids": []
+	"ids": [],
+	"invalid": []
 }

--- a/packages/kit/src/core/postbuild/fixtures/encoded-ids/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/encoded-ids/output.json
@@ -1,4 +1,9 @@
 {
-	"hrefs": ["/#sparkles-%E2%9C%A8"],
-	"ids": ["sparkles-✨"]
+	"hrefs": [
+		"/#sparkles-%E2%9C%A8"
+	],
+	"ids": [
+		"sparkles-✨"
+	],
+	"invalid": []
 }

--- a/packages/kit/src/core/postbuild/fixtures/href-with-character-reference/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/href-with-character-reference/output.json
@@ -7,5 +7,6 @@
 		"/test%E2%99%A1decimal",
 		"/test%E2%99%A5hex"
 	],
-	"ids": []
+	"ids": [],
+	"invalid": []
 }

--- a/packages/kit/src/core/postbuild/fixtures/ids/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/ids/output.json
@@ -1,4 +1,11 @@
 {
-	"hrefs": ["/#enc%C3%B6ded"],
-	"ids": ["before", "after", "encöded"]
+	"hrefs": [
+		"/#enc%C3%B6ded"
+	],
+	"ids": [
+		"before",
+		"after",
+		"encöded"
+	],
+	"invalid": []
 }

--- a/packages/kit/src/core/postbuild/fixtures/include-rel-external/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/include-rel-external/output.json
@@ -1,4 +1,9 @@
 {
-	"hrefs": ["/styles.css", "/favicon.png", "https://external.com/"],
-	"ids": []
+	"hrefs": [
+		"/styles.css",
+		"/favicon.png",
+		"https://external.com/"
+	],
+	"ids": [],
+	"invalid": []
 }

--- a/packages/kit/src/core/postbuild/fixtures/invalid-url/input.html
+++ b/packages/kit/src/core/postbuild/fixtures/invalid-url/input.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<base href="at://did:plc:base" />
+		<link rel="me" href="at://did:plc:abcdefghijklmnop/app.bsky.actor.profile/self" />
+		<link rel="stylesheet" href="/styles.css" />
+		<meta property="og:url" content="at://did:plc:ogurl" />
+	</head>
+	<body>
+		<img src="at://did:plc:imgsrc" srcset="at://did:plc:srcset 1x, /valid.jpg 2x" />
+		<a href="/valid">/valid</a>
+	</body>
+</html>

--- a/packages/kit/src/core/postbuild/fixtures/invalid-url/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/invalid-url/output.json
@@ -1,0 +1,11 @@
+{
+	"hrefs": ["/styles.css", "/valid.jpg", "/valid"],
+	"ids": [],
+	"invalid": [
+		"at://did:plc:base",
+		"at://did:plc:abcdefghijklmnop/app.bsky.actor.profile/self",
+		"at://did:plc:ogurl",
+		"at://did:plc:imgsrc",
+		"at://did:plc:srcset"
+	]
+}

--- a/packages/kit/src/core/postbuild/fixtures/meta/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/meta/output.json
@@ -5,5 +5,6 @@
 		"https://example.com/audio.mp3",
 		"/video.mp4"
 	],
-	"ids": []
+	"ids": [],
+	"invalid": []
 }

--- a/packages/kit/src/core/postbuild/fixtures/unquoted-attributes/output.json
+++ b/packages/kit/src/core/postbuild/fixtures/unquoted-attributes/output.json
@@ -1,4 +1,10 @@
 {
-	"hrefs": ["/styles.css", "/favicon.png", "https://external.com/", "/wheee"],
-	"ids": []
+	"hrefs": [
+		"/styles.css",
+		"/favicon.png",
+		"https://external.com/",
+		"/wheee"
+	],
+	"ids": [],
+	"invalid": []
 }

--- a/packages/kit/src/core/postbuild/prerender.js
+++ b/packages/kit/src/core/postbuild/prerender.js
@@ -178,6 +178,14 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env }) {
 		}
 	);
 
+	const handle_invalid_url = normalise_error_handler(
+		log,
+		config.prerender.handleInvalidUrl,
+		({ href, referrer }) => {
+			return `Invalid URL ${href}${referrer ? ` (linked from ${referrer})` : ''}`;
+		}
+	);
+
 	const q = queue(config.prerender.concurrency);
 
 	/**
@@ -332,7 +340,11 @@ async function prerender({ hash, out, manifest_path, metadata, verbose, env }) {
 
 		// if it's a 200 HTML response, crawl it. Skip error responses, as we don't save those
 		if (response.ok && config.prerender.crawl && headers['content-type'] === 'text/html') {
-			const { ids, hrefs } = crawl(body.toString(), decoded);
+			const { ids, hrefs, invalid } = crawl(body.toString(), decoded);
+
+			for (const href of invalid) {
+				handle_invalid_url({ href, referrer: decoded });
+			}
 
 			actual_hashlinks.set(decoded, ids);
 

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -11,6 +11,7 @@ import {
 	Prerendered,
 	PrerenderEntryGeneratorMismatchHandlerValue,
 	PrerenderHttpErrorHandlerValue,
+	PrerenderInvalidUrlHandlerValue,
 	PrerenderMissingIdHandlerValue,
 	PrerenderUnseenRoutesHandlerValue,
 	PrerenderOption,
@@ -796,6 +797,18 @@ export interface KitConfig {
 		 * @since 2.16.0
 		 */
 		handleUnseenRoutes?: PrerenderUnseenRoutesHandlerValue;
+		/**
+		 * How to respond when SvelteKit encounters a URL it cannot parse while crawling prerendered HTML (for example, an AT Protocol URL such as `at://did:plc:...`).
+		 *
+		 * - `'fail'` — fail the build
+		 * - `'ignore'` - silently ignore the failure and continue
+		 * - `'warn'` — continue, but print a warning
+		 * - `(details) => void` — a custom error handler that takes a `details` object with `href`, `referrer` and `message` properties. If you `throw` from this function, the build will fail
+		 *
+		 * @default "fail"
+		 * @since 2.67.0
+		 */
+		handleInvalidUrl?: PrerenderInvalidUrlHandlerValue;
 		/**
 		 * The value of `url.origin` during prerendering; useful if it is included in rendered content.
 		 * @default "http://sveltekit-prerender"

--- a/packages/kit/src/types/private.d.ts
+++ b/packages/kit/src/types/private.d.ts
@@ -224,6 +224,10 @@ export interface PrerenderUnseenRoutesHandler {
 	(details: { routes: string[]; message: string }): void;
 }
 
+export interface PrerenderInvalidUrlHandler {
+	(details: { href: string; referrer: string | null; message: string }): void;
+}
+
 export type PrerenderHttpErrorHandlerValue = 'fail' | 'warn' | 'ignore' | PrerenderHttpErrorHandler;
 export type PrerenderMissingIdHandlerValue = 'fail' | 'warn' | 'ignore' | PrerenderMissingIdHandler;
 export type PrerenderUnseenRoutesHandlerValue =
@@ -236,6 +240,11 @@ export type PrerenderEntryGeneratorMismatchHandlerValue =
 	| 'warn'
 	| 'ignore'
 	| PrerenderEntryGeneratorMismatchHandler;
+export type PrerenderInvalidUrlHandlerValue =
+	| 'fail'
+	| 'warn'
+	| 'ignore'
+	| PrerenderInvalidUrlHandler;
 
 export type PrerenderOption = boolean | 'auto';
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -771,6 +771,18 @@ declare module '@sveltejs/kit' {
 			 */
 			handleUnseenRoutes?: PrerenderUnseenRoutesHandlerValue;
 			/**
+			 * How to respond when SvelteKit encounters a URL it cannot parse while crawling prerendered HTML (for example, an AT Protocol URL such as `at://did:plc:...`).
+			 *
+			 * - `'fail'` — fail the build
+			 * - `'ignore'` - silently ignore the failure and continue
+			 * - `'warn'` — continue, but print a warning
+			 * - `(details) => void` — a custom error handler that takes a `details` object with `href`, `referrer` and `message` properties. If you `throw` from this function, the build will fail
+			 *
+			 * @default "fail"
+			 * @since 2.67.0
+			 */
+			handleInvalidUrl?: PrerenderInvalidUrlHandlerValue;
+			/**
 			 * The value of `url.origin` during prerendering; useful if it is included in rendered content.
 			 * @default "http://sveltekit-prerender"
 			 */
@@ -2559,6 +2571,10 @@ declare module '@sveltejs/kit' {
 		(details: { routes: string[]; message: string }): void;
 	}
 
+	interface PrerenderInvalidUrlHandler {
+		(details: { href: string; referrer: string | null; message: string }): void;
+	}
+
 	type PrerenderHttpErrorHandlerValue = 'fail' | 'warn' | 'ignore' | PrerenderHttpErrorHandler;
 	type PrerenderMissingIdHandlerValue = 'fail' | 'warn' | 'ignore' | PrerenderMissingIdHandler;
 	type PrerenderUnseenRoutesHandlerValue =
@@ -2571,6 +2587,11 @@ declare module '@sveltejs/kit' {
 		| 'warn'
 		| 'ignore'
 		| PrerenderEntryGeneratorMismatchHandler;
+	type PrerenderInvalidUrlHandlerValue =
+		| 'fail'
+		| 'warn'
+		| 'ignore'
+		| PrerenderInvalidUrlHandler;
 
 	export type PrerenderOption = boolean | 'auto';
 


### PR DESCRIPTION
closes #15935

When SvelteKit's prerender crawler encounters a URL scheme it cannot parse — like an AT Protocol URL (`at://did:plc:...`) — calling `new URL(href, base)` throws an unhandled `TypeError` and crashes the build. Since the AT Protocol identifier syntax embeds colons inside the host segment, WHATWG URL parsing interprets the part after the first colon as an invalid port number.

This adds a `handleInvalidUrl` option to `config.prerender`, following the same `normalise_error_handler` pattern already used by `handleHttpError`, `handleMissingId`, and `handleUnseenRoutes`. The default behavior throws with a message pointing users to the docs. Setting it to `'warn'` or `'ignore'` lets a build continue, and a custom function receives `{ href, referrer, message }`.

The crawl function now collects URLs that throw into an `invalid[]` array instead of crashing immediately, and `prerender.js` iterates that array to invoke the configured handler for each one.

Thanks to @Rich-Harris for proposing this exact design in #15935.