### PR TITLE
fix: resolve config paths only after we have `root`

### DIFF
--- a/.changeset/dry-ties-scream.md
+++ b/.changeset/dry-ties-scream.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: resolve service worker and `tsconfig.json` based on Vite `root` setting

--- a/documentation/docs/25-build-and-deploy/40-adapter-node.md
+++ b/documentation/docs/25-build-and-deploy/40-adapter-node.md
@@ -82,7 +82,7 @@ SOCKET_PATH=/tmp/socket node build
 
 HTTP doesn't give SvelteKit a reliable way to know the URL that is currently being requested. By default, SvelteKit will derive the origin from the request's `host` header (and the `https` protocol, if no `PROTOCOL_HEADER` is set).
 
-If your app is served from an origin that isn't known at request time — for example because it's behind a reverse proxy that doesn't pass the `host` header, or because you want to use a canonical origin for CSRF checks that differs from the request's host — you can set the [`paths.origin`](https://svelte.dev/docs/kit/configuration#paths.origin) option in your `vite.config.js`:
+If your app is served from an origin that isn't known at request time — for example because it's behind a reverse proxy that doesn't pass the `host` header, or because you want to use a canonical origin for CSRF checks that differs from the request's host — you can set the [`paths.origin`](configuration#paths) option in your `vite.config.js`:
 
 ```js
 // @errors: 2307

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -6,7 +6,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import * as url from 'node:url';
-import { options, kit_options, kit_experimental_options } from './options.js';
+import {
+	validate_kit_options,
+	kit_options,
+	kit_experimental_options,
+	validate_svelte_options
+} from './options.js';
 import { resolve_entry } from '../../utils/filesystem.js';
 import { import_peer } from '../../utils/import.js';
 
@@ -128,32 +133,91 @@ export async function load_vite_config(config) {
  */
 export function extract_svelte_config(vite_config) {
 	const plugin = vite_config.plugins.find((p) => p.name === 'vite-plugin-sveltekit-setup');
-	return plugin?.api.options ?? process_config({});
+	return plugin?.api.options ?? process_config(validate_config({}), vite_config.root);
+}
+
+/**
+ * @param {ValidatedConfig} config
+ * @param {string} cwd
+ * @returns {ValidatedConfig}
+ */
+export function process_config(config, cwd) {
+	if (
+		config.kit.csp?.directives?.['require-trusted-types-for']?.includes('script') &&
+		config.kit.serviceWorker.register &&
+		resolve_entry(path.resolve(cwd, config.kit.files.serviceWorker)) &&
+		!config.kit.csp?.directives?.['trusted-types']?.includes('svelte-trusted-html')
+	) {
+		throw new Error(
+			"The `csp.directives['trusted-types']` option must include 'sveltekit-trusted-url' when `serviceWorker.register` is true"
+		);
+	}
+
+	config.kit.outDir = path.resolve(cwd, config.kit.outDir);
+	config.kit.env.dir = path.resolve(cwd, config.kit.env.dir);
+
+	for (const key in config.kit.files) {
+		if (key === 'hooks') {
+			config.kit.files.hooks.client = path.resolve(cwd, config.kit.files.hooks.client);
+			config.kit.files.hooks.server = path.resolve(cwd, config.kit.files.hooks.server);
+			config.kit.files.hooks.universal = path.resolve(cwd, config.kit.files.hooks.universal);
+		} else {
+			// @ts-expect-error
+			config.kit.files[key] = path.resolve(cwd, config.kit.files[key]);
+		}
+	}
+
+	return config;
 }
 
 /**
  * @param {Config} config
  * @returns {ValidatedConfig}
  */
-export function process_config(config, { cwd = process.cwd() } = {}) {
+export function validate_config(config) {
 	try {
-		const validated = validate_config(config, cwd);
+		if (typeof config !== 'object') {
+			throw new Error(
+				'The SvelteKit options from the Vite config must be an object. See https://svelte.dev/docs/kit/configuration'
+			);
+		}
 
-		validated.kit.outDir = path.resolve(cwd, validated.kit.outDir);
-		validated.kit.env.dir = path.resolve(cwd, validated.kit.env.dir);
+		const validated = /** @type {ValidatedConfig} */ ({
+			...validate_svelte_options(config, 'config'),
+			kit: validate_kit_options(config.kit, 'config')
+		});
+		const files = validated.kit.files;
 
-		for (const key in validated.kit.files) {
-			if (key === 'hooks') {
-				validated.kit.files.hooks.client = path.resolve(cwd, validated.kit.files.hooks.client);
-				validated.kit.files.hooks.server = path.resolve(cwd, validated.kit.files.hooks.server);
-				validated.kit.files.hooks.universal = path.resolve(
-					cwd,
-					validated.kit.files.hooks.universal
+		files.hooks.client ??= path.join(files.src, 'hooks.client');
+		files.hooks.server ??= path.join(files.src, 'hooks.server');
+		files.hooks.universal ??= path.join(files.src, 'hooks');
+		files.lib ??= path.join(files.src, 'lib');
+		files.params ??= path.join(files.src, 'params');
+		files.routes ??= path.join(files.src, 'routes');
+		files.serviceWorker ??= path.join(files.src, 'service-worker');
+		files.appTemplate ??= path.join(files.src, 'app.html');
+		files.errorTemplate ??= path.join(files.src, 'error.html');
+
+		if (validated.kit.router.resolution === 'server') {
+			if (validated.kit.router.type === 'hash') {
+				throw new Error(
+					"The `router.resolution` option cannot be 'server' if `router.type` is 'hash'"
 				);
-			} else {
-				// @ts-expect-error
-				validated.kit.files[key] = path.resolve(cwd, validated.kit.files[key]);
 			}
+			if (validated.kit.output.bundleStrategy !== 'split') {
+				throw new Error(
+					"The `router.resolution` option cannot be 'server' if `output.bundleStrategy` is 'inline' or 'single'"
+				);
+			}
+		}
+
+		if (
+			validated.kit.csp?.directives?.['require-trusted-types-for']?.includes('script') &&
+			!validated.kit.csp?.directives?.['trusted-types']?.includes('svelte-trusted-html')
+		) {
+			throw new Error(
+				"The `csp.directives['trusted-types']` option must include 'svelte-trusted-html'"
+			);
 		}
 
 		return validated;
@@ -164,63 +228,4 @@ export function process_config(config, { cwd = process.cwd() } = {}) {
 		error.stack = `Error loading SvelteKit options from Vite config: ${error.message}\n`;
 		throw error;
 	}
-}
-
-/**
- * @param {Config} config
- * @param {string} [cwd]
- * @returns {ValidatedConfig}
- */
-export function validate_config(config, cwd = process.cwd()) {
-	if (typeof config !== 'object') {
-		throw new Error(
-			'The SvelteKit options from the Vite config must be an object. See https://svelte.dev/docs/kit/configuration'
-		);
-	}
-
-	/** @type {ValidatedConfig} */
-	const validated = options(config, 'config');
-	const files = validated.kit.files;
-
-	files.hooks.client ??= path.join(files.src, 'hooks.client');
-	files.hooks.server ??= path.join(files.src, 'hooks.server');
-	files.hooks.universal ??= path.join(files.src, 'hooks');
-	files.lib ??= path.join(files.src, 'lib');
-	files.params ??= path.join(files.src, 'params');
-	files.routes ??= path.join(files.src, 'routes');
-	files.serviceWorker ??= path.join(files.src, 'service-worker');
-	files.appTemplate ??= path.join(files.src, 'app.html');
-	files.errorTemplate ??= path.join(files.src, 'error.html');
-
-	if (validated.kit.router.resolution === 'server') {
-		if (validated.kit.router.type === 'hash') {
-			throw new Error(
-				"The `router.resolution` option cannot be 'server' if `router.type` is 'hash'"
-			);
-		}
-		if (validated.kit.output.bundleStrategy !== 'split') {
-			throw new Error(
-				"The `router.resolution` option cannot be 'server' if `output.bundleStrategy` is 'inline' or 'single'"
-			);
-		}
-	}
-
-	if (validated.kit.csp?.directives?.['require-trusted-types-for']?.includes('script')) {
-		if (!validated.kit.csp?.directives?.['trusted-types']?.includes('svelte-trusted-html')) {
-			throw new Error(
-				"The `csp.directives['trusted-types']` option must include 'svelte-trusted-html'"
-			);
-		}
-		if (
-			validated.kit.serviceWorker?.register &&
-			resolve_entry(path.resolve(cwd, validated.kit.files.serviceWorker)) &&
-			!validated.kit.csp?.directives?.['trusted-types']?.includes('sveltekit-trusted-url')
-		) {
-			throw new Error(
-				"The `csp.directives['trusted-types']` option must include 'sveltekit-trusted-url' when `serviceWorker.register` is true"
-			);
-		}
-	}
-
-	return validated;
 }

--- a/packages/kit/src/core/config/index.js
+++ b/packages/kit/src/core/config/index.js
@@ -146,7 +146,7 @@ export function process_config(config, cwd) {
 		config.kit.csp?.directives?.['require-trusted-types-for']?.includes('script') &&
 		config.kit.serviceWorker.register &&
 		resolve_entry(path.resolve(cwd, config.kit.files.serviceWorker)) &&
-		!config.kit.csp?.directives?.['trusted-types']?.includes('svelte-trusted-html')
+		!config.kit.csp?.directives?.['trusted-types']?.includes('sveltekit-trusted-url')
 	) {
 		throw new Error(
 			"The `csp.directives['trusted-types']` option must include 'sveltekit-trusted-url' when `serviceWorker.register` is true"

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -1,3 +1,5 @@
+/** @import { SvelteConfig } from '@sveltejs/vite-plugin-svelte' */
+/** @import { ValidatedKitConfig } from 'types' */
 /** @import { Validator } from './types.js' */
 
 const directives = object({
@@ -34,8 +36,8 @@ const directives = object({
 	referrer: string_array()
 });
 
-/** @type {Validator} */
-export const options = object(
+/** @type {Validator<{ extensions: string[] } & SvelteConfig>} */
+export const validate_svelte_options = object(
 	{
 		extensions: validate(['.svelte'], (input, keypath) => {
 			if (!Array.isArray(input) || !input.every((page) => typeof page === 'string')) {
@@ -53,288 +55,291 @@ export const options = object(
 			});
 
 			return input;
-		}),
-
-		kit: object({
-			adapter: validate(undefined, (input, keypath) => {
-				if (typeof input !== 'object' || !input.adapt) {
-					const message = `The SvelteKit Vite plugin ${keypath} should be an object with an \`adapt\` method`;
-					throw new Error(`${message}. See https://svelte.dev/docs/kit/adapters`);
-				}
-
-				return input;
-			}),
-
-			alias: validate({}, (input, keypath) => {
-				if (typeof input !== 'object') {
-					throw new Error(`${keypath} should be an object`);
-				}
-
-				for (const key in input) {
-					assert_string(input[key], `${keypath}.${key}`);
-				}
-
-				return input;
-			}),
-
-			appDir: validate('_app', (input, keypath) => {
-				assert_string(input, keypath);
-
-				if (input) {
-					if (input.startsWith('/') || input.endsWith('/')) {
-						throw new Error(
-							`${keypath} cannot start or end with '/'. See https://svelte.dev/docs/kit/configuration`
-						);
-					}
-				} else {
-					throw new Error(`${keypath} cannot be empty`);
-				}
-
-				return input;
-			}),
-
-			csp: object({
-				mode: list(['auto', 'hash', 'nonce']),
-				directives,
-				reportOnly: directives
-			}),
-
-			csrf: object({
-				checkOrigin: removed(
-					(keypath) => `\`${keypath}\` has been removed in favour of \`csrf.trustedOrigins\``
-				),
-				trustedOrigins: string_array([])
-			}),
-
-			embedded: boolean(false),
-
-			env: object({
-				dir: string('')
-			}),
-
-			experimental: object({
-				tracing: object({
-					server: boolean(false)
-				}),
-				instrumentation: object({
-					server: boolean(false)
-				}),
-				remoteFunctions: boolean(false),
-				forkPreloads: boolean(false),
-				handleRenderingErrors: boolean(false)
-			}),
-
-			files: object({
-				src: string('src'),
-				assets: string('static'),
-				hooks: object({
-					client: string(null),
-					server: string(null),
-					universal: string(null)
-				}),
-				lib: string(null),
-				params: string(null),
-				routes: string(null),
-				serviceWorker: string(null),
-				appTemplate: string(null),
-				errorTemplate: string(null)
-			}),
-
-			inlineStyleThreshold: number(0),
-
-			moduleExtensions: string_array(['.js', '.ts']),
-
-			outDir: string('.svelte-kit'),
-
-			output: object({
-				linkHeaderPreload: boolean(false),
-				preloadStrategy: removed(
-					(keypath) => `\`${keypath}\` has been removed. modulepreload will always be used`
-				),
-				bundleStrategy: list(['split', 'single', 'inline'])
-			}),
-
-			paths: object({
-				base: validate('', (input, keypath) => {
-					assert_string(input, keypath);
-
-					if (input !== '' && (input.endsWith('/') || !input.startsWith('/'))) {
-						throw new Error(
-							`${keypath} option must either be the empty string or a root-relative path that starts but doesn't end with '/'. See https://svelte.dev/docs/kit/configuration#paths`
-						);
-					}
-
-					return input;
-				}),
-				assets: validate('', (input, keypath) => {
-					assert_string(input, keypath);
-
-					if (input) {
-						if (!/^[a-z]+:\/\//.test(input)) {
-							throw new Error(
-								`${keypath} option must be an absolute path, if specified. See https://svelte.dev/docs/kit/configuration#paths`
-							);
-						}
-
-						if (input.endsWith('/')) {
-							throw new Error(
-								`${keypath} option must not end with '/'. See https://svelte.dev/docs/kit/configuration#paths`
-							);
-						}
-					}
-
-					return input;
-				}),
-				origin: validate(undefined, (input, keypath) => {
-					assert_string(input, keypath);
-
-					let url;
-
-					try {
-						url = new URL(input);
-					} catch {
-						throw new Error(
-							`${keypath} must be a valid origin (e.g. 'https://my-site.com'). '${input}' could not be parsed as a URL`
-						);
-					}
-
-					if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-						throw new Error(
-							`${keypath} must be a valid origin — only 'http' and 'https' protocols are supported, received '${url.protocol}'`
-						);
-					}
-
-					const origin = url.origin;
-
-					if (input !== origin) {
-						throw new Error(
-							`${keypath} must be a valid origin — received '${input}' which contains a path, query, or hash. Use the bare origin '${origin}' instead`
-						);
-					}
-
-					return origin;
-				}),
-				relative: boolean(true)
-			}),
-
-			prerender: object({
-				concurrency: number(1),
-				crawl: boolean(true),
-				entries: validate(['*'], (input, keypath) => {
-					if (!Array.isArray(input) || !input.every((page) => typeof page === 'string')) {
-						throw new Error(`${keypath} must be an array of strings`);
-					}
-
-					input.forEach((page) => {
-						if (page !== '*' && page[0] !== '/') {
-							throw new Error(
-								`Each member of ${keypath} must be either '*' or an absolute path beginning with '/' — saw '${page}'`
-							);
-						}
-					});
-
-					return input;
-				}),
-
-				handleHttpError: validate(
-					(/** @type {any} */ { message }) => {
-						throw new Error(
-							message +
-								'\nTo suppress or handle this error, implement `handleHttpError` in https://svelte.dev/docs/kit/configuration#prerender'
-						);
-					},
-					(input, keypath) => {
-						if (typeof input === 'function') return input;
-						if (['fail', 'warn', 'ignore'].includes(input)) return input;
-						throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
-					}
-				),
-
-				handleMissingId: validate(
-					(/** @type {any} */ { message }) => {
-						throw new Error(
-							message +
-								'\nTo suppress or handle this error, implement `handleMissingId` in https://svelte.dev/docs/kit/configuration#prerender'
-						);
-					},
-					(input, keypath) => {
-						if (typeof input === 'function') return input;
-						if (['fail', 'warn', 'ignore'].includes(input)) return input;
-						throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
-					}
-				),
-
-				handleEntryGeneratorMismatch: validate(
-					(/** @type {any} */ { message }) => {
-						throw new Error(
-							message +
-								'\nTo suppress or handle this error, implement `handleEntryGeneratorMismatch` in https://svelte.dev/docs/kit/configuration#prerender'
-						);
-					},
-					(input, keypath) => {
-						if (typeof input === 'function') return input;
-						if (['fail', 'warn', 'ignore'].includes(input)) return input;
-						throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
-					}
-				),
-
-				handleUnseenRoutes: validate(
-					(/** @type {any} */ { message }) => {
-						throw new Error(
-							message +
-								'\nTo suppress or handle this error, implement `handleUnseenRoutes` in https://svelte.dev/docs/kit/configuration#prerender'
-						);
-					},
-					(input, keypath) => {
-						if (typeof input === 'function') return input;
-						if (['fail', 'warn', 'ignore'].includes(input)) return input;
-						throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
-					}
-				),
-
-				handleInvalidUrl: validate(
-					(/** @type {any} */ { message }) => {
-						throw new Error(
-							message +
-								'\nTo suppress or handle this error, implement `handleInvalidUrl` in https://svelte.dev/docs/kit/configuration#prerender'
-						);
-					},
-					(input, keypath) => {
-						if (typeof input === 'function') return input;
-						if (['fail', 'warn', 'ignore'].includes(input)) return input;
-						throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
-					}
-				),
-
-				origin: removed(
-					(keypath) => `\`${keypath}\` has been removed in favour of \`config.paths.origin\``
-				)
-			}),
-
-			router: object({
-				type: list(['pathname', 'hash']),
-				resolution: list(['client', 'server'])
-			}),
-
-			serviceWorker: object({
-				register: boolean(true),
-				// options could be undefined but if it is defined we only validate that
-				// it's an object since the type comes from the browser itself
-				options: validate(undefined, object({}, true)),
-				files: fun((filename) => !/\.DS_Store/.test(filename))
-			}),
-
-			typescript: object({
-				config: fun((config) => config)
-			}),
-
-			version: object({
-				name: string(Date.now().toString()),
-				pollInterval: number(0)
-			})
 		})
 	},
 	true
