### PR TITLE
fix: drain unconsumed request bodies so keep-alive connections don't hang

### DIFF
--- a/.changeset/drain-unconsumed-request-body.md
+++ b/.changeset/drain-unconsumed-request-body.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: drain unconsumed request bodies so keep-alive connections don't hang

--- a/packages/kit/src/exports/node/index.js
+++ b/packages/kit/src/exports/node/index.js
@@ -4,6 +4,9 @@ import { SvelteKitError } from '../internal/index.js';
 import { noop } from '../../utils/functions.js';
 import { get_set_cookies } from '../../utils/http.js';
 
+/** @type {WeakMap<import('http').IncomingMessage, (chunk: Buffer) => void>} */
+const body_data_listeners = new WeakMap();
+
 /**
  * @param {import('http').IncomingMessage} req
  * @param {number} [body_size_limit]
@@ -52,17 +55,19 @@ function get_raw_body(req, body_size_limit) {
 				return;
 			}
 
-			req.on('error', (error) => {
+			/** @param {Error} error */
+			const on_error = (error) => {
 				cancelled = true;
 				controller.error(error);
-			});
+			};
 
-			req.on('end', () => {
+			const on_end = () => {
 				if (cancelled) return;
 				controller.close();
-			});
+			};
 
-			req.on('data', (chunk) => {
+			/** @param {Buffer} chunk */
+			const on_data = (chunk) => {
 				if (cancelled) return;
 
 				size += chunk.length;
@@ -94,7 +99,12 @@ function get_raw_body(req, body_size_limit) {
 				if (controller.desiredSize === null || controller.desiredSize <= 0) {
 					req.pause();
 				}
-			});
+			};
+
+			req.on('error', on_error);
+			req.on('end', on_end);
+			req.on('data', on_data);
+			body_data_listeners.set(req, on_data);
 		},
 
 		pull() {
@@ -160,6 +170,44 @@ export async function getRequest({ request, base, bodySizeLimit }) {
 }
 
 /**
+ * Drains any unconsumed request body once the response has been sent. When a
+ * route doesn't read the request body (for example a page route receiving a
+ * POST), the unread bytes remain buffered in the socket. On keep-alive
+ * connections Node's HTTP parser then reads those leftover bytes as the next
+ * request, fails to parse them, and resets the connection — losing any
+ * pipelined request. Resuming the request discards the bytes so the connection
+ * stays usable.
+ *
+ * Because `get_raw_body` attaches a `data` listener, Node marks the request as
+ * being consumed (`req._consuming`) and skips its own automatic drain, so we
+ * have to do it ourselves. The whole remaining body is read and discarded; this
+ * is the intended trade-off (keeping the connection reusable) over destroying it.
+ * @see https://github.com/sveltejs/kit/issues/14916
+ * @see https://github.com/sveltejs/kit/issues/15526
+ * @param {import('http').ServerResponse} res
+ */
+function drain_request(res) {
+	const req = res.req;
+	if (!req || req.readableEnded || req.destroyed) return;
+
+	// When the body went unread, get_raw_body's `data` listener is still attached
+	// and enqueues into a ReadableStream nobody consumes; it pauses the request at
+	// the high water mark, so one chunk sits in memory and the rest stays buffered
+	// in the socket. Remove only that `data` listener so the resumed stream drops
+	// the remaining bytes instead of re-buffering them. The `end` and `error`
+	// listeners stay attached so the body's ReadableStream is still closed (or
+	// errored) once draining completes, and a consumer that stopped reading
+	// mid-body sees a clean end instead of hanging.
+	const on_data = body_data_listeners.get(req);
+	if (on_data) {
+		req.removeListener('data', on_data);
+		body_data_listeners.delete(req);
+	}
+
+	req.resume();
+}
+
+/**
  * @param {import('http').ServerResponse} res
  * @param {Response} response
  * @returns {Promise<void>}
@@ -167,6 +215,9 @@ export async function getRequest({ request, base, bodySizeLimit }) {
 // TODO 3.0 make the signature synchronous?
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function setResponse(res, response) {
+	res.once('finish', () => drain_request(res));
+	res.once('close', () => drain_request(res));
+
 	for (const [key, value] of response.headers) {
 		try {
 			res.setHeader(key, key === 'set-cookie' ? get_set_cookies(response.headers) : value);

--- a/packages/kit/src/exports/node/index.spec.js
+++ b/packages/kit/src/exports/node/index.spec.js
@@ -1,6 +1,7 @@
+import { EventEmitter, once } from 'node:events';
 import { PassThrough } from 'node:stream';
-import { expect, test } from 'vitest';
-import { getRequest } from './index.js';
+import { expect, test, vi } from 'vitest';
+import { getRequest, setResponse } from './index.js';
 
 /**
  * @param {{
@@ -78,6 +79,138 @@ test('rejects request bodies that exceed content-length', async () => {
 		text: 'Payload Too Large',
 		message: 'request body size exceeded content-length of 4'
 	});
+});
+
+/**
+ * Minimal `ServerResponse` stand-in that emits `finish` when ended.
+ * @param {import('http').IncomingMessage} req
+ */
+function create_response(req) {
+	const res = /** @type {any} */ (new EventEmitter());
+	res.req = req;
+	res.destroyed = false;
+	res.setHeader = () => {};
+	res.getHeaderNames = () => [];
+	res.writeHead = () => res;
+	res.write = () => true;
+	res.end = () => {
+		res.emit('finish');
+		res.emit('close');
+	};
+	return /** @type {import('http').ServerResponse} */ (res);
+}
+
+/**
+ * @param {Record<string, string>} [headers]
+ * @param {import('stream').PassThrough} [stream]
+ */
+async function setup_post_request(headers = {}, stream) {
+	const req = stream ?? new PassThrough();
+	const incoming = /** @type {import('http').IncomingMessage} */ (/** @type {unknown} */ (req));
+	incoming.headers = {
+		'content-type': 'text/plain',
+		...headers
+	};
+	incoming.method = 'POST';
+	incoming.url = '/';
+	incoming.httpVersionMajor = 1;
+
+	const request = await getRequest({ request: incoming, base: 'http://localhost' });
+
+	return { req, incoming, request };
+}
+
+/**
+ * @param {import('stream').PassThrough} req
+ */
+async function expect_request_drained(req) {
+	if (!req.readableEnded) await once(req, 'end');
+	expect(req.readableEnded).toBe(true);
+}
+
+// https://github.com/sveltejs/kit/issues/14916
+// https://github.com/sveltejs/kit/issues/15526
+test('drains an unconsumed request body once the response finishes', async () => {
+	const { req, incoming } = await setup_post_request({ 'content-length': '30' });
+
+	// route never reads the body (e.g. a page route returning 405)
+	req.write(Buffer.from('0123456789'));
+	req.write(Buffer.from('0123456789'));
+	req.write(Buffer.from('0123456789'));
+	req.end();
+
+	await setResponse(create_response(incoming), new Response(null, { status: 405 }));
+
+	await expect_request_drained(req);
+});
+
+test('drains an unconsumed chunked request body once the response finishes', async () => {
+	const { req, incoming } = await setup_post_request({ 'transfer-encoding': 'chunked' });
+
+	req.write(Buffer.from('0123456789'));
+	req.write(Buffer.from('0123456789'));
+	req.write(Buffer.from('0123456789'));
+	req.end();
+
+	await setResponse(create_response(incoming), new Response(null, { status: 405 }));
+
+	await expect_request_drained(req);
+});
+
+test('closes the request body stream after draining an unconsumed body', async () => {
+	const { req, incoming, request } = await setup_post_request({ 'content-length': '30' });
+
+	req.write(Buffer.from('0123456789'));
+	req.write(Buffer.from('0123456789'));
+	req.write(Buffer.from('0123456789'));
+	req.end();
+
+	await setResponse(create_response(incoming), new Response(null, { status: 405 }));
+
+	await expect_request_drained(req);
+
+	// the unconsumed body stream should be closed (not left hanging), so reading
+	// it to completion resolves rather than blocking forever
+	const reader = /** @type {ReadableStream} */ (request.body).getReader();
+	for (;;) {
+		const { done } = await reader.read();
+		if (done) break;
+	}
+});
+
+test('drains the remainder of a partially consumed request body', async () => {
+	const { req, incoming, request } = await setup_post_request({ 'content-length': '30' });
+
+	req.write(Buffer.from('0123456789'));
+	req.write(Buffer.from('0123456789'));
+	req.write(Buffer.from('0123456789'));
+
+	const reader = request.body?.getReader();
+	if (!reader) throw new Error('expected request body');
+
+	await reader.read();
+
+	req.end();
+
+	await setResponse(create_response(incoming), new Response(null, { status: 200 }));
+
+	await expect_request_drained(req);
+});
+
+test('does not remove unrelated data listeners when draining', async () => {
+	const req = new PassThrough();
+	const unrelated = vi.fn();
+	req.on('data', unrelated);
+
+	const { incoming } = await setup_post_request({ 'content-length': '10' }, req);
+
+	req.write(Buffer.from('0123456789'));
+	req.end();
+
+	await setResponse(create_response(incoming), new Response(null, { status: 405 }));
+
+	await expect_request_drained(req);
+	expect(unrelated).toHaveBeenCalled();
 });
 
 // Test for fix of CVE-2026-40073


### PR DESCRIPTION
closes #14916
closes #15526

### Problem

When a Node route doesn't read the request body (e.g. a page route receiving a `POST`), the unread bytes stay buffered in the socket. On keep-alive connections Node's HTTP parser reads those leftover bytes as the *next* request, fails to parse them, and resets the connection — losing any pipelined request.

Because `get_raw_body` attaches a `data` listener, Node marks the request as consumed (`req._consuming`) and skips its own automatic drain, so we have to do it ourselves.

### Fix

After the response is sent (`finish`/`close`), `drain_request` removes the lingering `data` listener and calls `req.resume()` to discard the remaining bytes, keeping the connection usable. The `end`/`error` listeners stay attached so the body's `ReadableStream` is still closed/errored, and a consumer that stopped reading mid-body sees a clean end instead of hanging.

### Tests

Added unit tests in `packages/kit/src/exports/node/index.spec.js` covering:
- draining an unconsumed body (content-length and chunked)
- draining the remainder of a partially consumed body
- closing the body stream after draining

- [x] Tests added
- [x] Changeset added (`patch`)

### Edits
- [x] Allow edits from maintainers