### PR TITLE
fix: defer `refresh` until after command

### DIFF
--- a/.changeset/deferred-query-refresh.md
+++ b/.changeset/deferred-query-refresh.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: defer `query.refresh()` in server commands until after the command body completes

--- a/packages/kit/src/runtime/app/server/remote/query.js
+++ b/packages/kit/src/runtime/app/server/remote/query.js
@@ -411,20 +411,14 @@ export function refresh(event, state, internals, payload, fn) {
 
 	const key = create_remote_key(internals.id, payload);
 
-	// `fn()` is invoked eagerly here, which starts running the query immediately.
-	// The resulting promise is normally awaited (and its rejection handled) in
-	// `collect_remote_data`, but some code paths (e.g. a command throwing a
-	// non-redirect error) never reach that point. Attach a no-op `catch` to the
-	// promise so a rejection is always considered handled and can never become an
-	// unhandled promise rejection (which crashes the process on modern Node).
-	// We still store the original promise so `collect_remote_data` can serialize
-	// either its value or its error as before.
-	const promise = fn();
-	promise.catch(() => {});
-
+	// `fn` is stored rather than invoked eagerly. The query is run at the end of
+	// the command/form (in `collect_remote_data`), so that it observes any state
+	// mutations that happen after `refresh()` is called. If the developer re-awaits
+	// the query before the command finishes, the cache entry created by that await
+	// is reused instead of re-running the query.
 	(state.remote.explicit ??= new Map()).set(key, {
 		internals,
-		promise
+		fn
 	});
 }
 

