### PR TITLE
chore: posixify paths used on the server during development

### DIFF
--- a/packages/kit/src/core/utils.js
+++ b/packages/kit/src/core/utils.js
@@ -7,7 +7,7 @@ import { noop } from '../utils/functions.js';
 import { posixify } from '../utils/os.js';
 
 /**
- * Resolved path of the `runtime` directory
+ * Resolved path of the `runtime` directory posix-ified
  *
  * TODO Windows issue:
  * Vite or sth else somehow sets the driver letter inconsistently to lower or upper case depending on the run environment.
@@ -25,7 +25,7 @@ export const runtime_directory = posixify(fileURLToPath(new URL('../runtime', im
  */
 export function get_runtime_base(root) {
 	return runtime_directory.startsWith(root)
-		? `/${path.relative(root, runtime_directory)}`
+		? `/${posixify(path.relative(root, runtime_directory))}`
 		: to_fs(runtime_directory);
 }
 

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -457,7 +457,7 @@ function kit({ svelte_config }) {
 				}
 
 				const define = {
-					__SVELTEKIT_APP_DIR__: s(kit.appDir),
+					__SVELTEKIT_APP_DIR__: s(posixify(kit.appDir)),
 					__SVELTEKIT_APP_VERSION__: s(kit.version.name),
 					__SVELTEKIT_EMBEDDED__: s(kit.embedded),
 					__SVELTEKIT_FORK_PRELOADS__: s(kit.experimental.forkPreloads),

--- a/packages/kit/src/exports/vite/utils.js
+++ b/packages/kit/src/exports/vite/utils.js
@@ -18,13 +18,13 @@ import {
  *
  * @param {import('types').ValidatedKitConfig} config
  * @param {string} root
- * */
+ */
 export function get_config_aliases(config, root) {
 	/** @type {import('vite').Alias[]} */
 	const alias = [
 		// For now, we handle `$lib` specially here rather than make it a default value for
 		// `config.alias` since it has special meaning for packaging, etc.
-		{ find: '$lib', replacement: config.files.lib }
+		{ find: '$lib', replacement: posixify(config.files.lib) }
 	];
 
 	for (let [key, value] of Object.entries(config.alias)) {
@@ -36,16 +36,16 @@ export function get_config_aliases(config, root) {
 			// Doing just `{ find: key.slice(0, -2) ,..}` would mean `import .. from "key"` would also be matched, which we don't want
 			alias.push({
 				find: new RegExp(`^${escape_for_regexp(key.slice(0, -2))}\\/(.+)$`),
-				replacement: `${path.resolve(root, value)}/$1`
+				replacement: `${posixify(path.resolve(root, value))}/$1`
 			});
 		} else if (key + '/*' in config.alias) {
 			// key and key/* both exist -> the replacement for key needs to happen _only_ on import .. from "key"
 			alias.push({
 				find: new RegExp(`^${escape_for_regexp(key)}$`),
-				replacement: path.resolve(root, value)
+				replacement: posixify(path.resolve(root, value))
 			});
 		} else {
-			alias.push({ find: key, replacement: path.resolve(root, value) });
+			alias.push({ find: key, replacement: posixify(path.resolve(root, value)) });
 		}
 	}
 


### PR DESCRIPTION
splitting out more changes from https://github.com/sveltejs/kit/pull/15574

This PR ensures these paths use the correct slash separators which is important in the Cloudflare Vite environment