### PR TITLE
docs: update o11y docs for node tracing

### DIFF
--- a/documentation/docs/30-advanced/68-observability.md
+++ b/documentation/docs/30-advanced/68-observability.md
@@ -81,11 +81,9 @@ To view your first trace, you'll need to set up a local collector. We'll use [Ja
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
-import { createAddHookMessageChannel } from 'import-in-the-middle';
-import { register } from 'node:module';
+import { register } from 'import-in-the-middle/register-hooks.mjs';
 
-const { registerOptions } = createAddHookMessageChannel();
-register('import-in-the-middle/hook.mjs', import.meta.url, registerOptions);
+register();
 
 const sdk = new NodeSDK({
 	serviceName: 'test-sveltekit-tracing',
@@ -97,6 +95,38 @@ sdk.start();
 ```
 
 Now, server-side requests will begin generating traces, which you can view in Jaeger's web console at [localhost:16686](http://localhost:16686).
+
+> [!NOTE] `import-in-the-middle/register-hooks.mjs` registers the loader via [`module.registerHooks()`](https://nodejs.org/api/module.html#moduleregisterhooksoptions), which runs the hooks synchronously on the application thread. This avoids the inter-thread message channel that the older `module.register()`-based setup required.
+>
+> The synchronous loader needs Node.js 22.22.3+, 24.11.1+, 25.1.0+, or 26.0.0+. `register()` will throw on older Node.js versions. If you need to support them, fall back to the asynchronous loader:
+>
+> ```js
+> // @errors: 2307
+> /// file: src/instrumentation.server.js
+> import { NodeSDK } from '@opentelemetry/sdk-node';
+> import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+> import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
+> import { register, supportsSyncHooks } from 'import-in-the-middle/register-hooks.mjs';
+> import { createAddHookMessageChannel } from 'import-in-the-middle';
+> import { register as registerAsync } from 'node:module';
+>
+> if (supportsSyncHooks()) {
+> 	register();
+> } else {
+> 	const { registerOptions } = createAddHookMessageChannel();
+> 	registerAsync('import-in-the-middle/hook.mjs', import.meta.url, registerOptions);
+> }
+>
+> const sdk = new NodeSDK({
+> 	serviceName: 'test-sveltekit-tracing',
+> 	traceExporter: new OTLPTraceExporter(),
+> 	instrumentations: [getNodeAutoInstrumentations()]
+> });
+>
+> sdk.start();
+> ```
+>
+> The asynchronous `module.register()` API was deprecated in Node.js 25.9.0 and emits a runtime deprecation warning from 26.0.0, so prefer the synchronous path whenever your Node.js version supports it.
 
 ## `@opentelemetry/api`
 


### PR DESCRIPTION
Closes #16238 

Documents simpler and now-standard version; also guides users to the older version if they need it.