### PR TITLE
fix: render the nearest error page when a form submission receives a non-ActionResult error response

### DIFF
--- a/.changeset/curly-cats-smile.md
+++ b/.changeset/curly-cats-smile.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: render the nearest error page when a form submission receives a non-ActionResult error response

--- a/packages/kit/src/runtime/app/forms/client.js
+++ b/packages/kit/src/runtime/app/forms/client.js
@@ -1,4 +1,5 @@
 /** @import { ActionResult, SubmitFunction } from './types.js' */
+import { HttpError, SvelteKitError } from '@sveltejs/kit/internal';
 import { DEV } from 'esm-env';
 import { noop } from '../../../utils/functions.js';
 import { refreshAll } from '../navigation/index.js';
@@ -212,19 +213,15 @@ export function enhance(form_element, submit = noop) {
 						result.status = response.status;
 					}
 				} else if (!response.ok) {
-					// the action never ran, e.g. the CSRF check or a proxy rejected the request
-					// `status` on the error object is where the client reads the page status from
-					result = {
-						type: 'error',
-						status: response.status,
-						error:
-							parsed && typeof parsed === 'object'
-								? { ...parsed, status: response.status }
-								: {
-										message: typeof parsed === 'string' ? parsed : response.statusText,
-										status: response.status
-									}
-					};
+					// the action never ran, e.g. the CSRF check or a proxy rejected the request.
+					// an `App.Error`-shaped body is an expected error, anything else goes through `handleError`
+					throw parsed && typeof parsed === 'object' && typeof parsed.message === 'string'
+						? new HttpError({ ...parsed, status: response.status })
+						: new SvelteKitError(
+								response.status,
+								response.statusText,
+								typeof parsed === 'string' ? parsed : response.statusText
+							);
 				} else {
 					result = parsed;
 				}

