### PR TITLE
docs: clarify requested usage context

### DIFF
--- a/packages/kit/src/runtime/app/server/remote/requested.js
+++ b/packages/kit/src/runtime/app/server/remote/requested.js
@@ -8,16 +8,18 @@ import { get_cache } from './shared.js';
 import { refresh } from './query.js';
 
 /**
- * In the context of a remote `command` or `form` request, returns an iterable
- * of `{ arg, query }` entries for the refreshes requested by the client, up to
- * the supplied `limit`. Each `query` is a `RemoteQuery` bound to the original
- * client-side cache key, so `refresh()` / `set()` propagate correctly even when
- * the query's schema transforms the input. `arg` is the *validated* argument,
- * i.e. the value after the schema has run (so `InferOutput<Schema>` for queries
- * declared with a Standard Schema).
+ * Inside a remote `command` or `form` callback, returns an iterable of
+ * `{ arg, query }` entries for the query instances the client asked to refresh,
+ * up to the supplied `limit`. Each `query` is a `RemoteQuery` bound to the
+ * original client-side cache key, so `refresh()` / `set()` propagate correctly
+ * even when the query's schema transforms the input. `arg` is the *validated*
+ * argument, i.e. the value after the schema has run (so `InferOutput<Schema>`
+ * for queries declared with a Standard Schema).
  *
  * Arguments that fail validation or exceed `limit` are recorded as failures in
  * the response to the client.
+ * See [Client-requested refreshes](https://svelte.dev/docs/kit/remote-functions#Single-flight-mutations-Client-requested-refreshes)
+ * for usage in a remote `command` or `form`.
  *
  * @example
  * ```ts
@@ -54,14 +56,17 @@ import { refresh } from './query.js';
  * @returns {QueryRequestedResult<Validated, Output>}
  */
 /**
- * In the context of a remote `command` or `form` request, returns an iterable
- * of `{ arg, query }` entries for the reconnects requested by the client, up to
- * the supplied `limit`. Each `query` is a `RemoteLiveQuery` bound to the original
- * client-side cache key, so `reconnect()` propagates correctly even when
- * the query's schema transforms the input. `arg` is the *validated* argument.
+ * Inside a remote `command` or `form` callback, returns an iterable of
+ * `{ arg, query }` entries for the live query instances the client asked to
+ * reconnect, up to the supplied `limit`. Each `query` is a `RemoteLiveQuery`
+ * bound to the original client-side cache key, so `reconnect()` propagates
+ * correctly even when the query's schema transforms the input. `arg` is the
+ * *validated* argument.
  *
  * Arguments that fail validation or exceed `limit` are recorded as failures in
  * the response to the client.
+ * See [Client-requested refreshes](https://svelte.dev/docs/kit/remote-functions#Single-flight-mutations-Client-requested-refreshes)
+ * for usage in a remote `command` or `form`.
  *
  * @example
  * ```ts

--- a/packages/kit/src/runtime/app/server/remote/requested.js
+++ b/packages/kit/src/runtime/app/server/remote/requested.js
@@ -8,13 +8,13 @@ import { get_cache } from './shared.js';
 import { refresh } from './query.js';
 
 /**
- * Inside a remote `command` or `form` callback, returns an iterable of
- * `{ arg, query }` entries for the query instances the client asked to refresh,
- * up to the supplied `limit`. Each `query` is a `RemoteQuery` bound to the
- * original client-side cache key, so `refresh()` / `set()` propagate correctly
- * even when the query's schema transforms the input. `arg` is the *validated*
- * argument, i.e. the value after the schema has run (so `InferOutput<Schema>`
- * for queries declared with a Standard Schema).
+ * Inside a remote `command` or `form` callback, returns an iterable
+ * of `{ arg, query }` entries for the query instances the client asked to refresh, up to
+ * the supplied `limit`. Each `query` is a `RemoteQuery` bound to the original
+ * client-side cache key, so `refresh()` / `set()` propagate correctly even when
+ * the query's schema transforms the input. `arg` is the *validated* argument,
+ * i.e. the value after the schema has run (so `InferOutput<Schema>` for queries
+ * declared with a Standard Schema).
  *
  * Arguments that fail validation or exceed `limit` are recorded as failures in
  * the response to the client.
@@ -56,12 +56,11 @@ import { refresh } from './query.js';
  * @returns {QueryRequestedResult<Validated, Output>}
  */
 /**
- * Inside a remote `command` or `form` callback, returns an iterable of
- * `{ arg, query }` entries for the live query instances the client asked to
- * reconnect, up to the supplied `limit`. Each `query` is a `RemoteLiveQuery`
- * bound to the original client-side cache key, so `reconnect()` propagates
- * correctly even when the query's schema transforms the input. `arg` is the
- * *validated* argument.
+ * Inside a remote `command` or `form` callback, returns an iterable
+ * of `{ arg, query }` entries for the live query instances the client asked to reconnect, up to
+ * the supplied `limit`. Each `query` is a `RemoteLiveQuery` bound to the original
+ * client-side cache key, so `reconnect()` propagates correctly even when
+ * the query's schema transforms the input. `arg` is the *validated* argument.
  *
  * Arguments that fail validation or exceed `limit` are recorded as failures in
  * the response to the client.

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3623,13 +3623,13 @@ declare module '$app/server' {
 		function live<Schema extends StandardSchemaV1, Output>(schema: Schema, fn: (arg: StandardSchemaV1.InferOutput<Schema>) => RemoteLiveQueryUserFunctionReturnType<Output>): RemoteLiveQueryFunction<StandardSchemaV1.InferInput<Schema>, Output, StandardSchemaV1.InferOutput<Schema>>;
 	}
 	/**
-	 * Inside a remote `command` or `form` callback, returns an iterable of
-	 * `{ arg, query }` entries for the query instances the client asked to refresh,
-	 * up to the supplied `limit`. Each `query` is a `RemoteQuery` bound to the
-	 * original client-side cache key, so `refresh()` / `set()` propagate correctly
-	 * even when the query's schema transforms the input. `arg` is the *validated*
-	 * argument, i.e. the value after the schema has run (so `InferOutput<Schema>`
-	 * for queries declared with a Standard Schema).
+	 * Inside a remote `command` or `form` callback, returns an iterable
+	 * of `{ arg, query }` entries for the query instances the client asked to refresh, up to
+	 * the supplied `limit`. Each `query` is a `RemoteQuery` bound to the original
+	 * client-side cache key, so `refresh()` / `set()` propagate correctly even when
+	 * the query's schema transforms the input. `arg` is the *validated* argument,
+	 * i.e. the value after the schema has run (so `InferOutput<Schema>` for queries
+	 * declared with a Standard Schema).
 	 *
 	 * Arguments that fail validation or exceed `limit` are recorded as failures in
 	 * the response to the client.
@@ -3665,12 +3665,11 @@ declare module '$app/server' {
 	 * */
 	export function requested<Input, Output, Validated = Input>(query: RemoteQueryFunction<Input, Output, Validated>, limit: number): QueryRequestedResult<Validated, Output>;
 	/**
-	 * Inside a remote `command` or `form` callback, returns an iterable of
-	 * `{ arg, query }` entries for the live query instances the client asked to
-	 * reconnect, up to the supplied `limit`. Each `query` is a `RemoteLiveQuery`
-	 * bound to the original client-side cache key, so `reconnect()` propagates
-	 * correctly even when the query's schema transforms the input. `arg` is the
-	 * *validated* argument.
+	 * Inside a remote `command` or `form` callback, returns an iterable
+	 * of `{ arg, query }` entries for the live query instances the client asked to reconnect, up to
+	 * the supplied `limit`. Each `query` is a `RemoteLiveQuery` bound to the original
+	 * client-side cache key, so `reconnect()` propagates correctly even when
+	 * the query's schema transforms the input. `arg` is the *validated* argument.
 	 *
 	 * Arguments that fail validation or exceed `limit` are recorded as failures in
 	 * the response to the client.

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3623,16 +3623,18 @@ declare module '$app/server' {
 		function live<Schema extends StandardSchemaV1, Output>(schema: Schema, fn: (arg: StandardSchemaV1.InferOutput<Schema>) => RemoteLiveQueryUserFunctionReturnType<Output>): RemoteLiveQueryFunction<StandardSchemaV1.InferInput<Schema>, Output, StandardSchemaV1.InferOutput<Schema>>;
 	}
 	/**
-	 * In the context of a remote `command` or `form` request, returns an iterable
-	 * of `{ arg, query }` entries for the refreshes requested by the client, up to
-	 * the supplied `limit`. Each `query` is a `RemoteQuery` bound to the original
-	 * client-side cache key, so `refresh()` / `set()` propagate correctly even when
-	 * the query's schema transforms the input. `arg` is the *validated* argument,
-	 * i.e. the value after the schema has run (so `InferOutput<Schema>` for queries
-	 * declared with a Standard Schema).
+	 * Inside a remote `command` or `form` callback, returns an iterable of
+	 * `{ arg, query }` entries for the query instances the client asked to refresh,
+	 * up to the supplied `limit`. Each `query` is a `RemoteQuery` bound to the
+	 * original client-side cache key, so `refresh()` / `set()` propagate correctly
+	 * even when the query's schema transforms the input. `arg` is the *validated*
+	 * argument, i.e. the value after the schema has run (so `InferOutput<Schema>`
+	 * for queries declared with a Standard Schema).
 	 *
 	 * Arguments that fail validation or exceed `limit` are recorded as failures in
 	 * the response to the client.
+	 * See [Client-requested refreshes](https://svelte.dev/docs/kit/remote-functions#Single-flight-mutations-Client-requested-refreshes)
+	 * for usage in a remote `command` or `form`.
 	 *
 	 * @example
 	 * ```ts
@@ -3663,14 +3665,17 @@ declare module '$app/server' {
 	 * */
 	export function requested<Input, Output, Validated = Input>(query: RemoteQueryFunction<Input, Output, Validated>, limit: number): QueryRequestedResult<Validated, Output>;
 	/**
-	 * In the context of a remote `command` or `form` request, returns an iterable
-	 * of `{ arg, query }` entries for the reconnects requested by the client, up to
-	 * the supplied `limit`. Each `query` is a `RemoteLiveQuery` bound to the original
-	 * client-side cache key, so `reconnect()` propagates correctly even when
-	 * the query's schema transforms the input. `arg` is the *validated* argument.
+	 * Inside a remote `command` or `form` callback, returns an iterable of
+	 * `{ arg, query }` entries for the live query instances the client asked to
+	 * reconnect, up to the supplied `limit`. Each `query` is a `RemoteLiveQuery`
+	 * bound to the original client-side cache key, so `reconnect()` propagates
+	 * correctly even when the query's schema transforms the input. `arg` is the
+	 * *validated* argument.
 	 *
 	 * Arguments that fail validation or exceed `limit` are recorded as failures in
 	 * the response to the client.
+	 * See [Client-requested refreshes](https://svelte.dev/docs/kit/remote-functions#Single-flight-mutations-Client-requested-refreshes)
+	 * for usage in a remote `command` or `form`.
 	 *
 	 * @example
 	 * ```ts


### PR DESCRIPTION
closes #15900

Clarifies the `$app/server` `requested` API reference so it says to call it inside a remote `command` or `form` callback, describes the client-supplied query/live-query instances more directly, and links to the detailed Client-requested refreshes docs.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

Focused checks run:
- `pnpm -F @sveltejs/kit prepublishOnly`
- `pnpm -F @sveltejs/kit lint`
- `pnpm exec prettier --config .prettierrc --check packages/kit/src/runtime/app/server/remote/requested.js`
- `pnpm -F @sveltejs/kit check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

No changeset needed for this docs-only clarification.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.