### PR TITLE
fix: skip native_navigation when __data.json returns 404 on fallback page

### DIFF
--- a/.changeset/fix-fallback-data-404.md
+++ b/.changeset/fix-fallback-data-404.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: skip `native_navigation` when `__data.json` returns 404 on a static fallback page

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1459,7 +1459,8 @@ async function load_root_error_page({ status, error, url, route }) {
 				server_data_node = server_data.nodes[0] ?? null;
 			} catch (e) {
 				// at this point we have no choice but to fall back to the server, if it wouldn't
-				// bring us right back here, turning this into an endless loop
+				// bring us right back here, turning this into an endless loop.
+				// if __data.json returned 404, the route doesn't exist — don't reload or we loop
 				if (
 					!(e instanceof HttpError && e.status === 404) &&
 					(url.origin !== origin || url.pathname !== location.pathname || hydrated)

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1457,10 +1457,13 @@ async function load_root_error_page({ status, error, url, route }) {
 				}
 
 				server_data_node = server_data.nodes[0] ?? null;
-			} catch {
+			} catch (e) {
 				// at this point we have no choice but to fall back to the server, if it wouldn't
 				// bring us right back here, turning this into an endless loop
-				if (url.origin !== origin || url.pathname !== location.pathname || hydrated) {
+				if (
+					!(e instanceof HttpError && e.status === 404) &&
+					(url.origin !== origin || url.pathname !== location.pathname || hydrated)
+				) {
 					return await native_navigation(url);
 				}
 			}

--- a/packages/kit/test/apps/prerendered-app-error-pages/src/routes/+layout.server.ts
+++ b/packages/kit/test/apps/prerendered-app-error-pages/src/routes/+layout.server.ts
@@ -1,0 +1,3 @@
+export function load() {
+	return {};
+}

--- a/packages/kit/test/apps/prerendered-app-error-pages/src/routes/+layout.svelte
+++ b/packages/kit/test/apps/prerendered-app-error-pages/src/routes/+layout.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { setup } from '../../../../setup.js';
+
+	const { children } = $props();
+
+	setup();
+</script>
+
+{@render children?.()}

--- a/packages/kit/test/apps/prerendered-app-error-pages/test/test.js
+++ b/packages/kit/test/apps/prerendered-app-error-pages/test/test.js
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import { expect } from '@playwright/test';
 import { test } from '../../../utils.js';
 

--- a/packages/kit/test/apps/prerendered-app-error-pages/test/test.js
+++ b/packages/kit/test/apps/prerendered-app-error-pages/test/test.js
@@ -7,3 +7,14 @@ test('renders error page on nonexistent route', async ({ page }) => {
 	await page.goto('/nonexistent', { wait_for_started: false });
 	expect(await page.textContent('p')).toBe('This is your custom error page.');
 });
+
+test('renders error page after client-side navigation to nonexistent route', async ({
+	page,
+	app,
+	javaScriptEnabled
+}) => {
+	test.skip(!javaScriptEnabled);
+	await page.goto('/');
+	await Promise.all([page.waitForURL('/nonexistent'), app.goto('/nonexistent').catch(() => {})]);
+	expect(await page.textContent('p')).toBe('This is your custom error page.');
+});

--- a/packages/kit/test/apps/prerendered-app-error-pages/test/test.js
+++ b/packages/kit/test/apps/prerendered-app-error-pages/test/test.js
@@ -9,14 +9,35 @@ test('renders error page on nonexistent route', async ({ page }) => {
 	await expect(page.locator('p')).toHaveText('This is your custom error page.');
 });
 
-test('renders error page after client-side navigation to nonexistent route', async ({
+test('does not reload when __data.json returns 404 on static fallback page', async ({
 	page,
-	app,
 	javaScriptEnabled
 }) => {
 	test.skip(!javaScriptEnabled);
-	test.skip(!!process.env.DEV, 'infinite reload loop only manifests with static file serving');
-	await page.goto('/');
-	await app.goto('/nonexistent').catch(() => {});
+	test.skip(!!process.env.DEV);
+
+	// Simulate the adapter-static fallback scenario where the HTML served for an
+	// unknown URL doesn't match the route, forcing _hydrate() to fail and call
+	// load_root_error_page. That function fetches __data.json, which returns 404 for
+	// a nonexistent route. Without the fix, the catch block calls native_navigation
+	// unconditionally, causing an infinite reload loop.
+	await page.route('**/nonexistent', async (route) => {
+		const response = await route.fetch();
+		const body = (await response.text()).replace(
+			/node_ids: \[(\d+(?:, \d+)*), \d+\]/,
+			'node_ids: [$1, 99]'
+		);
+		await route.fulfill({ response, body });
+	});
+
+	let navCount = 0;
+	page.on('request', (req) => {
+		if (req.isNavigationRequest()) navCount++;
+	});
+
+	await page.goto('/nonexistent', { wait_for_started: false });
+	await page.waitForTimeout(2000);
+
+	expect(navCount).toBe(1);
 	await expect(page.locator('p')).toHaveText('This is your custom error page.');
 });

--- a/packages/kit/test/apps/prerendered-app-error-pages/test/test.js
+++ b/packages/kit/test/apps/prerendered-app-error-pages/test/test.js
@@ -15,6 +15,6 @@ test('renders error page after client-side navigation to nonexistent route', asy
 }) => {
 	test.skip(!javaScriptEnabled);
 	await page.goto('/');
-	await Promise.all([page.waitForURL('/nonexistent'), app.goto('/nonexistent').catch(() => {})]);
-	expect(await page.textContent('p')).toBe('This is your custom error page.');
+	await app.goto('/nonexistent').catch(() => {});
+	await expect(page.locator('p')).toHaveText('This is your custom error page.');
 });

--- a/packages/kit/test/apps/prerendered-app-error-pages/test/test.js
+++ b/packages/kit/test/apps/prerendered-app-error-pages/test/test.js
@@ -5,7 +5,7 @@ test.describe.configure({ mode: 'parallel' });
 
 test('renders error page on nonexistent route', async ({ page }) => {
 	await page.goto('/nonexistent', { wait_for_started: false });
-	expect(await page.textContent('p')).toBe('This is your custom error page.');
+	await expect(page.locator('p')).toHaveText('This is your custom error page.');
 });
 
 test('renders error page after client-side navigation to nonexistent route', async ({
@@ -14,6 +14,7 @@ test('renders error page after client-side navigation to nonexistent route', asy
 	javaScriptEnabled
 }) => {
 	test.skip(!javaScriptEnabled);
+	test.skip(!!process.env.DEV, 'infinite reload loop only manifests with static file serving');
 	await page.goto('/');
 	await app.goto('/nonexistent').catch(() => {});
 	await expect(page.locator('p')).toHaveText('This is your custom error page.');


### PR DESCRIPTION
closes #10733

In a static SvelteKit build (adapter-static with a fallback page), navigating to a non-existent route after the page has hydrated triggers an infinite reload loop.

When the root layout has a server load function, `load_root_error_page` calls `load_data` to fetch `__data.json`. For non-existent routes, that file does not exist on the static host, so the server returns 404 and `load_data` throws `HttpError(404)`.

The catch block then checks `hydrated` to decide whether to call `native_navigation`. Because `_hydrate` sets `hydrated = true` at its very start, this flag is always true by the time `load_root_error_page` runs. So `native_navigation` is called, the browser reloads the same URL, and the cycle repeats.

The fix adds a short-circuit for `HttpError(404)`: a 404 on `__data.json` means the file does not exist on this host and reloading will not help. In that case, the catch block falls through, leaving `server_data_node` as `null` (the same graceful degradation used when the root layout has no server load at all), and the error page renders correctly.

A `+layout.server.ts` (returning `{}`) is added to the prerendered-app-error-pages test fixture so that `app.server_loads[0] !== 0` and the `load_data` call is actually exercised. The new test navigates client-side from `/` to `/nonexistent`, catches the expected rejection when `native_navigation` destroys the Playwright execution context, waits for the URL to settle, and asserts the error page is visible.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.