### PR TITLE
fix: populate `$app/env` immediately in dev

### DIFF
--- a/.changeset/fix-app-env-vite-node.md
+++ b/.changeset/fix-app-env-vite-node.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: populate `$app/env/*` dynamic variables in contexts that don't run the dev server, such as `vite-node`

--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -94,8 +94,9 @@ export async function load_explicit_env(kit, file, root, mode) {
  * @param {Record<string, EnvVarConfig<any> | undefined> | null} variables
  * @param {Record<string, string>} env
  * @param {string | null} entry
+ * @param {boolean} is_dev
  */
-export function create_sveltekit_env(variables, env, entry) {
+export function create_sveltekit_env(variables, env, entry, is_dev) {
 	const imports = entry
 		? [
 				`import { variables } from ${JSON.stringify(entry)};`,
@@ -148,6 +149,19 @@ export function create_sveltekit_env(variables, env, entry) {
 				handle_issues(issues);
 			}`
 	];
+
+	// In dev, initialise the env immediately. Tools like `vite-node` load modules
+	// through the Vite config but don't run the SvelteKit dev server, which is what
+	// normally calls `set_env`. Without this, dynamic env vars imported from
+	// `$app/env/public` and `$app/env/private` would be `undefined` in such contexts.
+	if (is_dev) {
+		/** @type {Record<string, string>} */
+		const dev_env = {};
+		for (const name of Object.keys(variables ?? {})) {
+			if (name in env) dev_env[name] = env[name];
+		}
+		blocks.push(`set_env(${devalue.uneval(dev_env)});`);
+	}
 
 	const module = blocks.join('\n\n');
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -598,7 +598,7 @@ function kit({ svelte_config }) {
 						return create_service_worker_module(svelte_config);
 
 					case sveltekit_env:
-						return create_sveltekit_env(explicit_env_config, env, explicit_env_entry);
+						return create_sveltekit_env(explicit_env_config, env, explicit_env_entry, !is_build);
 
 					case sveltekit_env_public_client:
 						return create_sveltekit_env_public(


### PR DESCRIPTION
Closes #16201 

In dev, immediately populate dynamic env vars. We normally do this per-request in the development server, but some contexts don't actually run the development server.