### PR TITLE
chore: tidy up client code a bit

### DIFF
--- a/packages/kit/src/core/sync/write_root.js
+++ b/packages/kit/src/core/sync/write_root.js
@@ -19,33 +19,6 @@ export function write_root(manifest_data, output) {
 		levels.push(i);
 	}
 
-	// with the @const we force the data[depth] access to be derived, which is important to not fire updates needlessly
-	// TODO in Svelte 5 we should rethink the client.js side, we can likely make data a $state and only update indexes that changed there, simplifying this a lot
-	const pyramid = dedent`
-		{#snippet pyramid(depth)}
-			{@const Pyramid = constructors[depth]}
-			{#snippet failed(error)}
-				{@const ErrorPage = errors[depth]}
-				<ErrorPage {error} />
-			{/snippet}
-			<svelte:boundary failed={errors[depth] ? failed : undefined}>
-				{#if constructors[depth + 1]}
-					{@const d = data[depth]}
-					<!-- svelte-ignore binding_property_non_reactive -->
-					<Pyramid bind:this={components[depth]} data={d} {form} params={page.params}>
-						{@render pyramid(depth + 1)}
-					</Pyramid>
-				{:else}
-					{@const d = data[depth]}
-					<!-- svelte-ignore binding_property_non_reactive -->
-					<Pyramid bind:this={components[depth]} data={d} {form} params={page.params} {error} />
-				{/if}
-			</svelte:boundary>
-		{/snippet}
-
-		{@render pyramid(0)}
-	`;
-
 	write_if_changed(
 		`${output}/root.svelte`,
 		dedent`
@@ -71,11 +44,30 @@ export function write_root(manifest_data, output) {
 						mounted = true;
 					}
 				});
-
-				const Pyramid_${max_depth} = $derived(constructors[${max_depth}]);
 			</script>
 
-			${pyramid}
+			{#snippet pyramid(depth)}
+				{@const Pyramid = constructors[depth]}
+				{#snippet failed(error)}
+					{@const ErrorPage = errors[depth]}
+					<ErrorPage {error} />
+				{/snippet}
+				<svelte:boundary failed={errors[depth] ? failed : undefined}>
+					{#if constructors[depth + 1]}
+						{@const d = data[depth]}
+						<!-- svelte-ignore binding_property_non_reactive -->
+						<Pyramid bind:this={components[depth]} data={d} {form} params={page.params}>
+							{@render pyramid(depth + 1)}
+						</Pyramid>
+					{:else}
+						{@const d = data[depth]}
+						<!-- svelte-ignore binding_property_non_reactive -->
+						<Pyramid bind:this={components[depth]} data={d} {form} params={page.params} {error} />
+					{/if}
+				</svelte:boundary>
+			{/snippet}
+
+			{@render pyramid(0)}
 
 			{#if mounted}
 				<div id="svelte-announcer" aria-live="assertive" aria-atomic="true" style="position: absolute; left: 0; top: 0; clip: rect(0 0 0 0); clip-path: inset(50%); overflow: hidden; white-space: nowrap; width: 1px; height: 1px">

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2541,9 +2541,6 @@ export function pushState(url, state) {
 	has_navigated = true;
 
 	page.state = state;
-	root.$set({
-		page
-	});
 
 	clear_onward_history(current_history_index, current_navigation_index);
 }
@@ -2584,9 +2581,6 @@ export function replaceState(url, state) {
 	history.replaceState(opts, '', resolve_url(url));
 
 	page.state = state;
-	root.$set({
-		page
-	});
 }
 
 /**
@@ -2614,8 +2608,7 @@ export async function applyAction(result) {
 		root.$set({
 			// this brings Svelte's view of the world in line with SvelteKit's
 			// after use:enhance reset the form....
-			form: null,
-			page
+			form: null
 		});
 
 		// ...so that setting the `form` prop takes effect and isn't ignored


### PR DESCRIPTION
baby steps for now. the big change we eventually need here is to pass `root.svelte` a tree of components and data, rather than a bunch of arrays, but that will touch code in a whole bunch of places. trying to make whatever incremental changes i can in the meantime so that the diff isn't too crazy