### PR TITLE
fix: externalize `@opentelemetry/api` to prevent chunk colocation

### DIFF
--- a/.changeset/externalize-opentelemetry-api.md
+++ b/.changeset/externalize-opentelemetry-api.md
@@ -1,0 +1,6 @@
+---
+'@sveltejs/kit': patch
+'@sveltejs/adapter-node': patch
+---
+
+fix: externalize `@opentelemetry/api` to prevent bundler chunk colocation between `instrumentation.server.js` and application code

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -77,7 +77,12 @@ export default function (opts = {}) {
 				input,
 				external: [
 					// dependencies could have deep exports, so we need a regex
-					...Object.keys(pkg.dependencies || {}).map((d) => new RegExp(`^${d}(\\/.*)?$`))
+					...Object.keys(pkg.dependencies || {}).map((d) => new RegExp(`^${d}(\\/.*)?$`)),
+					// `@opentelemetry/api` is an optional peer dependency of `@sveltejs/kit`,
+					// so it's not in `pkg.dependencies` and wouldn't be matched by the regex above.
+					// It must stay external so that `instrumentation.server.js` and the SvelteKit
+					// runtime share a single instance — see https://github.com/sveltejs/kit/issues/16288
+					/^@opentelemetry\/api(\/.*)?$/
 				],
 				platform: 'node',
 				resolve: {

--- a/packages/adapter-node/index.js
+++ b/packages/adapter-node/index.js
@@ -93,7 +93,12 @@ export default function (opts = {}) {
 				input,
 				external: [
 					// dependencies could have deep exports, so we need a regex
-					...Object.keys(pkg.dependencies || {}).map((d) => new RegExp(`^${d}(\\/.*)?$`))
+					...Object.keys(pkg.dependencies || {}).map((d) => new RegExp(`^${d}(\\/.*)?$`)),
+					// `@opentelemetry/api` is an optional peer dependency of `@sveltejs/kit`,
+					// so it's not in `pkg.dependencies` and wouldn't be matched by the regex above.
+					// It must stay external so that `instrumentation.server.js` and the SvelteKit
+					// runtime share a single instance — see https://github.com/sveltejs/kit/issues/16288
+					/^@opentelemetry\/api(\/.*)?$/
 				],
 				platform: 'node',
 				resolve: {

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -555,7 +555,18 @@ function kit({ svelte_config }) {
 
 					// These Kit dependencies are packaged as CommonJS, which means they must always be externalized.
 					// Without this, the tests will still pass but `pnpm dev` will fail in projects that link `@sveltejs/kit`.
-					/** @type {NonNullable<UserConfig['ssr']>} */ (new_config.ssr).external = ['cookie'];
+					//
+					// `@opentelemetry/api` must be externalized so that `instrumentation.server.js` and the
+					// SvelteKit runtime share a single instance of the module (the global tracer/propagation
+					// is set on that instance — two bundled copies would mean instrumentation hooks are
+					// invisible to the runtime). Externalizing also prevents the bundler from colocating
+					// `@opentelemetry/api` into a shared chunk that also contains application modules, which
+					// would cause those modules to be evaluated before `Server.init()` sets env vars — see
+					// https://github.com/sveltejs/kit/issues/16288
+					/** @type {NonNullable<UserConfig['ssr']>} */ (new_config.ssr).external = [
+						'cookie',
+						'@opentelemetry/api'
+					];
 				}
 
 				// Vite's `define` is a compile-time text replacement, but Vitest strips

--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -494,7 +494,18 @@ function kit({ svelte_config }) {
 
 					// These Kit dependencies are packaged as CommonJS, which means they must always be externalized.
 					// Without this, the tests will still pass but `pnpm dev` will fail in projects that link `@sveltejs/kit`.
-					/** @type {NonNullable<UserConfig['ssr']>} */ (new_config.ssr).external = ['cookie'];
+					//
+					// `@opentelemetry/api` must be externalized so that `instrumentation.server.js` and the
+					// SvelteKit runtime share a single instance of the module (the global tracer/propagation
+					// is set on that instance — two bundled copies would mean instrumentation hooks are
+					// invisible to the runtime). Externalizing also prevents the bundler from colocating
+					// `@opentelemetry/api` into a shared chunk that also contains application modules, which
+					// would cause those modules to be evaluated before `Server.init()` sets env vars — see
+					// https://github.com/sveltejs/kit/issues/16288
+					/** @type {NonNullable<UserConfig['ssr']>} */ (new_config.ssr).external = [
+						'cookie',
+						'@opentelemetry/api'
+					];
 				}
 
 				// Vite's `define` is a compile-time text replacement, but Vitest strips


### PR DESCRIPTION
closes #16288

When `instrumentation.server.js` and application code both import `@opentelemetry/api`, the bundler may colocate it into a shared chunk that also contains application modules. The compiled instrumentation entry then imports that chunk — evaluating application modules **before** `Server.init()` has called `set_env()`. Any module that reads `$env/dynamic/private` at module scope silently captures `undefined`.

This is a nastier variant of #14286: there the env modules are imported *by instrumentation.server.ts itself*; here instrumentation never touches `$env` — it merely imports `@opentelemetry/api`, and the chunking pulls in unrelated app modules.

### What changed

- Added `@opentelemetry/api` to `ssr.external` in the kit Vite plugin, so it stays as a bare `import('@opentelemetry/api')` in the build output rather than being bundled into a shared chunk.
- Added `@opentelemetry/api` to adapter-node's external list (it's an optional peer dep, not in `pkg.dependencies`, so the existing regex wouldn't match it).

### Why externalize?

1. **Prevents chunk colocation** — no shared chunks between instrumentation and app code via this dep, so importing `@opentelemetry/api` from instrumentation can never cause app modules to evaluate.
2. **OTEL correctness** — OpenTelemetry requires a single `@opentelemetry/api` module instance. The global tracer/propagation is set on that instance. Two bundled copies would mean instrumentation hooks are invisible to the SvelteKit runtime's tracer.

Other adapters don't need changes:
- adapter-vercel serverless uses `nodeFileTrace` (copies deps, doesn't bundle) — the bare import resolves from `node_modules`.
- adapter-vercel edge and adapter-netlify edge already bundle instrumentation as a separate single-file graph, and the edge bundler resolves the bare import into the bundle.
- adapter-netlify serverless copies the kit server output directly via `builder.writeServer`.
