### PR TITLE
feat: add `ErrorProps` to generated types

### DIFF
--- a/.changeset/brave-canyons-crash.md
+++ b/.changeset/brave-canyons-crash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: add `ErrorProps` to generated types

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -231,7 +231,9 @@ function update_types(config, routes, route, root, to_delete = new Set()) {
 			'type OptionalUnion<U extends Record<string, any>, A extends keyof U = U extends U ? keyof U : never> = U extends unknown ? { [P in Exclude<A, keyof U>]?: never } & U : never;',
 
 			// Re-export `Snapshot` from @sveltejs/kit — in future we could use this to infer <T> from the return type of `snapshot.capture`
-			'export type Snapshot<T = any> = Kit.Snapshot<T>;'
+			'export type Snapshot<T = any> = Kit.Snapshot<T>;',
+
+			'export type ErrorProps = { error: App.Error };'
 		);
 	}
 
@@ -263,15 +265,8 @@ function update_types(config, routes, route, root, to_delete = new Set()) {
 
 		if (route.leaf.server) {
 			exports.push(
-				'export type Action<OutputData extends Record<string, any> | void = Record<string, any> | void> = Kit.Action<RouteParams, OutputData, RouteId>'
-			);
-			exports.push(
-				'export type Actions<OutputData extends Record<string, any> | void = Record<string, any> | void> = Kit.Actions<RouteParams, OutputData, RouteId>'
-			);
-		}
-
-		if (route.leaf.server) {
-			exports.push(
+				'export type Action<OutputData extends Record<string, any> | void = Record<string, any> | void> = Kit.Action<RouteParams, OutputData, RouteId>',
+				'export type Actions<OutputData extends Record<string, any> | void = Record<string, any> | void> = Kit.Actions<RouteParams, OutputData, RouteId>',
 				'export type PageProps = { params: RouteParams; data: PageData; form: ActionData }'
 			);
 		} else {


### PR DESCRIPTION
Adds an `ErrorProps` type to `./$types`:

```svelte
<script lang="ts">
	import type { ErrorProps } from './$types.js';

	const { error }: ErrorProps = $props();
</script>

<h1>{error.message}</h1>
```

Ideally this would be injected automatically, just like `PageProps` is today, for zero-config type safety.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
