### PR TITLE
feat: allow param matcher to be a standard schema

### DIFF
--- a/.changeset/ten-lands-send.md
+++ b/.changeset/ten-lands-send.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: add `parse` function to matcher files

--- a/.changeset/ten-lands-send.md
+++ b/.changeset/ten-lands-send.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': minor
 ---
 
-feat: add `parse` function to matcher files
+feat: allow param matcher to be a standard schema

--- a/documentation/docs/30-advanced/10-advanced-routing.md
+++ b/documentation/docs/30-advanced/10-advanced-routing.md
@@ -93,54 +93,22 @@ src/routes/fruits/[page+++=fruit+++]
 
 If the pathname doesn't match, SvelteKit will try to match other routes (using the sort order specified below), before eventually returning a 404.
 
-### Parsing
-
-In addition to `match`, a param module can export a `parse` function that converts the parameter string into a more useful type. If `parse` is not defined, the parameter value remains a string. If `match` is not defined, all values are considered valid (equivalent to `() => true`). If `parse` throws an error, the parameter is treated as invalid.
+Instead of a function, `match` can also be a [Standard Schema](https://standardschema.dev) — for example with [Valibot](https://valibot.dev):
 
 ```js
 /// file: src/params/number.js
-/** @type {import('@sveltejs/kit').ParamParser<number>} */
-export function parse(param) {
-	const n = Number(param);
-	if (!Number.isFinite(n)) throw new Error('not a number');
-	return n;
-}
+import * as v from 'valibot';
+
+export const match = v.pipe(v.string(), v.toNumber());
 ```
+
+When a schema is used, SvelteKit validates the parameter and uses the transformed output as the param value. If validation fails, the route does not match.
 
 ```js
 /// file: src/routes/items/[id=number]/+page.js
 /** @type {import('./$types').PageLoad} */
 export function load({ params }) {
 	console.log(typeof params.id); // 'number'
-}
-```
-
-You can use both `match` and `parse` in the same module — `match` validates the string, and `parse` converts it:
-
-```js
-/// file: src/params/number.js
-/** @type {import('@sveltejs/kit').ParamMatcher} */
-export function match(param) {
-	return /^\d+$/.test(param);
-}
-
-/** @type {import('@sveltejs/kit').ParamParser<number>} */
-export function parse(param) {
-	return Number(param);
-}
-```
-
-This also makes it possible to integrate with libraries like Valibot:
-
-```js
-/// file: src/params/number.js
-import * as v from 'valibot';
-
-const min3 = v.pipe(v.string(), v.minLength(3));
-
-/** @type {import('@sveltejs/kit').ParamParser<string>} */
-export function parse(param) {
-	return v.parse(min3, param);
 }
 ```
 

--- a/documentation/docs/30-advanced/10-advanced-routing.md
+++ b/documentation/docs/30-advanced/10-advanced-routing.md
@@ -93,6 +93,57 @@ src/routes/fruits/[page+++=fruit+++]
 
 If the pathname doesn't match, SvelteKit will try to match other routes (using the sort order specified below), before eventually returning a 404.
 
+### Parsing
+
+In addition to `match`, a param module can export a `parse` function that converts the parameter string into a more useful type. If `parse` is not defined, the parameter value remains a string. If `match` is not defined, all values are considered valid (equivalent to `() => true`). If `parse` throws an error, the parameter is treated as invalid.
+
+```js
+/// file: src/params/number.js
+/** @type {import('@sveltejs/kit').ParamParser<number>} */
+export function parse(param) {
+	const n = Number(param);
+	if (!Number.isFinite(n)) throw new Error('not a number');
+	return n;
+}
+```
+
+```js
+/// file: src/routes/items/[id=number]/+page.js
+/** @type {import('./$types').PageLoad} */
+export function load({ params }) {
+	console.log(typeof params.id); // 'number'
+}
+```
+
+You can use both `match` and `parse` in the same module — `match` validates the string, and `parse` converts it:
+
+```js
+/// file: src/params/number.js
+/** @type {import('@sveltejs/kit').ParamMatcher} */
+export function match(param) {
+	return /^\d+$/.test(param);
+}
+
+/** @type {import('@sveltejs/kit').ParamParser<number>} */
+export function parse(param) {
+	return Number(param);
+}
+```
+
+This also makes it possible to integrate with libraries like Valibot:
+
+```js
+/// file: src/params/number.js
+import * as v from 'valibot';
+
+const min3 = v.pipe(v.string(), v.minLength(3));
+
+/** @type {import('@sveltejs/kit').ParamParser<string>} */
+export function parse(param) {
+	return v.parse(min3, param);
+}
+```
+
 Each module in the `params` directory corresponds to a matcher, with the exception of `*.test.js` and `*.spec.js` files which may be used to unit test your matchers.
 
 > [!NOTE] Matchers run both on the server and in the browser.

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -40,6 +40,7 @@
 		"svelte": "catalog:",
 		"svelte-preprocess": "catalog:",
 		"typescript": "~6.0.0",
+		"valibot": "catalog:",
 		"vite": "catalog:",
 		"vitest": "catalog:"
 	},

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -137,9 +137,9 @@ export function generate_manifest({
 					${Array.from(
 						matchers,
 						type =>
-							`const __matcher_${type} = await import ('${join_relative(relative_path, `/entries/matchers/${type}.js`)}')`
+							`const { match: ${type} } = await import ('${join_relative(relative_path, `/entries/matchers/${type}.js`)}')`
 					).join('\n')}
-					return { ${Array.from(matchers).map((type) => `${type}: { match: __matcher_${type}.match, parse: __matcher_${type}.parse }`).join(', ')} };
+					return { ${Array.from(matchers).join(', ')} };
 				},
 				server_assets: ${s(files)}
 			}

