### PR TITLE
breaking: reject invalid relative routes in `goto`

### DIFF
--- a/.changeset/goto-errors-external-route.md
+++ b/.changeset/goto-errors-external-route.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: `goto` now rejects when called with a URL that does not resolve to a route within the app, matching the existing behaviour for external URLs

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1,4 +1,5 @@
 /** @import { RemoteFunctionDataNode, ServerNodesResponse, ServerRedirectNode } from 'types' */
+/** @import { NavigationIntent } from './types.js' */
 /** @import { CacheEntry } from './remote-functions/cache.svelte.js' */
 /** @import { Query } from './remote-functions/query/instance.svelte.js' */
 /** @import { LiveQuery } from './remote-functions/query-live/instance.svelte.js' */
@@ -529,7 +530,7 @@ function persist_state() {
  * @param {{ replaceState?: boolean; noScroll?: boolean; keepFocus?: boolean; invalidateAll?: boolean; invalidate?: Array<string | URL | ((url: URL) => boolean)>; state?: Record<string, any> }} options
  * @param {number} redirect_count
  * @param {{}} [nav_token]
- * @param {import('./types.js').NavigationIntent | undefined} [intent] navigation intent, when already known by the caller (avoids recomputing it)
+ * @param {NavigationIntent | undefined} [intent] navigation intent, when already known by the caller (avoids recomputing it)
  * @returns {Promise<void>}
  */
 export async function _goto(url, options, redirect_count, nav_token, intent) {
@@ -1706,7 +1707,7 @@ function _before_navigate({ url, type, intent, delta, event, scroll }) {
  *   accept?: () => void;
  *   block?: () => void;
  *   event?: Event;
- *   intent?: import('./types.js').NavigationIntent | undefined
+ *   intent?: NavigationIntent | undefined
  * }} opts
  * @returns {Promise<void>}
  */

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2316,8 +2316,9 @@ export function disableScrollHandling() {
  * Allows you to navigate programmatically to a given route, with options such as keeping the current element focused.
  * Returns a Promise that resolves when SvelteKit navigates (or fails to navigate, in which case the promise rejects) to the specified `url`.
  *
- * `goto` is intended for navigations to routes that belong to the app. For external URLs, use `window.location = url` instead of calling `goto(url)`.
- * If the URL does not resolve to a route within the app, the returned promise will reject — use `window.location = url` to perform a full-page navigation to such URLs.
+ * `goto` is intended for navigations to routes that belong to the app.
+ * If the URL does not resolve to a route within the app, the returned promise will reject. 
+ * For external URLs, use `window.location = url` to perform a full-page navigation instead of calling `goto(url)`.
  *
  * @param {string | URL} url Where to navigate to. Note that if you've set [`config.kit.paths.base`](https://svelte.dev/docs/kit/configuration#paths) and the URL is root-relative, you need to prepend the base path if you want to navigate within the app.
  * @param {Object} [opts] Options related to the navigation

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2317,7 +2317,7 @@ export function disableScrollHandling() {
  * Returns a Promise that resolves when SvelteKit navigates (or fails to navigate, in which case the promise rejects) to the specified `url`.
  *
  * `goto` is intended for navigations to routes that belong to the app.
- * If the URL does not resolve to a route within the app, the returned promise will reject. 
+ * If the URL does not resolve to a route within the app, the returned promise will reject.
  * For external URLs, use `window.location = url` to perform a full-page navigation instead of calling `goto(url)`.
  *
  * @param {string | URL} url Where to navigate to. Note that if you've set [`config.kit.paths.base`](https://svelte.dev/docs/kit/configuration#paths) and the URL is root-relative, you need to prepend the base path if you want to navigate within the app.

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -529,9 +529,10 @@ function persist_state() {
  * @param {{ replaceState?: boolean; noScroll?: boolean; keepFocus?: boolean; invalidateAll?: boolean; invalidate?: Array<string | URL | ((url: URL) => boolean)>; state?: Record<string, any> }} options
  * @param {number} redirect_count
  * @param {{}} [nav_token]
+ * @param {import('./types.js').NavigationIntent | undefined} [intent] navigation intent, when already known by the caller (avoids recomputing it)
  * @returns {Promise<void>}
  */
-export async function _goto(url, options, redirect_count, nav_token) {
+export async function _goto(url, options, redirect_count, nav_token, intent) {
 	/** @type {Set<string>} */
 	let query_keys;
 	/** @type {Set<string>} */
@@ -552,6 +553,7 @@ export async function _goto(url, options, redirect_count, nav_token) {
 		state: options.state,
 		redirect_count,
 		nav_token,
+		intent,
 		accept: () => {
 			if (options.invalidateAll) {
 				force_invalidation = true;
@@ -1703,7 +1705,8 @@ function _before_navigate({ url, type, intent, delta, event, scroll }) {
  *   nav_token?: {};
  *   accept?: () => void;
  *   block?: () => void;
- *   event?: Event
+ *   event?: Event;
+ *   intent?: import('./types.js').NavigationIntent | undefined
  * }} opts
  * @returns {Promise<void>}
  */
@@ -1719,12 +1722,13 @@ async function navigate({
 	nav_token = {},
 	accept = noop,
 	block = noop,
-	event
+	event,
+	intent
 }) {
 	const prev_token = token;
 	token = nav_token;
 
-	const intent = await get_navigation_intent(url, false);
+	intent ??= await get_navigation_intent(url, false);
 	const nav =
 		type === 'enter'
 			? create_navigation(current, intent, url, type)
@@ -2311,7 +2315,8 @@ export function disableScrollHandling() {
  * Allows you to navigate programmatically to a given route, with options such as keeping the current element focused.
  * Returns a Promise that resolves when SvelteKit navigates (or fails to navigate, in which case the promise rejects) to the specified `url`.
  *
- * For external URLs, use `window.location = url` instead of calling `goto(url)`.
+ * `goto` is intended for navigations to routes that belong to the app. For external URLs, use `window.location = url` instead of calling `goto(url)`.
+ * If the URL does not resolve to a route within the app, the returned promise will reject — use `window.location = url` to perform a full-page navigation to such URLs.
  *
  * @param {string | URL} url Where to navigate to. Note that if you've set [`config.kit.paths.base`](https://svelte.dev/docs/kit/configuration#paths) and the URL is root-relative, you need to prepend the base path if you want to navigate within the app.
  * @param {Object} [opts] Options related to the navigation
@@ -2323,7 +2328,7 @@ export function disableScrollHandling() {
  * @param {App.PageState} [opts.state] An optional object that will be available as `page.state`
  * @returns {Promise<void>}
  */
-export function goto(url, opts = {}) {
+export async function goto(url, opts = {}) {
 	if (!BROWSER) {
 		throw new Error('Cannot call goto(...) on the server');
 	}
@@ -2331,16 +2336,24 @@ export function goto(url, opts = {}) {
 	url = new URL(resolve_url(url));
 
 	if (url.origin !== origin) {
-		return Promise.reject(
-			new Error(
-				DEV
-					? `Cannot use \`goto\` with an external URL. Use \`window.location = "${url}"\` instead`
-					: 'goto: invalid URL'
-			)
+		throw new Error(
+			DEV
+				? `Cannot use \`goto\` with an external URL. Use \`window.location = "${url}"\` instead`
+				: 'goto: invalid URL'
 		);
 	}
 
-	return _goto(url, opts, 0);
+	const intent = await get_navigation_intent(url, false);
+
+	if (!intent) {
+		throw new Error(
+			DEV
+				? `Cannot use \`goto\` with a URL that does not resolve to a route within the app. Use \`window.location = "${url}"\` instead`
+				: 'goto: invalid URL'
+		);
+	}
+
+	return _goto(url, opts, 0, {}, intent);
 }
 
 /**

--- a/packages/kit/src/runtime/client/remote-functions/instance.unhandled.svelte.spec.js
+++ b/packages/kit/src/runtime/client/remote-functions/instance.unhandled.svelte.spec.js
@@ -12,7 +12,7 @@ vi.mock(new URL('../client.js', import.meta.url).pathname, () => ({
 	query_responses: {},
 	live_query_map: new Map(),
 	prerender_responses: {},
-	goto: () => {}
+	_goto: () => {}
 }));
 
 // `prerender.svelte.js` references the `__SVELTEKIT_DEV__` build-time constant at

--- a/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
@@ -2,7 +2,7 @@
 import { app_dir, base } from '$app/paths/internal/client';
 import { version } from '$app/env';
 import * as devalue from 'devalue';
-import { app, goto, prerender_responses } from '../client.js';
+import { app, _goto, prerender_responses } from '../client.js';
 import { get_remote_request_headers, remote_request, unwrap_node } from './shared.svelte.js';
 import { create_remote_key, stringify_remote_arg } from '../../shared.js';
 import { noop } from '../../../utils/functions.js';
@@ -98,7 +98,8 @@ export function prerender(id) {
 				const result = await remote_request(url, { headers });
 
 				if (result.redirect) {
-					void goto(result.redirect);
+					// Use internal version to allow redirects to external URLs
+					void _goto(result.redirect, {}, 0);
 					return;
 				}
 

--- a/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
@@ -1,6 +1,6 @@
 /** @import { RemoteQueryFunction } from '@sveltejs/kit' */
 import { app_dir, base } from '$app/paths/internal/client';
-import { goto } from '../client.js';
+import { _goto } from '../client.js';
 import { get_remote_request_headers, QUERY_FUNCTION_ID, remote_request } from './shared.svelte.js';
 import { QueryProxy } from './query/proxy.js';
 import { HttpError } from '@sveltejs/kit/internal';
@@ -50,7 +50,8 @@ export function query_batch(id) {
 						});
 
 						if (response.redirect) {
-							await goto(response.redirect);
+							// Use internal version to allow redirects to external URLs
+							await _goto(response.redirect, {}, 0);
 
 							// settle all batched promises (with `undefined`, like a redirect
 							// from a non-batched query) so that callers don't hang forever

--- a/packages/kit/src/runtime/client/remote-functions/query-live/proxy.svelte.spec.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/proxy.svelte.spec.js
@@ -10,7 +10,7 @@ vi.mock(new URL('../../client.js', import.meta.url).pathname, () => ({
 	query_map: new Map(),
 	query_responses: {},
 	live_query_map: new Map(),
-	goto: () => Promise.resolve()
+	_goto: () => Promise.resolve()
 }));
 
 vi.mock(new URL('./instance.svelte.js', import.meta.url).pathname, () => {

--- a/packages/kit/src/runtime/client/remote-functions/query/index.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/index.js
@@ -1,6 +1,6 @@
 /** @import { RemoteQueryFunction } from '@sveltejs/kit' */
 import { app_dir, base } from '$app/paths/internal/client';
-import { goto, query_map } from '../../client.js';
+import { _goto, query_map } from '../../client.js';
 import { get_remote_request_headers, QUERY_FUNCTION_ID, remote_request } from '../shared.svelte.js';
 import { DEV } from 'esm-env';
 import { QueryProxy } from './proxy.js';
@@ -29,7 +29,8 @@ export function query(id) {
 			const result = await remote_request(url, { headers: get_remote_request_headers() });
 
 			if (result.redirect) {
-				await goto(result.redirect);
+				// Use internal version to allow redirects to external URLs
+				await _goto(result.redirect, {}, 0);
 			}
 		});
 	};

--- a/packages/kit/src/runtime/client/remote-functions/query/proxy.svelte.spec.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/proxy.svelte.spec.js
@@ -10,7 +10,7 @@ vi.mock(new URL('../../client.js', import.meta.url).pathname, () => ({
 	query_map: new Map(),
 	query_responses: {},
 	live_query_map: new Map(),
-	goto: () => {}
+	_goto: () => {}
 }));
 
 const { QueryProxy } = await import('./proxy.js');

--- a/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
@@ -2,7 +2,7 @@
 /** @import { RemoteQueryUpdate } from '@sveltejs/kit' */
 /** @import { CacheEntry } from './cache.svelte.js' */
 import * as devalue from 'devalue';
-import { app, goto, live_query_map, query_map, query_responses } from '../client.js';
+import { app, _goto, live_query_map, query_map, query_responses } from '../client.js';
 import { HttpError, Redirect } from '@sveltejs/kit/internal';
 import { untrack } from 'svelte';
 import { create_remote_key, split_remote_key } from '../../shared.js';
@@ -190,7 +190,8 @@ export async function remote_request(url, init) {
  */
 export async function handle_side_channel_response(response) {
 	if (response.type === 'redirect') {
-		await goto(response.location);
+		// Use internal version to allow redirects to external URLs
+		await _goto(response.location, {}, 0);
 		throw new Redirect(307, response.location);
 	}
 

--- a/packages/kit/src/runtime/client/remote-functions/shared.transport.spec.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.transport.spec.js
@@ -9,7 +9,7 @@ vi.mock(new URL('../client.js', import.meta.url).pathname, () => ({
 	query_map: new Map(),
 	query_responses: {},
 	live_query_map: new Map(),
-	goto: () => {}
+	_goto: () => {}
 }));
 
 // Mock `state.svelte.js` — imports `navigating` and `page` which are reactive

--- a/packages/kit/test/apps/async/src/routes/remote/redirect-external/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/redirect-external/+page.svelte
@@ -1,0 +1,19 @@
+<script>
+	import { redirectOutsideApp } from './redirect.remote.js';
+
+	let status = $state('idle');
+
+	async function run() {
+		status = 'pending';
+
+		try {
+			await redirectOutsideApp();
+			status = 'resolved';
+		} catch {
+			status = 'rejected';
+		}
+	}
+</script>
+
+<button id="trigger" onclick={run}>trigger</button>
+<p id="status">{status}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/redirect-external/redirect.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/redirect-external/redirect.remote.js
@@ -1,0 +1,10 @@
+import { query } from '$app/server';
+import { redirect } from '@sveltejs/kit';
+
+// Regression for https://github.com/sveltejs/kit/issues/14285: a server-issued
+// redirect to a same-origin URL that is not a client route must still navigate,
+// rather than being rejected by the stricter `goto` behaviour.
+export const redirectOutsideApp = query(() => {
+	// `/robots.txt` is a real static asset but not a SvelteKit route
+	redirect(307, '/robots.txt');
+});

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -41,6 +41,19 @@ test.describe('remote functions', () => {
 		await expect(page.locator('#redirected')).toHaveText('redirected');
 	});
 
+	test('query redirect to a same-origin URL outside the app navigates', async ({ page }) => {
+		// Regression for https://github.com/sveltejs/kit/issues/14285 — a server-issued
+		// redirect to a URL that is not a client route must still navigate, instead of
+		// being rejected by the stricter `goto` behaviour. `/robots.txt` is a static
+		// asset that is not a SvelteKit route.
+		await page.goto('/remote/redirect-external');
+
+		await page.click('#trigger');
+
+		// the redirect performs a full-page navigation to the static asset
+		await expect(page).toHaveURL(/\/robots\.txt$/);
+	});
+
 	test("query that's awaited and throws a redirect doesn't trigger handleError hook", async ({
 		baseURL
 	}) => {

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -41,17 +41,26 @@ test.describe('remote functions', () => {
 		await expect(page.locator('#redirected')).toHaveText('redirected');
 	});
 
-	test('query redirect to a same-origin URL outside the app navigates', async ({ page }) => {
+	test('query redirect to a same-origin URL outside the app navigates', async ({
+		page,
+		javaScriptEnabled
+	}) => {
 		// Regression for https://github.com/sveltejs/kit/issues/14285 — a server-issued
 		// redirect to a URL that is not a client route must still navigate, instead of
 		// being rejected by the stricter `goto` behaviour. `/robots.txt` is a static
 		// asset that is not a SvelteKit route.
 		await page.goto('/remote/redirect-external');
 
-		await page.click('#trigger');
+		if (javaScriptEnabled) {
+			await page.click('#trigger');
 
-		// the redirect performs a full-page navigation to the static asset
-		await expect(page).toHaveURL(/\/robots\.txt$/);
+			// the redirect performs a full-page navigation to the static asset
+			await expect(page).toHaveURL(/\/robots\.txt$/);
+		} else {
+			// without JS the query mutation can't be invoked from the client, so the
+			// page just renders its initial state
+			await expect(page.locator('#status')).toHaveText('idle');
+		}
 	});
 
 	test("query that's awaited and throws a redirect doesn't trigger handleError hook", async ({

--- a/packages/kit/test/apps/basics/src/routes/goto/no-such-route/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/goto/no-such-route/+page.svelte
@@ -1,0 +1,17 @@
+<script>
+	import { goto } from '$app/navigation';
+
+	let message = $state('...');
+</script>
+
+<button
+	on:click={async () => {
+		try {
+			await goto('/this-route-does-not-exist');
+		} catch (e) {
+			message = e instanceof Error ? e.message : 'unknown error message';
+		}
+	}}>goto</button
+>
+
+<p>{message}</p>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1531,6 +1531,17 @@ test.describe('goto', () => {
 		await expect(page.locator('p')).toHaveText(message);
 	});
 
+	test('goto fails with a URL that does not resolve to a route', async ({ page }) => {
+		await page.goto('/goto/no-such-route');
+		await page.click('button');
+
+		await expect(page.locator('p')).toContainText(
+			process.env.DEV
+				? 'Cannot use `goto` with a URL that does not resolve to a route within the app'
+				: 'goto: invalid URL'
+		);
+	});
+
 	test.describe('navigation and redirects should be consistent between web native and sveltekit based', () => {
 		const testEntryPage = '/goto/testentry';
 		const testStartPage = '/goto/teststart';
@@ -1562,11 +1573,11 @@ test.describe('goto', () => {
 			test.describe('without replace', () => {
 				const expectGoback = makeExpectGoback(nonexistentPage, testStartPage);
 
-				test('app.goto', async ({ app, page }) => {
-					// navigating to nonexistent page causes playwright's page context to be destroyed
-					// thus this call throws an error unless caught
-					await app.goto(nonexistentPage, { replaceState: false }).catch(() => {});
-					await expectGoback(page);
+				test('app.goto rejects and does not navigate', async ({ app, page }) => {
+					// `goto` is only for routes within the app; navigating to a
+					// non-existent route rejects and leaves the URL unchanged
+					await expect(app.goto(nonexistentPage, { replaceState: false })).rejects.toBeTruthy();
+					await expect(page).toHaveURL(testStartPage);
 				});
 
 				test('location.assign', async ({ page }) => {
@@ -1580,11 +1591,11 @@ test.describe('goto', () => {
 			test.describe('with replace', () => {
 				const expectGoback = makeExpectGoback(nonexistentPage, testEntryPage);
 
-				test('app.goto', async ({ app, page }) => {
-					// navigating to nonexistent page causes playwright's page context to be destroyed
-					// thus this call throws an error unless caught
-					await app.goto(nonexistentPage, { replaceState: true }).catch(() => {});
-					await expectGoback(page);
+				test('app.goto rejects and does not navigate', async ({ app, page }) => {
+					// `goto` is only for routes within the app; navigating to a
+					// non-existent route rejects and leaves the URL unchanged
+					await expect(app.goto(nonexistentPage, { replaceState: true })).rejects.toBeTruthy();
+					await expect(page).toHaveURL(testStartPage);
 				});
 
 				test('location.replace', async ({ page }) => {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3204,7 +3204,8 @@ declare module '$app/navigation' {
 	 * Allows you to navigate programmatically to a given route, with options such as keeping the current element focused.
 	 * Returns a Promise that resolves when SvelteKit navigates (or fails to navigate, in which case the promise rejects) to the specified `url`.
 	 *
-	 * For external URLs, use `window.location = url` instead of calling `goto(url)`.
+	 * `goto` is intended for navigations to routes that belong to the app. For external URLs, use `window.location = url` instead of calling `goto(url)`.
+	 * If the URL does not resolve to a route within the app, the returned promise will reject — use `window.location = url` to perform a full-page navigation to such URLs.
 	 *
 	 * @param url Where to navigate to. Note that if you've set [`config.kit.paths.base`](https://svelte.dev/docs/kit/configuration#paths) and the URL is root-relative, you need to prepend the base path if you want to navigate within the app.
 	 * @param {Object} opts Options related to the navigation

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3204,8 +3204,9 @@ declare module '$app/navigation' {
 	 * Allows you to navigate programmatically to a given route, with options such as keeping the current element focused.
 	 * Returns a Promise that resolves when SvelteKit navigates (or fails to navigate, in which case the promise rejects) to the specified `url`.
 	 *
-	 * `goto` is intended for navigations to routes that belong to the app. For external URLs, use `window.location = url` instead of calling `goto(url)`.
-	 * If the URL does not resolve to a route within the app, the returned promise will reject — use `window.location = url` to perform a full-page navigation to such URLs.
+	 * `goto` is intended for navigations to routes that belong to the app.
+	 * If the URL does not resolve to a route within the app, the returned promise will reject.
+	 * For external URLs, use `window.location = url` to perform a full-page navigation instead of calling `goto(url)`.
 	 *
 	 * @param url Where to navigate to. Note that if you've set [`config.kit.paths.base`](https://svelte.dev/docs/kit/configuration#paths) and the URL is root-relative, you need to prepend the base path if you want to navigate within the app.
 	 * @param {Object} opts Options related to the navigation


### PR DESCRIPTION
closes #14285 

`goto` now errors if you navigate to a route that doesn't exist, even when it's a relative route

This also changes remote functions to use `_goto` to navigate to redirects so that they don't error for external redirects.