### PR TITLE
Move version into payload to avoid rotating client chunks

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -77,6 +77,7 @@ export default [
 			'packages/kit/test/apps/**/*',
 			'packages/kit/test/build-errors/**/*',
 			'packages/kit/test/prerendering/**/*',
+			'packages/kit/test/version-chunk-rotation/**/*',
 			'packages/test-redirect-importer/index.js',
 			'packages/adapter-netlify/test/preview.js'
 		]

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -98,6 +98,10 @@
 		"#app/env/public": {
 			"browser": "./src/runtime/app/env/public/client.js",
 			"default": "./src/runtime/app/env/public/server.js"
+		},
+		"#app/env/version": {
+			"browser": "./src/runtime/app/env/version/client.js",
+			"default": "./src/runtime/app/env/version/server.js"
 		}
 	},
 	"exports": {

--- a/packages/kit/src/core/sync/write_server.js
+++ b/packages/kit/src/core/sync/write_server.js
@@ -1,10 +1,9 @@
 import path from 'node:path';
 import process from 'node:process';
-import { hash } from '../../utils/hash.js';
 import { posixify, resolve_entry } from '../../utils/filesystem.js';
 import { s } from '../../utils/misc.js';
 import { load_error_page, load_template } from '../config/index.js';
-import { runtime_directory } from '../utils.js';
+import { runtime_directory, payload_hash } from '../utils.js';
 import { isSvelte5Plus, write_if_changed } from './utils.js';
 import colors from 'kleur';
 import { escape_html } from '../../utils/escape.js';
@@ -63,7 +62,7 @@ export const options = {
 			)},
 		error
 	},