--- a/packages/kit/src/core/generate_manifest/index.js
+++ b/packages/kit/src/core/generate_manifest/index.js
@@ -136,9 +136,10 @@ export function generate_manifest({
 				matchers: async () => {
 					${Array.from(
 						matchers,
-						type => `const { match: ${type} } = await import ('${(join_relative(relative_path, `/entries/matchers/${type}.js`))}')`
+						type =>
+							`const __matcher_${type} = await import ('${join_relative(relative_path, `/entries/matchers/${type}.js`)}')`
 					).join('\n')}
-					return { ${Array.from(matchers).join(', ')} };
+					return { ${Array.from(matchers).map((type) => `${type}: { match: __matcher_${type}.match, parse: __matcher_${type}.parse }`).join(', ')} };
 				},
 				server_assets: ${s(files)}
 			}

--- a/packages/kit/src/core/sync/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.spec.js
@@ -863,9 +863,12 @@ test('creates param matchers', () => {
 	});
 });
 
-test('creates param matchers with parse-only modules', () => {
+test('creates param matchers with schema modules', () => {
 	const parsed = path.resolve(cwd, 'params', 'parsed.js');
-	fs.writeFileSync(parsed, 'export function parse(param) { return Number(param); }');
+	fs.writeFileSync(
+		parsed,
+		`export const match = { '~standard': { validate() { return { value: 0 }; } } };`
+	);
 	try {
 		const { matchers } = create('samples/basic');
 

--- a/packages/kit/src/core/sync/create_manifest_data/index.spec.js
+++ b/packages/kit/src/core/sync/create_manifest_data/index.spec.js
@@ -863,6 +863,18 @@ test('creates param matchers', () => {
 	});
 });
 
+test('creates param matchers with parse-only modules', () => {
+	const parsed = path.resolve(cwd, 'params', 'parsed.js');
+	fs.writeFileSync(parsed, 'export function parse(param) { return Number(param); }');
+	try {
+		const { matchers } = create('samples/basic');
+
+		expect(matchers.parsed).toEqual(path.join('params', 'parsed.js'));
+	} finally {
+		fs.unlinkSync(parsed);
+	}
+});
+
 test('errors on param matchers with bad names', () => {
 	const boogaloo = path.resolve(cwd, 'params', 'boo-galoo.js');
 	fs.writeFileSync(boogaloo, '');

--- a/packages/kit/src/core/sync/write_client_manifest.js
+++ b/packages/kit/src/core/sync/write_client_manifest.js
@@ -196,8 +196,8 @@ export function write_client_manifest(kit, manifest_data, output, metadata) {
 		for (const key in manifest_data.matchers) {
 			const src = manifest_data.matchers[key];
 
-			imports.push(`import { match as ${key} } from ${s(relative_path(output, src))};`);
-			matchers.push(key);
+			imports.push(`import * as ${key} from ${s(relative_path(output, src))};`);
+			matchers.push(`${key}: { match: ${key}.match, parse: ${key}.parse }`);
 		}
 
 		const module = imports.length

--- a/packages/kit/src/core/sync/write_client_manifest.js
+++ b/packages/kit/src/core/sync/write_client_manifest.js
@@ -196,8 +196,8 @@ export function write_client_manifest(kit, manifest_data, output, metadata) {
 		for (const key in manifest_data.matchers) {
 			const src = manifest_data.matchers[key];
 
-			imports.push(`import * as ${key} from ${s(relative_path(output, src))};`);
-			matchers.push(`${key}: { match: ${key}.match, parse: ${key}.parse }`);
+			imports.push(`import { match as ${key} } from ${s(relative_path(output, src))};`);
+			matchers.push(key);
 		}
 
 		const module = imports.length

--- a/packages/kit/src/core/sync/write_non_ambient.js
+++ b/packages/kit/src/core/sync/write_non_ambient.js
@@ -98,7 +98,7 @@ function generate_app_types(manifest_data, config) {
 
 		let type = matcher_types.get(matcher);
 		if (!type) {
-			type = `MatcherParam<typeof import('${path_to_matcher(matcher)}').match>`;
+			type = `MatcherParam<typeof import('${path_to_matcher(matcher)}')>`;
 			matcher_types.set(matcher, type);
 		}
 
@@ -239,7 +239,7 @@ function generate_app_types(manifest_data, config) {
 
 	return [
 		'declare module "$app/types" {',
-		'\ttype MatcherParam<M> = M extends (param : string) => param is (infer U extends string) ? U : string;',
+		'\ttype MatcherParam<M> = M extends { parse: (param: string) => infer R } ? R : M extends { match: (param: string) => param is (infer U extends string) } ? U : string;',
 		'',
 		'\texport interface AppTypes {',
 		`\t\tRouteId(): ${manifest_data.routes.map((r) => s(r.id)).join(' | ')};`,

--- a/packages/kit/src/core/sync/write_non_ambient.js
+++ b/packages/kit/src/core/sync/write_non_ambient.js
@@ -98,7 +98,7 @@ function generate_app_types(manifest_data, config) {
 
 		let type = matcher_types.get(matcher);
 		if (!type) {
-			type = `MatcherParam<typeof import('${path_to_matcher(matcher)}')>`;
+			type = `import('@sveltejs/kit').MatcherParam<typeof import('${path_to_matcher(matcher)}').match>`;
 			matcher_types.set(matcher, type);
 		}
 
@@ -239,8 +239,6 @@ function generate_app_types(manifest_data, config) {
 
 	return [
 		'declare module "$app/types" {',
-		'\ttype MatcherParam<M> = M extends { parse: (param: string) => infer R } ? R : M extends { match: (param: string) => param is (infer U extends string) } ? U : string;',
-		'',
 		'\texport interface AppTypes {',
 		`\t\tRouteId(): ${manifest_data.routes.map((r) => s(r.id)).join(' | ')};`,
 		`\t\tRouteParams(): {\n\t\t\t${dynamic_routes.join(';\n\t\t\t')}\n\t\t};`,

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -198,11 +198,6 @@ function update_types(config, routes, route, root, to_delete = new Set()) {
 	// Makes sure a type is "repackaged" and therefore more readable
 	declarations.push('type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;');
 
-	// returns the predicate of a matcher's type guard - or string if there is no type guard
-	declarations.push(
-		'type MatcherParam<M> = M extends { parse: (param: string) => infer R } ? R : M extends { match: (param: string) => param is (infer U extends string) } ? U : string;'
-	);
-
 	declarations.push(
 		'type RouteParams = ' + generate_params_type(route.params, outdir, config) + ';'
 	);
@@ -613,7 +608,7 @@ function generate_params_type(params, outdir, config) {
 			(param) =>
 				`${param.name}${param.optional ? '?' : ''}: ${
 					param.matcher
-						? `MatcherParam<typeof import('${path_to_matcher(param.matcher)}')>`
+						? `Kit.MatcherParam<typeof import('${path_to_matcher(param.matcher)}').match>`
 						: 'string'
 				}${param.optional ? ' | undefined' : ''}`
 		)

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -200,7 +200,7 @@ function update_types(config, routes, route, root, to_delete = new Set()) {
 
 	// returns the predicate of a matcher's type guard - or string if there is no type guard
 	declarations.push(
-		'type MatcherParam<M> = M extends (param : string) => param is (infer U extends string) ? U : string;'
+		'type MatcherParam<M> = M extends { parse: (param: string) => infer R } ? R : M extends { match: (param: string) => param is (infer U extends string) } ? U : string;'
 	);
 
 	declarations.push(
@@ -613,7 +613,7 @@ function generate_params_type(params, outdir, config) {
 			(param) =>
 				`${param.name}${param.optional ? '?' : ''}: ${
 					param.matcher
-						? `MatcherParam<typeof import('${path_to_matcher(param.matcher)}').match>`
+						? `MatcherParam<typeof import('${path_to_matcher(param.matcher)}')>`
 						: 'string'
 				}${param.optional ? ' | undefined' : ''}`
 		)

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/package.json
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/package.json
@@ -3,7 +3,7 @@
 	"private": true,
 	"type": "module",
 	"devDependencies": {
-		"typescript": "~6.0.3"
+		"typescript": "~6.0.3",
 		"valibot": "catalog:"
 	},
 	"scripts": {

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/package.json
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/package.json
@@ -3,7 +3,8 @@
 	"private": true,
 	"type": "module",
 	"devDependencies": {
-		"typescript": "~6.0.0"
+		"typescript": "~6.0.0",
+		"valibot": "catalog:"
 	},
 	"scripts": {
 		"testtypes": "tsc"

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/params/number.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/params/number.js
@@ -1,6 +1,3 @@
-/** @type {import('@sveltejs/kit').ParamParser<number>} */
-export function parse(param) {
-	const n = Number(param);
-	if (!Number.isFinite(n)) throw new Error('not a number');
-	return n;
-}
+import * as v from 'valibot';
+
+export const match = v.pipe(v.string(), v.toNumber());

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/params/number.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/params/number.js
@@ -1,0 +1,6 @@
+/** @type {import('@sveltejs/kit').ParamParser<number>} */
+export function parse(param) {
+	const n = Number(param);
+	if (!Number.isFinite(n)) throw new Error('not a number');
+	return n;
+}

--- a/packages/kit/src/core/sync/write_types/test/param-type-inference/parsed/[id=number]/+page.js
+++ b/packages/kit/src/core/sync/write_types/test/param-type-inference/parsed/[id=number]/+page.js
@@ -1,0 +1,8 @@
+/* eslint-disable */
+
+/** @type {import('../../.svelte-kit/types/parsed/[id=number]/$types').PageLoad} */
+export function load({ params }) {
+	/** @type {number} */
+	let id;
+	id = params.id;
+}

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1429,21 +1429,17 @@ export interface Page<
 /**
  * The shape of a param matcher. See [matching](https://svelte.dev/docs/kit/advanced-routing#Matching) for more info.
  */
-export type ParamMatcher = (param: string) => boolean;
+export type ParamMatcher = ((param: string) => boolean) | StandardSchemaV1<string, any>;
 
 /**
- * The shape of a param parser. See [matching](https://svelte.dev/docs/kit/advanced-routing#Matching) for more info.
+ * Extracts the param type from a matcher — the output type of a Standard Schema, the predicate of a type guard, or `string`.
  */
-export type ParamParser<T = any> = (param: string) => T;
-
-/**
- * A param matcher module can export a `match` function, a `parse` function, or both.
- * See [matching](https://svelte.dev/docs/kit/advanced-routing#Matching) for more info.
- */
-export interface ParamMatcherModule {
-	match?: ParamMatcher;
-	parse?: ParamParser;
-}
+export type MatcherParam<M> =
+	M extends StandardSchemaV1<any, any>
+		? StandardSchemaV1.InferOutput<M>
+		: M extends ((param: string) => param is infer U extends string)
+			? U
+			: string;
 
 /**
  * A single entry yielded by [`requested`](https://svelte.dev/docs/kit/$app-server#requested)
@@ -1700,7 +1696,7 @@ export interface SSRManifest {
 		remotes: Record<string, () => Promise<any>>;
 		routes: SSRRoute[];
 		prerendered_routes: Set<string>;
-		matchers: () => Promise<Record<string, ParamMatcherModule>>;
+		matchers: () => Promise<Record<string, ParamMatcher>>;
 		/** A `[file]: size` map of all assets imported by server code. */
 		server_assets: Record<string, number>;
 	};

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1432,6 +1432,20 @@ export interface Page<
 export type ParamMatcher = (param: string) => boolean;
 
 /**
+ * The shape of a param parser. See [matching](https://svelte.dev/docs/kit/advanced-routing#Matching) for more info.
+ */
+export type ParamParser<T = any> = (param: string) => T;
+
+/**
+ * A param matcher module can export a `match` function, a `parse` function, or both.
+ * See [matching](https://svelte.dev/docs/kit/advanced-routing#Matching) for more info.
+ */
+export interface ParamMatcherModule {
+	match?: ParamMatcher;
+	parse?: ParamParser;
+}
+
+/**
  * A single entry yielded by [`requested`](https://svelte.dev/docs/kit/$app-server#requested)
  * when called with a regular `query`. `arg` is the validated argument (the input *after*
  * the query's schema validated and transformed it, if applicable); `query` is a
@@ -1686,7 +1700,7 @@ export interface SSRManifest {
 		remotes: Record<string, () => Promise<any>>;
 		routes: SSRRoute[];
 		prerendered_routes: Set<string>;
-		matchers: () => Promise<Record<string, ParamMatcher>>;
+		matchers: () => Promise<Record<string, ParamMatcherModule>>;
 		/** A `[file]: size` map of all assets imported by server code. */
 		server_assets: Record<string, number>;
 	};

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -288,7 +288,7 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, a
 					})
 				),
 				matchers: async () => {
-					/** @type {Record<string, import('@sveltejs/kit').ParamMatcher>} */
+					/** @type {Record<string, import('@sveltejs/kit').ParamMatcherModule>} */
 					const matchers = {};
 
 					for (const key in manifest_data.matchers) {
@@ -296,11 +296,11 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, a
 						const url = path.resolve(root, file);
 						const module = await vite.ssrLoadModule(url, { fixStacktrace: true });
 
-						if (module.match) {
-							matchers[key] = module.match;
-						} else {
-							throw new Error(`${file} does not export a \`match\` function`);
+						if (!module.match && !module.parse) {
+							throw new Error(`${file} must export a \`match\` and/or \`parse\` function`);
 						}
+
+						matchers[key] = { match: module.match, parse: module.parse };
 					}
 
 					return matchers;

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -288,7 +288,7 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, a
 					})
 				),
 				matchers: async () => {
-					/** @type {Record<string, import('@sveltejs/kit').ParamMatcherModule>} */
+					/** @type {Record<string, import('@sveltejs/kit').ParamMatcher>} */
 					const matchers = {};
 
 					for (const key in manifest_data.matchers) {
@@ -296,11 +296,11 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root, a
 						const url = path.resolve(root, file);
 						const module = await vite.ssrLoadModule(url, { fixStacktrace: true });
 
-						if (!module.match && !module.parse) {
-							throw new Error(`${file} must export a \`match\` and/or \`parse\` function`);
+						if (!module.match) {
+							throw new Error(`${file} does not export a \`match\` function or schema`);
 						}
 
-						matchers[key] = { match: module.match, parse: module.parse };
+						matchers[key] = module.match;
 					}
 
 					return matchers;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -8,12 +8,7 @@ import { HttpError, Redirect, SvelteKitError } from '@sveltejs/kit/internal';
 const { onMount, tick } = svelte;
 // Svelte 4 and under don't have `untrack`, so we have to fallback if `untrack` is not exported
 const untrack = svelte.untrack ?? ((value) => value());
-import {
-	decode_pathname,
-	strip_hash,
-	make_trackable,
-	normalize_path
-} from '../../utils/url.js';
+import { decode_pathname, strip_hash, make_trackable, normalize_path } from '../../utils/url.js';
 import { dev_fetch, initial_fetch, lock_fetch, subsequent_fetch, unlock_fetch } from './fetcher.js';
 import { parse, parse_server_route } from './parse.js';
 import * as storage from './session-storage.js';

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -9,7 +9,6 @@ const { onMount, tick } = svelte;
 // Svelte 4 and under don't have `untrack`, so we have to fallback if `untrack` is not exported
 const untrack = svelte.untrack ?? ((value) => value());
 import {
-	decode_params,
 	decode_pathname,
 	strip_hash,
 	make_trackable,
@@ -1604,7 +1603,7 @@ export async function get_navigation_intent(url, invalidating) {
 					id: get_page_key(url),
 					invalidating,
 					route,
-					params: decode_params(params),
+					params,
 					url
 				};
 			}

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -9,7 +9,7 @@ import {
 	TrailingSlash,
 	Uses
 } from 'types';
-import { Page, ParamMatcherModule } from '@sveltejs/kit';
+import { Page, ParamMatcher } from '@sveltejs/kit';
 
 export interface SvelteKitApp {
 	/**
@@ -39,11 +39,11 @@ export interface SvelteKitApp {
 	dictionary: Record<string, [leaf: number, layouts: number[], errors?: number[]]>;
 
 	/**
-	 * A map of `[matcherName: string]: ParamMatcherModule`, which is used to match and parse route parameters.
+	 * A map of `[matcherName: string]: ParamMatcher`, which is used to match and parse route parameters.
 	 *
 	 * In case of router.resolution=server, this object is empty, as resolution happens on the server.
 	 */
-	matchers: Record<string, ParamMatcherModule>;
+	matchers: Record<string, ParamMatcher>;
 
 	hooks: ClientHooks;
 

--- a/packages/kit/src/runtime/client/types.d.ts
+++ b/packages/kit/src/runtime/client/types.d.ts
@@ -9,7 +9,7 @@ import {
 	TrailingSlash,
 	Uses
 } from 'types';
-import { Page, ParamMatcher } from '@sveltejs/kit';
+import { Page, ParamMatcherModule } from '@sveltejs/kit';
 
 export interface SvelteKitApp {
 	/**
@@ -39,11 +39,11 @@ export interface SvelteKitApp {
 	dictionary: Record<string, [leaf: number, layouts: number[], errors?: number[]]>;
 
 	/**
-	 * A map of `[matcherName: string]: (..) => boolean`, which is used to match route parameters.
+	 * A map of `[matcherName: string]: ParamMatcherModule`, which is used to match and parse route parameters.
 	 *
 	 * In case of router.resolution=server, this object is empty, as resolution happens on the server.
 	 */
-	matchers: Record<string, ParamMatcher>;
+	matchers: Record<string, ParamMatcherModule>;
 
 	hooks: ClientHooks;
 

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -139,10 +139,6 @@ export function get_route_segments(route) {
  * @returns {{ success: true, value: any } | { success: false }}
  */
 function run_matcher(matcher, value) {
-	if (typeof matcher === 'function') {
-		return matcher(value) ? { success: true, value } : { success: false };
-	}
-
 	if ('~standard' in matcher) {
 		const result = matcher['~standard'].validate(value);
 
@@ -151,6 +147,10 @@ function run_matcher(matcher, value) {
 		}
 
 		return { success: true, value: result.value };
+	}
+
+	if (typeof matcher === 'function') {
+		return matcher(value) ? { success: true, value } : { success: false };
 	}
 
 	return { success: false };

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -134,9 +134,32 @@ export function get_route_segments(route) {
 }
 
 /**
+ * @param {import('@sveltejs/kit').ParamMatcher} matcher
+ * @param {string} value
+ * @returns {{ success: true, value: any } | { success: false }}
+ */
+function run_matcher(matcher, value) {
+	if (typeof matcher === 'function') {
+		return matcher(value) ? { success: true, value } : { success: false };
+	}
+
+	if ('~standard' in matcher) {
+		const result = matcher['~standard'].validate(value);
+
+		if (result instanceof Promise || result.issues) {
+			return { success: false };
+		}
+
+		return { success: true, value: result.value };
+	}
+
+	return { success: false };
+}
+
+/**
  * @param {RegExpMatchArray} match
  * @param {import('types').RouteParam[]} params
- * @param {Record<string, import('@sveltejs/kit').ParamMatcherModule>} matchers
+ * @param {Record<string, import('@sveltejs/kit').ParamMatcher>} matchers
  */
 export function exec(match, params, matchers) {
 	/** @type {Record<string, any>} */
@@ -175,9 +198,9 @@ export function exec(match, params, matchers) {
 		const decoded = decodeURIComponent(value);
 
 		if (param.matcher) {
-			const { match, parse } = matchers[param.matcher];
+			const outcome = run_matcher(matchers[param.matcher], decoded);
 
-			if (match && !match(decoded)) {
+			if (!outcome.success) {
 				// in the `/[[a=b]]/...` case, if the value didn't satisfy the matcher,
 				// keep track of the number of skipped optional parameters and continue
 				if (param.optional && param.chained) {
@@ -189,19 +212,7 @@ export function exec(match, params, matchers) {
 				return;
 			}
 
-			try {
-				result[param.name] = parse ? parse(decoded) : decoded;
-			} catch {
-				// in the `/[[a=b]]/...` case, if the value didn't satisfy the parser,
-				// keep track of the number of skipped optional parameters and continue
-				if (param.optional && param.chained) {
-					buffered++;
-					continue;
-				}
-
-				// otherwise, if the parser threw, the route did not match
-				return;
-			}
+			result[param.name] = outcome.value;
 		} else {
 			result[param.name] = decoded;
 		}
@@ -304,7 +315,7 @@ export function has_server_load(node) {
  * @template {{pattern: RegExp, params: import('types').RouteParam[]}} Route
  * @param {string} path - The decoded pathname to match
  * @param {Route[]} routes
- * @param {Record<string, import('@sveltejs/kit').ParamMatcherModule>} matchers
+ * @param {Record<string, import('@sveltejs/kit').ParamMatcher>} matchers
  * @returns {{ route: Route, params: Record<string, any> } | null}
  */
 export function find_route(path, routes, matchers) {

--- a/packages/kit/src/utils/routing.js
+++ b/packages/kit/src/utils/routing.js
@@ -1,5 +1,4 @@
 import { BROWSER } from 'esm-env';
-import { decode_params } from './url.js';
 
 const param_pattern = /^(\[)?(\.\.\.)?(\w+)(?:=(\w+))?(\])?$/;
 
@@ -137,10 +136,10 @@ export function get_route_segments(route) {
 /**
  * @param {RegExpMatchArray} match
  * @param {import('types').RouteParam[]} params
- * @param {Record<string, import('@sveltejs/kit').ParamMatcher>} matchers
+ * @param {Record<string, import('@sveltejs/kit').ParamMatcherModule>} matchers
  */
 export function exec(match, params, matchers) {
-	/** @type {Record<string, string>} */
+	/** @type {Record<string, any>} */
 	const result = {};
 
 	const values = match.slice(1);
@@ -173,37 +172,53 @@ export function exec(match, params, matchers) {
 			}
 		}
 
-		if (!param.matcher || matchers[param.matcher](value)) {
-			result[param.name] = value;
+		const decoded = decodeURIComponent(value);
 
-			// Now that the params match, reset the buffer if the next param isn't the [...rest]
-			// and the next value is defined, otherwise the buffer will cause us to skip values
-			const next_param = params[i + 1];
-			const next_value = values[i + 1];
-			if (next_param && !next_param.rest && next_param.optional && next_value && param.chained) {
-				buffered = 0;
+		if (param.matcher) {
+			const { match, parse } = matchers[param.matcher];
+
+			if (match && !match(decoded)) {
+				// in the `/[[a=b]]/...` case, if the value didn't satisfy the matcher,
+				// keep track of the number of skipped optional parameters and continue
+				if (param.optional && param.chained) {
+					buffered++;
+					continue;
+				}
+
+				// otherwise, if the matcher returns `false`, the route did not match
+				return;
 			}
 
-			// There are no more params and no more values, but all non-empty values have been matched
-			if (
-				!next_param &&
-				!next_value &&
-				Object.keys(result).length === values_needing_match.length
-			) {
-				buffered = 0;
+			try {
+				result[param.name] = parse ? parse(decoded) : decoded;
+			} catch {
+				// in the `/[[a=b]]/...` case, if the value didn't satisfy the parser,
+				// keep track of the number of skipped optional parameters and continue
+				if (param.optional && param.chained) {
+					buffered++;
+					continue;
+				}
+
+				// otherwise, if the parser threw, the route did not match
+				return;
 			}
-			continue;
+		} else {
+			result[param.name] = decoded;
 		}
 
-		// in the `/[[a=b]]/...` case, if the value didn't satisfy the matcher,
-		// keep track of the number of skipped optional parameters and continue
-		if (param.optional && param.chained) {
-			buffered++;
-			continue;
+		// Now that the params match, reset the buffer if the next param isn't the [...rest]
+		// and the next value is defined, otherwise the buffer will cause us to skip values
+		const next_param = params[i + 1];
+		const next_value = values[i + 1];
+		if (next_param && !next_param.rest && next_param.optional && next_value && param.chained) {
+			buffered = 0;
 		}
 
-		// otherwise, if the matcher returns `false`, the route did not match
-		return;
+		// There are no more params and no more values, but all non-empty values have been matched
+		if (!next_param && !next_value && Object.keys(result).length === values_needing_match.length) {
+			buffered = 0;
+		}
+		continue;
 	}
 
 	if (buffered) return;
@@ -289,8 +304,8 @@ export function has_server_load(node) {
  * @template {{pattern: RegExp, params: import('types').RouteParam[]}} Route
  * @param {string} path - The decoded pathname to match
  * @param {Route[]} routes
- * @param {Record<string, import('@sveltejs/kit').ParamMatcher>} matchers
- * @returns {{ route: Route, params: Record<string, string> } | null}
+ * @param {Record<string, import('@sveltejs/kit').ParamMatcherModule>} matchers
+ * @returns {{ route: Route, params: Record<string, any> } | null}
  */
 export function find_route(path, routes, matchers) {
 	for (const route of routes) {
@@ -301,7 +316,7 @@ export function find_route(path, routes, matchers) {
 		if (matched) {
 			return {
 				route,
-				params: decode_params(matched)
+				params: matched
 			};
 		}
 	}

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -299,6 +299,60 @@ describe('exec', () => {
 			expect(actual).toEqual(expected);
 		});
 	}
+
+	test('exec parses params with a parse function', () => {
+		const route = '/items/[id=number]';
+		const { pattern, params } = parse_route_id(route);
+		const match = pattern.exec('/items/42');
+		if (!match) throw new Error('Failed to match');
+
+		const actual = exec(match, params, {
+			number: {
+				parse: (param) => {
+					const n = Number(param);
+					if (!Number.isFinite(n)) throw new Error('not a number');
+					return n;
+				}
+			}
+		});
+
+		expect(actual).toEqual({ id: 42 });
+	});
+
+	test('exec rejects params when parse throws', () => {
+		const route = '/items/[id=number]';
+		const { pattern, params } = parse_route_id(route);
+		const match = pattern.exec('/items/abc');
+		if (!match) throw new Error('Failed to match');
+
+		const actual = exec(match, params, {
+			number: {
+				parse: (param) => {
+					const n = Number(param);
+					if (!Number.isFinite(n)) throw new Error('not a number');
+					return n;
+				}
+			}
+		});
+
+		expect(actual).toBeUndefined();
+	});
+
+	test('exec uses match and parse together', () => {
+		const route = '/items/[id=number]';
+		const { pattern, params } = parse_route_id(route);
+		const match = pattern.exec('/items/42');
+		if (!match) throw new Error('Failed to match');
+
+		const actual = exec(match, params, {
+			number: {
+				match: (param) => /^\d+$/.test(param),
+				parse: (param) => Number(param)
+			}
+		});
+
+		expect(actual).toEqual({ id: 42 });
+	});
 });
 
 describe('resolve_route', () => {
@@ -421,9 +475,9 @@ describe('find_route', () => {
 
 	test('respects matchers', () => {
 		const routes = [create_route('/blog/[slug=word]'), create_route('/blog/[slug]')];
-		/** @type {Record<string, import('@sveltejs/kit').ParamMatcher>} */
+		/** @type {Record<string, import('@sveltejs/kit').ParamMatcherModule>} */
 		const matchers = {
-			word: (param) => /^\w+$/.test(param)
+			word: { match: (param) => /^\w+$/.test(param) }
 		};
 
 		// "hello" matches the word matcher
@@ -433,6 +487,40 @@ describe('find_route', () => {
 		// "hello-world" doesn't match word matcher, falls through to [slug]
 		const result2 = find_route('/blog/hello-world', routes, matchers);
 		assert.equal(result2?.route.id, '/blog/[slug]');
+	});
+
+	test('parses params with a parse function', () => {
+		const routes = [create_route('/items/[id=number]')];
+		/** @type {Record<string, import('@sveltejs/kit').ParamMatcherModule>} */
+		const matchers = {
+			number: {
+				parse: (param) => {
+					const n = Number(param);
+					if (!Number.isFinite(n)) throw new Error('not a number');
+					return n;
+				}
+			}
+		};
+
+		const result = find_route('/items/42', routes, matchers);
+		assert.equal(result?.params.id, 42);
+	});
+
+	test('rejects params when parse throws', () => {
+		const routes = [create_route('/items/[id=number]')];
+		/** @type {Record<string, import('@sveltejs/kit').ParamMatcherModule>} */
+		const matchers = {
+			number: {
+				parse: (param) => {
+					const n = Number(param);
+					if (!Number.isFinite(n)) throw new Error('not a number');
+					return n;
+				}
+			}
+		};
+
+		const result = find_route('/items/abc', routes, matchers);
+		assert.equal(result, null);
 	});
 
 	test('decodes params', () => {

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -293,8 +293,8 @@ describe('exec', () => {
 			const match = pattern.exec(path);
 			if (!match) throw new Error(`Failed to match ${path}`);
 			const actual = exec(match, params, {
-				matches: () => true,
-				doesntmatch: () => false
+				matches: { match: () => true },
+				doesntmatch: { match: () => false }
 			});
 			expect(actual).toEqual(expected);
 		});

--- a/packages/kit/src/utils/routing.spec.js
+++ b/packages/kit/src/utils/routing.spec.js
@@ -1,5 +1,9 @@
 import { assert, expect, test, describe } from 'vitest';
+import * as v from 'valibot';
 import { exec, parse_route_id, resolve_route, find_route } from './routing.js';
+
+/** @type {import('@sveltejs/kit').ParamMatcher} */
+const number = v.pipe(v.string(), v.toNumber());
 
 describe('parse_route_id', () => {
 	const tests = {
@@ -293,65 +297,33 @@ describe('exec', () => {
 			const match = pattern.exec(path);
 			if (!match) throw new Error(`Failed to match ${path}`);
 			const actual = exec(match, params, {
-				matches: { match: () => true },
-				doesntmatch: { match: () => false }
+				matches: () => true,
+				doesntmatch: () => false
 			});
 			expect(actual).toEqual(expected);
 		});
 	}
 
-	test('exec parses params with a parse function', () => {
+	test('exec validates and transforms params with a standard schema', () => {
 		const route = '/items/[id=number]';
 		const { pattern, params } = parse_route_id(route);
 		const match = pattern.exec('/items/42');
 		if (!match) throw new Error('Failed to match');
 
-		const actual = exec(match, params, {
-			number: {
-				parse: (param) => {
-					const n = Number(param);
-					if (!Number.isFinite(n)) throw new Error('not a number');
-					return n;
-				}
-			}
-		});
+		const actual = exec(match, params, { number });
 
 		expect(actual).toEqual({ id: 42 });
 	});
 
-	test('exec rejects params when parse throws', () => {
+	test('exec rejects params when a standard schema fails validation', () => {
 		const route = '/items/[id=number]';
 		const { pattern, params } = parse_route_id(route);
 		const match = pattern.exec('/items/abc');
 		if (!match) throw new Error('Failed to match');
 
-		const actual = exec(match, params, {
-			number: {
-				parse: (param) => {
-					const n = Number(param);
-					if (!Number.isFinite(n)) throw new Error('not a number');
-					return n;
-				}
-			}
-		});
+		const actual = exec(match, params, { number });
 
 		expect(actual).toBeUndefined();
-	});
-
-	test('exec uses match and parse together', () => {
-		const route = '/items/[id=number]';
-		const { pattern, params } = parse_route_id(route);
-		const match = pattern.exec('/items/42');
-		if (!match) throw new Error('Failed to match');
-
-		const actual = exec(match, params, {
-			number: {
-				match: (param) => /^\d+$/.test(param),
-				parse: (param) => Number(param)
-			}
-		});
-
-		expect(actual).toEqual({ id: 42 });
 	});
 });
 
@@ -475,9 +447,9 @@ describe('find_route', () => {
 
 	test('respects matchers', () => {
 		const routes = [create_route('/blog/[slug=word]'), create_route('/blog/[slug]')];
-		/** @type {Record<string, import('@sveltejs/kit').ParamMatcherModule>} */
+		/** @type {Record<string, import('@sveltejs/kit').ParamMatcher>} */
 		const matchers = {
-			word: { match: (param) => /^\w+$/.test(param) }
+			word: (param) => /^\w+$/.test(param)
 		};
 
 		// "hello" matches the word matcher
@@ -489,35 +461,19 @@ describe('find_route', () => {
 		assert.equal(result2?.route.id, '/blog/[slug]');
 	});
 
-	test('parses params with a parse function', () => {
+	test('validates and transforms params with a standard schema', () => {
 		const routes = [create_route('/items/[id=number]')];
-		/** @type {Record<string, import('@sveltejs/kit').ParamMatcherModule>} */
-		const matchers = {
-			number: {
-				parse: (param) => {
-					const n = Number(param);
-					if (!Number.isFinite(n)) throw new Error('not a number');
-					return n;
-				}
-			}
-		};
+		/** @type {Record<string, import('@sveltejs/kit').ParamMatcher>} */
+		const matchers = { number };
 
 		const result = find_route('/items/42', routes, matchers);
 		assert.equal(result?.params.id, 42);
 	});
 
-	test('rejects params when parse throws', () => {
+	test('rejects params when a standard schema fails validation', () => {
 		const routes = [create_route('/items/[id=number]')];
-		/** @type {Record<string, import('@sveltejs/kit').ParamMatcherModule>} */
-		const matchers = {
-			number: {
-				parse: (param) => {
-					const n = Number(param);
-					if (!Number.isFinite(n)) throw new Error('not a number');
-					return n;
-				}
-			}
-		};
+		/** @type {Record<string, import('@sveltejs/kit').ParamMatcher>} */
+		const matchers = { number };
 
 		const result = find_route('/items/abc', routes, matchers);
 		assert.equal(result, null);

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1405,6 +1405,20 @@ declare module '@sveltejs/kit' {
 	export type ParamMatcher = (param: string) => boolean;
 
 	/**
+	 * The shape of a param parser. See [matching](https://svelte.dev/docs/kit/advanced-routing#Matching) for more info.
+	 */
+	export type ParamParser<T = any> = (param: string) => T;
+
+	/**
+	 * A param matcher module can export a `match` function, a `parse` function, or both.
+	 * See [matching](https://svelte.dev/docs/kit/advanced-routing#Matching) for more info.
+	 */
+	export interface ParamMatcherModule {
+		match?: ParamMatcher;
+		parse?: ParamParser;
+	}
+
+	/**
 	 * A single entry yielded by [`requested`](https://svelte.dev/docs/kit/$app-server#requested)
 	 * when called with a regular `query`. `arg` is the validated argument (the input *after*
 	 * the query's schema validated and transformed it, if applicable); `query` is a
@@ -1659,7 +1673,7 @@ declare module '@sveltejs/kit' {
 			remotes: Record<string, () => Promise<any>>;
 			routes: SSRRoute[];
 			prerendered_routes: Set<string>;
-			matchers: () => Promise<Record<string, ParamMatcher>>;
+			matchers: () => Promise<Record<string, ParamMatcherModule>>;
 			/** A `[file]: size` map of all assets imported by server code. */
 			server_assets: Record<string, number>;
 		};

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1402,21 +1402,17 @@ declare module '@sveltejs/kit' {
 	/**
 	 * The shape of a param matcher. See [matching](https://svelte.dev/docs/kit/advanced-routing#Matching) for more info.
 	 */
-	export type ParamMatcher = (param: string) => boolean;
+	export type ParamMatcher = ((param: string) => boolean) | StandardSchemaV1<string, any>;
 
 	/**
-	 * The shape of a param parser. See [matching](https://svelte.dev/docs/kit/advanced-routing#Matching) for more info.
+	 * Extracts the param type from a matcher — the output type of a Standard Schema, the predicate of a type guard, or `string`.
 	 */
-	export type ParamParser<T = any> = (param: string) => T;
-
-	/**
-	 * A param matcher module can export a `match` function, a `parse` function, or both.
-	 * See [matching](https://svelte.dev/docs/kit/advanced-routing#Matching) for more info.
-	 */
-	export interface ParamMatcherModule {
-		match?: ParamMatcher;
-		parse?: ParamParser;
-	}
+	export type MatcherParam<M> =
+		M extends StandardSchemaV1<any, any>
+			? StandardSchemaV1.InferOutput<M>
+			: M extends ((param: string) => param is infer U extends string)
+				? U
+				: string;
 
 	/**
 	 * A single entry yielded by [`requested`](https://svelte.dev/docs/kit/$app-server#requested)
@@ -1673,7 +1669,7 @@ declare module '@sveltejs/kit' {
 			remotes: Record<string, () => Promise<any>>;
 			routes: SSRRoute[];
 			prerendered_routes: Set<string>;
-			matchers: () => Promise<Record<string, ParamMatcherModule>>;
+			matchers: () => Promise<Record<string, ParamMatcher>>;
 			/** A `[file]: size` map of all assets imported by server code. */
 			server_assets: Record<string, number>;
 		};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,6 +602,9 @@ importers:
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
+      valibot:
+        specifier: 'catalog:'
+        version: 1.2.0(typescript@6.0.3)
       vite:
         specifier: 'catalog:'
         version: 8.0.16(@types/node@22.19.19)(esbuild@0.27.3)(jiti@2.4.2)(yaml@2.8.3)
@@ -638,6 +641,9 @@ importers:
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
+      valibot:
+        specifier: 'catalog:'
+        version: 1.2.0(typescript@6.0.3)
 
   packages/kit/src/core/sync/write_types/test/simple-page-server-and-shared:
     devDependencies:


### PR DESCRIPTION
Alternative to #16148

match can now also be a standard schema. If it parses you get the transformed value. If it throws it counts as invalid and the route will not be matched.

closes #10407
