### PR TITLE
fix: align MAX_COOKIE_SIZE with RFC 6265bis

### DIFF
--- a/.changeset/tame-donkeys-clap.md
+++ b/.changeset/tame-donkeys-clap.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: align MAX_COOKIE_SIZE with RFC 6265bis

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -256,7 +256,10 @@ export function get_cookies(request, url) {
 
 		if (DEV) {
 			// only the name/value pair counts towards MAX_COOKIE_SIZE, not the other attributes
-			if (text_encoder.encode(`${name}=${value}`).byteLength > MAX_COOKIE_SIZE) {
+			const encoder = cookie.options.encode || encodeURIComponent;
+			const size =
+				text_encoder.encode(name).byteLength + text_encoder.encode(encoder(value)).byteLength;
+			if (size > MAX_COOKIE_SIZE) {
 				throw new Error(`Cookie "${name}" is too large, and will be discarded by the browser`);
 			}
 

--- a/packages/kit/src/runtime/server/cookie.js
+++ b/packages/kit/src/runtime/server/cookie.js
@@ -15,10 +15,11 @@ const INVALID_COOKIE_CHARACTER_REGEX = /[\x00-\x1F\x7F()<>@,;:"/[\]?={} \t]/;
 const cookie_paths = {};
 
 /**
- * Cookies that are larger than this size (including the name and other
- * attributes) are discarded by browsers
+ * Cookies whose name and value combined are larger than this size are
+ * discarded by browsers. This is the limit codified for the name/value pair
+ * in RFC 6265bis: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-20#section-5.6-7.5.1
  */
-const MAX_COOKIE_SIZE = 4129;
+const MAX_COOKIE_SIZE = 4096;
 
 // TODO 3.0 remove this check
 /** @param {import('./page/types.js').Cookie['options']} options */
@@ -254,8 +255,8 @@ export function get_cookies(request, url) {
 		new_cookies.set(cookie_key, cookie);
 
 		if (DEV) {
-			const serialized = serialize(name, value, cookie.options);
-			if (text_encoder.encode(serialized).byteLength > MAX_COOKIE_SIZE) {
+			// only the name/value pair counts towards MAX_COOKIE_SIZE, not the other attributes
+			if (text_encoder.encode(`${name}=${value}`).byteLength > MAX_COOKIE_SIZE) {
 				throw new Error(`Cookie "${name}" is too large, and will be discarded by the browser`);
 			}
 

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -47,7 +47,7 @@ describe('cookies in dev', () => {
 		const { cookies } = cookies_setup();
 
 		// name ("a=") is 2 bytes, so the value alone must stay under 4094 bytes
-		expect(() => cookies.set('a', 'a'.repeat(4095), { path: '/' })).toThrowError(
+		expect(() => cookies.set('a', 'a'.repeat(4096), { path: '/' })).toThrowError(
 			'Cookie "a" is too large, and will be discarded by the browser'
 		);
 	});
@@ -55,7 +55,7 @@ describe('cookies in dev', () => {
 	test('does not throw if cookie name/value is at the 4,096 byte limit', () => {
 		const { cookies } = cookies_setup();
 
-		expect(() => cookies.set('a', 'a'.repeat(4094), { path: '/' })).not.toThrow();
+		expect(() => cookies.set('a', 'a'.repeat(4095), { path: '/' })).not.toThrow();
 	});
 });
 

--- a/packages/kit/src/runtime/server/cookie.spec.js
+++ b/packages/kit/src/runtime/server/cookie.spec.js
@@ -43,15 +43,19 @@ describe('cookies in dev', () => {
 		globalThis.__SVELTEKIT_DEV__ = true;
 	});
 
-	test('warns if cookie exceeds 4,129 bytes', () => {
-		try {
-			const { cookies } = cookies_setup();
-			cookies.set('a', 'a'.repeat(4097), { path: '/' });
-		} catch (e) {
-			const error = /** @type {Error} */ (e);
+	test('throws if cookie name/value exceeds 4,096 bytes', () => {
+		const { cookies } = cookies_setup();
 
-			assert.equal(error.message, 'Cookie "a" is too large, and will be discarded by the browser');
-		}
+		// name ("a=") is 2 bytes, so the value alone must stay under 4094 bytes
+		expect(() => cookies.set('a', 'a'.repeat(4095), { path: '/' })).toThrowError(
+			'Cookie "a" is too large, and will be discarded by the browser'
+		);
+	});
+
+	test('does not throw if cookie name/value is at the 4,096 byte limit', () => {
+		const { cookies } = cookies_setup();
+
+		expect(() => cookies.set('a', 'a'.repeat(4094), { path: '/' })).not.toThrow();
 	});
 });
 


### PR DESCRIPTION
Fixes #13948

`MAX_COOKIE_SIZE` was set to 4129, a magic number that came from testing browser behavior rather than any spec. RFC 6265bis section 5.6 codifies 4096 bytes as the limit for a cookie's name and value combined, and that's what Chromium and Firefox actually enforce, so this changes the constant to 4096 and cites the spec in the comment.

While digging into this I noticed the existing check compared `MAX_COOKIE_SIZE` against the fully serialized `Set-Cookie` string, so name, value, and all the attributes like `Path` and `SameSite`. That doesn't match what 4096 is defined for in the spec (name + value only), so I changed the check itself to only measure the name and value, not the serialized string with its attributes. Keeping the scope to this since that's the simplest fix that matches the spec, per benmccann's comment on the issue about preferring the simplest solution.

Updated the existing dev-mode cookie size test to reflect the new 4096 boundary and added a case for a cookie right at the limit not throwing.

This PR was written with the help of Claude Code (Anthropic). I read through the issue thread, the relevant code, and verified the change and tests myself before opening this.

Ran `pnpm -F @sveltejs/kit test:unit` (598 passed), `pnpm run format` and eslint on the changed files, and `tsc --noEmit` for the kit package; all clean. Added a changeset (patch for `@sveltejs/kit`).
