### PR TITLE
fix: ensure `ENV_PREFIX.length` works

### DIFF
--- a/.changeset/tender-cobras-grin.md
+++ b/.changeset/tender-cobras-grin.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+fix: ensure `ENV_PREFIX` is defined

--- a/packages/adapter-node/src/env.js
+++ b/packages/adapter-node/src/env.js
@@ -19,13 +19,15 @@ const expected = new Set([
 
 const expected_unprefixed = new Set(['LISTEN_PID', 'LISTEN_FDS']);
 
-if (ENV_PREFIX) {
+export const env_prefix = ENV_PREFIX;
+
+if (env_prefix) {
 	for (const name in process.env) {
-		if (name.startsWith(ENV_PREFIX)) {
-			const unprefixed = name.slice(ENV_PREFIX.length);
+		if (name.startsWith(env_prefix)) {
+			const unprefixed = name.slice(env_prefix.length);
 			if (!expected.has(unprefixed)) {
 				throw new Error(
-					`You should change envPrefix (${ENV_PREFIX}) to avoid conflicts with existing environment variables — unexpectedly saw ${name}`
+					`You should change envPrefix (${env_prefix}) to avoid conflicts with existing environment variables — unexpectedly saw ${name}`
 				);
 			}
 		}
@@ -37,7 +39,7 @@ if (ENV_PREFIX) {
  * @param {any} [fallback]
  */
 export function env(name, fallback) {
-	const prefix = expected_unprefixed.has(name) ? '' : ENV_PREFIX;
+	const prefix = expected_unprefixed.has(name) ? '' : env_prefix;
 	const prefixed = prefix + name;
 	return prefixed in process.env ? process.env[prefixed] : fallback;
 }

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -8,7 +8,7 @@ import { parse as polka_url_parser } from '@polka/url';
 import { getRequest, setResponse, createReadableStream } from '@sveltejs/kit/node';
 import { Server } from 'SERVER';
 import { manifest } from 'MANIFEST';
-import { env } from './env.js';
+import { env, env_prefix } from './env.js';
 import { parse_as_bytes, parse_origin } from '../utils.js';
 
 const prerendered = PRERENDERED;
@@ -121,7 +121,7 @@ const ssr = async (req, res) => {
 					if (!(address_header in req.headers)) {
 						throw new Error(
 							`Address header was specified with ${
-								ENV_PREFIX + 'ADDRESS_HEADER'
+								env_prefix + 'ADDRESS_HEADER'
 							}=${address_header} but is absent from request`
 						);
 					}
@@ -132,12 +132,12 @@ const ssr = async (req, res) => {
 						const addresses = value.split(',');
 
 						if (xff_depth < 1) {
-							throw new Error(`${ENV_PREFIX + 'XFF_DEPTH'} must be a positive integer`);
+							throw new Error(`${env_prefix + 'XFF_DEPTH'} must be a positive integer`);
 						}
 
 						if (xff_depth > addresses.length) {
 							throw new Error(
-								`${ENV_PREFIX + 'XFF_DEPTH'} is ${xff_depth}, but only found ${
+								`${env_prefix + 'XFF_DEPTH'} is ${xff_depth}, but only found ${
 									addresses.length
 								} addresses`
 							);


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/16090
closes https://github.com/sveltejs/kit/pull/16096

This PR is an alternative to https://github.com/sveltejs/kit/pull/16096 that reuses an existing pattern of storing the inlined variable in a constant and reusing that throughout the code. The added benefit is that we reduce the number of times the string literal appears in the build output.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
	- tests added in https://github.com/sveltejs/kit/pull/16104

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
