### PR TITLE
Root cause analysis: #16207 - stale values when navigating from within a boundary

### DIFF
--- a/.github/RCA-16207.md
+++ b/.github/RCA-16207.md
@@ -1,0 +1,74 @@
+# Root Cause Analysis: Issue #16207 — Stale values when navigating from within a boundary
+
+Reference: https://github.com/sveltejs/kit/issues/16207
+
+## Summary
+
+When navigating away from a route that is currently displaying a `<svelte:boundary>`'s `failed` snippet (i.e., the page threw a render error and the boundary caught it), stale DOM content persists and/or duplicate content renders. The target route may see stale data values, causing errors like `can't access property "y", (intermediate value).x is undefined`.
+
+## Root Cause
+
+The bug is in **Svelte's `Boundary` class** (`svelte/src/internal/client/dom/blocks/boundary.js`), specifically in the `#render()` method (line 243). The boundary's `#effect` is a **block effect** that, when re-run, calls `destroy_block_effect_children()` — which **intentionally skips branch effects** (`BRANCH_EFFECT` flag). However, `#main_effect`, `#failed_effect`, and `#pending_effect` are all created via `branch()`, so they are **never destroyed** when the boundary's block effect re-runs.
+
+**The `#render()` method creates new branch effects without destroying the old ones:**
+
+```js
+// boundary.js:243-265
+#render() {
+    try {
+        // ← NO cleanup of existing #failed_effect, #main_effect, or #pending_effect
+        this.#main_effect = branch(() => { this.#children(this.#anchor); });
+        ...
+    }
+}
+```
+
+Compare with the `reset()` function (line 437), which **does** clean up `#failed_effect` via `pause_effect()` before re-rendering. The `#render()` path — triggered when the block effect re-runs due to prop changes — lacks this cleanup.
+
+## Three Interacting Problems
+
+### 1. `#failed_effect` not destroyed on boundary recovery (Svelte)
+
+When a boundary is in a failed state (showing the `failed` snippet) and props change (from navigation), the block effect re-runs `#render()`. `destroy_block_effect_children()` skips the `#failed_effect` (branch effect), and `#render()` doesn't destroy it either. The stale error content persists in the DOM alongside the new content.
+
+### 2. `#main_effect` duplicated by preload fork (Svelte + SvelteKit)
+
+SvelteKit's `forkPreloads` experimental feature creates a preload fork on `mousedown`/`hover` (`packages/kit/src/runtime/client/client.js:2133-2144`). The fork calls `root.$set(target_props)` which triggers `#render()` (creating `#main_effect` #1). When the user clicks and `fork.commit()` runs, the block effect re-runs `#render()` again (creating `#main_effect` #2). Both are branch effects, neither is destroyed → **DOM duplication**.
+
+This was confirmed by toggling `forkPreloads: false`, which eliminated the duplication.
+
+### 3. Async `transformError` race condition (Svelte + SvelteKit)
+
+SvelteKit passes an **async** `transformError` callback to the boundary (`packages/kit/src/runtime/client/client.js:734`):
+
+```js
+transformError: async (e) => {
+    const error = await handle_error(e, current.nav);
+    ...
+    return error;
+}
+```
+
+The boundary's `#handle_error()` queues a microtask (line 501), which calls `transform_error()`. If `transform_error` returns a Promise, `handle_error_result` is deferred until that Promise resolves (line 518). This creates a window where the boundary's block effect can re-run (from navigation prop changes) **before** `handle_error_result` fires. When it finally fires, it creates a `#failed_effect` with the **stale error** from the previous route, overwriting or duplicating the recovered content.
+
+## Why `setTimeout` helps but `tick()`/`flushSync` don't
+
+- **`setTimeout`** defers to the next **macrotask**, allowing all pending microtasks (the boundary's `queue_micro_task` in `#handle_error`, the `transformError` Promise chain, and the fork's batch processing) to drain completely. The boundary reaches a stable state before navigation proceeds.
+- **`await tick()`** in async mode waits for `requestAnimationFrame`/`setTimeout` but doesn't guarantee the fork batch or `transformError` Promise has settled.
+- **`flushSync`** flushes synchronous effects but doesn't wait for the async `transformError` Promise or resolve the fork's deferred batch state.
+
+## Fix Location
+
+The primary fix belongs in **Svelte** (`svelte/src/internal/client/dom/blocks/boundary.js`):
+
+1. **`#render()` must destroy `#failed_effect`, `#main_effect`, and `#pending_effect`** before creating new ones — mirroring what `reset()` already does for `#failed_effect`.
+2. **`handle_error_result` must check if the boundary has recovered** (e.g., `#main_effect !== null`) before creating a `#failed_effect`, to handle the async `transformError` race.
+
+A secondary mitigation in **SvelteKit** could avoid creating preload forks when a boundary is in a failed state, or `await` the `transformError` Promise before allowing navigation to proceed.
+
+## Reproduction Confirmation
+
+A Playwright test in the `test-async` app (which uses `experimental.async: true`, `handleRenderingErrors: true`, `forkPreloads: true`) confirmed:
+
+- Navigating from a failed boundary to a target route produces **duplicate target content** (2× `#value` elements) and **persists the stale failed content**.
+- Disabling `forkPreloads` eliminates the duplication but the stale `#failed_effect` still persists (fixed by destroying it in `#render()`).

