### PR TITLE
docs: clarify server load fetch tracking

### DIFF
--- a/documentation/docs/20-core-concepts/20-load.md
+++ b/documentation/docs/20-core-concepts/20-load.md
@@ -281,6 +281,7 @@ To get data from an external API or a `+server.js` handler, you can use the prov
 - It can make relative requests on the server (ordinarily, `fetch` requires a URL with an origin when used in a server context).
 - Internal requests (e.g. for `+server.js` routes) go directly to the handler function when running on the server, without the overhead of an HTTP call.
 - During server-side rendering, the response will be captured and inlined into the rendered HTML by hooking into the `text`, `json` and `arrayBuffer` methods of the `Response` object. Note that headers will _not_ be serialized, unless explicitly included via [`filterSerializedResponseHeaders`](hooks#Server-hooks-handle).
+- In server `load` functions, `fetch(url)` does not create a tracked dependency. Use [`depends(url)`](#Manual-invalidation) when you need to invalidate a server-side request manually.
 - During hydration, the response will be read from the HTML, guaranteeing consistency and preventing an additional network request - if you received a warning in your browser console when using the browser `fetch` instead of the `load` `fetch`, this is why.
 
 ```js


### PR DESCRIPTION
Addresses sveltejs/kit#13805.

## Summary

- clarify that server `load` `fetch(url)` calls do not create tracked dependencies
- point readers to `depends(url)` when they need manual invalidation

## Testing

- docs change only
