### PR TITLE
refactor: simplify endpoint/page routing logic and extend to HEAD

### DIFF
--- a/.changeset/quiet-ravens-smile.md
+++ b/.changeset/quiet-ravens-smile.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: render pages over sibling endpoints without GET handlers
+fix: render pages over sibling endpoints without GET or HEAD handlers

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -630,16 +630,10 @@ export async function internal_respond(request, options, manifest, state) {
 						// Can the endpoint handle this request? render_endpoint falls back to
 						// GET for HEAD requests, so account for that.
 						const endpoint_can_handle =
-							endpoint[method] ||
-							endpoint.fallback ||
-							(method === 'HEAD' && endpoint.GET);
+							endpoint[method] || endpoint.fallback || (method === 'HEAD' && endpoint.GET);
 
 						// Prefer rendering the page if the endpoint can't handle this GET or HEAD request
-						if (
-							route.page &&
-							(method === 'GET' || method === 'HEAD') &&
-							!endpoint_can_handle
-						) {
+						if (route.page && (method === 'GET' || method === 'HEAD') && !endpoint_can_handle) {
 							endpoint = undefined;
 						}
 					}

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -620,17 +620,31 @@ export async function internal_respond(request, options, manifest, state) {
 						trailing_slash
 					);
 				} else {
-					const endpoint =
+					let endpoint;
+					if (
 						route.endpoint &&
 						(!route.page || (!state.prerendering && is_endpoint_request(event)))
-							? await route.endpoint()
-							: undefined;
-
-					if (
-						endpoint &&
-						// Prefer rendering an existing page if the endpoint has no GET handler
-						(!route.page || method !== 'GET' || endpoint.GET || endpoint.fallback)
 					) {
+						endpoint = await route.endpoint();
+
+						// Can the endpoint handle this request? render_endpoint falls back to
+						// GET for HEAD requests, so account for that.
+						const endpoint_can_handle =
+							endpoint[method] ||
+							endpoint.fallback ||
+							(method === 'HEAD' && endpoint.GET);
+
+						// Prefer rendering the page if the endpoint can't handle this GET or HEAD request
+						if (
+							route.page &&
+							(method === 'GET' || method === 'HEAD') &&
+							!endpoint_can_handle
+						) {
+							endpoint = undefined;
+						}
+					}
+
+					if (endpoint) {
 						response = await render_endpoint(event, event_state, endpoint, state);
 					} else if (route.page) {
 						if (!page_nodes) {
@@ -678,7 +692,11 @@ export async function internal_respond(request, options, manifest, state) {
 
 				// If the route contains a page and an endpoint, we need to add a
 				// `Vary: Accept` header to the response because of browser caching
-				if (request.method === 'GET' && route.page && route.endpoint) {
+				if (
+					(request.method === 'GET' || request.method === 'HEAD') &&
+					route.page &&
+					route.endpoint
+				) {
 					const vary = response.headers
 						.get('vary')
 						?.split(',')

--- a/packages/kit/test/apps/basics/src/routes/endpoint-output/fallback-with-page/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-output/fallback-with-page/+page.svelte
@@ -1,0 +1,1 @@
+<h1>fallback endpoint page</h1>

--- a/packages/kit/test/apps/basics/src/routes/endpoint-output/fallback-with-page/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/endpoint-output/fallback-with-page/+server.js
@@ -1,0 +1,3 @@
+export function fallback() {
+	return new Response('catch-all');
+}

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -305,6 +305,67 @@ test.describe('Endpoints', () => {
 		expect(await response.text()).toContain('POST-only endpoint page');
 	});
 
+	test('serves page for HEAD request when endpoint has no HEAD or GET handler', async ({
+		request
+	}) => {
+		const response = await request.fetch('/endpoint-output/post-only-with-page', {
+			method: 'HEAD',
+			headers: {
+				accept: '*/*'
+			}
+		});
+
+		expect(response.status()).toBe(200);
+		expect(response.headers()['content-type']).toContain('text/html');
+		expect(response.headers()['x-sveltekit-page']).toBe('true');
+		expect(await response.text()).toBe('');
+	});
+
+	test('POST to post-only endpoint with sibling page still hits endpoint', async ({ request }) => {
+		const response = await request.post('/endpoint-output/post-only-with-page');
+
+		expect(response.status()).toBe(200);
+		expect(await response.text()).toBe('ok');
+	});
+
+	test('uses fallback handler instead of page when endpoint has no GET but has fallback', async ({
+		request
+	}) => {
+		const response = await request.fetch('/endpoint-output/fallback-with-page', {
+			headers: {
+				accept: '*/*'
+			}
+		});
+
+		expect(response.status()).toBe(200);
+		expect(await response.text()).toBe('catch-all');
+	});
+
+	test('content negotiation: API requests hit endpoint, browser requests hit page', async ({
+		request
+	}) => {
+		// application/json → endpoint
+		const api_response = await request.fetch('/routing/content-negotiation', {
+			headers: {
+				accept: 'application/json'
+			}
+		});
+
+		expect(api_response.status()).toBe(200);
+		expect(await api_response.text()).toBe('GET');
+
+		// text/html → page
+		const html_response = await request.fetch('/routing/content-negotiation', {
+			headers: {
+				accept: 'text/html'
+			}
+		});
+
+		expect(html_response.status()).toBe(200);
+		expect(html_response.headers()['content-type']).toContain('text/html');
+		expect(await html_response.text()).toContain('Hi');
+	});
+
 	// TODO all the remaining tests in this section are really only testing
 	// setResponse, since we're not otherwise changing anything on the response.
 	// might be worth making these unit tests instead


### PR DESCRIPTION
Follow-up to #16125. No behavioral change to the GET fix — this refactors the endpoint load + decide flow for readability and extends the "prefer page" behavior to HEAD requests.

## Refactor

Restructures the endpoint loading and decision logic in `respond.js` into a single block with a positive `endpoint_can_handle` check, replacing:
- the `await`-in-ternary pattern (hard to scan)
- the duplicated `!route.page` check across load and use conditions
- the double-negative condition for the HEAD-falls-back-to-GET case

The "load, then maybe discard" intent is now explicit and colocated.

## HEAD fix

Extends the "prefer page" behavior to HEAD requests. Previously, a HEAD request with `accept: */*` to a page+endpoint route where the endpoint had neither HEAD nor GET would get 405 from `render_endpoint`, even though the page could handle HEAD. Now the page is rendered instead.

`render_endpoint` already falls back to GET for HEAD when GET exists — that case is preserved via the `endpoint_can_handle` check.

Also extends the `Vary: Accept` header to HEAD responses for page+endpoint routes, since HEAD can now be routed to either.

## Tests

- **HEAD request prefers page** when endpoint has no HEAD/GET/fallback
- **POST to post-only endpoint** with sibling page still hits the endpoint
- **Fallback handler used** instead of page when endpoint has no GET but has `fallback` (new `fallback-with-page` test route)
- **Content negotiation**: `accept: application/json` hits endpoint, `accept: text/html` hits page (using existing `routing/content-negotiation` route)