### PR TITLE
fix: reuse cached fetch responses when a cross-origin url is not in canonical form

### DIFF
--- a/.changeset/fetch-cache-non-canonical-url.md
+++ b/.changeset/fetch-cache-non-canonical-url.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': patch
+---
+
+fix: reuse SSR-cached fetch responses during hydration when a cross-origin URL is not in canonical form

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1074,12 +1074,11 @@ function resolve_fetch_url(input, init, url) {
 	// we must fixup relative urls so they are resolved from the target page
 	const resolved = new URL(input instanceof Request ? input.url : input, url);
 
-	// match ssr serialized data url, which is important to find cached responses
-	// (the server serializes the normalized href)
+	// match the server's serialization of `fetched.url` (see load_data.js): a path for same-origin
+	// urls, so prerendered pages can be served from any origin, the normalized href otherwise
 	const requested =
 		resolved.origin === url.origin ? resolved.href.slice(url.origin.length) : resolved.href;
 
-	// prerendered pages may be served from any origin, so `initial_fetch` urls shouldn't be resolved
 	const promise = started
 		? subsequent_fetch(requested, resolved.href, init)
 		: initial_fetch(requested, init);

--- a/packages/kit/src/runtime/client/client.js
+++ b/packages/kit/src/runtime/client/client.js
@@ -1071,15 +1071,13 @@ async function load_node({ loader, parent, url, params, route, server_data_node 
  * @param {URL} url
  */
 function resolve_fetch_url(input, init, url) {
-	let requested = input instanceof Request ? input.url : input;
-
 	// we must fixup relative urls so they are resolved from the target page
-	const resolved = new URL(requested, url);
+	const resolved = new URL(input instanceof Request ? input.url : input, url);
 
 	// match ssr serialized data url, which is important to find cached responses
-	if (resolved.origin === url.origin) {
-		requested = resolved.href.slice(url.origin.length);
-	}
+	// (the server serializes the normalized href)
+	const requested =
+		resolved.origin === url.origin ? resolved.href.slice(url.origin.length) : resolved.href;
 
 	// prerendered pages may be served from any origin, so `initial_fetch` urls shouldn't be resolved
 	const promise = started

--- a/packages/kit/src/runtime/client/fetcher.js
+++ b/packages/kit/src/runtime/client/fetcher.js
@@ -61,7 +61,7 @@ if (DEV && BROWSER) {
 		const method = input instanceof Request ? input.method : init?.method || 'GET';
 
 		if (method !== 'GET') {
-			cache.delete(build_selector(input));
+			cache.delete(build_selector(requested_url(input)));
 		}
 
 		return native_fetch(input, init);
@@ -71,7 +71,7 @@ if (DEV && BROWSER) {
 		const method = input instanceof Request ? input.method : init?.method || 'GET';
 
 		if (method !== 'GET') {
-			cache.delete(build_selector(input));
+			cache.delete(build_selector(requested_url(input)));
 		}
 
 		return native_fetch(input, init);
@@ -149,6 +149,18 @@ export function dev_fetch(resource, opts) {
 		configurable: true
 	});
 	return window.fetch(resource, patched_opts);
+}
+
+/**
+ * Mirror the url normalization in `resolve_fetch_url`, so that non-GET requests
+ * evict the cache entry regardless of how the url is spelled
+ * @param {RequestInfo | URL} input
+ */
+function requested_url(input) {
+	const resolved = new URL(input instanceof Request ? input.url : input, location.href);
+	return resolved.origin === location.origin
+		? resolved.href.slice(location.origin.length)
+		: resolved.href;
 }
 
 /**

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-external-non-canonical/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-external-non-canonical/+page.js
@@ -1,0 +1,9 @@
+/** @type {import('./$types').PageLoad} */
+export async function load({ fetch, url }) {
+	const port = url.searchParams.get('port');
+	// no trailing slash, so it differs from the normalized href
+	const res = await fetch(`http://localhost:${port}`);
+
+	const { count } = await res.json();
+	return { count };
+}

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-external-non-canonical/+page.js
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-external-non-canonical/+page.js
@@ -5,5 +5,5 @@ export async function load({ fetch, url }) {
 	const res = await fetch(`http://localhost:${port}`);
 
 	const { count } = await res.json();
-	return { count };
+	return { count, port };
 }

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-external-non-canonical/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-external-non-canonical/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+	/** @type {import('./$types').PageProps} */
+	let { data } = $props();
+</script>
+
+<h1>count: {data.count}</h1>

--- a/packages/kit/test/apps/basics/src/routes/load/fetch-external-non-canonical/+page.svelte
+++ b/packages/kit/test/apps/basics/src/routes/load/fetch-external-non-canonical/+page.svelte
@@ -1,6 +1,15 @@
 <script>
+	import { invalidate } from '$app/navigation';
+
 	/** @type {import('./$types').PageProps} */
 	let { data } = $props();
+
+	async function update() {
+		// no trailing slash, so it differs from the normalized cache key
+		await fetch(`http://localhost:${data.port}`, { method: 'POST' });
+		await invalidate(`http://localhost:${data.port}`);
+	}
 </script>
 
 <h1>count: {data.count}</h1>
+<button onclick={update}>update</button>

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -41,6 +41,27 @@ test.describe('Endpoints', () => {
 });
 
 test.describe('Load', () => {
+	test('does not refetch cross-origin urls in non-canonical form during hydration', async ({
+		page,
+		start_server
+	}) => {
+		let requests = 0;
+
+		const { port } = await start_server((req, res) => {
+			requests += 1;
+			res.writeHead(200, {
+				'Access-Control-Allow-Origin': '*',
+				'content-type': 'application/json'
+			});
+			res.end(JSON.stringify({ count: requests }));
+		});
+
+		await page.goto(`/load/fetch-external-non-canonical?port=${port}`);
+
+		await expect(page.locator('h1')).toHaveText('count: 1');
+		expect(requests).toBe(1);
+	});
+
 	test('load function is only called when necessary', async ({ app, page }) => {
 		test.slow();
 		await page.goto('/load/change-detection/one/a');

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -62,6 +62,29 @@ test.describe('Load', () => {
 		expect(requests).toBe(1);
 	});
 
+	test('busts cache if non-GET request to a non-canonical cross-origin url is made', async ({
+		page,
+		start_server
+	}) => {
+		let gets = 0;
+
+		const { port } = await start_server((req, res) => {
+			if (req.method === 'GET') gets += 1;
+			res.writeHead(200, {
+				'Access-Control-Allow-Origin': '*',
+				'cache-control': 'public, max-age=60',
+				'content-type': 'application/json'
+			});
+			res.end(JSON.stringify({ count: gets }));
+		});
+
+		await page.goto(`/load/fetch-external-non-canonical?port=${port}`);
+		await expect(page.locator('h1')).toHaveText('count: 1');
+
+		await page.locator('button').click();
+		await expect(page.locator('h1')).toHaveText('count: 2');
+	});
+
 	test('load function is only called when necessary', async ({ app, page }) => {
 		test.slow();
 		await page.goto('/load/change-detection/one/a');


### PR DESCRIPTION
closes #14781

During SSR, fetch responses are embedded as `<script data-sveltekit-fetched data-url=...>` tags, and during hydration the client rebuilds the url to find them instead of hitting the network. The two sides build it differently. The server serializes the normalized href from `new URL(input, event.url)`, while the client keeps the raw string, because prerendered pages may be served from any origin. That reasoning holds for same-origin urls, which are serialized path-relative, but cross-origin urls are absolute on both sides, so a raw string like `http://localhost:8080` without the trailing slash misses the cache and the request fires a second time from the browser.

The fix normalizes `requested` to `resolved.href` in the cross-origin case only. Normalizing in `build_selector` instead, as suggested in the issue, would break the same-origin case, `new URL('/mock')` throws without a base. `requested` also became a `const` derived from `resolved` since the mutation was no longer needed.

The new test fails on main, rendering `count: 2` after the hydration refetch overwrites the SSR data.

Not fixed here: request bodies are hashed as strings on the server but dropped from the client hash when they are not strings, so POST-with-body fetches still miss the cache. Can follow up separately.

Caching under the normalized href also meant a non-GET fetch spelled without the trailing slash could no longer evict the entry, so the second commit derives the eviction key the same way.

Also not fixed: on prerendered pages the server classifies same-origin against `prerender.origin` while the client uses the live origin, so an absolute url pointing at the deploy origin still misses the cache.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.

