### PR TITLE
test: assert that pages don't embed env when dynamic public env vars are unused

### DIFF
--- a/packages/kit/test/apps/options-2/test/env.test.js
+++ b/packages/kit/test/apps/options-2/test/env.test.js
@@ -36,13 +36,14 @@ test.describe('env', () => {
 		await expect(page.locator('body')).toHaveAttribute('data-message', 'hello');
 	});
 
-	test('does not import env.js from prerendered pages when there are no public dynamic environment variables', ({
+	test('does not import env.js or embed env in prerendered pages when there are no public dynamic environment variables', ({
 		javaScriptEnabled
 	}) => {
 		test.skip(javaScriptEnabled || !!process.env.DEV || !!process.env.DYNAMIC_PUBLIC_ENV);
 
 		const root_page = read('prerendered/pages/env/prerendered.html');
 		expect(root_page).not.toContain('_app/env.js');
+		expect(root_page).not.toMatch(/env: /);
 		expect(fs.existsSync(`${output}/prerendered/dependencies/_app/env.js`)).toBeFalsy();
 	});
 });


### PR DESCRIPTION
closes #8946

The follow-up I promised in #16024, a few weeks late. Retargeting it onto `version-3` turned it into a test, because the fix I wrote for `main` is already there. The env embed sits behind the same `client.uses_env_dynamic_public` check that the `$env/dynamic/public` branch has used since #11277:

```js
if (client.uses_env_dynamic_public) {
	properties.push(`env: ${load_env_eagerly ? 'null' : devalue.uneval(env.rendered_env)}`);
}
```

What's left is the regression coverage. On kit 2 with `experimental.explicitEnvironmentVariables` enabled, every server-rendered page ships an `env: {}` object the client can never read, since static values are inlined into the generated `$app/env/public` module as literals. Rich said as much reviewing #15934, "`rendered_env` is what gets sent from the server to the client. `static` variables are already in the client".

One assertion added to the existing options-2 prerender test, so version-3 can't regress into shipping the dead object again. Verified it passes on `version-3` and that the same assertion fails on `main` without the omitted fix.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
