### PR TITLE
breaking: Use the status code passed to `fail`, return 204 for no response

### DIFF
--- a/.changeset/elliott-is-uncreative.md
+++ b/.changeset/elliott-is-uncreative.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: return no content for 204 responses

--- a/.changeset/form-action-http-status-codes.md
+++ b/.changeset/form-action-http-status-codes.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: form action responses now use the HTTP status code returned from `fail`

--- a/documentation/docs/20-core-concepts/30-form-actions.md
+++ b/documentation/docs/20-core-concepts/30-form-actions.md
@@ -165,6 +165,8 @@ export const actions = {
 
 If the request couldn't be processed because of invalid data, you can return validation errors — along with the previously submitted form values — back to the user so that they can try again. The `fail` function lets you return an HTTP status code (typically 400 or 422, in the case of validation errors) along with the data. The status code is available through `page.status` and the data through `form`:
 
+When using `use:enhance` (or making a `fetch` request with the `accept: application/json` header), the HTTP response status code will match the status code passed to `fail`. When an action returns data, the response will have status 200, and when it returns nothing (i.e. `undefined`), the response will have status 204. This makes it easier to track form submission outcomes using observability tools.
+
 ```js
 /// file: src/routes/login/+page.server.js
 // @filename: ambient.d.ts
@@ -448,7 +450,10 @@ We can also implement progressive enhancement ourselves, without `use:enhance`, 
 		});
 
 		/** @type {import('@sveltejs/kit').ActionResult} */
-		const result = deserialize(await response.text());
+		const result =
+			response.status === 204
+				? { type: 'success', status: 204 }
+				: deserialize(await response.text());
 
 		if (result.type === 'success') {
 			// rerun all `load` functions, following the successful update

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -33,6 +33,10 @@ export { applyAction };
  * @returns {import('@sveltejs/kit').ActionResult<Success, Failure>}
  */
 export function deserialize(result) {
+	if (result === '') {
+		return { type: 'success', status: 204, data: undefined };
+	}
+
 	const parsed = JSON.parse(result);
 
 	if (parsed.data) {

--- a/packages/kit/src/runtime/app/forms.js
+++ b/packages/kit/src/runtime/app/forms.js
@@ -20,7 +20,10 @@ export { applyAction };
  *     body: new FormData(event.target)
  *   });
  *
- *   const result = deserialize(await response.text());
+ *   const result =
+ *     response.status === 204
+ *       ? { type: 'success', status: 204 }
+ *       : deserialize(await response.text());
  *   // ...
  * }
  * ```
@@ -197,8 +200,14 @@ export function enhance(form_element, submit = noop) {
 				signal: controller.signal
 			});
 
-			result = deserialize(await response.text());
-			if (result.type === 'error') result.status = response.status;
+			if (response.status === 204) {
+				result = { type: 'success', status: 204 };
+			} else {
+				result = deserialize(await response.text());
+				if (result.type === 'error' || result.type === 'failure') {
+					result.status = response.status;
+				}
+			}
 		} catch (error) {
 			if (/** @type {any} */ (error)?.name === 'AbortError') return;
 			result = { type: 'error', error };

--- a/packages/kit/src/runtime/server/page/actions.js
+++ b/packages/kit/src/runtime/server/page/actions.js
@@ -62,22 +62,27 @@ export async function handle_action_json_request(event, event_state, options, se
 		}
 
 		if (data instanceof ActionFailure) {
-			return action_json({
-				type: 'failure',
-				status: data.status,
-				// @ts-expect-error we assign a string to what is supposed to be an object. That's ok
-				// because we don't use the object outside, and this way we have better code navigation
-				// through knowing where the related interface is used.
-				data: stringify_action_response(
-					data.data,
-					/** @type {string} */ (event.route.id),
-					options.hooks.transport
-				)
-			});
-		} else {
+			return action_json(
+				{
+					type: 'failure',
+					status: data.status,
+					// @ts-expect-error we assign a string to what is supposed to be an object. That's ok
+					// because we don't use the object outside, and this way we have better code navigation
+					// through knowing where the related interface is used.
+					data: stringify_action_response(
+						data.data,
+						/** @type {string} */ (event.route.id),
+						options.hooks.transport
+					)
+				},
+				{
+					status: data.status
+				}
+			);
+		} else if (data) {
 			return action_json({
 				type: 'success',
-				status: data ? 200 : 204,
+				status: 200,
 				// @ts-expect-error see comment above
 				data: stringify_action_response(
 					data,
@@ -85,6 +90,9 @@ export async function handle_action_json_request(event, event_state, options, se
 					options.hooks.transport
 				)
 			});
+		} else {
+			// no data returned — use 204 No Content (without a body, per the spec)
+			return new Response(null, { status: 204 });
 		}
 	} catch (e) {
 		const err = normalize_error(e);

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -802,8 +802,23 @@ test.describe('Shadowed pages', () => {
 			}
 		});
 
-		expect(response.status()).toBe(200);
-		expect(await response.json()).toEqual({ data: '-1', type: 'success', status: 204 });
+		expect(response.status()).toBe(204);
+		expect(await response.text()).toBe('');
+	});
+
+	test('Action fail() returns matching HTTP status code', async ({ baseURL, request }) => {
+		const response = await request.post('/actions/form-errors', {
+			form: {},
+			headers: {
+				accept: 'application/json',
+				origin: new URL(baseURL).origin
+			}
+		});
+
+		expect(response.status()).toBe(400);
+		const body = await response.json();
+		expect(body.type).toBe('failure');
+		expect(body.status).toBe(400);
 	});
 });
 

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -3154,7 +3154,10 @@ declare module '$app/forms' {
 	 *     body: new FormData(event.target)
 	 *   });
 	 *
-	 *   const result = deserialize(await response.text());
+	 *   const result =
+	 *     response.status === 204
+	 *       ? { type: 'success', status: 204 }
+	 *       : deserialize(await response.text());
 	 *   // ...
 	 * }
 	 * ```


### PR DESCRIPTION
Closes https://github.com/sveltejs/kit/issues/12934

Uses the status code from `fail` in enhanced `form` responses.

The controversial breaking change is what to do around 204 responses. AFAICT the spec is pretty unambiguous that these responses must have no content-length and must have no content, so we can't return our normal envelope. I don't like this effect on DX. So the breaking change in the _other_ direction would be to return 200 in all success cases because we need to return content. Or go on breaking spec for funsies.