### PR TITLE
chore: bump cookie to v2

### DIFF
--- a/.changeset/chilly-berries-press.md
+++ b/.changeset/chilly-berries-press.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': major
 ---
 
-breaking: upgrade to cookie v1. Cookie names must now contain only ASCII characters
+breaking: upgrade to `cookie` v2. Cookie names must now contain only ASCII characters

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -21,7 +21,7 @@
 		"@standard-schema/spec": "^1.1.0",
 		"@sveltejs/acorn-typescript": "^1.0.10",
 		"acorn": "^8.17.0",
-		"cookie": "^1.1.1",
+		"cookie": "^2.0.0",
 		"devalue": "^5.8.1",
 		"esm-env": "^1.2.2",
 		"magic-string": "^0.30.21",

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -282,7 +282,7 @@ export interface Cookies {
 	 * The `path` option is `'/'` by default. You can use relative paths, or set `path: ''` to make the cookie only available on the current path and its children.
 	 * @param name the name of the cookie
 	 * @param value the cookie value
-	 * @param opts the options passed to `cookie.serialize` with the SvelteKit defaults described above. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookiestringifysetcookiesetcookieobj-options)
+	 * @param opts the options passed to `cookie.stringifySetCookie` with the SvelteKit defaults described above. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookiestringifysetcookiesetcookieobj-options)
 	 */
 	set: (name: string, value: string, opts: import('cookie').SerializeOptions) => void;
 
@@ -293,7 +293,7 @@ export interface Cookies {
 	 *
 	 * The `path` option is `'/'` by default. You can use relative paths, or set `path: ''` to make the cookie only available on the current path and its children.
 	 * @param name the name of the cookie
-	 * @param opts the options passed to `cookie.serialize` with the SvelteKit defaults described above. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookiestringifysetcookiesetcookieobj-options)
+	 * @param opts the options passed to `cookie.stringifySetCookie` with the SvelteKit defaults described above. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookiestringifysetcookiesetcookieobj-options)
 	 */
 	delete: (name: string, opts: import('cookie').SerializeOptions) => void;
 
