### PR TITLE
feat: add `optional` option to `EnvVarConfig` for optional environment variables

### DIFF
--- a/.changeset/optional-env-vars.md
+++ b/.changeset/optional-env-vars.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': minor
+---
+
+feat: add `optional` option to `EnvVarConfig` for optional environment variables

--- a/documentation/docs/20-core-concepts/70-environment-variables.md
+++ b/documentation/docs/20-core-concepts/70-environment-variables.md
@@ -139,6 +139,24 @@ export const variables = defineEnvVars({
 
 You can use validators to make values optional, or transform them (such as turning a string into a boolean, or parsing JSON) — see your validation library's documentation to learn how.
 
+### Optional variables
+
+By default, every variable is required: if a value is missing when the app runs, validation will fail. To allow a variable to be missing, set `optional: true`:
+
+```ts
+/// file: src/env.ts
+import { defineEnvVars } from '@sveltejs/kit/hooks';
+
+export const variables = defineEnvVars({
+	GOOGLE_ANALYTICS_ID: {
+		public: true,
+		+++optional: true+++
+	}
+});
+```
+
+When a variable is optional, its type is `string | undefined` (or, if a `schema` is provided, the schema's output type `| undefined`), and validation is skipped when the value is missing. This is equivalent to using a schema that accepts an optional value, but without the boilerplate.
+
 ### Static variables
 
 By default, variables are dynamic. If a variable is configured with `static: true`, it will be inlined into your application code, enabling optimisations like dead-code elimination:

--- a/packages/kit/src/core/env.js
+++ b/packages/kit/src/core/env.js
@@ -313,7 +313,7 @@ export function create_explicit_env_types(variables, relative, type) {
 			const type = config.schema
 				? `import('@sveltejs/kit/internal/types').StandardSchemaV1.InferOutput<typeof import('${relative}').variables.${name}.schema>`
 				: 'string';
-			return `${comment}export const ${name}: ${type};`;
+			return `${comment}export const ${name}: ${config.optional ? `${type} | undefined` : type};`;
 		});
 
 	return dedent`

--- a/packages/kit/src/exports/internal/env.js
+++ b/packages/kit/src/exports/internal/env.js
@@ -4,7 +4,7 @@
 import { stackless } from '../../utils/error.js';
 
 const MISSING = {
-	message: `Value is missing. If it is optional, add a Standard Schema validator declaring it as such.`
+	message: `Value is missing. If it is optional, set \`optional: true\` or add a Standard Schema validator declaring it as such.`
 };
 
 const BAD_VALIDATOR = {
@@ -25,6 +25,10 @@ const ASYNC_VALIDATOR = {
 export function validate(variables, value, name, issues) {
 	const config = variables[name] ?? {};
 	const validator = config.schema;
+
+	if (config.optional && !value) {
+		return undefined;
+	}
 
 	if (!validator) {
 		if (!value) issues[name] = [MISSING];

--- a/packages/kit/src/exports/internal/env.spec.js
+++ b/packages/kit/src/exports/internal/env.spec.js
@@ -1,0 +1,91 @@
+import { assert, describe, test } from 'vitest';
+import { validate, handle_issues } from './env.js';
+
+/**
+ * @param {Record<string, any>} variables
+ * @param {string | undefined} value
+ * @param {string} name
+ */
+function run(variables, value, name) {
+	/** @type {Record<string, any[]>} */
+	const issues = {};
+	const result = validate(variables, value, name, issues);
+	return { result, issues };
+}
+
+describe('validate', () => {
+	test('records a MISSING issue when a required variable without a schema is undefined', () => {
+		const { result, issues } = run({ FOO: {} }, undefined, 'FOO');
+		assert.equal(result, undefined);
+		assert.deepEqual(issues, { FOO: [issues.FOO[0]] });
+		assert.match(issues.FOO[0].message, /Value is missing/);
+	});
+
+	test('does not record an issue when an optional variable without a schema is undefined', () => {
+		const { result, issues } = run({ FOO: { optional: true } }, undefined, 'FOO');
+		assert.equal(result, undefined);
+		assert.deepEqual(issues, {});
+	});
+
+	test('does not record an issue when an optional variable without a schema is an empty string', () => {
+		const { result, issues } = run({ FOO: { optional: true } }, '', 'FOO');
+		assert.equal(result, undefined);
+		assert.deepEqual(issues, {});
+	});
+
+	test('returns the value unchanged when a required variable without a schema is present', () => {
+		const { result, issues } = run({ FOO: {} }, 'bar', 'FOO');
+		assert.equal(result, 'bar');
+		assert.deepEqual(issues, {});
+	});
+
+	test('returns the value unchanged when an optional variable is present', () => {
+		const { result, issues } = run({ FOO: { optional: true } }, 'bar', 'FOO');
+		assert.equal(result, 'bar');
+		assert.deepEqual(issues, {});
+	});
+
+	test('skips the schema validator when an optional variable is undefined', () => {
+		/** @type {any} */
+		const validator = {
+			'~standard': {
+			validate(/** @type {any} */ value) {
+				if (value === undefined) return { issues: [{ message: 'nope' }] };
+				return { value };
+			}
+			}
+		};
+		const { result, issues } = run(
+			{ FOO: { optional: true, schema: validator } },
+			undefined,
+			'FOO'
+		);
+		assert.equal(result, undefined);
+		assert.deepEqual(issues, {});
+	});
+
+	test('runs the schema validator when an optional variable is present', () => {
+		/** @type {any} */
+		const validator = {
+			'~standard': {
+			validate(/** @type {any} */ value) {
+				return { value: `validated:${value}` };
+			}
+			}
+		};
+		const { result, issues } = run({ FOO: { optional: true, schema: validator } }, 'bar', 'FOO');
+		assert.equal(result, 'validated:bar');
+		assert.deepEqual(issues, {});
+	});
+
+	test('handle_issues throws when there are issues', () => {
+		assert.throws(
+			() => handle_issues({ FOO: [{ message: 'bad' }] }),
+			/Invalid environment variables/
+		);
+	});
+
+	test('handle_issues is a no-op when there are no issues', () => {
+		handle_issues({});
+	});
+});

--- a/packages/kit/src/exports/internal/env.spec.js
+++ b/packages/kit/src/exports/internal/env.spec.js
@@ -49,10 +49,10 @@ describe('validate', () => {
 		/** @type {any} */
 		const validator = {
 			'~standard': {
-			validate(/** @type {any} */ value) {
-				if (value === undefined) return { issues: [{ message: 'nope' }] };
-				return { value };
-			}
+				validate(/** @type {any} */ value) {
+					if (value === undefined) return { issues: [{ message: 'nope' }] };
+					return { value };
+				}
 			}
 		};
 		const { result, issues } = run(
@@ -68,9 +68,9 @@ describe('validate', () => {
 		/** @type {any} */
 		const validator = {
 			'~standard': {
-			validate(/** @type {any} */ value) {
-				return { value: `validated:${value}` };
-			}
+				validate(/** @type {any} */ value) {
+					return { value: `validated:${value}` };
+				}
 			}
 		};
 		const { result, issues } = run({ FOO: { optional: true, schema: validator } }, 'bar', 'FOO');

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -2472,6 +2472,13 @@ export interface EnvVarConfig<T> {
 	 * A description of the variable that will be used for inline documentation on hover.
 	 */
 	description?: string;
+	/**
+	 * Whether the variable is required.
+	 * - if `true`, validation will not fail when the value is `undefined`. Its type will be `T | undefined`
+	 * - if `false`, the value must be present (and pass validation, if a `schema` is provided)
+	 * @default false
+	 */
+	optional?: boolean;
 }
 
 export * from './index.js';

--- a/packages/kit/src/exports/public.d.ts
+++ b/packages/kit/src/exports/public.d.ts
@@ -2473,7 +2473,7 @@ export interface EnvVarConfig<T> {
 	 */
 	description?: string;
 	/**
-	 * Whether the variable is required.
+	 * Whether the variable is optional.
 	 * - if `true`, validation will not fail when the value is `undefined`. Its type will be `T | undefined`
 	 * - if `false`, the value must be present (and pass validation, if a `schema` is provided)
 	 * @default false

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2443,6 +2443,13 @@ declare module '@sveltejs/kit' {
 		 * A description of the variable that will be used for inline documentation on hover.
 		 */
 		description?: string;
+		/**
+		 * Whether the variable is required.
+		 * - if `true`, validation will not fail when the value is `undefined`. Its type will be `T | undefined`
+		 * - if `false`, the value must be present (and pass validation, if a `schema` is provided)
+		 * @default false
+		 */
+		optional?: boolean;
 	}
 	interface AdapterEntry {
 		/**

--- a/packages/kit/types/index.d.ts
+++ b/packages/kit/types/index.d.ts
@@ -2444,7 +2444,7 @@ declare module '@sveltejs/kit' {
 		 */
 		description?: string;
 		/**
-		 * Whether the variable is required.
+		 * Whether the variable is optional.
 		 * - if `true`, validation will not fail when the value is `undefined`. Its type will be `T | undefined`
 		 * - if `false`, the value must be present (and pass validation, if a `schema` is provided)
 		 * @default false


### PR DESCRIPTION
This is an alternative approach to #16267. Rather than having a three-way enum, this adds a boolean, `optional: true`, alongside the existing `public: true` and `static: true`. (Credit to @elliott-with-the-longest-name-on-github for realising that there's no reason a static variable can't be optional — this is why a boolean matrix makes more sense than an enum.)

When a variable is marked optional, its type is `T | undefined` (where `T` is usually `string`). SvelteKit will not throw an error if the value is missing when the app runs. This is effectively a shorthand for using a schema:

```diff
export const variables = defineEnvVars({
  MY_OPTIONAL_THING: {
-   schema: v.optional(v.string())
+   optional: true
  }
});
```

Note that this isn't quite the same as the `'runtime'` option in #16267 — if you want variables to be required when `building` is `false`, you would still need to do something like this...

```diff
export const variables = defineEnvVars({
  MY_RUNTIME_ONLY_THING: {
-   schema: building ? v.undefined() : v.string()
  }
});
```

...which does leave open a valid question about whether this change is truly worthwhile. I leave it here for others to discuss.

Another possible design would be to flip it: instead of saying 'this variable is not needed at build time', we could make that the default (stubbing in the empty string for anything that wasn't present) and add an option that says 'this _is_ needed at build time', for things needed during prerendering etc:

```diff
export const variables = defineEnvVars({
  MY_RUNTIME_ONLY_THING: {},
  MY_PRERENDER_TIME_THING: {
+   build: true
  }
});
```

The type of both `MY_RUNTIME_ONLY_THING` and `MY_PRERENDER_TIME_THING` would be `string`; the value of `MY_RUNTIME_ONLY_THING` would be the empty string during build.

One small wrinkle here is that if you had a custom schema, we would have to use it to parse the empty string in case the value was transformed, and that would fail in some cases:

```diff
export const variables = defineEnvVars({
  MY_RUNTIME_ONLY_THING: {
+   schema: v.pipe(v.string(), v.parseJson())
  },
  MY_PRERENDER_TIME_THING: {
    build: true
  }
});
```

So the developer would have to jump through hoops in these cases:

```diff
export const variables = defineEnvVars({
  MY_RUNTIME_ONLY_THING: {
+   schema: v.pipe(building ? v.optional(v.string(), '{}') : v.string()), v.parseJson())
  },
  MY_PRERENDER_TIME_THING: {
    build: true
  }
});
```

Maybe that's an unusual enough case that it doesn't matter?

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [ ] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [ ] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
