### PR TITLE
fix: reset sveltekit-controlled error boundaries on navigation

### DIFF
--- a/.changeset/reset-failed-boundary-on-navigation.md
+++ b/.changeset/reset-failed-boundary-on-navigation.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: reset failed `<svelte:boundary>` on client navigation so a stale `+error.svelte` is torn down

--- a/packages/kit/src/core/sync/write_root.js
+++ b/packages/kit/src/core/sync/write_root.js
@@ -27,7 +27,7 @@ export function write_root(manifest_data, output) {
 			<script>
 				import { afterNavigate } from '$app/navigation';
 
-				let { page, constructors, components = [], form, errors = [], error, ${levels
+				let { page, constructors, components = [], form, errors = [], error, resetters = [], ${levels
 					.map((l) => `data_${l} = null`)
 					.join(', ')} } = $props();
 				let data = $derived({${levels.map((l) => `'${l}': data_${l}`).join(', ')}});
@@ -52,7 +52,7 @@ export function write_root(manifest_data, output) {
 					{@const ErrorPage = errors[depth]}
 					<ErrorPage {error} />
 				{/snippet}
-				<svelte:boundary failed={errors[depth] ? failed : undefined}>
+				<svelte:boundary failed={errors[depth] ? failed : undefined} onerror={errors[depth] ? (_, reset) => (resetters[depth] = reset) : undefined}>
 					{#if constructors[depth + 1]}
 						{@const d = data[depth]}
 						<!-- svelte-ignore binding_property_non_reactive -->

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -60,6 +60,17 @@ let errored = false;
  */
 let rendering_error = null;
 
+/**
+ * `reset` functions for `<svelte:boundary>`s in the generated root that have
+ * failed. A failed boundary stays failed until `reset()` is called — prop
+ * updates alone don't re-render its content — so without resetting, a client
+ * navigation away from a render error would leave the stale `+error.svelte`
+ * mounted. The boundary's `onerror` populates this array; `navigate` drains it
+ * after applying the new props. See sveltejs/kit#15694.
+ * @type {Array<(() => void) | undefined>}
+ */
+const resetters = [];
+
 // We track the scroll position associated with each history entry in sessionStorage,
 // rather than on history.state itself, because when navigation is driven by
 // popstate it's too late to update the scroll position associated with the
@@ -705,7 +716,7 @@ async function initialize(result, target, hydrate) {
 	// TODO: use mount()
 	root = new app.root({
 		target,
-		props: { ...result.props, components },
+		props: { ...result.props, components, resetters },
 		hydrate,
 		// Svelte 5 specific: asynchronously instantiate the component, i.e. don't call flushSync
 		sync: false,
@@ -1955,9 +1966,23 @@ async function navigate({
 
 		if (fork) {
 			commit_promise = fork.commit();
+			// `fork.commit()` applies the preloaded state synchronously before the
+			// first `await`, so reset any previously-failed boundaries now so the
+			// stale `+error.svelte` is torn down. See sveltejs/kit#15694.
+			for (const reset of resetters) {
+				reset?.();
+			}
+			resetters.length = 0;
 		} else {
 			rendering_error = null; // TODO this can break with forks, rethink for SvelteKit 3 where we can assume Svelte 5
 			root.$set(navigation_result.props);
+			// Reset any boundaries that failed on a previous navigation now that the
+			// new props are applied, otherwise the stale `+error.svelte` stays
+			// mounted above the new route's content. See sveltejs/kit#15694.
+			for (const reset of resetters) {
+				reset?.();
+			}
+			resetters.length = 0;
 			// Check for sync rendering error
 			if (rendering_error) {
 				Object.assign(navigation_result.props.page, rendering_error);

--- a/packages/kit/test/apps/async/src/routes/+error.svelte
+++ b/packages/kit/test/apps/async/src/routes/+error.svelte
@@ -12,6 +12,8 @@
 
 <p id="message">This is your custom error page saying: "<b>{error.message}</b>"</p>
 
+<a id="error-home" href="/">home</a>
+
 <style>
 	h1,
 	p {

--- a/packages/kit/test/apps/async/src/routes/server-error-boundary/async/+page.svelte
+++ b/packages/kit/test/apps/async/src/routes/server-error-boundary/async/+page.svelte
@@ -1,0 +1,9 @@
+<script>
+	import { error } from '@sveltejs/kit';
+
+	async function load() {
+		error(404, 'nope');
+	}
+</script>
+
+{await load()}

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -1177,6 +1177,68 @@ test.describe('client error boundaries', () => {
 		// The nested layout should still be visible
 		await expect(page.locator('#nested-layout')).toBeVisible();
 	});
+
+	test('client navigation away from a render error tears down the stale +error.svelte', async ({
+		page,
+		app
+	}) => {
+		await page.goto('/');
+		await app.goto('/server-error-boundary');
+		await expect(page.locator('#message')).toContainText(
+			'render error (500 Internal Error, on /server-error-boundary)'
+		);
+
+		await app.goto('/');
+		await expect(page.locator('#message')).toHaveCount(0);
+		await expect(page.locator('h3')).toHaveText('Tests');
+	});
+
+	test('client navigation away from a nested render error tears down the stale +error.svelte', async ({
+		page,
+		app
+	}) => {
+		await page.goto('/');
+		await app.goto('/server-error-boundary/nested');
+		await expect(page.locator('#nested-error-message')).toBeVisible();
+
+		await app.goto('/');
+		await expect(page.locator('#nested-error-message')).toHaveCount(0);
+		await expect(page.locator('#nested-layout')).toHaveCount(0);
+		await expect(page.locator('h3')).toHaveText('Tests');
+	});
+
+	test('client navigation away from an async render error tears down the stale +error.svelte', async ({
+		page,
+		app
+	}) => {
+		await page.goto('/');
+		await app.goto('/server-error-boundary/async');
+		// the awaited throw surfaces as a 404 through the root error boundary
+		await expect(page.locator('h1')).toHaveText('404');
+
+		await app.goto('/');
+		await expect(page.locator('#message')).toHaveCount(0);
+		await expect(page.locator('h3')).toHaveText('Tests');
+	});
+
+	test('client navigation using preloaded data away from a render error tears down the stale +error.svelte', async ({
+		page,
+		app
+	}) => {
+		await page.goto('/');
+		await app.goto('/server-error-boundary');
+		await expect(page.locator('#message')).toContainText('render error');
+
+		// preloading the home route creates a fork (forkPreloads is enabled);
+		// navigating via that fork must still tear down the failed boundary (#15694)
+		await app.preloadData('/');
+		await page.evaluate(() => new Promise((r) => setTimeout(r, 0)));
+		await page.locator('#error-home').click();
+		await expect(page).toHaveURL('/');
+		await expect(page.locator('#message')).toHaveCount(0);
+		await expect(page.locator('h3')).toHaveText('Tests');
+	});
+
 	test('redirecting from form clears result', async ({ page }) => {
 		await page.goto('/remote/form/reset-on-redirect');
 


### PR DESCRIPTION
Closes #15694

Keeps track of error boundaries' reset functions that SvelteKit controls, resetting them on navigate.