@@ -305,7 +305,7 @@ export interface Cookies {
 	 * The `path` option is `'/'` by default. You can use relative paths, or set `path: ''` to make the cookie only available on the current path and its children.
 	 * @param name the name of the cookie
 	 * @param value the cookie value
-	 * @param opts the options passed to `cookie.serialize` with the SvelteKit defaults described above. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookiestringifysetcookiesetcookieobj-options)
+	 * @param opts the options passed to `cookie.stringifySetCookie` with the SvelteKit defaults described above. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookiestringifysetcookiesetcookieobj-options)
 	 */
 	serialize: (name: string, value: string, opts: import('cookie').SerializeOptions) => string;
 }

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -264,13 +264,13 @@ export interface Cookies {
 	/**
 	 * Gets a cookie that was previously set with `cookies.set`, or from the request headers.
 	 * @param name the name of the cookie
-	 * @param opts the options, passed directly to `cookie.parse`. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookieparsecookiestr-options)
+	 * @param opts the options, passed directly to `cookie.parseCookie`. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookieparsecookiestr-options)
 	 */
 	get: (name: string, opts?: import('cookie').ParseOptions) => string | undefined;
 
 	/**
 	 * Gets all cookies that were previously set with `cookies.set`, or from the request headers.
-	 * @param opts the options, passed directly to `cookie.parse`. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookieparsecookiestr-options)
+	 * @param opts the options, passed directly to `cookie.parseCookie`. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookieparsecookiestr-options)
 	 */
 	getAll: (opts?: import('cookie').ParseOptions) => Array<{ name: string; value: string }>;
 

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -1,4 +1,4 @@
-import { parse, serialize } from 'cookie';
+import { parseCookie, serialize } from 'cookie';
 import { DEV } from 'esm-env';
 import { normalize_path, resolve } from '../../utils/url.js';
 import { add_data_suffix } from '../pathname.js';
@@ -39,7 +39,7 @@ function generate_cookie_key(domain, path, name) {
 export function get_cookies(request, url) {
 	const header = request.headers.get('cookie') ?? '';
 	const initial_cookies = /** @type {Record<string, string>} */ (
-		parse(header, { decode: (value) => value })
+		parseCookie(header, { decode: (value) => value })
 	);
 
 	/** @type {string | undefined} */
@@ -83,7 +83,7 @@ export function get_cookies(request, url) {
 				return best_match.options.maxAge === 0 ? undefined : best_match.value;
 			}
 
-			const req_cookies = parse(header, { decode: opts?.decode });
+			const req_cookies = parseCookie(header, { decode: opts?.decode });
 			const cookie = req_cookies[name]; // the decoded string or undefined
 
 			// in development, if the cookie was set during this session with `cookies.set`,
@@ -110,7 +110,7 @@ export function get_cookies(request, url) {
 		 * @param {import('cookie').ParseOptions} [opts]
 		 */
 		getAll(opts) {
-			const cookies = parse(header, { decode: opts?.decode });
+			const cookies = parseCookie(header, { decode: opts?.decode });
 
 			// Group cookies by name and find the most specific one for each name
 			const lookup = new Map();
@@ -200,7 +200,7 @@ export function get_cookies(request, url) {
 		// explicit header has highest precedence
 		if (header) {
 			const parsed = /** @type {Record<string, string>} */ (
-				parse(header, { decode: (value) => value })
+				parseCookie(header, { decode: (value) => value })
 			);
 			for (const name in parsed) {
 				combined_cookies[name] = parsed[name];

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -1,4 +1,4 @@
-import { parseCookie, serialize } from 'cookie';
+import { parseCookie, stringifySetCookie } from 'cookie';
 import { DEV } from 'esm-env';
 import { normalize_path, resolve } from '../../utils/url.js';
 import { add_data_suffix } from '../pathname.js';
@@ -48,7 +48,7 @@ export function get_cookies(request, url) {
 	/** @type {Map<string, import('./page/types.js').Cookie>} */
 	const new_cookies = new Map();
 
-	/** @type {import('cookie').SerializeOptions} */
+	/** @type {Omit<import('cookie').SetCookie, 'name' | 'value'>} */
 	const defaults = {
 		httpOnly: true,
 		path: '/',
@@ -163,7 +163,7 @@ export function get_cookies(request, url) {
 		 * @param {string} value
 		 * @param {import('cookie').SerializeOptions} options
 		 */
-		serialize(name, value, options) {
+		serialize(name, value, { encode, ...options }) {
 			let path = options.path ?? '/';
 
 			if (!options.domain || options.domain === url.hostname) {
@@ -173,7 +173,7 @@ export function get_cookies(request, url) {
 				path = resolve(normalized_url, path);
 			}
 
-			return serialize(name, value, { ...defaults, ...options, path });
+			return stringifySetCookie({ name, value, ...defaults, ...options, path }, { encode });
 		}
 	};
 
@@ -238,7 +238,8 @@ export function get_cookies(request, url) {
 		new_cookies.set(cookie_key, cookie);
 
 		if (DEV) {
-			const serialized = serialize(name, value, cookie.options);
+			const { encode, ...rest } = cookie.options;
+			const serialized = stringifySetCookie({ name, value, ...rest }, { encode });
 			if (text_encoder.encode(serialized).byteLength > MAX_COOKIE_SIZE) {
 				throw new Error(`Cookie "${name}" is too large, and will be discarded by the browser`);
 			}
@@ -296,15 +297,22 @@ export function path_matches(path, constraint) {
  */
 export function add_cookies_to_headers(headers, cookies) {
 	for (const new_cookie of cookies) {
-		const { name, value, options } = new_cookie;
-		headers.append('set-cookie', serialize(name, value, options));
+		const {
+			name,
+			value,
+			options: { encode, ...options }
+		} = new_cookie;
+		headers.append('set-cookie', stringifySetCookie({ name, value, ...options }, { encode }));
 
 		// special case — for routes ending with .html, the route data lives in a sibling
 		// `.html__data.json` file rather than a child `/__data.json` file, which means
 		// we need to duplicate the cookie
 		if (options.path.endsWith('.html')) {
 			const path = add_data_suffix(options.path);
-			headers.append('set-cookie', serialize(name, value, { ...options, path }));
+			headers.append(
+				'set-cookie',
+				stringifySetCookie({ name, value, ...options, path }, { encode })
+			);
 		}
 	}
 }

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -867,7 +867,7 @@ test.describe('setHeaders', () => {
 });
 
 test.describe('cookies', () => {
-	test('cookie.serialize created correct cookie header string', async ({ page }) => {
+	test('cookie.stringifySetCookie created correct cookie header string', async ({ page }) => {
 		const response = await page.goto('/cookies/serialize');
 		const cookies = response ? await response.headerValue('set-cookie') : '';
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -237,13 +237,13 @@ declare module '@sveltejs/kit' {
 		/**
 		 * Gets a cookie that was previously set with `cookies.set`, or from the request headers.
 		 * @param name the name of the cookie
-		 * @param opts the options, passed directly to `cookie.parse`. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookieparsecookiestr-options)
+		 * @param opts the options, passed directly to `cookie.parseCookie`. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookieparsecookiestr-options)
 		 */
 		get: (name: string, opts?: import('cookie').ParseOptions) => string | undefined;
 
 		/**
 		 * Gets all cookies that were previously set with `cookies.set`, or from the request headers.
-		 * @param opts the options, passed directly to `cookie.parse`. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookieparsecookiestr-options)
+		 * @param opts the options, passed directly to `cookie.parseCookie`. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookieparsecookiestr-options)
 		 */
 		getAll: (opts?: import('cookie').ParseOptions) => Array<{ name: string; value: string }>;
 
@@ -3561,9 +3561,9 @@ declare module '$app/server' {
 		 *
 		 * */
 		function live<Output>(fn: (arg: void) => RemoteLiveQueryUserFunctionReturnType<Output>): RemoteLiveQueryFunction<void, Output>;
-		
+
 		function live<Input, Output>(validate: "unchecked", fn: (arg: Input) => RemoteLiveQueryUserFunctionReturnType<Output>): RemoteLiveQueryFunction<Input, Output>;
-		
+
 		function live<Schema extends StandardSchemaV1, Output>(schema: Schema, fn: (arg: StandardSchemaV1.InferOutput<Schema>) => RemoteLiveQueryUserFunctionReturnType<Output>): RemoteLiveQueryFunction<StandardSchemaV1.InferInput<Schema>, Output, StandardSchemaV1.InferOutput<Schema>>;
 	}
 	/**
@@ -3730,11 +3730,11 @@ declare module '$app/state' {
 
 declare module '$app/stores' {
 	export function getStores(): {
-		
+
 		page: typeof page;
-		
+
 		navigating: typeof navigating;
-		
+
 		updated: typeof updated;
 	};
 	/**

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3561,9 +3561,9 @@ declare module '$app/server' {
 		 *
 		 * */
 		function live<Output>(fn: (arg: void) => RemoteLiveQueryUserFunctionReturnType<Output>): RemoteLiveQueryFunction<void, Output>;
-
+		
 		function live<Input, Output>(validate: "unchecked", fn: (arg: Input) => RemoteLiveQueryUserFunctionReturnType<Output>): RemoteLiveQueryFunction<Input, Output>;
-
+		
 		function live<Schema extends StandardSchemaV1, Output>(schema: Schema, fn: (arg: StandardSchemaV1.InferOutput<Schema>) => RemoteLiveQueryUserFunctionReturnType<Output>): RemoteLiveQueryFunction<StandardSchemaV1.InferInput<Schema>, Output, StandardSchemaV1.InferOutput<Schema>>;
 	}
 	/**
@@ -3730,11 +3730,11 @@ declare module '$app/state' {
 
 declare module '$app/stores' {
 	export function getStores(): {
-
+		
 		page: typeof page;
-
+		
 		navigating: typeof navigating;
-
+		
 		updated: typeof updated;
 	};
 	/**

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -255,7 +255,7 @@ declare module '@sveltejs/kit' {
 		 * The `path` option is `'/'` by default. You can use relative paths, or set `path: ''` to make the cookie only available on the current path and its children.
 		 * @param name the name of the cookie
 		 * @param value the cookie value
-		 * @param opts the options passed to `cookie.serialize` with the SvelteKit defaults described above. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookiestringifysetcookiesetcookieobj-options)
+		 * @param opts the options passed to `cookie.stringifySetCookie` with the SvelteKit defaults described above. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookiestringifysetcookiesetcookieobj-options)
 		 */
 		set: (name: string, value: string, opts: import('cookie').SerializeOptions) => void;
 
@@ -266,7 +266,7 @@ declare module '@sveltejs/kit' {
 		 *
 		 * The `path` option is `'/'` by default. You can use relative paths, or set `path: ''` to make the cookie only available on the current path and its children.
 		 * @param name the name of the cookie
-		 * @param opts the options passed to `cookie.serialize` with the SvelteKit defaults described above. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookiestringifysetcookiesetcookieobj-options)
+		 * @param opts the options passed to `cookie.stringifySetCookie` with the SvelteKit defaults described above. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookiestringifysetcookiesetcookieobj-options)
 		 */
 		delete: (name: string, opts: import('cookie').SerializeOptions) => void;
 
@@ -278,7 +278,7 @@ declare module '@sveltejs/kit' {
 		 * The `path` option is `'/'` by default. You can use relative paths, or set `path: ''` to make the cookie only available on the current path and its children.
 		 * @param name the name of the cookie
 		 * @param value the cookie value
-		 * @param opts the options passed to `cookie.serialize` with the SvelteKit defaults described above. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookiestringifysetcookiesetcookieobj-options)
+		 * @param opts the options passed to `cookie.stringifySetCookie` with the SvelteKit defaults described above. See documentation [here](https://github.com/jshttp/cookie?tab=readme-ov-file#cookiestringifysetcookiesetcookieobj-options)
 		 */
 		serialize: (name: string, value: string, opts: import('cookie').SerializeOptions) => string;
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -551,8 +551,8 @@ importers:
         specifier: ^8.17.0
         version: 8.17.0
       cookie:
-        specifier: ^1.1.1
-        version: 1.1.1
+        specifier: ^2.0.0
+        version: 2.0.0
       devalue:
         specifier: ^5.8.1
         version: 5.8.1
@@ -3712,6 +3712,10 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cookie@2.0.0:
+    resolution: {integrity: sha512-hRSFuKJ6SYHrFVNltQdagQFMk7e0Q/VrORTGqZGyUAmmhA3EwPeldHCTg0HqUaDodQOfQDe7qXuOtpf4lwCsaA==}
+    engines: {node: '>=22'}
 
   copy-file@11.0.0:
     resolution: {integrity: sha512-mFsNh/DIANLqFt5VHZoGirdg7bK5+oTWlhnGu6tgRhzBlnEKWaPX2xrFaLltii/6rmhqFMJqffUgknuRdpYlHw==}
@@ -8225,6 +8229,8 @@ snapshots:
   cookie-es@1.2.3: {}
 
   cookie@1.1.1: {}
+
+  cookie@2.0.0: {}
 
   copy-file@11.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,6 @@ minimumReleaseAgeExclude:
   - prettier-plugin-svelte
   - svelte-check
   - esm-env
-  - cookie@2.0.0 # TODO: remove this once it's been released long enough
 blockExoticSubdeps: true
 linkWorkspacePackages: true
 shellEmulator: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ minimumReleaseAgeExclude:
   - prettier-plugin-svelte
   - svelte-check
   - esm-env
+  - cookie@2.0.0 # TODO: remove this once it's been released long enough
 blockExoticSubdeps: true
 linkWorkspacePackages: true
 shellEmulator: true


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/16172

Bumps `cookie` from v1 to v2 which is ESM-only and changes its method names and signature for serialising a set-cookie value https://github.com/jshttp/cookie/releases/tag/v2.0.0 but our lockfile still has cookie v1 because of some Netlify deps but we will get rid of that when we move to platform tests

We should make a decision if we want to change our methods to match the new `cookie` API or leave it as is

EDIT: we decided to stick to our current API in the June monthly meeting

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
