### PR TITLE
fix: avoid overwriting `codeSplitting` for split apps

### DIFF
--- a/.changeset/silent-camels-clap.md
+++ b/.changeset/silent-camels-clap.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: avoid unnecessarily overriding a user's Vite 8 `codeSplitting` setting

--- a/packages/kit/src/exports/vite/build/build_service_worker.js
+++ b/packages/kit/src/exports/vite/build/build_service_worker.js
@@ -165,13 +165,6 @@ export async function build_service_worker(
 		}
 	};
 
-	// we must reference Vite 8 options conditionally. Otherwise, older Vite
-	// versions throw an error about unknown config options
-	if (is_rolldown && config?.build?.rollupOptions?.output) {
-		// @ts-ignore only available in Vite 8
-		config.build.rollupOptions.output.codeSplitting = true;
-	}
-
 	await vite.build(config);
 
 	// rename .mjs to .js to avoid incorrect MIME types with ancient webservers

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1147,13 +1147,9 @@ async function kit({ svelte_config }) {
 
 					// we must reference Vite 8 options conditionally. Otherwise, older Vite
 					// versions throw an error about unknown config options
-					if (is_rolldown && !split && new_config.build) {
+					if (is_rolldown && !split && new_config.build?.rollupOptions?.output) {
 						// @ts-ignore only available in Vite 8
-						new_config.build.rolldownOptions = {
-							output: {
-								codeSplitting: false
-							}
-						};
+						new_config.build.rollupOptions.output.codeSplitting = false;
 					}
 				} else {
 					new_config = {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1147,9 +1147,13 @@ async function kit({ svelte_config }) {
 
 					// we must reference Vite 8 options conditionally. Otherwise, older Vite
 					// versions throw an error about unknown config options
-					if (is_rolldown && new_config?.build?.rollupOptions?.output) {
+					if (is_rolldown && !split && new_config.build) {
 						// @ts-ignore only available in Vite 8
-						new_config.build.rollupOptions.output.codeSplitting = split;
+						new_config.build.rolldownOptions = {
+							output: {
+								codeSplitting: false
+							}
+						};
 					}
 				} else {
 					new_config = {


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/16117

This PR makes a change so that `codeSplitting: false` is only set for non-split apps to avoid overwriting the user's configuration. We also don't need to explicitly set it to `true` because that's the default for Vite 8.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
