### PR TITLE
chore: fix internal types export target

### DIFF
--- a/.changeset/fix-internal-types-export.md
+++ b/.changeset/fix-internal-types-export.md
@@ -1,5 +1,0 @@
----
-'@sveltejs/kit': patch
----
-
-fix: correct the internal types subpath export to point at the existing declaration file

--- a/.changeset/fix-internal-types-export.md
+++ b/.changeset/fix-internal-types-export.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: correct the internal types subpath export to point at the existing declaration file

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -115,7 +115,7 @@
 			"import": "./src/exports/internal/env.js"
 		},
 		"./internal/types": {
-			"import": "./src/exports/internal/types.js"
+			"types": "./src/exports/internal/types.d.ts"
 		},
 		"./internal/server": {
 			"types": "./types/index.d.ts",


### PR DESCRIPTION
Fixes the @sveltejs/kit ./internal/types subpath export so it points at the existing declaration file instead of a missing JavaScript target.

Validation:
- pnpm install --frozen-lockfile
- Node.js package export check: ./internal/types resolves to ./src/exports/internal/types.d.ts and the target exists
- pnpm -F @sveltejs/kit lint
- pnpm -F @sveltejs/kit check
- pnpm -F @sveltejs/kit test:unit
- pnpm -F @sveltejs/kit prepublishOnly

Bounty: charles-openclaw/charles-microbounties#3077