### PR TITLE
docs: clarify boundary pending SSR behavior

### DIFF
--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -83,7 +83,7 @@ The query returned from `getPosts` works as a [`Promise`](https://developer.mozi
 </ul>
 ```
 
-Until the promise resolves — and if it errors — the nearest [`<svelte:boundary>`](../svelte/svelte-boundary) will be invoked.
+Until the promise resolves — and if it errors — the nearest [`<svelte:boundary>`](../svelte/svelte-boundary) will be invoked. If that boundary defines a `pending` snippet, the awaited query will render the pending state instead of being server-rendered.
 
 While using `await` is recommended, as an alternative the query also has `loading`, `error` and `current` properties:
 


### PR DESCRIPTION
Addresses sveltejs/kit#15719.

## Summary

- clarify that an awaited remote query inside a `<svelte:boundary>` with a `pending` snippet renders the pending state instead of being server-rendered

## Testing

- docs change only
