### PR TITLE
fix: normalize Windows path casing in config warning

### DIFF
--- a/.changeset/windows-root-case.md
+++ b/.changeset/windows-root-case.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: avoid Vite override warnings for Windows path case differences

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -1640,6 +1640,30 @@ function warn_overridden_config(config, resolved_config) {
 	}
 }
 
+const case_insensitive_path_keys = new Set([
+	'root',
+	'publicDir',
+	'build.outDir',
+	'build.lib.entry',
+	'build.rollupOptions.input'
+]);
+
+/**
+ * @param {any} value
+ * @param {string} keypath
+ */
+function normalize_config_value(value, keypath) {
+	if (typeof value !== 'string') {
+		return value;
+	}
+
+	const normalized = posixify(value);
+	const is_path_config =
+		case_insensitive_path_keys.has(keypath) || keypath.startsWith('resolve.alias.');
+
+	return process.platform === 'win32' && is_path_config ? normalized.toLowerCase() : normalized;
+}
+
 /**
  * @param {Record<string, any>} config
  * @param {Record<string, any>} resolved_config
@@ -1660,8 +1684,8 @@ function find_overridden_config(config, resolved_config, enforced_config, path, 
 			if (enforced === true) {
 				// Normalize path separators before comparing to avoid false positives on Windows,
 				// where config values like `root` may use backslashes while SvelteKit uses forward slashes.
-				const a = typeof config[key] === 'string' ? posixify(config[key]) : config[key];
-				const b = typeof resolved === 'string' ? posixify(resolved) : resolved;
+				const a = normalize_config_value(config[key], path + key);
+				const b = normalize_config_value(resolved, path + key);
 				if (a !== b) {
 					out.push(path + key);
 				}


### PR DESCRIPTION
Fixes false positive Vite config override warnings on Windows when SvelteKit compares equivalent filesystem paths with different casing.

SvelteKit already normalizes path separators before comparing enforced Vite config values. However, on Windows, path casing can also differ between the incoming config and resolved config, for example `e:/...` vs `E:/...`. Those paths refer to the same filesystem location, but the current string comparison can still report an override warning such as:

```text
The following Vite config options will be overridden by SvelteKit:
  - root
```

This PR normalizes casing on Windows for enforced config values that are filesystem paths.

Related issue: https://github.com/sveltejs/kit/issues/16293

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
