### PR TITLE
fix: prevent prototype pollution when deleting file inputs

### DIFF
--- a/.changeset/tough-kings-own.md
+++ b/.changeset/tough-kings-own.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prevent prototype pollution when deleting file inputs

--- a/packages/kit/src/runtime/client/remote-functions/form.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/form.svelte.js
@@ -18,6 +18,7 @@ import {
 	build_path_string,
 	normalize_issue,
 	serialize_binary_form,
+	DELETE_KEY,
 	BINARY_FORM_CONTENT_TYPE
 } from '../../form-utils.js';
 
@@ -513,14 +514,7 @@ export function form(id) {
 					if (file) {
 						set_nested_value(input, name, file);
 					} else {
-						// Remove the property by setting to undefined and clean up
-						const path_parts = name.split(/\.|\[|\]/).filter(Boolean);
-						let current = /** @type {any} */ (input);
-						for (let i = 0; i < path_parts.length - 1; i++) {
-							if (current[path_parts[i]] == null) return;
-							current = current[path_parts[i]];
-						}
-						delete current[path_parts[path_parts.length - 1]];
+						set_nested_value(input, name, DELETE_KEY);
 					}
 				} else {
 					set_nested_value(

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -27,6 +27,9 @@ export function set_nested_value(object, path_string, value) {
 	deep_set(object, split_path(path_string), value);
 }
 
+/** Pass this to set_nested_value to delete the last part of the given path */
+export const DELETE_KEY = {};
+
 /**
  * Convert `FormData` into a POJO
  * @param {FormData} data
@@ -502,6 +505,10 @@ export function deep_set(object, keys, value) {
 		}
 
 		if (!exists) {
+			if (value === DELETE_KEY) {
+				// don't create the nested structure if we want to delete the key anyway
+				return;
+			}
 			current[key] = is_array ? [] : {};
 		}
 
@@ -510,7 +517,12 @@ export function deep_set(object, keys, value) {
 
 	const final_key = keys[keys.length - 1];
 	check_prototype_pollution(final_key);
-	current[final_key] = value;
+
+	if (value === DELETE_KEY) {
+		delete current[final_key];
+	} else {
+		current[final_key] = value;
+	}
 }
 
 /**

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, test } from 'vitest';
 import {
 	BINARY_FORM_CONTENT_TYPE,
+	DELETE_KEY,
 	convert_formdata,
 	deep_set,
 	deserialize_binary_form,
@@ -753,11 +754,20 @@ describe('deep_set', () => {
 	test.each(POLLUTION_ATTACKS)('avoids prototype injection', (attack) => {
 		const target = {};
 		expect(() => deep_set(target, attack.split('.'), 'bad')).toThrow(/Invalid key/);
+		expect(() => deep_set(target, attack.split('.'), DELETE_KEY)).toThrow(/Invalid key/);
 	});
 
 	test.each([null, undefined])('creates nested object when intermediate value is %s', (value) => {
 		const target = { nested: value };
 		deep_set(target, ['nested', 'name'], 'hello');
 		expect(target).toEqual({ nested: { name: 'hello' } });
+	});
+
+	test('deletes a nested value', () => {
+		const target = { nested: { file: 'hello' } };
+
+		deep_set(target, ['nested', 'file'], DELETE_KEY);
+
+		expect(target).toEqual({ nested: {} });
 	});
 });


### PR DESCRIPTION
If a file input of a remote form is deleted, and the path to that file contains things like `__proto__` you can do prototype pollution (you can e.g. delete methods from object prototypes).

This fixes that by reusing the same mechanisms we already have in place elsewhere.

Big big big edge case + remote functions are experimental, hence no SEV.
