### PR TITLE
docs: fix navigation type JSDoc formatting

### DIFF
--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1264,7 +1264,6 @@ export interface NavigationBase {
 
 export interface NavigationEnter extends NavigationBase {
 	/**
-	 * The type of navigation:
 	 * - `enter`: The app has hydrated/started
 	 */
 	type: 'enter';
@@ -1284,7 +1283,6 @@ export type NavigationExternal = NavigationGoto | NavigationLeave;
 
 export interface NavigationGoto extends NavigationBase {
 	/**
-	 * The type of navigation:
 	 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
 	 */
 	type: 'goto';
@@ -1299,7 +1297,6 @@ export interface NavigationGoto extends NavigationBase {
 
 export interface NavigationLeave extends NavigationBase {
 	/**
-	 * The type of navigation:
 	 * - `leave`: The app is being left either because the tab is being closed or a navigation to a different document is occurring
 	 */
 	type: 'leave';
@@ -1314,7 +1311,6 @@ export interface NavigationLeave extends NavigationBase {
 
 export interface NavigationFormSubmit extends NavigationBase {
 	/**
-	 * The type of navigation:
 	 * - `form`: The user submitted a `<form method="GET">`
 	 */
 	type: 'form';
@@ -1334,7 +1330,6 @@ export interface NavigationFormSubmit extends NavigationBase {
 
 export interface NavigationPopState extends NavigationBase {
 	/**
-	 * The type of navigation:
 	 * - `popstate`: Navigation was triggered by back/forward navigation
 	 */
 	type: 'popstate';
@@ -1352,7 +1347,6 @@ export interface NavigationPopState extends NavigationBase {
 
 export interface NavigationLink extends NavigationBase {
 	/**
-	 * The type of navigation:
 	 * - `link`: Navigation was triggered by a link click
 	 */
 	type: 'link';

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1238,7 +1238,6 @@ declare module '@sveltejs/kit' {
 
 	export interface NavigationEnter extends NavigationBase {
 		/**
-		 * The type of navigation:
 		 * - `enter`: The app has hydrated/started
 		 */
 		type: 'enter';
@@ -1258,7 +1257,6 @@ declare module '@sveltejs/kit' {
 
 	export interface NavigationGoto extends NavigationBase {
 		/**
-		 * The type of navigation:
 		 * - `goto`: Navigation was triggered by a `goto(...)` call or a redirect
 		 */
 		type: 'goto';
@@ -1273,7 +1271,6 @@ declare module '@sveltejs/kit' {
 
 	export interface NavigationLeave extends NavigationBase {
 		/**
-		 * The type of navigation:
 		 * - `leave`: The app is being left either because the tab is being closed or a navigation to a different document is occurring
 		 */
 		type: 'leave';
@@ -1288,7 +1285,6 @@ declare module '@sveltejs/kit' {
 
 	export interface NavigationFormSubmit extends NavigationBase {
 		/**
-		 * The type of navigation:
 		 * - `form`: The user submitted a `<form method="GET">`
 		 */
 		type: 'form';
@@ -1308,7 +1304,6 @@ declare module '@sveltejs/kit' {
 
 	export interface NavigationPopState extends NavigationBase {
 		/**
-		 * The type of navigation:
 		 * - `popstate`: Navigation was triggered by back/forward navigation
 		 */
 		type: 'popstate';
@@ -1326,7 +1321,6 @@ declare module '@sveltejs/kit' {
 
 	export interface NavigationLink extends NavigationBase {
 		/**
-		 * The type of navigation:
 		 * - `link`: Navigation was triggered by a link click
 		 */
 		type: 'link';


### PR DESCRIPTION
Closes #15910.\n\nRemoves the repeated `The type of navigation:` prefix from each navigation `type` JSDoc item so editors don't merge the prose into every union member hover.\n\nChecks:\n- `pnpm --dir packages/kit generate:types`\n- `pnpm --dir packages/kit lint`