### PR TITLE
fix: ensure server root directory is resolved correctly

### DIFF
--- a/.changeset/silver-cases-write.md
+++ b/.changeset/silver-cases-write.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+fix: correctly resolve client directory

--- a/.changeset/silver-cases-write.md
+++ b/.changeset/silver-cases-write.md
@@ -2,4 +2,4 @@
 '@sveltejs/adapter-node': patch
 ---
 
-fix: correctly resolve client directory
+fix: correctly resolve root directory on the server

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -85,7 +85,7 @@ export default function (opts = {}) {
 							if (id === 'MANIFEST') return `${server}/manifest.js`;
 						}
 					},
-					// ensure our entries that use `import.meta.url` resolves to the root
+					// ensure our entries that use `import.meta.url` resolve to the root
 					// even if their code has been moved to a shared chunk directory
 					// see https://rollupjs.org/plugin-development/#resolveimportmeta
 					{

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { rollup } from 'rollup';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
@@ -49,17 +50,18 @@ export default function (opts = {}) {
 
 			// Copy the entrypoints into `.svelte-kit/adapter-node/entries`,
 			// so that node modules are correctly resolved
-			builder.copy(files, `${tmp}/entries`);
+			const entries = `${tmp}/entries`;
+			builder.copy(files, entries);
 
 			const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
 			const server = builder.getServerDirectory();
 
 			/** @type {Record<string, string>} */
 			const input = {
-				index: `${tmp}/entries/index.js`,
-				env: `${tmp}/entries/env.js`,
-				handler: `${tmp}/entries/handler.js`,
-				shims: `${tmp}/entries/shims.js`
+				index: `${entries}/index.js`,
+				env: `${entries}/env.js`,
+				handler: `${entries}/handler.js`,
+				shims: `${entries}/shims.js`
 			};
 
 			if (builder.hasServerInstrumentationFile?.()) {
@@ -83,6 +85,19 @@ export default function (opts = {}) {
 							if (id === 'MANIFEST') return `${server}/manifest.js`;
 						}
 					},
+					// ensure our entries that use `import.meta.url` resolves to the root
+					// even if their code has been moved to a shared chunk directory
+					// see https://rollupjs.org/plugin-development/#resolveimportmeta
+					{
+						name: 'adapter-node:import-meta-url-current-module',
+						resolveImportMeta(property, { moduleId }) {
+							if (property === 'url' && moduleId.startsWith(entries)) {
+								const module_dir = path.dirname(moduleId);
+								return `new URL('${path.relative(module_dir, entries)}', import.meta.url)`;
+							}
+							return null;
+						}
+					},
 					nodeResolve({
 						preferBuiltins: true,
 						exportConditions: ['node']
@@ -92,7 +107,7 @@ export default function (opts = {}) {
 						// only replace tokens in the adapter's own entrypoints, so that
 						// identifiers like `BASE` in the user's app code or bundled
 						// dependencies aren't accidentally replaced
-						include: [`${tmp}/entries/**`],
+						include: [`${entries}/**`],
 						values: {
 							BASE: JSON.stringify(builder.config.kit.paths.base),
 							ENV_PREFIX: JSON.stringify(envPrefix),


### PR DESCRIPTION
closes #16095

This PR adds a Rollup plugin to correct module relative paths. It worked previously because the `import.meta.url` code was called from a file at the root. However, bundling the entries caused Rollup to move it to a shared chunk which lived in a nested directory. The new plugin ensures that entries creating a relative URL resolves correctly to the root

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.
	- https://github.com/sveltejs/kit/pull/16104#issuecomment-4765341052 adds tests

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
