### PR TITLE
breaking: change `form.error` type from `any` to `unknown`

### DIFF
--- a/.changeset/gentle-toys-talk.md
+++ b/.changeset/gentle-toys-talk.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': major
 ---
 
-breaking: change `form.error` type from `any` to `unknown`
+breaking: change `form.error` type from `any` to `App.Error | undefined`

--- a/.changeset/gentle-toys-talk.md
+++ b/.changeset/gentle-toys-talk.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: change `form.error` type from `any` to `unknown`

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -1086,7 +1086,7 @@ export type Transport = Record<string, Transporter>;
  */
 export interface Transporter<
 	T = any,
-	U = Exclude<any, false | 0 | '' | null | undefined | typeof NaN>
+	U = any /* minus falsy values, but we can't properly express that */
 > {
 	encode: (value: T) => false | U;
 	decode: (data: U) => T;
@@ -2293,7 +2293,7 @@ export type RemoteQueryUpdate =
 
 export type RemoteResource<T> = Promise<T> & {
 	/** The error in case the query fails. Most often this is a [`HttpError`](https://svelte.dev/docs/kit/@sveltejs-kit#HttpError) but it isn't guaranteed to be. */
-	get error(): any;
+	get error(): unknown;
 	/** `true` before the first result is available and during refreshes */
 	get loading(): boolean;
 } & (

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -2292,8 +2292,8 @@ export type RemoteQueryUpdate =
 	| RemoteQueryOverride;
 
 export type RemoteResource<T> = Promise<T> & {
-	/** The error in case the query fails. Most often this is a [`HttpError`](https://svelte.dev/docs/kit/@sveltejs-kit#HttpError) but it isn't guaranteed to be. */
-	get error(): unknown;
+	/** The error in case the query fails. */
+	get error(): App.Error | undefined;
 	/** `true` before the first result is available and during refreshes */
 	get loading(): boolean;
 } & (

--- a/packages/kit/src/runtime/client/remote-functions/cache.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/cache.svelte.js
@@ -1,8 +1,10 @@
+/** @import { Query } from './query/instance.svelte.js' */
+/** @import { LiveQuery } from './query-live/instance.svelte.js' */
 import { tick } from 'svelte';
 import { once } from '../../../utils/functions.js';
 
 /**
- * @template R
+ * @template [R=Query<any> | LiveQuery<any>]
  * @typedef {object} CacheEntry
  * @property {number} proxy_count The number of live proxy instances referencing this
  *   entry. The entry is eligible for eviction when this hits zero.

--- a/packages/kit/src/runtime/client/remote-functions/instance.unhandled.svelte.spec.js
+++ b/packages/kit/src/runtime/client/remote-functions/instance.unhandled.svelte.spec.js
@@ -1,19 +1,29 @@
 /* eslint-disable n/prefer-global/process */
 import { describe, expect, test, vi } from 'vitest';
 import { tick } from 'svelte';
+import { HttpError } from '@sveltejs/kit/internal';
 
 // Mock `client.js` because the real one pulls in the SvelteKit
 // router/hydration machinery and resolves `$app/paths` to a server-side
 // virtual module that only exists during a real SvelteKit build. We only need
 // the cache `Map`s and a stub `app` for the instances' interactions.
-vi.mock(new URL('../client.js', import.meta.url).pathname, () => ({
-	app: { hooks: { transport: {} }, decoders: {}, encoders: {} },
-	query_map: new Map(),
-	query_responses: {},
-	live_query_map: new Map(),
-	prerender_responses: {},
-	_goto: () => {}
-}));
+vi.mock(new URL('../client.js', import.meta.url).pathname, async () => {
+	const { HttpError } = await import('@sveltejs/kit/internal');
+	return {
+		app: { hooks: { transport: {} }, decoders: {}, encoders: {} },
+		query_map: new Map(),
+		query_responses: {},
+		live_query_map: new Map(),
+		prerender_responses: {},
+		_goto: () => {},
+		handle_error: (/** @type {any} */ error) =>
+			Promise.resolve(
+				error instanceof HttpError
+					? error.body
+					: { message: error?.message ?? String(error), status: 500 }
+			)
+	};
+});
 
 // `prerender.svelte.js` references the `__SVELTEKIT_DEV__` build-time constant at
 // module scope; it isn't provided by the unit-test config, so define it here.
@@ -48,7 +58,7 @@ describe('reactive consumption never produces unhandled rejections', () => {
 			const q = new Query('id/payload', () => Promise.reject(new Error('nope')));
 			void q.current; // reactive read triggers start()
 			await flush();
-			expect(q.error).toBeInstanceOf(Error);
+			expect(q.error).toEqual({ message: 'nope', status: 500 });
 			expect(tracker.unhandled).toEqual([]);
 		} finally {
 			tracker.stop();
@@ -59,9 +69,9 @@ describe('reactive consumption never produces unhandled rejections', () => {
 		const tracker = track_unhandled();
 		try {
 			const instance = new LiveQuery('id', 'id/payload', 'payload');
-			instance.fail(new Error('nope'));
+			instance.fail(new HttpError(500, 'nope'));
 			await flush();
-			expect(instance.error).toBeInstanceOf(Error);
+			expect(instance.error).toEqual({ message: 'nope', status: 500 });
 			expect(tracker.unhandled).toEqual([]);
 		} finally {
 			tracker.stop();
@@ -76,7 +86,7 @@ describe('reactive consumption never produces unhandled rejections', () => {
 			const resource = prerender('id')(undefined);
 			void resource.current; // reactive read, no awaiting
 			await flush();
-			expect(resource.error).toBeInstanceOf(Error);
+			expect(resource.error).toEqual({ message: 'nope', status: 500 });
 			expect(tracker.unhandled).toEqual([]);
 		} finally {
 			globalThis.fetch = original_fetch;

--- a/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/prerender.svelte.js
@@ -2,10 +2,11 @@
 import { app_dir, base } from '$app/paths/internal/client';
 import { version } from '$app/env';
 import * as devalue from 'devalue';
-import { app, _goto, prerender_responses } from '../client.js';
+import { app, _goto, handle_error, prerender_responses } from '../client.js';
 import { get_remote_request_headers, remote_request, unwrap_node } from './shared.svelte.js';
 import { create_remote_key, stringify_remote_arg } from '../../shared.js';
 import { noop } from '../../../utils/functions.js';
+import { HttpError } from '@sveltejs/kit/internal';
 
 // Initialize Cache API for prerender functions
 const CACHE_NAME = __SVELTEKIT_DEV__ ? `sveltekit:${Date.now()}` : `sveltekit:${version}`;
@@ -148,6 +149,7 @@ class Prerender {
 	/** @type {T | undefined} */
 	#current = $state.raw();
 
+	/** @type {App.Error | undefined} */
 	#error = $state.raw(undefined);
 
 	/**
@@ -162,10 +164,15 @@ class Prerender {
 				this.#error = undefined;
 				return value;
 			},
-			(error) => {
+			async (e) => {
+				const error = await handle_error(e, {
+					params: {},
+					route: { id: null },
+					url: new URL(location.href)
+				});
 				this.#loading = false;
 				this.#error = error;
-				throw error;
+				throw new HttpError(error.status, error); // so that transformError doesn't transform it again
 			}
 		);
 

--- a/packages/kit/src/runtime/client/remote-functions/query-live/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query-live/instance.svelte.js
@@ -1,4 +1,4 @@
-import { query_responses } from '../../client.js';
+import { query_responses, handle_error } from '../../client.js';
 import { HttpError, Redirect } from '@sveltejs/kit/internal';
 import { noop, once } from '../../../../utils/functions.js';
 import { SharedIterator } from '../../../../utils/shared-iterator.js';
@@ -24,7 +24,7 @@ export class LiveQuery {
 	#done = $state(false);
 	/** @type {T | undefined} */
 	#raw = $state.raw();
-	/** @type {any} */
+	/** @type {App.Error | undefined} */
 	#error = $state.raw(undefined);
 	/** @type {Promise<void>} */
 	#promise;
@@ -93,7 +93,7 @@ export class LiveQuery {
 				// and the query can recover
 				const error = new HttpError(node.e.status, node.e);
 				this.#loading = false;
-				this.#error = error;
+				this.#error = error.body;
 
 				promise.catch(noop);
 				this.#reject_first?.(error);
@@ -175,7 +175,7 @@ export class LiveQuery {
 
 				if (!this.#ready) {
 					// If we haven't successfully connected and received a value yet, surface the error
-					this.fail(error);
+					await this.#fail(error);
 					on_connect_failed(error);
 					break;
 				}
@@ -385,10 +385,10 @@ export class LiveQuery {
 		this.#fan_out.push(value);
 	}
 
-	/** @param {unknown} error */
+	/** @param {HttpError} error */
 	fail(error) {
 		this.#loading = false;
-		this.#error = error;
+		this.#error = error.body;
 		// `fail` is terminal — once a live query has hard-failed, the only way to start
 		// streaming again is via `reconnect()`. Mark it done and abort any in-flight
 		// request so that callers from outside the main loop (e.g. `apply_reconnections`)
@@ -408,6 +408,16 @@ export class LiveQuery {
 		}
 
 		this.#fan_out.fail(error);
+	}
+
+	/** @param {unknown} e */
+	async #fail(e) {
+		const error = await handle_error(e, {
+			params: {},
+			route: { id: null },
+			url: new URL(location.href)
+		});
+		this.fail(new HttpError(error.status, error));
 	}
 
 	get [Symbol.toStringTag]() {

--- a/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
@@ -132,14 +132,19 @@ export class Query {
 				//   to ensure the query is properly refreshed before the navigation completes
 				// - Instead of failing on transport-level errors, we should probably do what
 				//   LiveQuery does and preserve the last known good value and retry the connection
-				const idx = this.#latest.indexOf(resolve);
-				if (idx === -1) return;
+				if (this.#latest.indexOf(resolve) === -1) return;
 
 				const error = await handle_error(e, {
 					params: {},
 					route: { id: null },
 					url: new URL(location.href)
 				});
+
+				// Re-check after the async `handle_error` gap: a later request may have
+				// resolved/rejected while we were awaiting and superseded this one, so
+				// recompute the index and bail out if this request is no longer current
+				const idx = this.#latest.indexOf(resolve);
+				if (idx === -1) return;
 
 				untrack(() => {
 					this.#latest.splice(0, idx).forEach((r) => r(undefined));

--- a/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/query/instance.svelte.js
@@ -1,4 +1,4 @@
-import { query_responses } from '../../client.js';
+import { query_responses, handle_error } from '../../client.js';
 import { HttpError } from '@sveltejs/kit/internal';
 import { QUERY_OVERRIDE_KEY } from '../shared.svelte.js';
 import { noop } from '../../../../utils/functions.js';
@@ -37,7 +37,7 @@ export class Query {
 		return this.#overrides.reduce((v, r) => r(v), /** @type {T} */ (this.#raw));
 	});
 
-	/** @type {any} */
+	/** @type {App.Error | undefined} */
 	#error = $state.raw(undefined);
 
 	/** @type {Promise<T>['then']} */
@@ -126,7 +126,7 @@ export class Query {
 
 				resolve(undefined);
 			})
-			.catch((e) => {
+			.catch(async (e) => {
 				// TODO: Our behavior here could be better:
 				// - We should not reject on redirects, but should hook into the router
 				//   to ensure the query is properly refreshed before the navigation completes
@@ -135,13 +135,19 @@ export class Query {
 				const idx = this.#latest.indexOf(resolve);
 				if (idx === -1) return;
 
+				const error = await handle_error(e, {
+					params: {},
+					route: { id: null },
+					url: new URL(location.href)
+				});
+
 				untrack(() => {
 					this.#latest.splice(0, idx).forEach((r) => r(undefined));
-					this.#error = e;
+					this.#error = error;
 					this.#loading = false;
 				});
 
-				reject(e);
+				reject(new HttpError(error.status, error)); // so that transformError doesn't transform it again
 			});
 
 		return promise;
@@ -229,9 +235,7 @@ export class Query {
 		this.#promise = Promise.resolve();
 	}
 
-	/**
-	 * @param {unknown} error
-	 */
+	/** @param {HttpError} error */
 	fail(error) {
 		// normally consumed in the constructor, but make sure a leftover
 		// SSR record can never shadow the newly-set error
@@ -239,7 +243,7 @@ export class Query {
 
 		this.#clear_pending();
 		this.#loading = false;
-		this.#error = error;
+		this.#error = error.body;
 
 		const promise = Promise.reject(error);
 

--- a/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
+++ b/packages/kit/src/runtime/client/remote-functions/shared.svelte.js
@@ -137,9 +137,8 @@ export async function remote_request(url, init) {
 	);
 
 	/**
-	 *
 	 * @param {string} key
-	 * @param {CacheEntry<any> | undefined} entry
+	 * @param {CacheEntry | undefined} entry
 	 * @param {any} result
 	 */
 	function refresh(key, entry, result) {

--- a/packages/kit/test/apps/async/src/routes/remote/error-hydration/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/error-hydration/+page.svelte
@@ -1,14 +1,9 @@
 <script>
-	import { isHttpError } from '@sveltejs/kit';
 	import { failing } from './data.remote';
 
 	const q = failing();
 </script>
 
 <div id="q-error">
-	{isHttpError(q.error)
-		? `${q.error.status}: ${q.error.body?.message}`
-		: q.error
-			? JSON.stringify(q.error)
-			: 'none'}
+	{q.error ? `${q.error.status}: ${q.error.message}` : 'none'}
 </div>

--- a/packages/kit/test/apps/async/src/routes/remote/error-hydration/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/error-hydration/+page.svelte
@@ -1,7 +1,14 @@
 <script>
+	import { isHttpError } from '@sveltejs/kit';
 	import { failing } from './data.remote';
 
 	const q = failing();
 </script>
 
-<div id="q-error">{q.error ? `${q.error.status}: ${q.error.body?.message}` : 'none'}</div>
+<div id="q-error">
+	{isHttpError(q.error)
+		? `${q.error.status}: ${q.error.body?.message}`
+		: q.error
+			? JSON.stringify(q.error)
+			: 'none'}
+</div>

--- a/packages/kit/test/apps/async/src/routes/remote/error-hydration/batch/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/error-hydration/batch/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { isHttpError } from '@sveltejs/kit';
 	import { failing_batch } from '../data.remote';
 
 	const q = failing_batch('x');
@@ -17,4 +18,10 @@
 	{/snippet}
 </svelte:boundary>
 
-<div id="batch-error">{q.error ? `${q.error.status}: ${q.error.body?.message}` : 'none'}</div>
+<div id="batch-error">
+	{isHttpError(q.error)
+		? `${q.error.status}: ${q.error.body?.message}`
+		: q.error
+			? JSON.stringify(q.error)
+			: 'none'}
+</div>

--- a/packages/kit/test/apps/async/src/routes/remote/error-hydration/batch/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/error-hydration/batch/+page.svelte
@@ -1,5 +1,4 @@
 <script>
-	import { isHttpError } from '@sveltejs/kit';
 	import { failing_batch } from '../data.remote';
 
 	const q = failing_batch('x');
@@ -19,9 +18,5 @@
 </svelte:boundary>
 
 <div id="batch-error">
-	{isHttpError(q.error)
-		? `${q.error.status}: ${q.error.body?.message}`
-		: q.error
-			? JSON.stringify(q.error)
-			: 'none'}
+	{q.error ? `${q.error.status}: ${q.error.message}` : 'none'}
 </div>

--- a/packages/kit/test/apps/async/src/routes/remote/form/[test_name]/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/form/[test_name]/+page.svelte
@@ -3,10 +3,10 @@
 
 	const { params } = $props();
 
-	const message = get_message(params.test_name);
+	const message = $derived(get_message(params.test_name));
 
-	const scoped = set_message.for(`scoped:${params.test_name}`);
-	const enhanced = set_message.for(`enhanced:${params.test_name}`);
+	const scoped = $derived(set_message.for(`scoped:${params.test_name}`));
+	const enhanced = $derived(set_message.for(`enhanced:${params.test_name}`));
 
 	let submit_result = $state('none');
 	let imperative_submit_result = $state('none');

--- a/packages/kit/test/apps/async/src/routes/remote/live-error-seed/[key]/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/live-error-seed/[key]/+page.svelte
@@ -1,5 +1,4 @@
 <script>
-	import { isHttpError } from '@sveltejs/kit';
 	import { live_fail } from './data.remote';
 
 	const { params } = $props();
@@ -7,9 +6,5 @@
 </script>
 
 <div id="live-error">
-	{isHttpError(q.error)
-		? `${q.error.status}: ${q.error.body?.message}`
-		: q.error
-			? JSON.stringify(q.error)
-			: 'none'}
+	{q.error ? `${q.error.status}: ${q.error.message}` : 'none'}
 </div>

--- a/packages/kit/test/apps/async/src/routes/remote/live-error-seed/[key]/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/live-error-seed/[key]/+page.svelte
@@ -1,8 +1,15 @@
 <script>
+	import { isHttpError } from '@sveltejs/kit';
 	import { live_fail } from './data.remote';
 
 	const { params } = $props();
 	const q = $derived(live_fail(params.key));
 </script>
 
-<div id="live-error">{q.error ? `${q.error.status}: ${q.error.body.message}` : 'none'}</div>
+<div id="live-error">
+	{isHttpError(q.error)
+		? `${q.error.status}: ${q.error.body?.message}`
+		: q.error
+			? JSON.stringify(q.error)
+			: 'none'}
+</div>

--- a/packages/kit/test/apps/async/src/routes/remote/live-terminal/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/live-terminal/+page.svelte
@@ -1,5 +1,4 @@
 <script>
-	import { isHttpError } from '@sveltejs/kit';
 	import { get_value, get_connection_count, trigger } from './data.remote.js';
 
 	const live = get_value();
@@ -18,11 +17,7 @@
 
 <p id="value">{live.current}</p>
 <p id="error">
-	{isHttpError(live.error)
-		? `${live.error.status} ${live.error.body.message}`
-		: live.error
-			? JSON.stringify(live.error)
-			: ''}
+	{live.error ? `${live.error.status} ${live.error.message}` : ''}
 </p>
 <p id="connected">{String(live.connected)}</p>
 <p id="done">{String(live.done)}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/live-terminal/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/live-terminal/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { isHttpError } from '@sveltejs/kit';
 	import { get_value, get_connection_count, trigger } from './data.remote.js';
 
 	const live = get_value();
@@ -16,7 +17,13 @@
 <button id="refresh-connections" onclick={refresh_connections}>refresh connections</button>
 
 <p id="value">{live.current}</p>
-<p id="error">{live.error ? `${live.error.status} ${live.error.body.message}` : ''}</p>
+<p id="error">
+	{isHttpError(live.error)
+		? `${live.error.status} ${live.error.body.message}`
+		: live.error
+			? JSON.stringify(live.error)
+			: ''}
+</p>
 <p id="connected">{String(live.connected)}</p>
 <p id="done">{String(live.done)}</p>
 <p id="connections">{connections}</p>

--- a/packages/kit/test/apps/async/src/routes/remote/requested-limit/[key]/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/requested-limit/[key]/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { isHttpError } from '@sveltejs/kit';
 	import { bump, get_count } from './data.remote';
 
 	const { params } = $props();
@@ -6,6 +7,12 @@
 </script>
 
 <div id="value">{q.current ?? 'unset'}</div>
-<div id="error">{q.error ? `${q.error.status}: ${q.error.body.message}` : 'none'}</div>
+<div id="error">
+	{isHttpError(q.error)
+		? `${q.error.status}: ${q.error.body?.message}`
+		: q.error
+			? JSON.stringify(q.error)
+			: 'none'}
+</div>
 
 <button onclick={() => bump(params.key).updates(q)}>bump</button>

--- a/packages/kit/test/apps/async/src/routes/remote/requested-limit/[key]/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/requested-limit/[key]/+page.svelte
@@ -1,5 +1,4 @@
 <script>
-	import { isHttpError } from '@sveltejs/kit';
 	import { bump, get_count } from './data.remote';
 
 	const { params } = $props();
@@ -8,11 +7,7 @@
 
 <div id="value">{q.current ?? 'unset'}</div>
 <div id="error">
-	{isHttpError(q.error)
-		? `${q.error.status}: ${q.error.body?.message}`
-		: q.error
-			? JSON.stringify(q.error)
-			: 'none'}
+	{q.error ? `${q.error.status}: ${q.error.message}` : 'none'}
 </div>
 
 <button onclick={() => bump(params.key).updates(q)}>bump</button>

--- a/packages/kit/test/apps/async/src/routes/remote/transport-status/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/transport-status/+page.svelte
@@ -1,5 +1,4 @@
 <script>
-	import { isHttpError } from '@sveltejs/kit';
 	import { get_data } from './data.remote.js';
 
 	const result = get_data();
@@ -21,7 +20,7 @@
 >
 
 {#if result.error}
-	<p id="status">{isHttpError(result.error) ? result.error.status : ''}</p>
+	<p id="status">{result.error.status}</p>
 {:else if result.current !== undefined}
 	<p id="value">{result.current}</p>
 {/if}

--- a/packages/kit/test/apps/async/src/routes/remote/transport-status/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/transport-status/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import { isHttpError } from '@sveltejs/kit';
 	import { get_data } from './data.remote.js';
 
 	const result = get_data();
@@ -20,7 +21,7 @@
 >
 
 {#if result.error}
-	<p id="status">{result.error.status}</p>
+	<p id="status">{isHttpError(result.error) ? result.error.status : ''}</p>
 {:else if result.current !== undefined}
 	<p id="value">{result.current}</p>
 {/if}

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -1059,7 +1059,7 @@ declare module '@sveltejs/kit' {
 	 */
 	export interface Transporter<
 		T = any,
-		U = Exclude<any, false | 0 | '' | null | undefined | typeof NaN>
+		U = any /* minus falsy values, but we can't properly express that */
 	> {
 		encode: (value: T) => false | U;
 		decode: (data: U) => T;
@@ -2266,7 +2266,7 @@ declare module '@sveltejs/kit' {
 
 	export type RemoteResource<T> = Promise<T> & {
 		/** The error in case the query fails. Most often this is a [`HttpError`](https://svelte.dev/docs/kit/@sveltejs-kit#HttpError) but it isn't guaranteed to be. */
-		get error(): any;
+		get error(): unknown;
 		/** `true` before the first result is available and during refreshes */
 		get loading(): boolean;
 	} & (

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2265,8 +2265,8 @@ declare module '@sveltejs/kit' {
 		| RemoteQueryOverride;
 
 	export type RemoteResource<T> = Promise<T> & {
-		/** The error in case the query fails. Most often this is a [`HttpError`](https://svelte.dev/docs/kit/@sveltejs-kit#HttpError) but it isn't guaranteed to be. */
-		get error(): unknown;
+		/** The error in case the query fails. */
+		get error(): App.Error | undefined;
 		/** `true` before the first result is available and during refreshes */
 		get loading(): boolean;
 	} & (


### PR DESCRIPTION
The `error` property on `RemoteResource` (and by extension `RemoteQuery`, `RemoteLiveQuery`, and `RemotePrerenderFunction` results) is now typed as `App.Error | undefined` instead of `any`. All errors are now transformed through `handleError` before being surfaced on the `.error` property, matching how the server already serializes errors. This means `.error` is always an `App.Error`-shaped object (`{ message: string, status: number, ... }`) rather than potentially being an `HttpError` instance, a native `Error`, or a `TypeError` from network failures.

If you were using `isHttpError(resource.error)` to check the error shape, replace it with a simple truthiness check and access `.status`/`.message` directly:

```svelte
<!-- before -->
{isHttpError(q.error)
    ? `${q.error.status}: ${q.error.body?.message}`
    : q.error
        ? JSON.stringify(q.error)
        : 'none'}

<!-- after -->
{q.error ? `${q.error.status}: ${q.error.message}` : 'none'}
```


----

Went through the `any` types on `public.d.ts` and these are the only changes that feel necessary. All the other are either ok (because really "any", or part of generics", or internal.

Closes #15674
