### PR TITLE
docs: make server-only example more realistic

### DIFF
--- a/documentation/docs/30-advanced/50-server-only-modules.md
+++ b/documentation/docs/30-advanced/50-server-only-modules.md
@@ -25,14 +25,18 @@ Any time you have public-facing code that imports server-only code (whether dire
 
 ```js
 // @errors: 7005
-/// file: $lib/server/secrets.js
-export const atlantisCoordinates = [/* redacted */];
+/// file: $lib/server/db.js
+export const db = {
+	query() {
+		return 'connected';
+	}
+};
 ```
 
 ```js
 // @errors: 2307 7006 7005
 /// file: src/routes/utils.js
-export { atlantisCoordinates } from '$lib/server/secrets.js';
+export { db } from '$lib/server/db.js';
 
 export const add = (a, b) => a + b;
 ```
@@ -47,16 +51,16 @@ export const add = (a, b) => a + b;
 ...SvelteKit will error:
 
 ```
-Cannot import $lib/server/secrets.ts into code that runs in the browser, as this could leak sensitive information.
+Cannot import $lib/server/db.ts into code that runs in the browser, as this could leak server-only logic.
 
  src/routes/+page.svelte imports
   src/routes/utils.js imports
-   $lib/server/secrets.ts
+   $lib/server/db.ts
 
 If you're only using the import as a type, change it to `import type`.
 ```
 
-Even though the public-facing code — `src/routes/+page.svelte` — only uses the `add` export and not the secret `atlantisCoordinates` export, the secret code could end up in JavaScript that the browser downloads, and so the import chain is considered unsafe.
+Even though the public-facing code — `src/routes/+page.svelte` — only uses the `add` export and not the server-only `db` export, the server code could end up in JavaScript that the browser downloads, and so the import chain is considered unsafe.
 
 This feature also works with dynamic imports, even interpolated ones like ``await import(`./${foo}.js`)``.
 

--- a/documentation/docs/30-advanced/50-server-only-modules.md
+++ b/documentation/docs/30-advanced/50-server-only-modules.md
@@ -51,7 +51,7 @@ export const add = (a, b) => a + b;
 ...SvelteKit will error:
 
 ```
-Cannot import $lib/server/db.ts into code that runs in the browser, as this could leak server-only logic.
+Cannot import $lib/server/db.ts into code that runs in the browser, as this could leak sensitive information.
 
  src/routes/+page.svelte imports
   src/routes/utils.js imports


### PR DESCRIPTION
Addresses sveltejs/kit#13416.

## Summary

- replace the secret-looking server-only example with a more realistic server module example
- keep the explanation focused on why server-only imports are unsafe in public code

## Testing

- docs change only
