### PR TITLE
docs: Document the use of `fields.allIssues()` to check if remote form is valid

### DIFF
--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -668,7 +668,10 @@ To get a list of _all_ issues, rather than just those belonging to a single fiel
 `fields.allIssues()` is also useful for checking if the form is valid:
 
 ```svelte
-<button +++disabled={!!createPost.fields.allIssues()}+++>Publish!</button>
+<form {...createPost} oninput={() => createPost.validate()}>
+	<!-- -->
+	<button +++disabled={!!createPost.fields.allIssues()}+++ >Publish!</button>
+</form>
 ```
 
 ### Getting/setting inputs

--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -665,6 +665,12 @@ To get a list of _all_ issues, rather than just those belonging to a single fiel
 {/each}
 ```
 
+`fields.allIssues()` is also useful for checking if the form is valid:
+
+```svelte
+<button +++disabled={!!createPost.fields.allIssues()}+++>Publish!</button>
+```
+
 ### Getting/setting inputs
 
 Each field has a `value()` method that reflects its current value. As the user interacts with the form, it is automatically updated:


### PR DESCRIPTION
closes #16032

As discussed in #16080, the documentation should document the pattern of negating `fields.allIssues()` for checking the validity of the form. This PR adds an example of using this pattern for disabling the submit button.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it. (`N/A`)

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check` (`N/A`)

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`. (`N/A`)

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