--- a/packages/kit/test/apps/async/src/routes/issue-16207/+error.svelte
+++ b/packages/kit/test/apps/async/src/routes/issue-16207/+error.svelte
@@ -1,0 +1,7 @@
+<script>
+	let { error } = $props();
+</script>
+
+<p id="source-error">Source error: {error.message}</p>
+
+<a href="/issue-16207/target">Go</a>

--- a/packages/kit/test/apps/async/src/routes/issue-16207/+layout.svelte
+++ b/packages/kit/test/apps/async/src/routes/issue-16207/+layout.svelte
@@ -1,0 +1,8 @@
+<script>
+	let { children } = $props();
+</script>
+
+<div id="issue-layout">
+	<h2>Issue 16207 layout</h2>
+	{@render children?.()}
+</div>

--- a/packages/kit/test/apps/async/src/routes/issue-16207/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/issue-16207/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	throw new Error('source render error');
+</script>
+
+<h1>This should not be visible</h1>

--- a/packages/kit/test/apps/async/src/routes/issue-16207/target/+page.js
+++ b/packages/kit/test/apps/async/src/routes/issue-16207/target/+page.js
@@ -1,0 +1,3 @@
+export async function load() {
+	return { x: { y: 1 } };
+}

--- a/packages/kit/test/apps/async/src/routes/issue-16207/target/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/issue-16207/target/+page.svelte
@@ -1,0 +1,7 @@
+<script>
+	let { data } = $props();
+</script>
+
+<h1>Issue 16207 target</h1>
+
+<p id="value">{data.x.y}</p>

--- a/packages/kit/test/apps/async/test/test.js
+++ b/packages/kit/test/apps/async/test/test.js
@@ -925,6 +925,31 @@ test.describe('remote functions', () => {
 	});
 });
 
