### PR TITLE
chore: remove ts-expect-error

### DIFF
--- a/packages/kit/src/exports/vite/index.js
+++ b/packages/kit/src/exports/vite/index.js
@@ -743,11 +743,7 @@ function kit({ svelte_config }) {
 					(normalized.startsWith('$lib/') && server_only_directory_pattern.test(id)) ||
 					(is_internal && server_only_module_pattern.test(id));
 
-				// skip .server.js files outside the cwd or in node_modules, as the filename might not mean 'server-only module' in this context
-				// TODO: address https://github.com/sveltejs/kit/issues/12529
-				if (!is_server_only) {
-					return;
-				}
+				if (!is_server_only) return;
 
 				// in dev, this doesn't exist, so we need to create it
 				manifest_data ??= sync.all(svelte_config, root).manifest_data;

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -3286,9 +3286,6 @@ function reset_focus(url, scroll = true) {
 			const tabindex = root.getAttribute('tabindex');
 
 			root.tabIndex = -1;
-			// TODO: remove this when we switch to TypeScript 6
-			// @ts-ignore options.focusVisible is only typed in TypeScript 6
-			// See https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#browser_compatibility
 			root.focus({ preventScroll: true, focusVisible: false });
 
 			// restore `tabindex` as to prevent `root` from stealing input from elements

--- a/packages/kit/src/runtime/form-utils.js
+++ b/packages/kit/src/runtime/form-utils.js
@@ -150,10 +150,7 @@ export async function deserialize_binary_form(request) {
 		throw deserialize_error('no body');
 	}
 
-	// TODO: remove this workaround once we upgrade to TS 6.0
-	const reader = /** @type {ReadableStreamDefaultReader<Uint8Array<ArrayBuffer>>} */ (
-		request.body.getReader()
-	);
+	const reader = request.body.getReader();
 
 	/** @type {Array<Promise<Uint8Array<ArrayBuffer> | undefined>>} */
 	const chunks = [];

--- a/packages/kit/tsconfig.json
+++ b/packages/kit/tsconfig.json
@@ -3,13 +3,9 @@
 		"allowJs": true,
 		"checkJs": true,
 		"noEmit": true,
-		// TODO: remove when we switch to TS 6.0
-		"strict": true,
 		"target": "esnext",
 		"module": "nodenext",
 		"moduleResolution": "nodenext",
-		// TODO: remove when we switch to TS 6.0
-		"allowSyntheticDefaultImports": true,
 		"paths": {
 			"@sveltejs/kit": ["./src/exports/public.d.ts"],
 			"@sveltejs/kit/vite": ["./src/exports/vite/index.js"],


### PR DESCRIPTION
forgot to remove this when we migrated to ts6. If you see an error in your editor, it's likely the editor typescript sdk needs to point to v6 or kit's local node_modules typescript which is v6