+);
+
+/** @type {Validator<ValidatedKitConfig>} */
+export const validate_kit_options = object(
+	{
+		adapter: validate(undefined, (input, keypath) => {
+			if (typeof input !== 'object' || !input.adapt) {
+				const message = `The SvelteKit Vite plugin ${keypath} should be an object with an \`adapt\` method`;
+				throw new Error(`${message}. See https://svelte.dev/docs/kit/adapters`);
+			}
+
+			return input;
+		}),
+
+		alias: validate({}, (input, keypath) => {
+			if (typeof input !== 'object') {
+				throw new Error(`${keypath} should be an object`);
+			}
+
+			for (const key in input) {
+				assert_string(input[key], `${keypath}.${key}`);
+			}
+
+			return input;
+		}),
+
+		appDir: validate('_app', (input, keypath) => {
+			assert_string(input, keypath);
+
+			if (input) {
+				if (input.startsWith('/') || input.endsWith('/')) {
+					throw new Error(
+						`${keypath} cannot start or end with '/'. See https://svelte.dev/docs/kit/configuration`
+					);
+				}
+			} else {
+				throw new Error(`${keypath} cannot be empty`);
+			}
+
+			return input;
+		}),
+
+		csp: object({
+			mode: list(['auto', 'hash', 'nonce']),
+			directives,
+			reportOnly: directives
+		}),
+
+		csrf: object({
+			checkOrigin: removed(
+				(keypath) => `\`${keypath}\` has been removed in favour of \`csrf.trustedOrigins\``
+			),
+			trustedOrigins: string_array([])
+		}),
+
+		embedded: boolean(false),
+
+		env: object({
+			dir: string('')
+		}),
+
+		experimental: object({
+			tracing: object({
+				server: boolean(false)
+			}),
+			instrumentation: object({
+				server: boolean(false)
+			}),
+			remoteFunctions: boolean(false),
+			forkPreloads: boolean(false),
+			handleRenderingErrors: boolean(false)
+		}),
+
+		files: object({
+			src: string('src'),
+			assets: string('static'),
+			hooks: object({
+				client: string(null),
+				server: string(null),
+				universal: string(null)
+			}),
+			lib: string(null),
+			params: string(null),
+			routes: string(null),
+			serviceWorker: string(null),
+			appTemplate: string(null),
+			errorTemplate: string(null)
+		}),
+
+		inlineStyleThreshold: number(0),
+
+		moduleExtensions: string_array(['.js', '.ts']),
+
+		outDir: string('.svelte-kit'),
+
+		output: object({
+			linkHeaderPreload: boolean(false),
+			preloadStrategy: removed(
+				(keypath) => `\`${keypath}\` has been removed. modulepreload will always be used`
+			),
+			bundleStrategy: list(['split', 'single', 'inline'])
+		}),
+
+		paths: object({
+			base: validate('', (input, keypath) => {
+				assert_string(input, keypath);
+
+				if (input !== '' && (input.endsWith('/') || !input.startsWith('/'))) {
+					throw new Error(
+						`${keypath} option must either be the empty string or a root-relative path that starts but doesn't end with '/'. See https://svelte.dev/docs/kit/configuration#paths`
+					);
+				}
+
+				return input;
+			}),
+			assets: validate('', (input, keypath) => {
+				assert_string(input, keypath);
+
+				if (input) {
+					if (!/^[a-z]+:\/\//.test(input)) {
+						throw new Error(
+							`${keypath} option must be an absolute path, if specified. See https://svelte.dev/docs/kit/configuration#paths`
+						);
+					}
+
+					if (input.endsWith('/')) {
+						throw new Error(
+							`${keypath} option must not end with '/'. See https://svelte.dev/docs/kit/configuration#paths`
+						);
+					}
+				}
+
+				return input;
+			}),
+			origin: validate(undefined, (input, keypath) => {
+				assert_string(input, keypath);
+
+				let url;
+
+				try {
+					url = new URL(input);
+				} catch {
+					throw new Error(
+						`${keypath} must be a valid origin (e.g. 'https://my-site.com'). '${input}' could not be parsed as a URL`
+					);
+				}
+
+				if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+					throw new Error(
+						`${keypath} must be a valid origin — only 'http' and 'https' protocols are supported, received '${url.protocol}'`
+					);
+				}
+
+				const origin = url.origin;
+
+				if (input !== origin) {
+					throw new Error(
+						`${keypath} must be a valid origin — received '${input}' which contains a path, query, or hash. Use the bare origin '${origin}' instead`
+					);
+				}
+
+				return origin;
+			}),
+			relative: boolean(true)
+		}),
+
+		prerender: object({
+			concurrency: number(1),
+			crawl: boolean(true),
+			entries: validate(['*'], (input, keypath) => {
+				if (!Array.isArray(input) || !input.every((page) => typeof page === 'string')) {
+					throw new Error(`${keypath} must be an array of strings`);
+				}
+
+				input.forEach((page) => {
+					if (page !== '*' && page[0] !== '/') {
+						throw new Error(
+							`Each member of ${keypath} must be either '*' or an absolute path beginning with '/' — saw '${page}'`
+						);
+					}
+				});
+
+				return input;
+			}),
+
+			handleHttpError: validate(
+				(/** @type {any} */ { message }) => {
+					throw new Error(
+						message +
+							'\nTo suppress or handle this error, implement `handleHttpError` in https://svelte.dev/docs/kit/configuration#prerender'
+					);
+				},
+				(input, keypath) => {
+					if (typeof input === 'function') return input;
+					if (['fail', 'warn', 'ignore'].includes(input)) return input;
+					throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
+				}
+			),
+
+			handleMissingId: validate(
+				(/** @type {any} */ { message }) => {
+					throw new Error(
+						message +
+							'\nTo suppress or handle this error, implement `handleMissingId` in https://svelte.dev/docs/kit/configuration#prerender'
+					);
+				},
+				(input, keypath) => {
+					if (typeof input === 'function') return input;
+					if (['fail', 'warn', 'ignore'].includes(input)) return input;
+					throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
+				}
+			),
+
+			handleEntryGeneratorMismatch: validate(
+				(/** @type {any} */ { message }) => {
+					throw new Error(
+						message +
+							'\nTo suppress or handle this error, implement `handleEntryGeneratorMismatch` in https://svelte.dev/docs/kit/configuration#prerender'
+					);
+				},
+				(input, keypath) => {
+					if (typeof input === 'function') return input;
+					if (['fail', 'warn', 'ignore'].includes(input)) return input;
+					throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
+				}
+			),
+
+			handleUnseenRoutes: validate(
+				(/** @type {any} */ { message }) => {
+					throw new Error(
+						message +
+							'\nTo suppress or handle this error, implement `handleUnseenRoutes` in https://svelte.dev/docs/kit/configuration#prerender'
+					);
+				},
+				(input, keypath) => {
+					if (typeof input === 'function') return input;
+					if (['fail', 'warn', 'ignore'].includes(input)) return input;
+					throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
+				}
+			),
+
+			handleInvalidUrl: validate(
+				(/** @type {any} */ { message }) => {
+					throw new Error(
+						message +
+							'\nTo suppress or handle this error, implement `handleInvalidUrl` in https://svelte.dev/docs/kit/configuration#prerender'
+					);
+				},
+				(input, keypath) => {
+					if (typeof input === 'function') return input;
+					if (['fail', 'warn', 'ignore'].includes(input)) return input;
+					throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
+				}
+			),
+
+			origin: removed(
+				(keypath) => `\`${keypath}\` has been removed in favour of \`config.paths.origin\``
+			)
+		}),
+
+		router: object({
+			type: list(['pathname', 'hash']),
+			resolution: list(['client', 'server'])
+		}),
+
+		serviceWorker: object({
+			register: boolean(true),
+			// options could be undefined but if it is defined we only validate that
+			// it's an object since the type comes from the browser itself
+			options: validate(undefined, object({}, true)),
+			files: fun((filename) => !/\.DS_Store/.test(filename))
+		}),
+
+		typescript: object({
+			config: fun((config) => config)
+		}),
+
+		version: object({
+			name: string(Date.now().toString()),
+			pollInterval: number(0)
+		})
+	},
 );
 
 // /**