--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -368,7 +368,7 @@ export async function collect_remote_data(data, event, state, options) {
 	const promises = [];
 
 	if (state.remote.explicit) {
-		for (const [remote_key, { internals, promise }] of state.remote.explicit) {
+		for (const [remote_key, { internals, fn }] of state.remote.explicit) {
 			// there were explicit refreshes/reconnects (via `refresh()`/`set()`/`reconnect()`),
 			// so the client should apply these single-flight updates instead of calling `invalidateAll()`
 			data.r = true;
@@ -376,6 +376,11 @@ export async function collect_remote_data(data, event, state, options) {
 			const type = /** @type {'p' | 'q' | 'l'} */ (
 				internals.type === 'query_live' ? 'l' : internals.type[0]
 			);
+
+			// `fn` is deferred until now so the query runs after any state mutations
+			// in the command/form body. If the query was re-awaited in the meantime,
+			// `fn` returns the existing (fresh) cache entry rather than re-running.
+			const promise = fn();
 
 			await promise.then(
 				(v) => {

--- a/packages/kit/src/runtime/server/remote.js
+++ b/packages/kit/src/runtime/server/remote.js
@@ -380,20 +380,24 @@ export async function collect_remote_data(data, event, state, options) {
 			// `fn` is deferred until now so the query runs after any state mutations
 			// in the command/form body. If the query was re-awaited in the meantime,
 			// `fn` returns the existing (fresh) cache entry rather than re-running.
+			// Kick off the query immediately and collect the promise so that multiple
+			// explicit refreshes run concurrently rather than serially.
 			const promise = fn();
 
-			await promise.then(
-				(v) => {
-					((data[type] ??= {})[remote_key] ??= {}).v = v;
-				},
-				async (e) => {
-					if (e instanceof Redirect) {
-						// already handled elsewhere
-						return;
-					}
+			promises.push(
+				promise.then(
+					(v) => {
+						((data[type] ??= {})[remote_key] ??= {}).v = v;
+					},
+					async (e) => {
+						if (e instanceof Redirect) {
+							// already handled elsewhere
+							return;
+						}
 
-					((data[type] ??= {})[remote_key] ??= {}).e = await convert_error(e);
-				}
+						((data[type] ??= {})[remote_key] ??= {}).e = await convert_error(e);
+					}
+				)
 			);
 		}
 	}

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -727,7 +727,7 @@ export interface RequestState {
 			string,
 			{
 				internals: RemoteInternals;
-				promise: Promise<any>;
+				fn: () => Promise<any>;
 			}
 		>;
 		/** Instances created via `myForm.for(...)` */

--- a/packages/kit/test/apps/async/src/routes/remote/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/+page.svelte
@@ -11,6 +11,8 @@
 		set_count_partial_refresh_all,
 		set_count_server_refresh,
 		set_count_server_refresh_after_read,
+		set_count_server_refresh_before_mutation,
+		set_count_server_refresh_then_reawait,
 		set_count_server_set,
 		resolve_deferreds
 	} from './query-command.remote.js';
@@ -97,6 +99,22 @@
 	id="multiply-server-refresh-after-read-btn"
 >
 	command (query server refresh after read)
+</button>
+<button
+	onclick={async () => {
+		command_result = await set_count_server_refresh_before_mutation(12);
+	}}
+	id="multiply-server-refresh-before-mutation-btn"
+>
+	command (query server refresh before mutation)
+</button>
+<button
+	onclick={async () => {
+		command_result = await set_count_server_refresh_then_reawait(13);
+	}}
+	id="multiply-server-refresh-then-reawait-btn"
+>
+	command (query server refresh then re-await)
 </button>
 <button
 	onclick={async () => {

--- a/packages/kit/test/apps/async/src/routes/remote/query-command.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/query-command.remote.js
@@ -116,6 +116,25 @@ export const set_count_server_refresh_after_read = command('unchecked', async (c
 	return c;
 });
 
+export const set_count_server_refresh_before_mutation = command('unchecked', async (c) => {
+	// refresh BEFORE the mutation — the deferred refresh must see the new value
+	get_count().refresh();
+	await new Promise((resolve) => setTimeout(resolve, 10));
+	session().count = c;
+	return c;
+});
+
+export const set_count_server_refresh_then_reawait = command('unchecked', async (c) => {
+	// refresh BEFORE the mutation, then re-await to get fresh data within the command
+	get_count().refresh();
+	session().count = c;
+	const fresh = await get_count();
+	if (fresh !== c) {
+		throw new Error(`expected fresh value ${c}, got ${fresh}`);
+	}
+	return c;
+});
+
 export const set_count_server_set = command('unchecked', async (c) => {
 	const event = getRequestEvent();
 	session().count = c;

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -200,6 +200,36 @@ test.describe('remote function mutations', () => {
 		expect(request_count).toBe(1);
 	});
 
+	test('command refresh before mutation defers the query until after the mutation', async ({
+		page
+	}) => {
+		await page.goto('/remote');
+		await expect(page.locator('#count-result')).toHaveText('0 / 0 (false)');
+
+		let request_count = 0;
+		page.on('request', (r) => (request_count += r.url().includes('/_app/remote') ? 1 : 0));
+
+		await page.click('#multiply-server-refresh-before-mutation-btn');
+		await expect(page.locator('#command-result')).toHaveText('12');
+		await expect(page.locator('#count-result')).toHaveText('12 / 12 (false)');
+		await page.waitForTimeout(100); // allow all requests to finish (in case there are query refreshes which shouldn't happen)
+		expect(request_count).toBe(1);
+	});
+
+	test('command refresh then re-await uses the fresh cache entry', async ({ page }) => {
+		await page.goto('/remote');
+		await expect(page.locator('#count-result')).toHaveText('0 / 0 (false)');
+
+		let request_count = 0;
+		page.on('request', (r) => (request_count += r.url().includes('/_app/remote') ? 1 : 0));
+
+		await page.click('#multiply-server-refresh-then-reawait-btn');
+		await expect(page.locator('#command-result')).toHaveText('13');
+		await expect(page.locator('#count-result')).toHaveText('13 / 13 (false)');
+		await page.waitForTimeout(100); // allow all requests to finish (in case there are query refreshes which shouldn't happen)
+		expect(request_count).toBe(1);
+	});
+
 	test('command does server-initiated single flight mutation (set)', async ({ page }) => {
 		await page.goto('/remote');
 		await expect(page.locator('#count-result')).toHaveText('0 / 0 (false)');


### PR DESCRIPTION
Closes #16202 

Correctly defer `query.refresh` until after the command it's in completes. Essentially, `.refresh` in a server context means "clear the cache, then at the end of this command, repopulate the cache _if it's not already repopulated_ (which would happen if it were called / awaited again)".