### PR TITLE
fix: detect destructured route exports during type generation

### DIFF
--- a/.changeset/calm-types-bind.md
+++ b/.changeset/calm-types-bind.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: detect destructured `load` and `actions` exports during type generation

--- a/packages/kit/src/core/sync/write_types/index.js
+++ b/packages/kit/src/core/sync/write_types/index.js
@@ -636,6 +636,16 @@ export function tweak_types(content, is_server) {
 		const code = new MagicString(content);
 
 		const exports = new Map();
+		/** @param {import('typescript').BindingName} name */
+		function add_export(name) {
+			if (ts.isIdentifier(name)) {
+				if (names.has(name.text)) exports.set(name.text, name.text);
+			} else {
+				for (const element of name.elements) {
+					if (ts.isBindingElement(element)) add_export(element.name);
+				}
+			}
+		}
 
 		ast.forEachChild((node) => {
 			if (
@@ -662,9 +672,7 @@ export function tweak_types(content, is_server) {
 
 				if (ts.isVariableStatement(node)) {
 					node.declarationList.declarations.forEach((declaration) => {
-						if (ts.isIdentifier(declaration.name) && names.has(declaration.name.text)) {
-							exports.set(declaration.name.text, declaration.name.text);
-						}
+						add_export(declaration.name);
 					});
 				}
 			}

--- a/packages/kit/src/core/sync/write_types/index.spec.js
+++ b/packages/kit/src/core/sync/write_types/index.spec.js
@@ -187,6 +187,16 @@ test('Rewrites types for a JavaScript module with `const`', () => {
 	);
 });
 
+test('Detects destructured exports', () => {
+	const source = `
+		export const { load, actions } = create_page();
+	`;
+
+	const rewritten = tweak_types(source, true);
+
+	expect(rewritten?.exports).toEqual(['load', 'actions']);
+});
+
 test('Appends @ts-nocheck after @ts-check', () => {
 	const source = `// @ts-check
 		/** @type {import('./$types').Get} */


### PR DESCRIPTION
`tweak_types` currently skips route exports declared through destructuring because it only records identifier declarations. This walks binding patterns and records the actual bound names, so helper-produced `load` and `actions` contribute to generated route types. Added a regression test and patch changeset. The test fails without the fix, and the full `write_types` suite passes (11/11). Fixes #16326.
