### PR TITLE
fix: don't mask errors with a "header is already set" error when rendering the error page

### DIFF
--- a/.changeset/tidy-ravens-smile.md
+++ b/.changeset/tidy-ravens-smile.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': patch
 ---
 
-fix: don't mask errors with a "header is already set" error when rendering the error page
+fix: render the error page with the post-`handle` headers instead of failing on headers the crashed render already set

--- a/.changeset/tidy-ravens-smile.md
+++ b/.changeset/tidy-ravens-smile.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: don't mask errors with a "header is already set" error when rendering the error page

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -26,6 +26,9 @@ export async function respond_with_error({ event, state, error, resolve_opts }) 
 		return static_error_page(transformed.status, transformed.message);
 	}
 
+	// discard headers set by the failed render; the error page renders from scratch
+	state.reset_headers?.();
+
 	/** @type {import('./types.js').Fetched[]} */
 	const fetched = [];
 	try {

--- a/packages/kit/src/runtime/server/page/respond_with_error.js
+++ b/packages/kit/src/runtime/server/page/respond_with_error.js
@@ -26,7 +26,6 @@ export async function respond_with_error({ event, state, error, resolve_opts }) 
 		return static_error_page(transformed.status, transformed.message);
 	}
 
-	// discard headers set by the failed render; the error page renders from scratch
 	state.reset_headers?.();
 
 	/** @type {import('./types.js').Fetched[]} */

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -583,12 +583,8 @@ export async function internal_respond(request, state) {
 	 * @param {import('@sveltejs/kit/hooks').ResolveOptions} [opts]
 	 */
 	async function resolve(event, page_nodes, opts) {
-		// headers set so far came from `handle`. A failed render must not leak
-		// headers into the error page, so rendering it starts from this state
 		const handle_headers = { ...headers };
-		state.reset_headers ??= () => {
-			headers = { ...handle_headers };
-		};
+		state.reset_headers ??= () => (headers = { ...handle_headers });
 
 		try {
 			if (opts) {

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -175,7 +175,7 @@ export async function internal_respond(request, state) {
 	}
 
 	/** @type {Record<string, string>} */
-	const headers = {};
+	let headers = {};
 
 	const { cookies, new_cookies, get_cookie_header, set_internal, set_trailing_slash } = get_cookies(
 		request,
@@ -221,7 +221,7 @@ export async function internal_respond(request, state) {
 					// appendHeaders-style for Server-Timing https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing
 					if (lower === 'server-timing') {
 						headers[lower] += ', ' + value;
-					} else if (!state.error) {
+					} else {
 						throw new Error(`"${key}" header is already set`);
 					}
 				} else {
@@ -583,6 +583,13 @@ export async function internal_respond(request, state) {
 	 * @param {import('@sveltejs/kit/hooks').ResolveOptions} [opts]
 	 */
 	async function resolve(event, page_nodes, opts) {
+		// headers set so far came from `handle`. A failed render must not leak
+		// headers into the error page, so rendering it starts from this state
+		const handle_headers = { ...headers };
+		state.reset_headers ??= () => {
+			headers = { ...handle_headers };
+		};
+
 		try {
 			if (opts) {
 				resolve_opts = {

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -221,7 +221,7 @@ export async function internal_respond(request, state) {
 					// appendHeaders-style for Server-Timing https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing
 					if (lower === 'server-timing') {
 						headers[lower] += ', ' + value;
-					} else {
+					} else if (!state.error) {
 						throw new Error(`"${key}" header is already set`);
 					}
 				} else {

--- a/packages/kit/src/runtime/server/respond.js
+++ b/packages/kit/src/runtime/server/respond.js
@@ -200,7 +200,7 @@ export async function internal_respond(request, options, manifest, state) {
 					// appendHeaders-style for Server-Timing https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing
 					if (lower === 'server-timing') {
 						headers[lower] += ', ' + value;
-					} else {
+					} else if (!state.error) {
 						throw new Error(`"${key}" header is already set`);
 					}
 				} else {

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -696,6 +696,12 @@ export type RecordSpan = <T>(options: {
  * used for tracking things like remote function calls
  */
 export interface RequestState {
+	/**
+	 * Restores the response headers to their post-`handle` state, discarding
+	 * `setHeaders` calls made by a render that subsequently failed.
+	 * Assigned lazily when `resolve` is first called.
+	 */
+	reset_headers?(): void;
 	readonly getClientAddress: () => string;
 	readonly platform?: any;
 	/** @internal reads from the filesystem when user code tries to fetch a static asset */

--- a/packages/kit/src/types/internal.d.ts
+++ b/packages/kit/src/types/internal.d.ts
@@ -696,11 +696,7 @@ export type RecordSpan = <T>(options: {
  * used for tracking things like remote function calls
  */
 export interface RequestState {
-	/**
-	 * Restores the response headers to their post-`handle` state, discarding
-	 * `setHeaders` calls made by a render that subsequently failed.
-	 * Assigned lazily when `resolve` is first called.
-	 */
+	/** discards headers set by a render that failed, so the error page starts from the post-`handle` state */
 	reset_headers?(): void;
 	readonly getClientAddress: () => string;
 	readonly platform?: any;

--- a/packages/kit/test/apps/basics/src/hooks.server.js
+++ b/packages/kit/test/apps/basics/src/hooks.server.js
@@ -138,7 +138,14 @@ export const handle = sequence(
 		const response = await resolve(event, {
 			transformPageChunk: event.url.pathname.startsWith('/transform-page-chunk')
 				? ({ html }) => html.replace('__REPLACEME__', 'Worked!')
-				: undefined
+				: event.url.pathname === '/errors/error-page-setheaders'
+					? ({ html }) => {
+							if (html.includes('makes the page transform crash')) {
+								throw new Error('Crashing now');
+							}
+							return html;
+						}
+					: undefined
 		});
 
 		try {
@@ -192,7 +199,11 @@ export const handle = sequence(
 		return resolve(event);
 	},
 	async ({ event, resolve }) => {
-		if (['/non-existent-route', '/non-existent-route-loop'].includes(event.url.pathname)) {
+		if (
+			['/errors/error-page-setheaders', '/non-existent-route', '/non-existent-route-loop'].includes(
+				event.url.pathname
+			)
+		) {
 			event.locals.url = new URL(event.request.url);
 		}
 		return resolve(event);

--- a/packages/kit/test/apps/basics/src/hooks.server.js
+++ b/packages/kit/test/apps/basics/src/hooks.server.js
@@ -122,7 +122,14 @@ export const handle = sequence(
 		const response = await resolve(event, {
 			transformPageChunk: event.url.pathname.startsWith('/transform-page-chunk')
 				? ({ html }) => html.replace('__REPLACEME__', 'Worked!')
-				: undefined
+				: event.url.pathname === '/errors/error-page-setheaders'
+					? ({ html }) => {
+							if (html.includes('makes the page transform crash')) {
+								throw new Error('Crashing now');
+							}
+							return html;
+						}
+					: undefined
 		});
 
 		try {
@@ -176,7 +183,11 @@ export const handle = sequence(
 		return resolve(event);
 	},
 	async ({ event, resolve }) => {
-		if (['/non-existent-route', '/non-existent-route-loop'].includes(event.url.pathname)) {
+		if (
+			['/errors/error-page-setheaders', '/non-existent-route', '/non-existent-route-loop'].includes(
+				event.url.pathname
+			)
+		) {
 			event.locals.url = new URL(event.request.url);
 		}
 		return resolve(event);

--- a/packages/kit/test/apps/basics/src/hooks.server.js
+++ b/packages/kit/test/apps/basics/src/hooks.server.js
@@ -138,7 +138,7 @@ export const handle = sequence(
 		const response = await resolve(event, {
 			transformPageChunk: event.url.pathname.startsWith('/transform-page-chunk')
 				? ({ html }) => html.replace('__REPLACEME__', 'Worked!')
-				: event.url.pathname === '/errors/error-page-setheaders'
+				: event.url.pathname.startsWith('/errors/error-page-setheaders')
 					? ({ html }) => {
 							if (html.includes('makes the page transform crash')) {
 								throw new Error('Crashing now');
@@ -200,9 +200,8 @@ export const handle = sequence(
 	},
 	async ({ event, resolve }) => {
 		if (
-			['/errors/error-page-setheaders', '/non-existent-route', '/non-existent-route-loop'].includes(
-				event.url.pathname
-			)
+			event.url.pathname.startsWith('/errors/error-page-setheaders') ||
+			['/non-existent-route', '/non-existent-route-loop'].includes(event.url.pathname)
 		) {
 			event.locals.url = new URL(event.request.url);
 		}

--- a/packages/kit/test/apps/basics/src/routes/+layout.server.js
+++ b/packages/kit/test/apps/basics/src/routes/+layout.server.js
@@ -8,7 +8,7 @@ if (JSON.parse(SOME_JSON).answer !== 42) {
 
 /** @type {import('./$types').LayoutServerLoad} */
 export async function load({ cookies, locals, fetch, setHeaders }) {
-	if (locals.url?.pathname === '/errors/error-page-setheaders') {
+	if (locals.url?.pathname.startsWith('/errors/error-page-setheaders')) {
 		setHeaders({ 'cache-control': 'private, max-age=60' });
 	}
 

--- a/packages/kit/test/apps/basics/src/routes/+layout.server.js
+++ b/packages/kit/test/apps/basics/src/routes/+layout.server.js
@@ -7,7 +7,11 @@ if (JSON.parse(SOME_JSON).answer !== 42) {
 }
 
 /** @type {import('./$types').LayoutServerLoad} */
-export async function load({ cookies, locals, fetch }) {
+export async function load({ cookies, locals, fetch, setHeaders }) {
+	if (locals.url?.pathname === '/errors/error-page-setheaders') {
+		setHeaders({ 'cache-control': 'private, max-age=60' });
+	}
+
 	if (locals.url?.pathname === '/non-existent-route') {
 		await fetch('/prerendering/prerendered-endpoint/api').then((r) => r.json());
 	}

--- a/packages/kit/test/apps/basics/src/routes/errors/error-page-setheaders-leak/+page.server.js
+++ b/packages/kit/test/apps/basics/src/routes/errors/error-page-setheaders-leak/+page.server.js
@@ -1,0 +1,4 @@
+/** @type {import('./$types').PageServerLoad} */
+export function load({ setHeaders }) {
+	setHeaders({ 'x-failed-render': '1' });
+}

--- a/packages/kit/test/apps/basics/src/routes/errors/error-page-setheaders-leak/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/errors/error-page-setheaders-leak/+page.svelte
@@ -1,0 +1,1 @@
+<p>this text makes the page transform crash</p>

--- a/packages/kit/test/apps/basics/src/routes/errors/error-page-setheaders/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/errors/error-page-setheaders/+page.svelte
@@ -1,0 +1,1 @@
+<p>this text makes the page transform crash</p>

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -898,6 +898,14 @@ test.describe('setHeaders', () => {
 		expect(cookies).toMatch('cookie1=value1');
 		expect(cookies).toMatch('cookie2=value2');
 	});
+
+	test('renders the error page when the root layout sets headers', async ({ request }) => {
+		const response = await request.get('/errors/error-page-setheaders');
+
+		expect(response.status()).toBe(500);
+		expect(response.headers()['cache-control']).toBe('private, max-age=60');
+		expect(await response.text()).toContain('This is your custom error page saying:');
+	});
 });
 
 test.describe('cookies', () => {

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -1046,6 +1046,14 @@ test.describe('setHeaders', () => {
 		expect(cookies).toMatch('cookie1=value1');
 		expect(cookies).toMatch('cookie2=value2');
 	});
+
+	test('renders the error page when the root layout sets headers', async ({ request }) => {
+		const response = await request.get('/errors/error-page-setheaders');
+
+		expect(response.status()).toBe(500);
+		expect(response.headers()['cache-control']).toBe('private, max-age=60');
+		expect(await response.text()).toContain('This is your custom error page saying:');
+	});
 });
 
 test.describe('cookies', () => {

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -1054,6 +1054,15 @@ test.describe('setHeaders', () => {
 		expect(response.headers()['cache-control']).toBe('private, max-age=60');
 		expect(await response.text()).toContain('This is your custom error page saying:');
 	});
+
+	test('drops headers set by the failed render from the error page', async ({ request }) => {
+		const response = await request.get('/errors/error-page-setheaders-leak');
+
+		expect(response.status()).toBe(500);
+		expect(response.headers()['x-failed-render']).toBeUndefined();
+		expect(response.headers()['cache-control']).toBe('private, max-age=60');
+		expect(await response.text()).toContain('This is your custom error page saying:');
+	});
 });
 
 test.describe('cookies', () => {


### PR DESCRIPTION
If the root layout `load` calls `setHeaders` and something throws after the page rendered, the error page dies too. `respond_with_error` re-runs the root layout `load` on the same event, so the second `setHeaders` call hits the set-once check and throws `"cache-control" header is already set`. That error replaces the real one in `handle_error_and_jsonify`, so the log shows only the `setHeaders` complaint and the response falls back to the static error page instead of `+error.svelte`.

The set-once throw is by design (#5778) and stays untouched. Instead, `resolve` snapshots the headers `handle` has set before any route logic runs, and `respond_with_error` restores that snapshot before rendering, so the error page starts from the post-`handle` state and the re-run root layout `load` sets its headers on a clean slate. Headers the failed render set for the page that never shipped are dropped rather than leaked onto the error response, and `server-timing` no longer doubles up during the re-run. `locals` and cookies are deliberately left alone, a shallow copy can't undo mutations to nested state and rolling back a session cookie on an error page would log people out.

Finding a trigger takes more care here than on kit 2. `load` errors take the nearest-boundary path without re-running the root layout, and on `version-3` render errors are caught in place by the root `<svelte:boundary>` too, so neither reaches `respond_with_error` anymore. Anything that throws after the loads settled still does, `transformPageChunk` in the tests' case, and so does a page module that fails to import (the trigger in the original issue).

Fixes #11676
