### PR TITLE
fix: clear query cache on redirect

### DIFF
--- a/.changeset/quick-redirects-invalidate.md
+++ b/.changeset/quick-redirects-invalidate.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: invalidate query cache when a query throws a redirect

--- a/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-batch.svelte.js
@@ -50,8 +50,11 @@ export function query_batch(id) {
 						});
 
 						if (response.redirect) {
-							// Use internal version to allow redirects to external URLs
-							await _goto(response.redirect, {}, 0);
+							// Use internal version to allow redirects to external URLs.
+							// `invalidateAll` ensures the cache is reset so the queries
+							// re-fetch on the next visit, rather than returning the cached
+							// `undefined`.
+							await _goto(response.redirect, { invalidateAll: true }, 0);
 
 							// settle all batched promises (with `undefined`, like a redirect
 							// from a non-batched query) so that callers don't hang forever

--- a/packages/kit/src/runtime/client/remote-functions/query/index.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/index.js
@@ -29,8 +29,10 @@ export function query(id) {
 			const result = await remote_request(url, { headers: get_remote_request_headers() });
 
 			if (result.redirect) {
-				// Use internal version to allow redirects to external URLs
-				await _goto(result.redirect, {}, 0);
+				// Use internal version to allow redirects to external URLs.
+				// `invalidateAll` ensures the cache is reset so the query re-fetches
+				// on the next visit, rather than returning the cached `undefined`.
+				await _goto(result.redirect, { invalidateAll: true }, 0);
 			}
 		});
 	};

--- a/packages/kit/test/apps/async/src/routes/remote/query-redirect-cached/+layout.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/query-redirect-cached/+layout.svelte
@@ -1,0 +1,11 @@
+<script>
+	import { protected_query } from './data.remote.js';
+
+	let { children } = $props();
+
+	let data = $derived(await protected_query());
+</script>
+
+<p id="query-data">{data}</p>
+
+{@render children()}

--- a/packages/kit/test/apps/async/src/routes/remote/query-redirect-cached/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/query-redirect-cached/+page.svelte
@@ -1,0 +1,12 @@
+<script>
+	import { login } from './data.remote.js';
+	import { invalidateAll } from '$app/navigation';
+
+	async function handle_login() {
+		await login();
+		await invalidateAll();
+	}
+</script>
+
+<button id="login" onclick={handle_login}>login</button>
+<a href="/remote/query-redirect-cached/protected">protected</a>

--- a/packages/kit/test/apps/async/src/routes/remote/query-redirect-cached/data.remote.js
+++ b/packages/kit/test/apps/async/src/routes/remote/query-redirect-cached/data.remote.js
@@ -1,0 +1,34 @@
+import { command, getRequestEvent, query } from '$app/server';
+import { redirect } from '@sveltejs/kit';
+
+const sessions = new Map();
+
+/** @typedef {{ authenticated: boolean }} SessionState */
+
+/** @returns {SessionState} */
+function session() {
+	const id = getRequestEvent().cookies.get('count_session') ?? 'default';
+	let state = sessions.get(id);
+	if (!state) {
+		state = { authenticated: false };
+		sessions.set(id, state);
+	}
+	return state;
+}
+
+export const protected_query = query(() => {
+	const path = getRequestEvent().url.pathname;
+	if (path === '/remote/query-redirect-cached/protected' && !session().authenticated) {
+		redirect(307, '/remote/query-redirect-cached/redirected');
+	}
+
+	return session().authenticated ? 'authenticated' : 'unauthenticated';
+});
+
+export const login = command(() => {
+	session().authenticated = true;
+});
+
+export const logout = command(() => {
+	session().authenticated = false;
+});

--- a/packages/kit/test/apps/async/src/routes/remote/query-redirect-cached/protected/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/query-redirect-cached/protected/+page.svelte
@@ -1,0 +1,12 @@
+<script>
+	import { logout } from '../data.remote.js';
+	import { invalidateAll } from '$app/navigation';
+
+	async function handle_logout() {
+		await logout();
+		await invalidateAll();
+	}
+</script>
+
+<p id="protected">protected content</p>
+<button id="logout" onclick={handle_logout}>logout</button>

--- a/packages/kit/test/apps/async/src/routes/remote/query-redirect-cached/redirected/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/query-redirect-cached/redirected/+page.svelte
@@ -1,0 +1,13 @@
+<script>
+	import { login } from '../data.remote.js';
+	import { invalidateAll } from '$app/navigation';
+
+	async function handle_login() {
+		await login();
+		await invalidateAll();
+	}
+</script>
+
+<p id="redirected">redirected</p>
+<button id="login-from-redirected" onclick={handle_login}>login</button>
+<a href="/remote/query-redirect-cached/protected">back to protected</a>

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -81,6 +81,40 @@ test.describe('remote functions', () => {
 		expect(location).toBe('/remote/query-redirect/redirected');
 	});
 
+	test('query redirect does not cache undefined — re-fetches after invalidation', async ({
+		page
+	}) => {
+		// Regression for https://github.com/sveltejs/kit/issues/16192 — when a query
+		// throws a redirect, the `undefined` result must not be cached. Otherwise,
+		// after the redirect condition is resolved (e.g. re-authentication), the
+		// query would return the stale `undefined` instead of re-fetching.
+		await page.goto('/remote/query-redirect-cached');
+		await expect(page.locator('#query-data')).toHaveText('unauthenticated');
+
+		// log in — query re-fetches via invalidateAll and shows 'authenticated'
+		await page.click('#login');
+		await expect(page.locator('#query-data')).toHaveText('authenticated');
+
+		// navigate to the protected page — query succeeds (SSR)
+		await page.goto('/remote/query-redirect-cached/protected');
+		await expect(page.locator('#query-data')).toHaveText('authenticated');
+
+		// log out + invalidateAll — query re-runs on the client and redirects
+		await page.click('#logout');
+		await expect(page.locator('#redirected')).toHaveText('redirected');
+
+		// after the redirect, the query should have re-fetched (not returned
+		// cached undefined). The layout persists, so the cache entry is alive.
+		await expect(page.locator('#query-data')).toHaveText('unauthenticated');
+
+		// log back in and navigate to the protected page — query should re-fetch
+		// and return 'authenticated', not the stale cached undefined
+		await page.click('#login-from-redirected');
+		await expect(page.locator('#query-data')).toHaveText('authenticated');
+		await page.click('a[href="/remote/query-redirect-cached/protected"]');
+		await expect(page.locator('#query-data')).toHaveText('authenticated');
+	});
+
 	test('non-exported queries do not clobber each other', async ({ page }) => {
 		await page.goto('/remote/query-non-exported');
 


### PR DESCRIPTION
Closes #16192 

Uses `invalidateAll` in `_goto` when redirecting from queries. This prevents the redirect from being stored as an undefined value.

Draft because I'm not done testing yet. Out for the weekend, so if someone wants to finish this up, be my guest.