+test.describe('issue 16207 - stale values when navigating from within a boundary', () => {
+	// Demonstrates https://github.com/sveltejs/kit/issues/16207
+	// Navigating away from a boundary showing its `failed` snippet leaves
+	// stale `#failed_effect` content in the DOM and (with forkPreloads)
+	// duplicates the target's `#main_effect`. The hover triggers a preload
+	// fork which makes the race reliably reproducible. This test should
+	// pass once the fix lands in Svelte's Boundary class.
+	test.fixme(
+		'navigating from a failed boundary to a route that accesses nested data',
+		async ({ page, clicknav }) => {
+			await page.goto('/issue-16207');
+			await expect(page.locator('#source-error')).toBeVisible();
+			// Hover to trigger preload fork, then click to navigate
+			await page.locator('a[href="/issue-16207/target"]').hover();
+			await page.waitForTimeout(200);
+			await clicknav('a[href="/issue-16207/target"]', {
+				waitForURL: '/issue-16207/target'
+			});
+			// Should render exactly one #value element with fresh data
+			expect(await page.locator('#value').count()).toBe(1);
+			await expect(page.locator('#value')).toHaveText('1');
+		}
+	);
+});
+
 test.describe('server error boundaries', () => {
 	test('catches server render error and shows root +error.svelte', async ({ page }) => {
 		await page.goto('/server-error-boundary');


### PR DESCRIPTION
Warning: This is straight AI investigation I'm using to bookmark. Draft PR, no need to review. Will get back to it in the new week.

# Root Cause Analysis: Issue #16207 — Stale values when navigating from within a boundary

Reference: https://github.com/sveltejs/kit/issues/16207

## Summary

When navigating away from a route that is currently displaying a `<svelte:boundary>`'s `failed` snippet (i.e., the page threw a render error and the boundary caught it), stale DOM content persists and/or duplicate content renders. The target route may see stale data values, causing errors like `can't access property "y", (intermediate value).x is undefined`.

## Root Cause

The bug is in **Svelte's `Boundary` class** (`svelte/src/internal/client/dom/blocks/boundary.js`), specifically in the `#render()` method (line 243). The boundary's `#effect` is a **block effect** that, when re-run, calls `destroy_block_effect_children()` — which **intentionally skips branch effects** (`BRANCH_EFFECT` flag). However, `#main_effect`, `#failed_effect`, and `#pending_effect` are all created via `branch()`, so they are **never destroyed** when the boundary's block effect re-runs.

**The `#render()` method creates new branch effects without destroying the old ones:**

```js
// boundary.js:243-265
#render() {
    try {
        // ← NO cleanup of existing #failed_effect, #main_effect, or #pending_effect
        this.#main_effect = branch(() => { this.#children(this.#anchor); });
        ...
    }
}
```

Compare with the `reset()` function (line 437), which **does** clean up `#failed_effect` via `pause_effect()` before re-rendering. The `#render()` path — triggered when the block effect re-runs due to prop changes — lacks this cleanup.

## Three Interacting Problems

### 1. `#failed_effect` not destroyed on boundary recovery (Svelte)

When a boundary is in a failed state (showing the `failed` snippet) and props change (from navigation), the block effect re-runs `#render()`. `destroy_block_effect_children()` skips the `#failed_effect` (branch effect), and `#render()` doesn't destroy it either. The stale error content persists in the DOM alongside the new content.

### 2. `#main_effect` duplicated by preload fork (Svelte + SvelteKit)

SvelteKit's `forkPreloads` experimental feature creates a preload fork on `mousedown`/`hover` (`packages/kit/src/runtime/client/client.js:2133-2144`). The fork calls `root.$set(target_props)` which triggers `#render()` (creating `#main_effect` #1). When the user clicks and `fork.commit()` runs, the block effect re-runs `#render()` again (creating `#main_effect` #2). Both are branch effects, neither is destroyed → **DOM duplication**.

This was confirmed by toggling `forkPreloads: false`, which eliminated the duplication.

### 3. Async `transformError` race condition (Svelte + SvelteKit)

SvelteKit passes an **async** `transformError` callback to the boundary (`packages/kit/src/runtime/client/client.js:734`):

```js
transformError: async (e) => {
    const error = await handle_error(e, current.nav);
    ...
    return error;
}
```

The boundary's `#handle_error()` queues a microtask (line 501), which calls `transform_error()`. If `transform_error` returns a Promise, `handle_error_result` is deferred until that Promise resolves (line 518). This creates a window where the boundary's block effect can re-run (from navigation prop changes) **before** `handle_error_result` fires. When it finally fires, it creates a `#failed_effect` with the **stale error** from the previous route, overwriting or duplicating the recovered content.

## Why `setTimeout` helps but `tick()`/`flushSync` don't

- **`setTimeout`** defers to the next **macrotask**, allowing all pending microtasks (the boundary's `queue_micro_task` in `#handle_error`, the `transformError` Promise chain, and the fork's batch processing) to drain completely. The boundary reaches a stable state before navigation proceeds.
- **`await tick()`** in async mode waits for `requestAnimationFrame`/`setTimeout` but doesn't guarantee the fork batch or `transformError` Promise has settled.
- **`flushSync`** flushes synchronous effects but doesn't wait for the async `transformError` Promise or resolve the fork's deferred batch state.

## Fix Location

The primary fix belongs in **Svelte** (`svelte/src/internal/client/dom/blocks/boundary.js`):

1. **`#render()` must destroy `#failed_effect`, `#main_effect`, and `#pending_effect`** before creating new ones — mirroring what `reset()` already does for `#failed_effect`.
2. **`handle_error_result` must check if the boundary has recovered** (e.g., `#main_effect !== null`) before creating a `#failed_effect`, to handle the async `transformError` race.

A secondary mitigation in **SvelteKit** could avoid creating preload forks when a boundary is in a failed state, or `await` the `transformError` Promise before allowing navigation to proceed.

## Reproduction Confirmation

A Playwright test in the `test-async` app (which uses `experimental.async: true`, `handleRenderingErrors: true`, `forkPreloads: true`) confirmed:

- Navigating from a failed boundary to a target route produces **duplicate target content** (2× `#value` elements) and **persists the stale failed content**.
- Disabling `forkPreloads` eliminates the duplication but the stale `#failed_effect` still persists (fixed by destroying it in `#render()`).
