### PR TITLE
fix: prevent unhandled promise rejection

### DIFF
--- a/.changeset/true-chicken-poke.md
+++ b/.changeset/true-chicken-poke.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: prevent unhandled promise rejection

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -5,6 +5,7 @@
 import { DEV } from 'esm-env';
 import * as devalue from 'devalue';
 import { text_encoder } from './utils.js';
+import { noop } from '../utils/functions.js';
 import { SvelteKitError } from '@sveltejs/kit/internal';
 
 const decoder = new TextDecoder();
@@ -318,7 +319,7 @@ export async function deserialize_binary_form(request) {
 			const chunk = await get_chunk(chunks.length);
 			has_more = !!chunk;
 		}
-	})();
+	})().catch(noop); // prevent unhandled rejection potentially crashing the process
 
 	return { data, meta, form_data: null };
 }

--- a/packages/kit/src/runtime/server/page/load_data.js
+++ b/packages/kit/src/runtime/server/page/load_data.js
@@ -377,7 +377,7 @@ export function create_universal_fetch(event, state, fetched, csr, resolve_opts)
 						}
 
 						void push_fetched(base64_encode(result), true);
-					})();
+					})().catch(noop); // prevent unhandled rejection potentially crashing the process
 
 					return (teed_body = b);
 				}

--- a/packages/kit/src/utils/streaming.js
+++ b/packages/kit/src/utils/streaming.js
@@ -1,3 +1,4 @@
+import { noop } from './functions.js';
 import { with_resolvers } from './promise.js';
 
 /**
@@ -32,10 +33,19 @@ export function create_async_iterator() {
 			};
 		},
 		add: (promise) => {
-			deferred.push(with_resolvers());
-			void promise.then((value) => {
-				deferred[++resolved].resolve(value);
-			});
+			/** @type {import('./promise.js').PromiseWithResolvers<T>} */
+			const next = with_resolvers();
+			void next.promise.catch(noop); // prevent unhandled rejection potentially crashing the process
+			deferred.push(next);
+
+			void promise.then(
+				(value) => {
+					deferred[++resolved].resolve(value);
+				},
+				(error) => {
+					deferred[++resolved].reject(error);
+				}
+			);
 		}
 	};
 }

--- a/packages/kit/src/utils/streaming.spec.js
+++ b/packages/kit/src/utils/streaming.spec.js
@@ -14,3 +14,12 @@ test('works with fast consecutive promise resolutions', async () => {
 
 	expect(actual).toEqual([10, 20]);
 });
+
+test('rejects iterator entries when promises reject', async () => {
+	const { iterate, add } = create_async_iterator();
+	const error = new Error('nope');
+
+	add(Promise.reject(error));
+
+	await expect(iterate()[Symbol.asyncIterator]().next()).rejects.toBe(error);
+});


### PR DESCRIPTION
If the promise fails, nobody catches it, which can take down the process.

I added `.catch(...)` in two more places out of abundance of caution. They can right now not result in an unhandled promise rejection (because other code paths make sure they never throw) but if they start to in the future it's better to safe-guard against it now already.
