### PR TITLE
fix: snapshot form fields on read

### DIFF
--- a/.changeset/green-beds-arrive.md
+++ b/.changeset/green-beds-arrive.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: snapshot form fields on read

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -608,6 +608,33 @@ function get_type_prefix(field_type, is_array, input_value) {
 }
 
 /**
+ * A deep-clone implementation specifically for form data, where
+ * we don't need to worry about cycles and whatnot
+ * @param {any} value
+ */
+function deep_clone(value) {
+	if (value !== null && typeof value === 'object') {
+		if (value instanceof File) {
+			return value;
+		}
+
+		if (Array.isArray(value)) {
+			return value.map(deep_clone);
+		}
+
+		/** @type {Record<string, any>} */
+		const clone = {};
+		for (const key of Object.keys(value)) {
+			clone[key] = deep_clone(value[key]);
+		}
+
+		return clone;
+	}
+
+	return value;
+}
+
+/**
  * Creates a proxy-based field accessor for form data
  * @param {any} target - Function or empty POJO
  * @param {() => Record<string, any>} get_input - Function to get current input data
@@ -618,7 +645,8 @@ function get_type_prefix(field_type, is_array, input_value) {
  */
 export function create_field_proxy(target, get_input, set_input, get_issues, path = []) {
 	const get_value = () => {
-		return deep_get(get_input(), path);
+		const value = deep_get(get_input(), path);
+		return deep_clone(value);
 	};
 
 	return new Proxy(target, {

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -611,6 +611,7 @@ function get_type_prefix(field_type, is_array, input_value) {
  * A deep-clone implementation specifically for form data, where
  * we don't need to worry about cycles and whatnot
  * @param {any} value
+ * @returns {any}
  */
 function deep_clone(value) {
 	if (value !== null && typeof value === 'object') {

--- a/packages/kit/test/apps/async/src/routes/remote/form/snapshot/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/snapshot/+page.svelte
@@ -1,9 +1,9 @@
-<script>
+<script lang="ts">
 	import { update, release } from './snapshot.remote.ts';
 
 	let status = $state('idle');
-	let captured = $state('none');
-	let live = $state('none');
+	let captured = $state<string | undefined>('none');
+	let live = $state<string | undefined>('none');
 </script>
 
 <form
@@ -19,7 +19,7 @@
 
 		// the snapshot should reflect the values at the time it was taken, not
 		// any changes to the form that happened post-submission
-		captured = data.a.b.c;
+		captured = data.a?.b?.c;
 		live = form.fields.a.b.c.value();
 	})}
 >

--- a/packages/kit/test/apps/async/src/routes/remote/form/snapshot/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/snapshot/+page.svelte
@@ -1,0 +1,36 @@
+<script>
+	import { update, release } from './snapshot.remote.ts';
+
+	let status = $state('idle');
+	let captured = $state('none');
+	let live = $state('none');
+</script>
+
+<form
+	{...update.enhance(async (form) => {
+		// take a snapshot of the fields *before* doing any async work
+		const data = form.fields.value();
+
+		// the submission is held open by the server, giving the test a window
+		// to mutate the form state after the snapshot has been taken
+		status = 'submitting';
+		await form.submit();
+		status = 'done';
+
+		// the snapshot should reflect the values at the time it was taken, not
+		// any changes to the form that happened post-submission
+		captured = data.a.b.c;
+		live = form.fields.a.b.c.value();
+	})}
+>
+	<input {...update.fields.a.b.c.as('text')} />
+	<button>submit</button>
+</form>
+
+<form {...release}>
+	<button>release</button>
+</form>
+
+<p id="status">status: {status}</p>
+<p id="captured">captured: {captured}</p>
+<p id="live">live: {live}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/form/snapshot/snapshot.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/form/snapshot/snapshot.remote.ts
@@ -1,0 +1,32 @@
+import { form, getRequestEvent } from '$app/server';
+import * as v from 'valibot';
+
+const deferreds: Array<PromiseWithResolvers<void>> = [];
+
+export const update = form(
+	v.object({
+		a: v.object({
+			b: v.object({
+				c: v.string()
+			})
+		})
+	}),
+	async (data) => {
+		// hold the submission open until `release` is called, so that the test
+		// can mutate the form state while the submission is in flight
+		if (getRequestEvent().isRemoteRequest) {
+			const deferred = Promise.withResolvers<void>();
+			deferreds.push(deferred);
+			await deferred.promise;
+		}
+
+		return data.a.b.c;
+	}
+);
+
+export const release = form(v.object({}), () => {
+	for (const deferred of deferreds) {
+		deferred.resolve();
+	}
+	deferreds.length = 0;
+});

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -651,6 +651,33 @@ test.describe('remote functions', () => {
 		]);
 	});
 
+	test('form.fields.value() returns an immutable snapshot in an enhance callback', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		if (!javaScriptEnabled) return;
+
+		await page.goto('/remote/form/snapshot');
+
+		await page.fill('input[name="a.b.c"]', 'original');
+		await page.getByRole('button', { name: 'submit' }).click();
+
+		// wait until the snapshot has been taken and the submission is in flight
+		await expect(page.locator('#status')).toHaveText('status: submitting');
+
+		// mutate the form state *after* the snapshot was taken
+		await page.fill('input[name="a.b.c"]', 'changed');
+
+		// let the submission complete
+		await page.getByRole('button', { name: 'release' }).click();
+		await expect(page.locator('#status')).toHaveText('status: done');
+
+		// the captured snapshot must not reflect the post-submission change...
+		await expect(page.locator('#captured')).toHaveText('captured: original');
+		// ...while reading the field again reflects the current state
+		await expect(page.locator('#live')).toHaveText('live: changed');
+	});
+
 	test('nested field set is SSR rendered', async ({ page }) => {
 		await page.goto('/remote/form/set-ssr');
 		await expect(page.locator('#description')).toHaveText('Description: nested');


### PR DESCRIPTION
At the moment there's a big ol' `$state` object backing a form object's `fields`, which means the whole thing is mutable. As such you can end up with surprising results:

```js
myform.enhance(async (form) => {
  const data = form.fields.value();

  try {
    await form.submit();
  } catch (e) {
    showErrorUi(e, data.whatever);
  }
})
```

Inside the `catch` clause, `data.whatever` might be the value that was submitted, or it might be the value as it is _now_, if it was changed while the submission was happening.

This PR fixes it.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
