### PR TITLE
use type: 'module' for service worker registrations

### DIFF
--- a/.changeset/feat-service-worker-module.md
+++ b/.changeset/feat-service-worker-module.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": minor
+---
+
+feat: use `type: 'module'` for service worker registrations

--- a/documentation/docs/30-advanced/40-service-workers.md
+++ b/documentation/docs/30-advanced/40-service-workers.md
@@ -120,12 +120,10 @@ self.addEventListener('fetch', (event) => {
 You can [disable automatic registration](configuration#serviceWorker) if you need to register the service worker with your own logic. The default registration looks something like this:
 
 ```js
-import { dev } from '$app/env';
-
 if ('serviceWorker' in navigator) {
 	addEventListener('load', function () {
 		navigator.serviceWorker.register('./path/to/service-worker.js', {
-			type: dev ? 'module' : 'classic'
+			type: 'module'
 		});
 	});
 }

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -176,12 +176,6 @@ export function create_builder({
 			const payload = devalue.uneval(values);
 
 			write(`${dest}/env.js`, `export const env=${payload}`);
-
-			// service workers aren't ESM yet, so they load dynamic public env vars at runtime
-			// via `importScripts` of this module rather than importing `env.js`
-			if (build_data.service_worker) {
-				write(`${dest}/env.script.js`, `globalThis.__sveltekit_sw={env:${payload}}`);
-			}
 		},
 
 		generateManifest({ relativePath, routes: subset }) {

--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -218,9 +218,9 @@ export function create_sveltekit_env_public(variables, env, prelude) {
 }
 
 /**
- * Creates the `__sveltekit/env/service-worker` module used in production. Service workers
- * aren't ESM yet, so when an app uses dynamic public env vars they're loaded at runtime via
- * `importScripts` of the prerendered `env.script.js`. If there are none, values are inlined.
+ * Creates the `__sveltekit/env/service-worker` module used in production. When an app uses
+ * dynamic public env vars, they're loaded at runtime via an import of the prerendered
+ * `env.js`. If there are none, values are inlined.
  * @param {Record<string, EnvVarConfig<any>> | null} variables
  * @param {Record<string, string>} env
  * @param {string} global
@@ -237,11 +237,11 @@ export function create_sveltekit_env_service_worker(variables, env, global, base
 	}
 
 	return dedent`
+		import { env } from '${base}/${app_dir}/env.js';
+
 		globalThis.__SVELTEKIT_EXPERIMENTAL_EXPLICIT_ENVIRONMENT_VARIABLES__ = true;
 
-		importScripts('${base}/${app_dir}/env.script.js');
-
-		${global} = globalThis.__sveltekit_sw;
+		${global} = { env };
 	`;
 }
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -994,11 +994,13 @@ function kit({ svelte_config, adapter }) {
 					serviceWorker: {
 						build: {
 							modulePreload: false,
-							rolldownOptions: {
-								input: {
+								rolldownOptions: {
+									external: [`${kit.paths.base}/${kit.appDir}/env.js`],
+									input: {
 									'service-worker': service_worker_entry_file
 								},
 								output: {
+									format: 'es',
 									entryFileNames: 'service-worker.js',
 									assetFileNames: `${kit.appDir}/immutable/assets/[name].[hash][extname]`,
 									codeSplitting:
@@ -1162,10 +1164,8 @@ function kit({ svelte_config, adapter }) {
 				id: service_worker_entry_file || '<skip>'
 			},
 			handler(code) {
-				// in dev, we prepend the service worker with an import that
-				// configures `env`, in case `$app/env/public` is imported,
-				// in prod, where we currently use non-module service
-				// workers, we have to use `importScripts` instead
+				// we prepend the service worker with an import that
+				// configures `env`, in case `$app/env/public` is imported.
 				return {
 					code: `import '__sveltekit/env/service-worker';\n${code}`
 				};

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -994,9 +994,9 @@ function kit({ svelte_config, adapter }) {
 					serviceWorker: {
 						build: {
 							modulePreload: false,
-								rolldownOptions: {
-									external: [`${kit.paths.base}/${kit.appDir}/env.js`],
-									input: {
+							rolldownOptions: {
+								external: [`${kit.paths.base}/${kit.appDir}/env.js`],
+								input: {
 									'service-worker': service_worker_entry_file
 								},
 								output: {
@@ -1164,8 +1164,11 @@ function kit({ svelte_config, adapter }) {
 				id: service_worker_entry_file || '<skip>'
 			},
 			handler(code) {
-				// we prepend the service worker with an import that
-				// configures `env`, in case `$app/env/public` is imported.
+				// prepend the service worker with an import that configures
+				// `env`, in case `$app/env/public` is imported. In production
+				// this is required: dynamic public env vars aren't known at
+				// build time, so `env.js` is loaded at runtime. In dev, the
+				// imported module just inlines the current values instead.
 				return {
 					code: `import '__sveltekit/env/service-worker';\n${code}`
 				};

--- a/packages/kit/src/runtime/server/env_module.js
+++ b/packages/kit/src/runtime/server/env_module.js
@@ -16,7 +16,6 @@ let headers;
  */
 export function get_public_env(request) {
 	const env = rendered_env;
-	const script = request.url.endsWith('.script.js');
 
 	payload ??= devalue.uneval(env);
 	etag ??= `W/${Date.now()}`;
@@ -27,10 +26,6 @@ export function get_public_env(request) {
 
 	if (request.headers.get('if-none-match') === etag) {
 		return new Response(undefined, { status: 304, headers });
-	}
-
-	if (script) {
-		return new Response(`globalThis.__sveltekit_sw={env:${payload}}`, { headers });
 	}
 
 	return new Response(`export const env=${payload}`, { headers });

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -560,12 +560,9 @@ export async function render_response({
 		}
 
 		if (options.service_worker) {
-			let opts = __SVELTEKIT_DEV__ ? ", { type: 'module' }" : '';
+			let opts = ", { type: 'module' }";
 			if (options.service_worker_options != null) {
-				const service_worker_options = { ...options.service_worker_options };
-				if (__SVELTEKIT_DEV__) {
-					service_worker_options.type = 'module';
-				}
+				const service_worker_options = { ...options.service_worker_options, type: 'module' };
 				opts = `, ${s(service_worker_options)}`;
 			}
 

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -319,7 +319,7 @@ export async function internal_respond(request, options, manifest, state) {
 		return resolve_route(resolved_path, new URL(request.url), manifest);
 	}
 
-	if (resolved_path === `/${app_dir}/env.js` || resolved_path === `/${app_dir}/env.script.js`) {
+	if (resolved_path === `/${app_dir}/env.js`) {
 		return get_public_env(request);
 	}
 

--- a/packages/kit/test/apps/options-2/src/ambient.d.ts
+++ b/packages/kit/test/apps/options-2/src/ambient.d.ts
@@ -3,7 +3,3 @@ declare const __TEST_USER_DEFINE__: string;
 interface Window {
 	__test_user_define__: string;
 }
-
-// stubs for explicit environment variables when evaluating the service worker file
-declare var importScripts: () => void;
-declare var __sveltekit_sw: { env: {} };

--- a/packages/kit/test/apps/options-2/test/env.test.js
+++ b/packages/kit/test/apps/options-2/test/env.test.js
@@ -70,21 +70,21 @@ test.describe('$app/env', () => {
 	}) => {
 		test.skip(javaScriptEnabled || !!process.env.DEV || !process.env.DYNAMIC_PUBLIC_ENV);
 
-		const content = read('/prerendered/dependencies/_app/env.script.js');
+		const content = read('/prerendered/dependencies/_app/env.js');
 		expect(content).toContain('hello');
 
 		const service_worker = read('/client/service-worker.js');
-		expect(service_worker).toContain('importScripts("/basepath/_app/env.script.js");');
+		expect(service_worker).toContain('import { env } from "/basepath/_app/env.js"');
 	});
 
-	test('does not load env.script.js in the service worker when there are no public dynamic environment variables', ({
+	test('does not load env.js in the service worker when there are no public dynamic environment variables', ({
 		javaScriptEnabled
 	}) => {
 		test.skip(javaScriptEnabled || !!process.env.DEV || !!process.env.DYNAMIC_PUBLIC_ENV);
 
 		const serviceWorker = read('/client/service-worker.js');
-		expect(serviceWorker).not.toContain('importScripts("/basepath/_app/env.script.js");');
-		expect(fs.existsSync(`${output}/prerendered/dependencies/_app/env.script.js`)).toBeFalsy();
+		expect(serviceWorker).not.toContain('import { env } from "/basepath/_app/env.js"');
+		expect(fs.existsSync(`${output}/prerendered/dependencies/_app/env.js`)).toBeFalsy();
 	});
 
 	test('runtime-only validation', async ({ page, javaScriptEnabled }) => {

--- a/packages/kit/test/apps/options-2/test/service-worker.test.js
+++ b/packages/kit/test/apps/options-2/test/service-worker.test.js
@@ -34,12 +34,6 @@ test('build /basepath/service-worker.js', async ({ baseURL, request }) => {
 
 	const pathname = '/basepath/service-worker.js';
 
-	// stubs for explicit environment variables in service workers
-	globalThis.importScripts = () => {};
-	globalThis.__sveltekit_sw = {
-		env: {}
-	};
-
 	fn(self, {
 		href: baseURL + pathname,
 		pathname


### PR DESCRIPTION
Module service workers are baseline now, so we can stop registering classic workers in production. This also lets us delete the `env.script.js` workaround entirely and just import `env.js` directly.

closes #16158