### PR TITLE
fix: allow shallow routing during initial render

### DIFF
--- a/.changeset/shallow-routing-initial-effect.md
+++ b/.changeset/shallow-routing-initial-effect.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: allow `pushState` and `replaceState` to be called during initial render

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -278,6 +278,8 @@ let current = {
 /** this being true means we SSR'd */
 let hydrated = false;
 let started = false;
+/** True once shallow routing can be used, which is before `started` since effects run during initial render (#15927) */
+let router_initialized = false;
 let autoscroll = true;
 let updating = false;
 let is_navigating = false;
@@ -718,6 +720,10 @@ async function initialize(result, target, hydrate) {
 
 	update(/** @type {import('@sveltejs/kit').Page} */ (result.props.page));
 	current_tree = result.props.tree;
+
+	// effects flush synchronously while the root component is created below,
+	// so anything shallow routing needs must be ready before this point
+	router_initialized = true;
 
 	// TODO: use mount()
 	root = new Root({
@@ -2572,7 +2578,7 @@ export function pushState(url, state) {
 	}
 
 	if (DEV) {
-		if (!started) {
+		if (!router_initialized) {
 			throw new Error('Cannot call pushState(...) before router is initialized');
 		}
 
@@ -2590,7 +2596,8 @@ export function pushState(url, state) {
 	const opts = {
 		[HISTORY_INDEX]: (current_history_index += 1),
 		[NAVIGATION_INDEX]: current_navigation_index,
-		[PAGE_URL_KEY]: page.url.href,
+		// untracked so that effects calling this function don't depend on `page.url`
+		[PAGE_URL_KEY]: svelte.untrack(() => page.url.href),
 		[STATES_KEY]: state
 	};
 
@@ -2615,7 +2622,7 @@ export function replaceState(url, state) {
 	}
 
 	if (DEV) {
-		if (!started) {
+		if (!router_initialized) {
 			throw new Error('Cannot call replaceState(...) before router is initialized');
 		}
 
@@ -2631,7 +2638,8 @@ export function replaceState(url, state) {
 	const opts = {
 		[HISTORY_INDEX]: current_history_index,
 		[NAVIGATION_INDEX]: current_navigation_index,
-		[PAGE_URL_KEY]: page.url.href,
+		// untracked so that effects calling this function don't depend on `page.url`
+		[PAGE_URL_KEY]: svelte.untrack(() => page.url.href),
 		[STATES_KEY]: state
 	};
 

--- a/packages/kit/test/apps/basics/src/app.d.ts
+++ b/packages/kit/test/apps/basics/src/app.d.ts
@@ -12,6 +12,7 @@ declare global {
 		interface PageState {
 			active?: boolean;
 			count?: number;
+			initial?: boolean;
 		}
 	}
 }

--- a/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/initial-effect/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shallow-routing/push-state/initial-effect/+page.svelte
@@ -1,0 +1,10 @@
+<script>
+	import { pushState } from '$app/navigation';
+	import { page } from '$app/state';
+
+	$effect(() => {
+		pushState('', { initial: true });
+	});
+</script>
+
+<p>initial: {page.state.initial ?? false}</p>

--- a/packages/kit/test/apps/basics/src/routes/shallow-routing/replace-state/initial-effect/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/shallow-routing/replace-state/initial-effect/+page.svelte
@@ -1,0 +1,10 @@
+<script>
+	import { replaceState } from '$app/navigation';
+	import { page } from '$app/state';
+
+	$effect(() => {
+		replaceState('', { initial: true });
+	});
+</script>
+
+<p>initial: {page.state.initial ?? false}</p>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -1801,6 +1801,19 @@ test.describe('Shallow routing', () => {
 		await expect(page.locator('p')).toHaveText('active: false');
 		await expect(page.locator('span')).not.toHaveText(now);
 	});
+
+	test('pushState can be called in $effect during initial render', async ({ page }) => {
+		await page.goto('/shallow-routing/push-state/initial-effect');
+		await expect(page.locator('p')).toHaveText('initial: true');
+
+		await page.goBack();
+		await expect(page.locator('p')).toHaveText('initial: false');
+	});
+
+	test('replaceState can be called in $effect during initial render', async ({ page }) => {
+		await page.goto('/shallow-routing/replace-state/initial-effect');
+		await expect(page.locator('p')).toHaveText('initial: true');
+	});
 });
 
 test.describe('reroute', () => {


### PR DESCRIPTION
closes #15927

Calling `replaceState` or `pushState` inside a top-level `$effect` throws `Cannot call replaceState(...) before router is initialized` in dev, even though everything shallow routing needs already exists at that point.

Twas the release before Svelte 5, and `onMount` still ran before the router existed, so calling these functions there crashed on `root.$set` (#11466). #11968 wrapped that crash in a readable dev error, on the reasoning that Svelte 5 had made the problem unreachable since `onMount` now runs after initial render. That was right about `onMount` and wrong about `$effect`, which flushes while the root component is still being created. Everything shallow routing needs already exists in that window, `page` and the history indexes. So the dev error no longer means what it says.

Two changes.

- the dev guard now checks a `router_initialized` flag that flips right before the root component is created, once everything shallow routing needs is in place. Genuinely-too-early calls, from module scope or `load`, throw the same error as before.
- writing the back-navigation test surfaced a second bug that also breaks production. The `page.url.href` read inside both functions is tracked, so any effect calling them silently depends on `page.url`, and going back to a pushed entry re-ran the effect, which re-pushed the state it had just left. #13914 fixed this class for `clone_page`, this read escaped it. It's untracked now.

`started` is untouched, it also gates initial fetch handling, `navigating` and scroll behavior.

An earlier revision targeted `main`, where the stakes are higher: kit 2's `pushState`/`replaceState` still call `root.$set` for the legacy stores, so the same call crashes production with `TypeError: Cannot read properties of undefined (reading '$set')`. That part of the fix (falling back to the store while `root` doesn't exist yet) has no equivalent here since the stores are gone (#15499). If a 2.x patch is wanted I can reopen that version against `main`.

The new tests fail on `version-3` without the fix. In dev both hit the guard, in build the pushState test catches the effect re-run.

Overlaps with #16307 on the `PAGE_URL_KEY` lines. Whichever merges second, keep `resolve_url(url).href` and drop the `untrack`, since `resolve_url` never had the reactive dependency.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
