### PR TITLE
fix: return `undefined` from `fields.branch.issues()` when only `fields.branch.leaf` has issues

### DIFF
--- a/.changeset/pink-boats-smell.md
+++ b/.changeset/pink-boats-smell.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: return `undefined` from `fields.branch.issues()` when only `fields.branch.leaf` has issues

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -694,7 +694,7 @@ export function create_field_proxy(target, get_input, set_input, get_issues, pat
 							message: issue.message
 						}));
 
-					return issues && (issues.length > 0 ? issues : undefined);
+					return issues?.length ? issues : undefined);
 				};
 
 				return create_field_proxy(issues_func, get_input, set_input, get_issues, [...path, prop]);

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -694,7 +694,7 @@ export function create_field_proxy(target, get_input, set_input, get_issues, pat
 							message: issue.message
 						}));
 
-					return issues?.length ? issues : undefined);
+					return issues?.length ? issues : undefined;
 				};
 
 				return create_field_proxy(issues_func, get_input, set_input, get_issues, [...path, prop]);

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -687,12 +687,14 @@ export function create_field_proxy(target, get_input, set_input, get_issues, pat
 						}));
 					}
 
-					return all_issues
+					const issues = all_issues
 						?.filter((issue) => issue.name === key)
 						?.map((issue) => ({
 							path: issue.path,
 							message: issue.message
 						}));
+
+					return issues && (issues.length > 0 ? issues : undefined);
 				};
 
 				return create_field_proxy(issues_func, get_input, set_input, get_issues, [...path, prop]);


### PR DESCRIPTION
Companion to #16186 — right now we return an empty array when `undefined` is more helpful. Small/edgey enough that I didn't think it warranted a test

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
