### PR TITLE
docs: clarify handleFetch cookie forwarding

### DIFF
--- a/documentation/docs/30-advanced/20-hooks.md
+++ b/documentation/docs/30-advanced/20-hooks.md
@@ -143,6 +143,8 @@ export async function handleFetch({ event, request, fetch }) {
 }
 ```
 
+This only forwards cookies on the outgoing request. If the external API responds with a `set-cookie` header, you must handle that separately — for example by reading the response header and writing the cookie with `event.cookies.set(...)` or in an action.
+
 ### handleValidationError
 
 This hook is called when a remote function is called with an argument that does not match the provided [Standard Schema](https://standardschema.dev/). It must return an object matching the shape of [`App.Error`](types#Error).


### PR DESCRIPTION
Addresses sveltejs/kit#7705.

## Summary

- clarify that the `handleFetch` example only forwards cookies on the outgoing request
- note that `set-cookie` responses from the external API need separate handling

## Testing

- docs change only
