### PR TITLE
fix: allow reserved words as remote function names

### DIFF
--- a/.changeset/reserved-keyword-remote-exports.md
+++ b/.changeset/reserved-keyword-remote-exports.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow reserved words (e.g. `delete`, `class`) as remote function export names

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -18,7 +18,7 @@ import generate_fallback from '../postbuild/fallback.js';
 import { write } from '../sync/utils.js';
 import { list_files } from '../utils.js';
 import { find_server_assets } from '../generate_manifest/find_server_assets.js';
-import { reserved } from '../env.js';
+import { create_exported_declarations } from '../env.js';
 import { handle_issues, validate } from '../../exports/internal/env.js';
 
 const pipe = promisify(pipeline);
@@ -305,53 +305,25 @@ async function compress_file(file, format = 'gz') {
  * - Imports `exports` from the entrypoint (dynamically, if `tla` is true)
  * - Re-exports `exports` from the entrypoint
  *
- * `default` receives special treatment: It will be imported as `default` and exported with `export default`.
- *
  * @param {{ instrumentation: string; start: string; exports: string[] }} opts
  * @returns {string}
  */
 function create_instrumentation_facade({ instrumentation, start, exports }) {
 	const import_instrumentation = `import './${instrumentation}';`;
 
-	let alias_index = 0;
-	const aliases = new Map();
+	const { namespace, declarations, reexports } = create_exported_declarations(
+		exports,
+		(name, ns) => `${ns}.${name}`,
+		'__mod'
+	);
 
-	for (const name of exports.filter((name) => reserved.has(name))) {
-		/*
-		 * you can do evil things like `export { c as class }`.
-		 * in order to import these, you need to alias them, and then un-alias them when re-exporting
-		 * this map will allow us to generate the following:
-		 * import { class as _1 } from 'entrypoint';
-		 * export { _1 as class };
-		 */
-		let alias = `_${alias_index++}`;
-		while (exports.includes(alias)) {
-			alias = `_${alias_index++}`;
-		}
-
-		aliases.set(name, alias);
-	}
-
-	const import_statements = [];
-	const export_statements = [];
-
-	for (const name of exports) {
-		const alias = aliases.get(name);
-		if (alias) {
-			import_statements.push(`${name}: ${alias}`);
-			export_statements.push(`${alias} as ${name}`);
-		} else {
-			import_statements.push(`${name}`);
-			export_statements.push(`${name}`);
-		}
-	}
-
-	const entrypoint_facade = [
-		`const { ${import_statements.join(', ')} } = await import('./${start}');`,
-		export_statements.length > 0 ? `export { ${export_statements.join(', ')} };` : ''
+	const parts = [
+		`const ${namespace} = await import('./${start}');`,
+		declarations.join('\n'),
+		reexports.length > 0 ? `export { ${reexports.join(', ')} };` : ''
 	]
 		.filter(Boolean)
 		.join('\n');
 
-	return `${import_instrumentation}\n${entrypoint_facade}`;
+	return `${import_instrumentation}\n${parts}`;
 }

--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -375,3 +375,73 @@ export const reserved = new Set([
 ]);
 
 export const valid_identifier = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
+
+/**
+ * Generates `export const` declarations (and, for reserved-word names that need
+ * aliasing, `const` + re-export specifiers) for a set of named exports.
+ *
+ * For regular names, emits a single efficient `export const name = expr;` statement.
+ * For reserved-word names (e.g. `delete`, `class`), emits `const alias = expr;` plus
+ * a re-export specifier (`alias as name`), since reserved words can't be `const`
+ * binding names but CAN appear in export specifiers.
+ *
+ * You can do evil things like `export { c as class }`. In order to import/re-export
+ * these, you need to alias the binding, then un-alias it when re-exporting:
+ *
+ *   const _0 = ...; // safe binding name
+ *   export { _0 as class }; // valid — `class` is allowed in export specifiers
+ *
+ * Aliases are chosen to avoid collisions with any of the supplied names. The
+ * namespace binding (used to hold the imported module) is likewise chosen to
+ * avoid collisions.
+ *
+ * @param {Iterable<string>} names — the export names
+ * @param {(name: string, namespace: string) => string} build_expression —
+ *   called for each name to produce the right-hand side of the declaration;
+ *   receives the chosen namespace binding so it can reference the imported module
+ * @param {string} namespace_prefix — the preferred binding name for the namespace
+ *   (suffixed with a number if it collides with any export name)
+ * @returns {{ namespace: string, declarations: string[], reexports: string[] }}
+ */
+export function create_exported_declarations(names, build_expression, namespace_prefix) {
+	/** @type {Set<string>} */
+	const set = new Set(names);
+
+	let namespace = namespace_prefix;
+	let namespace_index = 0;
+	while (set.has(namespace)) {
+		namespace = `${namespace_prefix}${namespace_index++}`;
+	}
+
+	let alias_index = 0;
+	/** @type {Map<string, string>} */
+	const aliases = new Map();
+
+	for (const name of set) {
+		if (!reserved.has(name)) continue;
+
+		let alias = `_${alias_index++}`;
+		while (set.has(alias)) {
+			alias = `_${alias_index++}`;
+		}
+		aliases.set(name, alias);
+	}
+
+	/** @type {string[]} */
+	const declarations = [];
+	/** @type {string[]} */
+	const reexports = [];
+
+	for (const name of set) {
+		const alias = aliases.get(name);
+		const expr = build_expression(name, namespace);
+		if (alias) {
+			declarations.push(`const ${alias} = ${expr};`);
+			reexports.push(`${alias} as ${name}`);
+		} else {
+			declarations.push(`export const ${name} = ${expr};`);
+		}
+	}
+
+	return { namespace, declarations, reexports };
+}

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -17,7 +17,8 @@ import {
 	resolve_explicit_env_entry,
 	create_sveltekit_env_service_worker,
 	create_sveltekit_env_service_worker_dev,
-	create_sveltekit_env_private
+	create_sveltekit_env_private,
+	create_exported_declarations
 } from '../../core/env.js';
 import * as sync from '../../core/sync/sync.js';
 import { create_assets } from '../../core/sync/create_manifest_data/index.js';
@@ -937,15 +938,17 @@ function kit({ svelte_config }) {
 				}
 			}
 
-			let namespace = '__remote';
-			let uid = 1;
-			while (map.has(namespace)) namespace = `__remote${uid++}`;
+			const { namespace, declarations, reexports } = create_exported_declarations(
+				map.keys(),
+				(name, ns) => `${ns}.${map.get(name)}('${remote.hash}/${name}')`,
+				'__remote'
+			);
 
-			const exports = Array.from(map).map(([name, type]) => {
-				return `export const ${name} = ${namespace}.${type}('${remote.hash}/${name}');`;
-			});
-
-			let result = `import * as ${namespace} from '__sveltekit/remote';\n\n${exports.join('\n')}\n`;
+			let result = `import * as ${namespace} from '__sveltekit/remote';\n\n${declarations.join('\n')}`;
+			if (reexports.length > 0) {
+				result += `\nexport { ${reexports.join(', ')} };`;
+			}
+			result += '\n';
 
 			if (dev_server) {
 				result += `\nimport.meta.hot?.accept();\n`;

--- a/packages/kit/test/apps/async/src/routes/remote/reserved/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/remote/reserved/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import * as reserved from './reserved.remote';
+
+	let result = $state('pending');
+
+	async function run() {
+		const del = await reserved.delete();
+		const cls = await reserved.class();
+		const ret = await reserved.return();
+		result = `${del}/${cls}/${ret}`;
+	}
+</script>
+
+<p id="reserved-result">{result}</p>
+
+<button onclick={run} id="reserved-run">run</button>

--- a/packages/kit/test/apps/async/src/routes/remote/reserved/reserved.remote.ts
+++ b/packages/kit/test/apps/async/src/routes/remote/reserved/reserved.remote.ts
@@ -1,0 +1,7 @@
+import { command, query } from '$app/server';
+
+const _delete = command(() => 'deleted');
+const _class = query(() => 'classy');
+const _return = command(() => '42');
+
+export { _delete as delete, _class as class, _return as return };

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -422,6 +422,14 @@ test.describe('remote function mutations', () => {
 		await expect(page.locator('p')).toHaveText('success');
 	});
 
+	test('reserved words can be used as remote function export names', async ({ page }) => {
+		await page.goto('/remote/reserved');
+		await expect(page.locator('#reserved-result')).toHaveText('pending');
+
+		await page.click('#reserved-run');
+		await expect(page.locator('#reserved-result')).toHaveText('deleted/classy/42');
+	});
+
 	test('fields.set updates DOM before validate', async ({ page }) => {
 		await page.goto('/remote/form/imperative');
 


### PR DESCRIPTION
Closes #16261 

Standardized the behavior of the "import things that may or may not be reserved, make sure they're allowed as variable names within the module and do something with them, then reexport them either as consts or as renamed exports" pattern we already used for instrumentation facades, then used it in remote function facades.