### PR TITLE
fix: avoid externalising `node:async_hooks` for the browser

### DIFF
--- a/.changeset/open-wasps-shop.md
+++ b/.changeset/open-wasps-shop.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: avoid client build warning about externalising `node:async_hooks`

--- a/packages/kit/src/exports/internal/event.js
+++ b/packages/kit/src/exports/internal/event.js
@@ -10,9 +10,9 @@ let sync_store = null;
 /** @type {AsyncLocalStorage<RequestStore | null> | null} */
 let als;
 
-// mark the import as pure so that it can be treeshaken when we conditionally
-// call any of the functions in this file behind a BROWSER check
-/* @__PURE__ */ import('node:async_hooks')
+// mark the import as pure so we can treeshake it for the client build but
+// we remove it in a Vite `transform` hook for server builds
+/*@__PURE__*/ import('node:async_hooks')
 	.then((hooks) => (als = new hooks.AsyncLocalStorage()))
 	.catch(() => {
 		// can't use AsyncLocalStorage, but can still call getRequestEvent synchronously.

--- a/packages/kit/src/exports/internal/event.js
+++ b/packages/kit/src/exports/internal/event.js
@@ -10,7 +10,9 @@ let sync_store = null;
 /** @type {AsyncLocalStorage<RequestStore | null> | null} */
 let als;
 
-import('node:async_hooks')
+// mark the import as pure so that it can be treeshaken when we conditionally
+// call any of the functions in this file behind a BROWSER check
+/* @__PURE__ */ import('node:async_hooks')
 	.then((hooks) => (als = new hooks.AsyncLocalStorage()))
 	.catch(() => {
 		// can't use AsyncLocalStorage, but can still call getRequestEvent synchronously.

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1451,6 +1451,19 @@ function kit({ svelte_config }) {
 			return preview(vite, vite_config, svelte_config);
 		},
 
+		// allows us to treeshake the `node:async_hooks` import from client builds
+		// to avoid the Vite externalised for browser warning but keep it for server
+		// builds where it's needed
+		transform: {
+			filter: {
+				id: path.join(import.meta.dirname, '..', 'internal', 'event.js')
+			},
+			handler(code, _id, opt) {
+				if (!opt?.ssr) return;
+				return code.replace('/*@__PURE__*/', '');
+			}
+		},
+
 		renderChunk(code, chunk) {
 			if (code.includes('__SVELTEKIT_TRACK__')) {
 				return {

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -1493,16 +1493,3 @@ test.describe('Streaming', () => {
 		expect(error).toBeUndefined();
 	});
 });
-
-test.describe('Build', () => {
-	test.skip(!!process.env.DEV);
-
-	test('node built-ins are not externalised for the browser', async () => {
-		const content = fs.readFileSync(
-			path.join(process.cwd(), '.svelte-kit/output/client/.vite/manifest.json'),
-			'utf-8'
-		);
-		const manifest = JSON.parse(content);
-		expect(manifest['__vite-browser-external']).toBeUndefined();
-	});
-});

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -1,4 +1,3 @@
-/** @import { ReadableSpan } from '@opentelemetry/sdk-trace-node' */
 import process from 'node:process';
 import { expect } from '@playwright/test';
 import { test } from '../../../utils.js';
@@ -1492,5 +1491,16 @@ test.describe('Streaming', () => {
 		}
 
 		expect(error).toBeUndefined();
+	});
+});
+
+test.describe('Build', () => {
+	test('node built-ins are not externalised for the browser', async () => {
+		const content = fs.readFileSync(
+			path.join(process.cwd(), '.svelte-kit/output/client/.vite/manifest.json'),
+			'utf-8'
+		);
+		const manifest = JSON.parse(content);
+		expect(manifest['__vite-browser-external']).toBeUndefined();
 	});
 });

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -1495,6 +1495,8 @@ test.describe('Streaming', () => {
 });
 
 test.describe('Build', () => {
+	test.skip(!!process.env.DEV);
+
 	test('node built-ins are not externalised for the browser', async () => {
 		const content = fs.readFileSync(
 			path.join(process.cwd(), '.svelte-kit/output/client/.vite/manifest.json'),

--- a/packages/kit/test/apps/options/vite.custom.config.js
+++ b/packages/kit/test/apps/options/vite.custom.config.js
@@ -51,11 +51,6 @@ const config = {
 			},
 			router: {
 				resolution: /** @type {'client' | 'server'} */ (process.env.ROUTER_RESOLUTION) || 'client'
-			},
-			typescript: {
-				config(config) {
-					config.include.push('../unit-test');
-				}
 			}
 		})
 	],

--- a/packages/kit/test/apps/options/vite.custom.config.js
+++ b/packages/kit/test/apps/options/vite.custom.config.js
@@ -51,6 +51,11 @@ const config = {
 			},
 			router: {
 				resolution: /** @type {'client' | 'server'} */ (process.env.ROUTER_RESOLUTION) || 'client'
+			},
+			typescript: {
+				config(config) {
+					config.include.push('../unit-test');
+				}
 			}
 		})
 	],


### PR DESCRIPTION
Accidentally introduced in https://github.com/sveltejs/kit/pull/16198 because our shared exports now transitively imports a file that should only run on the server. Can be reproduced by building any of our test apps that import from `@sveltejs/kit` and you'll see an "externalized for browser" warning for the client build.

This PR marks the als import call as pure so it can be treeshaken correctly from the client code but we remove the pure annotation for server builds to keep it. Not proud of how hacky this is and am open to alternatives.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
