### PR TITLE
fix: allow prerelease versions of kit-related packages to install together

### DIFF
--- a/.changeset/prerelease-peer-deps.md
+++ b/.changeset/prerelease-peer-deps.md
@@ -1,0 +1,9 @@
+---
+'@sveltejs/adapter-auto': patch
+'@sveltejs/adapter-cloudflare': patch
+'@sveltejs/adapter-node': patch
+'@sveltejs/adapter-static': patch
+'@sveltejs/adapter-vercel': patch
+---
+
+fix: allow prerelease versions of SvelteKit 3 to satisfy the peer dependency range

--- a/packages/adapter-auto/package.json
+++ b/packages/adapter-auto/package.json
@@ -46,6 +46,6 @@
 		"vitest": "catalog:"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^3.0.0"
+		"@sveltejs/kit": "^3.0.0-next.0"
 	}
 }

--- a/packages/adapter-cloudflare/package.json
+++ b/packages/adapter-cloudflare/package.json
@@ -56,7 +56,7 @@
 		"vitest": "catalog:"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^3.0.0",
+		"@sveltejs/kit": "^3.0.0-next.0",
 		"wrangler": "^4.67.0"
 	}
 }

--- a/packages/adapter-node/package.json
+++ b/packages/adapter-node/package.json
@@ -54,6 +54,6 @@
 		"rolldown": "^1.1.2"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^3.0.0"
+		"@sveltejs/kit": "^3.0.0-next.0"
 	}
 }

--- a/packages/adapter-static/package.json
+++ b/packages/adapter-static/package.json
@@ -48,6 +48,6 @@
 		"vite": "catalog:"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^3.0.0"
+		"@sveltejs/kit": "^3.0.0-next.0"
 	}
 }

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -52,6 +52,6 @@
 		"vitest": "catalog:"
 	},
 	"peerDependencies": {
-		"@sveltejs/kit": "^3.0.0"
+		"@sveltejs/kit": "^3.0.0-next.0"
 	}
 }


### PR DESCRIPTION
Closes #16278 

Basically, for NPM, a -next version can't satisfy a non-next specifier, but a non-next version can satisfy a -next specifier. We'll just have to remove the -next suffix when we actually publish v3. (Technically we don't because it would work fine, but we should.)