### PR TITLE
precompress option also compress woff2 files

### DIFF
--- a/.changeset/fiery-jars-prove.md
+++ b/.changeset/fiery-jars-prove.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+`precompress` option also compress woff2 files

--- a/packages/kit/src/core/adapt/builder.js
+++ b/packages/kit/src/core/adapt/builder.js
@@ -33,7 +33,8 @@ const extensions = [
 	'.wasm',
 	'.txt',
 	'.md',
-	'.mdx'
+	'.mdx',
+	'.woff2'
 ];
 
 /**


### PR DESCRIPTION
We are serving our fonts by ourselves to not depend on any 3rd-party service like google. And we noticed that they aren't compressed. It seems like it's a sensible thing to do.

I noticed in the tests it doesn't have fixtures for all the extensions thus I decided it is unnecessary to introduce a new one.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
