### PR TITLE
fix: call reset function via prototype

### DIFF
--- a/.changeset/lemon-lines-walk.md
+++ b/.changeset/lemon-lines-walk.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: call reset function via prototype

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -94,7 +94,8 @@ export function form(id) {
 		let enhance_callback = async (instance) => {
 			if (await instance.submit()) {
 				await tick();
-				instance.element.reset();
+				// We call reset from the prototype to avoid DOM clobbering
+				HTMLFormElement.prototype.reset.call(instance.element);
 			}
 		};
 

--- a/packages/kit/test/apps/async/src/routes/remote/form/reset-id/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/reset-id/+page.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { reset_id } from './form.remote';
+</script>
+
+<form {...reset_id}>
+	<input id="reset" {...reset_id.fields.message.as('text')} />
+	<button>submit</button>
+</form>
+
+{#if reset_id.result?.message}
+	<div id="result">{reset_id.result.message}</div>
+{/if}

--- a/packages/kit/test/apps/async/src/routes/remote/form/reset-id/form.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/reset-id/form.remote.ts
@@ -1,0 +1,11 @@
+import { form } from '$app/server';
+import * as v from 'valibot';
+
+export const reset_id = form(
+	v.object({
+		message: v.string()
+	}),
+	({ message }) => {
+		return { success: true, message };
+	}
+);

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -1081,6 +1081,14 @@ test.describe('remote function mutations', () => {
 		// must not have been refreshed by an implicit invalidateAll
 		await expect(count).toHaveText('Count: 0');
 	});
+
+	test('form submission with element id `reset` resets the form', async ({ page }) => {
+		await page.goto('/remote/form/reset-id');
+		await page.locator('[name="message"]').fill('test');
+		await page.click('button');
+		await expect(page.locator('#result')).toHaveText('test');
+		await expect(page.locator('[name="message"]')).toBeEmpty();
+	});
 });
 
 test.describe('client error boundaries', () => {


### PR DESCRIPTION
I found a little bug when using remote functions. 
When you have a element in the form that has a id with the value "reset" the form is not reset. `instance.element.reset` is the element with the id reset. Using the prototype of HTMLFormElement fixes the issue.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
