### PR TITLE
fix: preserve emptied remote number defaults

### DIFF
--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -604,6 +604,21 @@ export function deep_get(object, path) {
 }
 
 /**
+ * @param {Record<string, any>} object
+ * @param {(string | number)[]} path
+ */
+function deep_has(object, path) {
+	let current = object;
+	for (const key of path) {
+		if (current == null || typeof current !== 'object' || !Object.hasOwn(current, key)) {
+			return false;
+		}
+		current = current[key];
+	}
+	return true;
+}
+
+/**
  *
  * @param {string} field_type
  * @param {boolean} is_array
@@ -662,6 +677,7 @@ export function create_field_proxy(target, get_input, set_input, get_issues, pat
 		const value = deep_get(get_input(), path);
 		return deep_clone(value);
 	};
+	const has_value = () => deep_has(get_input(), path);
 
 	return new Proxy(target, {
 		get(target, prop) {
@@ -869,7 +885,7 @@ export function create_field_proxy(target, get_input, set_input, get_issues, pat
 						value: {
 							enumerable: true,
 							get() {
-								const value = get_value() ?? input_value;
+								const value = has_value() ? get_value() : input_value;
 								return value != null ? String(value) : '';
 							}
 						}

--- a/packages/kit/src/runtime/form-utils.spec.js
+++ b/packages/kit/src/runtime/form-utils.spec.js
@@ -3,6 +3,7 @@ import {
 	BINARY_FORM_CONTENT_TYPE,
 	DELETE_KEY,
 	convert_formdata,
+	create_field_proxy,
 	deep_set,
 	deserialize_binary_form,
 	serialize_binary_form,
@@ -769,5 +770,24 @@ describe('deep_set', () => {
 		deep_set(target, ['nested', 'file'], DELETE_KEY);
 
 		expect(target).toEqual({ nested: {} });
+	});
+});
+
+describe('create_field_proxy', () => {
+	test('does not restore a number input default after the field is emptied', () => {
+		const input = {};
+		const fields = create_field_proxy(
+			{},
+			() => input,
+			(path, value) => deep_set(input, path.map(String), value),
+			() => ({})
+		);
+		const props = fields.age.as('number', 200);
+
+		expect(props.value).toBe('200');
+
+		fields.age.set(undefined);
+
+		expect(props.value).toBe('');
 	});
 });


### PR DESCRIPTION
Fixes #15937.

Remote form fields previously rendered their default whenever the backing value was `null` or `undefined`. Empty number inputs are converted to `undefined`, so deleting a defaulted number field caused the rendered value to snap back to the default.

This distinguishes a missing field from a field that exists with an `undefined` value. Missing fields still render defaults, while emptied number fields render as empty strings.

Tests:
- `pnpm --dir packages/kit exec vitest --config kit.vitest.config.js run src/runtime/form-utils.spec.js`
- `pnpm --dir packages/kit exec prettier --config ../../.prettierrc --check src/runtime/form-utils.js src/runtime/form-utils.spec.js`
- `pnpm --dir packages/kit exec tsc --noEmit --pretty false`