### PR TITLE
docs: link node env vars to runtime env docs

### DIFF
--- a/documentation/docs/20-core-concepts/70-environment-variables.md
+++ b/documentation/docs/20-core-concepts/70-environment-variables.md
@@ -4,6 +4,8 @@ title: Environment variables
 
 Environment variables are values your app needs that exist separately from the app's source code. They allow you to use sensitive information like API keys and database credentials without storing them in version control.
 
+If you're configuring a Node server, see the [Node servers](../build-and-deploy/40-adapter-node) page for the runtime-specific variables handled there.
+
 During development, and at build time, variables defined in a `.env` or `.env.local` file will be added to the environment:
 
 ```env

--- a/documentation/docs/20-core-concepts/70-environment-variables.md
+++ b/documentation/docs/20-core-concepts/70-environment-variables.md
@@ -4,7 +4,7 @@ title: Environment variables
 
 Environment variables are values your app needs that exist separately from the app's source code. They allow you to use sensitive information like API keys and database credentials without storing them in version control.
 
-If you're configuring a Node server, see the [Node servers](../build-and-deploy/40-adapter-node) page for the runtime-specific variables handled there.
+If you're configuring a Node server, see the [Node servers](adapter-node) page for the runtime-specific variables handled there.
 
 During development, and at build time, variables defined in a `.env` or `.env.local` file will be added to the environment:
 

--- a/documentation/docs/25-build-and-deploy/40-adapter-node.md
+++ b/documentation/docs/25-build-and-deploy/40-adapter-node.md
@@ -43,6 +43,8 @@ However, if you're building a [custom server](#Custom-server) and do want to add
 
 ## Environment variables
 
+If you're looking for environment variables used directly in app code, see the [Environment variables](../20-core-concepts/70-environment-variables) page.
+
 In `dev` and `preview`, SvelteKit will read environment variables from your `.env` file (or `.env.local`, or `.env.[mode]`, [as determined by Vite](https://vitejs.dev/guide/env-and-mode.html#env-files).)
 
 In production, `.env` files are _not_ automatically loaded. To do so, install `dotenv` in your project...

--- a/documentation/docs/25-build-and-deploy/40-adapter-node.md
+++ b/documentation/docs/25-build-and-deploy/40-adapter-node.md
@@ -43,7 +43,7 @@ However, if you're building a [custom server](#Custom-server) and do want to add
 
 ## Environment variables
 
-If you're looking for environment variables used directly in app code, see the [Environment variables](../20-core-concepts/70-environment-variables) page.
+If you're looking for environment variables used directly in app code, see the [Environment variables](environment-variables) page.
 
 In `dev` and `preview`, SvelteKit will read environment variables from your `.env` file (or `.env.local`, or `.env.[mode]`, [as determined by Vite](https://vitejs.dev/guide/env-and-mode.html#env-files).)
 


### PR DESCRIPTION
Addresses sveltejs/kit#12174.

## Summary

- add a pointer from Node server env vars to the runtime environment variables docs
- add the reciprocal pointer from runtime env vars back to the Node server page

## Testing

- docs change only
