### PR TITLE
breaking: don't abort navigation when calling `invalidate(All)` during navigation

### DIFF
--- a/.changeset/ripe-boats-think.md
+++ b/.changeset/ripe-boats-think.md
@@ -1,0 +1,6 @@
+---
+"@sveltejs/kit": major
+---
+
+breaking: don't abort navigation when calling `invalidate(All)` during navigation
+  

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -296,8 +296,17 @@ let current_history_index;
 /** @type {number} */
 let current_navigation_index;
 
-/** @type {{}} */
-let token;
+/** @type {{}} Token for the latest navigation. Updated on new navigations */
+let navigation_token;
+
+/**
+ * @type {{}}
+ * The latest invalidate(All) token. Superseeded by both later invalidate(All)s and navigations.
+ * This is separate to navigation_token because an invalidate(All) might be triggered while a navigation
+ * is in progress, and we want to be able to finish this navigation (unless the invalidation finishes before
+ * it and redirects, in which case we will do the redirect triggered by the invalidation).
+ */
+let invalidation_token;
 
 /**
  * A set of tokens which are associated to current preloads.
@@ -423,7 +432,9 @@ async function _invalidate(include_load_functions = true, reset_page_state = tru
 	if (!pending_invalidate) return;
 	pending_invalidate = null;
 
-	const nav_token = (token = {});
+	const token = (invalidation_token = {});
+	const nav_token = navigation_token;
+	const navigating = is_navigating;
 	const intent = await get_navigation_intent(current.url, true);
 
 	// Clear preload, it might be affected by the invalidation.
@@ -455,15 +466,23 @@ async function _invalidate(include_load_functions = true, reset_page_state = tru
 	if (include_load_functions) {
 		const prev_state = page.state;
 		const navigation_result = intent && (await load_route(intent));
-		if (!navigation_result || nav_token !== token) return;
+		if (!navigation_result || token !== invalidation_token || nav_token !== navigation_token) {
+			return;
+		}
 
 		if (navigation_result.type === 'redirect') {
 			return _goto(
 				new URL(navigation_result.location, current.url).href,
 				{ replaceState: true },
 				1,
-				nav_token
+				token
 			);
+		}
+
+		// A navigation started before the invalidation and ended before it finished. The invalidation did not redirect,
+		// hence it likely contains outdated data now, so we ignore it.
+		if (navigating && !is_navigating) {
+			return;
 		}
 
 		// This is a bit hacky but allows us not having to pass that boolean around, making things harder to reason about
@@ -1737,8 +1756,8 @@ async function navigate({
 	event,
 	intent
 }) {
-	const prev_token = token;
-	token = nav_token;
+	const prev_token = navigation_token;
+	navigation_token = invalidation_token = nav_token;
 
 	intent ??= await get_navigation_intent(url, false);
 	const nav =
@@ -1756,7 +1775,7 @@ async function navigate({
 
 	if (!nav) {
 		block();
-		if (token === nav_token) token = prev_token;
+		if (navigation_token === nav_token) navigation_token = prev_token;
 		return;
 	}
 
@@ -1820,7 +1839,7 @@ async function navigate({
 	url = intent?.url || url;
 
 	// abort if user navigated during update
-	if (token !== nav_token) {
+	if (navigation_token !== nav_token) {
 		nav.reject(new Error('navigation aborted'));
 		return;
 	}
@@ -1999,7 +2018,7 @@ async function navigate({
 	await svelte.tick();
 	await svelte.tick();
 
-	if (token !== nav_token) {
+	if (navigation_token !== nav_token) {
 		// a new navigation happened while we were waiting for the DOM to update, so abort
 		nav.reject(new Error('navigation aborted'));
 		return;
@@ -2906,7 +2925,7 @@ function _start_router() {
 
 		if (event.state?.[HISTORY_INDEX]) {
 			const history_index = event.state[HISTORY_INDEX];
-			token = {};
+			navigation_token = invalidation_token = {};
 
 			// if a popstate-driven navigation is cancelled, we need to counteract it
 			// with history.go, which means we end up back here, hence this check
@@ -2955,7 +2974,7 @@ function _start_router() {
 				block: () => {
 					history.go(-delta);
 				},
-				nav_token: token,
+				nav_token: navigation_token,
 				event
 			});
 		} else {

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1757,6 +1757,7 @@ async function navigate({
 	intent
 }) {
 	const prev_token = navigation_token;
+	const prev_invalidation_token = invalidation_token;
 	navigation_token = invalidation_token = nav_token;
 
 	intent ??= await get_navigation_intent(url, false);
@@ -1776,6 +1777,7 @@ async function navigate({
 	if (!nav) {
 		block();
 		if (navigation_token === nav_token) navigation_token = prev_token;
+		if (invalidation_token === nav_token) invalidation_token = prev_invalidation_token;
 		return;
 	}
 

--- a/packages/kit/test/apps/basics/src/routes/load/invalidation/during-navigation/[slug]/+layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/invalidation/during-navigation/[slug]/+layout.svelte
@@ -1,0 +1,25 @@
+<script>
+	import { invalidateAll } from '$app/navigation';
+	let { children } = $props();
+</script>
+
+<nav>
+	<a href="/load/invalidation/during-navigation/a" data-testid="nav-a">a</a>
+	<a href="/load/invalidation/during-navigation/b" data-testid="nav-b">b</a>
+	<a
+		href="/load/invalidation/during-navigation/b"
+		data-testid="nav-b-invalidate"
+		onclick={() => setTimeout(() => invalidateAll(), 10)}
+	>
+		b+invalidate
+	</a>
+	<a
+		href="/load/invalidation/during-navigation/a"
+		data-testid="nav-a-invalidate"
+		onclick={() => setTimeout(() => invalidateAll(), 10)}
+	>
+		a+invalidate
+	</a>
+</nav>
+
+{@render children()}

--- a/packages/kit/test/apps/basics/src/routes/load/invalidation/during-navigation/[slug]/+layout.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/invalidation/during-navigation/[slug]/+layout.svelte
@@ -9,14 +9,14 @@
 	<a
 		href="/load/invalidation/during-navigation/b"
 		data-testid="nav-b-invalidate"
-		onclick={() => setTimeout(() => invalidateAll(), 10)}
+		onclick={() => setTimeout(() => invalidateAll(), 50)}
 	>
 		b+invalidate
 	</a>
 	<a
 		href="/load/invalidation/during-navigation/a"
 		data-testid="nav-a-invalidate"
-		onclick={() => setTimeout(() => invalidateAll(), 10)}
+		onclick={() => setTimeout(() => invalidateAll(), 50)}
 	>
 		a+invalidate
 	</a>

--- a/packages/kit/test/apps/basics/src/routes/load/invalidation/during-navigation/[slug]/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/invalidation/during-navigation/[slug]/+page.server.js
@@ -1,0 +1,6 @@
+export async function load({ params }) {
+	await new Promise((res) => setTimeout(res, params.slug === 'b' ? 10 : 300));
+	return {
+		scores: params.slug === 'a' ? '1 - 1' : '2 - 2'
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/load/invalidation/during-navigation/[slug]/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/load/invalidation/during-navigation/[slug]/+page.server.js
@@ -1,3 +1,4 @@
+/** @type {import('./$types').PageServerLoad} */
 export async function load({ params }) {
 	await new Promise((res) => setTimeout(res, params.slug === 'b' ? 10 : 300));
 	return {

--- a/packages/kit/test/apps/basics/src/routes/load/invalidation/during-navigation/[slug]/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/invalidation/during-navigation/[slug]/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	let { data } = $props();
+</script>
+
+<p data-testid="scores">{data.scores}</p>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -902,6 +902,31 @@ test.describe('Invalidation', () => {
 		expect(next_layout_2).toBe(next_layout_1);
 		expect(next_page_2).not.toBe(next_page_1);
 	});
+
+	test('invalidateAll finishing after navigation does not apply stale data', async ({
+		page,
+		clicknav
+	}) => {
+		await page.goto('/load/invalidation/during-navigation/a');
+		await expect(page.locator('[data-testid="scores"]')).toHaveText('1 - 1');
+
+		await clicknav('[data-testid="nav-b-invalidate"]');
+		await expect(page.locator('[data-testid="scores"]')).toHaveText('2 - 2');
+
+		await page.waitForTimeout(400);
+		await expect(page.locator('[data-testid="scores"]')).toHaveText('2 - 2');
+	});
+
+	test('invalidateAll finishing before navigation ends does not prevent navigation', async ({
+		page,
+		clicknav
+	}) => {
+		await page.goto('/load/invalidation/during-navigation/b');
+		await expect(page.locator('[data-testid="scores"]')).toHaveText('2 - 2');
+
+		await clicknav('[data-testid="nav-a-invalidate"]');
+		await expect(page.locator('[data-testid="scores"]')).toHaveText('1 - 1');
+	});
 });
 
 test.describe('data-sveltekit attributes', () => {


### PR DESCRIPTION
When a navigation starts, `invalidate(All)` will no longer abort that navigation - previously it indirectly did that because both invalidation and navigation shared the same navigation token; then navigation thought "oh I'm outdated I abort".

Now there's a separate invalidation token so we can handle each case sensibly:
- when invalidation finishes after goto finishes, it will not apply its stale data. It _will_ apply redirects though since technically it's the last navigation that happened and so it should take precedence
- when invalidation finishes before goto finishes, it will apply, but it will not abort the navigation

Closes #9354
