### PR TITLE
breaking: delegate dev static asset CORS handling to Vite

### DIFF
--- a/.changeset/ripe-trains-dance.md
+++ b/.changeset/ripe-trains-dance.md
@@ -2,4 +2,4 @@
 '@sveltejs/kit': major
 ---
 
-breaking: delegate CORS handling to Vite for requests against the development server
+breaking: delegate CORS handling to Vite for static directory requests during development

--- a/.changeset/ripe-trains-dance.md
+++ b/.changeset/ripe-trains-dance.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/kit': major
+---
+
+breaking: delegate CORS handling to Vite for requests against the development server

--- a/packages/kit/src/exports/vite/dev/index.js
+++ b/packages/kit/src/exports/vite/dev/index.js
@@ -407,10 +407,7 @@ export async function dev(vite, vite_config, svelte_config, get_remotes, root) {
 		dev: true,
 		etag: true,
 		maxAge: 0,
-		extensions: [],
-		setHeaders: (res) => {
-			res.setHeader('access-control-allow-origin', '*');
-		}
+		extensions: []
 	});
 
 	vite.middlewares.use((req, res, next) => {

--- a/packages/kit/test/apps/basics/vite.config.js
+++ b/packages/kit/test/apps/basics/vite.config.js
@@ -96,6 +96,9 @@ export default defineConfig({
 	server: {
 		fs: {
 			allow: [path.resolve('../../../src')]
+		},
+		cors: {
+			origin: '*'
 		}
 	},
 	test: {


### PR DESCRIPTION
This PR removes the `allow-access-control-origin: *` header that was set for every static asset request. Sapphi mentioned that since Vite 7 https://github.com/vitejs/vite/pull/20222 the CORS middleware automatically applies so we can just allow the user to configure the CORS setting themselves. This is a breaking change since it was previously always set.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [ ] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Edits

- [x] Please ensure that 'Allow edits from maintainers' is checked. PRs without this option may be closed.
