### PR TITLE
fix: add `X-Accel-Buffering: no` header to `text/event-stream` responses

### DIFF
--- a/.changeset/eager-streams-flush.md
+++ b/.changeset/eager-streams-flush.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-node': patch
+---
+
+fix: add `X-Accel-Buffering: no` header to `text/event-stream` responses to prevent reverse proxies such as nginx from buffering streamed responses

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -109,53 +109,60 @@ const ssr = async (req, res) => {
 		return;
 	}
 
-	await setResponse(
-		res,
-		await server.respond(request, {
-			platform: { req },
-			getClientAddress: () => {
-				if (address_header) {
-					if (!(address_header in req.headers)) {
-						throw new Error(
-							`Address header was specified with ${
-								env_prefix + 'ADDRESS_HEADER'
-							}=${address_header} but is absent from request`
-						);
-					}
-
-					const value = /** @type {string} */ (req.headers[address_header]) || '';
-
-					if (address_header === 'x-forwarded-for') {
-						const addresses = value.split(',');
-
-						if (xff_depth < 1) {
-							throw new Error(`${env_prefix + 'XFF_DEPTH'} must be a positive integer`);
-						}
-
-						if (xff_depth > addresses.length) {
-							throw new Error(
-								`${env_prefix + 'XFF_DEPTH'} is ${xff_depth}, but only found ${
-									addresses.length
-								} addresses`
-							);
-						}
-						return addresses[addresses.length - xff_depth].trim();
-					}
-
-					return value;
+	const response = await server.respond(request, {
+		platform: { req },
+		getClientAddress: () => {
+			if (address_header) {
+				if (!(address_header in req.headers)) {
+					throw new Error(
+						`Address header was specified with ${
+							env_prefix + 'ADDRESS_HEADER'
+						}=${address_header} but is absent from request`
+					);
 				}
 
-				return (
-					req.connection?.remoteAddress ||
-					// @ts-expect-error
-					req.connection?.socket?.remoteAddress ||
-					req.socket?.remoteAddress ||
-					// @ts-expect-error
-					req.info?.remoteAddress
-				);
+				const value = /** @type {string} */ (req.headers[address_header]) || '';
+
+				if (address_header === 'x-forwarded-for') {
+					const addresses = value.split(',');
+
+					if (xff_depth < 1) {
+						throw new Error(`${env_prefix + 'XFF_DEPTH'} must be a positive integer`);
+					}
+
+					if (xff_depth > addresses.length) {
+						throw new Error(
+							`${env_prefix + 'XFF_DEPTH'} is ${xff_depth}, but only found ${
+								addresses.length
+							} addresses`
+						);
+					}
+					return addresses[addresses.length - xff_depth].trim();
+				}
+
+				return value;
 			}
-		})
-	);
+
+			return (
+				req.connection?.remoteAddress ||
+				// @ts-expect-error
+				req.connection?.socket?.remoteAddress ||
+				req.socket?.remoteAddress ||
+				// @ts-expect-error
+				req.info?.remoteAddress
+			);
+		}
+	});
+
+	// Reverse proxies such as nginx buffer responses by default (ignoring
+	// `cache-control`), which breaks streaming responses like server-sent events.
+	// `X-Accel-Buffering: no` opts out of that buffering and is a no-op on proxies
+	// that don't recognise it. See https://github.com/sveltejs/kit/issues/15790
+	if (response.headers.get('content-type')?.split(';', 1)[0].trim() === 'text/event-stream') {
+		response.headers.set('x-accel-buffering', 'no');
+	}
+
+	await setResponse(res, response);
 };
 
 /** @param {import('polka').Middleware[]} handlers */

--- a/packages/adapter-node/src/handler.js
+++ b/packages/adapter-node/src/handler.js
@@ -158,7 +158,7 @@ const ssr = async (req, res) => {
 	// `cache-control`), which breaks streaming responses like server-sent events.
 	// `X-Accel-Buffering: no` opts out of that buffering and is a no-op on proxies
 	// that don't recognise it. See https://github.com/sveltejs/kit/issues/15790
-	if (response.headers.get('content-type')?.split(';', 1)[0].trim() === 'text/event-stream') {
+	if (response.headers.get('content-type') === 'text/event-stream') {
 		response.headers.set('x-accel-buffering', 'no');
 	}
 

--- a/packages/adapter-node/test/apps/basic/src/routes/event-stream/+server.js
+++ b/packages/adapter-node/test/apps/basic/src/routes/event-stream/+server.js
@@ -1,0 +1,14 @@
+export function GET() {
+	const stream = new ReadableStream({
+		start(controller) {
+			controller.enqueue(new TextEncoder().encode('data: hello\n\n'));
+			controller.close();
+		}
+	});
+
+	return new Response(stream, {
+		headers: {
+			'content-type': 'text/event-stream'
+		}
+	});
+}

--- a/packages/adapter-node/test/apps/basic/test/test.js
+++ b/packages/adapter-node/test/apps/basic/test/test.js
@@ -11,3 +11,14 @@ test('CSR', async ({ page }) => {
 	await page.locator('button').click();
 	await expect(page.locator('button')).toContainText('Toggle: true');
 });
+
+test('sets X-Accel-Buffering header on text/event-stream responses', async ({ request }) => {
+	const response = await request.get('/event-stream');
+	expect(response.headers()['content-type']).toContain('text/event-stream');
+	expect(response.headers()['x-accel-buffering']).toBe('no');
+});
+
+test('does not set X-Accel-Buffering header on other responses', async ({ request }) => {
+	const response = await request.get('/');
+	expect(response.headers()['x-accel-buffering']).toBeUndefined();
+});


### PR DESCRIPTION
closes #15790, closes #16130. On nginx, responses are buffered by default to spare servers from keeping connections open to slow clients. When the response in question is an event stream, this is a very silly thing to do.

This PR fixes it by adding the `x-accel-buffering: no` header in those cases.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
