### PR TITLE
fix: exclude deleted cookies from `cookies.getAll`

### DIFF
--- a/.changeset/cookies-getall-delete-phantom.md
+++ b/.changeset/cookies-getall-delete-phantom.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: exclude deleted cookies from `cookies.getAll()` so it stays consistent with `cookies.get()`

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -124,7 +124,13 @@ export function get_cookies(request, url) {
 
 			// Add the most specific cookies to the result
 			for (const c of lookup.values()) {
-				cookies[c.name] = c.value;
+				// tombstones (deleted cookies) shadow request-header cookies,
+				// mirroring the behavior of `get()`
+				if (c.options.maxAge === 0) {
+					delete cookies[c.name];
+				} else {
+					cookies[c.name] = c.value;
+				}
 			}
 
 			return /** @type {Array<{ name: string; value: string }>} */ (

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -85,6 +85,16 @@ describe.skipIf(process.env.NODE_ENV !== 'production')('cookies in prod', () => 
 		assert.isUndefined(cookies.get('a'));
 	});
 
+	test('getAll should not include deleted cookies', () => {
+		const { cookies } = cookies_setup({ headers: { cookie: 'session=abc' } });
+		cookies.set('session', 'abc', { path: '/' });
+		expect(cookies.getAll()).toEqual([{ name: 'session', value: 'abc' }]);
+
+		cookies.delete('session', { path: '/' });
+		assert.isUndefined(cookies.get('session'));
+		expect(cookies.getAll()).toEqual([]);
+	});
+
 	test('default values when set is called', () => {
 		const { cookies, new_cookies } = cookies_setup();
 		cookies.set('a', 'b', { path: '/' });


### PR DESCRIPTION
Closes #16269