### PR TITLE
fix: make `paths.origin` type looser

### DIFF
--- a/.changeset/lemon-turkeys-drop.md
+++ b/.changeset/lemon-turkeys-drop.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/kit": patch
+---
+
+fix: make `paths.origin` type looser

--- a/documentation/docs/25-build-and-deploy/40-adapter-node.md
+++ b/documentation/docs/25-build-and-deploy/40-adapter-node.md
@@ -96,7 +96,7 @@ export default defineConfig({
 		sveltekit({
 			adapter: adapter(),
 			paths: {
-				origin: /** @type {`https://${string}`} */ (process.env.ORIGIN)
+				origin: process.env.ORIGIN
 			}
 		})
 	]

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -294,7 +294,6 @@ test('fails if paths.origin is not a valid origin', () => {
 		validate_config({
 			kit: {
 				paths: {
-					// @ts-expect-error
 					origin: 'not an origin'
 				}
 			}
@@ -309,7 +308,6 @@ test('fails if paths.origin uses an unsupported protocol', () => {
 				paths: {
 					// ftp:// is a parseable URL whose origin equals the input, so without
 					// a protocol check it would slip through validation.
-					// @ts-expect-error
 					origin: 'ftp://example.com'
 				}
 			}
@@ -350,7 +348,6 @@ test('fails if paths.origin is the empty string', () => {
 		validate_config({
 			kit: {
 				paths: {
-					// @ts-expect-error - empty string is no longer a valid value
 					origin: ''
 				}
 			}

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -727,7 +727,7 @@ export interface KitConfig {
 		 * @default undefined
 		 * @since 3.0
 		 */
-		origin?: `http://${string}` | `https://${string}`;
+		origin?: string;
 		/**
 		 * Whether to use relative asset paths.
 		 *

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -700,7 +700,7 @@ declare module '@sveltejs/kit' {
 			 * @default undefined
 			 * @since 3.0
 			 */
-			origin?: `http://${string}` | `https://${string}`;
+			origin?: string;
 			/**
 			 * Whether to use relative asset paths.
 			 *


### PR DESCRIPTION
see https://github.com/sveltejs/kit/pull/16213#discussion_r3513723120

This PR changes the `paths.origin` type to `string` rather than a string template of `https://*` so that it's easy to use with environment variables

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
