### PR TITLE
feat: add `cookies.parse` method

### DIFF
--- a/.changeset/silly-islands-greet.md
+++ b/.changeset/silly-islands-greet.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: add `cookies.parse` method

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -318,10 +318,8 @@ export interface Cookies {
 	 * ```
 	 *
 	 * Note the use of `headers.getSetCookie()`, which returns an array of cookie headers, _not_ `headers.get('set-cookie')` which returns a single comma-separated string.
-	 *
-	 * @param header A valid `Set-Cookie` header
 	 */
-	parse: (header: string, options: import('cookie').ParseOptions) => import('cookie').SetCookie;
+	parse: typeof import('cookie').parseSetCookie;
 
 	/**
 	 * Serialize a cookie name-value pair into a `Set-Cookie` header string, but don't apply it to the response.

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -321,7 +321,7 @@ export interface Cookies {
 	 *
 	 * @param header A valid `Set-Cookie` header
 	 */
-	parse: (header: string) => import('cookie').SetCookie;
+	parse: (header: string, options: import('cookie').ParseOptions) => import('cookie').SetCookie;
 
 	/**
 	 * Serialize a cookie name-value pair into a `Set-Cookie` header string, but don't apply it to the response.

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -301,11 +301,19 @@ export interface Cookies {
 	 * Parses a single `Set-Cookie` header. This allows you to apply cookies received from an external source:
 	 *
 	 * ```js
-	 * const response = await fetch('...');
+	 * import { getRequestEvent } from '$app/server';
 	 *
-	 * for (const str of response.headers.getSetCookie()) {
-	 * 	const { name, value, ...options } = cookies.parse(str);
-	 * 	cookies.set(name, value, { ...options, path: '/' });
+	 * export function GET() {
+	 * 	const { cookies } = getRequestEvent();
+	 *
+	 * 	const response = await fetch('...');
+	 *
+	 * 	for (const str of response.headers.getSetCookie()) {
+	 * 		const { name, value, ...options } = cookies.parse(str);
+	 * 		cookies.set(name, value, { ...options, path: '/' });
+	 * 	}
+	 *
+	 * 	// ...
 	 * }
 	 * ```
 	 *

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -298,6 +298,24 @@ export interface Cookies {
 	delete: (name: string, opts: import('cookie').SerializeOptions) => void;
 
 	/**
+	 * Parses a single `Set-Cookie` header. This allows you to apply cookies received from an external source:
+	 *
+	 * ```js
+	 * const response = await fetch('...');
+	 *
+	 * for (const str of response.headers.getSetCookie()) {
+	 * 	const { name, value, ...options } = cookies.parse(str);
+	 * 	cookies.set(name, value, { ...options, path: '/' });
+	 * }
+	 * ```
+	 *
+	 * Note the use of `headers.getSetCookie()`, which returns an array of cookie headers, _not_ `headers.get('set-cookie')` which returns a single comma-separated string.
+	 *
+	 * @param header A valid `Set-Cookie` header
+	 */
+	parse: (header: string) => import('cookie').SetCookie;
+
+	/**
 	 * Serialize a cookie name-value pair into a `Set-Cookie` header string, but don't apply it to the response.
 	 *
 	 * The `httpOnly` and `secure` options are `true` by default (except on http://localhost, where `secure` is `false`), and must be explicitly disabled if you want cookies to be readable by client-side JavaScript and/or transmitted over HTTP.

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -303,7 +303,7 @@ export interface Cookies {
 	 * ```js
 	 * import { getRequestEvent } from '$app/server';
 	 *
-	 * export function GET() {
+	 * export async function GET() {
 	 * 	const { cookies } = getRequestEvent();
 	 *
 	 * 	const response = await fetch('...');

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -1,4 +1,4 @@
-import { parseCookie, stringifySetCookie } from 'cookie';
+import { parseCookie, parseSetCookie, stringifySetCookie } from 'cookie';
 import { DEV } from 'esm-env';
 import { normalize_path, resolve } from '../../utils/url.js';
 import { add_data_suffix } from '../pathname.js';
@@ -158,88 +158,12 @@ export function get_cookies(request, url) {
 			cookies.set(name, '', { ...options, maxAge: 0 });
 		},
 
-		/** @param {string} header */
-		parse(header) {
-			const [head, ...tail] = header.split(';').filter((str) => str.trim() !== '');
-
-			const head_index = head.indexOf('=');
-			const name = head_index === -1 ? head : head.slice(0, head_index);
-			const value = head_index === -1 ? '' : head.slice(head_index + 1);
-
-			/** @type {import('cookie').SetCookie} */
-			const cookie = { name, value };
-
-			for (const pair of tail) {
-				const index = pair.indexOf('=');
-
-				const key = (index === -1 ? pair : pair.slice(0, index)).trim().toLowerCase();
-				const value = index === -1 ? '' : pair.slice(index + 1).trim();
-
-				switch (key) {
-					case 'expires': {
-						cookie.expires = new Date(value);
-						break;
-					}
-
-					case 'max-age': {
-						const age = parseInt(value, 10);
-						if (!isNaN(age)) cookie.maxAge = age;
-						break;
-					}
-
-					case 'secure': {
-						cookie.secure = true;
-						break;
-					}
-
-					case 'httponly': {
-						cookie.httpOnly = true;
-						break;
-					}
-
-					case 'partitioned': {
-						cookie.partitioned = true;
-						break;
-					}
-
-					case 'samesite': {
-						if (value === '') {
-							cookie.sameSite = 'strict';
-						} else {
-							const lower = value.toLowerCase();
-
-							if (lower === 'lax') cookie.sameSite = 'lax';
-							if (lower === 'none') cookie.sameSite = 'none';
-							if (lower === 'strict') cookie.sameSite = 'strict';
-						}
-
-						break;
-					}
-
-					// non-standard, but understood by e.g. Chrome
-					case 'priority': {
-						const lower = value.toLowerCase();
-
-						if (lower === 'low') cookie.priority = 'low';
-						if (lower === 'medium') cookie.priority = 'medium';
-						if (lower === 'high') cookie.priority = 'high';
-
-						break;
-					}
-
-					case 'domain': {
-						cookie.domain = value;
-						break;
-					}
-
-					case 'path': {
-						cookie.path = value;
-						break;
-					}
-				}
-			}
-
-			return cookie;
+		/**
+		 * @param {string} header
+		 * @param {import('cookie').ParseOptions} options
+		 */
+		parse(header, options) {
+			return parseSetCookie(header, options);
 		},
 
 		/**

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -63,10 +63,6 @@ export function get_cookies(request, url) {
 		// typescript users. `@type {import('@sveltejs/kit').Cookies}` above is not
 		// sufficient to do so.
 
-		/**
-		 * @param {string} name
-		 * @param {import('cookie').ParseOptions} [opts]
-		 */
 		get(name, opts) {
 			// Look for the most specific matching cookie from new_cookies
 			const best_match = Array.from(new_cookies.values())
@@ -106,9 +102,6 @@ export function get_cookies(request, url) {
 			return cookie;
 		},
 
-		/**
-		 * @param {import('cookie').ParseOptions} [opts]
-		 */
 		getAll(opts) {
 			const cookies = parseCookie(header, { decode: opts?.decode });
 
@@ -141,30 +134,16 @@ export function get_cookies(request, url) {
 			);
 		},
 
-		/**
-		 * @param {string} name
-		 * @param {string} value
-		 * @param {import('cookie').SerializeOptions} options
-		 */
 		set(name, value, options) {
 			set_internal(name, value, { ...defaults, ...options });
 		},
 
-		/**
-		 * @param {string} name
-		 * @param {import('cookie').SerializeOptions} options
-		 */
 		delete(name, options) {
 			cookies.set(name, '', { ...options, maxAge: 0 });
 		},
 
 		parse: parseSetCookie,
 
-		/**
-		 * @param {string} name
-		 * @param {string} value
-		 * @param {import('cookie').SerializeOptions} options
-		 */
 		serialize(name, value, { encode, ...options }) {
 			let path = options.path ?? '/';
 

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -162,16 +162,18 @@ export function get_cookies(request, url) {
 		parse(header) {
 			const [head, ...tail] = header.split(';').filter((str) => str.trim() !== '');
 
-			const [name, value] = head.split('=');
+			const head_index = head.indexOf('=');
+			const name = head_index === -1 ? head : head.slice(0, head_index);
+			const value = head_index === -1 ? '' : head.slice(head_index + 1);
 
 			/** @type {import('cookie').SetCookie} */
 			const cookie = { name, value };
 
 			for (const pair of tail) {
-				const parts = pair.split('=', 2);
+				const index = pair.indexOf('=');
 
-				const key = parts[0].trim().toLowerCase();
-				const value = parts[1]?.trim();
+				const key = (index === -1 ? pair : pair.slice(0, index)).trim().toLowerCase();
+				const value = index === -1 ? undefined : pair.slice(index + 1).trim();
 
 				switch (key) {
 					case 'expires': {

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -158,13 +158,7 @@ export function get_cookies(request, url) {
 			cookies.set(name, '', { ...options, maxAge: 0 });
 		},
 
-		/**
-		 * @param {string} header
-		 * @param {import('cookie').ParseOptions} options
-		 */
-		parse(header, options) {
-			return parseSetCookie(header, options);
-		},
+		parse: parseSetCookie,
 
 		/**
 		 * @param {string} name

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -173,7 +173,7 @@ export function get_cookies(request, url) {
 				const index = pair.indexOf('=');
 
 				const key = (index === -1 ? pair : pair.slice(0, index)).trim().toLowerCase();
-				const value = index === -1 ? undefined : pair.slice(index + 1).trim();
+				const value = index === -1 ? '' : pair.slice(index + 1).trim();
 
 				switch (key) {
 					case 'expires': {
@@ -203,7 +203,7 @@ export function get_cookies(request, url) {
 					}
 
 					case 'samesite': {
-						if (value === undefined) {
+						if (value === '') {
 							cookie.sameSite = 'strict';
 						} else {
 							const lower = value.toLowerCase();

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -158,6 +158,88 @@ export function get_cookies(request, url) {
 			cookies.set(name, '', { ...options, maxAge: 0 });
 		},
 
+		/** @param {string} header */
+		parse(header) {
+			const [head, ...tail] = header.split(';').filter((str) => str.trim() !== '');
+
+			const [name, value] = head.split('=');
+
+			/** @type {import('cookie').SetCookie} */
+			const cookie = { name, value };
+
+			for (const pair of tail) {
+				const parts = pair.split('=', 2);
+
+				const key = parts[0].trim().toLowerCase();
+				const value = parts[1]?.trim();
+
+				switch (key) {
+					case 'expires': {
+						cookie.expires = new Date(value);
+						break;
+					}
+
+					case 'max-age': {
+						const age = parseInt(value, 10);
+						if (!isNaN(age)) cookie.maxAge = age;
+						break;
+					}
+
+					case 'secure': {
+						cookie.secure = true;
+						break;
+					}
+
+					case 'httponly': {
+						cookie.httpOnly = true;
+						break;
+					}
+
+					case 'partitioned': {
+						cookie.partitioned = true;
+						break;
+					}
+
+					case 'samesite': {
+						if (value === undefined) {
+							cookie.sameSite = 'strict';
+						} else {
+							const lower = value.toLowerCase();
+
+							if (lower === 'lax') cookie.sameSite = 'lax';
+							if (lower === 'none') cookie.sameSite = 'none';
+							if (lower === 'strict') cookie.sameSite = 'strict';
+						}
+
+						break;
+					}
+
+					// non-standard, but understood by e.g. Chrome
+					case 'priority': {
+						const lower = value.toLowerCase();
+
+						if (lower === 'low') cookie.priority = 'low';
+						if (lower === 'medium') cookie.priority = 'medium';
+						if (lower === 'high') cookie.priority = 'high';
+
+						break;
+					}
+
+					case 'domain': {
+						cookie.domain = value;
+						break;
+					}
+
+					case 'path': {
+						cookie.path = value;
+						break;
+					}
+				}
+			}
+
+			return cookie;
+		},
+
 		/**
 		 * @param {string} name
 		 * @param {string} value

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -321,4 +321,11 @@ describe('cookies.parse', () => {
 			expires: date
 		});
 	});
+
+	test('includes trailing = characters', () => {
+		assert.deepEqual(cookies.parse('foo=bar=baz='), {
+			name: 'foo',
+			value: 'bar=baz='
+		});
+	});
 });

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -287,3 +287,38 @@ describe.skipIf(process.env.NODE_ENV !== 'production')('cookies in prod', () => 
 		expect(duplicate?.value).toEqual('foobar_value');
 	});
 });
+
+describe('cookies.parse', () => {
+	const { cookies } = cookies_setup();
+
+	test('parses a cookie', () => {
+		assert.deepEqual(cookies.parse('foo=bar'), {
+			name: 'foo',
+			value: 'bar'
+		});
+	});
+
+	test('ignores invalid properties', () => {
+		assert.deepEqual(cookies.parse('foo=bar; samesite=laxative'), {
+			name: 'foo',
+			value: 'bar'
+		});
+	});
+
+	test('ignores unknown properties', () => {
+		assert.deepEqual(cookies.parse('foo=bar; potato=salad'), {
+			name: 'foo',
+			value: 'bar'
+		});
+	});
+
+	test('converts expires', () => {
+		const date = new Date();
+
+		assert.deepEqual(cookies.parse(`foo=bar; expires=${date.toISOString()}`), {
+			name: 'foo',
+			value: 'bar',
+			expires: date
+		});
+	});
+});

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -274,11 +274,19 @@ declare module '@sveltejs/kit' {
 		 * Parses a single `Set-Cookie` header. This allows you to apply cookies received from an external source:
 		 *
 		 * ```js
-		 * const response = await fetch('...');
+		 * import { getRequestEvent } from '$app/server';
 		 *
-		 * for (const str of response.headers.getSetCookie()) {
-		 * 	const { name, value, ...options } = cookies.parse(str);
-		 * 	cookies.set(name, value, { ...options, path: '/' });
+		 * export function GET() {
+		 * 	const { cookies } = getRequestEvent();
+		 *
+		 * 	const response = await fetch('...');
+		 *
+		 * 	for (const str of response.headers.getSetCookie()) {
+		 * 		const { name, value, ...options } = cookies.parse(str);
+		 * 		cookies.set(name, value, { ...options, path: '/' });
+		 * 	}
+		 *
+		 * 	// ...
 		 * }
 		 * ```
 		 *

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -291,10 +291,8 @@ declare module '@sveltejs/kit' {
 		 * ```
 		 *
 		 * Note the use of `headers.getSetCookie()`, which returns an array of cookie headers, _not_ `headers.get('set-cookie')` which returns a single comma-separated string.
-		 *
-		 * @param header A valid `Set-Cookie` header
 		 */
-		parse: (header: string) => import('cookie').SetCookie;
+		parse: typeof import('cookie').parseSetCookie;
 
 		/**
 		 * Serialize a cookie name-value pair into a `Set-Cookie` header string, but don't apply it to the response.

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -276,7 +276,7 @@ declare module '@sveltejs/kit' {
 		 * ```js
 		 * import { getRequestEvent } from '$app/server';
 		 *
-		 * export function GET() {
+		 * export async function GET() {
 		 * 	const { cookies } = getRequestEvent();
 		 *
 		 * 	const response = await fetch('...');

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -271,6 +271,24 @@ declare module '@sveltejs/kit' {
 		delete: (name: string, opts: import('cookie').SerializeOptions) => void;
 
 		/**
+		 * Parses a single `Set-Cookie` header. This allows you to apply cookies received from an external source:
+		 *
+		 * ```js
+		 * const response = await fetch('...');
+		 *
+		 * for (const str of response.headers.getSetCookie()) {
+		 * 	const { name, value, ...options } = cookies.parse(str);
+		 * 	cookies.set(name, value, { ...options, path: '/' });
+		 * }
+		 * ```
+		 *
+		 * Note the use of `headers.getSetCookie()`, which returns an array of cookie headers, _not_ `headers.get('set-cookie')` which returns a single comma-separated string.
+		 *
+		 * @param header A valid `Set-Cookie` header
+		 */
+		parse: (header: string) => import('cookie').SetCookie;
+
+		/**
 		 * Serialize a cookie name-value pair into a `Set-Cookie` header string, but don't apply it to the response.
 		 *
 		 * The `httpOnly` and `secure` options are `true` by default (except on http://localhost, where `secure` is `false`), and must be explicitly disabled if you want cookies to be readable by client-side JavaScript and/or transmitted over HTTP.


### PR DESCRIPTION
closes #13680
closes #13681
closes https://github.com/sveltejs/kit/discussions/8564

Adds a `cookies.parse` method for dealing with cookie headers from external sources:

```js
const response = await fetch('...');

for (const str of response.headers.getSetCookie()) {
	const { name, value, ...options } = cookies.parse(str);
	cookies.set(name, value, { ...options, path: '/' });
}
```

Design decisions that might warrant discussion:

- invalid values are ignored. If you do `SameSite=Nope` instead of SameSite=None`, nothing will happen. Maybe it should throw instead? Or maybe it should just apply the value even if it's gibberish, to make it future-proof?
- same for invalid properties — it only recognises `Expires`, `Max-Age`, `Secure`, `HttpOnly`, `Partitioned`, `Priority`, `SameSite`, `Domain` and `Path`

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
