### PR TITLE
chore: ensure `wait_for_start` appears in autocomplete

### DIFF
--- a/packages/kit/test/types.d.ts
+++ b/packages/kit/test/types.d.ts
@@ -11,7 +11,7 @@ import '../types/index.d.ts';
 import { AfterNavigate, BeforeNavigate } from '@sveltejs/kit';
 
 export const test: TestType<
-	PlaywrightTestArgs &
+	Omit<PlaywrightTestArgs, 'page'> &
 		PlaywrightTestOptions & {
 			app: {
 				goto(url: string, opts?: { replaceState?: boolean }): Promise<void>;
@@ -36,10 +36,13 @@ export const test: TestType<
 			start_server(
 				handler: (req: IncomingMessage, res: ServerResponse) => void
 			): Promise<{ port: number }>;
-			page: Page & {
+			page: Omit<Page, 'goto'> & {
 				goto: (
 					url: string,
-					opts?: Parameters<Page['goto']>[1] & { wait_for_started?: boolean }
+					opts?: Parameters<Page['goto']>[1] & {
+						/** Wait for `onMount` to add the 'started' class to the `<body>` */
+						wait_for_started?: boolean
+					}
 				) => ReturnType<Page['goto']>;
 			};
 			baseURL: string;

--- a/packages/kit/test/types.d.ts
+++ b/packages/kit/test/types.d.ts
@@ -41,7 +41,7 @@ export const test: TestType<
 					url: string,
 					opts?: Parameters<Page['goto']>[1] & {
 						/** Wait for `onMount` to add the 'started' class to the `<body>` */
-						wait_for_started?: boolean
+						wait_for_started?: boolean;
 					}
 				) => ReturnType<Page['goto']>;
 			};


### PR DESCRIPTION
Very insignificant but omitting the default `goto` type from the playwright test fixture allows us to override it correctly

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
