### PR TITLE
docs: show how to handle redirects from shared helpers in command functions

### DIFF
--- a/documentation/docs/20-core-concepts/60-remote-functions.md
+++ b/documentation/docs/20-core-concepts/60-remote-functions.md
@@ -1301,3 +1301,36 @@ Note that some properties of `RequestEvent` are different inside remote function
 ## Redirects
 
 Inside `query`, `form` and `prerender` functions it is possible to use the [`redirect(...)`](@sveltejs-kit#redirect) function. It is *not* possible inside `command` functions, as you should avoid redirecting here. (If you absolutely have to, you can return a `{ redirect: location }` object and deal with it in the client.)
+
+This matters when a shared helper built on [`getRequestEvent`]($app-server#getRequestEvent) throws a `redirect()` — reused inside a `command`, it will fail with an error. Catch it with [`isRedirect`](@sveltejs-kit#isRedirect) and return the location instead:
+
+```js
+/// file: src/routes/todos.remote.js
+import { command } from '$app/server';
+import { isRedirect } from '@sveltejs/kit';
+import { requireLogin } from '$lib/server/auth';
+import * as db from '$lib/server/database';
+
+export const addTodo = command('unchecked', async (text) => {
+	try {
+		const user = requireLogin();
+		await db.addTodo(user, text);
+	} catch (e) {
+		if (isRedirect(e)) return { redirect: e.location };
+		throw e;
+	}
+});
+```
+
+```svelte
+<!--- file: src/routes/+page.svelte --->
+<script>
+	import { goto } from '$app/navigation';
+	import { addTodo } from './todos.remote';
+
+	async function add(text) {
+		const result = await addTodo(text);
+		if (result?.redirect) goto(result.redirect);
+	}
+</script>
+```


### PR DESCRIPTION
Fixes #16275.

The docs promote shared `getRequestEvent()` helpers, and the canonical `requireLogin()` example throws `redirect()`, which explodes with a confusing client error when reused inside a `command`. This expands the existing Redirects section with the intended pattern, catch with `isRedirect` and return the location for the client to `goto`.

For context, allowing `redirect()` inside `command()` natively was floated by Conduitry on #14858 and didn't get maintainer buy-in, so this documents the intended pattern rather than a stopgap.