-	version_hash: ${s(hash(config.kit.version.name))}
+	version_hash: ${s(payload_hash(config.kit))}
 };
 
 export async function get_hooks() {

--- a/packages/kit/src/core/utils.js
+++ b/packages/kit/src/core/utils.js
@@ -25,6 +25,8 @@ import { hash } from '../utils/hash.js';
  * @returns {string}
  */
 export function payload_hash(kit) {
+	if (kit.embedded) return hash(kit.version.name);
+
 	const root = path.dirname(kit.outDir);
 
 	let name = '';
@@ -34,6 +36,8 @@ export function payload_hash(kit) {
 	} catch {
 		// TODO log error or similiar
 	}
+
+	if (!name) name = path.basename(root);
 
 	return hash(`${name}\n${kit.paths.base}\n${kit.appDir}`);
 }

--- a/packages/kit/src/core/utils.js
+++ b/packages/kit/src/core/utils.js
@@ -5,6 +5,38 @@ import { fileURLToPath } from 'node:url';
 import colors from 'kleur';
 import { posixify, to_fs } from '../utils/filesystem.js';
 import { noop } from '../utils/functions.js';
+import { hash } from '../utils/hash.js';
+
+/**
+ * Returns a deterministic identifier for the `globalThis.__sveltekit_${payload_hash}`
+ * payload global.
+ *
+ * It must not be derived from `kit.version.name`: the name is inlined into
+ * content-hashed client chunks in `__SVELTEKIT_PAYLOAD__` via the
+ * `$env/dynamic/public` virtual module, so a version-derived identifier rotates the
+ * hashed filename of every chunk referencing it on each deploy (#12260).
+ *
+ * It must still distinguish SvelteKit apps from different projects embedded in the
+ * same document (#9576), so it is derived from the project's `package.json` name
+ * plus `paths.base` and `appDir` — all deterministic across repeated config loads
+ * within a build and across machines.
+ *
+ * @param {import('types').ValidatedKitConfig} kit
+ * @returns {string}
+ */
+export function payload_hash(kit) {
+	const root = path.dirname(kit.outDir);
+
+	let name = '';
+
+	try {
+		name = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf-8')).name ?? '';
+	} catch {
+		// TODO log error or similiar
+	}
+
+	return hash(`${name}\n${kit.paths.base}\n${kit.appDir}`);
+}
 
 /**
  * Resolved path of the `runtime` directory

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -21,7 +21,7 @@ import {
 } from '../../core/env.js';
 import * as sync from '../../core/sync/sync.js';
 import { create_assets } from '../../core/sync/create_manifest_data/index.js';
-import { runtime_directory, logger } from '../../core/utils.js';
+import { runtime_directory, logger, payload_hash } from '../../core/utils.js';
 import { load_svelte_config, process_config, split_config } from '../../core/config/index.js';
 import { generate_manifest } from '../../core/generate_manifest/index.js';
 import { build_server_nodes } from './build/build_server.js';
@@ -244,7 +244,7 @@ async function kit({ svelte_config }) {
 	/** The base directory for the Vite builds */
 	const out = `${out_dir}/output`;
 
-	const version_hash = hash(kit.version.name);
+	const version_hash = payload_hash(kit);
 
 	/** @type {ResolvedConfig} */
 	let vite_config;

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -212,6 +212,12 @@ export async function sveltekit(config) {
 
 let secondary_build_started = false;
 
+/**
+ * config loads twice so we cache the value of the first load so client and server bundles read the same value
+ * @type {string | undefined}
+ */
+let resolved_version_name;
+
 /** @type {import('types').ManifestData} */
 let manifest_data;
 
@@ -298,6 +304,19 @@ async function kit({ svelte_config }) {
 				initial_config = config;
 				vite_config_env = config_env;
 				is_build = config_env.command === 'build';
+
+				if (is_build) {
+					if (resolved_version_name === undefined) {
+						resolved_version_name = kit.version.name;
+					} else if (kit.version.name !== resolved_version_name) {
+						console.warn(
+							`svelte.config.js computed a different kit.version.name on each load ` +
+								`("${resolved_version_name}" vs "${kit.version.name}"). Using the first value ` +
+								`for the whole build — make version.name deterministic to silence this warning.`
+						);
+					}
+					kit.version.name = resolved_version_name;
+				}
 
 				env = get_env(kit.env, vite_config_env.mode);
 

--- a/packages/kit/src/runtime/app/env/internal.js
+++ b/packages/kit/src/runtime/app/env/internal.js
@@ -1,4 +1,4 @@
-export const version = __SVELTEKIT_APP_VERSION__;
+export { version } from '#app/env/version';
 export let building = false;
 export let prerendering = false;
 

--- a/packages/kit/src/runtime/app/env/version/client.js
+++ b/packages/kit/src/runtime/app/env/version/client.js
@@ -1,0 +1,1 @@
+export const version = /** @type {string} */ (__SVELTEKIT_PAYLOAD__?.version);

--- a/packages/kit/src/runtime/app/env/version/server.js
+++ b/packages/kit/src/runtime/app/env/version/server.js
@@ -1,0 +1,1 @@
+export const version = __SVELTEKIT_APP_VERSION__;

--- a/packages/kit/src/runtime/server/page/render.js
+++ b/packages/kit/src/runtime/server/page/render.js
@@ -412,7 +412,10 @@ export async function render_response({
 
 		const blocks = [];
 
-		const properties = [`base: ${base_expression}`];
+		const properties = [
+			`base: ${base_expression}`,
+			`version: ${devalue.uneval(__SVELTEKIT_APP_VERSION__)}`
+		];
 
 		if (paths.assets) {
 			properties.push(`assets: ${s(paths.assets)}`);

--- a/packages/kit/src/types/global-private.d.ts
+++ b/packages/kit/src/types/global-private.d.ts
@@ -37,6 +37,8 @@ declare global {
 	const __SVELTEKIT_PAYLOAD__: {
 		/** The basepath, usually relative to the current page */
 		base: string;
+		/** determinsitically computed from package name + config.appDir + config.base */
+		version?: string;
 		/** Path to externally-hosted assets */
 		assets?: string;
 		/** Public environment variables */

--- a/packages/kit/test/version-chunk-rotation/app/package.json
+++ b/packages/kit/test/version-chunk-rotation/app/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "test-version-chunk-rotation-app",
+	"private": true,
+	"version": "0.0.0",
+	"type": "module",
+	"scripts": {
+		"dev": "vite dev",
+		"build": "svelte-kit sync && vite build",
+		"preview": "vite preview",
+		"prepare": "svelte-kit sync",
+		"check": "svelte-kit sync && tsc && svelte-check"
+	},
+	"devDependencies": {
+		"@sveltejs/adapter-auto": "workspace:^",
+		"@sveltejs/kit": "workspace:^",
+		"@sveltejs/vite-plugin-svelte": "catalog:",
+		"svelte": "catalog:",
+		"svelte-check": "catalog:",
+		"typescript": "catalog:",
+		"vite": "catalog:"
+	}
+}

--- a/packages/kit/test/version-chunk-rotation/app/src/app.d.ts
+++ b/packages/kit/test/version-chunk-rotation/app/src/app.d.ts
@@ -1,0 +1,5 @@
+declare global {
+	namespace App {}
+}
+
+export {};

--- a/packages/kit/test/version-chunk-rotation/app/src/app.html
+++ b/packages/kit/test/version-chunk-rotation/app/src/app.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%sveltekit.head%
+	</head>
+	<body>
+		<div>%sveltekit.body%</div>
+	</body>
+</html>

--- a/packages/kit/test/version-chunk-rotation/app/src/lib/shared.js
+++ b/packages/kit/test/version-chunk-rotation/app/src/lib/shared.js
@@ -1,0 +1,6 @@
+export const sharedMessage = 'shared between routes';
+
+/** @param {number} n */
+export function double(n) {
+	return n * 2;
+}

--- a/packages/kit/test/version-chunk-rotation/app/src/routes/+page.svelte
+++ b/packages/kit/test/version-chunk-rotation/app/src/routes/+page.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { double, sharedMessage } from '$lib/shared.js';
+</script>
+
+<h1>home</h1>
+<p>{sharedMessage}: {double(21)}</p>
+<a href="/about">about</a>

--- a/packages/kit/test/version-chunk-rotation/app/src/routes/about/+page.svelte
+++ b/packages/kit/test/version-chunk-rotation/app/src/routes/about/+page.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { double, sharedMessage } from '$lib/shared.js';
+</script>
+
+<h1>about</h1>
+<p>{sharedMessage}: {double(50)}</p>
+<a href="/">home</a>

--- a/packages/kit/test/version-chunk-rotation/app/src/routes/prerendered/+page.js
+++ b/packages/kit/test/version-chunk-rotation/app/src/routes/prerendered/+page.js
@@ -1,0 +1,1 @@
+export const prerender = true;

--- a/packages/kit/test/version-chunk-rotation/app/src/routes/prerendered/+page.svelte
+++ b/packages/kit/test/version-chunk-rotation/app/src/routes/prerendered/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	import { sharedMessage } from '$lib/shared.js';
+</script>
+
+<h1>prerendered</h1>
+<p>{sharedMessage}</p>

--- a/packages/kit/test/version-chunk-rotation/app/svelte.config.js
+++ b/packages/kit/test/version-chunk-rotation/app/svelte.config.js
@@ -6,7 +6,7 @@ const config = {
 	kit: {
 		adapter: adapter(),
 		version: {
-			name: process.env.SK_VERSION || 'control'
+			name: process.env.SK_VERSION || Date.now().toString()
 		}
 	}
 };

--- a/packages/kit/test/version-chunk-rotation/app/svelte.config.js
+++ b/packages/kit/test/version-chunk-rotation/app/svelte.config.js
@@ -1,0 +1,14 @@
+import adapter from '../../../../adapter-auto/index.js';
+import process from 'node:process';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	kit: {
+		adapter: adapter(),
+		version: {
+			name: process.env.SK_VERSION || 'control'
+		}
+	}
+};
+
+export default config;

--- a/packages/kit/test/version-chunk-rotation/app/tsconfig.json
+++ b/packages/kit/test/version-chunk-rotation/app/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"noEmit": true
+	},
+	"extends": "./.svelte-kit/tsconfig.json"
+}

--- a/packages/kit/test/version-chunk-rotation/app/vite.config.js
+++ b/packages/kit/test/version-chunk-rotation/app/vite.config.js
@@ -1,0 +1,23 @@
+import * as path from 'node:path';
+import { sveltekit } from '@sveltejs/kit/vite';
+
+/** @type {import('vite').UserConfig} */
+const config = {
+	build: {
+		minify: false
+	},
+
+	clearScreen: false,
+
+	logLevel: 'silent',
+
+	plugins: [sveltekit()],
+
+	server: {
+		fs: {
+			allow: [path.resolve('../../../src')]
+		}
+	}
+};
+
+export default config;

--- a/packages/kit/test/version-chunk-rotation/classify.js
+++ b/packages/kit/test/version-chunk-rotation/classify.js
@@ -1,0 +1,88 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * @typedef {object} Chunk
+ * @property {string} bytes_hash
+ * @property {boolean} contains_version
+ */
+
+const VERSION_DERIVED_PAYLOAD_KEY = /__sveltekit_(?!dev\b)[A-Za-z0-9]+/;
+
+/** @param {string} code */
+const bytes_hash = (code) => createHash('sha256').update(code).digest('hex').slice(0, 12);
+
+/**
+ * @param {string} dir
+ * @param {string} [base]
+ * @param {string[]} [found]
+ * @returns {string[]}
+ */
+function js_files(dir, base = dir, found = []) {
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const abs = path.join(dir, entry.name);
+		if (entry.isDirectory()) js_files(abs, base, found);
+		else if (entry.name.endsWith('.js')) found.push(path.relative(base, abs));
+	}
+	return found.sort();
+}
+
+/**
+ * @param {string} dir
+ * @param {string} version
+ * @returns {Map<string, Chunk>}
+ */
+export function snapshot(dir, version) {
+	/** @type {Map<string, Chunk>} */
+	const chunks = new Map();
+
+	for (const filename of js_files(dir)) {
+		const code = fs.readFileSync(path.join(dir, filename), 'utf-8');
+
+		chunks.set(filename, {
+			bytes_hash: bytes_hash(code),
+			contains_version: code.includes(version) || VERSION_DERIVED_PAYLOAD_KEY.test(code)
+		});
+	}
+
+	return chunks;
+}
+
+/**
+ * @param {Map<string, Chunk>} before
+ * @param {Map<string, Chunk>} after
+ */
+export function compare(before, after) {
+	/** @type {Array<{ name: string, contains_version: boolean }>} */
+	const rotated = [];
+	/** @type {Array<{ name: string, contains_version: boolean }>} */
+	const mutable = [];
+
+	for (const [name, chunk] of before) {
+		const replacement = after.get(name);
+		if (!replacement) {
+			rotated.push({ name, contains_version: chunk.contains_version });
+		} else if (replacement.bytes_hash !== chunk.bytes_hash) {
+			mutable.push({
+				name,
+				contains_version: chunk.contains_version || replacement.contains_version
+			});
+		}
+	}
+
+	return { total: before.size, rotated, mutable };
+}
+
+/** @param {ReturnType<typeof compare>} result */
+export function format_report(result) {
+	/** @param {{ name: string, contains_version: boolean }} finding */
+	const line = ({ name, contains_version }) =>
+		`${name}${contains_version ? '  ← contains the version' : ''}`;
+
+	return [
+		`${result.total} chunks total · ${result.rotated.length} rotated · ${result.mutable.length} mutable (same name, new bytes)`,
+		...result.mutable.map((finding) => `  MUTABLE ${line(finding)}`),
+		...result.rotated.map((finding) => `  ROTATED ${line(finding)}`)
+	].join('\n');
+}

--- a/packages/kit/test/version-chunk-rotation/classify.spec.js
+++ b/packages/kit/test/version-chunk-rotation/classify.spec.js
@@ -1,0 +1,72 @@
+import { assert, test } from 'vitest';
+import { compare } from './classify.js';
+
+/**
+ * @param {object} [options]
+ * @param {string} [options.bytes]
+ * @param {boolean} [options.contains_version]
+ * @returns {import('./classify.js').Chunk}
+ */
+function chunk({ bytes = 'same-bytes', contains_version = false } = {}) {
+	return { bytes_hash: bytes, contains_version };
+}
+
+/** @param {Record<string, import('./classify.js').Chunk>} chunks */
+const build = (chunks) => new Map(Object.entries(chunks));
+
+test('identical builds produce no findings', () => {
+	const output = build({
+		'chunks/AAAAAAAA.js': chunk(),
+		'entry/app.BBBBBBBB.js': chunk({ contains_version: true })
+	});
+
+	const result = compare(output, output);
+
+	assert.deepEqual(result.rotated, []);
+	assert.deepEqual(result.mutable, []);
+});
+
+test('a chunk whose bytes change under a stable filename is mutable', () => {
+	const before = build({ 'chunks/AAAAAAAA.js': chunk({ bytes: 'old', contains_version: true }) });
+	const after = build({ 'chunks/AAAAAAAA.js': chunk({ bytes: 'new', contains_version: true }) });
+
+	const result = compare(before, after);
+
+	assert.deepEqual(result.rotated, []);
+	assert.deepEqual(result.mutable, [{ name: 'chunks/AAAAAAAA.js', contains_version: true }]);
+});
+
+test('a rotated chunk is reported with its version flag', () => {
+	const before = build({
+		'chunks/AAAAAAAA.js': chunk({ contains_version: true }),
+		'nodes/0.BBBBBBBB.js': chunk({ bytes: 'imports-AAAAAAAA' })
+	});
+	const after = build({
+		'chunks/CCCCCCCC.js': chunk({ contains_version: true }),
+		'nodes/0.DDDDDDDD.js': chunk({ bytes: 'imports-CCCCCCCC' })
+	});
+
+	const result = compare(before, after);
+
+	assert.deepEqual(result.rotated, [
+		{ name: 'chunks/AAAAAAAA.js', contains_version: true },
+		{ name: 'nodes/0.BBBBBBBB.js', contains_version: false }
+	]);
+	assert.deepEqual(result.mutable, []);
+});
+
+test('an unchanged chunk is not reported even when siblings rotate', () => {
+	const before = build({
+		'chunks/AAAAAAAA.js': chunk(),
+		'chunks/BBBBBBBB.js': chunk({ contains_version: true })
+	});
+	const after = build({
+		'chunks/AAAAAAAA.js': chunk(),
+		'chunks/CCCCCCCC.js': chunk({ contains_version: true })
+	});
+
+	const result = compare(before, after);
+
+	assert.deepEqual(result.rotated, [{ name: 'chunks/BBBBBBBB.js', contains_version: true }]);
+	assert.deepEqual(result.mutable, []);
+});

--- a/packages/kit/test/version-chunk-rotation/consistency.spec.js
+++ b/packages/kit/test/version-chunk-rotation/consistency.spec.js
@@ -1,0 +1,56 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { assert, test } from 'vitest';
+
+const timeout = 180_000;
+
+const app_dir = fileURLToPath(new URL('./app', import.meta.url));
+
+/** @param {string} [version] omit to build with the fixture's per-config-load default */
+function build(version) {
+	const env = { ...process.env };
+	if (version === undefined) delete env.SK_VERSION;
+	else env.SK_VERSION = version;
+
+	fs.rmSync(path.join(app_dir, '.svelte-kit/output'), { recursive: true, force: true });
+	execSync('pnpm build', { cwd: app_dir, stdio: 'pipe', timeout, env });
+
+	return {
+		prerendered_page: fs.readFileSync(
+			path.join(app_dir, '.svelte-kit/output/prerendered/pages/prerendered.html'),
+			'utf-8'
+		),
+		version_json: /** @type {{ version: string }} */ (
+			JSON.parse(
+				fs.readFileSync(path.join(app_dir, '.svelte-kit/output/client/_app/version.json'), 'utf-8')
+			)
+		)
+	};
+}
+
+test('a version containing </script> cannot terminate the payload script', { timeout }, () => {
+	const dangerous_version = '</script><script>alert(1)</script>';
+
+	const { prerendered_page, version_json } = build(dangerous_version);
+
+	assert.notInclude(prerendered_page, dangerous_version);
+	assert.include(prerendered_page, '\\u003C/script>', 'the version is escaped, not dropped');
+	assert.equal(version_json.version, dangerous_version);
+});
+
+test(
+	'a version computed per config load resolves to one value for the whole build (#14166)',
+	{ timeout },
+	() => {
+		const { prerendered_page, version_json } = build();
+
+		assert.include(
+			prerendered_page,
+			`version: "${version_json.version}"`,
+			'the payload version and _app/version.json must agree'
+		);
+	}
+);

--- a/packages/kit/test/version-chunk-rotation/package.json
+++ b/packages/kit/test/version-chunk-rotation/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "test-version-chunk-rotation",
+	"private": true,
+	"version": "0.0.0",
+	"type": "module",
+	"scripts": {
+		"test": "vitest run",
+		"test:cross-platform:build": "vitest run"
+	},
+	"devDependencies": {
+		"vitest": "catalog:"
+	}
+}

--- a/packages/kit/test/version-chunk-rotation/payload-hash.spec.js
+++ b/packages/kit/test/version-chunk-rotation/payload-hash.spec.js
@@ -1,0 +1,91 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { assert, test } from 'vitest';
+import { payload_hash } from '../../src/core/utils.js';
+import { hash } from '../../src/utils/hash.js';
+
+/** @param {{ name?: string, package_json?: boolean }} [options] */
+function project({ name, package_json = true } = {}) {
+	const root = mkdtempSync(join(tmpdir(), 'kit-payload-hash-'));
+	if (package_json) writeFileSync(join(root, 'package.json'), JSON.stringify({ name }));
+	return root;
+}
+
+/**
+ * @param {object} options
+ * @param {string} options.root
+ * @param {string} [options.base]
+ * @param {string} [options.app_dir]
+ * @param {string} [options.version]
+ * @param {boolean} [options.embedded]
+ * @returns {import('types').ValidatedKitConfig}
+ */
+function kit_config({ root, base = '', app_dir = '_app', version = 'v1', embedded = false }) {
+	return /** @type {import('types').ValidatedKitConfig} */ (
+		/** @type {unknown} */ ({
+			outDir: join(root, '.svelte-kit'),
+			appDir: app_dir,
+			paths: { base },
+			version: { name: version },
+			embedded
+		})
+	);
+}
+
+test('is independent of version.name', () => {
+	const root = project({ name: 'my-app' });
+
+	assert.equal(
+		payload_hash(kit_config({ root, version: 'v-alpha' })),
+		payload_hash(kit_config({ root, version: 'v-bravo' }))
+	);
+});
+
+test('differs between projects with different package names', () => {
+	assert.notEqual(
+		payload_hash(kit_config({ root: project({ name: 'app-one' }) })),
+		payload_hash(kit_config({ root: project({ name: 'app-two' }) }))
+	);
+});
+
+test('differs when paths.base differs', () => {
+	const root = project({ name: 'my-app' });
+
+	assert.notEqual(
+		payload_hash(kit_config({ root, base: '' })),
+		payload_hash(kit_config({ root, base: '/docs' }))
+	);
+});
+
+test('differs when appDir differs', () => {
+	const root = project({ name: 'my-app' });
+
+	assert.notEqual(
+		payload_hash(kit_config({ root, app_dir: '_app' })),
+		payload_hash(kit_config({ root, app_dir: '_custom' }))
+	);
+});
+
+test('embedded apps keep the version-derived key for cross-deploy isolation', () => {
+	const root = project({ name: 'my-app' });
+
+	assert.equal(
+		payload_hash(kit_config({ root, embedded: true, version: 'v-alpha' })),
+		hash('v-alpha')
+	);
+});
+
+test('projects without a package.json still get distinct keys', () => {
+	assert.notEqual(
+		payload_hash(kit_config({ root: project({ package_json: false }) })),
+		payload_hash(kit_config({ root: project({ package_json: false }) }))
+	);
+});
+
+test('projects with a nameless package.json still get distinct keys', () => {
+	assert.notEqual(
+		payload_hash(kit_config({ root: project() })),
+		payload_hash(kit_config({ root: project() }))
+	);
+});

--- a/packages/kit/test/version-chunk-rotation/rotation.spec.js
+++ b/packages/kit/test/version-chunk-rotation/rotation.spec.js
@@ -1,19 +1,3 @@
-// Reproduction gate for sveltejs/kit#12260: `kit.version.name` leaks into
-// content-hashed client chunks, so a version bump rotates their hashed filenames — and
-// every chunk that imports them — even when the app code is byte-identical. That
-// defeats the immutable caching of `_app/immutable/**`.
-//
-// This suite builds the fixture app under ./app three times and diffs the emitted
-// client chunks: twice at the SAME version (CONTROL — proves the build is otherwise
-// deterministic) and once at a DIFFERENT version (VARIABLE — a version bump must
-// rotate 0 chunks and mutate 0 chunks).
-//
-// EXPECTED STATE: the VARIABLE test is RED on kit without the version-decoupling fix —
-// it reproduces the bug. It turns GREEN, with no edits here, once the fix keeps the
-// version off the client import graph. The CONTROL test and classify.spec.js are GREEN
-// today. (If red CI is noisy before the fix lands, `test.skip` the VARIABLE test with a
-// TODO referencing the follow-up — but the default is an honest, un-skipped gate.)
-
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -27,11 +11,7 @@ const timeout = 180_000;
 const app_dir = fileURLToPath(new URL('./app', import.meta.url));
 const immutable_dir = path.join(app_dir, '.svelte-kit/output/client/_app/immutable');
 
-/**
- * Build the fixture with the given `kit.version.name` and snapshot its client
- * bundle. Output is cleaned first so the snapshot reflects only this build.
- * @param {string} version
- */
+/** @param {string} version */
 function build(version) {
 	fs.rmSync(path.join(app_dir, '.svelte-kit/output'), { recursive: true, force: true });
 	execSync('pnpm build', {
@@ -40,14 +20,22 @@ function build(version) {
 		timeout,
 		env: { ...process.env, SK_VERSION: version }
 	});
-	return snapshot(immutable_dir, version);
+
+	return {
+		version,
+		chunks: snapshot(immutable_dir, version),
+		prerendered_page: fs.readFileSync(
+			path.join(app_dir, '.svelte-kit/output/prerendered/pages/prerendered.html'),
+			'utf-8'
+		)
+	};
 }
 
-/** @type {ReturnType<typeof snapshot>} */
+/** @type {ReturnType<typeof build>} */
 let control_a;
-/** @type {ReturnType<typeof snapshot>} */
+/** @type {ReturnType<typeof build>} */
 let control_b;
-/** @type {ReturnType<typeof snapshot>} */
+/** @type {ReturnType<typeof build>} */
 let bumped;
 
 beforeAll(() => {
@@ -57,25 +45,41 @@ beforeAll(() => {
 }, timeout);
 
 test('the same version builds an identical client bundle', () => {
-	const r = compare(control_a, control_b);
+	const result = compare(control_a.chunks, control_b.chunks);
+
 	assert.equal(
-		r.rotated.length,
+		result.rotated.length,
 		0,
-		`build is nondeterministic at a fixed version — ${r.rotated.length} chunk(s) rotated:\n${format_report(r)}`
+		`build is nondeterministic at a fixed version — ${result.rotated.length} chunk(s) rotated:\n${format_report(result)}`
 	);
-	assert.equal(r.mutable.length, 0, `mutable chunks at a fixed version:\n${format_report(r)}`);
+	assert.equal(
+		result.mutable.length,
+		0,
+		`mutable chunks at a fixed version:\n${format_report(result)}`
+	);
 });
 
 test('bumping kit.version.name rotates no client chunks', () => {
-	const r = compare(control_a, bumped);
+	const result = compare(control_a.chunks, bumped.chunks);
+
 	assert.equal(
-		r.mutable.length,
+		result.mutable.length,
 		0,
-		`chunks changed bytes under a stable filename (breaks immutable caching):\n${format_report(r)}`
+		`chunks changed bytes under a stable filename (breaks immutable caching):\n${format_report(result)}`
 	);
 	assert.equal(
-		r.rotated.length,
+		result.rotated.length,
 		0,
-		`a version bump rotated ${r.rotated.length} client chunk(s) with no app-code change (#12260):\n${format_report(r)}`
+		`a version bump rotated ${result.rotated.length} client chunk(s) with no app-code change (#12260):\n${format_report(result)}`
 	);
+});
+
+test('the server-rendered payload carries the version of its own build', () => {
+	for (const { version, prerendered_page } of [control_a, bumped]) {
+		assert.include(
+			prerendered_page,
+			`version: "${version}"`,
+			`the payload of the "${version}" build should carry that version`
+		);
+	}
 });

--- a/packages/kit/test/version-chunk-rotation/rotation.spec.js
+++ b/packages/kit/test/version-chunk-rotation/rotation.spec.js
@@ -31,6 +31,15 @@ function build(version) {
 	};
 }
 
+/**
+ * @param {ReturnType<typeof compare>} result
+ * @param {string} when
+ */
+function assert_bundle_unchanged(result, when) {
+	assert.equal(result.mutable.length, 0, `chunks mutated ${when}:\n${format_report(result)}`);
+	assert.equal(result.rotated.length, 0, `chunks rotated ${when}:\n${format_report(result)}`);
+}
+
 /** @type {ReturnType<typeof build>} */
 let control_a;
 /** @type {ReturnType<typeof build>} */
@@ -45,41 +54,18 @@ beforeAll(() => {
 }, timeout);
 
 test('the same version builds an identical client bundle', () => {
-	const result = compare(control_a.chunks, control_b.chunks);
-
-	assert.equal(
-		result.rotated.length,
-		0,
-		`build is nondeterministic at a fixed version — ${result.rotated.length} chunk(s) rotated:\n${format_report(result)}`
-	);
-	assert.equal(
-		result.mutable.length,
-		0,
-		`mutable chunks at a fixed version:\n${format_report(result)}`
-	);
+	assert_bundle_unchanged(compare(control_a.chunks, control_b.chunks), 'at a fixed version');
 });
 
 test('bumping kit.version.name rotates no client chunks', () => {
-	const result = compare(control_a.chunks, bumped.chunks);
-
-	assert.equal(
-		result.mutable.length,
-		0,
-		`chunks changed bytes under a stable filename (breaks immutable caching):\n${format_report(result)}`
-	);
-	assert.equal(
-		result.rotated.length,
-		0,
-		`a version bump rotated ${result.rotated.length} client chunk(s) with no app-code change (#12260):\n${format_report(result)}`
+	assert_bundle_unchanged(
+		compare(control_a.chunks, bumped.chunks),
+		'after a version bump with no app-code change'
 	);
 });
 
 test('the server-rendered payload carries the version of its own build', () => {
 	for (const { version, prerendered_page } of [control_a, bumped]) {
-		assert.include(
-			prerendered_page,
-			`version: "${version}"`,
-			`the payload of the "${version}" build should carry that version`
-		);
+		assert.include(prerendered_page, `version: "${version}"`);
 	}
 });

--- a/packages/kit/test/version-chunk-rotation/rotation.spec.js
+++ b/packages/kit/test/version-chunk-rotation/rotation.spec.js
@@ -1,0 +1,81 @@
+// Reproduction gate for sveltejs/kit#12260: `kit.version.name` leaks into
+// content-hashed client chunks, so a version bump rotates their hashed filenames — and
+// every chunk that imports them — even when the app code is byte-identical. That
+// defeats the immutable caching of `_app/immutable/**`.
+//
+// This suite builds the fixture app under ./app three times and diffs the emitted
+// client chunks: twice at the SAME version (CONTROL — proves the build is otherwise
+// deterministic) and once at a DIFFERENT version (VARIABLE — a version bump must
+// rotate 0 chunks and mutate 0 chunks).
+//
+// EXPECTED STATE: the VARIABLE test is RED on kit without the version-decoupling fix —
+// it reproduces the bug. It turns GREEN, with no edits here, once the fix keeps the
+// version off the client import graph. The CONTROL test and classify.spec.js are GREEN
+// today. (If red CI is noisy before the fix lands, `test.skip` the VARIABLE test with a
+// TODO referencing the follow-up — but the default is an honest, un-skipped gate.)
+
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { assert, beforeAll, test } from 'vitest';
+import { compare, format_report, snapshot } from './classify.js';
+
+const timeout = 180_000;
+
+const app_dir = fileURLToPath(new URL('./app', import.meta.url));
+const immutable_dir = path.join(app_dir, '.svelte-kit/output/client/_app/immutable');
+
+/**
+ * Build the fixture with the given `kit.version.name` and snapshot its client
+ * bundle. Output is cleaned first so the snapshot reflects only this build.
+ * @param {string} version
+ */
+function build(version) {
+	fs.rmSync(path.join(app_dir, '.svelte-kit/output'), { recursive: true, force: true });
+	execSync('pnpm build', {
+		cwd: app_dir,
+		stdio: 'pipe',
+		timeout,
+		env: { ...process.env, SK_VERSION: version }
+	});
+	return snapshot(immutable_dir, version);
+}
+
+/** @type {ReturnType<typeof snapshot>} */
+let control_a;
+/** @type {ReturnType<typeof snapshot>} */
+let control_b;
+/** @type {ReturnType<typeof snapshot>} */
+let bumped;
+
+beforeAll(() => {
+	control_a = build('version-alpha');
+	control_b = build('version-alpha');
+	bumped = build('version-bravo');
+}, timeout);
+
+test('the same version builds an identical client bundle', () => {
+	const r = compare(control_a, control_b);
+	assert.equal(
+		r.rotated.length,
+		0,
+		`build is nondeterministic at a fixed version — ${r.rotated.length} chunk(s) rotated:\n${format_report(r)}`
+	);
+	assert.equal(r.mutable.length, 0, `mutable chunks at a fixed version:\n${format_report(r)}`);
+});
+
+test('bumping kit.version.name rotates no client chunks', () => {
+	const r = compare(control_a, bumped);
+	assert.equal(
+		r.mutable.length,
+		0,
+		`chunks changed bytes under a stable filename (breaks immutable caching):\n${format_report(r)}`
+	);
+	assert.equal(
+		r.rotated.length,
+		0,
+		`a version bump rotated ${r.rotated.length} client chunk(s) with no app-code change (#12260):\n${format_report(r)}`
+	);
+});

--- a/packages/kit/test/version-chunk-rotation/vitest.config.js
+++ b/packages/kit/test/version-chunk-rotation/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		// rotation.spec.js and consistency.spec.js both build ./app in place —
+		// concurrent builds in the same directory would corrupt each other's output
+		fileParallelism: false
+	}
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1392,6 +1392,36 @@ importers:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@18.19.130)(@vitest/browser-playwright@4.1.9)(jsdom@26.1.0)(vite@6.4.3(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
 
+  packages/kit/test/version-chunk-rotation:
+    devDependencies:
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@18.19.130)(@vitest/browser-playwright@4.1.9)(jsdom@26.1.0)(vite@6.4.3(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+
+  packages/kit/test/version-chunk-rotation/app:
+    devDependencies:
+      '@sveltejs/adapter-auto':
+        specifier: workspace:^
+        version: link:../../../../adapter-auto
+      '@sveltejs/kit':
+        specifier: workspace:^
+        version: link:../../..
+      '@sveltejs/vite-plugin-svelte':
+        specifier: 'catalog:'
+        version: 6.2.4(svelte@5.56.3(@typescript-eslint/types@8.61.1))(vite@6.4.3(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3))
+      svelte:
+        specifier: 'catalog:'
+        version: 5.56.3(@typescript-eslint/types@8.61.1)
+      svelte-check:
+        specifier: 'catalog:'
+        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.61.1))(typescript@6.0.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.2
+      vite:
+        specifier: 'catalog:'
+        version: 6.4.3(@types/node@18.19.130)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.3)
+
   packages/package:
     dependencies:
       chokidar:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,8 @@ packages:
   - packages/kit/test/prerendering/*
   - packages/kit/test/build-errors/**
   - packages/kit/test/build-errors/apps/*
+  - packages/kit/test/version-chunk-rotation
+  - packages/kit/test/version-chunk-rotation/app
   - '!.test-tmp/**'
   - playgrounds/*
 allowBuilds:


### PR DESCRIPTION
closes 
#12260
#9576

--- 
Somewhat adjacent to #14176 


### Context 

For context we're running a svelte kit app and deploying many times per day. Currently svelte kit places the version into the client bundle, causing the chunks to rotate their hashes invalidating the caching whenever we deploy as described in #12260. This contributes to a degraded user experience in our case .e.g. a user will open a modal but the chunk will 404's the client chunks because the server version has rotated. We're using our git SHA as our version.

## Description 

This PR aims to solve the bundle rotating by refactoring the mechanism of how svelte kit defines and deliver the version within each client / server context.

Here is a simple visual flow of how the current `version` leaks into the client bundle via two seperate sources. 

[[see](https://vite.dev/config/shared-options#define)](https://vite.dev/config/shared-options#define) for how `__SVELTEKIT_PAYLOAD__` is replaced by vite

```
kit.version.name  = 'version-alpha'
        │
        ├─▶ __sveltekit/environment emits  export const version = "version-alpha"
        │       └─▶ imported by runtime/client/utils.js (the `updated` poll)
        │
        └─▶ version_hash = hash(name)  ─▶  __SVELTEKIT_PAYLOAD__ (vite define  replacement)
                                            = globalThis.__sveltekit_<version_hash> -▶ __sveltekit__99avfu
        │
        ▼
both inlined into ONE shared client chunk   ←  its bytes change resulting in its content hash changing
        │ 
        ▼
every chunk that imports it gets a new hash  ← causes cascade effect across the entire client bundle
(entry/app, entry/start, nodes/*, other shared chunks)
```

Because the client uses the version hash as part of the global definition we need to keep it stable if we want to avoid the cascade effect. 

For that reason we are using a combination of config values to avoid any global collisions in embedded sveltekit version like in #14176  
```
hash(`${name}\n${kit.paths.base}\n${kit.appDir}`);
```

(Open to other suggestions on other combinations here)

Now the `version_hash` is stable on globalThis between deploys we pass the actual version through the payload.

Then we pass the version as a prop within the payload 

```
	const properties = [
			`base: ${base_expression}`,
			`version: ${devalue.uneval(__SVELTEKIT_APP_VERSION__)}`
		];
```

N.B Perhaps `version_hash` needs to be renamed now as our definitions of "version" diverge a bit. I'd like to get a bit more feedback on the general approach here before continuing further refactoring.

### Tests

I've added some tests to demonstrate the current issue. In these tests we build multiple versions of the app with different version inputs and compare the content of the built chunks to avoid running into situations similar to https://github.com/sveltejs/kit/pull/12779 (even though we are not using post build plugins).

### Production testing

Our app is currently pinned to a slightly older version of kit but we're happy to test the core of these changes out on a subset of production traffic to help verify.


---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

I haven't made a change set yet but I will on confirmation the maintainers are happy with the direction of this PR.
### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.