### PR TITLE
fix: replace adapter-node env prefix length

### DIFF
--- a/.changeset/fix-adapter-node-env-prefix.md
+++ b/.changeset/fix-adapter-node-env-prefix.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+Fix `envPrefix` replacement in adapter-node builds

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -96,6 +96,7 @@ export default function (opts = {}) {
 						values: {
 							BASE: JSON.stringify(builder.config.kit.paths.base),
 							ENV_PREFIX: JSON.stringify(envPrefix),
+							ENV_PREFIX_LENGTH: JSON.stringify(envPrefix.length),
 							PRECOMPRESS: JSON.stringify(precompress),
 							PRERENDERED: `new Set(${JSON.stringify(builder.prerendered.paths)})`
 						},

--- a/packages/adapter-node/internal.d.ts
+++ b/packages/adapter-node/internal.d.ts
@@ -9,5 +9,6 @@ declare module 'SERVER' {
 
 declare const BASE: string;
 declare const ENV_PREFIX: string;
+declare const ENV_PREFIX_LENGTH: number;
 declare const PRECOMPRESS: boolean;
 declare const PRERENDERED: Set<string>;

--- a/packages/adapter-node/src/env.js
+++ b/packages/adapter-node/src/env.js
@@ -22,7 +22,7 @@ const expected_unprefixed = new Set(['LISTEN_PID', 'LISTEN_FDS']);
 if (ENV_PREFIX) {
 	for (const name in process.env) {
 		if (name.startsWith(ENV_PREFIX)) {
-			const unprefixed = name.slice(ENV_PREFIX.length);
+			const unprefixed = name.slice(ENV_PREFIX_LENGTH);
 			if (!expected.has(unprefixed)) {
 				throw new Error(
 					`You should change envPrefix (${ENV_PREFIX}) to avoid conflicts with existing environment variables — unexpectedly saw ${name}`


### PR DESCRIPTION
## Summary
- replace `ENV_PREFIX.length` in generated adapter-node env code with a build-time `ENV_PREFIX_LENGTH` token
- declare the generated constant for adapter-node internals
- add a patch changeset

Closes #16090

## Tests
- pnpm -F @sveltejs/adapter-node test
- pnpm -F @sveltejs/adapter-node lint
- pnpm -F @sveltejs/adapter-node check
- git diff --check