@@ -361,13 +366,13 @@ export const options = object(
 // Derive the names of SvelteKit's own config options from the schema, so they
 // stay in sync automatically. These are used to separate Kit's options from
 // `vite-plugin-svelte`'s options when config is passed via the Vite plugin.
-const defaults = /** @type {Record<string, any>} */ (options({}, 'config'));
+const kit_defaults = validate_kit_options({}, 'config');
 
 /** The names of the options that live under the `kit` namespace */
-export const kit_options = Object.keys(defaults.kit);
+export const kit_options = Object.keys(kit_defaults);
 
 /** The names of the options that live under the `kit.experimental` namespace */
-export const kit_experimental_options = Object.keys(defaults.kit.experimental);
+export const kit_experimental_options = Object.keys(kit_defaults.experimental);
 
 /**
  * @param {(keypath: string) => string} get_message
@@ -378,8 +383,6 @@ function removed(
 		`The \`${keypath}\` option has been removed. Please see the list of breaking changes for your major release`
 ) {
 	return (input, keypath) => {
-		keypath = remove_kit_prefix(keypath);
-
 		if (typeof input !== 'undefined') {
 			throw new Error(get_message(keypath));
 		}
@@ -393,8 +396,6 @@ function removed(
  */
 export function object(children, allow_unknown = false) {
 	return (input, keypath) => {
-		keypath = remove_kit_prefix(keypath);
-
 		/** @type {Record<string, any>} */
 		const output = {};
 
@@ -410,7 +411,7 @@ export function object(children, allow_unknown = false) {
 					let message = `Unexpected option ${keypath}.${key}`;
 
 					// special case
-					if (keypath === 'config.kit' && key in options) {
+					if (keypath === 'config.kit' && key in kit_options) {
 						message += ` (did you mean config.${key}?)`;
 					}
 
@@ -435,7 +436,6 @@ export function object(children, allow_unknown = false) {
  */
 export function validate(fallback, fn) {
 	return (input, keypath) => {
-		keypath = remove_kit_prefix(keypath);
 		return input === undefined ? fallback : fn(input, keypath);
 	};
 }
@@ -533,16 +533,7 @@ function fun(fallback) {
  * @param {string} keypath
  */
 function assert_string(input, keypath) {
-	keypath = remove_kit_prefix(keypath);
 	if (typeof input !== 'string') {
 		throw new Error(`${keypath} should be a string, if specified`);
 	}
-}
-
-/**
- * @param {string} keypath
- * @deprecated TODO get rid of the nesting so this is unnecessary
- */
-function remove_kit_prefix(keypath) {
-	return keypath.replace('.kit.', '.');
 }

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -61,286 +61,284 @@ export const validate_svelte_options = object(
 );
 
 /** @type {Validator<ValidatedKitConfig>} */
-export const validate_kit_options = object(
-	{
-		adapter: validate(undefined, (input, keypath) => {
-			if (typeof input !== 'object' || !input.adapt) {
-				const message = `The SvelteKit Vite plugin ${keypath} should be an object with an \`adapt\` method`;
-				throw new Error(`${message}. See https://svelte.dev/docs/kit/adapters`);
+export const validate_kit_options = object({
+	adapter: validate(undefined, (input, keypath) => {
+		if (typeof input !== 'object' || !input.adapt) {
+			const message = `The SvelteKit Vite plugin ${keypath} should be an object with an \`adapt\` method`;
+			throw new Error(`${message}. See https://svelte.dev/docs/kit/adapters`);
+		}
+
+		return input;
+	}),
+
+	alias: validate({}, (input, keypath) => {
+		if (typeof input !== 'object') {
+			throw new Error(`${keypath} should be an object`);
+		}
+
+		for (const key in input) {
+			assert_string(input[key], `${keypath}.${key}`);
+		}
+
+		return input;
+	}),
+
+	appDir: validate('_app', (input, keypath) => {
+		assert_string(input, keypath);
+
+		if (input) {
+			if (input.startsWith('/') || input.endsWith('/')) {
+				throw new Error(
+					`${keypath} cannot start or end with '/'. See https://svelte.dev/docs/kit/configuration`
+				);
+			}
+		} else {
+			throw new Error(`${keypath} cannot be empty`);
+		}
+
+		return input;
+	}),
+
+	csp: object({
+		mode: list(['auto', 'hash', 'nonce']),
+		directives,
+		reportOnly: directives
+	}),
+
+	csrf: object({
+		checkOrigin: removed(
+			(keypath) => `\`${keypath}\` has been removed in favour of \`csrf.trustedOrigins\``
+		),
+		trustedOrigins: string_array([])
+	}),
+
+	embedded: boolean(false),
+
+	env: object({
+		dir: string('')
+	}),
+
+	experimental: object({
+		tracing: object({
+			server: boolean(false)
+		}),
+		instrumentation: object({
+			server: boolean(false)
+		}),
+		remoteFunctions: boolean(false),
+		forkPreloads: boolean(false),
+		handleRenderingErrors: boolean(false)
+	}),
+
+	files: object({
+		src: string('src'),
+		assets: string('static'),
+		hooks: object({
+			client: string(null),
+			server: string(null),
+			universal: string(null)
+		}),
+		lib: string(null),
+		params: string(null),
+		routes: string(null),
+		serviceWorker: string(null),
+		appTemplate: string(null),
+		errorTemplate: string(null)
+	}),
+
+	inlineStyleThreshold: number(0),
+
+	moduleExtensions: string_array(['.js', '.ts']),
+
+	outDir: string('.svelte-kit'),
+
+	output: object({
+		linkHeaderPreload: boolean(false),
+		preloadStrategy: removed(
+			(keypath) => `\`${keypath}\` has been removed. modulepreload will always be used`
+		),
+		bundleStrategy: list(['split', 'single', 'inline'])
+	}),
+
+	paths: object({
+		base: validate('', (input, keypath) => {
+			assert_string(input, keypath);
+
+			if (input !== '' && (input.endsWith('/') || !input.startsWith('/'))) {
+				throw new Error(
+					`${keypath} option must either be the empty string or a root-relative path that starts but doesn't end with '/'. See https://svelte.dev/docs/kit/configuration#paths`
+				);
 			}
 
 			return input;
 		}),
-
-		alias: validate({}, (input, keypath) => {
-			if (typeof input !== 'object') {
-				throw new Error(`${keypath} should be an object`);
-			}
-
-			for (const key in input) {
-				assert_string(input[key], `${keypath}.${key}`);
-			}
-
-			return input;
-		}),
-
-		appDir: validate('_app', (input, keypath) => {
+		assets: validate('', (input, keypath) => {
 			assert_string(input, keypath);
 
 			if (input) {
-				if (input.startsWith('/') || input.endsWith('/')) {
+				if (!/^[a-z]+:\/\//.test(input)) {
 					throw new Error(
-						`${keypath} cannot start or end with '/'. See https://svelte.dev/docs/kit/configuration`
+						`${keypath} option must be an absolute path, if specified. See https://svelte.dev/docs/kit/configuration#paths`
 					);
 				}
-			} else {
-				throw new Error(`${keypath} cannot be empty`);
+
+				if (input.endsWith('/')) {
+					throw new Error(
+						`${keypath} option must not end with '/'. See https://svelte.dev/docs/kit/configuration#paths`
+					);
+				}
 			}
 
 			return input;
 		}),
+		origin: validate(undefined, (input, keypath) => {
+			assert_string(input, keypath);
 
-		csp: object({
-			mode: list(['auto', 'hash', 'nonce']),
-			directives,
-			reportOnly: directives
+			let url;
+
+			try {
+				url = new URL(input);
+			} catch {
+				throw new Error(
+					`${keypath} must be a valid origin (e.g. 'https://my-site.com'). '${input}' could not be parsed as a URL`
+				);
+			}
+
+			if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+				throw new Error(
+					`${keypath} must be a valid origin — only 'http' and 'https' protocols are supported, received '${url.protocol}'`
+				);
+			}
+
+			const origin = url.origin;
+
+			if (input !== origin) {
+				throw new Error(
+					`${keypath} must be a valid origin — received '${input}' which contains a path, query, or hash. Use the bare origin '${origin}' instead`
+				);
+			}
+
+			return origin;
 		}),
+		relative: boolean(true)
+	}),
 
-		csrf: object({
-			checkOrigin: removed(
-				(keypath) => `\`${keypath}\` has been removed in favour of \`csrf.trustedOrigins\``
-			),
-			trustedOrigins: string_array([])
-		}),
+	prerender: object({
+		concurrency: number(1),
+		crawl: boolean(true),
+		entries: validate(['*'], (input, keypath) => {
+			if (!Array.isArray(input) || !input.every((page) => typeof page === 'string')) {
+				throw new Error(`${keypath} must be an array of strings`);
+			}
 
-		embedded: boolean(false),
-
-		env: object({
-			dir: string('')
-		}),
-
-		experimental: object({
-			tracing: object({
-				server: boolean(false)
-			}),
-			instrumentation: object({
-				server: boolean(false)
-			}),
-			remoteFunctions: boolean(false),
-			forkPreloads: boolean(false),
-			handleRenderingErrors: boolean(false)
-		}),
-
-		files: object({
-			src: string('src'),
-			assets: string('static'),
-			hooks: object({
-				client: string(null),
-				server: string(null),
-				universal: string(null)
-			}),
-			lib: string(null),
-			params: string(null),
-			routes: string(null),
-			serviceWorker: string(null),
-			appTemplate: string(null),
-			errorTemplate: string(null)
-		}),
-
-		inlineStyleThreshold: number(0),
-
-		moduleExtensions: string_array(['.js', '.ts']),
-
-		outDir: string('.svelte-kit'),
-
-		output: object({
-			linkHeaderPreload: boolean(false),
-			preloadStrategy: removed(
-				(keypath) => `\`${keypath}\` has been removed. modulepreload will always be used`
-			),
-			bundleStrategy: list(['split', 'single', 'inline'])
-		}),
-
-		paths: object({
-			base: validate('', (input, keypath) => {
-				assert_string(input, keypath);
-
-				if (input !== '' && (input.endsWith('/') || !input.startsWith('/'))) {
+			input.forEach((page) => {
+				if (page !== '*' && page[0] !== '/') {
 					throw new Error(
-						`${keypath} option must either be the empty string or a root-relative path that starts but doesn't end with '/'. See https://svelte.dev/docs/kit/configuration#paths`
+						`Each member of ${keypath} must be either '*' or an absolute path beginning with '/' — saw '${page}'`
 					);
 				}
+			});
 
-				return input;
-			}),
-			assets: validate('', (input, keypath) => {
-				assert_string(input, keypath);
-
-				if (input) {
-					if (!/^[a-z]+:\/\//.test(input)) {
-						throw new Error(
-							`${keypath} option must be an absolute path, if specified. See https://svelte.dev/docs/kit/configuration#paths`
-						);
-					}
-
-					if (input.endsWith('/')) {
-						throw new Error(
-							`${keypath} option must not end with '/'. See https://svelte.dev/docs/kit/configuration#paths`
-						);
-					}
-				}
-
-				return input;
-			}),
-			origin: validate(undefined, (input, keypath) => {
-				assert_string(input, keypath);
-
-				let url;
-
-				try {
-					url = new URL(input);
-				} catch {
-					throw new Error(
-						`${keypath} must be a valid origin (e.g. 'https://my-site.com'). '${input}' could not be parsed as a URL`
-					);
-				}
-
-				if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-					throw new Error(
-						`${keypath} must be a valid origin — only 'http' and 'https' protocols are supported, received '${url.protocol}'`
-					);
-				}
-
-				const origin = url.origin;
-
-				if (input !== origin) {
-					throw new Error(
-						`${keypath} must be a valid origin — received '${input}' which contains a path, query, or hash. Use the bare origin '${origin}' instead`
-					);
-				}
-
-				return origin;
-			}),
-			relative: boolean(true)
+			return input;
 		}),
 
-		prerender: object({
-			concurrency: number(1),
-			crawl: boolean(true),
-			entries: validate(['*'], (input, keypath) => {
-				if (!Array.isArray(input) || !input.every((page) => typeof page === 'string')) {
-					throw new Error(`${keypath} must be an array of strings`);
-				}
+		handleHttpError: validate(
+			(/** @type {any} */ { message }) => {
+				throw new Error(
+					message +
+						'\nTo suppress or handle this error, implement `handleHttpError` in https://svelte.dev/docs/kit/configuration#prerender'
+				);
+			},
+			(input, keypath) => {
+				if (typeof input === 'function') return input;
+				if (['fail', 'warn', 'ignore'].includes(input)) return input;
+				throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
+			}
+		),
 
-				input.forEach((page) => {
-					if (page !== '*' && page[0] !== '/') {
-						throw new Error(
-							`Each member of ${keypath} must be either '*' or an absolute path beginning with '/' — saw '${page}'`
-						);
-					}
-				});
+		handleMissingId: validate(
+			(/** @type {any} */ { message }) => {
+				throw new Error(
+					message +
+						'\nTo suppress or handle this error, implement `handleMissingId` in https://svelte.dev/docs/kit/configuration#prerender'
+				);
+			},
+			(input, keypath) => {
+				if (typeof input === 'function') return input;
+				if (['fail', 'warn', 'ignore'].includes(input)) return input;
+				throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
+			}
+		),
 
-				return input;
-			}),
+		handleEntryGeneratorMismatch: validate(
+			(/** @type {any} */ { message }) => {
+				throw new Error(
+					message +
+						'\nTo suppress or handle this error, implement `handleEntryGeneratorMismatch` in https://svelte.dev/docs/kit/configuration#prerender'
+				);
+			},
+			(input, keypath) => {
+				if (typeof input === 'function') return input;
+				if (['fail', 'warn', 'ignore'].includes(input)) return input;
+				throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
+			}
+		),
 
-			handleHttpError: validate(
-				(/** @type {any} */ { message }) => {
-					throw new Error(
-						message +
-							'\nTo suppress or handle this error, implement `handleHttpError` in https://svelte.dev/docs/kit/configuration#prerender'
-					);
-				},
-				(input, keypath) => {
-					if (typeof input === 'function') return input;
-					if (['fail', 'warn', 'ignore'].includes(input)) return input;
-					throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
-				}
-			),
+		handleUnseenRoutes: validate(
+			(/** @type {any} */ { message }) => {
+				throw new Error(
+					message +
+						'\nTo suppress or handle this error, implement `handleUnseenRoutes` in https://svelte.dev/docs/kit/configuration#prerender'
+				);
+			},
+			(input, keypath) => {
+				if (typeof input === 'function') return input;
+				if (['fail', 'warn', 'ignore'].includes(input)) return input;
+				throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
+			}
+		),
 
-			handleMissingId: validate(
-				(/** @type {any} */ { message }) => {
-					throw new Error(
-						message +
-							'\nTo suppress or handle this error, implement `handleMissingId` in https://svelte.dev/docs/kit/configuration#prerender'
-					);
-				},
-				(input, keypath) => {
-					if (typeof input === 'function') return input;
-					if (['fail', 'warn', 'ignore'].includes(input)) return input;
-					throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
-				}
-			),
+		handleInvalidUrl: validate(
+			(/** @type {any} */ { message }) => {
+				throw new Error(
+					message +
+						'\nTo suppress or handle this error, implement `handleInvalidUrl` in https://svelte.dev/docs/kit/configuration#prerender'
+				);
+			},
+			(input, keypath) => {
+				if (typeof input === 'function') return input;
+				if (['fail', 'warn', 'ignore'].includes(input)) return input;
+				throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
+			}
+		),
 
-			handleEntryGeneratorMismatch: validate(
-				(/** @type {any} */ { message }) => {
-					throw new Error(
-						message +
-							'\nTo suppress or handle this error, implement `handleEntryGeneratorMismatch` in https://svelte.dev/docs/kit/configuration#prerender'
-					);
-				},
-				(input, keypath) => {
-					if (typeof input === 'function') return input;
-					if (['fail', 'warn', 'ignore'].includes(input)) return input;
-					throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
-				}
-			),
+		origin: removed(
+			(keypath) => `\`${keypath}\` has been removed in favour of \`config.paths.origin\``
+		)
+	}),
 
-			handleUnseenRoutes: validate(
-				(/** @type {any} */ { message }) => {
-					throw new Error(
-						message +
-							'\nTo suppress or handle this error, implement `handleUnseenRoutes` in https://svelte.dev/docs/kit/configuration#prerender'
-					);
-				},
-				(input, keypath) => {
-					if (typeof input === 'function') return input;
-					if (['fail', 'warn', 'ignore'].includes(input)) return input;
-					throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
-				}
-			),
+	router: object({
+		type: list(['pathname', 'hash']),
+		resolution: list(['client', 'server'])
+	}),
 
-			handleInvalidUrl: validate(
-				(/** @type {any} */ { message }) => {
-					throw new Error(
-						message +
-							'\nTo suppress or handle this error, implement `handleInvalidUrl` in https://svelte.dev/docs/kit/configuration#prerender'
-					);
-				},
-				(input, keypath) => {
-					if (typeof input === 'function') return input;
-					if (['fail', 'warn', 'ignore'].includes(input)) return input;
-					throw new Error(`${keypath} should be "fail", "warn", "ignore" or a custom function`);
-				}
-			),
+	serviceWorker: object({
+		register: boolean(true),
+		// options could be undefined but if it is defined we only validate that
+		// it's an object since the type comes from the browser itself
+		options: validate(undefined, object({}, true)),
+		files: fun((filename) => !/\.DS_Store/.test(filename))
+	}),
 
-			origin: removed(
-				(keypath) => `\`${keypath}\` has been removed in favour of \`config.paths.origin\``
-			)
-		}),
+	typescript: object({
+		config: fun((config) => config)
+	}),
 
-		router: object({
-			type: list(['pathname', 'hash']),
-			resolution: list(['client', 'server'])
-		}),
-
-		serviceWorker: object({
-			register: boolean(true),
-			// options could be undefined but if it is defined we only validate that
-			// it's an object since the type comes from the browser itself
-			options: validate(undefined, object({}, true)),
-			files: fun((filename) => !/\.DS_Store/.test(filename))
-		}),
-
-		typescript: object({
-			config: fun((config) => config)
-		}),
-
-		version: object({
-			name: string(Date.now().toString()),
-			pollInterval: number(0)
-		})
-	},
-);
+	version: object({
+		name: string(Date.now().toString()),
+		pollInterval: number(0)
+	})
+});
 
 // /**
 //  * @param {Validator} fn

--- a/packages/kit/src/core/config/types.d.ts
+++ b/packages/kit/src/core/config/types.d.ts
@@ -1,1 +1,1 @@
-export type Validator<T = any> = (input: T, keypath: string) => T;
+export type Validator<T = any> = (input: any, keypath: string) => T;

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1148,7 +1148,6 @@ function kit({ svelte_config }) {
 			return !!service_worker_entry_file && environment.config.consumer === 'client';
 		},
 		transform(code, id) {
-			console.log({ service_worker_entry_file, id });
 			if (id !== service_worker_entry_file) return;
 
 			// prepend the service worker with an import that configures

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -981,6 +981,8 @@ function kit({ svelte_config }) {
 
 			if (!service_worker_entry_file) return;
 
+			service_worker_entry_file = posixify(service_worker_entry_file);
+
 			if (kit.paths.assets) {
 				throw new Error('Cannot use service worker alongside config.paths.assets');
 			}
@@ -1162,6 +1164,7 @@ function kit({ svelte_config }) {
 			return !!service_worker_entry_file && environment.config.consumer === 'client';
 		},
 		transform(code, id) {
+			console.log({ service_worker_entry_file, id });
 			if (id !== service_worker_entry_file) return;
 
 			// prepend the service worker with an import that configures

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -323,6 +323,10 @@ function kit({ svelte_config }) {
 			options: svelte_config
 		},
 
+		applyToEnvironment(environment) {
+			return environment.name !== 'serviceWorker';
+		},
+
 		/**
 		 * Build the SvelteKit-provided Vite config to be merged with the user's vite.config.js file.
 		 * @see https://vitejs.dev/guide/api-plugin.html#config
@@ -517,6 +521,10 @@ function kit({ svelte_config }) {
 	const plugin_virtual_modules = {
 		name: 'vite-plugin-sveltekit-virtual-modules',
 
+		applyToEnvironment(environment) {
+			return environment.name !== 'serviceWorker';
+		},
+
 		async configResolved(config) {
 			explicit_env_entry = resolve_explicit_env_entry(kit);
 			explicit_env_config = await sync.env(kit, explicit_env_entry, config.root, config.mode);
@@ -550,10 +558,6 @@ function kit({ svelte_config }) {
 					server.ws.send({ type: 'full-reload' });
 				}
 			});
-		},
-
-		applyToEnvironment(environment) {
-			return environment.name !== 'serviceWorker';
 		},
 
 		resolveId: {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -54,10 +54,13 @@ import {
 import { import_peer } from '../../utils/import.js';
 import { compact } from '../../utils/array.js';
 import { should_ignore, has_children } from './static_analysis/utils.js';
-import { process_config, split_config } from '../../core/config/index.js';
+import { process_config, split_config, validate_config } from '../../core/config/index.js';
 import { treeshake_prerendered_remotes } from './build/remote.js';
 
-/** @type {string} */
+/**
+ * Populated after Vite plugins' `config` hooks run
+ * @type {string}
+ */
 let root;
 
 /** @type {import('./types.js').EnforcedConfig} */
@@ -162,7 +165,7 @@ export async function sveltekit(config) {
 	// any options passed to the plugin that SvelteKit doesn't use itself are
 	// forwarded to vite-plugin-svelte, which does its own validation
 	const split = split_config(config ?? {});
-	const svelte_config = process_config(split.svelte_config, { cwd });
+	const svelte_config = validate_config(split.svelte_config);
 
 	if (Array.isArray(svelte_config.preprocess)) {
 		svelte_config.preprocess.push(warning_preprocessor);
@@ -197,7 +200,7 @@ export async function sveltekit(config) {
 	}
 
 	return [
-		plugin_svelte_config(),
+		plugin_root(),
 		...vite_plugin_svelte.svelte(inline_vps_config),
 		...kit({
 			svelte_config
@@ -213,7 +216,7 @@ function resolve_root(vite_config) {
 /**
  * @return {Plugin}
  */
-function plugin_svelte_config() {
+function plugin_root() {
 	return {
 		name: 'vite-plugin-sveltekit-resolve-svelte-config',
 		// make sure it runs first
@@ -223,9 +226,8 @@ function plugin_svelte_config() {
 			handler(config) {
 				root = resolve_root(config);
 
-				// TODO: mjs mts?
 				const config_file = ['svelte.config.js', 'svelte.config.ts'].find((file) =>
-					fs.existsSync(`${root}/${file}`)
+					fs.existsSync(path.join(root, file))
 				);
 				if (config_file) {
 					throw new Error(
@@ -255,7 +257,7 @@ function plugin_svelte_config() {
  * - https://rolldown.rs/apis/plugin-api#output-generation-hooks
  *
  * @param {object} opts
- * @param {import('types').ValidatedConfig} opts.svelte_config options are only resolved after the Vite `config` hook runs
+ * @param {import('types').ValidatedConfig} opts.svelte_config
  * @return {Plugin[]}
  */
 function kit({ svelte_config }) {
@@ -291,7 +293,7 @@ function kit({ svelte_config }) {
 	let initial_config;
 
 	/** @type {string | null} */
-	let service_worker_entry_file = resolve_entry(svelte_config.kit.files.serviceWorker);
+	let service_worker_entry_file;
 	/** @type {import('node:path').ParsedPath} */
 	let parsed_service_worker;
 
@@ -335,7 +337,8 @@ function kit({ svelte_config }) {
 				initial_config = config;
 				is_build = config_env.command === 'build';
 
-				({ kit } = svelte_config);
+				kit = process_config(svelte_config, root).kit;
+
 				out_dir = posixify(kit.outDir);
 				out = `${out_dir}/output`;
 
@@ -1022,8 +1025,8 @@ function kit({ svelte_config }) {
 			return new_config;
 		},
 
-		// the serviceWorker environment only applies during build because Vite currently
-		// only supports the default client environment during development
+		// our serviceWorker environment only exists when building because Vite only
+		// supports the default client environment during development (for now)
 		applyToEnvironment(environment) {
 			return environment.name === 'serviceWorker';
 		},
@@ -1150,18 +1153,12 @@ function kit({ svelte_config }) {
 					`Cannot import ${stripped} into service-worker code. Only the modules $service-worker and $app/env/public are available in service workers.`
 				);
 			}
-		}
-	};
-
-	/** @type {Plugin} */
-	const plugin_service_worker_env = {
-		name: 'vite-plugin-sveltekit-service-worker-env',
+		},
 
 		transform: {
-			filter: {
-				id: service_worker_entry_file || '<skip>'
-			},
-			handler(code) {
+			handler(code, id) {
+				if (id !== service_worker_entry_file) return;
+
 				// prepend the service worker with an import that configures
 				// `env`, in case `$app/env/public` is imported. In production
 				// this is required: dynamic public env vars aren't known at
@@ -1854,7 +1851,6 @@ function kit({ svelte_config }) {
 			plugin_remote,
 			plugin_virtual_modules,
 			process.env.TEST !== 'true' ? plugin_guard : undefined,
-			service_worker_entry_file ? plugin_service_worker_env : undefined,
 			plugin_service_worker,
 			plugin_compile,
 			plugin_adapter

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -952,28 +952,6 @@ function kit({ svelte_config }) {
 		}
 	};
 
-	/** @type {Plugin} */
-	const plugin_service_worker_env = {
-		name: 'vite-plugin-sveltekit-service-worker-env',
-		applyToEnvironment(environment) {
-			return !!service_worker_entry_file && environment.config.consumer === 'client';
-		},
-		transform: {
-			handler(code, id) {
-				if (id !== service_worker_entry_file) return;
-
-				// prepend the service worker with an import that configures
-				// `env`, in case `$app/env/public` is imported. In production
-				// this is required: dynamic public env vars aren't known at
-				// build time, so `env.js` is loaded at runtime. In dev, the
-				// imported module just inlines the current values instead.
-				return {
-					code: `import '__sveltekit/env/service-worker';\n${code}`
-				};
-			}
-		}
-	};
-
 	/** @type {Manifest} */
 	let vite_server_manifest;
 	/** @type {Manifest | null} */
@@ -1169,6 +1147,28 @@ function kit({ svelte_config }) {
 				throw new Error(
 					`Cannot import ${stripped} into service-worker code. Only the modules $service-worker and $app/env/public are available in service workers.`
 				);
+			}
+		}
+	};
+
+	/** @type {Plugin} */
+	const plugin_service_worker_env = {
+		name: 'vite-plugin-sveltekit-service-worker-env',
+		applyToEnvironment(environment) {
+			return !!service_worker_entry_file && environment.config.consumer === 'client';
+		},
+		transform: {
+			handler(code, id) {
+				if (id !== service_worker_entry_file) return;
+
+				// prepend the service worker with an import that configures
+				// `env`, in case `$app/env/public` is imported. In production
+				// this is required: dynamic public env vars aren't known at
+				// build time, so `env.js` is loaded at runtime. In dev, the
+				// imported module just inlines the current values instead.
+				return {
+					code: `import '__sveltekit/env/service-worker';\n${code}`
+				};
 			}
 		}
 	};

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -323,10 +323,6 @@ function kit({ svelte_config }) {
 			options: svelte_config
 		},
 
-		applyToEnvironment(environment) {
-			return environment.name !== 'serviceWorker';
-		},
-
 		/**
 		 * Build the SvelteKit-provided Vite config to be merged with the user's vite.config.js file.
 		 * @see https://vitejs.dev/guide/api-plugin.html#config
@@ -521,10 +517,6 @@ function kit({ svelte_config }) {
 	const plugin_virtual_modules = {
 		name: 'vite-plugin-sveltekit-virtual-modules',
 
-		applyToEnvironment(environment) {
-			return environment.name !== 'serviceWorker';
-		},
-
 		async configResolved(config) {
 			explicit_env_entry = resolve_explicit_env_entry(kit);
 			explicit_env_config = await sync.env(kit, explicit_env_entry, config.root, config.mode);
@@ -558,6 +550,10 @@ function kit({ svelte_config }) {
 					server.ws.send({ type: 'full-reload' });
 				}
 			});
+		},
+
+		applyToEnvironment(environment) {
+			return environment.name !== 'serviceWorker';
 		},
 
 		resolveId: {
@@ -807,7 +803,7 @@ function kit({ svelte_config }) {
 		name: 'vite-plugin-sveltekit-remote',
 
 		applyToEnvironment(environment) {
-			return environment.name !== 'serviceWorker';
+			return svelte_config.kit.experimental.remoteFunctions && environment.name !== 'serviceWorker';
 		},
 
 		// prevent other plugins from resolving our remote virtual module
@@ -825,10 +821,6 @@ function kit({ svelte_config }) {
 				id: prefixRegex('\0sveltekit-remote:')
 			},
 			handler(id) {
-				if (!kit.experimental.remoteFunctions) {
-					return null;
-				}
-
 				// On-the-fly generated entry point for remote file just forwards the original module
 				// We're not using manualChunks because it can cause problems with circular dependencies
 				// (e.g. https://github.com/sveltejs/kit/issues/14679) and module ordering in general
@@ -841,18 +833,10 @@ function kit({ svelte_config }) {
 		},
 
 		configureServer(_dev_server) {
-			if (!kit.experimental.remoteFunctions) {
-				return;
-			}
-
 			dev_server = _dev_server;
 		},
 
 		async transform(code, id) {
-			if (!kit.experimental.remoteFunctions) {
-				return;
-			}
-
 			const normalized = normalize_id(id, normalized_lib, normalized_cwd);
 			if (!svelte_config.kit.moduleExtensions.some((ext) => normalized.endsWith(`.remote${ext}`))) {
 				return;
@@ -1185,10 +1169,6 @@ function kit({ svelte_config }) {
 	const plugin_compile = {
 		name: 'vite-plugin-sveltekit-compile',
 
-		applyToEnvironment(environment) {
-			return environment.name !== 'serviceWorker';
-		},
-
 		/**
 		 * Build the SvelteKit-provided Vite config to be merged with the user's vite.config.js file.
 		 * @see https://vitejs.dev/guide/api-plugin.html#config
@@ -1453,6 +1433,10 @@ function kit({ svelte_config }) {
 		 */
 		configurePreviewServer(vite) {
 			return preview(vite, vite_config, svelte_config);
+		},
+
+		applyToEnvironment(environment) {
+			return environment.name !== 'serviceWorker';
 		},
 
 		renderChunk(code, chunk) {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -337,7 +337,7 @@ function kit({ svelte_config }) {
 				initial_config = config;
 				is_build = config_env.command === 'build';
 
-				kit = process_config(svelte_config, root).kit;
+				({ kit } = process_config(svelte_config, root));
 
 				out_dir = posixify(kit.outDir);
 				out = `${out_dir}/output`;
@@ -1153,12 +1153,18 @@ function kit({ svelte_config }) {
 					`Cannot import ${stripped} into service-worker code. Only the modules $service-worker and $app/env/public are available in service workers.`
 				);
 			}
-		},
+		}
+	};
+
+	/** @type {Plugin} */
+	const plugin_service_worker_env = {
+		name: 'vite-plugin-sveltekit-service-worker-env',
 
 		transform: {
-			handler(code, id) {
-				if (id !== service_worker_entry_file) return;
-
+			filter: {
+				id: service_worker_entry_file
+			},
+			handler(code) {
 				// prepend the service worker with an import that configures
 				// `env`, in case `$app/env/public` is imported. In production
 				// this is required: dynamic public env vars aren't known at

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -334,7 +334,6 @@ function kit({ svelte_config }) {
 				is_build = config_env.command === 'build';
 
 				({ kit } = process_config(svelte_config, root));
-
 				out_dir = posixify(kit.outDir);
 				out = `${out_dir}/output`;
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1157,19 +1157,17 @@ function kit({ svelte_config }) {
 		applyToEnvironment(environment) {
 			return !!service_worker_entry_file && environment.config.consumer === 'client';
 		},
-		transform: {
-			handler(code, id) {
-				if (id !== service_worker_entry_file) return;
+		transform(code, id) {
+			if (id !== service_worker_entry_file) return;
 
-				// prepend the service worker with an import that configures
-				// `env`, in case `$app/env/public` is imported. In production
-				// this is required: dynamic public env vars aren't known at
-				// build time, so `env.js` is loaded at runtime. In dev, the
-				// imported module just inlines the current values instead.
-				return {
-					code: `import '__sveltekit/env/service-worker';\n${code}`
-				};
-			}
+			// prepend the service worker with an import that configures
+			// `env`, in case `$app/env/public` is imported. In production
+			// this is required: dynamic public env vars aren't known at
+			// build time, so `env.js` is loaded at runtime. In dev, the
+			// imported module just inlines the current values instead.
+			return {
+				code: `import '__sveltekit/env/service-worker';\n${code}`
+			};
 		}
 	};
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -957,6 +957,28 @@ function kit({ svelte_config }) {
 		}
 	};
 
+	/** @type {Plugin} */
+	const plugin_service_worker_env = {
+		name: 'vite-plugin-sveltekit-service-worker-env',
+		applyToEnvironment(environment) {
+			return !!service_worker_entry_file && environment.config.consumer === 'client';
+		},
+		transform: {
+			handler(code, id) {
+				if (id !== service_worker_entry_file) return;
+
+				// prepend the service worker with an import that configures
+				// `env`, in case `$app/env/public` is imported. In production
+				// this is required: dynamic public env vars aren't known at
+				// build time, so `env.js` is loaded at runtime. In dev, the
+				// imported module just inlines the current values instead.
+				return {
+					code: `import '__sveltekit/env/service-worker';\n${code}`
+				};
+			}
+		}
+	};
+
 	/** @type {Manifest} */
 	let vite_server_manifest;
 	/** @type {Manifest | null} */
@@ -1152,27 +1174,6 @@ function kit({ svelte_config }) {
 				throw new Error(
 					`Cannot import ${stripped} into service-worker code. Only the modules $service-worker and $app/env/public are available in service workers.`
 				);
-			}
-		}
-	};
-
-	/** @type {Plugin} */
-	const plugin_service_worker_env = {
-		name: 'vite-plugin-sveltekit-service-worker-env',
-
-		transform: {
-			filter: {
-				id: service_worker_entry_file
-			},
-			handler(code) {
-				// prepend the service worker with an import that configures
-				// `env`, in case `$app/env/public` is imported. In production
-				// this is required: dynamic public env vars aren't known at
-				// build time, so `env.js` is loaded at runtime. In dev, the
-				// imported module just inlines the current values instead.
-				return {
-					code: `import '__sveltekit/env/service-worker';\n${code}`
-				};
 			}
 		}
 	};
@@ -1858,6 +1859,7 @@ function kit({ svelte_config }) {
 			plugin_virtual_modules,
 			process.env.TEST !== 'true' ? plugin_guard : undefined,
 			plugin_service_worker,
+			plugin_service_worker_env,
 			plugin_compile,
 			plugin_adapter
 		].filter(Boolean)

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -323,10 +323,6 @@ function kit({ svelte_config }) {
 			options: svelte_config
 		},
 
-		applyToEnvironment(environment) {
-			return environment.name !== 'serviceWorker';
-		},
-
 		/**
 		 * Build the SvelteKit-provided Vite config to be merged with the user's vite.config.js file.
 		 * @see https://vitejs.dev/guide/api-plugin.html#config
@@ -522,10 +518,6 @@ function kit({ svelte_config }) {
 	const plugin_virtual_modules = {
 		name: 'vite-plugin-sveltekit-virtual-modules',
 
-		applyToEnvironment(environment) {
-			return environment.name !== 'serviceWorker';
-		},
-
 		async configResolved(config) {
 			explicit_env_entry = resolve_explicit_env_entry(kit);
 			explicit_env_config = await sync.env(kit, explicit_env_entry, config.root, config.mode);
@@ -559,6 +551,10 @@ function kit({ svelte_config }) {
 					server.ws.send({ type: 'full-reload' });
 				}
 			});
+		},
+
+		applyToEnvironment(environment) {
+			return environment.name !== 'serviceWorker';
 		},
 
 		resolveId: {

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -247,7 +247,7 @@ export type RecursiveRequired<T> = {
 	// Recursive implementation of TypeScript's Required utility type.
 	// Will recursively continue until it reaches a primitive or Function
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-	[K in keyof T]-?: Extract<T[K], Function> extends never // If it does not have a Function type
+	[K in keyof T]-?: Extract<T[K], Function | (`${string}:` & {})> extends never // If it does not have a Function type
 		? RecursiveRequired<T[K]> // recursively continue through.
 		: T[K]; // Use the exact type for everything else
 };

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -598,7 +598,7 @@ export interface Uses {
 	search_params: Set<string>;
 }
 
-export type ValidatedConfig = Config & {
+export type ValidatedConfig = Omit<Config, 'kit'> & {
 	kit: ValidatedKitConfig;
 	extensions: string[];
 };

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2900,7 +2900,7 @@ declare module '@sveltejs/kit' {
 		leaf: [has_server_load: boolean, node_id: number];
 	}
 
-	type ValidatedConfig = Config & {
+	type ValidatedConfig = Omit<Config, 'kit'> & {
 		kit: ValidatedKitConfig;
 		extensions: string[];
 	};

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2749,7 +2749,7 @@ declare module '@sveltejs/kit' {
 		// Recursive implementation of TypeScript's Required utility type.
 		// Will recursively continue until it reaches a primitive or Function
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-		[K in keyof T]-?: Extract<T[K], Function> extends never // If it does not have a Function type
+		[K in keyof T]-?: Extract<T[K], Function | (`${string}:` & {})> extends never // If it does not have a Function type
 			? RecursiveRequired<T[K]> // recursively continue through.
 			: T[K]; // Use the exact type for everything else
 	};


### PR DESCRIPTION
This PR separates the config processing from the validation because the processing needs to happen _after_ we've retrieved the Vite `root` value. This is important for proper monorepo support. Otherwise, tooling such as our language tools and Vitest end up resolving file paths relative to where the process started rather than relative to the project root

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
