### PR TITLE
fix (enhanced-img): the basePixels bug

### DIFF
--- a/packages/enhanced-img/src/index.js
+++ b/packages/enhanced-img/src/index.js
@@ -57,7 +57,7 @@ function imagetools_plugin(opts) {
 			return new URLSearchParams({
 				as: 'picture',
 				format: opts.defaultFormats(meta),
-				...widthParams
+				...width_params
 			});
 		},
 		namedExports: false

--- a/packages/enhanced-img/src/index.js
+++ b/packages/enhanced-img/src/index.js
@@ -52,7 +52,7 @@ function imagetools_plugin(opts) {
 				return new URLSearchParams();
 			}
 
-			const widthParams = qs.has('w') ? {} : opts.defaultWidths(width, qs.get('imgSizes'));
+			const width_params = qs.has('w') ? {} : opts.defaultWidths(width, qs.get('imgSizes'));
 
 			return new URLSearchParams({
 				as: 'picture',

--- a/packages/enhanced-img/src/index.js
+++ b/packages/enhanced-img/src/index.js
@@ -52,10 +52,12 @@ function imagetools_plugin(opts) {
 				return new URLSearchParams();
 			}
 
+			const widthParams = qs.has('w') ? {} : opts.defaultWidths(width, qs.get('imgSizes'));
+
 			return new URLSearchParams({
 				as: 'picture',
 				format: opts.defaultFormats(meta),
-				...opts.defaultWidths(width, qs.get('imgSizes'))
+				...widthParams
 			});
 		},
 		namedExports: false


### PR DESCRIPTION
Fix the bug where basePixels is now always emitted in the pixel-density case even when the user supplies an explicit w

fixes this bug https://github.com/sveltejs/kit/pull/16086#pullrequestreview-4528352739 introduced in https://github.com/sveltejs/kit/pull/15354

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
