### PR TITLE
chore: don't persist git credentials on checkout in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
-          fetch-depth: 0
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -44,8 +43,6 @@ jobs:
           publish-script: pnpm changeset:release
           version-script: pnpm changeset:version
           github-token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          NPM_CONFIG_PROVENANCE: true
 
       # TODO alert discord
       # - name: Send a Slack notification if a publish happens


### PR DESCRIPTION
I'm a Changesets maintainer. @teemingc reported issues with your publishing workflow (see a failed run [here](https://github.com/sveltejs/kit/actions/runs/28802273733/job/85422444547#step:6:407)). 

I think this is caused by https://github.com/changesets/action/pull/670 . I have not anticipated this to clash with the default `persist-credentials: true` of `actions/checkout`. 

While I need to fix this in `changesets/action`, I think there is no strong reason for you to persist this git credential here - so to unblock you sooner, I'm proposing this patch

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
