### PR TITLE
fix: bump cookie to 0.7.0 to resolve GHSA-pxg6-pf52-xh8x and update encode test

### DIFF
--- a/.changeset/nice-readers-pump.md
+++ b/.changeset/nice-readers-pump.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: bump cookie to 0.7.0 to address GHSA-pxg6-pf52-xh8x

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -22,7 +22,7 @@
 		"@sveltejs/acorn-typescript": "^1.0.9",
 		"@types/cookie": "^0.6.0",
 		"acorn": "^8.16.0",
-		"cookie": "^0.6.0",
+		"cookie": "^0.7.0",
 		"devalue": "^5.8.1",
 		"esm-env": "^1.2.2",
 		"kleur": "^4.1.5",

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -181,9 +181,9 @@ describe('cookies in prod', () => {
 			}
 		});
 		cookies.set('c', 'fö', { path: '/' }); // should use default encoding
-		cookies.set('d', 'fö', { path: '/', encode: () => 'öf' }); // should respect `encode`
+		cookies.set('d', 'fö', { path: '/', encode: () => 'custom-encoded' }); // should respect `encode`
 		const header = get_cookie_header(new URL(href), 'e=f%C3%A4; f=foo+bar');
-		assert.equal(header, 'a=f%C3%BC; b=foo+bar; c=f%C3%B6; d=öf; e=f%C3%A4; f=foo+bar');
+		assert.equal(header, 'a=f%C3%BC; b=foo+bar; c=f%C3%B6; d=custom-encoded; e=f%C3%A4; f=foo+bar');
 	});
 
 	test('get all cookies from header and set calls', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,8 +557,8 @@ importers:
         specifier: ^8.16.0
         version: 8.16.0
       cookie:
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.0
+        version: 0.7.2
       devalue:
         specifier: ^5.8.1
         version: 5.8.1
@@ -3946,10 +3946,6 @@ packages:
 
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
-
-  cookie@0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
-    engines: {node: '>= 0.6'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -8675,8 +8671,6 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie-es@1.2.3: {}
-
-  cookie@0.6.0: {}
 
   cookie@0.7.2: {}
 


### PR DESCRIPTION
## Goal

Fix the low-severity vulnerability GHSA-pxg6-pf52-xh8x in the `cookie` package, which affects SvelteKit versions up to 2.66.0. Bump the minimum required `cookie` version to `^0.7.0` and update the relevant test to align with the new `cookie` API.

## Changes

- **Dependency bump** in `packages/kit/package.json`: change `"cookie"` from the previous range (which allowed <0.7.0) to `^0.7.0`.
- **Test update** in `packages/kit/src/runtime/server/cookie.spec.js`: the `"serialized cookie header should be url-encoded"` test used an `encode` option that returned a non-ASCII value (`'öf'`). Starting from `cookie@0.7.0`, `encode` must produce a valid cookie-value (ASCII-only). Replaced it with a compliant custom encoding (`'custom-encoded'`) while preserving the intent of the test.

## Testing

- `pnpm -F @sveltejs/kit test:unit` passes after the changes.
- `pnpm lint` and `pnpm check` pass.

## Additional notes

This is a patch-level change that does not affect SvelteKit’s public API.