### PR TITLE
fix: load the URL shown in the address bar when returning to a `pushState`/`replaceState` history entry

### DIFF
--- a/.changeset/pushstate-page-url-key.md
+++ b/.changeset/pushstate-page-url-key.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: load the URL shown in the address bar when returning to a `pushState`/`replaceState` history entry

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2587,14 +2587,17 @@ export function pushState(url, state) {
 
 	update_scroll_positions(current_history_index);
 
+	const resolved = resolve_url(url);
+
 	const opts = {
 		[HISTORY_INDEX]: (current_history_index += 1),
 		[NAVIGATION_INDEX]: current_navigation_index,
-		[PAGE_URL_KEY]: page.url.href,
+		// store the address bar URL, so returning to this entry loads what the user saw
+		[PAGE_URL_KEY]: resolved.href,
 		[STATES_KEY]: state
 	};
 
-	history.pushState(opts, '', resolve_url(url));
+	history.pushState(opts, '', resolved);
 	has_navigated = true;
 
 	page.state = state;
@@ -2628,14 +2631,16 @@ export function replaceState(url, state) {
 		}
 	}
 
+	const resolved = resolve_url(url);
+
 	const opts = {
 		[HISTORY_INDEX]: current_history_index,
 		[NAVIGATION_INDEX]: current_navigation_index,
-		[PAGE_URL_KEY]: page.url.href,
+		[PAGE_URL_KEY]: resolved.href,
 		[STATES_KEY]: state
 	};
 
-	history.replaceState(opts, '', resolve_url(url));
+	history.replaceState(opts, '', resolved);
 
 	page.state = state;
 }

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -2560,6 +2560,15 @@ export async function preloadCode(pathname) {
 }
 
 /**
+ * Resolves a shallow routing `url` argument, where `''` means the current URL.
+ * `new URL('', ...)` drops the fragment, which would lose the hash route or anchor.
+ * @param {string | URL} url
+ */
+function resolve_shallow_url(url) {
+	return url === '' ? new URL(location.href) : resolve_url(url);
+}
+
+/**
  * Programmatically create a new history entry with the given `page.state`. To use the current URL, you can pass `''` as the first argument. Used for [shallow routing](https://svelte.dev/docs/kit/shallow-routing).
  *
  * @param {string | URL} url
@@ -2587,7 +2596,7 @@ export function pushState(url, state) {
 
 	update_scroll_positions(current_history_index);
 
-	const resolved = resolve_url(url);
+	const resolved = resolve_shallow_url(url);
 
 	const opts = {
 		[HISTORY_INDEX]: (current_history_index += 1),
@@ -2631,7 +2640,7 @@ export function replaceState(url, state) {
 		}
 	}
 
-	const resolved = resolve_url(url);
+	const resolved = resolve_shallow_url(url);
 
 	const opts = {
 		[HISTORY_INDEX]: current_history_index,

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1709,6 +1709,24 @@ test.describe('Shallow routing', () => {
 		await expect(page.locator('p')).toHaveText('active: true');
 	});
 
+	test('Loads the pushed URL when returning from a subsequent navigation', async ({
+		baseURL,
+		page,
+		clicknav
+	}) => {
+		await page.goto('/shallow-routing/push-state');
+		await page.locator('[data-id="two"]').click();
+		expect(page.url()).toBe(`${baseURL}/shallow-routing/push-state/a`);
+		await expect(page.locator('h1')).toHaveText('parent');
+
+		await clicknav('a[href="/shallow-routing/push-state/b"]');
+		await page.goBack();
+
+		expect(page.url()).toBe(`${baseURL}/shallow-routing/push-state/a`);
+		await expect(page.locator('h1')).toHaveText('a');
+		await expect(page.locator('p')).toHaveText('active: true');
+	});
+
 	test('Replaces state on the current URL', async ({ baseURL, page, clicknav }) => {
 		await page.goto('/shallow-routing/replace-state/b');
 		await clicknav('[href="/shallow-routing/replace-state"]');
@@ -1739,7 +1757,7 @@ test.describe('Shallow routing', () => {
 
 		await page.goForward();
 		expect(page.url()).toBe(`${baseURL}/shallow-routing/replace-state/a`);
-		await expect(page.locator('h1')).toHaveText('parent');
+		await expect(page.locator('h1')).toHaveText('a');
 		await expect(page.locator('p')).toHaveText('active: true');
 	});
 

--- a/packages/kit/test/apps/hash-based-routing/src/routes/+layout.svelte
+++ b/packages/kit/test/apps/hash-based-routing/src/routes/+layout.svelte
@@ -17,6 +17,7 @@
 <a href="/#/reroute-b">/#/reroute-b</a>
 <button data-goto onclick={() => goto('/#/b')}>goto /#/b</button>
 <button data-push onclick={() => pushState('/#/b', {})}>pushState /#/b</button>
+<button data-push-current onclick={() => pushState('', {})}>pushState ''</button>
 <button data-replace onclick={() => replaceState('/#/a#b', {})}>replaceState /#/a#b</button>
 
 {@render children()}

--- a/packages/kit/test/apps/hash-based-routing/test/test.js
+++ b/packages/kit/test/apps/hash-based-routing/test/test.js
@@ -50,6 +50,23 @@ test.describe('hash based navigation', () => {
 		expect(url.hash).toBe('#/a#b');
 	});
 
+	test('pushState with empty url keeps the hash route', async ({ page }) => {
+		await page.goto('/#/a');
+		await expect(page.locator('p')).toHaveText('a');
+
+		await page.locator('button[data-push-current]').click();
+		let url = new URL(page.url());
+		expect(url.hash).toBe('#/a');
+
+		await page.locator('a[href="/#/b"]').click();
+		await expect(page.locator('p')).toHaveText('b');
+
+		await page.goBack();
+		await expect(page.locator('p')).toHaveText('a');
+		url = new URL(page.url());
+		expect(url.hash).toBe('#/a');
+	});
+
 	test('navigates to correct page on load', async ({ page }) => {
 		await page.goto('/#/a');
 		await expect(page.locator('p')).toHaveText('a');


### PR DESCRIPTION
closes #11465

`pushState` and `replaceState` write one URL to the address bar and store a different one in the history entry:

```js
const opts = {
	[HISTORY_INDEX]: (current_history_index += 1),
	[NAVIGATION_INDEX]: current_navigation_index,
	[PAGE_URL_KEY]: page.url.href, // the page we were on
	[STATES_KEY]: state
};

history.pushState(opts, '', resolve_url(url)); // the URL the user sees
```

When you later return to that entry, the popstate handler feeds `PAGE_URL_KEY` to `navigate`, so `load` runs with the old URL while the address bar shows the pushed one. That's the report in the issue, `url.searchParams` in `load` missing params that are visibly in the URL after going back.

Both functions now store the same resolved URL they push. This follows teemingc's comment on the issue, keep the page store URL at push time but update the URL that subsequent loads run with.

One existing assertion changes. "Replaces state on a new URL" expected that going forward to a replaced entry renders the old page under the new URL, which is the inconsistency being fixed. It now expects the route the address bar shows, with `page.state` still restored. A new test covers the reported sequence, push, navigate away, go back, and fails on main.

This doesn't touch the invalidate-after-pushState case from #11503. That needs a decision on push-time load semantics, and an existing test ("Invalidates the correct route after pushing state to a new URL") deliberately locks in the current behavior, so I left it alone. Happy to take it as a follow-up if there's an agreed direction.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
