### PR TITLE
fix: handle rejected streamed data race condition

### DIFF
--- a/.changeset/quiet-masks-shop.md
+++ b/.changeset/quiet-masks-shop.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: handle rejected streamed server data after delayed loads

--- a/packages/kit/src/runtime/server/data/index.js
+++ b/packages/kit/src/runtime/server/data/index.js
@@ -96,16 +96,13 @@ export async function render_data(
 			return fn();
 		});
 
-		let length = promises.length;
-		const nodes = await Promise.all(
-			promises.map((p, i) =>
-				p.catch(async (error) => {
+		const data_serializer = server_data_serializer_json(event, event_state, options);
+		await Promise.all(
+			promises.map(async (p, i) => {
+				const node = await p.catch(async (error) => {
 					if (error instanceof Redirect) {
 						throw error;
 					}
-
-					// Math.min because array isn't guaranteed to resolve in order
-					length = Math.min(length, i + 1);
 
 					const transformed = await handle_error_and_jsonify(event, event_state, options, error);
 
@@ -113,12 +110,11 @@ export async function render_data(
 						type: 'error',
 						error: transformed
 					});
-				})
-			)
-		);
+				});
 
-		const data_serializer = server_data_serializer_json(event, event_state, options);
-		for (let i = 0; i < nodes.length; i++) data_serializer.add_node(i, nodes[i]);
+				data_serializer.add_node(i, node);
+			})
+		);
 		const { data, chunks } = data_serializer.get_data();
 
 		if (!chunks) {

--- a/packages/kit/test/apps/basics/src/routes/streaming/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/streaming/+page.svelte
@@ -1,3 +1,4 @@
 <a href="/streaming/universal">Universal</a>
 <a href="/streaming/server">Server</a>
 <a href="/streaming/server-error">Server Error</a>
+<a href="/streaming/server/delayed-rejection">Server Delayed Rejection</a>

--- a/packages/kit/test/apps/basics/src/routes/streaming/server/delayed-rejection/+layout.server.js
+++ b/packages/kit/test/apps/basics/src/routes/streaming/server/delayed-rejection/+layout.server.js
@@ -1,0 +1,4 @@
+export async function load() {
+	await new Promise((resolve) => setTimeout(resolve, 100));
+	return {};
+}

--- a/packages/kit/test/apps/basics/src/routes/streaming/server/delayed-rejection/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/streaming/server/delayed-rejection/+page.server.js
@@ -1,0 +1,6 @@
+export function load() {
+	return {
+		eager: 'eager',
+		streamed: Promise.reject(new Error('delayed rejection'))
+	};
+}

--- a/packages/kit/test/apps/basics/src/routes/streaming/server/delayed-rejection/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/streaming/server/delayed-rejection/+page.svelte
@@ -1,0 +1,12 @@
+<script>
+	/** @type {import('./$types').PageData} */
+	export let data;
+</script>
+
+<p class="eager">{data.eager}</p>
+
+{#await data.streamed}
+	<p class="loading">Loading</p>
+{:catch error}
+	<p class="fail">{error.message}</p>
+{/await}

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1362,6 +1362,16 @@ test.describe('Streaming', () => {
 		expect(page.locator('p.fail')).toBeVisible();
 	});
 
+	test('Catches rejected streamed server data after another load delays data serialization', async ({
+		page
+	}) => {
+		await page.goto('/streaming');
+		await page.click('[href="/streaming/server/delayed-rejection"]');
+
+		await expect(page.locator('p.eager')).toHaveText('eager');
+		await expect(page.locator('p.fail')).toHaveText('delayed rejection (500 Internal Error)');
+	});
+
 	// TODO `vite preview` buffers responses, causing these tests to fail
 	if (process.env.DEV) {
 		test('Works for universal load functions (direct hit)', async ({ page }) => {


### PR DESCRIPTION
Related to #9785, but this PR targets a distinct streamed-data rejection race condition demonstrated by the added regression test.

## Summary

Thanks for SvelteKit. I really appreciate the care that goes into this project.

This PR fixes a timing issue in streamed server data handling. Previously, the JSON data response waited for all server load promises to settle before serializing any node. If one load returned a rejected streamed promise while another load was still pending, the rejection could occur before SvelteKit had attached the stream rejection handler.

The change creates the JSON data serializer earlier and adds each node as its load result resolves, while still waiting for all nodes before emitting the final data response. That preserves the response shape/order but attaches stream handlers earlier.

I also added a regression route/test where one server load delays serialization and another returns a rejected streamed promise.

## Validation

Passed:

- `pnpm exec prettier --check ...` on touched files
- `pnpm --dir packages/kit check`
- `pnpm --dir packages/kit/test/apps/basics check`
- `pnpm run lint`
- `pnpm run check`
- Focused Playwright regression in dev mode
- Focused Playwright regression in build/preview mode

I also ran `pnpm test:kit` locally with reduced workers/retries. The new regression passed inside that run, but the full command failed on an existing unrelated no-SSR dev test (`SPA mode / no SSR › cannot use browser-only global on page because of ssr config in +page.js`). I did not change that area.

Disclosure: I used AI-assisted coding tools while preparing this PR. I reviewed the changes myself, tested them, and take responsibility for the implementation and any follow-up revisions needed.
