### PR TITLE
breaking: move tracing out of the experimental namespace and remove instrumentation flag

### DIFF
--- a/.changeset/o11y-leave-experimental.md
+++ b/.changeset/o11y-leave-experimental.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: move tracing out of the experimental namespace and remove the instrumentation flag

--- a/documentation/docs/30-advanced/68-observability.md
+++ b/documentation/docs/30-advanced/68-observability.md
@@ -13,9 +13,9 @@ Sometimes, you may need to observe how your application is behaving in order to 
 - [Form actions](form-actions)
 - [Remote functions](remote-functions)
 
-Just telling SvelteKit to emit spans won't get you far, though — you need to actually collect them somewhere to be able to view them. SvelteKit provides `src/instrumentation.server.ts` as a place to write your tracing setup and instrumentation code. It's guaranteed to be run prior to your application code being imported, providing your deployment platform supports it and your adapter is aware of it.
+Just telling SvelteKit to emit spans won't get you far, though — you need to actually collect them somewhere to be able to view them. SvelteKit provides `src/instrumentation.server.ts` as a place to write your tracing setup and instrumentation code. If this file exists, it is loaded before your application code (provided your deployment platform supports it and your adapter is aware of it).
 
-Both of these features are currently experimental, meaning they are likely to contain bugs and are subject to change without notice. You must opt in by adding the `experimental.tracing.server` and `experimental.instrumentation.server` option of the SvelteKit plugin in your `vite.config.js`:
+To enable SvelteKit's built-in span emission, set the `tracing.server` option of the SvelteKit plugin in your `vite.config.js` to `true`:
 
 ```js
 /// file: vite.config.js
@@ -25,14 +25,9 @@ import { defineConfig } from 'vite';
 export default defineConfig({
 	plugins: [
 		sveltekit({
-			experimental: {
-				+++tracing: {
-					server: true
-				},
-				instrumentation: {
-					server: true
-				}+++
-			}
+			+++tracing: {
+				server: true
+			}+++
 		})
 	]
 });
@@ -68,7 +63,7 @@ async function authenticate() {
 
 To view your first trace, you'll need to set up a local collector. We'll use [Jaeger](https://www.jaegertracing.io/docs/getting-started/) in this example, as they provide an easy-to-use quickstart command. Once your collector is running locally:
 
-- Turn on the experimental flags mentioned earlier in your `vite.config.js` file
+- Enable tracing as described earlier in your `vite.config.js` file, and create `src/instrumentation.server.js` (which SvelteKit will load automatically)
 - Use your package manager to install the dependencies you'll need:
   ```sh
   npm i @opentelemetry/sdk-node @opentelemetry/auto-instrumentations-node @opentelemetry/exporter-trace-otlp-proto import-in-the-middle

--- a/packages/adapter-netlify/test/apps/instrumentation/vite.config.ts
+++ b/packages/adapter-netlify/test/apps/instrumentation/vite.config.ts
@@ -8,12 +8,7 @@ const config: UserConfig = {
 	},
 	plugins: [
 		sveltekit({
-			adapter: adapter(),
-			experimental: {
-				instrumentation: {
-					server: true
-				}
-			}
+			adapter: adapter()
 		})
 	]
 };

