### PR TITLE
chore: make test less flaky

### DIFF
--- a/packages/kit/test/apps/basics/test/cross-platform/client.test.js
+++ b/packages/kit/test/apps/basics/test/cross-platform/client.test.js
@@ -103,7 +103,7 @@ test.describe('a11y', () => {
 		await page.goto('/keepfocus');
 
 		await Promise.all([
-			page.type('#input', 'bar'),
+			page.locator('#input').pressSequentially('bar', { delay: 100 }),
 			page.waitForFunction(() => window.location.search === '?foo=bar')
 		]);
 		await expect(page.locator('#input')).toBeFocused();


### PR DESCRIPTION
hopefully switching to non-deprecated version + delaying (mimicking typing more closely) helps
