### PR TITLE
fix: stabilize route manifest traversal

### DIFF
--- a/.changeset/fix-manifest-route-order.md
+++ b/.changeset/fix-manifest-route-order.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+Stabilize route manifest node indexes across runtimes

--- a/packages/kit/src/core/sync/create_manifest_data/index.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.js
@@ -222,10 +222,13 @@ function create_routes_and_nodes(cwd, config, fallback) {
 
 			// We can't use withFileTypes because of a NodeJs bug which returns wrong results
 			// with isDirectory() in case of symlinks: https://github.com/nodejs/node/issues/30646
-			const files = fs.readdirSync(dir).map((name) => ({
-				is_dir: fs.statSync(path.join(dir, name)).isDirectory(),
-				name
-			}));
+			const files = fs
+				.readdirSync(dir)
+				.sort()
+				.map((name) => ({
+					is_dir: fs.statSync(path.join(dir, name)).isDirectory(),
+					name
+				}));
 
 			// process files first
 			for (const file of files) {

--- a/packages/kit/src/core/sync/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.spec.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { assert, expect, test } from 'vitest';
+import { assert, expect, test, vi } from 'vitest';
 import create_manifest_data from './index.js';
 import { sort_routes } from './sort.js';
 import { validate_config } from '../../config/index.js';
@@ -108,6 +108,25 @@ test('creates routes', () => {
 			page: { layouts: [0], errors: [1], leaf: 5 }
 		}
 	]);
+});
+
+test('creates stable node indexes regardless of directory traversal order', () => {
+	const expected = create('samples/basic');
+	const readdirSync = fs.readdirSync;
+
+	const spy = vi.spyOn(fs, 'readdirSync').mockImplementation((dir, options) => {
+		const entries = readdirSync.call(fs, dir, options);
+		return Array.isArray(entries) ? entries.slice().reverse() : entries;
+	});
+
+	try {
+		const actual = create('samples/basic');
+
+		expect(actual.nodes.map(simplify_node)).toEqual(expected.nodes.map(simplify_node));
+		expect(actual.routes.map(simplify_route)).toEqual(expected.routes.map(simplify_route));
+	} finally {
+		spy.mockRestore();
+	}
 });
 
 const symlink_survived_git = fs


### PR DESCRIPTION
## Summary
- sort route directory entries before assigning manifest node indexes
- add a regression test that reverses `readdirSync` order and verifies stable routes/nodes
- add a patch changeset

Closes #15313

## Tests
- pnpm -F @sveltejs/kit test:unit src/core/sync/create_manifest_data/index.spec.js
- pnpm -F @sveltejs/kit lint
- git diff --check