--- a/packages/kit/src/core/config/index.spec.js
+++ b/packages/kit/src/core/config/index.spec.js
@@ -70,8 +70,6 @@ const get_defaults = (prefix = '') => ({
 			dir: prefix
 		},
 		experimental: {
-			tracing: { server: false },
-			instrumentation: { server: false },
 			remoteFunctions: false,
 			forkPreloads: false,
 			handleRenderingErrors: false
@@ -103,6 +101,7 @@ const get_defaults = (prefix = '') => ({
 			options: undefined,
 			register: true
 		},
+		tracing: { server: false },
 		typescript: {},
 		paths: {
 			base: '',
@@ -442,9 +441,7 @@ test('accepts valid tracing values', () => {
 	assert.doesNotThrow(() => {
 		validate_config({
 			kit: {
-				experimental: {
-					tracing: { server: true }
-				}
+				tracing: { server: true }
 			}
 		});
 	});
@@ -452,9 +449,7 @@ test('accepts valid tracing values', () => {
 	assert.doesNotThrow(() => {
 		validate_config({
 			kit: {
-				experimental: {
-					tracing: { server: false }
-				}
+				tracing: { server: false }
 			}
 		});
 	});
@@ -462,9 +457,7 @@ test('accepts valid tracing values', () => {
 	assert.doesNotThrow(() => {
 		validate_config({
 			kit: {
-				experimental: {
-					tracing: undefined
-				}
+				tracing: undefined
 			}
 		});
 	});
@@ -474,35 +467,53 @@ test('errors on invalid tracing values', () => {
 	assert.throws(() => {
 		validate_config({
 			kit: {
+				// @ts-expect-error - given value expected to throw
+				tracing: true
+			}
+		});
+	}, /^config\.tracing should be an object$/);
+
+	assert.throws(() => {
+		validate_config({
+			kit: {
+				// @ts-expect-error - given value expected to throw
+				tracing: 'server'
+			}
+		});
+	}, /^config\.tracing should be an object$/);
+
+	assert.throws(() => {
+		validate_config({
+			kit: {
+				// @ts-expect-error - given value expected to throw
+				tracing: { server: 'invalid' }
+			}
+		});
+	}, /^config\.tracing\.server should be true or false, if specified$/);
+});
+
+test('errors on removed experimental.tracing and experimental.instrumentation', () => {
+	assert.throws(() => {
+		validate_config({
+			kit: {
 				experimental: {
-					// @ts-expect-error - given value expected to throw
-					tracing: true
+					// @ts-expect-error - removed option expected to throw
+					tracing: { server: true }
 				}
 			}
 		});
-	}, /^config\.experimental\.tracing should be an object$/);
+	}, /`config\.experimental\.tracing` has been removed/);
 
 	assert.throws(() => {
 		validate_config({
 			kit: {
 				experimental: {
-					// @ts-expect-error - given value expected to throw
-					tracing: 'server'
+					// @ts-expect-error - removed option expected to throw
+					instrumentation: { server: true }
 				}
 			}
 		});
-	}, /^config\.experimental\.tracing should be an object$/);
-
-	assert.throws(() => {
-		validate_config({
-			kit: {
-				experimental: {
-					// @ts-expect-error - given value expected to throw
-					tracing: { server: 'invalid' }
-				}
-			}
-		});
-	}, /^config\.experimental\.tracing\.server should be true or false, if specified$/);
+	}, /`config\.experimental\.instrumentation` has been removed/);
 });
 
 test('errors on invalid forkPreloads values', () => {

--- a/packages/kit/src/core/config/options.js
+++ b/packages/kit/src/core/config/options.js
@@ -119,12 +119,14 @@ export const validate_kit_options = object({
 	}),
 
 	experimental: object({
-		tracing: object({
-			server: boolean(false)
-		}),
-		instrumentation: object({
-			server: boolean(false)
-		}),
+		tracing: removed(
+			(keypath) =>
+				`\`${keypath}\` has been removed. Server-side tracing is now configured via \`tracing.server\``
+		),
+		instrumentation: removed(
+			(keypath) =>
+				`\`${keypath}\` has been removed. \`src/instrumentation.server.js\` is now included in the build automatically when it exists; no opt-in is required`
+		),
 		remoteFunctions: boolean(false),
 		forkPreloads: boolean(false),
 		handleRenderingErrors: boolean(false)
@@ -328,6 +330,10 @@ export const validate_kit_options = object({
 		// it's an object since the type comes from the browser itself
 		options: validate(undefined, object({}, true)),
 		files: fun((filename) => !/\.DS_Store/.test(filename))
+	}),
+
+	tracing: object({
+		server: boolean(false)
 	}),
 
 	typescript: object({

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -499,32 +499,6 @@ export interface KitConfig {
 	/** Experimental features. Here be dragons. These are not subject to semantic versioning, so breaking changes or removal can happen in any release. */
 	experimental?: {
 		/**
-		 * Options for enabling server-side [OpenTelemetry](https://opentelemetry.io/) tracing for SvelteKit operations including the [`handle` hook](https://svelte.dev/docs/kit/hooks#Server-hooks-handle), [`load` functions](https://svelte.dev/docs/kit/load), [form actions](https://svelte.dev/docs/kit/form-actions), and [remote functions](https://svelte.dev/docs/kit/remote-functions).
-		 * @default { server: false, serverFile: false }
-		 * @since 2.31.0
-		 */
-		tracing?: {
-			/**
-			 * Enables server-side [OpenTelemetry](https://opentelemetry.io/) span emission for SvelteKit operations including the [`handle` hook](https://svelte.dev/docs/kit/hooks#Server-hooks-handle), [`load` functions](https://svelte.dev/docs/kit/load), [form actions](https://svelte.dev/docs/kit/form-actions), and [remote functions](https://svelte.dev/docs/kit/remote-functions).
-			 * @default false
-			 * @since 2.31.0
-			 */
-			server?: boolean;
-		};
-
-		/**
-		 * @since 2.31.0
-		 */
-		instrumentation?: {
-			/**
-			 * Enables `instrumentation.server.js` for tracing and observability instrumentation.
-			 * @default false
-			 * @since 2.31.0
-			 */
-			server?: boolean;
-		};
-
-		/**
 		 * Whether to enable the experimental remote functions feature. This feature is not yet stable and may be changed or removed at any time.
 		 * @default false
 		 */
@@ -912,6 +886,17 @@ export interface KitConfig {
 				register?: false;
 		  }
 	);
+	/**
+	 * Options for enabling [OpenTelemetry](https://opentelemetry.io/) tracing for SvelteKit operations.
+	 * @default { server: false }
+	 */
+	tracing?: {
+		/**
+		 * Enables server-side [OpenTelemetry](https://opentelemetry.io/) span emission for SvelteKit operations including the [`handle` hook](https://svelte.dev/docs/kit/hooks#Server-hooks-handle), [`load` functions](https://svelte.dev/docs/kit/load), [form actions](https://svelte.dev/docs/kit/form-actions), and [remote functions](https://svelte.dev/docs/kit/remote-functions). Tracing — and more significantly, observability instrumentation — can have a nontrivial overhead, so consider whether you really need it, or if it might be more appropriate to turn it on in development and preview environments only.
+		 * @default false
+		 */
+		server?: boolean;
+	};
 	typescript?: {
 		/**
 		 * A function that allows you to edit the generated `tsconfig.json`. You can mutate the config (recommended) or return a new one.

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -464,7 +464,7 @@ function kit({ svelte_config }) {
 					__SVELTEKIT_PATHS_RELATIVE__: s(kit.paths.relative),
 					__SVELTEKIT_CLIENT_ROUTING__: s(kit.router.resolution === 'client'),
 					__SVELTEKIT_HASH_ROUTING__: s(kit.router.type === 'hash'),
-					__SVELTEKIT_SERVER_TRACING_ENABLED__: s(kit.experimental.tracing.server),
+					__SVELTEKIT_SERVER_TRACING_ENABLED__: s(kit.tracing.server),
 					__SVELTEKIT_EXPERIMENTAL_USE_TRANSFORM_ERROR__: s(kit.experimental.handleRenderingErrors),
 					__SVELTEKIT_ROOT__: s(root),
 					__SVELTEKIT_DEV__: s(!is_build)
@@ -783,11 +783,7 @@ function kit({ svelte_config }) {
 							.join(' imports\n');
 
 						if (includes_remote_file) {
-							error_for_missing_config(
-								'remote functions',
-								'kit.experimental.remoteFunctions',
-								'true'
-							);
+							error_for_missing_config('remote functions', 'experimental.remoteFunctions', 'true');
 						}
 
 						let message = `Cannot import ${normalized} into code that runs in the browser, as this could leak sensitive information.`;
@@ -1256,13 +1252,6 @@ function kit({ svelte_config }) {
 					if (server_instrumentation) {
 						if (kit.adapter && !kit.adapter.supports?.instrumentation?.()) {
 							throw new Error(`${server_instrumentation} is unsupported in ${kit.adapter.name}.`);
-						}
-						if (!kit.experimental.instrumentation.server) {
-							error_for_missing_config(
-								'`instrumentation.server.js`',
-								'kit.experimental.instrumentation.server',
-								'true'
-							);
 						}
 						server_input['instrumentation.server'] = server_instrumentation;
 					}

--- a/packages/kit/src/exports/vite/utils.js
+++ b/packages/kit/src/exports/vite/utils.js
@@ -152,17 +152,15 @@ export function normalize_id(id, lib, cwd) {
 export const strip_virtual_prefix = /** @param {string} id */ (id) => id.replace('\0virtual:', '');
 
 /**
- * For `error_for_missing_config('instrumentation.server.js', 'experimental.instrumentation.server', true)`,
+ * For `error_for_missing_config('remote functions', 'experimental.remoteFunctions', 'true')`,
  * returns:
  *
  * ```
- * To enable `instrumentation.server.js`, add the following to the SvelteKit plugin in your `vite.config.js`:
+ * To enable remote functions, add the following to the SvelteKit plugin in your `vite.config.js`:
  *
  *\`\`\`js
  *	experimental: {
- *		instrumentation: {
- *			server: true
- *		}
+ *		remoteFunctions: true
  *	}
  *\`\`\`
  *```

--- a/packages/kit/src/exports/vite/utils.spec.js
+++ b/packages/kit/src/exports/vite/utils.spec.js
@@ -51,19 +51,13 @@ test('error_for_missing_config - simple single level config', () => {
 
 test('error_for_missing_config - nested config', () => {
 	expect(() =>
-		error_for_missing_config(
-			'instrumentation.server.js',
-			'experimental.instrumentation.server',
-			'true'
-		)
+		error_for_missing_config('remote functions', 'experimental.remoteFunctions', 'true')
 	).toThrow(
 		dedent`
-			To enable instrumentation.server.js, add the following to your SvelteKit plugin in \`vite.config.js\`:
+			To enable remote functions, add the following to your SvelteKit plugin in \`vite.config.js\`:
 
 			experimental: {
-			  instrumentation: {
-			    server: true
-			  }
+			  remoteFunctions: true
 			}
 		`
 	);

--- a/packages/kit/src/runtime/telemetry/otel.js
+++ b/packages/kit/src/runtime/telemetry/otel.js
@@ -15,7 +15,7 @@ if (__SVELTEKIT_SERVER_TRACING_ENABLED__) {
 		})
 		.catch(() => {
 			throw new Error(
-				'Tracing is enabled (see the SvelteKit plugin `experimental.instrumentation.server` option in your vite.config.js), but `@opentelemetry/api` is not available. This error will likely resolve itself when you set up your tracing instrumentation in `instrumentation.server.js`. For more information, see https://svelte.dev/docs/kit/observability#opentelemetry-api'
+				'Tracing is enabled (see the SvelteKit plugin `tracing.server` option in your vite.config.js), but `@opentelemetry/api` is not available. This error will likely resolve itself when you set up your tracing instrumentation in `instrumentation.server.js`. For more information, see https://svelte.dev/docs/kit/observability#opentelemetry-api'
 			);
 		});
 }

--- a/packages/kit/src/runtime/telemetry/otel.missing.spec.js
+++ b/packages/kit/src/runtime/telemetry/otel.missing.spec.js
@@ -11,6 +11,6 @@ vi.mock('@opentelemetry/api', () => {
 test('otel should throw an error when tracing is enabled but @opentelemetry/api is not available', async () => {
 	const { otel } = await import('./otel.js');
 	await expect(otel).rejects.toThrow(
-		'Tracing is enabled (see the SvelteKit plugin `experimental.instrumentation.server` option in your vite.config.js), but `@opentelemetry/api` is not available. This error will likely resolve itself when you set up your tracing instrumentation in `instrumentation.server.js`. For more information, see https://svelte.dev/docs/kit/observability#opentelemetry-api'
+		'Tracing is enabled (see the SvelteKit plugin `tracing.server` option in your vite.config.js), but `@opentelemetry/api` is not available. This error will likely resolve itself when you set up your tracing instrumentation in `instrumentation.server.js`. For more information, see https://svelte.dev/docs/kit/observability#opentelemetry-api'
 	);
 });

--- a/packages/kit/src/types/global-private.d.ts
+++ b/packages/kit/src/types/global-private.d.ts
@@ -15,7 +15,7 @@ declare global {
 	const __SVELTEKIT_PATHS_ASSETS__: string;
 	const __SVELTEKIT_PATHS_BASE__: string;
 	const __SVELTEKIT_PATHS_RELATIVE__: boolean;
-	/** True if `config.experimental.instrumentation.server` is `true` */
+	/** True if `config.tracing.server` is `true` */
 	const __SVELTEKIT_SERVER_TRACING_ENABLED__: boolean;
 	/** True if `config.experimental.forkPreloads` is `true` */
 	const __SVELTEKIT_FORK_PRELOADS__: boolean;

--- a/packages/kit/test/apps/basics/vite.config.js
+++ b/packages/kit/test/apps/basics/vite.config.js
@@ -45,13 +45,11 @@ export default defineConfig({
 			},
 
 			experimental: {
-				remoteFunctions: true,
-				tracing: {
-					server: true
-				},
-				instrumentation: {
-					server: true
-				}
+				remoteFunctions: true
+			},
+
+			tracing: {
+				server: true
 			},
 
 			csrf: {

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -472,32 +472,6 @@ declare module '@sveltejs/kit' {
 		/** Experimental features. Here be dragons. These are not subject to semantic versioning, so breaking changes or removal can happen in any release. */
 		experimental?: {
 			/**
-			 * Options for enabling server-side [OpenTelemetry](https://opentelemetry.io/) tracing for SvelteKit operations including the [`handle` hook](https://svelte.dev/docs/kit/hooks#Server-hooks-handle), [`load` functions](https://svelte.dev/docs/kit/load), [form actions](https://svelte.dev/docs/kit/form-actions), and [remote functions](https://svelte.dev/docs/kit/remote-functions).
-			 * @default { server: false, serverFile: false }
-			 * @since 2.31.0
-			 */
-			tracing?: {
-				/**
-				 * Enables server-side [OpenTelemetry](https://opentelemetry.io/) span emission for SvelteKit operations including the [`handle` hook](https://svelte.dev/docs/kit/hooks#Server-hooks-handle), [`load` functions](https://svelte.dev/docs/kit/load), [form actions](https://svelte.dev/docs/kit/form-actions), and [remote functions](https://svelte.dev/docs/kit/remote-functions).
-				 * @default false
-				 * @since 2.31.0
-				 */
-				server?: boolean;
-			};
-
-			/**
-			 * @since 2.31.0
-			 */
-			instrumentation?: {
-				/**
-				 * Enables `instrumentation.server.js` for tracing and observability instrumentation.
-				 * @default false
-				 * @since 2.31.0
-				 */
-				server?: boolean;
-			};
-
-			/**
 			 * Whether to enable the experimental remote functions feature. This feature is not yet stable and may be changed or removed at any time.
 			 * @default false
 			 */
@@ -885,6 +859,17 @@ declare module '@sveltejs/kit' {
 					register?: false;
 			  }
 		);
+		/**
+		 * Options for enabling [OpenTelemetry](https://opentelemetry.io/) tracing for SvelteKit operations.
+		 * @default { server: false }
+		 */
+		tracing?: {
+			/**
+			 * Enables server-side [OpenTelemetry](https://opentelemetry.io/) span emission for SvelteKit operations including the [`handle` hook](https://svelte.dev/docs/kit/hooks#Server-hooks-handle), [`load` functions](https://svelte.dev/docs/kit/load), [form actions](https://svelte.dev/docs/kit/form-actions), and [remote functions](https://svelte.dev/docs/kit/remote-functions). Tracing — and more significantly, observability instrumentation — can have a nontrivial overhead, so consider whether you really need it, or if it might be more appropriate to turn it on in development and preview environments only.
+			 * @default false
+			 */
+			server?: boolean;
+		};
 		typescript?: {
 			/**
 			 * A function that allows you to edit the generated `tsconfig.json`. You can mutate the config (recommended) or return a new one.


### PR DESCRIPTION
What it says on the tin. Tracing GA baby!