--- a/packages/kit/src/runtime/app/forms/client.js
+++ b/packages/kit/src/runtime/app/forms/client.js
@@ -186,9 +186,32 @@ export function enhance(form_element, submit = noop) {
 			// detect new deployments from the response header
 			notify_version(response.headers.get('x-sveltekit-version'));
 
-			result = deserialize(await response.text());
-			if (result.type === 'error' || result.type === 'failure') {
-				result.status = response.status;
+			if (response.status === 204) {
+				result = { type: 'success', status: 204 };
+			} else {
+				const parsed = /** @type {any} */ (deserialize(await response.text()));
+
+				if (
+					parsed?.type === 'success' ||
+					parsed?.type === 'failure' ||
+					parsed?.type === 'redirect' ||
+					parsed?.type === 'error'
+				) {
+					result = parsed;
+					if (result.type === 'error' || result.type === 'failure') {
+						result.status = response.status;
+					}
+				} else if (!response.ok) {
+					// the action never ran, e.g. the CSRF check rejected the request
+					// `status` on the error object is where the client reads the page status from
+					result = {
+						type: 'error',
+						status: response.status,
+						error: { ...parsed, status: response.status }
+					};
+				} else {
+					result = parsed;
+				}
 			}
 		} catch (error) {
 			if (/** @type {any} */ (error)?.name === 'AbortError') return;

--- a/packages/kit/src/runtime/app/forms/client.js
+++ b/packages/kit/src/runtime/app/forms/client.js
@@ -187,44 +187,40 @@ export function enhance(form_element, submit = noop) {
 			// detect new deployments from the response header
 			notify_version(response.headers.get('x-sveltekit-version'));
 
-			if (response.status === 204) {
-				result = { type: 'success', status: 204 };
+			const text = await response.text();
+
+			/** @type {any} */
+			let parsed;
+			try {
+				// an empty body carries no result for an error response
+				parsed = text === '' && !response.ok ? undefined : deserialize(text);
+			} catch (error) {
+				// only an error response may have a non-ActionResult body, e.g. an HTML error page
+				if (response.ok) throw error;
+			}
+
+			if (
+				parsed?.type === 'success' ||
+				parsed?.type === 'failure' ||
+				parsed?.type === 'redirect' ||
+				parsed?.type === 'error'
+			) {
+				result = parsed;
+				if (result.type === 'error' || result.type === 'failure') {
+					result.status = response.status;
+				}
+			} else if (!response.ok) {
+				// the action never ran, e.g. the CSRF check or a proxy rejected the request.
+				// an `App.Error`-shaped body is an expected error, anything else goes through `handleError`
+				throw parsed && typeof parsed === 'object' && typeof parsed.message === 'string'
+					? new HttpError({ ...parsed, status: response.status })
+					: new SvelteKitError(
+							response.status,
+							response.statusText,
+							typeof parsed === 'string' ? parsed : response.statusText
+						);
 			} else {
-				const text = await response.text();
-
-				/** @type {any} */
-				let parsed;
-				try {
-					// an empty body carries no result for an error response
-					parsed = text === '' && !response.ok ? undefined : deserialize(text);
-				} catch (error) {
-					// only an error response may have a non-ActionResult body, e.g. an HTML error page
-					if (response.ok) throw error;
-				}
-
-				if (
-					parsed?.type === 'success' ||
-					parsed?.type === 'failure' ||
-					parsed?.type === 'redirect' ||
-					parsed?.type === 'error'
-				) {
-					result = parsed;
-					if (result.type === 'error' || result.type === 'failure') {
-						result.status = response.status;
-					}
-				} else if (!response.ok) {
-					// the action never ran, e.g. the CSRF check or a proxy rejected the request.
-					// an `App.Error`-shaped body is an expected error, anything else goes through `handleError`
-					throw parsed && typeof parsed === 'object' && typeof parsed.message === 'string'
-						? new HttpError({ ...parsed, status: response.status })
-						: new SvelteKitError(
-								response.status,
-								response.statusText,
-								typeof parsed === 'string' ? parsed : response.statusText
-							);
-				} else {
-					result = parsed;
-				}
+				result = parsed;
 			}
 		} catch (error) {
 			if (/** @type {any} */ (error)?.name === 'AbortError') return;

--- a/packages/kit/src/runtime/app/forms/client.js
+++ b/packages/kit/src/runtime/app/forms/client.js
@@ -189,7 +189,17 @@ export function enhance(form_element, submit = noop) {
 			if (response.status === 204) {
 				result = { type: 'success', status: 204 };
 			} else {
-				const parsed = /** @type {any} */ (deserialize(await response.text()));
+				const text = await response.text();
+
+				/** @type {any} */
+				let parsed;
+				try {
+					// an empty body carries no result for an error response
+					parsed = text === '' && !response.ok ? undefined : deserialize(text);
+				} catch (error) {
+					// only an error response may have a non-ActionResult body, e.g. an HTML error page
+					if (response.ok) throw error;
+				}
 
 				if (
 					parsed?.type === 'success' ||
@@ -202,12 +212,18 @@ export function enhance(form_element, submit = noop) {
 						result.status = response.status;
 					}
 				} else if (!response.ok) {
-					// the action never ran, e.g. the CSRF check rejected the request
+					// the action never ran, e.g. the CSRF check or a proxy rejected the request
 					// `status` on the error object is where the client reads the page status from
 					result = {
 						type: 'error',
 						status: response.status,
-						error: { ...parsed, status: response.status }
+						error:
+							parsed && typeof parsed === 'object'
+								? { ...parsed, status: response.status }
+								: {
+										message: typeof parsed === 'string' ? parsed : response.statusText,
+										status: response.status
+									}
 					};
 				} else {
 					result = parsed;

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance-non-action-response/+error.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance-non-action-response/+error.svelte
@@ -1,0 +1,6 @@
+<script>
+	import { page } from '$app/state';
+</script>
+
+<h1>{page.status}</h1>
+<p>{page.error?.message}</p>

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance-non-action-response/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance-non-action-response/+page.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { enhance } from '$app/forms';
+</script>
+
+<form method="POST" action="/actions/enhance-non-action-response/reject" use:enhance>
+	<button>Submit</button>
+</form>

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance-non-action-response/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance-non-action-response/+page.svelte
@@ -3,5 +3,13 @@
 </script>
 
 <form method="POST" action="/actions/enhance-non-action-response/reject" use:enhance>
-	<button>Submit</button>
+	<button class="json">Submit</button>
+</form>
+
+<form method="POST" action="/actions/enhance-non-action-response/reject?body=html" use:enhance>
+	<button class="html">Submit</button>
+</form>
+
+<form method="POST" action="/actions/enhance-non-action-response/reject?body=empty" use:enhance>
+	<button class="empty">Submit</button>
 </form>

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance-non-action-response/reject/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance-non-action-response/reject/+server.js
@@ -1,5 +1,6 @@
 import { json } from '@sveltejs/kit';
 
+/** @type {import('./$types').RequestHandler} */
 export function POST({ url }) {
 	const body = url.searchParams.get('body');
 

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance-non-action-response/reject/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance-non-action-response/reject/+server.js
@@ -1,5 +1,19 @@
 import { json } from '@sveltejs/kit';
 
-export function POST() {
+export function POST({ url }) {
+	const body = url.searchParams.get('body');
+
+	if (body === 'html') {
+		return new Response('<!DOCTYPE html><h1>upstream error</h1>', {
+			status: 502,
+			statusText: 'Bad Gateway',
+			headers: { 'content-type': 'text/html' }
+		});
+	}
+
+	if (body === 'empty') {
+		return new Response(null, { status: 403, statusText: 'Forbidden' });
+	}
+
 	return json({ message: 'Cross-site POST form submissions are forbidden' }, { status: 403 });
 }

--- a/packages/kit/test/apps/basics/src/routes/actions/enhance-non-action-response/reject/+server.js
+++ b/packages/kit/test/apps/basics/src/routes/actions/enhance-non-action-response/reject/+server.js
@@ -1,0 +1,5 @@
+import { json } from '@sveltejs/kit';
+
+export function POST() {
+	return json({ message: 'Cross-site POST form submissions are forbidden' }, { status: 403 });
+}

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1270,13 +1270,14 @@ test.describe('Actions', () => {
 		await page.locator('button.html').click();
 
 		await expect(page.locator('h1')).toHaveText('502');
-		await expect(page.locator('p')).toHaveText('Bad Gateway');
+		// the suffix comes from the `handleError` hook in hooks.client.js
+		await expect(page.locator('p')).toHaveText('Bad Gateway (502 Bad Gateway)');
 
 		await page.goto('/actions/enhance-non-action-response');
 		await page.locator('button.empty').click();
 
 		await expect(page.locator('h1')).toHaveText('403');
-		await expect(page.locator('p')).toHaveText('Forbidden');
+		await expect(page.locator('p')).toHaveText('Forbidden (403 Forbidden)');
 	});
 
 	test('use:enhance abort controller', async ({ page, javaScriptEnabled }) => {

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1261,10 +1261,22 @@ test.describe('Actions', () => {
 	}) => {
 		test.skip(!javaScriptEnabled, 'Skip when JavaScript is disabled');
 		await page.goto('/actions/enhance-non-action-response');
-		await page.locator('button').click();
+		await page.locator('button.json').click();
 
 		await expect(page.locator('h1')).toHaveText('403');
 		await expect(page.locator('p')).toHaveText('Cross-site POST form submissions are forbidden');
+
+		await page.goto('/actions/enhance-non-action-response');
+		await page.locator('button.html').click();
+
+		await expect(page.locator('h1')).toHaveText('502');
+		await expect(page.locator('p')).toHaveText('Bad Gateway');
+
+		await page.goto('/actions/enhance-non-action-response');
+		await page.locator('button.empty').click();
+
+		await expect(page.locator('h1')).toHaveText('403');
+		await expect(page.locator('p')).toHaveText('Forbidden');
 	});
 
 	test('use:enhance abort controller', async ({ page, javaScriptEnabled }) => {

--- a/packages/kit/test/apps/basics/test/test.js
+++ b/packages/kit/test/apps/basics/test/test.js
@@ -1255,6 +1255,18 @@ test.describe('Actions', () => {
 		await expect(page.locator('input[name=username]')).toHaveValue('');
 	});
 
+	test('use:enhance renders an error page for a non-ActionResult error response', async ({
+		page,
+		javaScriptEnabled
+	}) => {
+		test.skip(!javaScriptEnabled, 'Skip when JavaScript is disabled');
+		await page.goto('/actions/enhance-non-action-response');
+		await page.locator('button').click();
+
+		await expect(page.locator('h1')).toHaveText('403');
+		await expect(page.locator('p')).toHaveText('Cross-site POST form submissions are forbidden');
+	});
+
 	test('use:enhance abort controller', async ({ page, javaScriptEnabled }) => {
 		await page.goto('/actions/enhance');
 


### PR DESCRIPTION
closes #15737

Submitting a `use:enhance` form that trips the CSRF origin check does nothing visible. The 403 response is right there in the network tab:

```json
{ "message": "Cross-site POST form submissions are forbidden" }
```

but it has no `type`, so it isn't an ActionResult and every branch in the submit handler and `applyAction` skips it. Non-JSON responses already become `{ type: 'error' }` through the catch around `deserialize`, so JSON that isn't an ActionResult was the one shape that failed silently.

Error responses without a recognized `type` now throw into that same catch and render the nearest `+error.svelte`. A body shaped like an `App.Error` becomes `page.error` as-is, the way an `error(403, { message })` body does. Anything else goes through `handleError`, which #16162 routed this catch through, so the hook keeps seeing these failures and `page.error` keeps its declared shape. 2xx responses are untouched.

PatrickG suggested rendering the error page in the issue. teemingc flagged the same gap in #10464 with a server-side shape fix in mind; doing it on the client also covers proxy and middleware responses that kit's server never shaped. #10855 reports the same class of unhelpful failure for non-action endpoints; the non-2xx half of it is covered here.

Responses that do parse as an ActionResult pass through regardless of status, which keeps the pattern that prompted the #13197 revert (#13397) working. The docs line that revert added says posting to a `+server.js` endpoint results in an error; with this change that error surfaces instead of failing silently.

The test mimics the CSRF response with an endpoint, since the real check can't fire same-origin in Playwright. It fails on `version-3` and passes with this change, in dev and build. The hook suffix in two of the assertions is `handleError` running.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
