### PR TITLE
breaking: disallow omitted Content-Type header

### DIFF
--- a/.changeset/neat-gifts-feel.md
+++ b/.changeset/neat-gifts-feel.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: disallow cross-origin form submissions without a `Content-Type` header

--- a/packages/kit/src/runtime/server/csrf.js
+++ b/packages/kit/src/runtime/server/csrf.js
@@ -36,7 +36,7 @@ export function get_self_origin(paths_origin, url_origin) {
  */
 export function is_csrf_forbidden({ request, request_origin, self_origin, trusted_origins }) {
 	return (
-		is_form_content_type(request) &&
+		(!request.headers.get('content-type') || is_form_content_type(request)) &&
 		mutating_form_methods.has(request.method) &&
 		request_origin !== self_origin &&
 		(!request_origin || !trusted_origins.includes(request_origin))

--- a/packages/kit/src/runtime/server/csrf.spec.js
+++ b/packages/kit/src/runtime/server/csrf.spec.js
@@ -119,6 +119,22 @@ describe('is_csrf_forbidden', () => {
 		);
 	});
 
+	test('forbids a request with no content-type header', () => {
+		assert.equal(
+			is_csrf_forbidden({
+				request: form_post({
+					headers: {
+						origin: 'https://malicious.test'
+					}
+				}),
+				request_origin: 'https://malicious.test',
+				self_origin: 'http://self.test',
+				trusted_origins: []
+			}),
+			true
+		);
+	});
+
 	test('allows GET requests regardless of origin', () => {
 		assert.equal(
 			is_csrf_forbidden({

--- a/packages/kit/test/apps/async/test/client.test.js
+++ b/packages/kit/test/apps/async/test/client.test.js
@@ -322,8 +322,8 @@ test.describe('remote function mutations', () => {
 		await expect(page.locator('#result')).toHaveText('action: hello');
 	});
 
-	test('command inside handle hook works with POST', async ({ request }) => {
-		const response = await request.post('/remote/hook-command');
+	test('command inside handle hook works with POST', async ({ request, baseURL }) => {
+		const response = await request.post('/remote/hook-command', { headers: { origin: baseURL } });
 		expect(response.status()).toBe(200);
 		const data = await response.json();
 		expect(data.result).toBe('action: from-hook');

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -530,7 +530,9 @@ test.describe('Invalidation', () => {
 		request,
 		baseURL
 	}) => {
-		const res = await request.post(baseURL + '/load/invalidation/forced/reset-states');
+		const res = await request.post(baseURL + '/load/invalidation/forced/reset-states', {
+			headers: { origin: baseURL }
+		});
 		expect(res.ok()).toBe(true);
 
 		await page.goto('/load/invalidation/forced');
@@ -554,7 +556,9 @@ test.describe('Invalidation', () => {
 		request,
 		baseURL
 	}) => {
-		const res = await request.post(baseURL + '/load/invalidation/forced-goto/reset-states');
+		const res = await request.post(baseURL + '/load/invalidation/forced-goto/reset-states', {
+			headers: { origin: baseURL }
+		});
 		expect(res.ok()).toBe(true);
 		await page.goto('/load/invalidation/forced-goto');
 		expect(await page.textContent('h1')).toBe('a: 0, b: 0');

--- a/packages/kit/test/apps/basics/test/client.test.js
+++ b/packages/kit/test/apps/basics/test/client.test.js
@@ -531,7 +531,7 @@ test.describe('Invalidation', () => {
 		baseURL
 	}) => {
 		const res = await request.post(baseURL + '/load/invalidation/forced/reset-states', {
-			headers: { origin: baseURL }
+			headers: { origin: 'https://trusted.example.com' }
 		});
 		expect(res.ok()).toBe(true);
 
@@ -557,7 +557,7 @@ test.describe('Invalidation', () => {
 		baseURL
 	}) => {
 		const res = await request.post(baseURL + '/load/invalidation/forced-goto/reset-states', {
-			headers: { origin: baseURL }
+			headers: { origin: 'https://trusted.example.com' }
 		});
 		expect(res.ok()).toBe(true);
 		await page.goto('/load/invalidation/forced-goto');

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -270,8 +270,10 @@ test.describe('Endpoints', () => {
 		}
 	});
 
-	test('invalid request method returns allow header', async ({ request }) => {
-		const response = await request.post('/endpoint-output/body');
+	test('invalid request method returns allow header', async ({ request, baseURL }) => {
+		const response = await request.post('/endpoint-output/body', {
+			headers: { origin: baseURL }
+		});
 
 		expect(response.status()).toBe(405);
 
@@ -280,8 +282,10 @@ test.describe('Endpoints', () => {
 		expect(allow_header).toMatch(/\bHEAD\b/);
 	});
 
-	test('405 allow header has no duplicate methods listed', async ({ request }) => {
-		const response = await request.post('/endpoint-output/head-handler');
+	test('405 allow header has no duplicate methods listed', async ({ request, baseURL }) => {
+		const response = await request.post('/endpoint-output/head-handler', {
+			headers: { origin: baseURL }
+		});
 
 		expect(response.status()).toBe(405);
 
@@ -320,8 +324,13 @@ test.describe('Endpoints', () => {
 		expect(await response.text()).toBe('');
 	});
 
-	test('POST to post-only endpoint with sibling page still hits endpoint', async ({ request }) => {
-		const response = await request.post('/endpoint-output/post-only-with-page');
+	test('POST to post-only endpoint with sibling page still hits endpoint', async ({
+		request,
+		baseURL
+	}) => {
+		const response = await request.post('/endpoint-output/post-only-with-page', {
+			headers: { origin: baseURL }
+		});
 
 		expect(response.status()).toBe(200);
 		expect(await response.text()).toBe('ok');
@@ -510,8 +519,10 @@ test.describe('Errors', () => {
 		);
 	});
 
-	test('unhandled http method', async ({ request }) => {
-		const response = await request.put('/errors/invalid-route-response');
+	test('unhandled http method', async ({ request, baseURL }) => {
+		const response = await request.put('/errors/invalid-route-response', {
+			headers: { origin: baseURL }
+		});
 
 		expect(response.status()).toBe(405);
 		expect(await response.text()).toMatch('PUT method not allowed');
@@ -591,10 +602,11 @@ test.describe('Errors', () => {
 		expect(await page.textContent('h1')).toBe('the answer is 42');
 	});
 
-	test('POST to missing page endpoint', async ({ request }) => {
+	test('POST to missing page endpoint', async ({ request, baseURL }) => {
 		const res = await request.post('/errors/missing-actions', {
 			headers: {
-				accept: 'text/html'
+				accept: 'text/html',
+				origin: baseURL
 			}
 		});
 		expect(res?.status()).toBe(405);

--- a/packages/kit/test/apps/basics/test/server.test.js
+++ b/packages/kit/test/apps/basics/test/server.test.js
@@ -270,9 +270,9 @@ test.describe('Endpoints', () => {
 		}
 	});
 
-	test('invalid request method returns allow header', async ({ request, baseURL }) => {
+	test('invalid request method returns allow header', async ({ request }) => {
 		const response = await request.post('/endpoint-output/body', {
-			headers: { origin: baseURL }
+			headers: { origin: 'https://trusted.example.com' }
 		});
 
 		expect(response.status()).toBe(405);
@@ -282,9 +282,9 @@ test.describe('Endpoints', () => {
 		expect(allow_header).toMatch(/\bHEAD\b/);
 	});
 
-	test('405 allow header has no duplicate methods listed', async ({ request, baseURL }) => {
+	test('405 allow header has no duplicate methods listed', async ({ request }) => {
 		const response = await request.post('/endpoint-output/head-handler', {
-			headers: { origin: baseURL }
+			headers: { origin: 'https://trusted.example.com' }
 		});
 
 		expect(response.status()).toBe(405);
@@ -324,12 +324,9 @@ test.describe('Endpoints', () => {
 		expect(await response.text()).toBe('');
 	});
 
-	test('POST to post-only endpoint with sibling page still hits endpoint', async ({
-		request,
-		baseURL
-	}) => {
+	test('POST to post-only endpoint with sibling page still hits endpoint', async ({ request }) => {
 		const response = await request.post('/endpoint-output/post-only-with-page', {
-			headers: { origin: baseURL }
+			headers: { origin: 'https://trusted.example.com' }
 		});
 
 		expect(response.status()).toBe(200);
@@ -519,9 +516,9 @@ test.describe('Errors', () => {
 		);
 	});
 
-	test('unhandled http method', async ({ request, baseURL }) => {
+	test('unhandled http method', async ({ request }) => {
 		const response = await request.put('/errors/invalid-route-response', {
-			headers: { origin: baseURL }
+			headers: { origin: 'https://trusted.example.com' }
 		});
 
 		expect(response.status()).toBe(405);
@@ -602,18 +599,19 @@ test.describe('Errors', () => {
 		expect(await page.textContent('h1')).toBe('the answer is 42');
 	});
 
-	test('POST to missing page endpoint', async ({ request, baseURL }) => {
+	test('POST to missing page endpoint', async ({ request }) => {
 		const res = await request.post('/errors/missing-actions', {
 			headers: {
 				accept: 'text/html',
-				origin: baseURL
+				origin: 'https://trusted.example.com'
 			}
 		});
 		expect(res?.status()).toBe(405);
 
 		const res_json = await request.post('/errors/missing-actions', {
 			headers: {
-				accept: 'application/json'
+				accept: 'application/json',
+				origin: 'https://trusted.example.com'
 			}
 		});
 		expect(res_json?.status()).toBe(405);


### PR DESCRIPTION
closes https://github.com/sveltejs/kit/issues/15389

This PR changes the CSRF check to disallow requests omitting a content-type header.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [x] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
