### PR TITLE
fix: render pages over sibling endpoints without GET handlers

### DIFF
--- a/.changeset/quiet-ravens-smile.md
+++ b/.changeset/quiet-ravens-smile.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: render pages over sibling endpoints without GET handlers
+fix: render pages over sibling endpoints without GET or HEAD handlers

--- a/.changeset/quiet-ravens-smile.md
+++ b/.changeset/quiet-ravens-smile.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: render pages over sibling endpoints without GET handlers

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -620,17 +620,25 @@ export async function internal_respond(request, options, manifest, state) {
 						trailing_slash
 					);
 				} else {
-					const endpoint =
+					let endpoint;
+					if (
 						route.endpoint &&
 						(!route.page || (!state.prerendering && is_endpoint_request(event)))
-							? await route.endpoint()
-							: undefined;
-
-					if (
-						endpoint &&
-						// Prefer rendering an existing page if the endpoint has no GET handler
-						(!route.page || method !== 'GET' || endpoint.GET || endpoint.fallback)
 					) {
+						endpoint = await route.endpoint();
+
+						// Can the endpoint handle this request? render_endpoint falls back to
+						// GET for HEAD requests, so account for that.
+						const endpoint_can_handle =
+							endpoint[method] || endpoint.fallback || (method === 'HEAD' && endpoint.GET);
+
+						// Prefer rendering the page if the endpoint can't handle this GET or HEAD request
+						if (route.page && (method === 'GET' || method === 'HEAD') && !endpoint_can_handle) {
+							endpoint = undefined;
+						}
+					}
+
+					if (endpoint) {
 						response = await render_endpoint(event, event_state, endpoint, state);
 					} else if (route.page) {
 						if (!page_nodes) {
@@ -678,7 +686,11 @@ export async function internal_respond(request, options, manifest, state) {
 
 				// If the route contains a page and an endpoint, we need to add a
 				// `Vary: Accept` header to the response because of browser caching
-				if (request.method === 'GET' && route.page && route.endpoint) {
+				if (
+					(request.method === 'GET' || request.method === 'HEAD') &&
+					route.page &&
+					route.endpoint
+				) {
 					const vary = response.headers
 						.get('vary')
 						?.split(',')

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -627,14 +627,12 @@ export async function internal_respond(request, options, manifest, state) {
 					) {
 						endpoint = await route.endpoint();
 
-						// Can the endpoint handle this request? render_endpoint falls back to
-						// GET for HEAD requests, so account for that.
-						const endpoint_can_handle =
-							endpoint[method] || endpoint.fallback || (method === 'HEAD' && endpoint.GET);
-
 						// Prefer rendering the page if the endpoint can't handle this GET or HEAD request
-						if (route.page && (method === 'GET' || method === 'HEAD') && !endpoint_can_handle) {
-							endpoint = undefined;
+						if (route.page && (method === 'GET' || method === 'HEAD')) {
+							const endpoint_can_handle = !!(endpoint.GET || endpoint.fallback || (method === 'HEAD' && endpoint.HEAD));
+							if (!endpoint_can_handle) {
+								endpoint = undefined;
+							}
 						}
 					}
 

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -629,7 +629,11 @@ export async function internal_respond(request, options, manifest, state) {
 
 						// Prefer rendering the page if the endpoint can't handle this GET or HEAD request
 						if (route.page && (method === 'GET' || method === 'HEAD')) {
-							const endpoint_can_handle = !!(endpoint.GET || endpoint.fallback || (method === 'HEAD' && endpoint.HEAD));
+							const endpoint_can_handle = !!(
+								endpoint.GET ||
+								endpoint.fallback ||
+								(method === 'HEAD' && endpoint.HEAD)
+							);
 							if (!endpoint_can_handle) {
 								endpoint = undefined;
 							}

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -619,52 +619,61 @@ export async function internal_respond(request, options, manifest, state) {
 						invalidated_data_nodes,
 						trailing_slash
 					);
-				} else if (
-					route.endpoint &&
-					(!route.page || (!state.prerendering && is_endpoint_request(event)))
-				) {
-					response = await render_endpoint(event, event_state, await route.endpoint(), state);
-				} else if (route.page) {
-					if (!page_nodes) {
-						throw new Error('page_nodes not found. This should never happen');
-					} else if (page_methods.has(method)) {
-						response = await render_page(
-							event,
-							event_state,
-							route.page,
-							options,
-							manifest,
-							state,
-							page_nodes,
-							resolve_opts
-						);
-					} else {
-						const allowed_methods = new Set(allowed_page_methods);
-						const node = await manifest._.nodes[route.page.leaf]();
-						if (node?.server?.actions) {
-							allowed_methods.add('POST');
-						}
-
-						if (method === 'OPTIONS') {
-							// This will deny CORS preflight requests implicitly because we don't
-							// add the required CORS headers to the response.
-							response = new Response(null, {
-								status: 204,
-								headers: {
-									allow: Array.from(allowed_methods.values()).join(', ')
-								}
-							});
-						} else {
-							const mod = [...allowed_methods].reduce((acc, curr) => {
-								acc[curr] = true;
-								return acc;
-							}, /** @type {Record<string, any>} */ ({}));
-							response = method_not_allowed(mod, method);
-						}
-					}
 				} else {
-					// a route will always have a page or an endpoint, but TypeScript doesn't know that
-					throw new Error('Route is neither page nor endpoint. This should never happen');
+					const endpoint =
+						route.endpoint &&
+						(!route.page || (!state.prerendering && is_endpoint_request(event)))
+							? await route.endpoint()
+							: undefined;
+
+					if (
+						endpoint &&
+						// Prefer rendering an existing page if the endpoint has no GET handler
+						(!route.page || method !== 'GET' || endpoint.GET || endpoint.fallback)
+					) {
+						response = await render_endpoint(event, event_state, endpoint, state);
+					} else if (route.page) {
+						if (!page_nodes) {
+							throw new Error('page_nodes not found. This should never happen');
+						} else if (page_methods.has(method)) {
+							response = await render_page(
+								event,
+								event_state,
+								route.page,
+								options,
+								manifest,
+								state,
+								page_nodes,
+								resolve_opts
+							);
+						} else {
+							const allowed_methods = new Set(allowed_page_methods);
+							const node = await manifest._.nodes[route.page.leaf]();
+							if (node?.server?.actions) {
+								allowed_methods.add('POST');
+							}
+
+							if (method === 'OPTIONS') {
+								// This will deny CORS preflight requests implicitly because we don't
+								// add the required CORS headers to the response.
+								response = new Response(null, {
+									status: 204,
+									headers: {
+										allow: Array.from(allowed_methods.values()).join(', ')
+									}
+								});
+							} else {
+								const mod = [...allowed_methods].reduce((acc, curr) => {
+									acc[curr] = true;
+									return acc;
+								}, /** @type {Record<string, any>} */ ({}));
+								response = method_not_allowed(mod, method);
+							}
+						}
+					} else {
+						// a route will always have a page or an endpoint, but TypeScript doesn't know that
+						throw new Error('Route is neither page nor endpoint. This should never happen');
+					}
 				}
 
 				// If the route contains a page and an endpoint, we need to add a

--- a/packages/kit/test/apps/basics/src/routes/endpoint-output/fallback-with-page/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-output/fallback-with-page/+page.svelte
@@ -1,0 +1,1 @@
+<h1>fallback endpoint page</h1>

--- a/packages/kit/test/apps/basics/src/routes/endpoint-output/fallback-with-page/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-output/fallback-with-page/+server.js
@@ -1,0 +1,3 @@
+export function fallback() {
+	return new Response('catch-all');
+}

--- a/packages/kit/test/apps/basics/src/routes/endpoint-output/post-only-with-page/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-output/post-only-with-page/+page.svelte
@@ -1,0 +1,1 @@
+<h1>POST-only endpoint page</h1>

--- a/packages/kit/test/apps/basics/src/routes/endpoint-output/post-only-with-page/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-output/post-only-with-page/+server.js
@@ -1,0 +1,3 @@
+export function POST() {
+	return new Response('ok');
+}

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -305,6 +305,67 @@ test.describe('Endpoints', () => {
 		expect(await response.text()).toContain('POST-only endpoint page');
 	});
 
+	test('serves page for HEAD request when endpoint has no HEAD or GET handler', async ({
+		request
+	}) => {
+		const response = await request.fetch('/endpoint-output/post-only-with-page', {
+			method: 'HEAD',
+			headers: {
+				accept: '*/*'
+			}
+		});
+
+		expect(response.status()).toBe(200);
+		expect(response.headers()['content-type']).toContain('text/html');
+		expect(response.headers()['x-sveltekit-page']).toBe('true');
+		expect(await response.text()).toBe('');
+	});
+
+	test('POST to post-only endpoint with sibling page still hits endpoint', async ({ request }) => {
+		const response = await request.post('/endpoint-output/post-only-with-page');
+
+		expect(response.status()).toBe(200);
+		expect(await response.text()).toBe('ok');
+	});
+
+	test('uses fallback handler instead of page when endpoint has no GET but has fallback', async ({
+		request
+	}) => {
+		const response = await request.fetch('/endpoint-output/fallback-with-page', {
+			headers: {
+				accept: '*/*'
+			}
+		});
+
+		expect(response.status()).toBe(200);
+		expect(await response.text()).toBe('catch-all');
+	});
+
+	test('content negotiation: API requests hit endpoint, browser requests hit page', async ({
+		request
+	}) => {
+		// application/json → endpoint
+		const api_response = await request.fetch('/routing/content-negotiation', {
+			headers: {
+				accept: 'application/json'
+			}
+		});
+
+		expect(api_response.status()).toBe(200);
+		expect(await api_response.text()).toBe('GET');
+
+		// text/html → page
+		const html_response = await request.fetch('/routing/content-negotiation', {
+			headers: {
+				accept: 'text/html'
+			}
+		});
+
+		expect(html_response.status()).toBe(200);
+		expect(html_response.headers()['content-type']).toContain('text/html');
+		expect(await html_response.text()).toContain('Hi');
+	});
+
 	// TODO all the remaining tests in this section are really only testing
 	// setResponse, since we're not otherwise changing anything on the response.
 	// might be worth making these unit tests instead

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -293,6 +293,18 @@ test.describe('Endpoints', () => {
 		expect(methods).toEqual(unique_methods);
 	});
 
+	test('serves page for GET request when endpoint has no GET handler', async ({ request }) => {
+		const response = await request.fetch('/endpoint-output/post-only-with-page', {
+			headers: {
+				accept: '*/*'
+			}
+		});
+
+		expect(response.status()).toBe(200);
+		expect(response.headers()['content-type']).toContain('text/html');
+		expect(await response.text()).toContain('POST-only endpoint page');
+	});
+
 	// TODO all the remaining tests in this section are really only testing
 	// setResponse, since we're not otherwise changing anything on the response.
 	// might be worth making these unit tests instead


### PR DESCRIPTION
Fixes #11794
