### PR TITLE
fix(adapter-node): restore envPrefix replacement by splitting ENV_PREFIX_LENGTH

### DIFF
--- a/.changeset/fix-adapter-node-env-prefix-length.md
+++ b/.changeset/fix-adapter-node-env-prefix-length.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+fix: restore `envPrefix` behaviour in adapter-node by splitting the build-time replacement of `ENV_PREFIX.length` into a separate `ENV_PREFIX_LENGTH` token

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -96,6 +96,7 @@ export default function (opts = {}) {
 						values: {
 							BASE: JSON.stringify(builder.config.kit.paths.base),
 							ENV_PREFIX: JSON.stringify(envPrefix),
+							ENV_PREFIX_LENGTH: JSON.stringify(envPrefix.length),
 							PRECOMPRESS: JSON.stringify(precompress),
 							PRERENDERED: `new Set(${JSON.stringify(builder.prerendered.paths)})`
 						},

--- a/packages/adapter-node/internal.d.ts
+++ b/packages/adapter-node/internal.d.ts
@@ -9,5 +9,6 @@ declare module 'SERVER' {
 
 declare const BASE: string;
 declare const ENV_PREFIX: string;
+declare const ENV_PREFIX_LENGTH: number;
 declare const PRECOMPRESS: boolean;
 declare const PRERENDERED: Set<string>;

--- a/packages/adapter-node/src/env.js
+++ b/packages/adapter-node/src/env.js
@@ -22,7 +22,7 @@ const expected_unprefixed = new Set(['LISTEN_PID', 'LISTEN_FDS']);
 if (ENV_PREFIX) {
 	for (const name in process.env) {
 		if (name.startsWith(ENV_PREFIX)) {
-			const unprefixed = name.slice(ENV_PREFIX.length);
+			const unprefixed = name.slice(ENV_PREFIX_LENGTH);
 			if (!expected.has(unprefixed)) {
 				throw new Error(
 					`You should change envPrefix (${ENV_PREFIX}) to avoid conflicts with existing environment variables — unexpectedly saw ${name}`


### PR DESCRIPTION
Closes #16090.

`@rollup/plugin-replace` doesn't substitute `ENV_PREFIX` when it appears as `ENV_PREFIX.length`, so the build-time replacement only happens at the standalone-identifier sites in `packages/adapter-node/src/env.js`. The `.length` reference survives into the emitted `build/env.js` and throws at startup with the configured `envPrefix`:

```
ReferenceError: ENV_PREFIX is not defined
    at file:///home/conv/foo/build/env.js:25:34
```

@Conduitry called this out and proposed splitting the length into its own build-time constant. This PR adopts that suggestion verbatim: add `ENV_PREFIX_LENGTH` to the `replace` values in `packages/adapter-node/index.js`, declare it in `packages/adapter-node/internal.d.ts`, and use it instead of `ENV_PREFIX.length` in `packages/adapter-node/src/env.js`. As a bonus the `.length` lookup moves off the runtime hot path.

### Tests

`pnpm -F @sveltejs/adapter-node test` (34/34 pass) and `pnpm -F @sveltejs/adapter-node check` are both green. `pnpm run format` reports no diff. A changeset (`@sveltejs/adapter-node: patch`) is included.