### PR TITLE
chore: remove duplicate `netlify` job in the platform tests workflow

### DIFF
--- a/.github/workflows/platform-tests-all.yml
+++ b/.github/workflows/platform-tests-all.yml
@@ -30,12 +30,6 @@ jobs:
       sha: ${{ inputs.sha }}
     secrets: inherit
 
-  netlify:
-    uses: ./.github/workflows/platform-tests-netlify.yml
-    with:
-      sha: ${{ inputs.sha }}
-    secrets: inherit
-
   report-status:
     if: always()
     needs: [vercel, netlify, node]


### PR DESCRIPTION
The `version-3` branch currently shows this error whenever workflows are parsed:

```
Invalid workflow file: .github/workflows/platform-tests-all.yml#L1
(Line: 33, Col: 3): 'netlify' is already defined
```

#16254 added the `netlify` job to this workflow on `version-3`. #16281 backported it to `main`, and the merge of `main` into `version-3` (96898e96) kept both copies. This removes the duplicate, making the file identical to the one on `main`.