### PR TITLE
docs: explain when the service worker is updated

### DIFF
--- a/documentation/docs/30-advanced/40-service-workers.md
+++ b/documentation/docs/30-advanced/40-service-workers.md
@@ -142,8 +142,6 @@ SvelteKit calls [`registration.update()`](https://developer.mozilla.org/en-US/do
 If you want new deployments to be picked up more eagerly, you can trigger an update check yourself — for example on every client-side navigation, in your root layout:
 
 ```js
-/// <reference types="@sveltejs/kit" />
-// ---cut---
 import { afterNavigate } from '$app/navigation';
 
 afterNavigate(async () => {

--- a/documentation/docs/30-advanced/40-service-workers.md
+++ b/documentation/docs/30-advanced/40-service-workers.md
@@ -133,6 +133,27 @@ if ('serviceWorker' in navigator) {
 
 > [!NOTE] The service worker is bundled for production, but not during development.
 
+## Updating the service worker
+
+Browsers check for an updated service worker when a full-page navigation happens within its scope, and after functional events such as `push` and `sync`. Client-side navigations are neither, so navigating around your app will not by itself cause a new deployment's service worker to be picked up.
+
+SvelteKit calls [`registration.update()`](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/update) only as part of error recovery — if a route module fails to load or a navigation results in an error status, and [version polling](configuration#version) detects that the app has been redeployed, the service worker is updated before SvelteKit falls back to a full-page navigation.
+
+If you want new deployments to be picked up more eagerly, you can trigger an update check yourself — for example on every client-side navigation, in your root layout:
+
+```js
+/// <reference types="@sveltejs/kit" />
+// ---cut---
+import { afterNavigate } from '$app/navigation';
+
+afterNavigate(async () => {
+	if ('serviceWorker' in navigator) {
+		const registration = await navigator.serviceWorker.getRegistration();
+		await registration?.update();
+	}
+});
+```
+
 ## Other solutions
 
 SvelteKit's service worker implementation is designed to be easy to work with and is probably a good solution for most users. However, outside of SvelteKit, many PWA applications leverage the [Workbox](https://web.dev/learn/pwa/workbox) library. If you're used to using Workbox you may prefer [Vite PWA plugin](https://vite-pwa-org.netlify.app/frameworks/sveltekit.html).

--- a/documentation/docs/30-advanced/40-service-workers.md
+++ b/documentation/docs/30-advanced/40-service-workers.md
@@ -152,6 +152,8 @@ afterNavigate(async () => {
 });
 ```
 
+This will not cause the new service worker (if there is one) to take over the existing page immediately — instead, it will be installed in the background and take over as soon as the number of tabs managed by the existing service worker drops to zero.
+
 ## Other solutions
 
 SvelteKit's service worker implementation is designed to be easy to work with and is probably a good solution for most users. However, outside of SvelteKit, many PWA applications leverage the [Workbox](https://web.dev/learn/pwa/workbox) library. If you're used to using Workbox you may prefer [Vite PWA plugin](https://vite-pwa-org.netlify.app/frameworks/sveltekit.html).


### PR DESCRIPTION
In #14341 someone asked whether `registration.update()` runs on client-side navigations. It doesn't, and the service workers docs page says nothing about update behavior at all, so I promised a docs PR there.

This adds an "Updating the service worker" section covering the three things that answer covered. Browsers only check on full-page navigations and functional events, SvelteKit itself only updates the worker as part of error recovery (route module fails to load or a navigation errors, plus version polling says the app was redeployed), and an `afterNavigate` snippet for anyone who wants updates picked up eagerly. The error recovery behavior is verified against the two `update_service_worker()` call sites in `client.js` on current main.

Docs only, no changeset.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
